### PR TITLE
Add agent readiness guides

### DIFF
--- a/.github/AGENT.md
+++ b/.github/AGENT.md
@@ -87,8 +87,8 @@ changing application behavior.
   unrelated baseline churn.
 - Full V2 smoke checks start local processes and use fixed runtime files; stop
   stale instances before diagnosing product failures.
-- Release tags deploy to AWS and create a GitHub release; every pushed branch is
-  deployed to Fly by the current workflow.
+- Pushes to `main` deploy the production Fly app. Release tags also deploy to
+  AWS and create a GitHub release. Feature branches never target production.
 
 ## Files requiring special handling
 
@@ -108,8 +108,8 @@ Treat these as review-sensitive rather than forbidden:
 
 - `v2/core-c/include/cosy_kernel.h` and journal action codes, because ABI or
   replay changes can invalidate history;
-- production profiles, workflows, `Dockerfile`, and `fly.toml`, because a branch
-  push deploys to Fly;
+- production profiles, workflows, `Dockerfile`, and `fly.toml`, because a merge
+  to `main` deploys to Fly;
 - authored IDs, entitlement authorities, attributions, and pack dependencies,
   because they are persisted or externally meaningful.
 

--- a/.github/AGENT.md
+++ b/.github/AGENT.md
@@ -1,0 +1,124 @@
+# Automated contribution policy
+
+This policy applies to every automated contributor. No repository-specific
+model override is required: choose a model with enough context and reasoning
+for the issue, but make correctness depend on checked-in evidence and tests,
+not on a model name.
+
+## Before editing
+
+1. Read the complete issue and linked specifications. Treat unchecked
+   acceptance criteria as required until current evidence proves they are stale
+   or contradictory.
+2. Inspect `git status` before touching files. The checkout may contain another
+   contributor's work; preserve it and use an isolated worktree when needed.
+3. Read `CLAUDE.md`, `ENG.md`, the relevant focused doc under `v2/docs/`, and
+   the current implementation. Issue line numbers and design assumptions drift.
+4. Identify the authoritative path and the evidence that will prove completion.
+   Do not use a UI assertion to prove a kernel rule or a unit test to prove
+   replay, deployment, or multiplayer behavior.
+
+If the issue's premise is contradicted by current `main`, record the concrete
+consumers or invariant and close/rewrite it transparently; do not delete active
+behavior merely to satisfy stale wording.
+
+## Tests before a PR
+
+Always run:
+
+```sh
+git diff --check
+npm run check:version
+```
+
+Then run every row that matches the change:
+
+| Surface | Required checks |
+| --- | --- |
+| Markdown-only docs | inspect links/commands; `npm run check:version` |
+| Legacy Node (`src/`, `test/`) | `npm test`; `npm run lint` when linted source changes |
+| Pack/content/compiler | `npm run v2:worldpack` |
+| C kernel or ABI | `npm run v2:kernel`; `npm run v2:rust:test` |
+| Rust orchestrator | `npm run v2:rust:test`; targeted Rust test while iterating |
+| Browser, HTTP, persistence, or multiplayer | `npm run v2:check` |
+| Broad V2 or release change | `npm run check:local` and the relevant build |
+
+CI is the final cross-platform authority and runs Node 20, stable Rust,
+`npm run lint`, `npm run check`, a Rust build, and the web build. A local suite
+that opens ephemeral HTTP listeners may fail inside a restricted sandbox with
+`listen EPERM`; rerun it where loopback binding is permitted rather than
+changing application behavior.
+
+## PR contract
+
+- Use an imperative, outcome-oriented title, for example
+  `Preserve room state across journal replay`.
+- Keep one coherent behavior or extraction per PR. Split unrelated deployment,
+  content, and feature changes.
+- The body must contain:
+  - `## Summary` with the user-visible or architectural outcome;
+  - `Closes #<issue>` for work that fully satisfies an issue;
+  - `## Validation` listing exact commands and observed results;
+  - migration, generated-file, deployment, or compatibility notes when relevant;
+  - a short review checklist confirming tests and generated artifacts.
+- Open as draft until local validation is complete. Do not merge with failing or
+  pending required checks.
+- Bump `package.json` and the root versions in `package-lock.json`; CI rejects a
+  PR whose version matches the base branch.
+
+## Known traps
+
+- V2 is canonical. Do not implement new gameplay in the legacy Node companion
+  just because its service graph is easier to navigate.
+- `v2/orchestrator-rust/src/main.rs` is very large. Use exact searches and narrow
+  reads; do not mix opportunistic refactoring into a feature fix.
+- `v2/content/official/**` is compiled output. Editing it without the owning
+  source pack produces a stale lock/bundle failure.
+- A changed official pack set changes bundle identity. Old snapshots and action
+  journals must not be silently loaded under the new identity.
+- Journal replay is more authoritative than snapshots. Snapshot-only tests do
+  not prove persistence.
+- Browser/query wallet claims are development conveniences unless the explicit
+  debug flag is enabled. Production access comes from protected feeds and
+  signed sessions.
+- Dialogue inference fails visibly and without substitute speech. Deterministic
+  fallback is allowed only for explicitly designed non-dialogue content/media.
+- Generated visual baselines use an intentional update flag. Never accept
+  unrelated baseline churn.
+- Full V2 smoke checks start local processes and use fixed runtime files; stop
+  stale instances before diagnosing product failures.
+- Release tags deploy to AWS and create a GitHub release; every pushed branch is
+  deployed to Fly by the current workflow.
+
+## Files requiring special handling
+
+Do not edit or commit these directly:
+
+- `.env`, `.env.*`, keys, wallet files, bearer tokens, logs, or runtime SQLite
+  and snapshot data;
+- `v2/content/official/**` except as output from the worldpack compiler;
+- `v2/worlds/official/world.lock.json` except through the lock command;
+- `package-lock.json` except through an intentional dependency/version update;
+- `v2/tests/visual-baselines/**` except for a reviewed UI change using the
+  documented baseline update flow;
+- build outputs such as `target/`, `dist/`, coverage, generated runtime assets,
+  or `.runtime/`.
+
+Treat these as review-sensitive rather than forbidden:
+
+- `v2/core-c/include/cosy_kernel.h` and journal action codes, because ABI or
+  replay changes can invalidate history;
+- production profiles, workflows, `Dockerfile`, and `fly.toml`, because a branch
+  push deploys to Fly;
+- authored IDs, entitlement authorities, attributions, and pack dependencies,
+  because they are persisted or externally meaningful.
+
+## Completion checklist
+
+- Every acceptance criterion has direct evidence.
+- Authority, authorization, idempotency, and replay paths were reviewed.
+- New state survives restart; new rules have authoritative tests.
+- Generated artifacts match their source and contain no unrelated churn.
+- Public copy passes the writing-register checks.
+- No secret or local runtime file appears in the diff.
+- The PR is versioned, validated, linked to its issue, and ready for CI.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
 
@@ -22,6 +22,7 @@ env:
 jobs:
   fly:
     name: Deploy to Fly
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ attached_assets/*
 
 # Generated files
 src/config/user.config.json
-CLAUDE.md
 .lore-*
 .runtime/
 v2/orchestrator-rust/.runtime/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ validation and commitment through the normal world-event path.
 - `v2/cli/`: terminal client.
 - `src/`: legacy Node companion and its service/container architecture.
 - `test/`: legacy Node and cross-surface Vitest coverage.
-- `.github/workflows/`: CI, per-branch Fly deployment, and tagged AWS release.
+- `.github/workflows/`: CI, production Fly deployment, and tagged AWS release.
 - `ENG.md`: current engineering invariants and priorities.
 - `v2/README.md`: runtime behavior, endpoints, configuration, and operations.
 - `v2/docs/`: focused worldpack, combat, simulation, voice, and writing specs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,149 @@
+# CosyWorld contributor guide
+
+This is the compact operating guide for automated contributors. It is named
+`CLAUDE.md` for tool interoperability; its instructions apply regardless of
+model or agent implementation.
+
+## Product and authority
+
+CosyWorld V2 is the canonical product: a shared browser MUD backed by a
+deterministic C kernel and a Rust HTTP/SSE orchestrator. The older Node service
+under `src/` remains a companion for inherited Discord, social, marketplace,
+media, and administration integrations. Unless an issue explicitly names that
+companion, gameplay work belongs under `v2/`.
+
+Authority is deliberately split:
+
+1. Authored packs under `v2/content/*` describe world data.
+2. `v2/scripts/compile-worldpack.mjs` validates and compiles the selected,
+   locked pack set into `v2/content/official/`.
+3. The Rust orchestrator authenticates requests, owns persistence and public
+   projections, asks AI for bounded proposals, and calls the C ABI.
+4. The C kernel validates deterministic actions and emits authoritative events.
+5. The append-only SQLite action journal is the source of truth. Replaying it
+   rebuilds state; JSON snapshots are disposable boot accelerators.
+
+AI may propose dialogue, labels, or other bounded content. It never grants an
+item, changes access, resolves combat, spends currency, fills a clock, or
+mutates authoritative state directly. A proposal becomes visible only after
+validation and commitment through the normal world-event path.
+
+## Repository map
+
+- `v2/core-c/`: deterministic rules kernel, public ABI, and C tests.
+- `v2/orchestrator-rust/`: Axum server, C bridge, journal/replay, snapshots,
+  browser client, SSE, authentication, moderation, AI, and projections.
+- `v2/ai-model-rust/`: small native/WASM model-selection library.
+- `v2/content/<pack>/`: authored pack manifests, resources, attribution, and
+  assets. These are the source files to edit.
+- `v2/worlds/official/`: selected pack set and integrity lock.
+- `v2/content/official/`: generated runtime bundle; never edit it by hand.
+- `v2/scripts/`: worldpack compiler/validator and deployment smoke tests.
+- `v2/cli/`: terminal client.
+- `src/`: legacy Node companion and its service/container architecture.
+- `test/`: legacy Node and cross-surface Vitest coverage.
+- `.github/workflows/`: CI, per-branch Fly deployment, and tagged AWS release.
+- `ENG.md`: current engineering invariants and priorities.
+- `v2/README.md`: runtime behavior, endpoints, configuration, and operations.
+- `v2/docs/`: focused worldpack, combat, simulation, voice, and writing specs.
+
+The Rust orchestrator is still concentrated in `main.rs`. Prefer an existing
+focused module when one owns the behavior (`account_auth`, `ai_gateway`,
+`content_packs`, `kernel`, `moderation`, `mud`, `routes`, `turns`, or
+`world_simulation`). Do not make an unrelated extraction inside a behavior PR.
+
+## Set up, run, and verify
+
+CI uses Node 20 and stable Rust. Install JavaScript dependencies with `npm ci`.
+The full V2 check also needs a C compiler and the Rust `wasm32-unknown-unknown`
+target.
+
+```sh
+rustup target add wasm32-unknown-unknown
+npm ci
+npm run dev                 # canonical V2 browser runtime
+npm run dev:node            # legacy Node companion only
+```
+
+Use the narrowest relevant checks while iterating:
+
+```sh
+npm test                    # Vitest suite
+npm run v2:worldpack        # import, lock, compile, content and voice checks
+npm run v2:kernel           # compile and run the C kernel tests
+npm run v2:rust:test        # Rust format check and tests
+npm run v2:syntax           # JS/Python smoke-script syntax
+npm run check:version       # PR version guard
+git diff --check
+```
+
+Before opening a PR, run the authoritative gate for the affected surface. For
+most V2 changes that is `npm run check:local`; CI runs `npm run check`, the Rust
+release build, lint, and the web build. UI or end-to-end changes also require
+`npm run v2:check`, which exercises production-profile, browser, terminal, and
+visual smoke paths. Local HTTP tests may require permission to bind loopback
+ports; `listen EPERM` from a restricted sandbox is not a test assertion.
+
+Every PR must bump the root package version because CI runs
+`npm run check:version`. Update both `package.json` and the root package entries
+in `package-lock.json`.
+
+## Non-negotiable invariants
+
+- There is one shared authoritative world per runtime, not a private chat state.
+- Deterministic world mutations cross the C kernel boundary.
+- Accepted actions and their deterministic seeds are append-only and replayable.
+- New persistent state must survive journal replay and snapshot round trips.
+- Claim keys make every reward, spend, mint, and one-shot effect idempotent.
+- Player identity and actor authority come from server-issued sessions; browser
+  fields and wallet query parameters are never trusted in production.
+- AI failures do not invent authoritative fallback speech or state changes.
+- Sanctuary cannot receive offscreen danger or irreversible loss from background
+  simulation; consequential frontier change must be caused by relevant play.
+- Packs use stable IDs and declared dependencies. Cross-pack topology belongs in
+  composition data rather than either reusable pack.
+- Bundle identity is persisted. Never erase a mismatched hash to force a load;
+  use the documented fresh-seed or explicit migration path.
+- Content and client copy follow `v2/docs/writing-style.md` and its executable
+  register checks.
+- Secrets, bearer tokens, wallet material, runtime databases, logs, and `.env*`
+  files never enter commits or diagnostic output.
+
+## Change a feature end to end
+
+1. Start from the issue's acceptance criteria and identify the authority layer.
+   Pure presentation belongs in Rust/client projections; deterministic state
+   validation or mutation belongs in C; world facts belong in a source pack.
+2. Change authored content under its owning pack. Run
+   `npm run v2:worldpack:lock` only for an intentional source/selection change,
+   then `npm run v2:worldpack`; commit the generated bundle and lock together.
+3. For a kernel rule, update `cosy_kernel.h`, `cosy_kernel.c`, C tests, the Rust
+   FFI wrapper, replay mapping, and Rust integration tests in the same change.
+4. For Rust-owned behavior, update route authorization, state projection,
+   journal/snapshot compatibility, and public event handling together.
+5. Update the embedded browser or terminal client only after the server contract
+   is authoritative. Clients suggest actions; they do not decide outcomes.
+6. Add the narrow unit/integration test and an end-to-end smoke assertion when
+   the behavior crosses HTTP, persistence, multiplayer fanout, or the browser.
+7. Update the closest focused doc, bump the version, run the relevant gate, and
+   inspect the final diff for generated churn or unrelated changes.
+
+## Conventions and failure modes
+
+- JavaScript is ESM; Rust follows `cargo fmt`; C compiles as C11 with warnings.
+- Keep IDs stable and error messages actionable. Do not silently coerce invalid
+  authoritative input.
+- Prefer typed descriptors and closed vocabularies over executable pack logic or
+  free-form state-changing AI output.
+- Preserve old journal action semantics. A new interpretation needs a new action
+  code or explicit migration so replay cannot change history.
+- `v2/content/official/**`, lockfiles, visual baselines, and package lockfiles may
+  be generated, but they still require review. Regenerate only through their
+  owning command.
+- The full runtime has production-only requirements. Use the hermetic smoke
+  scripts instead of weakening production validation for local convenience.
+- The root `index.js`, older Webpack UI, and much of `src/` are legacy surfaces;
+  the production Dockerfile launches the Rust V2 binary.
+
+See `.github/AGENT.md` for PR formatting, required preflight checks, and the
+files that need special handling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -195,3 +195,18 @@ pack's namespace. See `docs/rules-adapter.md` for the mapping boundary.
 depends on Core and SRD 5.1, adds a five-room adventure with one progress/danger
 arc, and owns four level-one character archetypes through the character-creation
 contract above.
+
+## Factions
+
+A faction is either **resident-anchored** or **player-facing**.
+
+- A resident-anchored faction lists one or more authored resident actors in
+  `member_actor_ids`. Those actors carry the faction's presence in the world.
+- A player-facing faction has an empty `member_actor_ids` array and sets
+  `player_facing: true`. Its membership is avatars, not authored residents;
+  players join and represent the faction through play.
+
+An empty `member_actor_ids` is valid when `player_facing` is `true`. The
+worldpack validator warns about factions that have no member actors and are not
+marked player-facing, so deliberately avatar-recruited factions such as the
+Great Library remain valid and explicit.


### PR DESCRIPTION
## Summary

- add a tracked root `CLAUDE.md` with the current V2 architecture, authority boundaries, directory map, invariants, commands, conventions, and end-to-end feature workflow
- add `.github/AGENT.md` with model guidance, required checks, PR conventions, known traps, special-handling files, and a completion checklist
- document resident-anchored versus player-facing factions and record the Great Library's avatar-membership model
- prevent feature branches and non-release manual refs from deploying over the single production Fly app; only `main` and `v*` tags may deploy it
- remove the stale `CLAUDE.md` ignore rule and bump the release version to 0.0.34
- audit every open issue and leave acceptance-criteria rewrite suggestions on #52, #55, #60, and #61 without editing their bodies
- verify the `agent` queue and all agent lifecycle labels through GitHub CLI

Closes #17
Closes #67

## Why the deployment guard is included

Production verification showed a newer feature-branch push had overwritten the merged #58 image on the shared `cosyworld` Fly app. The active image label pointed to `fix/issue-64-restore-register-ear`, while `main` contained the reduced official bundle. Restricting the workflow makes branch CI non-destructive and lets a merge to `main` remain the production source of truth.

## Validation

- `npm run check:version`
- `git diff --check`
- `actionlint .github/workflows/deploy.yml`
- verified current `check-worldpack.mjs` accepts `player_facing: true` with empty `member_actor_ids` and warns on undocumented empty factions
- `gh issue list --repo cenetex/cosyworld --label agent --state open`
- `gh label list --repo cenetex/cosyworld --limit 100 --json name` confirms `agent`, `agent:running`, `agent:waiting`, `agent:failed`, `agent:succeeded`, and `agent:queued`
- reviewed every top-level source/configuration file; local secret-bearing `.env*` files were intentionally not opened

## Review checklist

- [x] Documentation reflects the canonical V2 runtime rather than the legacy Node architecture.
- [x] Commands match `package.json` and CI workflow names.
- [x] Feature branches can no longer deploy the production Fly app.
- [x] Faction documentation matches existing validation and Great Library content.
- [x] No generated world content, runtime state, or secrets changed.
- [x] Issue-audit comments are posted separately and issue bodies are untouched.