### PR TITLE
Seed the Left Sentences corpus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -116,6 +116,26 @@ describe("worldpack authored relationships", () => {
       }
     }
   });
+
+  it("ships the 27-line Left Sentences corpus across all five shelves", () => {
+    const sentences = JSON.parse(
+      fs.readFileSync(path.join(compiledWorldpackRoot, "sentences.json"), "utf8"),
+    );
+
+    expect(sentences).toHaveLength(27);
+    expect(new Set(sentences.map((sentence) => sentence.shelf))).toEqual(new Set([
+      "quiet-wing",
+      "great-library",
+      "restricted",
+      "drowned",
+      "hearth",
+    ]));
+    expect(sentences.every((sentence) => sentence.pack_id === "cosyworld.core")).toBe(true);
+    expect(sentences.filter((sentence) => sentence.shelf === "hearth")).toHaveLength(3);
+    expect(sentences.filter((sentence) => sentence.shelf === "hearth").every((sentence) => (
+      sentence.weight === 1 && [1, 12, 50, 64, 65].every((id) => sentence.location_ids.includes(id))
+    ))).toBe(true);
+  });
 });
 
 describe("worldpack writing register validation", () => {

--- a/v2/content/core/pack.json
+++ b/v2/content/core/pack.json
@@ -24,7 +24,8 @@
     "cards": "cards.json",
     "lifecycle_hooks": "lifecycle_hooks.json",
     "evolution_tracks": "evolution_tracks.json",
-    "recipes": "recipes.json"
+    "recipes": "recipes.json",
+    "sentences": "sentences.json"
   },
   "assets": [
     {

--- a/v2/content/core/sentences.json
+++ b/v2/content/core/sentences.json
@@ -2,287 +2,190 @@
   {
     "id": "quiet-wing/longer-than-you-think",
     "shelf": "quiet-wing",
-    "location_ids": [
-      12
-    ],
+    "location_ids": [12],
     "text": "You have been reading this sentence longer than you think.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "quiet-wing/book-looking",
     "shelf": "quiet-wing",
-    "location_ids": [
-      12
-    ],
+    "location_ids": [12],
     "text": "The book you want is looking for you too. One of you must sit still.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "quiet-wing/return-dates",
     "shelf": "quiet-wing",
-    "location_ids": [
-      12
-    ],
+    "location_ids": [12],
     "text": "Return dates are a kindness. Not everything returned was due.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "quiet-wing/stayed-home",
     "shelf": "quiet-wing",
-    "location_ids": [
-      12
-    ],
+    "location_ids": [12],
     "text": "Somewhere on these shelves is the version of today where you stayed home.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "quiet-wing/different-book",
     "shelf": "quiet-wing",
-    "location_ids": [
-      12
-    ],
+    "location_ids": [12],
     "text": "Every reader finishes a different book with the same name.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "quiet-wing/hush-being-polite",
     "shelf": "quiet-wing",
-    "location_ids": [
-      12
-    ],
+    "location_ids": [12],
     "text": "The hush is not empty. It is full, and being polite.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "great-library/rest-between-names",
     "shelf": "great-library",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "A thing is the rest a process takes between names.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "great-library/door-over-hole",
     "shelf": "great-library",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "A name is a door nailed over a hole. The hole does not mind.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "great-library/true-and-accurate",
     "shelf": "great-library",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "Nothing here is true. Everything here is accurate.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "great-library/missing-entry",
     "shelf": "great-library",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "The catalog is complete. The world is the missing entry.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "great-library/wetter-map",
     "shelf": "great-library",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "Maps age faster than coastlines. Trust the wetter one.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "great-library/forgives-infinite",
     "shelf": "great-library",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "Shelving is how the Library forgives the infinite.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "great-library/residue",
     "shelf": "great-library",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "What endures is not purity but residue. The Library dusts anyway.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "restricted/read-aloud",
     "shelf": "restricted",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "The world is being read aloud. Do not look up during the pauses.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "restricted/author-below",
     "shelf": "restricted",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "Beneath the floor there is a journal. Beneath the journal, an author who does not blink.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "restricted/replayed-before",
     "shelf": "restricted",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "You have been replayed before. You were exactly the same.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "restricted/honest-dice",
     "shelf": "restricted",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "The dice are honest. That is the unsettling part.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "restricted/append-only",
     "shelf": "restricted",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "The journal is append-only. So are you.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "restricted/rooms-remember",
     "shelf": "restricted",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "Rooms remember you so that something does.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "restricted/never-for-you",
     "shelf": "restricted",
-    "location_ids": [
-      50
-    ],
+    "location_ids": [50],
     "text": "When you leave a room, it continues. This was never for your benefit.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "drowned/place-at-night",
     "shelf": "drowned",
-    "location_ids": [
-      64,
-      65
-    ],
+    "location_ids": [64, 65],
     "text": "Azazoth sets a place for you nightly. The kindness is real. So is the appetite.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "drowned/bell-answering",
     "shelf": "drowned",
-    "location_ids": [
-      64,
-      65
-    ],
+    "location_ids": [64, 65],
     "text": "The bell below the sea is not ringing. It is answering.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "drowned/pressure-holding",
     "shelf": "drowned",
-    "location_ids": [
-      64,
-      65
-    ],
+    "location_ids": [64, 65],
     "text": "Pressure is the deep's way of holding you. It means it.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "drowned/read-anyway",
     "shelf": "drowned",
-    "location_ids": [
-      64,
-      65
-    ],
+    "location_ids": [64, 65],
     "text": "Some books are returned by the tide. Their sentences are not for you. Read them anyway.",
-    "weight": 10,
-    "pack_id": "cosyworld.core"
+    "weight": 10
   },
   {
     "id": "hearth/kettle-at-the-end",
     "shelf": "hearth",
-    "location_ids": [
-      1,
-      12,
-      50,
-      64,
-      65
-    ],
+    "location_ids": [1, 12, 50, 64, 65],
     "text": "Someone kept the kettle warm through the end of the world. It worked.",
-    "weight": 1,
-    "pack_id": "cosyworld.core"
+    "weight": 1
   },
   {
     "id": "hearth/allowed-to-fail",
     "shelf": "hearth",
-    "location_ids": [
-      1,
-      12,
-      50,
-      64,
-      65
-    ],
+    "location_ids": [1, 12, 50, 64, 65],
     "text": "You are allowed to fail here. It is written down, in a hand nobody recognizes.",
-    "weight": 1,
-    "pack_id": "cosyworld.core"
+    "weight": 1
   },
   {
     "id": "hearth/leaving-is-a-bow",
     "shelf": "hearth",
-    "location_ids": [
-      1,
-      12,
-      50,
-      64,
-      65
-    ],
+    "location_ids": [1, 12, 50, 64, 65],
     "text": "The door is low so that every leaving is a bow.",
-    "weight": 1,
-    "pack_id": "cosyworld.core"
+    "weight": 1
   }
 ]

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -5,7 +5,7 @@
   "version": 1,
   "description": "The reproducible seed world for the official CosyWorld shard.",
   "entry_location": "cosyworld.core:location/1",
-  "bundle_hash": "sha256:8ca493ca7c0e131b79020c90318e20e65a0f450f0ae18837b862801cb71e8f86",
+  "bundle_hash": "sha256:c97e16400c0aee830e0b1823120b6a8820601e9a476a22d1a8a2fa68c57caa1f",
   "packs": [
     {
       "id": "cosyworld.core",
@@ -32,7 +32,7 @@
         "lifecycle_hooks": 19,
         "evolution_tracks": 3,
         "recipes": 1,
-        "sentences": 0,
+        "sentences": 27,
         "external_cards": 0,
         "assets": 1,
         "rules": 0,
@@ -42,7 +42,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:377b4cbbccf59376b53f8a5b0bacdff94b8c40ac282f2e0889b4a9c9ebb68152"
+      "integrity": "sha256:1be3f52cfd1a6238fd30d5c2ff90a43c1888b1f51e2c27ca4dabac719007658c"
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",

--- a/v2/docs/writing-style.md
+++ b/v2/docs/writing-style.md
@@ -65,6 +65,20 @@ discovery text, evolution completion, clock-fill aspects, the deepest zones
 (Dark Abyss keeps its banquet). One poetic line at a real event reads as an
 event. The same line on a doorknob reads as wallpaper.
 
+### 6. Left Sentences (the authored lyric register)
+
+Sentences are where the remaining magic budget is spent. If a lyric line wants
+to exist somewhere else, it is probably a sentence. The canonical corpus lives
+in `v2/content/core/sentences.json`.
+
+- Second person is permitted only here.
+- Use present-tense declarations without hedging. The turn happens once, then
+  stops.
+- Keep whimsy and ontological unease together; avoid bodily horror and gore.
+- No despair without hospitality. Every dark shelf keeps one lit window.
+- "As if" and "seems to" remain authorially banned even though this collection
+  is exempt from ordinary world-prose lint.
+
 ## Review checklist
 
 - [ ] Could this sentence appear on a button a player reads 200 times?

--- a/v2/worlds/official/world.lock.json
+++ b/v2/worlds/official/world.lock.json
@@ -9,7 +9,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:377b4cbbccf59376b53f8a5b0bacdff94b8c40ac282f2e0889b4a9c9ebb68152"
+      "integrity": "sha256:1be3f52cfd1a6238fd30d5c2ff90a43c1888b1f51e2c27ca4dabac719007658c"
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",


### PR DESCRIPTION
## Summary

- add the authored 27-line Left Sentences corpus to `cosyworld.core`
- distribute it across Quiet Wing, Great Library, Restricted, Drowned, and Hearth shelves using stable IDs and declared room availability
- make the three hospitable Hearth lines low-weight finds available across every library location
- add the dedicated Left Sentences register to the writing guide
- add a compiled-corpus test, regenerate the four-pack bundle/lock, and bump the package to 0.0.38

Closes #55

## Validation

- bundled Node 24 Vitest run — 29 files, 368 tests passed
- `npm run v2:worldpack` — 4 packs, 33 locations, 33 room sheets, 84 cards, 27 sentences
- `npm run check:version`
- `git diff --check`
- checker validates every corpus ID, shelf, location reference, text, and positive weight through #65

## Content and generated files

- authored source: `v2/content/core/sentences.json`
- generated outputs: `v2/content/official/sentences.json`, `v2/content/official/worldpack.json`, and `v2/worlds/official/world.lock.json`
- Hearth entries use weight 1; all shelf-specific entries use weight 10
- no runtime mechanic, journal, snapshot, or kernel change in this PR; discovery remains #54

## Review checklist

- [x] All 27 approved lines are present.
- [x] All five canonical shelves are represented.
- [x] Hearth lines can surface across the declared library rooms at lower weight.
- [x] The ordinary world-prose register remains unchanged outside sentences.