### PR TITLE
Define goblin as a licensed trade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/core/actors.json
+++ b/v2/content/core/actors.json
@@ -892,7 +892,7 @@
     "name": "Nib",
     "speech_mode": "prose",
     "title": "Goblin Market Loophole Clerk",
-    "description": "A small goblin with an enormous receipt roll who offers three prices for everything, circles the kindest one in green, and becomes offended when nobody reads the fine print.",
+    "description": "A licensed goblin — a tinker and dealer in salvage, oddments, and loose coins — with an enormous receipt roll who offers three prices for everything, circles the kindest one in green, and becomes offended when nobody reads the fine print.",
     "location_id": 34,
     "desires": [
       {

--- a/v2/content/core/room_features.json
+++ b/v2/content/core/room_features.json
@@ -230,5 +230,18 @@
         "text": "The Story Button clicks inside the hollow. Old Oak answers with a story it had kept for a kinder listener."
       }
     ]
+  },
+  {
+    "location_id": 34,
+    "key": "nibs_stall",
+    "name": "Nib's Stall",
+    "aliases": [
+      "stall",
+      "counter",
+      "receipt roll",
+      "roll"
+    ],
+    "look": "A plank counter stacked with salvage, oddments, and a receipt roll wider than the stall itself.",
+    "search": "Three prices are inked beside each item. The kindest one is circled in green. The fine print is very fine."
   }
 ]

--- a/v2/content/official/actors.json
+++ b/v2/content/official/actors.json
@@ -927,7 +927,7 @@
     "name": "Nib",
     "speech_mode": "prose",
     "title": "Goblin Market Loophole Clerk",
-    "description": "A small goblin with an enormous receipt roll who offers three prices for everything, circles the kindest one in green, and becomes offended when nobody reads the fine print.",
+    "description": "A licensed goblin — a tinker and dealer in salvage, oddments, and loose coins — with an enormous receipt roll who offers three prices for everything, circles the kindest one in green, and becomes offended when nobody reads the fine print.",
     "location_id": 34,
     "desires": [
       {

--- a/v2/content/official/room_features.json
+++ b/v2/content/official/room_features.json
@@ -248,6 +248,20 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "location_id": 34,
+    "key": "nibs_stall",
+    "name": "Nib's Stall",
+    "aliases": [
+      "stall",
+      "counter",
+      "receipt roll",
+      "roll"
+    ],
+    "look": "A plank counter stacked with salvage, oddments, and a receipt roll wider than the stall itself.",
+    "search": "Three prices are inked beside each item. The kindest one is circled in green. The fine print is very fine.",
+    "pack_id": "cosyworld.core"
+  },
+  {
     "location_id": 800,
     "key": "failing_lantern",
     "name": "Failing Lantern",

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -5,7 +5,7 @@
   "version": 1,
   "description": "The reproducible seed world for the official CosyWorld shard.",
   "entry_location": "cosyworld.core:location/1",
-  "bundle_hash": "sha256:fbe91073919deecc17a1abec85de9db7ac8be99f762e004d9320b125386b4ea5",
+  "bundle_hash": "sha256:957ce4c287ee3e47189c6b1d2a6a81d264d268004dc02668092837f8a75c5205",
   "packs": [
     {
       "id": "cosyworld.core",
@@ -23,7 +23,7 @@
         "locations": 28,
         "exits": 70,
         "hidden_exits": 1,
-        "room_features": 16,
+        "room_features": 17,
         "room_sheets": 28,
         "clocks": 10,
         "jobs": 5,
@@ -41,7 +41,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:ed77f07031157898a81475fc218c92510f44d7a6d2c79d6e19954c9a0361b084"
+      "integrity": "sha256:377b4cbbccf59376b53f8a5b0bacdff94b8c40ac282f2e0889b4a9c9ebb68152"
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",

--- a/v2/docs/canon.md
+++ b/v2/docs/canon.md
@@ -1,0 +1,12 @@
+# Decided canon
+
+This file is the authority content authors and agents check before inventing
+species, lore, or worldbuilding rules. Each entry below is a settled decision;
+new decisions append to the list.
+
+1. **"Goblin" is a job title, not a species.** A goblin is a tinker and dealer
+   in eclectic materials — salvage, oddments, components, loose coins, things
+   with three prices. Anyone may take up goblining; a licensed goblin may be a
+   mouse, a badger, a raven, or something less classifiable. The Goblin Market
+   is the trade guild that licenses the trade, not a species' homeland.
+   Membership is open across actors regardless of kind.

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -46445,7 +46445,7 @@ mod tests {
                 && exit.to_location_id == MOONLIT_TRAIL_LOCATION_ID
         }));
         assert_eq!(content.hidden_exits.len(), 1);
-        assert_eq!(content.room_features.len(), 21);
+        assert_eq!(content.room_features.len(), 22);
         assert_eq!(content.room_sheets.len(), 33);
         assert_eq!(content.clocks.len(), 12);
         assert_eq!(content.jobs.len(), 6);

--- a/v2/worlds/official/world.lock.json
+++ b/v2/worlds/official/world.lock.json
@@ -9,7 +9,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:ed77f07031157898a81475fc218c92510f44d7a6d2c79d6e19954c9a0361b084"
+      "integrity": "sha256:377b4cbbccf59376b53f8a5b0bacdff94b8c40ac282f2e0889b4a9c9ebb68152"
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",


### PR DESCRIPTION
## Summary

- make Nib's description explicitly define a goblin as a licensed tinker and dealer rather than a species
- add Nib's concrete stall to Goblin Cave while preserving its three-price guild behavior
- add `v2/docs/canon.md` as the authority for settled lore decisions
- regenerate the reduced four-pack official bundle and bump the package to 0.0.36

Closes #66

## Validation

- bundled Node 24 Vitest run — 29 files, 366 tests passed
- `npm run v2:worldpack` — 4 packs, 33 locations, 33 room sheets, 84 cards
- `npm run check:version`
- `git diff --check`
- audited every `goblin` occurrence under `v2/content`; remaining prose refers only to the trade/guild or the intentionally retained Goblin Cave place name

## Generated files

- `v2/content/official/**` and `v2/worlds/official/world.lock.json` were regenerated from authored Core content through the worldpack lock/compiler commands
- no schema, journal, or snapshot migration

## Review checklist

- [x] Nib reads unambiguously as a licensed professional.
- [x] Canon authority records goblin-as-trade and open membership.
- [x] Official bundle remains the four-pack reduced world.
- [x] Full JavaScript and worldpack checks pass.