### PR TITLE
Allow AWS deploy to read bucket website config

### DIFF
--- a/infra/aws-lonely-forest/main.tf
+++ b/infra/aws-lonely-forest/main.tf
@@ -305,6 +305,7 @@ data "aws_iam_policy_document" "github_actions_deploy" {
       "s3:GetBucketPublicAccessBlock",
       "s3:GetBucketAcl",
       "s3:GetBucketCORS",
+      "s3:GetBucketWebsite",
       "s3:GetBucketVersioning",
       "s3:GetEncryptionConfiguration",
       "s3:ListBucket",


### PR DESCRIPTION
## Summary
- grant the GitHub Actions deploy role `s3:GetBucketWebsite`
- allow Terraform to refresh the archive bucket during tagged AWS deploys

## Verification
- `terraform -chdir=infra/aws-lonely-forest fmt -check`
- targeted Terraform plan: 0 add, 1 change, 0 destroy
- applied to AWS and verified ECS revision 5 is healthy at https://lonelyforest.com/health