### PR TITLE
Restore second-person use text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -146,6 +146,27 @@ describe("worldpack writing register validation", () => {
     expect(result.stderr).toContain("use text assigns sentiment to an object");
   });
 
+  it("allows second person in use-texts but rejects it in location descriptions", () => {
+    const root = worldpackFixture();
+    const features = JSON.parse(fs.readFileSync(path.join(root, "room_features.json"), "utf8"));
+    features.find((feature) => feature.uses?.length).uses[0].text = "The tonic warms in your hand.";
+    writeJson(root, "room_features.json", features);
+
+    const passResult = runChecker(root);
+
+    expect(passResult.status, passResult.stderr).toBe(0);
+    expect(passResult.stdout).toContain("worldpack ok");
+
+    const locations = JSON.parse(fs.readFileSync(path.join(root, "locations.json"), "utf8"));
+    locations[0].description = "You see a warm hearth.";
+    writeJson(root, "locations.json", locations);
+
+    const failResult = runChecker(root);
+
+    expect(failResult.status).toBe(1);
+    expect(failResult.stderr).toContain("uses second person outside the sentences register");
+  });
+
   it("leaves the sentences register exempt", () => {
     const root = worldpackFixture();
     writeJson(root, "sentences.json", [{

--- a/v2/content/core/room_features.json
+++ b/v2/content/core/room_features.json
@@ -13,7 +13,7 @@
     "uses": [
       {
         "item_id": 2001,
-        "text": "The tonic warms against the skin. The hearth is warmer."
+        "text": "The tonic warms in your hand. The hearth is warmer."
       }
     ]
   },
@@ -106,7 +106,7 @@
       "sign"
     ],
     "look": "A silvered post with no distance marked.",
-    "search": "Three scratches read: guard, take only what is earned, leave early."
+    "search": "Three scratches read: prove the guard, take what is earned, leave early."
   },
   {
     "location_id": 3,
@@ -122,7 +122,7 @@
     "uses": [
       {
         "item_id": 2003,
-        "text": "The charm cools against the skin."
+        "text": "The charm cools in your palm."
       }
     ]
   },

--- a/v2/content/official/room_features.json
+++ b/v2/content/official/room_features.json
@@ -13,7 +13,7 @@
     "uses": [
       {
         "item_id": 2001,
-        "text": "The tonic warms against the skin. The hearth is warmer."
+        "text": "The tonic warms in your hand. The hearth is warmer."
       }
     ],
     "pack_id": "cosyworld.core"
@@ -112,7 +112,7 @@
       "sign"
     ],
     "look": "A silvered post with no distance marked.",
-    "search": "Three scratches read: guard, take only what is earned, leave early.",
+    "search": "Three scratches read: prove the guard, take what is earned, leave early.",
     "pack_id": "cosyworld.core"
   },
   {
@@ -129,7 +129,7 @@
     "uses": [
       {
         "item_id": 2003,
-        "text": "The charm cools against the skin."
+        "text": "The charm cools in your palm."
       }
     ],
     "pack_id": "cosyworld.core"

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -5,7 +5,7 @@
   "version": 1,
   "description": "The reproducible seed world for the official CosyWorld shard.",
   "entry_location": "cosyworld.core:location/1",
-  "bundle_hash": "sha256:61a5ba1795f37f1307dd9668f0112508c6955809cf77873d496a8600b2b47e56",
+  "bundle_hash": "sha256:fbe91073919deecc17a1abec85de9db7ac8be99f762e004d9320b125386b4ea5",
   "packs": [
     {
       "id": "cosyworld.core",
@@ -41,7 +41,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:4623570673025701f2051dd3bc2d42e8223566d158c34ff6141bd6c0084970c3"
+      "integrity": "sha256:ed77f07031157898a81475fc218c92510f44d7a6d2c79d6e19954c9a0361b084"
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",

--- a/v2/docs/writing-style.md
+++ b/v2/docs/writing-style.md
@@ -31,8 +31,8 @@ Invisible. Verbs and objects only.
 Concrete nouns, short sentences, at most one image. The second sentence must
 add information, never restate the first one's mood.
 
-- Objects report physical state, never feelings. "The charm cools against the
-  skin." — not "…pleased by the circle's restraint."
+- Objects report physical state, never feelings. "The charm cools in your
+  palm." — not "…pleased by the circle's restraint."
 - Second person belongs to the Left Sentences register. Routine world prose
   reports what is present without telling the player what they perceive.
 - Never explain the subtext. "The dust shows careful footwork and no blood."
@@ -75,3 +75,8 @@ event. The same line on a doorknob reads as wallpaper.
 - [ ] Grep the diff for "as if" and "seems to" in look/search/use/description
       fields.
 - [ ] Was lyricism spent on a rare system moment, or on furniture?
+
+## Governance
+
+The lint conforms to this document. When lint and doc disagree, the doc wins
+and the lint changes.

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -44450,7 +44450,7 @@ mod tests {
                 assert_eq!(item_id, 2003);
                 assert_eq!(location_id, MOONLIT_TRAIL_LOCATION_ID);
                 assert_eq!(feature_key, "practice_circle");
-                assert!(output.contains("The charm cools against the skin."));
+                assert!(output.contains("The charm cools in your palm."));
                 (item_id, location_id, feature_key, output)
             }
             other => panic!("project feature use should resolve to use_feature, got {other:?}"),

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -134,7 +134,8 @@ function validateWritingRegister(contentCollections) {
             if (pattern.test(value)) fail(`${label} uses banned environment tell "${tell}"`);
           }
         }
-        if (secondPersonPattern.test(value)) {
+        const isUseText = trail.at(-1) === "text" && trail.at(-3) === "uses";
+        if (secondPersonPattern.test(value) && !isUseText) {
           fail(`${label} uses second person outside the sentences register`);
         }
       });

--- a/v2/worlds/official/world.lock.json
+++ b/v2/worlds/official/world.lock.json
@@ -9,7 +9,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:4623570673025701f2051dd3bc2d42e8223566d158c34ff6141bd6c0084970c3"
+      "integrity": "sha256:ed77f07031157898a81475fc218c92510f44d7a6d2c79d6e19954c9a0361b084"
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",


### PR DESCRIPTION
## Summary

- exempt direct `uses[].text` action feedback from the environment register's second-person ban while retaining object-sentiment checks
- restore the three author-approved tonic, charm, and guard lines
- restore the physical-state exemplar and add the lint-governance rule to the writing guide
- add a boundary test proving use-text second person passes while location-description second person still fails
- regenerate the reduced four-pack official bundle and bump the release to 0.0.35

Closes #64

## Validation

- `npm test` with Node 24 — 366 passed
- `npm run v2:worldpack` — 4 packs, 33 locations, 33 room sheets, 84 cards
- `npm run check:version`
- `git diff --check`
- verified official pack IDs remain Core, Lantern Keeper, Lonely Forest characters, and Ruby High

## Migration and deployment

- no schema, journal, or snapshot migration
- this branch is based on the merged production-deploy guard, so feature-branch pushes do not target Fly

## Review checklist

- [x] Test covers the exact exemption boundary.
- [x] Object-sentiment validation remains active.
- [x] Generated bundle and lock were refreshed from source.
- [x] Unmounted Holy Land and SRD packs remain unmounted.