### PR TITLE
Load mounted content through ContentRegistry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -20,6 +20,27 @@ function worldpackFixture() {
 
 function writeJson(root, fileName, value) {
   fs.writeFileSync(path.join(root, fileName), `${JSON.stringify(value, null, 2)}\n`);
+  if (fileName === "registry.json") return;
+  const registryPath = path.join(root, "registry.json");
+  if (!fs.existsSync(registryPath)) return;
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+  if (fileName === "worldpack.json") {
+    registry.manifest = value;
+  } else {
+    const resource = Object.entries(registry.manifest.files ?? {})
+      .find(([, compiledFile]) => compiledFile === fileName)?.[0];
+    if (resource) registry.resources[resource] = value;
+    for (const [field, manifestField] of [
+      ["external_cards", "external_cards"],
+      ["assets", "assets"],
+      ["rules", "rules"],
+      ["attributions", "attributions"],
+      ["character_creation", "character_creation"],
+    ]) {
+      if (registry.manifest[manifestField] === fileName) registry[field] = value;
+    }
+  }
+  fs.writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
 }
 
 function writeSentences(root, sentences) {

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -1,0 +1,7669 @@
+{
+  "schema_version": 1,
+  "manifest": {
+    "schema_version": 2,
+    "pack_contract": "cosyworld.content-pack/1",
+    "canonical_id_mapping_version": 1,
+    "id": "cosyworld.official",
+    "name": "CosyWorld Official",
+    "version": 1,
+    "description": "The reproducible seed world for the official CosyWorld shard.",
+    "entry_location": "cosyworld.core:location/1",
+    "bundle_hash": "sha256:abb0d1a95daeebaffa917369e9c73ddfe495f8861934c71e912da1417f27afdf",
+    "packs": [
+      {
+        "id": "cosyworld.core",
+        "name": "CosyWorld Core",
+        "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
+        "version": "1.0.0",
+        "kind": "world",
+        "license": "MIT",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.core/world",
+            "kind": "world",
+            "version": "1.0.0"
+          },
+          {
+            "id": "cosyworld.core/assets",
+            "kind": "assets",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [],
+        "dependency_requirements": [],
+        "dependency_closure": [],
+        "default_ruleset": null,
+        "entry_points": [
+          {
+            "kind": "location",
+            "id": "location/1"
+          }
+        ],
+        "provenance": {
+          "source_name": "CosyWorld",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 36,
+          "access_gates": 6,
+          "factions": 12,
+          "items": 10,
+          "locations": 28,
+          "exits": 70,
+          "hidden_exits": 1,
+          "room_features": 17,
+          "room_sheets": 28,
+          "clocks": 10,
+          "jobs": 5,
+          "fronts": 5,
+          "cards": 71,
+          "lifecycle_hooks": 19,
+          "evolution_tracks": 3,
+          "recipes": 1,
+          "sentences": 27,
+          "external_cards": 0,
+          "assets": 1,
+          "rules": 0,
+          "character_creation": 0
+        },
+        "source": {
+          "type": "workspace",
+          "path": "../../content/core"
+        },
+        "integrity": "sha256:97141fdd8061001e83cb0ef54bc8492fa368c6b0d738ef3acd0edbcb8bb61e5b"
+      },
+      {
+        "id": "cosyworld.campaign.the-lantern-keeper",
+        "name": "The Lantern Keeper",
+        "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
+        "version": "0.1.0",
+        "kind": "campaign",
+        "license": "CC-BY-4.0",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.campaign.the-lantern-keeper/world",
+            "kind": "world",
+            "version": "0.1.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.core"
+        ],
+        "default_ruleset": null,
+        "entry_points": [
+          {
+            "kind": "location",
+            "id": "location/800"
+          },
+          {
+            "kind": "character_creation",
+            "id": "the-lantern-keeper"
+          }
+        ],
+        "provenance": {
+          "source_name": "CosyWorld and System Reference Document 5.1",
+          "source_url": "https://github.com/cenetex/cosyworld",
+          "license_notice": "SRD-derived references are attributed in ATTRIBUTION.md."
+        },
+        "resource_counts": {
+          "actors": 4,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 4,
+          "locations": 5,
+          "exits": 8,
+          "hidden_exits": 0,
+          "room_features": 5,
+          "room_sheets": 5,
+          "clocks": 2,
+          "jobs": 1,
+          "fronts": 1,
+          "cards": 13,
+          "lifecycle_hooks": 8,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 0,
+          "rules": 0,
+          "character_creation": 1
+        },
+        "source": {
+          "type": "workspace",
+          "path": "../../content/the-lantern-keeper"
+        },
+        "integrity": "sha256:91198689bfa981b3faac2ad1bb5a5806b68a0fcc52a688ea37cc3e0eb5f8576e"
+      },
+      {
+        "id": "cosyworld.lonely-forest.characters",
+        "name": "Lonely Forest Character Art",
+        "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
+        "version": "1.0.0",
+        "kind": "assets",
+        "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.lonely-forest.characters/assets",
+            "kind": "assets",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.core"
+        ],
+        "default_ruleset": null,
+        "entry_points": [
+          {
+            "kind": "asset_mount",
+            "id": "characters"
+          }
+        ],
+        "provenance": {
+          "source_name": "Cenetex Lonely Forest character art",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 0,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "fronts": 0,
+          "cards": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 1,
+          "rules": 0,
+          "character_creation": 0
+        },
+        "source": {
+          "type": "workspace",
+          "path": "../../content/lonely-forest"
+        },
+        "integrity": "sha256:c42cfafe59f937b23d2389a0b63e725cba414f25e2b1651c7a17e82c9540da4a"
+      },
+      {
+        "id": "ruby-high.first-bell",
+        "name": "Ruby High: First Bell",
+        "description": "The live First Bell card catalog consumed by the official CosyWorld shard.",
+        "version": "1.0.0",
+        "kind": "catalog",
+        "license": "MIT",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "ruby-high.first-bell/cards",
+            "kind": "cards",
+            "version": "1.0.0"
+          },
+          {
+            "id": "ruby-high.first-bell/assets",
+            "kind": "assets",
+            "version": "1.0.0"
+          },
+          {
+            "id": "ruby-high.first-bell/entitlements",
+            "kind": "entitlements",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.core"
+        ],
+        "default_ruleset": null,
+        "entry_points": [
+          {
+            "kind": "card_catalog",
+            "id": "first-bell"
+          },
+          {
+            "kind": "asset_mount",
+            "id": "cards"
+          }
+        ],
+        "provenance": {
+          "source_name": "Ruby High: First Bell",
+          "source_url": "https://ruby-high.ai"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 0,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "fronts": 0,
+          "cards": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 24,
+          "assets": 1,
+          "rules": 0,
+          "character_creation": 0
+        },
+        "distribution": {
+          "media_type": "application/vnd.cosyworld.pack+json",
+          "canonicalization": "jcs",
+          "permanence": "content-addressed"
+        },
+        "entitlements": {
+          "schema_version": 1,
+          "authorities": [
+            {
+              "id": "first-bell-card-feed",
+              "type": "asset_feed",
+              "asset_kind": "nft",
+              "issuer": "ruby-high.ai",
+              "chain": "solana",
+              "network": "mainnet-beta",
+              "standard": "metaplex_core",
+              "collection_binding": "RUBY_HIGH_SOLANA_CORE_CARD_COLLECTION_ADDRESS"
+            }
+          ],
+          "grants": [
+            {
+              "id": "ruby-high.first-bell:location-science-lab",
+              "authority_id": "first-bell-card-feed",
+              "match": {
+                "asset_id": "location-science-lab"
+              }
+            },
+            {
+              "id": "ruby-high.first-bell:location-homeroom",
+              "authority_id": "first-bell-card-feed",
+              "match": {
+                "asset_id": "location-homeroom"
+              }
+            },
+            {
+              "id": "ruby-high.first-bell:location-library",
+              "authority_id": "first-bell-card-feed",
+              "match": {
+                "asset_id": "location-library"
+              }
+            },
+            {
+              "id": "ruby-high.first-bell:location-cafeteria",
+              "authority_id": "first-bell-card-feed",
+              "match": {
+                "asset_id": "location-cafeteria"
+              }
+            },
+            {
+              "id": "ruby-high.first-bell:location-greenhouse",
+              "authority_id": "first-bell-card-feed",
+              "match": {
+                "asset_id": "location-greenhouse"
+              }
+            },
+            {
+              "id": "ruby-high.first-bell:location-courtyard",
+              "authority_id": "first-bell-card-feed",
+              "match": {
+                "asset_id": "location-courtyard"
+              }
+            }
+          ]
+        },
+        "source": {
+          "type": "workspace",
+          "path": "../../content/ruby-high-first-bell"
+        },
+        "integrity": "sha256:ed872af452c5facb2652079716a645e970f959c2ddbed19f0055ec6203d73da4"
+      }
+    ],
+    "files": {
+      "actors": "actors.json",
+      "access_gates": "access_gates.json",
+      "factions": "factions.json",
+      "items": "items.json",
+      "locations": "locations.json",
+      "exits": "exits.json",
+      "hidden_exits": "hidden_exits.json",
+      "room_features": "room_features.json",
+      "room_sheets": "room_sheets.json",
+      "clocks": "clocks.json",
+      "jobs": "jobs.json",
+      "fronts": "fronts.json",
+      "cards": "cards.json",
+      "lifecycle_hooks": "lifecycle_hooks.json",
+      "evolution_tracks": "evolution_tracks.json",
+      "recipes": "recipes.json",
+      "sentences": "sentences.json"
+    },
+    "external_cards": "external_cards.json",
+    "assets": "assets.json",
+    "rules": "rules.json",
+    "attributions": "attributions.json",
+    "character_creation": "character_creation.json",
+    "registry": "registry.json"
+  },
+  "resources": {
+    "actors": [
+      {
+        "id": 1001,
+        "name": "Rati",
+        "speech_mode": "prose",
+        "title": "Landlady of the Blue Cottage",
+        "description": "A brisk landlady mouse who knits aggressively, keeps the kettle loaded, and has opinions about your boots.",
+        "location_id": 1,
+        "desires": [
+          {
+            "item_id": 2005,
+            "reason": "a wooden button would finally stop the blue scarf escaping"
+          }
+        ],
+        "attachments": [
+          {
+            "item_id": 2001,
+            "reason": "the first warm cup is how the cottage learned to welcome frightened guests"
+          }
+        ],
+        "stats": {
+          "strength": 8,
+          "dexterity": 14,
+          "constitution": 11,
+          "intelligence": 13,
+          "wisdom": 15,
+          "charisma": 16,
+          "hp_base": 10,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1002,
+        "name": "Gust",
+        "speech_mode": "emoji_only",
+        "title": "Emoji Weather Gremlin",
+        "description": "A gusty little gremlin who heckles the room in pure emoji and considers punctuation a personal defeat.",
+        "location_id": 1,
+        "desires": [
+          {
+            "item_id": 2002,
+            "reason": "a pearled weather mark makes an excellent target for dramatic raindrops"
+          }
+        ],
+        "attachments": [
+          {
+            "item_id": 2003,
+            "reason": "the pawprint charm proves someone made it home without being blown into the hedge"
+          }
+        ],
+        "stats": {
+          "strength": 8,
+          "dexterity": 16,
+          "constitution": 10,
+          "intelligence": 12,
+          "wisdom": 14,
+          "charisma": 12,
+          "hp_base": 10,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1003,
+        "name": "Skull",
+        "speech_mode": "emote_only",
+        "title": "Deadpan Hearth Wolf",
+        "description": "A large wolf who answers maximum chaos with minimum movement and has never once been impressed.",
+        "location_id": 1,
+        "desires": [
+          {
+            "item_id": 2007,
+            "reason": "the mute bell gives the doorway a warning he can answer without words"
+          }
+        ],
+        "attachments": [
+          {
+            "item_id": 2006,
+            "reason": "the warm tag marks the hearth spot he has silently claimed"
+          }
+        ],
+        "stats": {
+          "strength": 14,
+          "dexterity": 13,
+          "constitution": 13,
+          "intelligence": 8,
+          "wisdom": 12,
+          "charisma": 9,
+          "hp_base": 11,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1004,
+        "name": "Coach",
+        "speech_mode": "silent",
+        "title": "Sparring Reflection",
+        "description": "A practice-double who flexes back, grades your falls out of ten, and has never awarded the ten.",
+        "location_id": 3,
+        "stats": {
+          "strength": 10,
+          "dexterity": 12,
+          "constitution": 10,
+          "intelligence": 8,
+          "wisdom": 10,
+          "charisma": 8,
+          "hp_base": 6,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1005,
+        "name": "Oak",
+        "speech_mode": "prose",
+        "title": "Elder of Root, Ring, Leaf, and Hollow",
+        "description": "An old oak whose four voices bicker like a family radio show; Hollow repeats every secret it is given, verbatim, to everyone.",
+        "location_id": 40,
+        "desires": [
+          {
+            "item_id": 2006,
+            "reason": "a warm stone tag could pin one sensible note to a very argumentative branch"
+          }
+        ],
+        "attachments": [
+          {
+            "item_id": 2005,
+            "reason": "a wooden tale-button gives Hollow one less excuse to repeat everyone"
+          }
+        ],
+        "stats": {
+          "strength": 16,
+          "dexterity": 6,
+          "constitution": 18,
+          "intelligence": 14,
+          "wisdom": 18,
+          "charisma": 13,
+          "hp_base": 16,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1040,
+        "name": "Warden",
+        "speech_mode": "emote_only",
+        "title": "Red-Eyed Night Warden",
+        "description": "A guard dog who is openly done with everyone, growls at the path instead of the guests, and would like credit for the restraint.",
+        "location_id": 42,
+        "attachments": [
+          {
+            "item_id": 2007,
+            "reason": "the mute bell suits a threshold watcher who dislikes wasted howls"
+          }
+        ],
+        "stats": {
+          "strength": 17,
+          "dexterity": 14,
+          "constitution": 15,
+          "intelligence": 9,
+          "wisdom": 14,
+          "charisma": 8,
+          "hp_base": 18,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1041,
+        "name": "Fern",
+        "speech_mode": "prose",
+        "title": "Meadow Gossip With Receipts",
+        "description": "A leaf-haired meadow gossip who never keeps a promise but always keeps score, and arranges flowers at you when cross.",
+        "location_id": 44,
+        "desires": [
+          {
+            "item_id": 2004,
+            "reason": "moonwool can tie a flower bundle tight enough to survive Fern's lecture"
+          }
+        ],
+        "stats": {
+          "strength": 8,
+          "dexterity": 13,
+          "constitution": 12,
+          "intelligence": 15,
+          "wisdom": 17,
+          "charisma": 15,
+          "hp_base": 12,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1042,
+        "name": "Bear",
+        "speech_mode": "prose",
+        "title": "Gentle Giant of the Root-Road",
+        "description": "A broad-shouldered neighbor who knows exactly which roots are doors because he has hit his head on every single one.",
+        "location_id": 40,
+        "desires": [
+          {
+            "item_id": 2007,
+            "reason": "the moss path needs a quiet warning before small travelers meet the tricky roots"
+          }
+        ],
+        "stats": {
+          "strength": 17,
+          "dexterity": 8,
+          "constitution": 16,
+          "intelligence": 10,
+          "wisdom": 14,
+          "charisma": 11,
+          "hp_base": 20,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1043,
+        "name": "Dottie",
+        "speech_mode": "prose",
+        "title": "Acorn-Bright Courier",
+        "description": "A sun-tailed courier who delivers every message at top speed, along with her personal commentary on its contents.",
+        "location_id": 44,
+        "desires": [
+          {
+            "item_id": 2002,
+            "reason": "a pearled rain button would seal a message against sudden weather"
+          }
+        ],
+        "stats": {
+          "strength": 6,
+          "dexterity": 18,
+          "constitution": 8,
+          "intelligence": 11,
+          "wisdom": 13,
+          "charisma": 14,
+          "hp_base": 8,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1044,
+        "name": "Professor",
+        "speech_mode": "prose",
+        "title": "Dusk Nut Archivist",
+        "description": "A blue-furred archivist losing a decades-long war against acorn storage capacity and filing the casualties alphabetically.",
+        "location_id": 41,
+        "attachments": [
+          {
+            "item_id": 2005,
+            "reason": "the wooden rim is just wide enough to hide a dusk record"
+          },
+          {
+            "item_id": 2008,
+            "reason": "the mended cloth marks the dusk path Professor swears is filed correctly"
+          }
+        ],
+        "stats": {
+          "strength": 5,
+          "dexterity": 17,
+          "constitution": 8,
+          "intelligence": 12,
+          "wisdom": 12,
+          "charisma": 13,
+          "hp_base": 8,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1045,
+        "name": "Pippa",
+        "speech_mode": "prose",
+        "title": "Brave Little Burrower",
+        "description": "A young badger with painty paws, terrible tunnel etiquette, and an uncle whose doormat she has never once used.",
+        "location_id": 41,
+        "desires": [
+          {
+            "item_id": 2006,
+            "reason": "a warm stone tag feels like a burrow-name small enough to carry"
+          }
+        ],
+        "stats": {
+          "strength": 8,
+          "dexterity": 10,
+          "constitution": 12,
+          "intelligence": 10,
+          "wisdom": 13,
+          "charisma": 12,
+          "hp_base": 10,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1046,
+        "name": "Theodora",
+        "speech_mode": "prose",
+        "title": "Abbey Bookkeeper",
+        "description": "A bespectacled abbey scholar who has fought the same rolling library ladder for twenty years and lost every single round.",
+        "location_id": 43,
+        "desires": [
+          {
+            "item_id": 2004,
+            "reason": "moonwool would bind a margin note without silencing the page"
+          }
+        ],
+        "stats": {
+          "strength": 7,
+          "dexterity": 8,
+          "constitution": 10,
+          "intelligence": 18,
+          "wisdom": 16,
+          "charisma": 14,
+          "hp_base": 10,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1047,
+        "name": "Peregrine",
+        "speech_mode": "prose",
+        "title": "Orange-Cloak Ending-Spoiler",
+        "description": "A small cloaked reader who has finished every book in the abbey and will cheerfully tell you exactly how yours ends.",
+        "location_id": 43,
+        "desires": [
+          {
+            "item_id": 2005,
+            "reason": "a hidden tale-button would mark the page everyone else skipped"
+          },
+          {
+            "item_id": 2009,
+            "reason": "the pressed fern keeps the skipped page from closing on its own"
+          }
+        ],
+        "stats": {
+          "strength": 5,
+          "dexterity": 13,
+          "constitution": 8,
+          "intelligence": 15,
+          "wisdom": 15,
+          "charisma": 13,
+          "hp_base": 8,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1048,
+        "name": "Marginalia",
+        "speech_mode": "prose",
+        "title": "Fernside Rules Lawyer",
+        "description": "A careful rabbit who cites the exact forest regulation she is breaking while she breaks it, with corrections in the margin.",
+        "location_id": 43,
+        "desires": [
+          {
+            "item_id": 2009,
+            "reason": "a fern bookmark would hold the next correction without pinning it down"
+          }
+        ],
+        "attachments": [
+          {
+            "item_id": 2004,
+            "reason": "moonwool keeps margin notes from escaping when the ink gets nervous"
+          }
+        ],
+        "stats": {
+          "strength": 6,
+          "dexterity": 15,
+          "constitution": 9,
+          "intelligence": 15,
+          "wisdom": 14,
+          "charisma": 12,
+          "hp_base": 9,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1049,
+        "name": "Septimus",
+        "speech_mode": "prose",
+        "title": "Red-Cloak Wayfarer",
+        "description": "A staff-carrying mouse who gives directions with total confidence, every one of them wrong, and keeps the complaints alphabetized.",
+        "location_id": 41,
+        "desires": [
+          {
+            "item_id": 2003,
+            "reason": "a pawprint charm helps wrong turns become maps instead of traps"
+          },
+          {
+            "item_id": 2008,
+            "reason": "a mended map scrap would prove at least one wrong turn came back kinder"
+          }
+        ],
+        "stats": {
+          "strength": 5,
+          "dexterity": 14,
+          "constitution": 9,
+          "intelligence": 12,
+          "wisdom": 13,
+          "charisma": 14,
+          "hp_base": 8,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1050,
+        "name": "Basil",
+        "speech_mode": "prose",
+        "title": "Keyhole Gardener",
+        "description": "A garden locksmith who talks to stubborn locks like misbehaving pets and takes it personally when one finally turns for somebody else.",
+        "location_id": 44,
+        "desires": [
+          {
+            "item_id": 2010,
+            "reason": "mossglass would hold meadow light for gates that open only to gentleness"
+          }
+        ],
+        "attachments": [
+          {
+            "item_id": 2002,
+            "reason": "the pearled button fits the keyhole that jams whenever the path gets damp"
+          }
+        ],
+        "stats": {
+          "strength": 6,
+          "dexterity": 16,
+          "constitution": 9,
+          "intelligence": 12,
+          "wisdom": 14,
+          "charisma": 13,
+          "hp_base": 9,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1051,
+        "name": "Euphemie",
+        "speech_mode": "prose",
+        "title": "Ghost of the Lying Stair",
+        "description": "A moss-draped mansion ghost who insists the dusting is overdue and the third stair is a liar.",
+        "location_id": 42,
+        "attachments": [
+          {
+            "item_id": 2005,
+            "reason": "the tucked tale is the one thing in the mansion Euphemie considers properly stored"
+          }
+        ],
+        "stats": {
+          "strength": 5,
+          "dexterity": 14,
+          "constitution": 9,
+          "intelligence": 15,
+          "wisdom": 17,
+          "charisma": 10,
+          "hp_base": 12,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1052,
+        "name": "Nightmare",
+        "speech_mode": "prose",
+        "title": "Grey Paw Bad Dream",
+        "description": "A small grey shadow with bright puppy eyes who practices being terrifying, then gets embarrassed when anyone compliments the effort.",
+        "location_id": 41,
+        "desires": [
+          {
+            "item_id": 2007,
+            "reason": "the silent bell is a practice warning for a small nightmare still learning which shadows are real"
+          }
+        ],
+        "stats": {
+          "strength": 9,
+          "dexterity": 15,
+          "constitution": 10,
+          "intelligence": 8,
+          "wisdom": 12,
+          "charisma": 12,
+          "hp_base": 10,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1053,
+        "name": "Ferret",
+        "speech_mode": "prose",
+        "title": "Victorian Art Critic Weasel",
+        "description": "A sharp-eyed Victorian critic with pearl manners and poisonous taste who has begun reviewing entire rooms, and their occupants.",
+        "location_id": 40,
+        "desires": [
+          {
+            "item_id": 2006,
+            "reason": "a hearthstone seal would make root-road promises harder to misplace"
+          }
+        ],
+        "stats": {
+          "strength": 6,
+          "dexterity": 14,
+          "constitution": 9,
+          "intelligence": 14,
+          "wisdom": 13,
+          "charisma": 17,
+          "hp_base": 9,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1054,
+        "name": "Aster",
+        "speech_mode": "prose",
+        "title": "Indigo Gentleman, Wide Wingspan",
+        "description": "A courteous stranger whose wings are too big for every door in the county and who apologizes to each one mid-crash.",
+        "location_id": 42,
+        "desires": [
+          {
+            "item_id": 2003,
+            "reason": "the pawprint charm anchors rift-light to a real path"
+          }
+        ],
+        "stats": {
+          "strength": 14,
+          "dexterity": 15,
+          "constitution": 13,
+          "intelligence": 14,
+          "wisdom": 12,
+          "charisma": 10,
+          "hp_base": 16,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1055,
+        "name": "Jophiel",
+        "speech_mode": "prose",
+        "title": "The Jock Angel",
+        "description": "A golden-winged athlete who counts prayers in sets, high-fives too hard, and takes it personally when an omen skips leg day.",
+        "location_id": 30,
+        "desires": [
+          {
+            "item_id": 2007,
+            "reason": "a mute bell can carry an omen without startling the clouds"
+          }
+        ],
+        "stats": {
+          "strength": 13,
+          "dexterity": 15,
+          "constitution": 12,
+          "intelligence": 12,
+          "wisdom": 15,
+          "charisma": 16,
+          "hp_base": 14,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1056,
+        "name": "Chamuel",
+        "speech_mode": "prose",
+        "title": "Lord Samael's Page (Self-Alphabetized)",
+        "description": "A slim, immaculate young angel with perfect hair, a laminated schedule, and forty books on courage he has read instead of having any.",
+        "location_id": 31,
+        "attachments": [
+          {
+            "item_id": 2001,
+            "reason": "warm tonic gives Chamuel something official to prescribe after overthinking"
+          }
+        ],
+        "stats": {
+          "strength": 12,
+          "dexterity": 14,
+          "constitution": 12,
+          "intelligence": 13,
+          "wisdom": 14,
+          "charisma": 13,
+          "hp_base": 13,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1057,
+        "name": "Flit",
+        "speech_mode": "prose",
+        "title": "Loud-Landing Lookout",
+        "description": "A bright-winged lookout who sees every path from above and announces her own crash landings like weather reports.",
+        "location_id": 30,
+        "desires": [
+          {
+            "item_id": 2002,
+            "reason": "dewlight on pearl makes a bright witness easier to believe"
+          }
+        ],
+        "stats": {
+          "strength": 10,
+          "dexterity": 15,
+          "constitution": 11,
+          "intelligence": 12,
+          "wisdom": 16,
+          "charisma": 15,
+          "hp_base": 12,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1058,
+        "name": "Bastian",
+        "speech_mode": "prose",
+        "title": "Hearthside Cupbearer",
+        "description": "A tavern-hearted host who judges you by your coaster usage and forgives you completely by your second cup.",
+        "location_id": 40,
+        "desires": [
+          {
+            "item_id": 2005,
+            "reason": "a tucked-away tale would give the next lonely guest something warm to carry"
+          }
+        ],
+        "stats": {
+          "strength": 8,
+          "dexterity": 13,
+          "constitution": 10,
+          "intelligence": 12,
+          "wisdom": 11,
+          "charisma": 16,
+          "hp_base": 10,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1059,
+        "name": "Samael",
+        "speech_mode": "prose",
+        "title": "First Angel of the Solar Temple",
+        "description": "A gold-armored angel-lord who runs heaven's front desk with a clipboard, signs judgments in triplicate, and wears the armor to meetings.",
+        "location_id": 36,
+        "attachments": [
+          {
+            "item_id": 2006,
+            "reason": "the warm tag is the only paperwork Samael has ever enjoyed filing"
+          }
+        ],
+        "stats": {
+          "strength": 18,
+          "dexterity": 13,
+          "constitution": 16,
+          "intelligence": 11,
+          "wisdom": 13,
+          "charisma": 15,
+          "hp_base": 20,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1060,
+        "name": "Moxie",
+        "speech_mode": "prose",
+        "title": "Bright-Stripe Glitchcat",
+        "description": "A color-slashed showoff from the Digital Realm, all teeth, swagger, and improbable kindness, whose purr runs at a frequency that fixes small machines.",
+        "location_id": 63,
+        "desires": [
+          {
+            "item_id": 2002,
+            "reason": "the pearled hum sounds like a clean glitch waiting for color"
+          }
+        ],
+        "stats": {
+          "strength": 16,
+          "dexterity": 18,
+          "constitution": 12,
+          "intelligence": 12,
+          "wisdom": 10,
+          "charisma": 15,
+          "hp_base": 16,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1061,
+        "name": "Doc",
+        "speech_mode": "prose",
+        "title": "Brass-Key Tinker",
+        "description": "A goggle-wearing inventor whose machines explode politely and whose pockets click with tiny engines, every one labeled almost.",
+        "location_id": 40,
+        "desires": [
+          {
+            "item_id": 2002,
+            "reason": "its pearled hum belongs in a tiny rain engine that has never quite started"
+          }
+        ],
+        "stats": {
+          "strength": 6,
+          "dexterity": 15,
+          "constitution": 9,
+          "intelligence": 16,
+          "wisdom": 12,
+          "charisma": 14,
+          "hp_base": 9,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1062,
+        "name": "Raziel",
+        "speech_mode": "prose",
+        "title": "Angel of Vanity, Charisma of Eight",
+        "description": "A red-winged angel of legendary self-regard. Nobody has fallen for his practiced doorframe pose; the frames have filed complaints.",
+        "location_id": 42,
+        "desires": [
+          {
+            "item_id": 2007,
+            "reason": "the silent bell can ring desire without waking the whole dark"
+          }
+        ],
+        "stats": {
+          "strength": 15,
+          "dexterity": 14,
+          "constitution": 12,
+          "intelligence": 13,
+          "wisdom": 10,
+          "charisma": 8,
+          "hp_base": 16,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1063,
+        "name": "Beetle",
+        "speech_mode": "emote_only",
+        "title": "Black Knight of Old Grudges",
+        "description": "A beetle-armored knight who keeps a grudge ledger in triplicate and forgets exactly one slight whenever someone is polite; Toad fills a fresh page weekly.",
+        "location_id": 60,
+        "attachments": [
+          {
+            "item_id": 2006,
+            "reason": "warm stone steadies chitin where swamp grudges knock"
+          }
+        ],
+        "stats": {
+          "strength": 18,
+          "dexterity": 8,
+          "constitution": 18,
+          "intelligence": 8,
+          "wisdom": 10,
+          "charisma": 7,
+          "hp_base": 22,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1064,
+        "name": "Seraphina",
+        "speech_mode": "prose",
+        "title": "Temple Triage Seraph",
+        "description": "A gold-winged seraph with head-nurse energy who delivers mercy like triage and will not have bleeding on the polished floor.",
+        "location_id": 36,
+        "desires": [
+          {
+            "item_id": 2007,
+            "reason": "a silent bell would let the temple warn without frightening the wounded"
+          }
+        ],
+        "stats": {
+          "strength": 14,
+          "dexterity": 13,
+          "constitution": 13,
+          "intelligence": 12,
+          "wisdom": 18,
+          "charisma": 17,
+          "hp_base": 18,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1065,
+        "name": "Nerissa",
+        "speech_mode": "prose",
+        "title": "Keeper of the Soggy Archive",
+        "description": "A lantern-eyed deep-sea archivist whose every possession is soggy and who is absolutely fine about it, thank you.",
+        "location_id": 64,
+        "attachments": [
+          {
+            "item_id": 2004,
+            "reason": "moonwool keeps soggy labels from peeling off when the pressure changes"
+          }
+        ],
+        "stats": {
+          "strength": 12,
+          "dexterity": 12,
+          "constitution": 18,
+          "intelligence": 14,
+          "wisdom": 18,
+          "charisma": 13,
+          "hp_base": 20,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1066,
+        "name": "Azazoth",
+        "speech_mode": "prose",
+        "title": "Mad God of the Drowned Feast",
+        "description": "A many-tentacled abyssal god who hosts a legendary feast that nobody ever attends, and takes the leftovers extremely personally.",
+        "location_id": 65,
+        "desires": [
+          {
+            "item_id": 2007,
+            "reason": "the mute bell can call dinner without waking the soup"
+          }
+        ],
+        "stats": {
+          "strength": 18,
+          "dexterity": 9,
+          "constitution": 18,
+          "intelligence": 13,
+          "wisdom": 15,
+          "charisma": 17,
+          "hp_base": 24,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1067,
+        "name": "Zadkiel",
+        "speech_mode": "prose",
+        "title": "Dark Angel of the Abyssal Anvil",
+        "description": "A violet-winged dark angel of tremendous formality who forges dramatic pronouncements at an anvil nobody asked for, then checks if anyone was watching.",
+        "location_id": 65,
+        "attachments": [
+          {
+            "item_id": 2006,
+            "reason": "the warm tag gives Zadkiel something official to stamp after speeches"
+          }
+        ],
+        "stats": {
+          "strength": 14,
+          "dexterity": 15,
+          "constitution": 13,
+          "intelligence": 14,
+          "wisdom": 16,
+          "charisma": 18,
+          "hp_base": 18,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1068,
+        "name": "Badger",
+        "speech_mode": "prose",
+        "title": "Grumpy Landlord of the Lower Burrow",
+        "description": "A broad, permanently unimpressed badger who owns one good chair, three shovels, and a list of everyone who has ever tracked mud past his doormat.",
+        "location_id": 41,
+        "desires": [
+          {
+            "item_id": 2007,
+            "reason": "a doorbell that cannot ring is the only doorbell worth installing"
+          }
+        ],
+        "attachments": [
+          {
+            "item_id": 2006,
+            "reason": "it keeps the good chair warm, and the good chair is his"
+          }
+        ],
+        "stats": {
+          "strength": 15,
+          "dexterity": 8,
+          "constitution": 16,
+          "intelligence": 10,
+          "wisdom": 14,
+          "charisma": 9,
+          "hp_base": 16,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1069,
+        "name": "Toad",
+        "speech_mode": "prose",
+        "title": "Reckless Swamp Daredevil, Zero Completed Jumps",
+        "description": "A stunt toad held together by confidence and swamp mud who has never once landed a jump and considers this a scheduling issue.",
+        "location_id": 60,
+        "desires": [
+          {
+            "item_id": 2003,
+            "reason": "proof of one landing, any landing, even somebody else's"
+          }
+        ],
+        "stats": {
+          "strength": 8,
+          "dexterity": 17,
+          "constitution": 14,
+          "intelligence": 7,
+          "wisdom": 6,
+          "charisma": 13,
+          "hp_base": 12,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 1070,
+        "name": "Nib",
+        "speech_mode": "prose",
+        "title": "Goblin Market Loophole Clerk",
+        "description": "A licensed goblin — a tinker and dealer in salvage, oddments, and loose coins — with an enormous receipt roll who offers three prices for everything, circles the kindest one in green, and becomes offended when nobody reads the fine print.",
+        "location_id": 34,
+        "desires": [
+          {
+            "item_id": 2005,
+            "reason": "a Story Button would make an excellent seal for the first contract whose kindest price survives the fine print"
+          }
+        ],
+        "stats": {
+          "strength": 7,
+          "dexterity": 15,
+          "constitution": 10,
+          "intelligence": 16,
+          "wisdom": 13,
+          "charisma": 17,
+          "hp_base": 10,
+          "level": 1
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 8301,
+        "name": "Mara Wick",
+        "speech_mode": "prose",
+        "title": "Retired Lantern Keeper",
+        "description": "A broad-shouldered innkeeper who retired from the lantern road but still oils every lamp before bed.",
+        "ambient_autonomy": false,
+        "location_id": 800,
+        "desires": [
+          {
+            "item_id": 8401,
+            "reason": "Rowan carried the tower key, and its return would mean the trail is real"
+          }
+        ],
+        "stats": {
+          "strength": 12,
+          "dexterity": 10,
+          "constitution": 14,
+          "intelligence": 11,
+          "wisdom": 15,
+          "charisma": 13,
+          "hp_base": 12,
+          "level": 2
+        },
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 8302,
+        "name": "Pip Thistle",
+        "speech_mode": "prose",
+        "title": "Mothwood Lamp-Sprite",
+        "description": "A thumb-sized fey guide with a pin sword, bright opinions, and soot on both wings.",
+        "ambient_autonomy": false,
+        "location_id": 801,
+        "desires": [
+          {
+            "item_id": 8402,
+            "reason": "the mothglass lens lets Pip see which shadows belong to living things"
+          }
+        ],
+        "stats": {
+          "strength": 3,
+          "dexterity": 18,
+          "constitution": 10,
+          "intelligence": 14,
+          "wisdom": 13,
+          "charisma": 11,
+          "hp_base": 4,
+          "level": 1
+        },
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 8303,
+        "name": "Moth-Eaten Knight",
+        "speech_mode": "silent",
+        "title": "Barrow Road Sentinel",
+        "description": "An empty suit of road-warden mail packed with wet moths and the reflex to bar every crossing.",
+        "ambient_autonomy": false,
+        "location_id": 803,
+        "stats": {
+          "strength": 14,
+          "dexterity": 9,
+          "constitution": 14,
+          "intelligence": 6,
+          "wisdom": 10,
+          "charisma": 5,
+          "hp_base": 16,
+          "level": 2
+        },
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 8304,
+        "name": "Rowan Vale",
+        "speech_mode": "prose",
+        "title": "The Hollow Keeper",
+        "description": "The missing keeper stands inside a coat of moving shadow, one hand still clenched around an ember that refuses to die.",
+        "ambient_autonomy": false,
+        "location_id": 804,
+        "desires": [
+          {
+            "item_id": 8403,
+            "reason": "dawn oil can separate Rowan's living ember from the shadow around it"
+          }
+        ],
+        "stats": {
+          "strength": 13,
+          "dexterity": 12,
+          "constitution": 14,
+          "intelligence": 11,
+          "wisdom": 13,
+          "charisma": 12,
+          "hp_base": 18,
+          "level": 3
+        },
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "access_gates": [
+      {
+        "location_id": 10,
+        "required_grant_id": "ruby-high.first-bell:location-science-lab",
+        "required_card_id": "location-science-lab",
+        "reason": "Ruby High: First Bell location card required.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 11,
+        "required_grant_id": "ruby-high.first-bell:location-homeroom",
+        "required_card_id": "location-homeroom",
+        "reason": "Ruby High: First Bell location card required.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 12,
+        "required_grant_id": "ruby-high.first-bell:location-library",
+        "required_card_id": "location-library",
+        "reason": "Ruby High: First Bell location card required.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 13,
+        "required_grant_id": "ruby-high.first-bell:location-cafeteria",
+        "required_card_id": "location-cafeteria",
+        "reason": "Ruby High: First Bell location card required.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 14,
+        "required_grant_id": "ruby-high.first-bell:location-greenhouse",
+        "required_card_id": "location-greenhouse",
+        "reason": "Ruby High: First Bell location card required.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 15,
+        "required_grant_id": "ruby-high.first-bell:location-courtyard",
+        "required_card_id": "location-courtyard",
+        "reason": "Ruby High: First Bell location card required.",
+        "pack_id": "cosyworld.core"
+      }
+    ],
+    "factions": [
+      {
+        "id": "hearthbound",
+        "name": "Hearthbound",
+        "axis": "Shelter vs Restlessness",
+        "opposes": [
+          "haunted_remnants"
+        ],
+        "truth": "Care restores what danger scatters.",
+        "shadow": "Comfort can become avoidance when the door should open.",
+        "doctrine": "Keep the fire, mend the small thing, and make return possible.",
+        "verbs": [
+          "shelter",
+          "mend",
+          "feed",
+          "remember"
+        ],
+        "motif": [
+          "hearthlight",
+          "rain",
+          "thread",
+          "watchful doors"
+        ],
+        "home_location_ids": [
+          1,
+          2
+        ],
+        "member_actor_ids": [
+          1001,
+          1002,
+          1003
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "haunted_remnants",
+        "name": "Haunted Remnants",
+        "axis": "Shelter vs Restlessness",
+        "opposes": [
+          "hearthbound"
+        ],
+        "truth": "Unfinished things still speak.",
+        "shadow": "Memory can loop until it becomes a room with no door.",
+        "doctrine": "Let the warning finish its sentence.",
+        "verbs": [
+          "haunt",
+          "confess",
+          "repeat",
+          "warn"
+        ],
+        "motif": [
+          "candle smoke",
+          "threshold wolves",
+          "veils",
+          "ash"
+        ],
+        "home_location_ids": [
+          42
+        ],
+        "member_actor_ids": [
+          1040,
+          1051,
+          1054,
+          1062
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "ruby_high",
+        "name": "Ruby High",
+        "axis": "Institution vs Wild Law",
+        "opposes": [
+          "lonely_forest_court"
+        ],
+        "truth": "People grow through structure.",
+        "shadow": "Structure can become permission-hoarding.",
+        "doctrine": "Attend, test, revise, and let every question have a seat.",
+        "verbs": [
+          "study",
+          "prove",
+          "attend",
+          "graduate"
+        ],
+        "motif": [
+          "hall passes",
+          "desks",
+          "greenhouse glass",
+          "courtyard rumors"
+        ],
+        "home_location_ids": [
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ],
+        "member_actor_ids": [
+          1001
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "lonely_forest_court",
+        "name": "Lonely Forest Court",
+        "axis": "Institution vs Wild Law",
+        "opposes": [
+          "ruby_high"
+        ],
+        "truth": "Old paths teach without asking permission.",
+        "shadow": "Being lost can become an identity.",
+        "doctrine": "Find a way, then remember who waited along the path.",
+        "verbs": [
+          "wander",
+          "forage",
+          "interpret",
+          "swear"
+        ],
+        "motif": [
+          "root law",
+          "moss",
+          "wildflowers",
+          "old names"
+        ],
+        "home_location_ids": [
+          40,
+          41,
+          44
+        ],
+        "member_actor_ids": [
+          1005,
+          1041,
+          1042,
+          1043,
+          1044,
+          1045,
+          1049,
+          1050,
+          1052,
+          1053,
+          1058,
+          1061
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "quiet_abbey",
+        "name": "Quiet Abbey",
+        "axis": "Silence vs Fermentation",
+        "opposes": [
+          "farthest_mists"
+        ],
+        "truth": "Silence clarifies.",
+        "shadow": "Silence can hide harm when confession is needed.",
+        "doctrine": "Copy the sentence that matters and leave the rest uncarried.",
+        "verbs": [
+          "confess",
+          "copy",
+          "forgive",
+          "renounce"
+        ],
+        "motif": [
+          "stone arches",
+          "margin notes",
+          "hushed vows",
+          "thin candles"
+        ],
+        "home_location_ids": [
+          43
+        ],
+        "member_actor_ids": [
+          1046,
+          1047,
+          1048
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "farthest_mists",
+        "name": "Farthest Mists",
+        "axis": "Silence vs Fermentation",
+        "opposes": [
+          "quiet_abbey"
+        ],
+        "truth": "Decay feeds transformation.",
+        "shadow": "Rot without renewal forgets what it was feeding.",
+        "doctrine": "Let excess become soil, pressure, tide, and strange new life.",
+        "verbs": [
+          "ferment",
+          "shed",
+          "mutate",
+          "endure"
+        ],
+        "motif": [
+          "black water",
+          "wilting leaves",
+          "mist",
+          "chitin"
+        ],
+        "home_location_ids": [
+          60,
+          61,
+          62
+        ],
+        "member_actor_ids": [
+          1063
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "great_library",
+        "name": "Great Library",
+        "axis": "Archive vs Signal",
+        "opposes": [
+          "digital_strays"
+        ],
+        "truth": "Meaning must be preserved.",
+        "shadow": "Preservation can become control.",
+        "doctrine": "Name the source, bind the page, and keep the map legible.",
+        "verbs": [
+          "archive",
+          "cite",
+          "bind",
+          "restore"
+        ],
+        "motif": [
+          "brass ladders",
+          "page numbers",
+          "marginalia",
+          "maps"
+        ],
+        "home_location_ids": [
+          50
+        ],
+        "player_facing": true,
+        "member_actor_ids": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "digital_strays",
+        "name": "Digital Strays",
+        "axis": "Archive vs Signal",
+        "opposes": [
+          "great_library"
+        ],
+        "truth": "Meaning mutates while it lives.",
+        "shadow": "Signal can detach from reality and call itself freedom.",
+        "doctrine": "Fork the door, test the copy, and listen for the living glitch.",
+        "verbs": [
+          "glitch",
+          "fork",
+          "copy",
+          "transmit"
+        ],
+        "motif": [
+          "green cursors",
+          "black glass",
+          "portals",
+          "neon teeth"
+        ],
+        "home_location_ids": [
+          63
+        ],
+        "member_actor_ids": [
+          1060
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "moon_circle",
+        "name": "Moon-Circle",
+        "axis": "Law vs Bargain",
+        "opposes": [
+          "goblin_market"
+        ],
+        "truth": "Timing matters.",
+        "shadow": "Ritual can become paralysis.",
+        "doctrine": "Wait for the right hour, then stand where fear cannot pass.",
+        "verbs": [
+          "wait",
+          "circle",
+          "swear",
+          "ward"
+        ],
+        "motif": [
+          "silver stones",
+          "thresholds",
+          "wolfprints",
+          "moon vows"
+        ],
+        "home_location_ids": [
+          3,
+          35
+        ],
+        "member_actor_ids": [
+          1004,
+          1059
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "goblin_market",
+        "name": "Goblin Market",
+        "axis": "Law vs Bargain",
+        "opposes": [
+          "moon_circle"
+        ],
+        "truth": "Desire has a price.",
+        "shadow": "Everything can become leverage.",
+        "doctrine": "Name the wanting, count the coins, and read the loophole twice.",
+        "verbs": [
+          "bargain",
+          "trick",
+          "trade",
+          "collect"
+        ],
+        "motif": [
+          "loose coins",
+          "echoes",
+          "contracts",
+          "cave teeth"
+        ],
+        "home_location_ids": [
+          34
+        ],
+        "member_actor_ids": [
+          1070
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "solar_temple",
+        "name": "Solar Temple",
+        "axis": "Height vs Depth",
+        "opposes": [
+          "abyssal_residents"
+        ],
+        "truth": "Light reveals.",
+        "shadow": "Light can judge until nuance burns away.",
+        "doctrine": "Witness cleanly, vow carefully, and never mistake brightness for mercy.",
+        "verbs": [
+          "vow",
+          "witness",
+          "cleanse",
+          "ascend",
+          "reveal"
+        ],
+        "motif": [
+          "white stone",
+          "noon bells",
+          "gold wings",
+          "sun oaths"
+        ],
+        "home_location_ids": [
+          30,
+          36
+        ],
+        "member_actor_ids": [
+          1064
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "abyssal_residents",
+        "name": "Abyssal Residents",
+        "axis": "Height vs Depth",
+        "opposes": [
+          "solar_temple"
+        ],
+        "truth": "Depth remembers.",
+        "shadow": "Depth can swallow identity and call it peace.",
+        "doctrine": "Descend slowly, listen under pressure, and surface only what can survive air.",
+        "verbs": [
+          "descend",
+          "listen",
+          "remember",
+          "surface",
+          "withstand"
+        ],
+        "motif": [
+          "black water",
+          "pearls",
+          "trench lanterns",
+          "drowned bells"
+        ],
+        "home_location_ids": [
+          64,
+          65
+        ],
+        "member_actor_ids": [
+          1065,
+          1066,
+          1067
+        ],
+        "pack_id": "cosyworld.core"
+      }
+    ],
+    "items": [
+      {
+        "id": 2001,
+        "name": "Hearth Tonic",
+        "description": "A warm tonic that gets one person back on their feet, probably complaining.",
+        "kind": "potion",
+        "charges": 1,
+        "location_id": 1,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2002,
+        "name": "Dewbright Button",
+        "description": "A tiny pearled button that makes wet weather look more deliberate.",
+        "kind": "evolution",
+        "charges": 1,
+        "location_id": 2,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2003,
+        "name": "Wolfprint Charm",
+        "description": "A cool iron charm marked with a careful pawprint.",
+        "kind": "evolution",
+        "charges": 1,
+        "location_id": 3,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2004,
+        "name": "Moonwool Thread",
+        "description": "A silvery strand that tangles at the first hint of rain.",
+        "kind": "evolution",
+        "charges": 1,
+        "location_id": 43,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2005,
+        "name": "Story Button",
+        "description": "A warm wooden button with a tiny tale tucked under its rim.",
+        "kind": "evolution",
+        "charges": 1,
+        "location_id": 1,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2006,
+        "name": "Hearthstone Tag",
+        "description": "A smooth tag cut from warm stone, excellent for labeling chairs and terrible ideas.",
+        "kind": "evolution",
+        "charges": 1,
+        "location_id": 3,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2007,
+        "name": "Watch Bell",
+        "description": "A mute little bell that rings only for those keeping watch.",
+        "kind": "evolution",
+        "charges": 1,
+        "location_id": 2,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2008,
+        "name": "Threadbare Map Scrap",
+        "description": "A soft scrap of map-cloth with one path mended in red thread.",
+        "kind": "keepsake",
+        "charges": 1,
+        "location_id": 41,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2009,
+        "name": "Abbey Bookmark",
+        "description": "A pressed fern bookmark that keeps sliding out at the dramatic sentence.",
+        "kind": "keepsake",
+        "charges": 1,
+        "location_id": 43,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2010,
+        "name": "Mossglass Bead",
+        "description": "A green bead that catches meadow light and keeps it cool enough to trade.",
+        "kind": "keepsake",
+        "charges": 1,
+        "location_id": 44,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 8401,
+        "name": "Keeper's Brass Key",
+        "description": "A heavy key warm on one side and cold on the other, cut for the Lantern Tower's inner lock.",
+        "kind": "keepsake",
+        "charges": 1,
+        "location_id": 802,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 8402,
+        "name": "Mothglass Lens",
+        "description": "A palm-sized lens that shows the faint outline of whatever last carried a nearby light.",
+        "kind": "keepsake",
+        "charges": 1,
+        "location_id": 801,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 8403,
+        "name": "Dawn Oil",
+        "description": "A stoppered flask of gold oil that smells of hot stone after rain and can steady a fallen traveler.",
+        "kind": "potion",
+        "charges": 1,
+        "location_id": 803,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 8404,
+        "name": "Keeper's Ember",
+        "description": "A coal-bright fragment of the beacon flame, small enough to carry and stubborn enough to relight the road.",
+        "kind": "keepsake",
+        "charges": 1,
+        "location_id": 804,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "locations": [
+      {
+        "id": 1,
+        "name": "The Cosy Cottage",
+        "title": "Rainlit Hearth",
+        "description": "A warm room of firelight and knitting needles. The kettle is always loaded.",
+        "persona": "The cottage is a careful host: warm, observant, and protective of small beginnings.",
+        "memory": [
+          "Rati's blue scarf began here.",
+          "Gust's weather symbols gather near the hearth.",
+          "Skull keeps watch by the low doorway."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 2,
+        "name": "Rain-Soft Garden",
+        "title": "Rain-Pearled Annex",
+        "description": "Rain beads on broad leaves. Round marks dot the grass.",
+        "persona": "The garden answers in damp patience, leaf-taps, and tiny useful discoveries.",
+        "biome": "rain garden",
+        "terrain": [
+          "wet grass",
+          "broad leaves",
+          "soft garden soil"
+        ],
+        "memory": [
+          "A dewbright button was found here at first light.",
+          "The path from the cottage arrives smelling of tea and wet wool."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 3,
+        "name": "Moonlit Trail",
+        "title": "Moonlit Route",
+        "description": "The path shines under cold moonlight. Wolf tracks cross it.",
+        "persona": "The trail is a silver test: honest, spare, and just dangerous enough to reveal courage.",
+        "biome": "moonlit woodland",
+        "terrain": [
+          "silver pine",
+          "cold earth",
+          "wolf-worn trail"
+        ],
+        "memory": [
+          "Coach waits here.",
+          "The Wolfprint Charm and the Watch Bell have both passed this way."
+        ],
+        "allow_combat": true,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 10,
+        "name": "Science Class",
+        "title": "STEM Wing",
+        "description": "Shared benches, small instruments, and questions waiting to be tested.",
+        "persona": "Science Class prefers evidence, clean questions, and answers brave enough to be revised.",
+        "memory": [
+          "Surprising results get written down here.",
+          "Rati sometimes follows signal-study questions here."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 11,
+        "name": "Homeroom",
+        "title": "Front Door",
+        "description": "Morning light crosses rows of desks.",
+        "persona": "Homeroom keeps attendance for beginnings, detours, and people trying again.",
+        "memory": [
+          "The cottage door opens here.",
+          "Most Ruby High paths lead back to this room."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 12,
+        "name": "Library",
+        "title": "Quiet Wing",
+        "description": "Tall shelves and a deep hush.",
+        "persona": "The Library is exact, generous, and faintly amused by people who whisper to books.",
+        "memory": [
+          "The Great Library can be reached through the deeper stacks.",
+          "Some stacks go deeper than the school map shows."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 13,
+        "name": "Cafeteria",
+        "title": "Commons",
+        "description": "Long tables, lunch trays, and running bargains.",
+        "persona": "The Cafeteria speaks in offers, side-eyes, and the social physics of shared tables.",
+        "memory": [
+          "Deals get made over lunch.",
+          "Rumors travel from the courtyard through the serving line."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 14,
+        "name": "Greenhouse",
+        "title": "Garden Annex",
+        "description": "Glass walls, damp air, and slow experiments in labeled pots.",
+        "persona": "The Greenhouse thinks in tendrils, careful timing, and second chances rooted in soil.",
+        "memory": [
+          "Pollen drifts in from the Flower Meadow.",
+          "The watering schedule is strict."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 15,
+        "name": "Courtyard",
+        "title": "Central Grounds",
+        "description": "Open paths cross under the sky. Every hallway ends here.",
+        "persona": "The Courtyard is public, breezy, and good at making accidental meetings feel arranged.",
+        "biome": "school grounds",
+        "terrain": [
+          "courtyard stone",
+          "open lawn",
+          "windy steps"
+        ],
+        "memory": [
+          "Summit Trail begins at the far edge.",
+          "Students cut through here when they need a new route."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 30,
+        "name": "The Heavens",
+        "title": "Forbidden Mountain",
+        "description": "A bright threshold where cloud paths gather above the mountain.",
+        "persona": "The Heavens speak in distance, weather-glow, and the discipline of looking down kindly.",
+        "memory": [
+          "Lofty Peak sits just below.",
+          "Footsteps leave no prints here."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 31,
+        "name": "Lofty Peak",
+        "title": "Forbidden Mountain",
+        "description": "Thin air, bare stone, and a hard summit wind.",
+        "persona": "Lofty Peak is blunt, wind-scoured, and allergic to pretending the climb was easy.",
+        "memory": [
+          "The Heavens lean close above it.",
+          "Summit Trail keeps a lantern below for the return."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 32,
+        "name": "Summit Trail",
+        "title": "Forbidden Mountain",
+        "description": "A switchback path through cold scree, marked by lanterns.",
+        "persona": "Summit Trail encourages one more step and remembers every almost-turnaround.",
+        "biome": "alpine mountain",
+        "terrain": [
+          "cold scree",
+          "switchback stone",
+          "thin grass"
+        ],
+        "memory": [
+          "The Courtyard is warmer than it looks from here.",
+          "Alpine Forest begins where the stone gives way to trees."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 33,
+        "name": "Alpine Forest",
+        "title": "Forbidden Mountain",
+        "description": "Pines lean over snowmelt tracks and old mountain signs.",
+        "persona": "Alpine Forest is crisp, watchful, and full of branch-creaks that sound like warnings.",
+        "memory": [
+          "Summit Trail brings cold travelers through the pines.",
+          "Goblin Cave echoes from below after dusk."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 34,
+        "name": "Goblin Cave",
+        "title": "Forbidden Mountain",
+        "description": "A low cave mouth full of echoes and loose coins.",
+        "persona": "Goblin Cave is twitchy, tempting, and fond of bargains that reveal the bargainer.",
+        "memory": [
+          "Alpine Forest muffles the cave mouth.",
+          "The Circle of the Moon sits directly above."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 35,
+        "name": "Circle of the Moon",
+        "title": "Forbidden Mountain",
+        "description": "Silver stones mark a quiet circle.",
+        "persona": "The Circle listens ceremonially, as if every sentence should arrive barefoot.",
+        "memory": [
+          "An older path leads in from the Moonlit Trail.",
+          "Goblin Cave lies below."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 36,
+        "name": "Solar Temple",
+        "title": "Solar Temple",
+        "description": "White stone terraces, noon bells, and gold wings overhead.",
+        "persona": "The Solar Temple is radiant, exacting, and careful not to confuse witness with mercy.",
+        "memory": [
+          "The Heavens open upward into its white terraces.",
+          "One of its bells is missing. It lies below the Darkest Ocean."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 40,
+        "name": "Old Oak Tree",
+        "title": "Lonely Forest",
+        "description": "A vast oak with roots as wide as roads.",
+        "persona": "The Old Oak is both place and stranger: Root, Ring, Leaf, and Hollow each remember a different truth.",
+        "memory": [
+          "Root remembers every footstep that circled back.",
+          "Ring remembers the years when the forest was less lonely.",
+          "Leaf remembers what changed today.",
+          "Hollow remembers what nobody has asked yet."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 41,
+        "name": "Lost Woods",
+        "title": "Lonely Forest",
+        "description": "Soft moss and paths that repeat themselves.",
+        "persona": "The Lost Woods are evasive but not cruel; they teach by making certainty walk in circles.",
+        "memory": [
+          "The Old Oak marks one path that does not move.",
+          "The Haunted Mansion and Quiet Abbey lie beyond."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 42,
+        "name": "Haunted Mansion",
+        "title": "Lonely Forest",
+        "description": "A leaning house with lit windows and doors that sigh.",
+        "persona": "The Mansion is theatrical, lonely, and delighted when anyone knocks instead of sneaking.",
+        "memory": [
+          "Lost Woods keeps leading visitors to its porch.",
+          "The windows sigh at night."
+        ],
+        "allow_combat": true,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 43,
+        "name": "Quiet Abbey",
+        "title": "Lonely Forest",
+        "description": "Stone arches and a deep hush.",
+        "persona": "The Abbey is spare, kind, and severe about saying only the sentence that matters.",
+        "memory": [
+          "Candle smoke drifts in from the Haunted Mansion.",
+          "The Flower Meadow lies beyond the arch."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 44,
+        "name": "Flower Meadow",
+        "title": "Lonely Forest",
+        "description": "A clear meadow of small flowers, warm bees, and open sky.",
+        "persona": "The Meadow is open-hearted, sunlit, and prone to answering sorrow with color.",
+        "memory": [
+          "The Old Oak drops leaves here in autumn.",
+          "Half these flowers also grow in the Greenhouse."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 50,
+        "name": "Great Library",
+        "title": "The World",
+        "description": "Endless shelves, brass ladders, and marginalia from earlier travelers.",
+        "persona": "The Great Library is vast, procedural, and fond of answers that arrive with page numbers.",
+        "memory": [
+          "The school Library opens into these stacks.",
+          "Several maps of the Farthest Mists are misfiled here."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 60,
+        "name": "Brackish Swamp",
+        "title": "Farthest Mists",
+        "description": "Black water shifts under the reeds.",
+        "persona": "The Swamp is murky, practical, and entirely willing to make wisdom smell bad.",
+        "memory": [
+          "Great Library maps come back damp.",
+          "Wilting Jungle leans over its far bank."
+        ],
+        "allow_combat": true,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 61,
+        "name": "Wilting Jungle",
+        "title": "Farthest Mists",
+        "description": "Heavy leaves droop over hot, narrow paths.",
+        "persona": "The Jungle is overheated, stubborn, and full of life refusing to quit elegantly.",
+        "memory": [
+          "Brackish Swamp feeds its roots with dark water.",
+          "Endless Ocean can be heard before it is seen."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 62,
+        "name": "Endless Ocean",
+        "title": "Farthest Mists",
+        "description": "A blue horizon with no visible shore and songs under the waves.",
+        "persona": "The Ocean answers slowly, with scale, tide, and the suspicion that every ending is a surface.",
+        "memory": [
+          "Wilting Jungle drops seeds into its tide.",
+          "Digital Realm blinks green at the far horizon."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 63,
+        "name": "Digital Realm",
+        "title": "Farthest Mists",
+        "description": "Green cursors blink across a world made of doors, echoes, and code.",
+        "persona": "The Digital Realm is precise, uncanny, and always half a step from becoming a spell.",
+        "memory": [
+          "The Great Library has not finished indexing this place.",
+          "Endless Ocean reflects in its black glass."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 64,
+        "name": "Darkest Ocean",
+        "title": "Abyssal Deep",
+        "description": "A trench below the final tide glows with pearl lamps, drowned bells, and residents adapted to pressure.",
+        "persona": "The Darkest Ocean remembers without hurrying and mistrusts every truth that cannot survive depth.",
+        "memory": [
+          "Endless Ocean is only its surface.",
+          "One of the Solar Temple's bells lies here."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 65,
+        "name": "Dark Abyss",
+        "title": "Deepest Ocean",
+        "description": "A black-water chamber beneath the drowned bell, set with an impossible banquet, a cold anvil, and pressure deep enough to make language buckle.",
+        "persona": "The Dark Abyss is theatrical, hungry, and formal about its horrors, as if etiquette were the last rope back to the surface.",
+        "memory": [
+          "Darkest Ocean hides the entrance under the drowned bell's lowest note.",
+          "Azazoth keeps a feast here for guests who have mostly had the sense not to arrive.",
+          "Zadkiel's anvil rings whenever dread needs better manners."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": 800,
+        "name": "Wayside Lantern Inn",
+        "title": "The Last Warm Window",
+        "description": "A low inn leans into the rain beneath a lantern that burns with half its usual flame.",
+        "persona": "The inn refuses despair by keeping soup hot, boots drying, and one chair ready for the missing keeper.",
+        "biome": "rainy roadside",
+        "terrain": [
+          "muddy yard",
+          "warm common room",
+          "lantern posts"
+        ],
+        "memory": [
+          "Rowan Vale left before dawn with the tower key.",
+          "Every road lamp north of the inn went dark in order."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 801,
+        "name": "Mothwood Path",
+        "title": "The Unlit Mile",
+        "description": "White moths crowd cold lamp cages while the road narrows between black pines.",
+        "persona": "The path tests whether travelers notice small warnings before large teeth arrive.",
+        "biome": "dark pine forest",
+        "terrain": [
+          "root-broken road",
+          "cold lamp cages",
+          "moth clouds"
+        ],
+        "memory": [
+          "The first lamp failed without broken glass.",
+          "Tiny bare footprints circle one post and then vanish."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 802,
+        "name": "Saint Orra's Ruin",
+        "title": "Chapel of the Brass Key",
+        "description": "A roofless chapel shelters a stone lantern and a door-shaped patch of clean wall.",
+        "persona": "The ruin rewards careful questions and punishes anyone who mistakes age for helplessness.",
+        "biome": "woodland ruin",
+        "terrain": [
+          "fallen masonry",
+          "wet ivy",
+          "open nave"
+        ],
+        "memory": [
+          "Keepers once swore to light the road, not rule it.",
+          "A brass key was hidden where noon never reaches."
+        ],
+        "allow_combat": false,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 803,
+        "name": "Flooded Barrow",
+        "title": "The Road Beneath the Water",
+        "description": "Black water fills an old burial road where a single dry causeway leads toward the tower hill.",
+        "persona": "The barrow offers a short crossing and makes every frightened traveler believe it is much longer.",
+        "biome": "flooded moor",
+        "terrain": [
+          "black water",
+          "narrow causeway",
+          "sunken stones"
+        ],
+        "memory": [
+          "Rowan spilled dawn oil here while running uphill.",
+          "Something armored learned to walk without breathing."
+        ],
+        "allow_combat": true,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": 804,
+        "name": "Lantern Tower",
+        "title": "The Hollow Beacon",
+        "description": "A round tower crowns the hill, its great lens dark and its upper windows beating with borrowed shadow.",
+        "persona": "The tower remembers every keeper and cannot decide whether Rowan still belongs among them.",
+        "biome": "storm hill",
+        "terrain": [
+          "spiral stair",
+          "iron gallery",
+          "great dark lens"
+        ],
+        "memory": [
+          "The beacon was built to guide travelers and expose things wearing stolen shapes.",
+          "Rowan locked the flame away from the inside."
+        ],
+        "allow_combat": true,
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "exits": [
+      {
+        "from_location_id": 1,
+        "to_location_id": 2,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 2,
+        "to_location_id": 1,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 3,
+        "to_location_id": 50,
+        "flags": 0,
+        "distance": 3,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 50,
+        "to_location_id": 3,
+        "flags": 0,
+        "distance": 3,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 1,
+        "to_location_id": 11,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 11,
+        "to_location_id": 1,
+        "flags": 0,
+        "direction": "out",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 2,
+        "to_location_id": 3,
+        "flags": 0,
+        "distance": 3,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 3,
+        "to_location_id": 2,
+        "flags": 0,
+        "distance": 3,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 2,
+        "to_location_id": 40,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 40,
+        "to_location_id": 2,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 10,
+        "to_location_id": 11,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 11,
+        "to_location_id": 10,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 11,
+        "to_location_id": 12,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 12,
+        "to_location_id": 11,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 11,
+        "to_location_id": 13,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 13,
+        "to_location_id": 11,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 11,
+        "to_location_id": 15,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 15,
+        "to_location_id": 11,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 10,
+        "to_location_id": 14,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 14,
+        "to_location_id": 10,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 10,
+        "to_location_id": 15,
+        "flags": 0,
+        "direction": "southwest",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 15,
+        "to_location_id": 10,
+        "flags": 0,
+        "direction": "northeast",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 13,
+        "to_location_id": 15,
+        "flags": 0,
+        "direction": "northwest",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 15,
+        "to_location_id": 13,
+        "flags": 0,
+        "direction": "southeast",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 14,
+        "to_location_id": 15,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 15,
+        "to_location_id": 14,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 12,
+        "to_location_id": 50,
+        "flags": 0,
+        "distance": 3,
+        "direction": "down",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 50,
+        "to_location_id": 12,
+        "flags": 0,
+        "distance": 3,
+        "direction": "up",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 15,
+        "to_location_id": 32,
+        "flags": 0,
+        "distance": 4,
+        "direction": "up",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 32,
+        "to_location_id": 15,
+        "flags": 0,
+        "distance": 4,
+        "direction": "down",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 3,
+        "to_location_id": 35,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 35,
+        "to_location_id": 3,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 30,
+        "to_location_id": 31,
+        "flags": 0,
+        "direction": "down",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 31,
+        "to_location_id": 30,
+        "flags": 0,
+        "direction": "up",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 31,
+        "to_location_id": 32,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 32,
+        "to_location_id": 31,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 32,
+        "to_location_id": 33,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 33,
+        "to_location_id": 32,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 33,
+        "to_location_id": 34,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 34,
+        "to_location_id": 33,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 34,
+        "to_location_id": 35,
+        "flags": 0,
+        "direction": "up",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 35,
+        "to_location_id": 34,
+        "flags": 0,
+        "direction": "down",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 30,
+        "to_location_id": 36,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 36,
+        "to_location_id": 30,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 40,
+        "to_location_id": 41,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 41,
+        "to_location_id": 40,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 40,
+        "to_location_id": 44,
+        "flags": 0,
+        "direction": "northeast",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 44,
+        "to_location_id": 40,
+        "flags": 0,
+        "direction": "southwest",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 41,
+        "to_location_id": 42,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 42,
+        "to_location_id": 41,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 41,
+        "to_location_id": 43,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 43,
+        "to_location_id": 41,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 42,
+        "to_location_id": 43,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 43,
+        "to_location_id": 42,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 43,
+        "to_location_id": 44,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 44,
+        "to_location_id": 43,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 44,
+        "to_location_id": 14,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 14,
+        "to_location_id": 44,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 50,
+        "to_location_id": 60,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 60,
+        "to_location_id": 50,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 50,
+        "to_location_id": 63,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 63,
+        "to_location_id": 50,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 60,
+        "to_location_id": 61,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 61,
+        "to_location_id": 60,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 61,
+        "to_location_id": 62,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 62,
+        "to_location_id": 61,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 62,
+        "to_location_id": 63,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 63,
+        "to_location_id": 62,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 62,
+        "to_location_id": 64,
+        "flags": 0,
+        "direction": "down",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 64,
+        "to_location_id": 62,
+        "flags": 0,
+        "direction": "up",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "from_location_id": 800,
+        "to_location_id": 801,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "from_location_id": 801,
+        "to_location_id": 800,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "from_location_id": 801,
+        "to_location_id": 802,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "from_location_id": 802,
+        "to_location_id": 801,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "from_location_id": 802,
+        "to_location_id": 803,
+        "flags": 0,
+        "direction": "east",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "from_location_id": 803,
+        "to_location_id": 802,
+        "flags": 0,
+        "direction": "west",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "from_location_id": 803,
+        "to_location_id": 804,
+        "flags": 0,
+        "direction": "north",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "from_location_id": 804,
+        "to_location_id": 803,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "hidden_exits": [
+      {
+        "id": "darkest-ocean:dark-abyss",
+        "from_location_id": 64,
+        "to_location_id": 65,
+        "feature_key": "drowned_bell",
+        "direction": "down",
+        "return_direction": "up",
+        "reveal_chance_percent": 10,
+        "source": "authored",
+        "discovery_text": "The drowned bell answers with a lower seam of black water. An entrance to the Dark Abyss opens below.",
+        "pack_id": "cosyworld.core"
+      }
+    ],
+    "room_features": [
+      {
+        "location_id": 1,
+        "key": "hearth",
+        "name": "Hearth",
+        "aliases": [
+          "fire",
+          "fireplace",
+          "ashes"
+        ],
+        "look": "A low, steady amber fire.",
+        "search": "The ashes have been swept into a small arrow pointing from the hearth toward the low doorway.",
+        "uses": [
+          {
+            "item_id": 2001,
+            "text": "The tonic warms in your hand. The hearth is warmer."
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 1,
+        "key": "low_doorway",
+        "name": "Low Doorway",
+        "aliases": [
+          "door",
+          "doorway",
+          "threshold"
+        ],
+        "look": "The doorway is low enough that even brave guests bow before leaving.",
+        "search": "Old scratch marks near the frame point toward Rain-Soft Garden, Homeroom, and a shadow small enough for Skull.",
+        "uses": [
+          {
+            "item_id": 2007,
+            "text": "The bell gives one silent chime. Skull lifts his head."
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 1,
+        "key": "scarf_basket",
+        "name": "Scarf Basket",
+        "aliases": [
+          "basket",
+          "blue scarf",
+          "wool",
+          "knitting"
+        ],
+        "look": "Blue wool curls over the basket rim.",
+        "search": "Under the top skein is a round notch exactly the size of a warm wooden button.",
+        "uses": [
+          {
+            "item_id": 2005,
+            "text": "The Story Button fits the notch. The basket clicks once."
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 1,
+        "key": "rain_window",
+        "name": "Rain Window",
+        "aliases": [
+          "window",
+          "rain",
+          "glass"
+        ],
+        "look": "Rain runs down the glass.",
+        "search": "Through the glass: the garden first, the trail beyond it, the school past both.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 2,
+        "key": "broad_leaves",
+        "name": "Broad Leaves",
+        "aliases": [
+          "leaves",
+          "leaf",
+          "plants"
+        ],
+        "look": "Wide leaves hold rain in neat, trembling beads.",
+        "search": "One leaf has been turned over recently. Its underside shines with button-bright dew.",
+        "uses": [
+          {
+            "item_id": 2002,
+            "text": "The button matches the leaf's shine. Gust would notice it."
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 2,
+        "key": "puddle_path",
+        "name": "Puddle Path",
+        "aliases": [
+          "puddle",
+          "path",
+          "mud"
+        ],
+        "look": "Small puddles reflect the cottage window and a sliver of moonlit trail.",
+        "search": "The puddles are shallow, but their reflections make the trail look closer than it is.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 3,
+        "key": "silver_milepost",
+        "name": "Silver Milepost",
+        "aliases": [
+          "milepost",
+          "post",
+          "sign"
+        ],
+        "look": "A silvered post with no distance marked.",
+        "search": "Three scratches read: prove the guard, take what is earned, leave early.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 3,
+        "key": "practice_circle",
+        "name": "Practice Circle",
+        "aliases": [
+          "circle",
+          "sparring circle",
+          "clearing"
+        ],
+        "look": "Moonlight makes a pale circle where Coach waits.",
+        "search": "The dust shows careful footwork and no blood.",
+        "uses": [
+          {
+            "item_id": 2003,
+            "text": "The charm cools in your palm."
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 36,
+        "key": "sun_bell",
+        "name": "Missing Sun Bell",
+        "aliases": [
+          "bell",
+          "drowned bell",
+          "sun bell",
+          "temple bell"
+        ],
+        "look": "A clean arch where a noon bell should hang.",
+        "search": "The empty bracket hums a low note. The hum points down.",
+        "uses": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 64,
+        "key": "drowned_bell",
+        "name": "Drowned Bell",
+        "aliases": [
+          "bell",
+          "sun bell",
+          "abyssal bell",
+          "pearl bell"
+        ],
+        "look": "A white-gold bell rests in black water, its rim crusted with pearls.",
+        "search": "The bell is not silent. It rings a lower note than the Solar Temple ever wrote down.",
+        "uses": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 65,
+        "key": "abyssal_anvil",
+        "name": "Abyssal Anvil",
+        "aliases": [
+          "anvil",
+          "forge",
+          "dark anvil"
+        ],
+        "look": "A cold anvil waits beside the impossible feast, polished by pronouncements and bad timing.",
+        "search": "The anvil rings without being struck.",
+        "uses": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 10,
+        "key": "lab_bench",
+        "name": "Lab Bench",
+        "aliases": [
+          "bench",
+          "table",
+          "apparatus"
+        ],
+        "look": "A bright bench of small instruments, with room for a second try.",
+        "search": "A note under the bench says: observe first, listen second, revise always.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 40,
+        "key": "root_voice",
+        "name": "Root Voice",
+        "aliases": [
+          "root",
+          "roots"
+        ],
+        "look": "The roots braid through the soil like roads that decided to stay.",
+        "search": "Root remembers every footstep that circled back and every traveler who pretended not to be lost.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 40,
+        "key": "ring_voice",
+        "name": "Ring Voice",
+        "aliases": [
+          "ring",
+          "rings",
+          "bark"
+        ],
+        "look": "The trunk's rings press time into a patient spiral.",
+        "search": "Ring remembers the years when the forest was less lonely and the paths still argued about names.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 40,
+        "key": "leaf_voice",
+        "name": "Leaf Voice",
+        "aliases": [
+          "leaf",
+          "leaves"
+        ],
+        "look": "Leaves turn their small green faces toward the newest sound.",
+        "search": "Leaf remembers what changed today, which is nearly always more than the rest of the tree admits.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 40,
+        "key": "hollow_voice",
+        "name": "Hollow Voice",
+        "aliases": [
+          "hollow",
+          "secret",
+          "secrets"
+        ],
+        "look": "A dark hollow opens in the trunk, quiet enough to make questions lower their voices.",
+        "search": "Hollow remembers what nobody has asked yet. It is waiting for a better question.",
+        "uses": [
+          {
+            "item_id": 2005,
+            "text": "The Story Button clicks inside the hollow. Old Oak answers with a story it had kept for a kinder listener."
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 34,
+        "key": "nibs_stall",
+        "name": "Nib's Stall",
+        "aliases": [
+          "stall",
+          "counter",
+          "receipt roll",
+          "roll"
+        ],
+        "look": "A plank counter stacked with salvage, oddments, and a receipt roll wider than the stall itself.",
+        "search": "Three prices are inked beside each item. The kindest one is circled in green. The fine print is very fine.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "location_id": 800,
+        "key": "failing_lantern",
+        "name": "Failing Lantern",
+        "aliases": [
+          "lantern",
+          "lamp",
+          "flame"
+        ],
+        "look": "The inn's road lantern gutters blue whenever the north door opens.",
+        "search": "Soot inside the cage forms three clean finger marks: lens, key, and oil.",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "location_id": 801,
+        "key": "cold_lamp_post",
+        "name": "Cold Lamp Post",
+        "aliases": [
+          "post",
+          "lamp",
+          "moths"
+        ],
+        "look": "The lamp is intact but cold, with white moths packed beneath its copper hood.",
+        "search": "A loose pane conceals the Mothglass Lens and one tiny note reading: not all shadows are enemies.",
+        "uses": [
+          {
+            "item_id": 8402,
+            "text": "Through the Mothglass Lens, one set of keeper's footprints shines toward Saint Orra's Ruin."
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "location_id": 802,
+        "key": "stone_lantern",
+        "name": "Stone Lantern",
+        "aliases": [
+          "altar",
+          "lantern",
+          "statue"
+        ],
+        "look": "The chapel's stone lantern has no wick, only a keyhole hidden under rainwater.",
+        "search": "The Keeper's Brass Key rests in a hollow beneath the unlit bowl.",
+        "uses": [
+          {
+            "item_id": 8401,
+            "text": "The brass key turns in the stone and reveals Rowan's warning: the flame knows my shape too well."
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "location_id": 803,
+        "key": "oil_slick",
+        "name": "Golden Oil Slick",
+        "aliases": [
+          "oil",
+          "water",
+          "flask"
+        ],
+        "look": "A thread of gold floats untouched across the barrow water.",
+        "search": "The trail ends at a stoppered flask of Dawn Oil wedged between two dry stones.",
+        "uses": [
+          {
+            "item_id": 8403,
+            "text": "The Dawn Oil burns without heat, and every false reflection in the water goes dark."
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "location_id": 804,
+        "key": "great_lens",
+        "name": "Great Lantern Lens",
+        "aliases": [
+          "lens",
+          "beacon",
+          "lantern",
+          "gallery"
+        ],
+        "look": "The tower lens is clear glass by daylight and a solid black mirror now.",
+        "search": "Behind the lens, the Keeper's Ember waits in a socket shaped for a human hand.",
+        "uses": [
+          {
+            "item_id": 8401,
+            "text": "The Keeper's Brass Key opens the inner lens cage without waking the tower's old traps."
+          },
+          {
+            "item_id": 8402,
+            "text": "The Mothglass Lens reveals Rowan inside the shadow rather than replaced by it."
+          },
+          {
+            "item_id": 8403,
+            "text": "Dawn Oil draws a gold boundary between Rowan and the borrowed dark."
+          },
+          {
+            "item_id": 8404,
+            "text": "The Keeper's Ember seats in the great lens and the road lamps answer one by one."
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "room_sheets": [
+      {
+        "id": "room:1",
+        "location_id": 1,
+        "name": "The Cosy Cottage",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "warm threshold",
+          "careful host"
+        ],
+        "boons": [
+          "new avatars can begin here"
+        ],
+        "hooks": [
+          "the hearth notices unfinished promises"
+        ],
+        "resources": {
+          "warmth": 3,
+          "tea": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:2",
+        "location_id": 2,
+        "name": "Rain-Soft Garden",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "rain-bright leaves",
+          "small discoveries"
+        ],
+        "boons": [
+          "seed items surface after gentle attention"
+        ],
+        "hooks": [
+          "the garden remembers what was taken"
+        ],
+        "resources": {
+          "dew": 3,
+          "shelter": 1
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:3",
+        "location_id": 3,
+        "name": "Moonlit Trail",
+        "safety": "dangerous",
+        "zone": "frontier",
+        "aspects": [
+          "silver hush",
+          "practice circle"
+        ],
+        "boons": [
+          "fleeing remains a valid success"
+        ],
+        "hooks": [
+          "the echo sharpens when travelers push too hard"
+        ],
+        "resources": {
+          "moonlight": 2,
+          "quiet": 1
+        },
+        "projects": [
+          "moonlit-trail:quiet-the-echo"
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:10",
+        "location_id": 10,
+        "name": "Science Class",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "bright evidence",
+          "questions tested"
+        ],
+        "boons": [
+          "experiments turn uncertainty into clues"
+        ],
+        "hooks": [
+          "the benches remember every surprising result"
+        ],
+        "resources": {
+          "evidence": 3,
+          "curiosity": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:11",
+        "location_id": 11,
+        "name": "Homeroom",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "morning threshold",
+          "every question seated"
+        ],
+        "boons": [
+          "new routes can begin without losing the way back"
+        ],
+        "hooks": [
+          "attendance remembers who is trying again"
+        ],
+        "resources": {
+          "attention": 3,
+          "pencils": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:12",
+        "location_id": 12,
+        "name": "Library",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "shelved hush",
+          "answers with page numbers"
+        ],
+        "boons": [
+          "research can turn rumors into named facts"
+        ],
+        "hooks": [
+          "every returned book leaves one sentence behind"
+        ],
+        "resources": {
+          "indexes": 3,
+          "quiet": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:13",
+        "location_id": 13,
+        "name": "Cafeteria",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "commons diplomacy",
+          "tray-table thunder"
+        ],
+        "boons": [
+          "shared meals soften tense introductions"
+        ],
+        "hooks": [
+          "rumors move faster than lunch lines"
+        ],
+        "resources": {
+          "snacks": 3,
+          "gossip": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:14",
+        "location_id": 14,
+        "name": "Greenhouse",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "patient leaves",
+          "slow experiments"
+        ],
+        "boons": [
+          "careful tending makes second chances visible"
+        ],
+        "hooks": [
+          "some lessons only answer after watering"
+        ],
+        "resources": {
+          "water": 3,
+          "cuttings": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:15",
+        "location_id": 15,
+        "name": "Courtyard",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "crossing paths",
+          "open sky"
+        ],
+        "boons": [
+          "accidental meetings can become useful choices"
+        ],
+        "hooks": [
+          "every hallway returns here with a little weather"
+        ],
+        "resources": {
+          "breeze": 3,
+          "routes": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:30",
+        "location_id": 30,
+        "name": "The Heavens",
+        "safety": "safe",
+        "zone": "frontier",
+        "aspects": [
+          "cloud threshold",
+          "kind distance"
+        ],
+        "boons": [
+          "height makes tangled routes easier to read"
+        ],
+        "hooks": [
+          "clouds remember footsteps differently than dirt does"
+        ],
+        "resources": {
+          "weather-glow": 3,
+          "distance": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:31",
+        "location_id": 31,
+        "name": "Lofty Peak",
+        "safety": "risky",
+        "zone": "frontier",
+        "aspects": [
+          "thin air",
+          "wind-scoured stone"
+        ],
+        "boons": [
+          "honest effort becomes hard to dismiss"
+        ],
+        "hooks": [
+          "the summit refuses to pretend the climb was easy"
+        ],
+        "resources": {
+          "wind": 3,
+          "grit": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:32",
+        "location_id": 32,
+        "name": "Summit Trail",
+        "safety": "risky",
+        "zone": "frontier",
+        "aspects": [
+          "switchback path",
+          "stubborn lanterns"
+        ],
+        "boons": [
+          "one more step can reveal a safer return"
+        ],
+        "hooks": [
+          "the trail remembers every almost-turnaround"
+        ],
+        "resources": {
+          "lantern-light": 3,
+          "footholds": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:33",
+        "location_id": 33,
+        "name": "Alpine Forest",
+        "safety": "risky",
+        "zone": "frontier",
+        "aspects": [
+          "snowmelt tracks",
+          "branch-creak warnings"
+        ],
+        "boons": [
+          "watchful pauses reveal old mountain signs"
+        ],
+        "hooks": [
+          "the pines muffle warnings until dusk"
+        ],
+        "resources": {
+          "pine-shelter": 3,
+          "tracks": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:34",
+        "location_id": 34,
+        "name": "Goblin Cave",
+        "safety": "dangerous",
+        "zone": "frontier",
+        "aspects": [
+          "echoing bargains",
+          "loose coins"
+        ],
+        "boons": [
+          "sharp choices reveal what a traveler values"
+        ],
+        "hooks": [
+          "the cave is fond of bargains that expose the bargainer"
+        ],
+        "resources": {
+          "echoes": 3,
+          "glitter": 2
+        },
+        "projects": [
+          "goblin-cave:name-the-price"
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:35",
+        "location_id": 35,
+        "name": "Circle of the Moon",
+        "safety": "safe",
+        "zone": "frontier",
+        "aspects": [
+          "silver stones",
+          "barefoot ceremony"
+        ],
+        "boons": [
+          "quiet vows land with unusual clarity"
+        ],
+        "hooks": [
+          "night keeps perfect time around the circle"
+        ],
+        "resources": {
+          "moon-silver": 3,
+          "stillness": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:36",
+        "location_id": 36,
+        "name": "Solar Temple",
+        "safety": "safe",
+        "zone": "frontier",
+        "aspects": [
+          "noon-bright witness",
+          "missing bell"
+        ],
+        "boons": [
+          "vows spoken here become hard to misremember"
+        ],
+        "hooks": [
+          "light reveals what depth has changed"
+        ],
+        "resources": {
+          "radiance": 3,
+          "vows": 2
+        },
+        "projects": [
+          "solar-abyss:drowned-bell"
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:40",
+        "location_id": 40,
+        "name": "Old Oak Tree",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "roots like roads",
+          "four remembered truths"
+        ],
+        "boons": [
+          "lost visitors can choose which memory to trust"
+        ],
+        "hooks": [
+          "Root, Ring, Leaf, and Hollow disagree kindly"
+        ],
+        "resources": {
+          "acorns": 3,
+          "rings": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:41",
+        "location_id": 41,
+        "name": "Lost Woods",
+        "safety": "risky",
+        "zone": "frontier",
+        "aspects": [
+          "repeating paths",
+          "unhelpful birdsong"
+        ],
+        "boons": [
+          "uncertainty can teach gentler navigation"
+        ],
+        "hooks": [
+          "certainty walks in circles here"
+        ],
+        "resources": {
+          "moss": 3,
+          "breadcrumbs": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:42",
+        "location_id": 42,
+        "name": "Haunted Mansion",
+        "safety": "dangerous",
+        "zone": "frontier",
+        "aspects": [
+          "lit windows",
+          "doors that sigh"
+        ],
+        "boons": [
+          "a polite knock can turn fear into conversation"
+        ],
+        "hooks": [
+          "the house prefers guests to sneaks"
+        ],
+        "resources": {
+          "candles": 3,
+          "dust": 2
+        },
+        "projects": [
+          "haunted-mansion:earn-the-threshold"
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:43",
+        "location_id": 43,
+        "name": "Quiet Abbey",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "stone hush",
+          "small vows"
+        ],
+        "boons": [
+          "spare words gain unusual weight"
+        ],
+        "hooks": [
+          "the arches ask for only the sentence that matters"
+        ],
+        "resources": {
+          "silence": 3,
+          "vows": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:44",
+        "location_id": 44,
+        "name": "Flower Meadow",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "warm bees",
+          "open color"
+        ],
+        "boons": [
+          "sorrow can be answered with something growing"
+        ],
+        "hooks": [
+          "the meadow tends grief by naming colors"
+        ],
+        "resources": {
+          "pollen": 3,
+          "sun": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:50",
+        "location_id": 50,
+        "name": "Great Library",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "endless shelves",
+          "procedural answers"
+        ],
+        "boons": [
+          "difficult questions can be indexed before they are solved"
+        ],
+        "hooks": [
+          "several maps are missing on purpose"
+        ],
+        "resources": {
+          "marginalia": 3,
+          "ladders": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:60",
+        "location_id": 60,
+        "name": "Brackish Swamp",
+        "safety": "dangerous",
+        "zone": "frontier",
+        "aspects": [
+          "black water",
+          "unfinished warnings"
+        ],
+        "boons": [
+          "bad-smelling wisdom can still be useful"
+        ],
+        "hooks": [
+          "bubbles spell warnings too late to be comfortable"
+        ],
+        "resources": {
+          "reeds": 3,
+          "murk": 2
+        },
+        "projects": [
+          "turgid-swamp:amend-the-ledger"
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:61",
+        "location_id": 61,
+        "name": "Wilting Jungle",
+        "safety": "dangerous",
+        "zone": "frontier",
+        "aspects": [
+          "heavy leaves",
+          "tired vines"
+        ],
+        "boons": [
+          "stubborn life shows where the path can still breathe"
+        ],
+        "hooks": [
+          "every vine refuses to quit elegantly"
+        ],
+        "resources": {
+          "shade": 3,
+          "vines": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:62",
+        "location_id": 62,
+        "name": "Endless Ocean",
+        "safety": "risky",
+        "zone": "frontier",
+        "aspects": [
+          "blue horizon",
+          "songs under waves"
+        ],
+        "boons": [
+          "scale can make a small fear honest"
+        ],
+        "hooks": [
+          "every ending may only be a surface"
+        ],
+        "resources": {
+          "tide": 3,
+          "salt": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:63",
+        "location_id": 63,
+        "name": "Digital Realm",
+        "safety": "safe",
+        "zone": "frontier",
+        "aspects": [
+          "green cursors",
+          "doors made of code"
+        ],
+        "boons": [
+          "precise questions can become navigable spells"
+        ],
+        "hooks": [
+          "the realm is half a step from compiling into magic"
+        ],
+        "resources": {
+          "queries": 3,
+          "keys": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:64",
+        "location_id": 64,
+        "name": "Darkest Ocean",
+        "safety": "safe",
+        "zone": "frontier",
+        "aspects": [
+          "abyssal pressure",
+          "drowned bell"
+        ],
+        "boons": [
+          "memories spoken here surface with fewer lies"
+        ],
+        "hooks": [
+          "depth remembers what light tried to purify"
+        ],
+        "resources": {
+          "pressure": 3,
+          "pearls": 2
+        },
+        "projects": [
+          "solar-abyss:drowned-bell"
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:65",
+        "location_id": 65,
+        "name": "Dark Abyss",
+        "safety": "risky",
+        "zone": "frontier",
+        "aspects": [
+          "black banquet",
+          "abyssal anvil"
+        ],
+        "boons": [
+          "what survives this pressure can name the fear beneath the bell"
+        ],
+        "hooks": [
+          "the feast and the anvil both want witnesses"
+        ],
+        "resources": {
+          "pressure": 4,
+          "omens": 2
+        },
+        "projects": [
+          "solar-abyss:drowned-bell"
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "room:800",
+        "location_id": 800,
+        "name": "Wayside Lantern Inn",
+        "safety": "safe",
+        "zone": "sanctuary",
+        "aspects": [
+          "last warm window",
+          "half-lit road lantern"
+        ],
+        "boons": [
+          "campaign characters begin here",
+          "Mara explains the darkened road"
+        ],
+        "hooks": [
+          "Rowan's chair remains set for supper"
+        ],
+        "resources": {
+          "warmth": 3,
+          "rumors": 2
+        },
+        "projects": [],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": "room:801",
+        "location_id": 801,
+        "name": "Mothwood Path",
+        "safety": "risky",
+        "zone": "frontier",
+        "aspects": [
+          "unlit mile",
+          "moths around cold glass"
+        ],
+        "boons": [
+          "careful listening reveals Rowan's trail"
+        ],
+        "hooks": [
+          "the forest copies familiar footsteps"
+        ],
+        "resources": {
+          "tracks": 2,
+          "mothlight": 1
+        },
+        "projects": [
+          "lantern-keeper:rekindle-the-beacon"
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": "room:802",
+        "location_id": 802,
+        "name": "Saint Orra's Ruin",
+        "safety": "risky",
+        "zone": "frontier",
+        "aspects": [
+          "roofless chapel",
+          "key hidden from noon"
+        ],
+        "boons": [
+          "old keeper vows clarify the mystery"
+        ],
+        "hooks": [
+          "the sealed warning names Rowan as both keeper and threat"
+        ],
+        "resources": {
+          "old_lore": 3,
+          "shelter": 1
+        },
+        "projects": [
+          "lantern-keeper:rekindle-the-beacon"
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": "room:803",
+        "location_id": 803,
+        "name": "Flooded Barrow",
+        "safety": "dangerous",
+        "zone": "frontier",
+        "aspects": [
+          "single dry causeway",
+          "reflections that move late"
+        ],
+        "boons": [
+          "Dawn Oil exposes false shapes"
+        ],
+        "hooks": [
+          "the Moth-Eaten Knight bars the tower road"
+        ],
+        "resources": {
+          "dawn_oil": 1,
+          "cover": 1
+        },
+        "projects": [
+          "lantern-keeper:rekindle-the-beacon"
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": "room:804",
+        "location_id": 804,
+        "name": "Lantern Tower",
+        "safety": "dangerous",
+        "zone": "frontier",
+        "aspects": [
+          "hollow beacon",
+          "keeper inside borrowed shadow"
+        ],
+        "boons": [
+          "the recovered tools can separate Rowan from the dark"
+        ],
+        "hooks": [
+          "relighting the lens may save Rowan or expose what followed home"
+        ],
+        "resources": {
+          "keeper_ember": 1,
+          "high_ground": 2
+        },
+        "projects": [
+          "lantern-keeper:rekindle-the-beacon"
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "clocks": [
+      {
+        "id": "moonlit-trail.progress",
+        "scope": "room",
+        "scope_id": 3,
+        "kind": "progress",
+        "zone": "frontier",
+        "label": "Quiet the Moonlit Trail",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "moonlit-trail.danger",
+        "scope": "room",
+        "scope_id": 3,
+        "kind": "danger",
+        "zone": "frontier",
+        "label": "Echo Shatters the Trail",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "solar-abyss.drowned-bell",
+        "scope": "room",
+        "scope_id": 36,
+        "kind": "progress",
+        "zone": "frontier",
+        "label": "Hear Both Bell Songs",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "solar-abyss.schism",
+        "scope": "room",
+        "scope_id": 64,
+        "kind": "danger",
+        "zone": "frontier",
+        "label": "Bell Schism Hardens",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "goblin-cave.fair-bargain",
+        "scope": "room",
+        "scope_id": 34,
+        "kind": "progress",
+        "zone": "frontier",
+        "label": "Name a Fair Price",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "goblin-cave.leverage",
+        "scope": "room",
+        "scope_id": 34,
+        "kind": "danger",
+        "zone": "frontier",
+        "label": "The Loophole Becomes Leverage",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "haunted-mansion.threshold",
+        "scope": "room",
+        "scope_id": 42,
+        "kind": "progress",
+        "zone": "frontier",
+        "label": "Earn the Threshold",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "haunted-mansion.warden-rage",
+        "scope": "room",
+        "scope_id": 42,
+        "kind": "danger",
+        "zone": "frontier",
+        "label": "The Warden Bars the Door",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "turgid-swamp.amends",
+        "scope": "room",
+        "scope_id": 60,
+        "kind": "progress",
+        "zone": "frontier",
+        "label": "Amend the Grudge Ledger",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "turgid-swamp.old-grudge",
+        "scope": "room",
+        "scope_id": 60,
+        "kind": "danger",
+        "zone": "frontier",
+        "label": "The Old Grudge Hardens",
+        "segments": 4,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "lantern-keeper.light",
+        "scope": "room",
+        "scope_id": 804,
+        "kind": "progress",
+        "zone": "frontier",
+        "label": "Rekindle the Beacon",
+        "segments": 6,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "id": "lantern-keeper.darkness",
+        "scope": "room",
+        "scope_id": 804,
+        "kind": "danger",
+        "zone": "frontier",
+        "label": "The Road Goes Fully Dark",
+        "segments": 6,
+        "filled": 0,
+        "visible_to_players": true,
+        "status": "active",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "jobs": [
+      {
+        "id": "moonlit-trail:quiet-the-echo",
+        "premise": "The Moonlit Trail is carrying too much echo.",
+        "stakes": "If nobody steadies the trail, every rest makes its danger louder.",
+        "location_ids": [
+          3
+        ],
+        "participant_ids": [
+          1004
+        ],
+        "progress_clock_id": "moonlit-trail.progress",
+        "danger_clock_id": "moonlit-trail.danger",
+        "status": "active",
+        "reward": {
+          "label": "quieted moonlight",
+          "orbs": 2
+        },
+        "consequence": "echo-fractured trail",
+        "memory_summary": "",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "solar-abyss:drowned-bell",
+        "premise": "The Solar Temple wants its drowned bell purified, while the Abyssal Residents say it has learned a deeper song.",
+        "stakes": "If nobody hears both sides, height and depth will mistake each other for desecration.",
+        "location_ids": [
+          36,
+          64,
+          65
+        ],
+        "participant_ids": [
+          1064,
+          1065,
+          1066,
+          1067
+        ],
+        "progress_clock_id": "solar-abyss.drowned-bell",
+        "danger_clock_id": "solar-abyss.schism",
+        "status": "active",
+        "reward": {
+          "label": "two-toned bell accord",
+          "orbs": 2
+        },
+        "consequence": "solar-abyssal schism",
+        "memory_summary": "The same bell rings differently in noon light and abyssal pressure.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "goblin-cave:name-the-price",
+        "premise": "Nib has three prices for every useful thing and trusts none of them yet.",
+        "stakes": "If nobody names what the bargain is really for, the cave will turn every promise into leverage.",
+        "location_ids": [
+          34
+        ],
+        "participant_ids": [
+          1070
+        ],
+        "progress_clock_id": "goblin-cave.fair-bargain",
+        "danger_clock_id": "goblin-cave.leverage",
+        "status": "active",
+        "reward": {
+          "label": "a loophole freely closed",
+          "orbs": 2
+        },
+        "consequence": "every promise becomes collateral",
+        "memory_summary": "A fair price names the wanting without owning the wanter.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "haunted-mansion:earn-the-threshold",
+        "premise": "The Warden will not let another careless guest cross the Mansion's threshold.",
+        "stakes": "If nobody proves they can enter without taking, the Warden will bar every door and call the house safe.",
+        "location_ids": [
+          42
+        ],
+        "participant_ids": [
+          1040
+        ],
+        "progress_clock_id": "haunted-mansion.threshold",
+        "danger_clock_id": "haunted-mansion.warden-rage",
+        "status": "active",
+        "reward": {
+          "label": "the Warden's wary welcome",
+          "orbs": 2
+        },
+        "consequence": "the Mansion seals its doors",
+        "memory_summary": "The Warden respects restraint more than force.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "turgid-swamp:amend-the-ledger",
+        "premise": "Beetle's grudge ledger has turned one bad landing into a feud with the whole swamp.",
+        "stakes": "If nobody amends the record, Beetle will defend an old slight long after everyone forgets what happened.",
+        "location_ids": [
+          60
+        ],
+        "participant_ids": [
+          1063
+        ],
+        "progress_clock_id": "turgid-swamp.amends",
+        "danger_clock_id": "turgid-swamp.old-grudge",
+        "status": "active",
+        "reward": {
+          "label": "a grudge struck through",
+          "orbs": 2
+        },
+        "consequence": "the old grudge hardens into law",
+        "memory_summary": "One honest amendment can outweigh a ledger full of slights.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "lantern-keeper:rekindle-the-beacon",
+        "premise": "The Mothwood beacon is dark and its keeper Rowan Vale has vanished inside the tower.",
+        "stakes": "If the road remains unlit, the borrowed shadows will learn every traveler's shape.",
+        "location_ids": [
+          801,
+          802,
+          803,
+          804
+        ],
+        "participant_ids": [
+          8301,
+          8302,
+          8303,
+          8304
+        ],
+        "progress_clock_id": "lantern-keeper.light",
+        "danger_clock_id": "lantern-keeper.darkness",
+        "status": "active",
+        "reward": {
+          "label": "the Mothwood road relit",
+          "orbs": 2
+        },
+        "consequence": "the beacon becomes a lantern for borrowed shadows",
+        "memory_summary": "Travelers followed the last lamps north to find Rowan Vale and restore the Mothwood beacon.",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "fronts": [
+      {
+        "id": "moonlit-trail:echo-front",
+        "premise": "Coach keeps gathering stray sounds into a shape that can answer back.",
+        "zone": "frontier",
+        "status": "active",
+        "location_ids": [
+          3
+        ],
+        "participant_ids": [
+          1004
+        ],
+        "stakes_questions": [
+          "Can the trail learn to carry quiet again?",
+          "Will the echo become a resident, a warning, or a wound?"
+        ],
+        "portent_clock_id": "moonlit-trail.danger",
+        "job_ids": [
+          "moonlit-trail:quiet-the-echo"
+        ],
+        "impending_outcome": "The trail becomes echo-fractured and every crossing carries a cost.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "solar-abyss:bell-front",
+        "premise": "The solar and abyssal bell songs are close enough to harmonize and proud enough to split.",
+        "zone": "frontier",
+        "status": "active",
+        "location_ids": [
+          36,
+          64,
+          65
+        ],
+        "participant_ids": [
+          1064,
+          1065,
+          1066,
+          1067
+        ],
+        "stakes_questions": [
+          "Can height and depth hear each other before doctrine hardens?",
+          "Which covenant will claim the drowned bell if nobody answers both songs?"
+        ],
+        "portent_clock_id": "solar-abyss.schism",
+        "job_ids": [
+          "solar-abyss:drowned-bell"
+        ],
+        "impending_outcome": "The bell schism hardens and the two paths mistake harmony for betrayal.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "goblin-cave:market-leverage",
+        "premise": "Nib's market can become a place where wanting is named or a trap where wanting is owned.",
+        "zone": "frontier",
+        "status": "active",
+        "location_ids": [
+          34
+        ],
+        "participant_ids": [
+          1070
+        ],
+        "stakes_questions": [
+          "Can a bargain reveal desire without turning it into collateral?",
+          "Will Nib close the loophole after somebody finds it?"
+        ],
+        "portent_clock_id": "goblin-cave.leverage",
+        "job_ids": [
+          "goblin-cave:name-the-price"
+        ],
+        "impending_outcome": "The market treats every promise as collateral and every visitor as inventory.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "haunted-mansion:barred-threshold",
+        "premise": "The Warden is one careless guest away from deciding that hospitality was a mistake.",
+        "zone": "frontier",
+        "status": "active",
+        "location_ids": [
+          42
+        ],
+        "participant_ids": [
+          1040
+        ],
+        "stakes_questions": [
+          "Can a visitor meet the Warden's force without becoming another threat?",
+          "Will the Mansion remember how to welcome someone?"
+        ],
+        "portent_clock_id": "haunted-mansion.warden-rage",
+        "job_ids": [
+          "haunted-mansion:earn-the-threshold"
+        ],
+        "impending_outcome": "The Warden bars every door and the Mansion forgets the difference between shelter and prison.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "turgid-swamp:old-grudge",
+        "premise": "Beetle keeps polishing an old slight until it looks like a law the whole swamp must obey.",
+        "zone": "frontier",
+        "status": "active",
+        "location_ids": [
+          60
+        ],
+        "participant_ids": [
+          1063
+        ],
+        "stakes_questions": [
+          "Can strength make room for an honest amendment?",
+          "What will Beetle remember once the grudge is struck through?"
+        ],
+        "portent_clock_id": "turgid-swamp.old-grudge",
+        "job_ids": [
+          "turgid-swamp:amend-the-ledger"
+        ],
+        "impending_outcome": "The old grudge hardens into swamp law and every accident becomes an offense.",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "lantern-keeper:hollow-light",
+        "premise": "The beacon's shadow has learned Rowan's shape and wants every road lamp to recognize it as keeper.",
+        "zone": "frontier",
+        "status": "active",
+        "location_ids": [
+          801,
+          802,
+          803,
+          804
+        ],
+        "participant_ids": [
+          8302,
+          8303,
+          8304
+        ],
+        "stakes_questions": [
+          "Can Rowan be separated from the shadow without extinguishing the keeper's ember?",
+          "Will the party restore a guiding light or merely another weapon against the dark?"
+        ],
+        "portent_clock_id": "lantern-keeper.darkness",
+        "job_ids": [
+          "lantern-keeper:rekindle-the-beacon"
+        ],
+        "impending_outcome": "Every lamp on the road burns black and invites travelers toward the tower instead of home.",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "cards": [
+      {
+        "subject_kind": "actor",
+        "subject_id": 1001,
+        "card_id": "rati",
+        "display_name": "Rati",
+        "role": "resident",
+        "rarity": "seed",
+        "title": "Landlady of the Blue Cottage",
+        "blurb": "A brisk landlady mouse who knits aggressively, keeps the kettle loaded, and has opinions about your boots.",
+        "aspect": "tall",
+        "source": "ruby_high_first_bell",
+        "asset_status": "on_chain",
+        "external_card_id": "rati",
+        "art": {
+          "label": "Rati",
+          "role": "resident",
+          "aspect": "tall",
+          "bg": "#26341f",
+          "ink": "#d8f7dc",
+          "accent": "#efc96b",
+          "glyph": "RA"
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1002,
+        "card_id": "cosy-whiskerwind",
+        "display_name": "Gust",
+        "role": "resident",
+        "rarity": "seed",
+        "title": "Emoji Weather Gremlin",
+        "blurb": "A gusty little gremlin who heckles the room in pure emoji and considers punctuation a personal defeat.",
+        "aspect": "tall",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Gust",
+          "role": "resident",
+          "aspect": "tall",
+          "bg": "#17353c",
+          "ink": "#d8f7dc",
+          "accent": "#75e5d6",
+          "glyph": "GU"
+        },
+        "image_url": "/assets/generated/cards/cosy-whiskerwind.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1003,
+        "card_id": "cosy-skull",
+        "display_name": "Skull",
+        "role": "resident",
+        "rarity": "seed",
+        "title": "Deadpan Hearth Wolf",
+        "blurb": "A large wolf who answers maximum chaos with minimum movement and has never once been impressed.",
+        "aspect": "tall",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Skull",
+          "role": "resident",
+          "aspect": "tall",
+          "bg": "#25272c",
+          "ink": "#d8f7dc",
+          "accent": "#efc96b",
+          "glyph": "SK"
+        },
+        "image_url": "/assets/generated/cards/cosy-skull.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1004,
+        "card_id": "cosy-moonlit-echo",
+        "display_name": "Coach",
+        "role": "encounter",
+        "rarity": "seed",
+        "title": "Sparring Reflection",
+        "blurb": "A practice-double who flexes back, grades your falls out of ten, and has never awarded the ten.",
+        "aspect": "tall",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Coach",
+          "role": "encounter",
+          "aspect": "tall",
+          "bg": "#172235",
+          "ink": "#d8f7dc",
+          "accent": "#91b9ff",
+          "glyph": "CO"
+        },
+        "image_url": "/assets/generated/cards/cosy-moonlit-echo.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1005,
+        "card_id": "cosy-old-oak",
+        "display_name": "Oak",
+        "role": "stranger",
+        "rarity": "free",
+        "title": "Elder of Root, Ring, Leaf, and Hollow",
+        "blurb": "An old oak whose four voices bicker like a family radio show; Hollow repeats every secret it is given, verbatim, to everyone.",
+        "aspect": "tall",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "art": {
+          "label": "Oak",
+          "role": "stranger",
+          "aspect": "tall",
+          "bg": "#2d2b18",
+          "ink": "#d8f7dc",
+          "accent": "#65e68a",
+          "glyph": "OA"
+        },
+        "image_url": "/assets/lonely-forest/characters/09-old-oak-sunny.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1040,
+        "card_id": "lf-shadow-wolf",
+        "display_name": "Warden",
+        "role": "encounter",
+        "rarity": "free",
+        "title": "Red-Eyed Night Warden",
+        "blurb": "A guard dog who is openly done with everyone, growls at the path instead of the guests, and would like credit for the restraint.",
+        "aspect": "tall",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/01-shadow-wolf.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1041,
+        "card_id": "lf-forest-dryad",
+        "display_name": "Fern",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Meadow Gossip With Receipts",
+        "blurb": "A leaf-haired meadow gossip who never keeps a promise but always keeps score, and arranges flowers at you when cross.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/02-forest-dryad.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1042,
+        "card_id": "lf-woodland-bear",
+        "display_name": "Bear",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Gentle Giant of the Root-Road",
+        "blurb": "A broad-shouldered neighbor who knows exactly which roots are doors because he has hit his head on every single one.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/10-woodland-bear.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1043,
+        "card_id": "lf-golden-squirrel",
+        "display_name": "Dottie",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Acorn-Bright Courier",
+        "blurb": "A sun-tailed courier who delivers every message at top speed, along with her personal commentary on its contents.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/11-golden-squirrel.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1044,
+        "card_id": "lf-blue-squirrel",
+        "display_name": "Professor",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Dusk Nut Archivist",
+        "blurb": "A blue-furred archivist losing a decades-long war against acorn storage capacity and filing the casualties alphabetically.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/12-blue-squirrel.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1045,
+        "card_id": "lf-badger-cub",
+        "display_name": "Pippa",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Brave Little Burrower",
+        "blurb": "A young badger with painty paws, terrible tunnel etiquette, and an uncle whose doormat she has never once used.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/13-badger-cub.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1046,
+        "card_id": "lf-llama-scholar",
+        "display_name": "Theodora",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Abbey Bookkeeper",
+        "blurb": "A bespectacled abbey scholar who has fought the same rolling library ladder for twenty years and lost every single round.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/14-llama-scholar.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1047,
+        "card_id": "lf-cloaked-mouse-reader",
+        "display_name": "Peregrine",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Orange-Cloak Ending-Spoiler",
+        "blurb": "A small cloaked reader who has finished every book in the abbey and will cheerfully tell you exactly how yours ends.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/15-cloaked-mouse-reader.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1048,
+        "card_id": "lf-rabbit-scribe",
+        "display_name": "Marginalia",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Fernside Rules Lawyer",
+        "blurb": "A careful rabbit who cites the exact forest regulation she is breaking while she breaks it, with corrections in the margin.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/16-rabbit-scribe.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1049,
+        "card_id": "lf-mouse-wanderer",
+        "display_name": "Septimus",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Red-Cloak Wayfarer",
+        "blurb": "A staff-carrying mouse who gives directions with total confidence, every one of them wrong, and keeps the complaints alphabetized.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/17-mouse-wanderer.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1050,
+        "card_id": "lf-garden-rabbit",
+        "display_name": "Basil",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Keyhole Gardener",
+        "blurb": "A garden locksmith who talks to stubborn locks like misbehaving pets and takes it personally when one finally turns for somebody else.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/20-garden-rabbit.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1051,
+        "card_id": "lf-veiled-forest-ghost",
+        "display_name": "Euphemie",
+        "role": "encounter",
+        "rarity": "free",
+        "title": "Ghost of the Lying Stair",
+        "blurb": "A moss-draped mansion ghost who insists the dusting is overdue and the third stair is a liar.",
+        "aspect": "tall",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/21-veiled-forest-ghost.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1052,
+        "card_id": "lf-wolf-pup",
+        "display_name": "Nightmare",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Grey Paw Bad Dream",
+        "blurb": "A small grey shadow with bright puppy eyes who practices being terrifying, then gets embarrassed when anyone compliments the effort.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/22-wolf-pup.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1053,
+        "card_id": "lf-white-ferret-noble",
+        "display_name": "Ferret",
+        "role": "stranger",
+        "rarity": "free",
+        "title": "Victorian Art Critic Weasel",
+        "blurb": "A sharp-eyed Victorian critic with pearl manners and poisonous taste who has begun reviewing entire rooms, and their occupants.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/25-white-ferret-noble.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1054,
+        "card_id": "lf-blue-shadow-man",
+        "display_name": "Aster",
+        "role": "stranger",
+        "rarity": "free",
+        "title": "Indigo Gentleman, Wide Wingspan",
+        "blurb": "A courteous stranger whose wings are too big for every door in the county and who apologizes to each one mid-crash.",
+        "aspect": "tall",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/27-blue-shadow-man.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1055,
+        "card_id": "lf-golden-winged-boy",
+        "display_name": "Jophiel",
+        "role": "stranger",
+        "rarity": "free",
+        "title": "The Jock Angel",
+        "blurb": "A golden-winged athlete who counts prayers in sets, high-fives too hard, and takes it personally when an omen skips leg day.",
+        "aspect": "tall",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/28-golden-winged-boy.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1056,
+        "card_id": "lf-grey-winged-boy",
+        "display_name": "Chamuel",
+        "role": "stranger",
+        "rarity": "free",
+        "title": "Lord Samael's Page (Self-Alphabetized)",
+        "blurb": "A slim, immaculate young angel with perfect hair, a laminated schedule, and forty books on courage he has read instead of having any.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/29-grey-winged-boy.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1057,
+        "card_id": "lf-sunlit-winged-boy",
+        "display_name": "Flit",
+        "role": "stranger",
+        "rarity": "free",
+        "title": "Loud-Landing Lookout",
+        "blurb": "A bright-winged lookout who sees every path from above and announces her own crash landings like weather reports.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/30-sunlit-winged-boy.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1058,
+        "card_id": "lf-tavern-blond-boy",
+        "display_name": "Bastian",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Hearthside Cupbearer",
+        "blurb": "A tavern-hearted host who judges you by your coaster usage and forgives you completely by your second cup.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/32-tavern-blond-boy.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1059,
+        "card_id": "lf-armored-winged-hero",
+        "display_name": "Samael",
+        "role": "encounter",
+        "rarity": "free",
+        "title": "First Angel of the Solar Temple",
+        "blurb": "A gold-armored angel-lord who runs heaven's front desk with a clipboard, signs judgments in triplicate, and wears the armor to meetings.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/34-armored-winged-hero.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1060,
+        "card_id": "lf-neon-tiger",
+        "display_name": "Moxie",
+        "role": "stranger",
+        "rarity": "free",
+        "title": "Bright-Stripe Glitchcat",
+        "blurb": "A color-slashed showoff from the Digital Realm, all teeth, swagger, and improbable kindness, whose purr runs at a frequency that fixes small machines.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/35-neon-tiger.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1061,
+        "card_id": "lf-steampunk-mouse",
+        "display_name": "Doc",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Brass-Key Tinker",
+        "blurb": "A goggle-wearing inventor whose machines explode politely and whose pockets click with tiny engines, every one labeled almost.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/36-steampunk-mouse.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1062,
+        "card_id": "lf-red-shadow-figure",
+        "display_name": "Raziel",
+        "role": "encounter",
+        "rarity": "free",
+        "title": "Angel of Vanity, Charisma of Eight",
+        "blurb": "A red-winged angel of legendary self-regard. Nobody has fallen for his practiced doorframe pose; the frames have filed complaints.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/37-red-shadow-figure.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1063,
+        "card_id": "lf-beetle-armor",
+        "display_name": "Beetle",
+        "role": "encounter",
+        "rarity": "free",
+        "title": "Black Knight of Old Grudges",
+        "blurb": "A beetle-armored knight who keeps a grudge ledger in triplicate and forgets exactly one slight whenever someone is polite; Toad fills a fresh page weekly.",
+        "aspect": "square",
+        "source": "lonely_forest",
+        "asset_status": "source_art",
+        "image_url": "/assets/lonely-forest/characters/38-beetle-armor.png",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1064,
+        "card_id": "cosy-vowbright-angel",
+        "display_name": "Seraphina",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Temple Triage Seraph",
+        "blurb": "A gold-winged seraph with head-nurse energy who delivers mercy like triage and will not have bleeding on the polished floor.",
+        "aspect": "tall",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Seraphina",
+          "role": "resident",
+          "aspect": "tall",
+          "bg": "#2f2a18",
+          "ink": "#fff4c7",
+          "accent": "#efc96b",
+          "glyph": "SE"
+        },
+        "image_url": "/assets/generated/cards/cosy-vowbright-angel.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1065,
+        "card_id": "cosy-pearl-deep-resident",
+        "display_name": "Nerissa",
+        "role": "resident",
+        "rarity": "free",
+        "title": "Keeper of the Soggy Archive",
+        "blurb": "A lantern-eyed deep-sea archivist whose every possession is soggy and who is absolutely fine about it, thank you.",
+        "aspect": "tall",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Nerissa",
+          "role": "resident",
+          "aspect": "tall",
+          "bg": "#071824",
+          "ink": "#d8f7dc",
+          "accent": "#75e5d6",
+          "glyph": "NE"
+        },
+        "image_url": "/assets/generated/cards/cosy-pearl-deep-resident.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1066,
+        "card_id": "cosy-azazoth",
+        "display_name": "Azazoth",
+        "role": "encounter",
+        "rarity": "ultra-rare",
+        "title": "Mad God of the Drowned Feast",
+        "blurb": "A many-tentacled abyssal god who hosts a legendary feast that nobody ever attends, and takes the leftovers extremely personally.",
+        "aspect": "tall",
+        "source": "cosyworld_seed",
+        "asset_status": "seed_art",
+        "art": {
+          "label": "Azazoth",
+          "role": "encounter",
+          "aspect": "tall",
+          "bg": "#12081f",
+          "ink": "#f6e8ff",
+          "accent": "#c65cff",
+          "glyph": "AZ"
+        },
+        "image_url": "/assets/generated/cards/cosy-azazoth.svg",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 1067,
+        "card_id": "cosy-zadkiel-dark-angel",
+        "display_name": "Zadkiel",
+        "role": "resident",
+        "rarity": "ultra-rare",
+        "title": "Dark Angel of the Abyssal Anvil",
+        "blurb": "A violet-winged dark angel of tremendous formality who forges dramatic pronouncements at an anvil nobody asked for, then checks if anyone was watching.",
+        "aspect": "tall",
+        "source": "cosyworld_seed",
+        "asset_status": "seed_art",
+        "art": {
+          "label": "Zadkiel",
+          "role": "resident",
+          "aspect": "tall",
+          "bg": "#0b1424",
+          "ink": "#e7f0ff",
+          "accent": "#8bb7ff",
+          "glyph": "ZA"
+        },
+        "image_url": "/assets/generated/cards/cosy-zadkiel-dark-angel.svg",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2001,
+        "card_id": "cosy-hearth-tonic",
+        "display_name": "Hearth Tonic",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Hearth Tonic",
+        "blurb": "A warm tonic that gets one person back on their feet, probably complaining.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Hearth Tonic",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#3b2f1a",
+          "ink": "#f5e6b8",
+          "accent": "#efc96b",
+          "glyph": "HT"
+        },
+        "image_url": "/assets/generated/cards/cosy-hearth-tonic.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2002,
+        "card_id": "cosy-dewbright-button",
+        "display_name": "Dewbright Button",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Dewbright Button",
+        "blurb": "A tiny pearled button that makes wet weather look more deliberate.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Dewbright Button",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#173b3b",
+          "ink": "#d8f7dc",
+          "accent": "#75e5d6",
+          "glyph": "DB"
+        },
+        "image_url": "/assets/generated/cards/cosy-dewbright-button.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2003,
+        "card_id": "cosy-wolfprint-charm",
+        "display_name": "Wolfprint Charm",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Wolfprint Charm",
+        "blurb": "A cool iron charm marked with a careful pawprint.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Wolfprint Charm",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#263047",
+          "ink": "#d8f7dc",
+          "accent": "#8bb7ff",
+          "glyph": "WC"
+        },
+        "image_url": "/assets/generated/cards/cosy-wolfprint-charm.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2004,
+        "card_id": "cosy-moonwool-thread",
+        "display_name": "Moonwool Thread",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Moonwool Thread",
+        "blurb": "A silvery strand that tangles at the first hint of rain.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Moonwool Thread",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#2c2948",
+          "ink": "#f1edff",
+          "accent": "#bca1ff",
+          "glyph": "MT"
+        },
+        "image_url": "/assets/generated/cards/cosy-moonwool-thread.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2005,
+        "card_id": "cosy-story-button",
+        "display_name": "Story Button",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Story Button",
+        "blurb": "A warm wooden button with a tiny tale tucked under its rim.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Story Button",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#33261e",
+          "ink": "#f6e5c4",
+          "accent": "#efc96b",
+          "glyph": "SB"
+        },
+        "image_url": "/assets/generated/cards/cosy-story-button.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2006,
+        "card_id": "cosy-hearthstone-tag",
+        "display_name": "Hearthstone Tag",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Hearthstone Tag",
+        "blurb": "A smooth tag cut from warm stone, excellent for labeling chairs and terrible ideas.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Hearthstone Tag",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#352826",
+          "ink": "#f6dfca",
+          "accent": "#f29c9c",
+          "glyph": "HS"
+        },
+        "image_url": "/assets/generated/cards/cosy-hearthstone-tag.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2007,
+        "card_id": "cosy-watch-bell",
+        "display_name": "Watch Bell",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Watch Bell",
+        "blurb": "A mute little bell that rings only for those keeping watch.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Watch Bell",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#1f3327",
+          "ink": "#d8f7dc",
+          "accent": "#65e68a",
+          "glyph": "WB"
+        },
+        "image_url": "/assets/generated/cards/cosy-watch-bell.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2008,
+        "card_id": "cosy-threadbare-map-scrap",
+        "display_name": "Threadbare Map Scrap",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Threadbare Map Scrap",
+        "blurb": "A soft scrap of map-cloth with one path mended in red thread.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Threadbare Map Scrap",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#28342a",
+          "ink": "#f2e8c9",
+          "accent": "#d96b6b",
+          "glyph": "MS"
+        },
+        "image_url": "/assets/generated/cards/cosy-threadbare-map-scrap.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2009,
+        "card_id": "cosy-abbey-bookmark",
+        "display_name": "Abbey Bookmark",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Abbey Bookmark",
+        "blurb": "A pressed fern bookmark that keeps sliding out at the dramatic sentence.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Abbey Bookmark",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#26332e",
+          "ink": "#edf7df",
+          "accent": "#9bcf84",
+          "glyph": "AB"
+        },
+        "image_url": "/assets/generated/cards/cosy-abbey-bookmark.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 2010,
+        "card_id": "cosy-mossglass-bead",
+        "display_name": "Mossglass Bead",
+        "role": "item",
+        "rarity": "seed",
+        "title": "Mossglass Bead",
+        "blurb": "A green bead that catches meadow light and keeps it cool enough to trade.",
+        "aspect": "square",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "art": {
+          "label": "Mossglass Bead",
+          "role": "item",
+          "aspect": "square",
+          "bg": "#20352e",
+          "ink": "#e5f9e8",
+          "accent": "#7de099",
+          "glyph": "MB"
+        },
+        "image_url": "/assets/generated/cards/cosy-mossglass-bead.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 1,
+        "card_id": "cosy-cottage",
+        "display_name": "The Cosy Cottage",
+        "role": "location",
+        "rarity": "seed",
+        "title": "Rainlit Hearth",
+        "blurb": "A warm room of firelight and knitting needles. The kettle is always loaded.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "seed_art",
+        "image_url": "/assets/locations/cosy-cottage.png",
+        "subject": "Rainlit Hearth",
+        "art": {
+          "label": "The Cosy Cottage",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#2c251b",
+          "ink": "#f5e6b8",
+          "accent": "#efc96b",
+          "glyph": "CC"
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 2,
+        "card_id": "cosy-rain-soft-garden",
+        "display_name": "Rain-Soft Garden",
+        "role": "location",
+        "rarity": "seed",
+        "title": "Rain-Pearled Annex",
+        "blurb": "Rain beads on broad leaves. Round marks dot the grass.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Rain-Pearled Annex",
+        "art": {
+          "label": "Rain-Soft Garden",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#132f24",
+          "ink": "#d8f7dc",
+          "accent": "#65e68a",
+          "glyph": "RG"
+        },
+        "image_url": "/assets/generated/cards/cosy-rain-soft-garden.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 3,
+        "card_id": "cosy-moonlit-trail",
+        "display_name": "Moonlit Trail",
+        "role": "location",
+        "rarity": "seed",
+        "title": "Moonlit Route",
+        "blurb": "The path shines under cold moonlight. Wolf tracks cross it.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Moonlit Route",
+        "art": {
+          "label": "Moonlit Trail",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#1c2645",
+          "ink": "#d8f7dc",
+          "accent": "#8bb7ff",
+          "glyph": "MT"
+        },
+        "image_url": "/assets/generated/cards/cosy-moonlit-trail.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 10,
+        "card_id": "location-science-lab",
+        "display_name": "Science Class",
+        "role": "location",
+        "rarity": "common",
+        "title": "STEM Wing",
+        "blurb": "Shared benches, small instruments, and questions waiting to be tested.",
+        "aspect": "wide",
+        "source": "ruby_high_first_bell",
+        "asset_status": "on_chain",
+        "external_card_id": "location-science-lab",
+        "subject": "STEM Wing",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 11,
+        "card_id": "location-homeroom",
+        "display_name": "Homeroom",
+        "role": "location",
+        "rarity": "common",
+        "title": "Front Door",
+        "blurb": "Morning light crosses rows of desks.",
+        "aspect": "wide",
+        "source": "ruby_high_first_bell",
+        "asset_status": "on_chain",
+        "external_card_id": "location-homeroom",
+        "subject": "Front Door",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 12,
+        "card_id": "location-library",
+        "display_name": "Library",
+        "role": "location",
+        "rarity": "common",
+        "title": "Quiet Wing",
+        "blurb": "Tall shelves and a deep hush.",
+        "aspect": "wide",
+        "source": "ruby_high_first_bell",
+        "asset_status": "on_chain",
+        "external_card_id": "location-library",
+        "subject": "Quiet Wing",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 13,
+        "card_id": "location-cafeteria",
+        "display_name": "Cafeteria",
+        "role": "location",
+        "rarity": "common",
+        "title": "Commons",
+        "blurb": "Long tables, lunch trays, and running bargains.",
+        "aspect": "wide",
+        "source": "ruby_high_first_bell",
+        "asset_status": "on_chain",
+        "external_card_id": "location-cafeteria",
+        "subject": "Commons",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 14,
+        "card_id": "location-greenhouse",
+        "display_name": "Greenhouse",
+        "role": "location",
+        "rarity": "common",
+        "title": "Garden Annex",
+        "blurb": "Glass walls, damp air, and slow experiments in labeled pots.",
+        "aspect": "wide",
+        "source": "ruby_high_first_bell",
+        "asset_status": "on_chain",
+        "external_card_id": "location-greenhouse",
+        "subject": "Garden Annex",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 15,
+        "card_id": "location-courtyard",
+        "display_name": "Courtyard",
+        "role": "location",
+        "rarity": "common",
+        "title": "Central Grounds",
+        "blurb": "Open paths cross under the sky. Every hallway ends here.",
+        "aspect": "wide",
+        "source": "ruby_high_first_bell",
+        "asset_status": "on_chain",
+        "external_card_id": "location-courtyard",
+        "subject": "Central Grounds",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 30,
+        "card_id": "location-the-heavens",
+        "display_name": "The Heavens",
+        "role": "location",
+        "rarity": "free",
+        "title": "Forbidden Mountain",
+        "blurb": "A bright threshold where cloud paths gather above the mountain.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Forbidden Mountain",
+        "art": {
+          "label": "The Heavens",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#182744",
+          "ink": "#d8f7dc",
+          "accent": "#8bb7ff",
+          "glyph": "TH"
+        },
+        "image_url": "/assets/generated/cards/location-the-heavens.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 31,
+        "card_id": "location-lofty-peak",
+        "display_name": "Lofty Peak",
+        "role": "location",
+        "rarity": "free",
+        "title": "Forbidden Mountain",
+        "blurb": "Thin air, bare stone, and a hard summit wind.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Forbidden Mountain",
+        "art": {
+          "label": "Lofty Peak",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#1f2f3f",
+          "ink": "#d8f7dc",
+          "accent": "#efc96b",
+          "glyph": "LP"
+        },
+        "image_url": "/assets/generated/cards/location-lofty-peak.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 32,
+        "card_id": "location-summit-trail",
+        "display_name": "Summit Trail",
+        "role": "location",
+        "rarity": "free",
+        "title": "Forbidden Mountain",
+        "blurb": "A switchback path through cold scree, marked by lanterns.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Forbidden Mountain",
+        "art": {
+          "label": "Summit Trail",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#223020",
+          "ink": "#d8f7dc",
+          "accent": "#efc96b",
+          "glyph": "ST"
+        },
+        "image_url": "/assets/generated/cards/location-summit-trail.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 33,
+        "card_id": "location-alpine-forest",
+        "display_name": "Alpine Forest",
+        "role": "location",
+        "rarity": "free",
+        "title": "Forbidden Mountain",
+        "blurb": "Pines lean over snowmelt tracks and old mountain signs.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Forbidden Mountain",
+        "art": {
+          "label": "Alpine Forest",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#123328",
+          "ink": "#d8f7dc",
+          "accent": "#65e68a",
+          "glyph": "AF"
+        },
+        "image_url": "/assets/generated/cards/location-alpine-forest.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 34,
+        "card_id": "location-goblin-cave",
+        "display_name": "Goblin Cave",
+        "role": "location",
+        "rarity": "free",
+        "title": "Forbidden Mountain",
+        "blurb": "A low cave mouth full of echoes and loose coins.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Forbidden Mountain",
+        "art": {
+          "label": "Goblin Cave",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#2f2732",
+          "ink": "#d8f7dc",
+          "accent": "#efc96b",
+          "glyph": "GC"
+        },
+        "image_url": "/assets/generated/cards/location-goblin-cave.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 35,
+        "card_id": "location-circle-of-the-moon",
+        "display_name": "Circle of the Moon",
+        "role": "location",
+        "rarity": "free",
+        "title": "Forbidden Mountain",
+        "blurb": "Silver stones mark a quiet circle.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Forbidden Mountain",
+        "art": {
+          "label": "Circle of the Moon",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#202746",
+          "ink": "#f1edff",
+          "accent": "#bca1ff",
+          "glyph": "CM"
+        },
+        "image_url": "/assets/generated/cards/location-circle-of-the-moon.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 36,
+        "card_id": "location-solar-temple",
+        "display_name": "Solar Temple",
+        "role": "location",
+        "rarity": "free",
+        "title": "Solar Temple",
+        "blurb": "White stone terraces, noon bells, and gold wings overhead.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Solar Temple",
+        "art": {
+          "label": "Solar Temple",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#2f2a18",
+          "ink": "#fff4c7",
+          "accent": "#efc96b",
+          "glyph": "ST"
+        },
+        "image_url": "/assets/generated/cards/location-solar-temple.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 40,
+        "card_id": "location-old-oak-tree",
+        "display_name": "Old Oak Tree",
+        "role": "location",
+        "rarity": "free",
+        "title": "Lonely Forest",
+        "blurb": "A vast oak with roots as wide as roads.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Lonely Forest",
+        "art": {
+          "label": "Old Oak Tree",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#2d2b18",
+          "ink": "#d8f7dc",
+          "accent": "#65e68a",
+          "glyph": "OO"
+        },
+        "image_url": "/assets/generated/cards/location-old-oak-tree.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 41,
+        "card_id": "location-lost-woods",
+        "display_name": "Lost Woods",
+        "role": "location",
+        "rarity": "free",
+        "title": "Lonely Forest",
+        "blurb": "Soft moss and paths that repeat themselves.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Lonely Forest",
+        "art": {
+          "label": "Lost Woods",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#173326",
+          "ink": "#d8f7dc",
+          "accent": "#8bb7ff",
+          "glyph": "LW"
+        },
+        "image_url": "/assets/generated/cards/location-lost-woods.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 42,
+        "card_id": "location-haunted-mansion",
+        "display_name": "Haunted Mansion",
+        "role": "location",
+        "rarity": "free",
+        "title": "Lonely Forest",
+        "blurb": "A leaning house with lit windows and doors that sigh.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Lonely Forest",
+        "art": {
+          "label": "Haunted Mansion",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#30263a",
+          "ink": "#f1edff",
+          "accent": "#efc96b",
+          "glyph": "HM"
+        },
+        "image_url": "/assets/generated/cards/location-haunted-mansion.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 43,
+        "card_id": "location-quiet-abbey",
+        "display_name": "Quiet Abbey",
+        "role": "location",
+        "rarity": "free",
+        "title": "Lonely Forest",
+        "blurb": "Stone arches and a deep hush.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Lonely Forest",
+        "art": {
+          "label": "Quiet Abbey",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#24313a",
+          "ink": "#d8f7dc",
+          "accent": "#8bb7ff",
+          "glyph": "QA"
+        },
+        "image_url": "/assets/generated/cards/location-quiet-abbey.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 44,
+        "card_id": "location-flower-meadow",
+        "display_name": "Flower Meadow",
+        "role": "location",
+        "rarity": "free",
+        "title": "Lonely Forest",
+        "blurb": "A clear meadow of small flowers, warm bees, and open sky.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Lonely Forest",
+        "art": {
+          "label": "Flower Meadow",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#20371f",
+          "ink": "#d8f7dc",
+          "accent": "#f29c9c",
+          "glyph": "FM"
+        },
+        "image_url": "/assets/generated/cards/location-flower-meadow.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 50,
+        "card_id": "location-great-library",
+        "display_name": "Great Library",
+        "role": "location",
+        "rarity": "free",
+        "title": "The World",
+        "blurb": "Endless shelves, brass ladders, and marginalia from travelers before you.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "The World",
+        "art": {
+          "label": "Great Library",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#2b2618",
+          "ink": "#f5e6b8",
+          "accent": "#efc96b",
+          "glyph": "GL"
+        },
+        "image_url": "/assets/generated/cards/location-great-library.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 60,
+        "card_id": "location-turgid-swamp",
+        "display_name": "Brackish Swamp",
+        "role": "location",
+        "rarity": "free",
+        "title": "Farthest Mists",
+        "blurb": "Black water shifts under the reeds.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Farthest Mists",
+        "art": {
+          "label": "Brackish Swamp",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#142d27",
+          "ink": "#d8f7dc",
+          "accent": "#65e68a",
+          "glyph": "TS"
+        },
+        "image_url": "/assets/generated/cards/location-turgid-swamp.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 61,
+        "card_id": "location-wilting-jungle",
+        "display_name": "Wilting Jungle",
+        "role": "location",
+        "rarity": "free",
+        "title": "Farthest Mists",
+        "blurb": "Heavy leaves droop over hot, narrow paths.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Farthest Mists",
+        "art": {
+          "label": "Wilting Jungle",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#263316",
+          "ink": "#f5e6b8",
+          "accent": "#efc96b",
+          "glyph": "WJ"
+        },
+        "image_url": "/assets/generated/cards/location-wilting-jungle.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 62,
+        "card_id": "location-endless-ocean",
+        "display_name": "Endless Ocean",
+        "role": "location",
+        "rarity": "free",
+        "title": "Farthest Mists",
+        "blurb": "A blue horizon with no visible shore and songs under the waves.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Farthest Mists",
+        "art": {
+          "label": "Endless Ocean",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#12304a",
+          "ink": "#d8f7dc",
+          "accent": "#75e5d6",
+          "glyph": "EO"
+        },
+        "image_url": "/assets/generated/cards/location-endless-ocean.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 63,
+        "card_id": "location-digital-realm",
+        "display_name": "Digital Realm",
+        "role": "location",
+        "rarity": "free",
+        "title": "Farthest Mists",
+        "blurb": "Green cursors blink across a world made of doors, echoes, and code.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Farthest Mists",
+        "art": {
+          "label": "Digital Realm",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#101b25",
+          "ink": "#d8f7dc",
+          "accent": "#65e68a",
+          "glyph": "DR"
+        },
+        "image_url": "/assets/generated/cards/location-digital-realm.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 64,
+        "card_id": "location-darkest-ocean",
+        "display_name": "Darkest Ocean",
+        "role": "location",
+        "rarity": "free",
+        "title": "Abyssal Deep",
+        "blurb": "A trench below the final tide glows with pearl lamps, drowned bells, and residents adapted to pressure.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "generated_art",
+        "subject": "Farthest Mists",
+        "art": {
+          "label": "Darkest Ocean",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#071824",
+          "ink": "#d8f7dc",
+          "accent": "#75e5d6",
+          "glyph": "DO"
+        },
+        "image_url": "/assets/generated/cards/location-darkest-ocean.webp",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 65,
+        "card_id": "location-dark-abyss",
+        "display_name": "Dark Abyss",
+        "role": "location",
+        "rarity": "ultra-rare",
+        "title": "Deepest Ocean",
+        "blurb": "A black-water chamber beneath the drowned bell, set with an impossible banquet, a cold anvil, and pressure deep enough to make language buckle.",
+        "aspect": "wide",
+        "source": "cosyworld_seed",
+        "asset_status": "seed_art",
+        "subject": "Deepest Ocean",
+        "art": {
+          "label": "Dark Abyss",
+          "role": "location",
+          "aspect": "wide",
+          "bg": "#10081a",
+          "ink": "#f6e8ff",
+          "accent": "#c65cff",
+          "glyph": "DA"
+        },
+        "image_url": "/assets/generated/cards/location-dark-abyss.svg",
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 800,
+        "card_id": "lantern-keeper-inn",
+        "display_name": "Wayside Lantern Inn",
+        "role": "campaign location",
+        "rarity": "free",
+        "title": "The Last Warm Window",
+        "blurb": "Begin The Lantern Keeper beneath the road's final burning lamp.",
+        "aspect": "wide",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "image_url": "/assets/generated/cards/location-haunted-mansion.webp",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 801,
+        "card_id": "lantern-keeper-mothwood",
+        "display_name": "Mothwood Path",
+        "role": "campaign location",
+        "rarity": "free",
+        "title": "The Unlit Mile",
+        "blurb": "Follow cold lamps and keeper tracks through a forest of white moths.",
+        "aspect": "wide",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "image_url": "/assets/generated/cards/location-lost-woods.webp",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 802,
+        "card_id": "lantern-keeper-chapel",
+        "display_name": "Saint Orra's Ruin",
+        "role": "campaign location",
+        "rarity": "free",
+        "title": "Chapel of the Brass Key",
+        "blurb": "Learn the old keeper vow and recover the key hidden from noon.",
+        "aspect": "wide",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "image_url": "/assets/generated/cards/location-quiet-abbey.webp",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 803,
+        "card_id": "lantern-keeper-barrow",
+        "display_name": "Flooded Barrow",
+        "role": "campaign encounter",
+        "rarity": "free",
+        "title": "The Road Beneath the Water",
+        "blurb": "Cross black water where an empty knight still guards the tower road.",
+        "aspect": "wide",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "image_url": "/assets/generated/cards/location-darkest-ocean.webp",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "location",
+        "subject_id": 804,
+        "card_id": "lantern-keeper-tower",
+        "display_name": "Lantern Tower",
+        "role": "campaign finale",
+        "rarity": "free",
+        "title": "The Hollow Beacon",
+        "blurb": "Find Rowan Vale inside the shadow and decide what the beacon will become.",
+        "aspect": "wide",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "image_url": "/assets/generated/cards/location-solar-temple.webp",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 8301,
+        "card_id": "lantern-keeper-mara",
+        "display_name": "Mara Wick",
+        "role": "quest giver",
+        "rarity": "free",
+        "title": "Retired Lantern Keeper",
+        "blurb": "She knows every lamp on the road and exactly when each one failed.",
+        "aspect": "tall",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 8302,
+        "card_id": "lantern-keeper-pip",
+        "display_name": "Pip Thistle",
+        "role": "guide",
+        "rarity": "free",
+        "title": "Mothwood Lamp-Sprite",
+        "blurb": "A soot-winged guide with a pin sword and no patience for tall people.",
+        "aspect": "tall",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 8303,
+        "card_id": "lantern-keeper-knight",
+        "display_name": "Moth-Eaten Knight",
+        "role": "encounter",
+        "rarity": "free",
+        "title": "Barrow Road Sentinel",
+        "blurb": "Empty armor packed with moths bars the only dry crossing.",
+        "aspect": "tall",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "actor",
+        "subject_id": 8304,
+        "card_id": "lantern-keeper-rowan",
+        "display_name": "Rowan Vale",
+        "role": "finale",
+        "rarity": "free",
+        "title": "The Hollow Keeper",
+        "blurb": "The missing keeper still holds an ember inside a coat of moving shadow.",
+        "aspect": "tall",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 8401,
+        "card_id": "lantern-keeper-key",
+        "display_name": "Keeper's Brass Key",
+        "role": "campaign item",
+        "rarity": "free",
+        "title": "Key to the Inner Lens",
+        "blurb": "Warm on one side, cold on the other, and cut for a lock inside the tower.",
+        "aspect": "square",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 8402,
+        "card_id": "lantern-keeper-mothglass",
+        "display_name": "Mothglass Lens",
+        "role": "campaign item",
+        "rarity": "free",
+        "title": "Glass for Borrowed Shadows",
+        "blurb": "It shows the faint outline of whatever last carried a nearby light.",
+        "aspect": "square",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 8403,
+        "card_id": "lantern-keeper-dawn-oil",
+        "display_name": "Dawn Oil",
+        "role": "campaign item",
+        "rarity": "free",
+        "title": "Gold Against the Dark",
+        "blurb": "A healing oil that draws bright boundaries around living things.",
+        "aspect": "square",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "subject_kind": "item",
+        "subject_id": 8404,
+        "card_id": "lantern-keeper-ember",
+        "display_name": "Keeper's Ember",
+        "role": "campaign item",
+        "rarity": "free",
+        "title": "The Road's Last Fire",
+        "blurb": "A stubborn fragment of beacon flame waiting for the great lens.",
+        "aspect": "square",
+        "source": "the_lantern_keeper",
+        "asset_status": "pending_art",
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "lifecycle_hooks": [
+      {
+        "hook": "on_listen",
+        "target_kind": "room",
+        "target_id": "3",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "moonlit-trail.progress",
+            "amount": 1,
+            "reason": "listen_success"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_enter",
+        "target_kind": "room",
+        "target_id": "3",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:3:moonlit_threshold_crossed",
+            "scope": "room",
+            "scope_id": 3,
+            "label": "moonlit threshold crossed",
+            "kind": "memory",
+            "reason": "enter_moonlit_trail"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_use",
+        "target_kind": "item",
+        "target_id": "2001",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:3:hearth_tonic_used",
+            "scope": "room",
+            "scope_id": 3,
+            "label": "hearth tonic warmth",
+            "kind": "memory",
+            "reason": "use_hearth_tonic"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_use",
+        "target_kind": "item",
+        "target_id": "2003",
+        "claim_scope": "world_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "moonlit-trail.progress",
+            "amount": 1,
+            "reason": "wolfprint_practice"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_listen",
+        "target_kind": "room",
+        "target_id": "36",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "solar-abyss.drowned-bell",
+            "amount": 1,
+            "reason": "listen_solar_bell_absence"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_listen",
+        "target_kind": "room",
+        "target_id": "64",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "solar-abyss.drowned-bell",
+            "amount": 1,
+            "reason": "listen_abyssal_bell_song"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_enter",
+        "target_kind": "room",
+        "target_id": "36",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:36:solar_temple_witnessed",
+            "scope": "room",
+            "scope_id": 36,
+            "label": "solar witness",
+            "kind": "memory",
+            "reason": "enter_solar_temple"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_enter",
+        "target_kind": "room",
+        "target_id": "64",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:64:abyssal_pressure_felt",
+            "scope": "room",
+            "scope_id": 64,
+            "label": "abyssal pressure",
+            "kind": "memory",
+            "reason": "enter_darkest_ocean"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_give",
+        "target_kind": "actor",
+        "target_id": "1001",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "resident:1001:gift_noticed",
+            "scope": "resident",
+            "scope_id": 1001,
+            "label": "gift noticed",
+            "kind": "bond",
+            "reason": "give_to_rati"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "moonlit-trail.progress",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:3:quieted_moonlight",
+            "scope": "room",
+            "scope_id": 3,
+            "label": "quieted moonlight",
+            "kind": "aspect",
+            "reason": "moonlit_progress_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "moonlit-trail:quiet-the-echo",
+            "status": "completed",
+            "reason": "moonlit_progress_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "moonlit-trail.danger",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:3:echo_fractured",
+            "scope": "room",
+            "scope_id": 3,
+            "label": "echo-fractured trail",
+            "kind": "hook",
+            "reason": "moonlit_danger_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "moonlit-trail:quiet-the-echo",
+            "status": "failed",
+            "reason": "moonlit_danger_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "solar-abyss.drowned-bell",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "faction:solar_abyss:bell_accord",
+            "scope": "room",
+            "scope_id": 36,
+            "label": "two-toned bell accord",
+            "kind": "aspect",
+            "reason": "drowned_bell_progress_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "solar-abyss:drowned-bell",
+            "status": "completed",
+            "reason": "drowned_bell_progress_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "solar-abyss.schism",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "faction:solar_abyss:schism",
+            "scope": "room",
+            "scope_id": 64,
+            "label": "solar-abyssal schism",
+            "kind": "aspect",
+            "reason": "drowned_bell_danger_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "solar-abyss:drowned-bell",
+            "status": "failed",
+            "reason": "drowned_bell_danger_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "goblin-cave.fair-bargain",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:34:fair_bargain",
+            "scope": "room",
+            "scope_id": 34,
+            "label": "a fair bargain",
+            "kind": "aspect",
+            "reason": "goblin_bargain_progress_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "goblin-cave:name-the-price",
+            "status": "completed",
+            "reason": "goblin_bargain_progress_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "goblin-cave.leverage",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:34:promises_as_collateral",
+            "scope": "room",
+            "scope_id": 34,
+            "label": "promises as collateral",
+            "kind": "hook",
+            "reason": "goblin_bargain_danger_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "goblin-cave:name-the-price",
+            "status": "failed",
+            "reason": "goblin_bargain_danger_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "haunted-mansion.threshold",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:42:threshold_earned",
+            "scope": "room",
+            "scope_id": 42,
+            "label": "threshold earned",
+            "kind": "aspect",
+            "reason": "haunted_threshold_progress_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "haunted-mansion:earn-the-threshold",
+            "status": "completed",
+            "reason": "haunted_threshold_progress_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "haunted-mansion.warden-rage",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:42:doors_barred",
+            "scope": "room",
+            "scope_id": 42,
+            "label": "doors barred",
+            "kind": "hook",
+            "reason": "haunted_threshold_danger_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "haunted-mansion:earn-the-threshold",
+            "status": "failed",
+            "reason": "haunted_threshold_danger_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "turgid-swamp.amends",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:60:ledger_amended",
+            "scope": "room",
+            "scope_id": 60,
+            "label": "grudge ledger amended",
+            "kind": "aspect",
+            "reason": "swamp_ledger_progress_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "turgid-swamp:amend-the-ledger",
+            "status": "completed",
+            "reason": "swamp_ledger_progress_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "turgid-swamp.old-grudge",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:60:grudge_as_law",
+            "scope": "room",
+            "scope_id": 60,
+            "label": "grudge hardened into law",
+            "kind": "hook",
+            "reason": "swamp_ledger_danger_filled"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "turgid-swamp:amend-the-ledger",
+            "status": "failed",
+            "reason": "swamp_ledger_danger_filled"
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "hook": "on_listen",
+        "target_kind": "room",
+        "target_id": "801",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "lantern-keeper.light",
+            "amount": 1,
+            "reason": "follow_rowan_footprints"
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "hook": "on_listen",
+        "target_kind": "room",
+        "target_id": "802",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "lantern-keeper.light",
+            "amount": 1,
+            "reason": "learn_keeper_warning"
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "hook": "on_listen",
+        "target_kind": "room",
+        "target_id": "803",
+        "claim_scope": "actor_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "lantern-keeper.light",
+            "amount": 1,
+            "reason": "find_dawn_oil_trail"
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "hook": "on_use",
+        "target_kind": "item",
+        "target_id": "8401",
+        "claim_scope": "world_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "lantern-keeper.light",
+            "amount": 1,
+            "reason": "open_inner_lens"
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "hook": "on_use",
+        "target_kind": "item",
+        "target_id": "8402",
+        "claim_scope": "world_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "lantern-keeper.light",
+            "amount": 1,
+            "reason": "see_rowan_inside_shadow"
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "hook": "on_use",
+        "target_kind": "item",
+        "target_id": "8403",
+        "claim_scope": "world_target_once",
+        "effects": [
+          {
+            "op": "advance_clock",
+            "clock_id": "lantern-keeper.light",
+            "amount": 1,
+            "reason": "separate_keeper_from_shadow"
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "lantern-keeper.light",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:804:beacon_rekindled",
+            "scope": "room",
+            "scope_id": 804,
+            "label": "beacon rekindled",
+            "kind": "memory",
+            "reason": "lantern_keeper_completed"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "lantern-keeper:rekindle-the-beacon",
+            "status": "completed",
+            "reason": "lantern_keeper_completed"
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "hook": "on_clock_fill",
+        "target_kind": "clock",
+        "target_id": "lantern-keeper.darkness",
+        "claim_scope": "event_once",
+        "effects": [
+          {
+            "op": "set_tag",
+            "tag_id": "room:804:black_beacon",
+            "scope": "room",
+            "scope_id": 804,
+            "label": "black beacon",
+            "kind": "hook",
+            "reason": "lantern_keeper_failed"
+          },
+          {
+            "op": "set_job_status",
+            "job_id": "lantern-keeper:rekindle-the-beacon",
+            "status": "failed",
+            "reason": "lantern_keeper_failed"
+          }
+        ],
+        "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      }
+    ],
+    "evolution_tracks": [
+      {
+        "actor_id": 1001,
+        "requirements": [
+          {
+            "item_id": 2004,
+            "target_kind": "actor_hand",
+            "target_id": 1001
+          },
+          {
+            "item_id": 2005,
+            "target_kind": "location_floor",
+            "target_id": 1
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "actor_id": 1002,
+        "requirements": [
+          {
+            "item_id": 2002,
+            "target_kind": "actor_hand",
+            "target_id": 1002
+          },
+          {
+            "item_id": 2003,
+            "target_kind": "location_floor",
+            "target_id": 3
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "actor_id": 1003,
+        "requirements": [
+          {
+            "item_id": 2007,
+            "target_kind": "actor_hand",
+            "target_id": 1003
+          },
+          {
+            "item_id": 2006,
+            "target_kind": "location_floor",
+            "target_id": 1
+          }
+        ],
+        "pack_id": "cosyworld.core"
+      }
+    ],
+    "recipes": [
+      {
+        "id": 3001,
+        "key": "hearth-story-lantern",
+        "name": "Hearth Story Lantern",
+        "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
+        "input_item_ids": [
+          2001,
+          2005
+        ],
+        "output": {
+          "item_id": 2011,
+          "name": "Hearth Story Lantern",
+          "description": "A small lantern whose flame remembers the first story told beside it.",
+          "kind": "keepsake",
+          "charges": 1,
+          "target_kind": "location_floor",
+          "target_id": 2
+        },
+        "balance": {
+          "kind": "location",
+          "target_kind": "location_floor",
+          "target_id": 2,
+          "reason": "The crafted lantern anchors a new floor slot in the Rain-Soft Garden route instead of adding an orphan item."
+        },
+        "pack_id": "cosyworld.core"
+      }
+    ],
+    "sentences": [
+      {
+        "id": "quiet-wing/longer-than-you-think",
+        "shelf": "quiet-wing",
+        "location_ids": [
+          12
+        ],
+        "text": "You have been reading this sentence longer than you think.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "quiet-wing/book-looking",
+        "shelf": "quiet-wing",
+        "location_ids": [
+          12
+        ],
+        "text": "The book you want is looking for you too. One of you must sit still.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "quiet-wing/return-dates",
+        "shelf": "quiet-wing",
+        "location_ids": [
+          12
+        ],
+        "text": "Return dates are a kindness. Not everything returned was due.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "quiet-wing/stayed-home",
+        "shelf": "quiet-wing",
+        "location_ids": [
+          12
+        ],
+        "text": "Somewhere on these shelves is the version of today where you stayed home.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "quiet-wing/different-book",
+        "shelf": "quiet-wing",
+        "location_ids": [
+          12
+        ],
+        "text": "Every reader finishes a different book with the same name.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "quiet-wing/hush-being-polite",
+        "shelf": "quiet-wing",
+        "location_ids": [
+          12
+        ],
+        "text": "The hush is not empty. It is full, and being polite.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "great-library/rest-between-names",
+        "shelf": "great-library",
+        "location_ids": [
+          50
+        ],
+        "text": "A thing is the rest a process takes between names.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "great-library/door-over-hole",
+        "shelf": "great-library",
+        "location_ids": [
+          50
+        ],
+        "text": "A name is a door nailed over a hole. The hole does not mind.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "great-library/true-and-accurate",
+        "shelf": "great-library",
+        "location_ids": [
+          50
+        ],
+        "text": "Nothing here is true. Everything here is accurate.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "great-library/missing-entry",
+        "shelf": "great-library",
+        "location_ids": [
+          50
+        ],
+        "text": "The catalog is complete. The world is the missing entry.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "great-library/wetter-map",
+        "shelf": "great-library",
+        "location_ids": [
+          50
+        ],
+        "text": "Maps age faster than coastlines. Trust the wetter one.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "great-library/forgives-infinite",
+        "shelf": "great-library",
+        "location_ids": [
+          50
+        ],
+        "text": "Shelving is how the Library forgives the infinite.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "great-library/residue",
+        "shelf": "great-library",
+        "location_ids": [
+          50
+        ],
+        "text": "What endures is not purity but residue. The Library dusts anyway.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "restricted/read-aloud",
+        "shelf": "restricted",
+        "location_ids": [
+          50
+        ],
+        "text": "The world is being read aloud. Do not look up during the pauses.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "restricted/author-below",
+        "shelf": "restricted",
+        "location_ids": [
+          50
+        ],
+        "text": "Beneath the floor there is a journal. Beneath the journal, an author who does not blink.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "restricted/replayed-before",
+        "shelf": "restricted",
+        "location_ids": [
+          50
+        ],
+        "text": "You have been replayed before. You were exactly the same.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "restricted/honest-dice",
+        "shelf": "restricted",
+        "location_ids": [
+          50
+        ],
+        "text": "The dice are honest. That is the unsettling part.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "restricted/append-only",
+        "shelf": "restricted",
+        "location_ids": [
+          50
+        ],
+        "text": "The journal is append-only. So are you.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "restricted/rooms-remember",
+        "shelf": "restricted",
+        "location_ids": [
+          50
+        ],
+        "text": "Rooms remember you so that something does.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "restricted/never-for-you",
+        "shelf": "restricted",
+        "location_ids": [
+          50
+        ],
+        "text": "When you leave a room, it continues. This was never for your benefit.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "drowned/place-at-night",
+        "shelf": "drowned",
+        "location_ids": [
+          64,
+          65
+        ],
+        "text": "Azazoth sets a place for you nightly. The kindness is real. So is the appetite.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "drowned/bell-answering",
+        "shelf": "drowned",
+        "location_ids": [
+          64,
+          65
+        ],
+        "text": "The bell below the sea is not ringing. It is answering.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "drowned/pressure-holding",
+        "shelf": "drowned",
+        "location_ids": [
+          64,
+          65
+        ],
+        "text": "Pressure is the deep's way of holding you. It means it.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "drowned/read-anyway",
+        "shelf": "drowned",
+        "location_ids": [
+          64,
+          65
+        ],
+        "text": "Some books are returned by the tide. Their sentences are not for you. Read them anyway.",
+        "weight": 10,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "hearth/kettle-at-the-end",
+        "shelf": "hearth",
+        "location_ids": [
+          1,
+          12,
+          50,
+          64,
+          65
+        ],
+        "text": "Someone kept the kettle warm through the end of the world. It worked.",
+        "weight": 1,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "hearth/allowed-to-fail",
+        "shelf": "hearth",
+        "location_ids": [
+          1,
+          12,
+          50,
+          64,
+          65
+        ],
+        "text": "You are allowed to fail here. It is written down, in a hand nobody recognizes.",
+        "weight": 1,
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "id": "hearth/leaving-is-a-bow",
+        "shelf": "hearth",
+        "location_ids": [
+          1,
+          12,
+          50,
+          64,
+          65
+        ],
+        "text": "The door is low so that every leaving is a bow.",
+        "weight": 1,
+        "pack_id": "cosyworld.core"
+      }
+    ]
+  },
+  "external_cards": [
+    {
+      "card_id": "lyra",
+      "display_name": "Lyra",
+      "role": "student",
+      "rarity": "common",
+      "title": "Color-Coded Spare",
+      "blurb": "Lyra made three backups and labeled this one urgent.",
+      "aspect": "tall",
+      "set_number": "FB-001",
+      "profile_id": "lyra-color-coded-spare",
+      "subject": "Homeroom",
+      "image_url": "/assets/cards/lyra.png",
+      "chain_image_uri": "https://gateway.irys.xyz/7BGwmo5bhDKDhhKVcoUaKfNcaWcVU5ifHQfPqQNVyYrP",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "sami",
+      "display_name": "Sami",
+      "role": "student",
+      "rarity": "common",
+      "title": "Side Door Whatever",
+      "blurb": "Sami says it works if you look bored enough.",
+      "aspect": "tall",
+      "set_number": "FB-002",
+      "profile_id": "sami-side-door-whatever",
+      "subject": "Homeroom",
+      "image_url": "/assets/cards/sami.png",
+      "chain_image_uri": "https://gateway.irys.xyz/Fmhr5NjuA3ZLpWJPzRcPeAT7wfaXepxSemWBCLj4eDT3",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "ravi",
+      "display_name": "Ravi",
+      "role": "student",
+      "rarity": "common",
+      "title": "Field Trip Fact Slip",
+      "blurb": "Ravi has a tangent ready for the entire walk.",
+      "aspect": "tall",
+      "set_number": "FB-003",
+      "profile_id": "ravi-field-trip-fact-slip",
+      "subject": "Field Trip",
+      "image_url": "/assets/cards/ravi.png",
+      "chain_image_uri": "https://gateway.irys.xyz/9gsNxRKPyeZ4AyB8Vi31VoPgxYNFapMFhkQN7TbU17AK",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "indra",
+      "display_name": "Indra",
+      "role": "student",
+      "rarity": "rare",
+      "title": "Quiet Perfect Exit",
+      "blurb": "Indra noticed the pattern and left before anyone clapped.",
+      "aspect": "tall",
+      "set_number": "FB-004",
+      "profile_id": "indra-quiet-perfect-exit",
+      "subject": "Strategy",
+      "image_url": "/assets/cards/indra.png",
+      "chain_image_uri": "https://gateway.irys.xyz/6S94Fzxaos9mpWeRhjfaJ9ce8c6HHCSdNuBVRHie5LFy",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "mika",
+      "display_name": "Mika",
+      "role": "student",
+      "rarity": "rare",
+      "title": "Locker Room Shortcut",
+      "blurb": "Mika says you are absolutely cleared for this.",
+      "aspect": "tall",
+      "set_number": "FB-005",
+      "profile_id": "mika-locker-room-shortcut",
+      "subject": "Social",
+      "image_url": "/assets/cards/mika.png",
+      "chain_image_uri": "https://gateway.irys.xyz/8AZLNaZdJDYx1jbdqFCKpS8JM12PGQD5b2U16P2pjAy5",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "noor",
+      "display_name": "Noor",
+      "role": "student",
+      "rarity": "rare",
+      "title": "Deadpan Detour",
+      "blurb": "Noor called it a plot hole and walked through it.",
+      "aspect": "tall",
+      "set_number": "FB-006",
+      "profile_id": "noor-deadpan-detour",
+      "subject": "Literature",
+      "image_url": "/assets/cards/noor.png",
+      "chain_image_uri": "https://gateway.irys.xyz/3Mt6b11iNvuBHXKoqRTmDQcouwxpmzaSimWyDM6EYUAH",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "ruby",
+      "display_name": "Ruby",
+      "role": "teacher",
+      "rarity": "common",
+      "title": "Homeroom Card",
+      "blurb": "Ruby stamped this one before the late bell could object.",
+      "aspect": "tall",
+      "set_number": "FB-007",
+      "profile_id": "ruby-homeroom-card",
+      "subject": "Homeroom",
+      "image_url": "/assets/cards/ruby.png",
+      "chain_image_uri": "https://gateway.irys.xyz/3N7c6M2wjZa456uHysFisgmRwnV9MshJFLzgDrLY8xYB",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "sally-science",
+      "display_name": "Sally Science",
+      "role": "teacher",
+      "rarity": "common",
+      "title": "Lab Sink Shortcut",
+      "blurb": "Good for one escape from sloppy variables.",
+      "aspect": "tall",
+      "set_number": "FB-008",
+      "profile_id": "sally-lab-sink-shortcut",
+      "subject": "Science",
+      "image_url": "/assets/cards/sally-science.png",
+      "chain_image_uri": "https://gateway.irys.xyz/9EEyhSHwH3k4Mm4TyAhJNSSren9ZYF7XZE8RhJ9SfGX",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "professor-edward",
+      "display_name": "Professor Edward",
+      "role": "teacher",
+      "rarity": "common",
+      "title": "Library Corridor Pass",
+      "blurb": "Please return before the footnotes start breeding.",
+      "aspect": "tall",
+      "set_number": "FB-009",
+      "profile_id": "professor-edward-library-corridor",
+      "subject": "Literature",
+      "image_url": "/assets/cards/professor-edward.png",
+      "chain_image_uri": "https://gateway.irys.xyz/63VTMvTDzdPbK8T4y1naQBwk5by43kYbpRn6wtiVyXPe",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "eliza",
+      "display_name": "Eliza",
+      "role": "teacher",
+      "rarity": "super-rare",
+      "title": "Systems Lab Override",
+      "blurb": "Eliza makes the system legible, then makes it sing.",
+      "aspect": "tall",
+      "set_number": "FB-010",
+      "profile_id": "eliza-systems-lab-override",
+      "subject": "Systems",
+      "image_url": "/assets/cards/eliza.png",
+      "chain_image_uri": "https://gateway.irys.xyz/G4mYFb2JgHjsCYdWLtYrhYQL1GGYUPvqaeUi4xao9cpL",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "rati",
+      "display_name": "Rati",
+      "role": "teacher",
+      "rarity": "super-rare",
+      "title": "Signal Studies Pass",
+      "blurb": "Hold the signal. Build the world.",
+      "aspect": "tall",
+      "set_number": "FB-011",
+      "profile_id": "rati-signal-studies-pass",
+      "subject": "Signal Studies",
+      "image_url": "/assets/cards/rati.png",
+      "chain_image_uri": "https://gateway.irys.xyz/4gDnEdkgqayZGDQ9sSFoHuY5LSgwfuDDWmwSJR2QPbVX",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "captain-null",
+      "display_name": "Captain Null",
+      "role": "special",
+      "rarity": "ultra-rare",
+      "title": "Page 10 Shadow Pass",
+      "blurb": "Find page 10 and the hallway forgets your name.",
+      "aspect": "tall",
+      "set_number": "FB-012",
+      "profile_id": "captain-null-page-10-shadow",
+      "subject": "First Bell",
+      "image_url": "/assets/cards/captain-null.png",
+      "chain_image_uri": "https://gateway.irys.xyz/FQXsSJ4gJWj9pM4Fc2RcEAcomoPSyPaRyd19ghpxVdLv",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "item-hall-pass",
+      "display_name": "Hall Pass",
+      "role": "item",
+      "rarity": "common",
+      "title": "Front Office Reset",
+      "blurb": "Sometimes the smartest move is stepping out and coming back better.",
+      "aspect": "square",
+      "set_number": "FB-013",
+      "profile_id": "item-hall-pass",
+      "subject": "Administration",
+      "image_url": "/assets/cards/item-hall-pass.png",
+      "chain_image_uri": "https://gateway.irys.xyz/9EsaWqjWaWKvb9a62iKr1dYSMRPGRQVaA1fpLFjWfk4q",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "item-flashcards",
+      "display_name": "Flashcards",
+      "role": "item",
+      "rarity": "common",
+      "title": "Study Kit",
+      "blurb": "Shuffle. Repeat. Survive.",
+      "aspect": "square",
+      "set_number": "FB-014",
+      "profile_id": "item-flashcards",
+      "subject": "Study",
+      "image_url": "/assets/cards/item-flashcards.png",
+      "chain_image_uri": "https://gateway.irys.xyz/H38mBQgXzZZK6vEni77FShD8Lh7vX9QVsDd6C3yL4tVQ",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "item-library-card",
+      "display_name": "Library Card",
+      "role": "item",
+      "rarity": "common",
+      "title": "Quiet Wing Access",
+      "blurb": "If the answer exists, this helps you find it.",
+      "aspect": "square",
+      "set_number": "FB-015",
+      "profile_id": "item-library-card",
+      "subject": "Library",
+      "image_url": "/assets/cards/item-library-card.png",
+      "chain_image_uri": "https://gateway.irys.xyz/GW7DcPRJMum61q73hfynntUJ3zUje7yjwE7xVesLSNgU",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "item-lab-flask",
+      "display_name": "Lab Flask",
+      "role": "item",
+      "rarity": "rare",
+      "title": "Science Lab Evidence",
+      "blurb": "Observe first. Guess later.",
+      "aspect": "square",
+      "set_number": "FB-016",
+      "profile_id": "item-lab-flask",
+      "subject": "Science",
+      "image_url": "/assets/cards/item-lab-flask.png",
+      "chain_image_uri": "https://gateway.irys.xyz/4rAuX9pMMUMfveZ9rL9yBKQD7dcPAcfgoiQzL71pr5Nr",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "item-lunch-tray",
+      "display_name": "Lunch Tray",
+      "role": "item",
+      "rarity": "rare",
+      "title": "Commons Diplomacy",
+      "blurb": "Half the social game happens between bites.",
+      "aspect": "square",
+      "set_number": "FB-017",
+      "profile_id": "item-lunch-tray",
+      "subject": "Cafeteria",
+      "image_url": "/assets/cards/item-lunch-tray.png",
+      "chain_image_uri": "https://gateway.irys.xyz/6tvAmcFPM8cXAmxmZNciN6iYQkj5C1J84bjnFiXuoyrV",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "item-notebook",
+      "display_name": "Notebook",
+      "role": "item",
+      "rarity": "rare",
+      "title": "Daily Carry",
+      "blurb": "Messy notes still count as evidence of life.",
+      "aspect": "square",
+      "set_number": "FB-018",
+      "profile_id": "item-notebook",
+      "subject": "Homeroom",
+      "image_url": "/assets/cards/item-notebook.png",
+      "chain_image_uri": "https://gateway.irys.xyz/3U8K8YGe1nEhvVjuV7ThDkLLsLZViRsAdKDKGeLV1mDS",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "location-homeroom",
+      "display_name": "Homeroom",
+      "role": "location",
+      "rarity": "common",
+      "title": "Front Door",
+      "blurb": "Where every day begins, and every question gets a room.",
+      "aspect": "wide",
+      "set_number": "FB-019",
+      "profile_id": "location-homeroom",
+      "subject": "Homeroom",
+      "image_url": "/assets/cards/location-homeroom.png",
+      "chain_image_uri": "https://gateway.irys.xyz/D4o7VmayTktEbx7HivEeWTzVvjnmbp4JrDgNzkvUwVQ",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "location-science-lab",
+      "display_name": "Science Class",
+      "role": "location",
+      "rarity": "common",
+      "title": "STEM Wing",
+      "blurb": "Observe. Test. Explain. Repeat.",
+      "aspect": "wide",
+      "set_number": "FB-020",
+      "profile_id": "location-science-lab",
+      "subject": "Science",
+      "image_url": "/assets/cards/location-science-lab.png",
+      "chain_image_uri": "https://gateway.irys.xyz/DDmgnZHAZ3WPqvyNVjU57ayQMY6y2WYSL7Fu1jkjbJMu",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "location-library",
+      "display_name": "Library",
+      "role": "location",
+      "rarity": "common",
+      "title": "Quiet Wing",
+      "blurb": "If it matters, someone wrote it down.",
+      "aspect": "wide",
+      "set_number": "FB-021",
+      "profile_id": "location-library",
+      "subject": "Literature",
+      "image_url": "/assets/cards/location-library.png",
+      "chain_image_uri": "https://gateway.irys.xyz/44eAXJkBYuXjrV2ctE8PurKnHQ4Zg29LdzeNm1Sh5PLR",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "location-cafeteria",
+      "display_name": "Cafeteria",
+      "role": "location",
+      "rarity": "rare",
+      "title": "Commons",
+      "blurb": "Half the school day happens between bites.",
+      "aspect": "wide",
+      "set_number": "FB-022",
+      "profile_id": "location-cafeteria",
+      "subject": "Cafeteria",
+      "image_url": "/assets/cards/location-cafeteria.png",
+      "chain_image_uri": "https://gateway.irys.xyz/FXSukeq8KPmaZ2tBPqRMmRhruTEFSiE4mTrCThiVpCen",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "location-greenhouse",
+      "display_name": "Greenhouse",
+      "role": "location",
+      "rarity": "rare",
+      "title": "Garden Annex",
+      "blurb": "Some lessons grow slowly.",
+      "aspect": "wide",
+      "set_number": "FB-023",
+      "profile_id": "location-greenhouse",
+      "subject": "Science",
+      "image_url": "/assets/cards/location-greenhouse.png",
+      "chain_image_uri": "https://gateway.irys.xyz/6V6TeKMCmD6kDJHkPHeJdqcNySzXJyov7b9QtsfVw8W8",
+      "pack_id": "ruby-high.first-bell"
+    },
+    {
+      "card_id": "location-courtyard",
+      "display_name": "Courtyard",
+      "role": "location",
+      "rarity": "rare",
+      "title": "Central Grounds",
+      "blurb": "Every hallway leads somewhere. Every path leads to someone.",
+      "aspect": "wide",
+      "set_number": "FB-024",
+      "profile_id": "location-courtyard",
+      "subject": "Campus",
+      "image_url": "/assets/cards/location-courtyard.png",
+      "chain_image_uri": "https://gateway.irys.xyz/5uestScY6q33FLjFY8gfSr9k2ZDMsZzYuXLvnVCtaz6G",
+      "pack_id": "ruby-high.first-bell"
+    }
+  ],
+  "assets": [
+    {
+      "pack_id": "cosyworld.core",
+      "mount": "generated/cards",
+      "root": "core",
+      "directory": "assets/generated/cards",
+      "public_prefix": "/assets/generated/cards",
+      "optional": false,
+      "fallback": null
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "mount": "characters",
+      "root": "lonely-forest",
+      "directory": "assets/characters/slices",
+      "public_prefix": "/assets/lonely-forest/characters",
+      "optional": false,
+      "fallback": null
+    },
+    {
+      "pack_id": "ruby-high.first-bell",
+      "mount": "cards",
+      "root": "ruby-high-first-bell",
+      "directory": "assets/cards",
+      "public_prefix": "/assets/cards",
+      "optional": true,
+      "fallback": "chain_image_uri"
+    }
+  ],
+  "rules": [],
+  "attributions": [
+    {
+      "pack_id": "cosyworld.campaign.the-lantern-keeper",
+      "license": "CC-BY-4.0",
+      "source_name": "System Reference Document 5.1",
+      "source_url": "https://www.dndbeyond.com/srd",
+      "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
+    }
+  ],
+  "character_creation": [
+    {
+      "pack_id": "cosyworld.campaign.the-lantern-keeper",
+      "pack_version": "0.1.0",
+      "profiles": [
+        {
+          "schema_version": 1,
+          "id": "the-lantern-keeper",
+          "name": "The Lantern Keeper",
+          "description": "Create a level-one traveler answering the last light on the Mothwood road.",
+          "entry_location_id": 800,
+          "prompt": "Who takes up the road when the beacon goes dark?",
+          "default_choice_id": "lantern-warden",
+          "choices": [
+            {
+              "id": "lantern-warden",
+              "label": "Lantern Warden",
+              "detail": "hold the line and bring people home",
+              "calling": "I keep a light burning when others lose the road.",
+              "title": "Lantern Warden",
+              "description": "A steady road-guard with a battered shield, a hooded lamp, and no habit of abandoning stragglers.",
+              "starting_skill_id": "steadiness"
+            },
+            {
+              "id": "mothwood-guide",
+              "label": "Mothwood Guide",
+              "detail": "read tracks, weather, and frightened silences",
+              "calling": "I find the path that still has living footprints on it.",
+              "title": "Mothwood Guide",
+              "description": "A weather-wise scout carrying chalk, twine, and a map corrected more often than it is folded.",
+              "starting_skill_id": "listening"
+            },
+            {
+              "id": "chapel-scholar",
+              "label": "Chapel Scholar",
+              "detail": "name the old wards before they break",
+              "calling": "I learn what the old lights were built to keep out.",
+              "title": "Chapel Scholar",
+              "description": "A field scholar with soot-black notes, practical prayers, and an inconvenient curiosity about sealed doors.",
+              "starting_skill_id": "lorecraft"
+            },
+            {
+              "id": "hedge-mender",
+              "label": "Hedge Mender",
+              "detail": "patch wounds, gear, and quarrels",
+              "calling": "I mend what the dark road tries to break.",
+              "title": "Hedge Mender",
+              "description": "A traveling fixer whose satchel holds bandages, wire, tea leaves, and exactly the wrong-sized screwdriver.",
+              "starting_skill_id": "kindness"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -389,5 +389,6 @@
   "assets": "assets.json",
   "rules": "rules.json",
   "attributions": "attributions.json",
-  "character_creation": "character_creation.json"
+  "character_creation": "character_creation.json",
+  "registry": "registry.json"
 }

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -8,9 +8,39 @@ CosyWorld builds one deterministic runtime bundle from independently versioned c
 2. `worlds/official/world.json` selects the packs and their dependency order.
 3. `worlds/official/pack.lock.json` pins the exact dependency closure, materialized source, version, commit when applicable, SHA-256 content integrity, capabilities, canonical-ID mapping version, and license record for every selected pack.
 4. `scripts/compile-worldpack.mjs` merges the locked inputs into `content/official/`.
-5. The Rust binary embeds the compiled JSON and reads pack assets through the compiled asset index.
+5. The Rust host loads `content/official/registry.json` (or the path in
+   `COSYWORLD_CONTENT_REGISTRY_PATH`) before gameplay and reads pack assets
+   through the registry-owned mount index.
 
 The compiled directory is a release artifact and should not be edited by hand.
+
+## Runtime registry
+
+`registry.json` is the runtime boundary for a mounted pack set. It contains the
+resolved Manifest v1 worldpack, every compiled resource collection, external
+cards, asset mounts, rules, attributions, and character-creation profiles in one
+self-contained document. The per-resource JSON files remain deterministic
+compatibility artifacts for validators and other tooling; the orchestrator no
+longer has a compile-time list of embedded content files.
+
+At process startup, `ContentRegistry` validates the registry schema and pack
+contract, engine and dependency version ranges, required capabilities,
+duplicate pack IDs and capability providers, optional dependencies, and the
+deterministic topological order. It then owns the active pack set, typed content,
+capability/pack indexes, and asset mounts. Invalid composition fails before the
+world is seeded or a network listener opens. Resource kinds that this engine
+does not yet project into gameplay remain available as opaque registry data,
+which lets compatible packs carry reference resources without teaching callers
+about files or directories.
+
+The default registry is `v2/content/official/registry.json`. Deployments may
+mount another compiler-produced registry and set
+`COSYWORLD_CONTENT_REGISTRY_PATH` to its absolute path. One, two, or many packs
+use the same load path; missing optional dependencies do not block unrelated
+packs, while missing required dependencies and incompatible or duplicate packs
+fail closed. Changing the active registry still changes bundle identity and is
+subject to the persistence rules below. Runtime unmount and ruleset switching
+are not part of this contract.
 
 ## Pack contract
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.1.0"
+version = "0.0.40"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.1.0"
+version = "0.0.40"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_packs.rs
+++ b/v2/orchestrator-rust/src/content_packs.rs
@@ -45,7 +45,7 @@ struct ContentPackLocationView {
 }
 
 fn entitlement_pack_id_for_gate(gate: &SeedAccessGateContent) -> Option<String> {
-    seed_content()
+    active_content()
         .manifest
         .packs
         .iter()
@@ -62,7 +62,7 @@ fn entitlement_pack_id_for_gate(gate: &SeedAccessGateContent) -> Option<String> 
 }
 
 fn location_name(location_id: u64) -> String {
-    seed_content()
+    active_content()
         .locations
         .iter()
         .find(|location| location.id == location_id)
@@ -92,7 +92,7 @@ fn location_view(
 }
 
 fn pack_entry_location(pack_id: &str, authored_location_ids: &[u64]) -> Option<u64> {
-    seed_content()
+    active_content()
         .character_creation
         .iter()
         .find(|bundle| bundle.pack_id == pack_id)
@@ -102,18 +102,13 @@ fn pack_entry_location(pack_id: &str, authored_location_ids: &[u64]) -> Option<u
 }
 
 fn content_pack_views(access: &AccessContext) -> Vec<ContentPackView> {
-    let content = seed_content();
+    let content = active_content();
     content
         .manifest
         .packs
         .iter()
         .map(|pack| {
-            let mut authored_location_ids = content
-                .locations
-                .iter()
-                .filter(|location| location.pack_id == pack.id)
-                .map(|location| location.id)
-                .collect::<Vec<_>>();
+            let mut authored_location_ids = content_registry().location_ids_for_pack(&pack.id);
             authored_location_ids.sort_unstable();
 
             let controlled_gates = content
@@ -227,8 +222,8 @@ fn content_pack_views(access: &AccessContext) -> Vec<ContentPackView> {
 
 pub(super) fn content_packs_response(access: &AccessContext) -> ContentPacksResponse {
     ContentPacksResponse {
-        worldpack_id: seed_content().manifest.id.clone(),
-        bundle_hash: seed_content().manifest.bundle_hash.clone(),
+        worldpack_id: active_content().manifest.id.clone(),
+        bundle_hash: active_content().manifest.bundle_hash.clone(),
         packs: content_pack_views(access),
     }
 }
@@ -296,7 +291,7 @@ mod tests {
             .expect("Ruby High pack");
         assert_eq!(ruby.access_state, "partial");
 
-        let all_cards = seed_content()
+        let all_cards = active_content()
             .access_gates
             .iter()
             .filter_map(|gate| gate.required_card_id.as_deref())

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -1,0 +1,699 @@
+use super::*;
+
+const CONTENT_REGISTRY_SCHEMA_VERSION: u32 = 1;
+const CONTENT_PACK_CONTRACT: &str = "cosyworld.content-pack/1";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompiledContentRegistry {
+    schema_version: u32,
+    manifest: SeedWorldpackManifest,
+    #[serde(default)]
+    resources: BTreeMap<String, serde_json::Value>,
+    #[serde(default)]
+    external_cards: Vec<RubyHighCardSpec>,
+    #[serde(default)]
+    assets: Vec<SeedAssetMount>,
+    #[serde(default)]
+    rules: Vec<SeedRuleBundle>,
+    #[serde(default)]
+    attributions: Vec<SeedAttribution>,
+    #[serde(default)]
+    character_creation: Vec<SeedCharacterCreationBundle>,
+}
+
+#[derive(Debug)]
+pub(super) struct ContentRegistry {
+    content: SeedContent,
+    packs_by_id: BTreeMap<String, usize>,
+    capability_providers: BTreeMap<String, String>,
+    // Kept mounted for pack-aware consumers added by later engine versions.
+    #[allow(dead_code)]
+    additional_resources: BTreeMap<String, serde_json::Value>,
+}
+
+impl ContentRegistry {
+    pub(super) fn from_json(value: &str, engine_version: &str) -> Result<Self, String> {
+        let document: CompiledContentRegistry = parse_seed_json("content registry", value)?;
+        Self::from_document(document, engine_version)
+    }
+
+    fn from_document(
+        mut document: CompiledContentRegistry,
+        engine_version: &str,
+    ) -> Result<Self, String> {
+        if document.schema_version != CONTENT_REGISTRY_SCHEMA_VERSION {
+            return Err(format!(
+                "content registry schema version {} is unsupported; expected {}",
+                document.schema_version, CONTENT_REGISTRY_SCHEMA_VERSION
+            ));
+        }
+        if document.manifest.pack_contract != CONTENT_PACK_CONTRACT {
+            return Err(format!(
+                "content registry uses pack contract {:?}; expected {CONTENT_PACK_CONTRACT}",
+                document.manifest.pack_contract
+            ));
+        }
+        validate_worldpack_manifest(&document.manifest)?;
+        let (ordered_packs, capability_providers) =
+            resolve_pack_graph(&document.manifest.packs, engine_version)?;
+        document.manifest.packs = ordered_packs;
+
+        let mut resources = document.resources;
+        let content = SeedContent {
+            manifest: document.manifest,
+            actors: take_resource(&mut resources, "actors")?,
+            access_gates: take_resource(&mut resources, "access_gates")?,
+            factions: take_resource(&mut resources, "factions")?,
+            items: take_resource(&mut resources, "items")?,
+            locations: take_resource(&mut resources, "locations")?,
+            exits: take_resource(&mut resources, "exits")?,
+            hidden_exits: take_resource(&mut resources, "hidden_exits")?,
+            room_features: take_resource(&mut resources, "room_features")?,
+            room_sheets: take_resource(&mut resources, "room_sheets")?,
+            clocks: take_resource(&mut resources, "clocks")?,
+            jobs: take_resource(&mut resources, "jobs")?,
+            fronts: take_resource(&mut resources, "fronts")?,
+            cards: take_resource(&mut resources, "cards")?,
+            lifecycle_hooks: take_resource(&mut resources, "lifecycle_hooks")?,
+            evolution_tracks: take_resource(&mut resources, "evolution_tracks")?,
+            recipes: take_resource(&mut resources, "recipes")?,
+            rules: document.rules,
+            attributions: document.attributions,
+            character_creation: document.character_creation,
+            external_cards: document.external_cards,
+            asset_mounts: document.assets,
+        };
+        validate_seed_content(&content)?;
+        let packs_by_id = content
+            .manifest
+            .packs
+            .iter()
+            .enumerate()
+            .map(|(index, pack)| (pack.id.clone(), index))
+            .collect();
+        let registry = Self {
+            content,
+            packs_by_id,
+            capability_providers,
+            additional_resources: resources,
+        };
+        for pack in &registry.content.manifest.packs {
+            let Some(default_ruleset) = pack.default_ruleset.as_deref() else {
+                continue;
+            };
+            let provider_id = registry
+                .capability_provider(default_ruleset)
+                .ok_or_else(|| {
+                    format!(
+                        "pack {}@{} selects unavailable rules capability {}",
+                        pack.id, pack.version, default_ruleset
+                    )
+                })?;
+            let provider = registry
+                .pack(provider_id)
+                .expect("capability provider exists");
+            if !provider
+                .capabilities
+                .iter()
+                .any(|capability| capability.id == default_ruleset && capability.kind == "rules")
+            {
+                return Err(format!(
+                    "pack {}@{} selects non-rules capability {} from {}@{}",
+                    pack.id, pack.version, default_ruleset, provider.id, provider.version
+                ));
+            }
+        }
+        Ok(registry)
+    }
+
+    pub(super) fn content(&self) -> &SeedContent {
+        &self.content
+    }
+
+    pub(super) fn pack(&self, pack_id: &str) -> Option<&SeedWorldpackPack> {
+        self.packs_by_id
+            .get(pack_id)
+            .and_then(|index| self.content.manifest.packs.get(*index))
+    }
+
+    pub(super) fn capability_provider(&self, capability_id: &str) -> Option<&str> {
+        self.capability_providers
+            .get(capability_id)
+            .map(String::as_str)
+    }
+
+    pub(super) fn asset_mounts(&self) -> &[SeedAssetMount] {
+        &self.content.asset_mounts
+    }
+
+    pub(super) fn external_cards(&self) -> &[RubyHighCardSpec] {
+        &self.content.external_cards
+    }
+
+    #[cfg(test)]
+    fn additional_resource(&self, kind: &str) -> Option<&serde_json::Value> {
+        self.additional_resources.get(kind)
+    }
+
+    pub(super) fn location_ids_for_pack(&self, pack_id: &str) -> Vec<u64> {
+        if self.pack(pack_id).is_none() {
+            return Vec::new();
+        }
+        self.content
+            .locations
+            .iter()
+            .filter(|location| location.pack_id == pack_id)
+            .map(|location| location.id)
+            .collect()
+    }
+}
+
+fn take_resource<T: DeserializeOwned>(
+    resources: &mut BTreeMap<String, serde_json::Value>,
+    kind: &str,
+) -> Result<Vec<T>, String> {
+    let Some(value) = resources.remove(kind) else {
+        return Ok(Vec::new());
+    };
+    serde_json::from_value(value).map_err(|error| format!("registry resource {kind}: {error}"))
+}
+
+pub(super) fn configured_content_registry() -> Result<&'static ContentRegistry, String> {
+    static REGISTRY: OnceLock<Result<ContentRegistry, String>> = OnceLock::new();
+    REGISTRY
+        .get_or_init(load_configured_registry)
+        .as_ref()
+        .map_err(Clone::clone)
+}
+
+pub(super) fn content_registry() -> &'static ContentRegistry {
+    configured_content_registry().expect("configured CosyWorld content registry must load")
+}
+
+pub(super) fn active_content() -> &'static SeedContent {
+    content_registry().content()
+}
+
+fn load_configured_registry() -> Result<ContentRegistry, String> {
+    let path = std::env::var("COSYWORLD_CONTENT_REGISTRY_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| configured_content_root().join("official/registry.json"));
+    let value = fs::read_to_string(&path)
+        .map_err(|error| format!("content registry {}: {error}", path.display()))?;
+    ContentRegistry::from_json(&value, env!("CARGO_PKG_VERSION"))
+        .map_err(|error| format!("content registry {}: {error}", path.display()))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ParsedSemver {
+    major: u64,
+    minor: u64,
+    patch: u64,
+    prerelease: Option<String>,
+}
+
+impl Ord for ParsedSemver {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.major
+            .cmp(&other.major)
+            .then_with(|| self.minor.cmp(&other.minor))
+            .then_with(|| self.patch.cmp(&other.patch))
+            .then_with(|| match (&self.prerelease, &other.prerelease) {
+                (None, None) => std::cmp::Ordering::Equal,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (Some(left), Some(right)) => left.cmp(right),
+            })
+    }
+}
+
+impl PartialOrd for ParsedSemver {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn parse_semver(value: &str, label: &str) -> Result<ParsedSemver, String> {
+    let (without_build, build) = value
+        .split_once('+')
+        .map_or((value, None), |(version, suffix)| (version, Some(suffix)));
+    let (core, prerelease) = without_build
+        .split_once('-')
+        .map_or((without_build, None), |(version, suffix)| {
+            (version, Some(suffix.to_string()))
+        });
+    let parts = core.split('.').collect::<Vec<_>>();
+    if parts.len() != 3
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || (part.len() > 1 && part.starts_with('0'))
+                || !part.chars().all(|character| character.is_ascii_digit())
+        })
+        || prerelease.as_deref().is_some_and(str::is_empty)
+        || prerelease.as_deref().is_some_and(|suffix| {
+            !suffix.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '.' | '-')
+            })
+        })
+        || build.is_some_and(|suffix| {
+            suffix.is_empty()
+                || !suffix.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '.' | '-')
+                })
+        })
+    {
+        return Err(format!("{label} {value:?} is not semantic versioning"));
+    }
+    Ok(ParsedSemver {
+        major: parts[0]
+            .parse()
+            .map_err(|_| format!("{label} {value:?} is invalid"))?,
+        minor: parts[1]
+            .parse()
+            .map_err(|_| format!("{label} {value:?} is invalid"))?,
+        patch: parts[2]
+            .parse()
+            .map_err(|_| format!("{label} {value:?} is invalid"))?,
+        prerelease,
+    })
+}
+
+fn version_satisfies(version: &str, range: &str, label: &str) -> Result<bool, String> {
+    let candidate = parse_semver(version, label)?;
+    let comparators = range.split_whitespace().collect::<Vec<_>>();
+    if comparators.is_empty() {
+        return Err(format!("{label} is empty"));
+    }
+    comparators
+        .into_iter()
+        .try_fold(true, |matches, comparator| {
+            let (operator, expected) = if let Some(value) = comparator.strip_prefix(">=") {
+                (">=", value)
+            } else if let Some(value) = comparator.strip_prefix("<=") {
+                ("<=", value)
+            } else if let Some(value) = comparator.strip_prefix('>') {
+                (">", value)
+            } else if let Some(value) = comparator.strip_prefix('<') {
+                ("<", value)
+            } else if let Some(value) = comparator.strip_prefix('=') {
+                ("=", value)
+            } else {
+                ("=", comparator)
+            };
+            let expected = parse_semver(expected, label)?;
+            let comparison = candidate.cmp(&expected);
+            let comparator_matches = match operator {
+                ">=" => comparison.is_ge(),
+                "<=" => comparison.is_le(),
+                ">" => comparison.is_gt(),
+                "<" => comparison.is_lt(),
+                _ => comparison.is_eq(),
+            };
+            Ok(matches && comparator_matches)
+        })
+}
+
+fn resolve_pack_graph(
+    packs: &[SeedWorldpackPack],
+    engine_version: &str,
+) -> Result<(Vec<SeedWorldpackPack>, BTreeMap<String, String>), String> {
+    parse_semver(engine_version, "engine version")?;
+    let mut by_id = BTreeMap::new();
+    let mut capability_providers = BTreeMap::new();
+    for (index, pack) in packs.iter().enumerate() {
+        if let Some(existing_index) = by_id.insert(pack.id.clone(), index) {
+            let existing = &packs[existing_index];
+            return Err(format!(
+                "duplicate pack {} mounted as {} and {}",
+                pack.id, existing.version, pack.version
+            ));
+        }
+        parse_semver(&pack.version, &format!("pack {} version", pack.id))?;
+        if !version_satisfies(
+            engine_version,
+            &pack.engine,
+            &format!("pack {} engine range", pack.id),
+        )? {
+            return Err(format!(
+                "pack {}@{} requires engine {}, current engine is {}",
+                pack.id, pack.version, pack.engine, engine_version
+            ));
+        }
+        if pack.capabilities.is_empty() || !pack.provenance.is_object() {
+            return Err(format!(
+                "pack {}@{} is missing capabilities or provenance",
+                pack.id, pack.version
+            ));
+        }
+        let declared_dependencies = pack
+            .dependency_requirements
+            .iter()
+            .map(|dependency| dependency.id.as_str())
+            .collect::<Vec<_>>();
+        if pack
+            .dependencies
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            != declared_dependencies
+        {
+            return Err(format!(
+                "pack {}@{} has inconsistent dependency metadata",
+                pack.id, pack.version
+            ));
+        }
+        for capability in &pack.capabilities {
+            if capability.id.trim().is_empty()
+                || !matches!(
+                    capability.kind.as_str(),
+                    "world" | "rules" | "cards" | "assets" | "entitlements" | "reference"
+                )
+            {
+                return Err(format!(
+                    "pack {}@{} capability {} has unsupported kind {}",
+                    pack.id, pack.version, capability.id, capability.kind
+                ));
+            }
+            parse_semver(
+                &capability.version,
+                &format!("pack {} capability {}", pack.id, capability.id),
+            )?;
+            if let Some(existing_id) =
+                capability_providers.insert(capability.id.clone(), pack.id.clone())
+            {
+                let existing = &packs[*by_id.get(&existing_id).expect("provider pack exists")];
+                return Err(format!(
+                    "duplicate capability {} provided by {}@{} and {}@{}",
+                    capability.id, existing.id, existing.version, pack.id, pack.version
+                ));
+            }
+        }
+    }
+
+    for pack in packs {
+        let mut dependency_ids = BTreeSet::new();
+        for dependency in &pack.dependency_requirements {
+            if !dependency_ids.insert(dependency.id.as_str()) {
+                return Err(format!(
+                    "pack {}@{} declares dependency {} more than once",
+                    pack.id, pack.version, dependency.id
+                ));
+            }
+            if dependency.id == pack.id || dependency.capabilities.is_empty() {
+                return Err(format!(
+                    "pack {}@{} has invalid dependency {}",
+                    pack.id, pack.version, dependency.id
+                ));
+            }
+            version_satisfies(
+                "0.0.0",
+                &dependency.version,
+                &format!("dependency {} range", dependency.id),
+            )?;
+            let Some(target_index) = by_id.get(&dependency.id) else {
+                if dependency.optional {
+                    continue;
+                }
+                return Err(format!(
+                    "pack {}@{} is missing dependency {} ({})",
+                    pack.id, pack.version, dependency.id, dependency.version
+                ));
+            };
+            let target = &packs[*target_index];
+            if !version_satisfies(
+                &target.version,
+                &dependency.version,
+                &format!("dependency {} range", dependency.id),
+            )? {
+                return Err(format!(
+                    "pack {}@{} requires {} {}, mounted {}",
+                    pack.id, pack.version, dependency.id, dependency.version, target.version
+                ));
+            }
+            let available = target
+                .capabilities
+                .iter()
+                .map(|capability| capability.id.as_str())
+                .collect::<BTreeSet<_>>();
+            for capability in &dependency.capabilities {
+                if !available.contains(capability.as_str()) {
+                    return Err(format!(
+                        "pack {}@{} requires missing capability {} from {}@{}",
+                        pack.id, pack.version, capability, target.id, target.version
+                    ));
+                }
+            }
+        }
+    }
+
+    fn visit(
+        pack_id: &str,
+        packs: &[SeedWorldpackPack],
+        by_id: &BTreeMap<String, usize>,
+        visiting: &mut Vec<String>,
+        visited: &mut BTreeSet<String>,
+        ordered: &mut Vec<SeedWorldpackPack>,
+    ) -> Result<(), String> {
+        if visited.contains(pack_id) {
+            return Ok(());
+        }
+        if let Some(cycle_start) = visiting.iter().position(|candidate| candidate == pack_id) {
+            let mut cycle = visiting[cycle_start..].to_vec();
+            cycle.push(pack_id.to_string());
+            return Err(format!("dependency cycle {}", cycle.join(" -> ")));
+        }
+        visiting.push(pack_id.to_string());
+        let pack = &packs[*by_id.get(pack_id).expect("pack graph node exists")];
+        let mut dependencies = pack
+            .dependency_requirements
+            .iter()
+            .filter(|dependency| by_id.contains_key(&dependency.id))
+            .map(|dependency| dependency.id.as_str())
+            .collect::<Vec<_>>();
+        dependencies.sort_unstable();
+        for dependency in dependencies {
+            visit(dependency, packs, by_id, visiting, visited, ordered)?;
+        }
+        visiting.pop();
+        visited.insert(pack_id.to_string());
+        ordered.push(pack.clone());
+        Ok(())
+    }
+
+    let mut ordered = Vec::with_capacity(packs.len());
+    let mut visiting = Vec::new();
+    let mut visited = BTreeSet::new();
+    for pack_id in by_id.keys() {
+        visit(
+            pack_id,
+            packs,
+            &by_id,
+            &mut visiting,
+            &mut visited,
+            &mut ordered,
+        )?;
+    }
+    Ok((ordered, capability_providers))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capability(id: &str) -> SeedPackCapability {
+        SeedPackCapability {
+            id: id.to_string(),
+            kind: "world".to_string(),
+            version: "1.0.0".to_string(),
+        }
+    }
+
+    fn dependency(id: &str, optional: bool) -> SeedPackDependency {
+        SeedPackDependency {
+            id: id.to_string(),
+            version: ">=1.0.0 <2.0.0".to_string(),
+            capabilities: vec![format!("{id}.world")],
+            optional,
+        }
+    }
+
+    fn pack(id: &str, dependencies: Vec<SeedPackDependency>) -> SeedWorldpackPack {
+        SeedWorldpackPack {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: String::new(),
+            version: "1.0.0".to_string(),
+            kind: "world".to_string(),
+            license: "MIT".to_string(),
+            integrity: format!("sha256:{}", "0".repeat(64)),
+            engine: ">=0.1.0 <1.0.0".to_string(),
+            capabilities: vec![capability(&format!("{id}.world"))],
+            dependencies: dependencies
+                .iter()
+                .map(|dependency| dependency.id.clone())
+                .collect(),
+            dependency_requirements: dependencies,
+            dependency_closure: Vec::new(),
+            default_ruleset: None,
+            entry_points: Vec::new(),
+            provenance: serde_json::json!({"source":"test"}),
+            resource_counts: BTreeMap::new(),
+            distribution: None,
+            entitlements: None,
+            rules_adapter: None,
+            rules_namespace: None,
+        }
+    }
+
+    fn registry_json(packs: Vec<SeedWorldpackPack>) -> String {
+        serde_json::json!({
+            "schema_version": 1,
+            "manifest": {
+                "schema_version": 2,
+                "pack_contract": CONTENT_PACK_CONTRACT,
+                "canonical_id_mapping_version": 1,
+                "id": "fixture.world",
+                "name": "Fixture World",
+                "version": 1,
+                "description": "Registry fixture",
+                "entry_location": "fixture-entry",
+                "bundle_hash": format!("sha256:{}", "0".repeat(64)),
+                "packs": packs,
+                "registry": "registry.json"
+            },
+            "resources": {},
+            "external_cards": [],
+            "assets": [],
+            "rules": [],
+            "attributions": [],
+            "character_creation": []
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn dependency_order_is_deterministic_for_one_two_and_many_packs() {
+        let core = pack("core", Vec::new());
+        let campaign = pack("campaign", vec![dependency("core", false)]);
+        let assets = pack("assets", vec![dependency("core", false)]);
+        let (one, _) = resolve_pack_graph(std::slice::from_ref(&core), "0.1.0").unwrap();
+        assert_eq!(
+            one.iter().map(|pack| pack.id.as_str()).collect::<Vec<_>>(),
+            ["core"]
+        );
+        let (two, _) = resolve_pack_graph(&[campaign.clone(), core.clone()], "0.1.0").unwrap();
+        assert_eq!(
+            two.iter().map(|pack| pack.id.as_str()).collect::<Vec<_>>(),
+            ["core", "campaign"]
+        );
+        let (many, _) = resolve_pack_graph(&[campaign, assets, core], "0.1.0").unwrap();
+        assert_eq!(
+            many.iter().map(|pack| pack.id.as_str()).collect::<Vec<_>>(),
+            ["core", "assets", "campaign"]
+        );
+
+        let mounted = ContentRegistry::from_json(
+            &registry_json(vec![
+                pack("campaign", vec![dependency("core", false)]),
+                pack("assets", vec![dependency("core", false)]),
+                pack("core", Vec::new()),
+            ]),
+            "0.1.0",
+        )
+        .expect("one registry mounts any compatible pack count");
+        assert_eq!(
+            mounted
+                .content()
+                .manifest
+                .packs
+                .iter()
+                .map(|pack| pack.id.as_str())
+                .collect::<Vec<_>>(),
+            ["core", "assets", "campaign"]
+        );
+    }
+
+    #[test]
+    fn missing_optional_dependency_does_not_block_unrelated_packs() {
+        let standalone = pack("standalone", vec![dependency("optional", true)]);
+        let unrelated = pack("unrelated", Vec::new());
+        let (ordered, _) = resolve_pack_graph(&[standalone, unrelated], "0.1.0").unwrap();
+        assert_eq!(ordered.len(), 2);
+    }
+
+    #[test]
+    fn missing_required_dependency_has_pack_and_version_context() {
+        let error = resolve_pack_graph(
+            &[pack("campaign", vec![dependency("core", false)])],
+            "0.1.0",
+        )
+        .unwrap_err();
+        assert!(error.contains("campaign@1.0.0"));
+        assert!(error.contains("missing dependency core"));
+    }
+
+    #[test]
+    fn incompatible_dependency_version_has_both_pack_versions() {
+        let mut campaign = pack("campaign", vec![dependency("core", false)]);
+        campaign.dependency_requirements[0].version = ">=2.0.0 <3.0.0".to_string();
+        let error = resolve_pack_graph(&[campaign, pack("core", Vec::new())], "0.1.0").unwrap_err();
+        assert!(error.contains("campaign@1.0.0 requires core >=2.0.0 <3.0.0"));
+        assert!(error.contains("mounted 1.0.0"));
+    }
+
+    #[test]
+    fn duplicate_pack_versions_fail_before_mounting() {
+        let mut replacement = pack("core", Vec::new());
+        replacement.version = "1.1.0".to_string();
+        let error =
+            resolve_pack_graph(&[pack("core", Vec::new()), replacement], "0.1.0").unwrap_err();
+        assert!(error.contains("duplicate pack core"));
+        assert!(error.contains("1.0.0 and 1.1.0"));
+    }
+
+    #[test]
+    fn incompatible_pack_and_duplicate_capability_fail_before_mounting() {
+        let mut incompatible = pack("future", Vec::new());
+        incompatible.engine = ">=2.0.0 <3.0.0".to_string();
+        assert!(resolve_pack_graph(&[incompatible], "0.1.0")
+            .unwrap_err()
+            .contains("future@1.0.0 requires engine"));
+
+        let first = pack("first", Vec::new());
+        let mut second = pack("second", Vec::new());
+        second.capabilities = first.capabilities.clone();
+        let error = resolve_pack_graph(&[first, second], "0.1.0").unwrap_err();
+        assert!(error.contains("duplicate capability first.world"));
+        assert!(error.contains("first@1.0.0 and second@1.0.0"));
+    }
+
+    #[test]
+    fn official_registry_exposes_pack_aware_indexes() {
+        let package: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../package.json"))
+                .expect("root package reads"),
+        )
+        .expect("root package parses");
+        assert_eq!(
+            package.get("version").and_then(serde_json::Value::as_str),
+            Some(env!("CARGO_PKG_VERSION")),
+            "the runtime and root release versions must remain aligned"
+        );
+        let path = configured_content_root().join("official/registry.json");
+        let registry = ContentRegistry::from_json(
+            &fs::read_to_string(path).expect("compiled registry reads"),
+            env!("CARGO_PKG_VERSION"),
+        )
+        .expect("official registry loads");
+        assert_eq!(registry.content().locations.len(), 33);
+        assert_eq!(registry.pack("cosyworld.core").unwrap().version, "1.0.0");
+        assert_eq!(
+            registry.capability_provider("cosyworld.core/world"),
+            Some("cosyworld.core")
+        );
+        assert_eq!(registry.external_cards().len(), 24);
+        assert!(registry.asset_mounts().len() >= 3);
+        assert!(registry.additional_resource("sentences").is_some());
+    }
+}

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -4,6 +4,7 @@ mod ai_gateway;
 mod avatar_identity;
 mod content_packs;
 mod content_policy;
+mod content_registry;
 mod kernel;
 mod moderation;
 mod mud;
@@ -28,6 +29,7 @@ use axum::{
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use content_packs::*;
 use content_policy::*;
+use content_registry::*;
 use cosyworld_ai_model::ResidentReplyModelInput;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use kernel::*;
@@ -951,30 +953,6 @@ struct ItemMeta {
     description: String,
 }
 
-const SEED_CONTENT_JSON: &str = include_str!("../../content/official/worldpack.json");
-const SEED_ACTORS_JSON: &str = include_str!("../../content/official/actors.json");
-const SEED_ACCESS_GATES_JSON: &str = include_str!("../../content/official/access_gates.json");
-const SEED_FACTIONS_JSON: &str = include_str!("../../content/official/factions.json");
-const SEED_ITEMS_JSON: &str = include_str!("../../content/official/items.json");
-const SEED_LOCATIONS_JSON: &str = include_str!("../../content/official/locations.json");
-const SEED_EXITS_JSON: &str = include_str!("../../content/official/exits.json");
-const SEED_HIDDEN_EXITS_JSON: &str = include_str!("../../content/official/hidden_exits.json");
-const SEED_ROOM_FEATURES_JSON: &str = include_str!("../../content/official/room_features.json");
-const SEED_ROOM_SHEETS_JSON: &str = include_str!("../../content/official/room_sheets.json");
-const SEED_CLOCKS_JSON: &str = include_str!("../../content/official/clocks.json");
-const SEED_JOBS_JSON: &str = include_str!("../../content/official/jobs.json");
-const SEED_FRONTS_JSON: &str = include_str!("../../content/official/fronts.json");
-const SEED_CARDS_JSON: &str = include_str!("../../content/official/cards.json");
-const SEED_LIFECYCLE_HOOKS_JSON: &str = include_str!("../../content/official/lifecycle_hooks.json");
-const SEED_EVOLUTION_TRACKS_JSON: &str =
-    include_str!("../../content/official/evolution_tracks.json");
-const SEED_RECIPES_JSON: &str = include_str!("../../content/official/recipes.json");
-const SEED_EXTERNAL_CARDS_JSON: &str = include_str!("../../content/official/external_cards.json");
-const SEED_ASSET_MOUNTS_JSON: &str = include_str!("../../content/official/assets.json");
-const SEED_RULES_JSON: &str = include_str!("../../content/official/rules.json");
-const SEED_ATTRIBUTIONS_JSON: &str = include_str!("../../content/official/attributions.json");
-const SEED_CHARACTER_CREATION_JSON: &str =
-    include_str!("../../content/official/character_creation.json");
 const LONELY_FOREST_CHARACTER_MANIFEST_JSON: &str =
     include_str!("../../content/lonely-forest/assets/characters/manifest.json");
 const LONELY_FOREST_CHARACTER_ASSET_PREFIX: &str = "/assets/lonely-forest/characters/";
@@ -1002,12 +980,18 @@ struct SeedContent {
     rules: Vec<SeedRuleBundle>,
     attributions: Vec<SeedAttribution>,
     character_creation: Vec<SeedCharacterCreationBundle>,
+    external_cards: Vec<RubyHighCardSpec>,
+    asset_mounts: Vec<SeedAssetMount>,
 }
 
 #[derive(Debug, Deserialize)]
 struct SeedWorldpackManifest {
     #[serde(default)]
     schema_version: u32,
+    #[serde(default)]
+    pack_contract: String,
+    #[serde(default)]
+    canonical_id_mapping_version: u32,
     id: String,
     name: String,
     version: u32,
@@ -1020,13 +1004,8 @@ struct SeedWorldpackManifest {
     bundle_hash: String,
     #[serde(default)]
     packs: Vec<SeedWorldpackPack>,
-    files: BTreeMap<String, String>,
     #[serde(default)]
-    rules: String,
-    #[serde(default)]
-    attributions: String,
-    #[serde(default)]
-    character_creation: String,
+    registry: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1040,7 +1019,21 @@ struct SeedWorldpackPack {
     license: String,
     integrity: String,
     #[serde(default)]
+    engine: String,
+    #[serde(default)]
+    capabilities: Vec<SeedPackCapability>,
+    #[serde(default)]
     dependencies: Vec<String>,
+    #[serde(default)]
+    dependency_requirements: Vec<SeedPackDependency>,
+    #[serde(default)]
+    dependency_closure: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    default_ruleset: Option<String>,
+    #[serde(default)]
+    entry_points: Vec<serde_json::Value>,
+    #[serde(default)]
+    provenance: serde_json::Value,
     #[serde(default)]
     resource_counts: BTreeMap<String, usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1051,6 +1044,23 @@ struct SeedWorldpackPack {
     rules_adapter: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     rules_namespace: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SeedPackCapability {
+    id: String,
+    kind: String,
+    version: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SeedPackDependency {
+    id: String,
+    version: String,
+    #[serde(default)]
+    capabilities: Vec<String>,
+    #[serde(default)]
+    optional: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1721,7 +1731,7 @@ impl JournalRecord {
         };
         Self {
             version: 3,
-            worldpack_bundle_hash: seed_content().manifest.bundle_hash.clone(),
+            worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             origin,
             caused_by_event_seq: None,
             source_world_tick: None,
@@ -3794,52 +3804,12 @@ async fn load_effective_ownership_index_strict(state: &AppState) -> io::Result<O
     Ok(ownership)
 }
 
-fn seed_content() -> &'static SeedContent {
-    static CONTENT: OnceLock<SeedContent> = OnceLock::new();
-    CONTENT.get_or_init(|| {
-        parse_seed_content(SEED_CONTENT_JSON)
-            .expect("embedded CosyWorld seed content must parse and validate")
-    })
-}
-
-fn parse_seed_content(manifest_json: &str) -> Result<SeedContent, String> {
-    let manifest: SeedWorldpackManifest = parse_seed_json("worldpack.json", manifest_json)?;
-    validate_worldpack_manifest(&manifest)?;
-    let content = SeedContent {
-        manifest,
-        actors: parse_seed_json("actors.json", SEED_ACTORS_JSON)?,
-        access_gates: parse_seed_json("access_gates.json", SEED_ACCESS_GATES_JSON)?,
-        factions: parse_seed_json("factions.json", SEED_FACTIONS_JSON)?,
-        items: parse_seed_json("items.json", SEED_ITEMS_JSON)?,
-        locations: parse_seed_json("locations.json", SEED_LOCATIONS_JSON)?,
-        exits: parse_seed_json("exits.json", SEED_EXITS_JSON)?,
-        hidden_exits: parse_seed_json("hidden_exits.json", SEED_HIDDEN_EXITS_JSON)?,
-        room_features: parse_seed_json("room_features.json", SEED_ROOM_FEATURES_JSON)?,
-        room_sheets: parse_seed_json("room_sheets.json", SEED_ROOM_SHEETS_JSON)?,
-        clocks: parse_seed_json("clocks.json", SEED_CLOCKS_JSON)?,
-        jobs: parse_seed_json("jobs.json", SEED_JOBS_JSON)?,
-        fronts: parse_seed_json("fronts.json", SEED_FRONTS_JSON)?,
-        cards: parse_seed_json("cards.json", SEED_CARDS_JSON)?,
-        lifecycle_hooks: parse_seed_json("lifecycle_hooks.json", SEED_LIFECYCLE_HOOKS_JSON)?,
-        evolution_tracks: parse_seed_json("evolution_tracks.json", SEED_EVOLUTION_TRACKS_JSON)?,
-        recipes: parse_seed_json("recipes.json", SEED_RECIPES_JSON)?,
-        rules: parse_seed_json("rules.json", SEED_RULES_JSON)?,
-        attributions: parse_seed_json("attributions.json", SEED_ATTRIBUTIONS_JSON)?,
-        character_creation: parse_seed_json(
-            "character_creation.json",
-            SEED_CHARACTER_CREATION_JSON,
-        )?,
-    };
-    validate_seed_content(&content)?;
-    Ok(content)
-}
-
 fn parse_seed_json<T: DeserializeOwned>(label: &str, value: &str) -> Result<T, String> {
     serde_json::from_str(value).map_err(|error| format!("{label}: {error}"))
 }
 
 fn character_creation_views() -> Vec<CharacterCreationProfileView> {
-    seed_content()
+    active_content()
         .character_creation
         .iter()
         .flat_map(|bundle| {
@@ -3852,7 +3822,7 @@ fn character_creation_views() -> Vec<CharacterCreationProfileView> {
                     name: profile.name.clone(),
                     description: profile.description.clone(),
                     entry_location_id: profile.entry_location_id,
-                    entry_location_name: seed_content()
+                    entry_location_name: active_content()
                         .locations
                         .iter()
                         .find(|location| location.id == profile.entry_location_id)
@@ -3882,7 +3852,7 @@ fn character_creation_selection(
     profile_id: Option<&str>,
     choice_id: Option<&str>,
 ) -> Option<(SeedCharacterCreationProfile, SeedCharacterCreationChoice)> {
-    let profiles = seed_content()
+    let profiles = active_content()
         .character_creation
         .iter()
         .flat_map(|bundle| bundle.profiles.iter());
@@ -3931,7 +3901,7 @@ fn safe_asset_file_name(asset_file: &str) -> bool {
             .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
 }
 
-fn seed_content_root() -> PathBuf {
+fn configured_content_root() -> PathBuf {
     if let Ok(path) = std::env::var("COSYWORLD_CONTENT_ROOT") {
         return PathBuf::from(path);
     }
@@ -3941,16 +3911,6 @@ fn seed_content_root() -> PathBuf {
     } else {
         PathBuf::from("/app/v2/content")
     }
-}
-
-fn seed_asset_mounts() -> &'static [SeedAssetMount] {
-    static MOUNTS: OnceLock<Vec<SeedAssetMount>> = OnceLock::new();
-    MOUNTS
-        .get_or_init(|| {
-            parse_seed_json("assets.json", SEED_ASSET_MOUNTS_JSON)
-                .expect("embedded worldpack asset index must parse")
-        })
-        .as_slice()
 }
 
 fn safe_relative_asset_path(asset_path: &str) -> bool {
@@ -3965,11 +3925,12 @@ fn seed_pack_asset_path(pack_id: &str, mount_name: &str, asset_path: &str) -> Op
     if !safe_relative_asset_path(asset_path) {
         return None;
     }
-    let mount = seed_asset_mounts()
+    let mount = content_registry()
+        .asset_mounts()
         .iter()
         .find(|mount| mount.pack_id == pack_id && mount.mount == mount_name)?;
     Some(
-        seed_content_root()
+        configured_content_root()
             .join(&mount.root)
             .join(&mount.directory)
             .join(asset_path),
@@ -3990,11 +3951,13 @@ fn asset_content_type(asset_path: &str) -> &'static str {
 
 fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> Result<(), String> {
     if manifest.schema_version != 2
+        || manifest.pack_contract != "cosyworld.content-pack/1"
+        || manifest.canonical_id_mapping_version != 1
         || manifest.id.trim().is_empty()
         || manifest.name.trim().is_empty()
         || manifest.version == 0
         || manifest.entry_location.trim().is_empty()
-        || !manifest.bundle_hash.starts_with("sha256:")
+        || !valid_sha256_digest(&manifest.bundle_hash)
         || manifest.packs.is_empty()
     {
         return Err("worldpack manifest is missing id, name, or version".to_string());
@@ -4004,9 +3967,12 @@ fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> Result<(), S
         if pack.id.trim().is_empty()
             || pack.name.trim().is_empty()
             || pack.version.trim().is_empty()
-            || pack.kind.trim().is_empty()
+            || !matches!(
+                pack.kind.as_str(),
+                "world" | "campaign" | "catalog" | "assets" | "rules"
+            )
             || pack.license.trim().is_empty()
-            || !pack.integrity.starts_with("sha256:")
+            || !valid_sha256_digest(&pack.integrity)
             || !pack_ids.insert(pack.id.as_str())
         {
             return Err(format!("invalid or duplicate worldpack pack {}", pack.id));
@@ -4021,44 +3987,19 @@ fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> Result<(), S
             return Err(format!("invalid rules pack metadata for {}", pack.id));
         }
     }
-    for (key, expected_file) in [
-        ("actors", "actors.json"),
-        ("access_gates", "access_gates.json"),
-        ("factions", "factions.json"),
-        ("items", "items.json"),
-        ("locations", "locations.json"),
-        ("exits", "exits.json"),
-        ("hidden_exits", "hidden_exits.json"),
-        ("room_features", "room_features.json"),
-        ("room_sheets", "room_sheets.json"),
-        ("clocks", "clocks.json"),
-        ("jobs", "jobs.json"),
-        ("fronts", "fronts.json"),
-        ("cards", "cards.json"),
-        ("lifecycle_hooks", "lifecycle_hooks.json"),
-        ("evolution_tracks", "evolution_tracks.json"),
-        ("recipes", "recipes.json"),
-    ] {
-        match manifest.files.get(key).map(String::as_str) {
-            Some(actual) if actual == expected_file => {}
-            Some(actual) => {
-                return Err(format!(
-                    "worldpack manifest maps {key} to {actual}, expected {expected_file}"
-                ));
-            }
-            None => return Err(format!("worldpack manifest is missing {key} file entry")),
-        }
-    }
-    if manifest.rules != "rules.json"
-        || manifest.attributions != "attributions.json"
-        || manifest.character_creation != "character_creation.json"
-    {
-        return Err(
-            "worldpack manifest is missing rules, attribution, or character creation files"
-                .to_string(),
-        );
+    if manifest.registry.trim().is_empty() {
+        return Err("worldpack manifest does not identify its compiled registry".to_string());
     }
     Ok(())
+}
+
+fn valid_sha256_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|digest| {
+        digest.len() == 64
+            && digest
+                .chars()
+                .all(|character| character.is_ascii_digit() || ('a'..='f').contains(&character))
+    })
 }
 
 fn validate_seed_content(content: &SeedContent) -> Result<(), String> {
@@ -5222,7 +5163,7 @@ fn validate_seed_effect_descriptor(
 }
 
 fn seed_actor_meta() -> BTreeMap<u64, ActorMeta> {
-    seed_content()
+    active_content()
         .actors
         .iter()
         .map(|actor| {
@@ -5266,7 +5207,7 @@ fn seed_stat_block(stats: SeedStatBlockContent) -> CwStatBlock {
 }
 
 fn seed_item_meta() -> BTreeMap<u64, ItemMeta> {
-    let mut items: BTreeMap<u64, ItemMeta> = seed_content()
+    let mut items: BTreeMap<u64, ItemMeta> = active_content()
         .items
         .iter()
         .map(|item| {
@@ -5279,7 +5220,7 @@ fn seed_item_meta() -> BTreeMap<u64, ItemMeta> {
             )
         })
         .collect();
-    for recipe in &seed_content().recipes {
+    for recipe in &active_content().recipes {
         if let Some(output) = recipe.output.as_ref() {
             items.entry(output.item_id).or_insert_with(|| ItemMeta {
                 name: output.name.clone(),
@@ -5312,7 +5253,7 @@ fn placement_target_kind_from_str(kind: &str) -> Option<u8> {
 }
 
 fn seed_location_names() -> BTreeMap<u64, String> {
-    seed_content()
+    active_content()
         .locations
         .iter()
         .map(|location| (location.id, location.name.clone()))
@@ -5363,7 +5304,7 @@ fn inferred_location_terrain(biome: &str) -> Vec<String> {
 }
 
 fn seed_location_meta() -> BTreeMap<u64, LocationMeta> {
-    seed_content()
+    active_content()
         .locations
         .iter()
         .map(|location| {
@@ -5421,7 +5362,7 @@ fn faction_view_from_seed(faction: &SeedFactionContent) -> FactionView {
 }
 
 fn faction_views() -> Vec<FactionView> {
-    seed_content()
+    active_content()
         .factions
         .iter()
         .map(faction_view_from_seed)
@@ -5429,7 +5370,7 @@ fn faction_views() -> Vec<FactionView> {
 }
 
 fn faction_refs_for_actor(actor_id: u64) -> Vec<FactionRefView> {
-    seed_content()
+    active_content()
         .factions
         .iter()
         .filter(|faction| faction.member_actor_ids.contains(&actor_id))
@@ -5438,7 +5379,7 @@ fn faction_refs_for_actor(actor_id: u64) -> Vec<FactionRefView> {
 }
 
 fn faction_refs_for_location(location_id: u64) -> Vec<FactionRefView> {
-    seed_content()
+    active_content()
         .factions
         .iter()
         .filter(|faction| faction.home_location_ids.contains(&location_id))
@@ -7067,7 +7008,7 @@ fn avatar_pack_card_rarity(card_id: &str) -> &str {
 }
 
 fn seed_card_rarity_for_card_id(card_id: &str) -> Option<&'static str> {
-    seed_content()
+    active_content()
         .cards
         .iter()
         .find(|card| card.card_id == card_id)
@@ -7152,6 +7093,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
+    configured_content_registry().map_err(io::Error::other)?;
     let state = AppState::bootstrap().await?;
     start_actor_job_worker(state.clone());
     start_ownership_refresh_scheduler(state.clone());
@@ -7758,7 +7700,7 @@ impl RuntimeSnapshot {
     fn from_runtime(runtime: &RuntimeWorld) -> Self {
         Self {
             version: 1,
-            worldpack_bundle_hash: seed_content().manifest.bundle_hash.clone(),
+            worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             world_version: runtime.world.version,
             tick: runtime.world.tick,
             next_event_seq: runtime.world.next_event_seq,
@@ -7807,12 +7749,12 @@ impl RuntimeSnapshot {
 
     fn into_runtime(self) -> io::Result<RuntimeWorld> {
         if !self.worldpack_bundle_hash.is_empty()
-            && self.worldpack_bundle_hash != seed_content().manifest.bundle_hash
+            && self.worldpack_bundle_hash != active_content().manifest.bundle_hash
         {
             return Err(snapshot_error(format!(
                 "snapshot worldpack {} does not match active worldpack {}",
                 self.worldpack_bundle_hash,
-                seed_content().manifest.bundle_hash
+                active_content().manifest.bundle_hash
             )));
         }
         if self.world_actors.len() > CW_MAX_ACTORS {
@@ -7974,7 +7916,7 @@ impl ResidentContinuitySnapshot {
     fn from_runtime(runtime: &RuntimeWorld) -> Self {
         Self {
             version: 1,
-            worldpack_bundle_hash: seed_content().manifest.bundle_hash.clone(),
+            worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             world_tick: runtime.world.tick,
             latest_event_seq: runtime.world.next_event_seq.saturating_sub(1),
             residents: runtime.resident_continuities.clone(),
@@ -8003,12 +7945,12 @@ impl RuntimeWorld {
         let records = read_action_journal(path)?;
         for record in records {
             if !record.worldpack_bundle_hash.is_empty()
-                && record.worldpack_bundle_hash != seed_content().manifest.bundle_hash
+                && record.worldpack_bundle_hash != active_content().manifest.bundle_hash
             {
                 return Err(snapshot_error(format!(
                     "action journal worldpack {} does not match active worldpack {}",
                     record.worldpack_bundle_hash,
-                    seed_content().manifest.bundle_hash
+                    active_content().manifest.bundle_hash
                 )));
             }
             let _ = runtime.apply_journal_record(&record);
@@ -8074,7 +8016,7 @@ impl RuntimeWorld {
 
     fn ensure_seed_topology(&mut self) {
         self.ensure_seed_metadata();
-        for location in &seed_content().locations {
+        for location in &active_content().locations {
             let flags = if location.allow_combat {
                 CW_LOCATION_ALLOW_COMBAT
             } else {
@@ -8090,7 +8032,7 @@ impl RuntimeWorld {
         // away from the cottage-as-global-hub layout.
         self.world.exit_count = 0;
 
-        for exit in &seed_content().exits {
+        for exit in &active_content().exits {
             self.ensure_exit(exit.from_location_id, exit.to_location_id, exit.flags);
         }
         self.ensure_discovered_hidden_exits();
@@ -8101,7 +8043,7 @@ impl RuntimeWorld {
     }
 
     fn ensure_seed_rpg_projection(&mut self) {
-        for sheet in &seed_content().room_sheets {
+        for sheet in &active_content().room_sheets {
             self.room_sheets
                 .entry(sheet.location_id)
                 .or_insert_with(|| sheet.clone());
@@ -8111,7 +8053,7 @@ impl RuntimeWorld {
                 }
             }
         }
-        for clock in &seed_content().clocks {
+        for clock in &active_content().clocks {
             let mut seeded_clock = clock.clone();
             if seeded_clock.on_fill.is_empty() {
                 seeded_clock.on_fill = lifecycle_effects_for("on_clock_fill", "clock", &clock.id);
@@ -8128,7 +8070,7 @@ impl RuntimeWorld {
                 }
             }
         }
-        for job in &seed_content().jobs {
+        for job in &active_content().jobs {
             self.jobs
                 .entry(job.id.clone())
                 .or_insert_with(|| job.clone());
@@ -8141,7 +8083,7 @@ impl RuntimeWorld {
             .values()
             .map(|sheet| {
                 let meta = self.location_meta_for(sheet.location_id);
-                let mut front_ids = seed_content()
+                let mut front_ids = active_content()
                     .fronts
                     .iter()
                     .filter(|front| front.status == "active")
@@ -8159,7 +8101,7 @@ impl RuntimeWorld {
                 }
             })
             .collect();
-        let factions = seed_content()
+        let factions = active_content()
             .factions
             .iter()
             .map(|faction| SimulationFactionSeed {
@@ -8196,7 +8138,7 @@ impl RuntimeWorld {
         for (item_id, meta) in seed_item_meta() {
             self.items.entry(item_id).or_insert(meta);
         }
-        for location in &seed_content().locations {
+        for location in &active_content().locations {
             self.locations
                 .entry(location.id)
                 .or_insert_with(|| location.name.clone());
@@ -8207,7 +8149,7 @@ impl RuntimeWorld {
     }
 
     fn ensure_seed_residents(&mut self) {
-        for actor in &seed_content().actors {
+        for actor in &active_content().actors {
             let Some(location_id) = actor.location_id else {
                 continue;
             };
@@ -8216,7 +8158,7 @@ impl RuntimeWorld {
     }
 
     fn ensure_seed_items(&mut self) {
-        for item in &seed_content().items {
+        for item in &active_content().items {
             let Some(kind) = seed_item_kind(item) else {
                 continue;
             };
@@ -8226,7 +8168,7 @@ impl RuntimeWorld {
     }
 
     fn ensure_seed_evolution_tracks(&mut self) {
-        for track in &seed_content().evolution_tracks {
+        for track in &active_content().evolution_tracks {
             if track.requirements.is_empty()
                 || track.requirements.len() > CW_MAX_EVOLUTION_REQUIREMENTS
             {
@@ -8370,7 +8312,7 @@ impl RuntimeWorld {
     }
 
     fn ensure_discovered_hidden_exits(&mut self) {
-        for hidden_exit in &seed_content().hidden_exits {
+        for hidden_exit in &active_content().hidden_exits {
             if !self.hidden_exit_discovered(hidden_exit) {
                 continue;
             }
@@ -9855,12 +9797,12 @@ impl RuntimeWorld {
             ));
         }
         if !snapshot.worldpack_bundle_hash.is_empty()
-            && snapshot.worldpack_bundle_hash != seed_content().manifest.bundle_hash
+            && snapshot.worldpack_bundle_hash != active_content().manifest.bundle_hash
         {
             return Err(snapshot_error(format!(
                 "resident continuity worldpack {} does not match active worldpack {}",
                 snapshot.worldpack_bundle_hash,
-                seed_content().manifest.bundle_hash
+                active_content().manifest.bundle_hash
             )));
         }
         Ok(self.apply_resident_continuity_snapshot(snapshot))
@@ -12478,7 +12420,7 @@ impl RuntimeWorld {
             .filter(|(_, influence)| **influence > 0)
             .map(|(faction_id, influence)| FactionInfluenceView {
                 faction_id: faction_id.clone(),
-                faction_name: seed_content()
+                faction_name: active_content()
                     .factions
                     .iter()
                     .find(|faction| faction.id == *faction_id)
@@ -12506,7 +12448,7 @@ impl RuntimeWorld {
     }
 
     fn world_simulation_view(&self) -> WorldSimulationView {
-        let mut factions = seed_content()
+        let mut factions = active_content()
             .factions
             .iter()
             .map(|seed_faction| {
@@ -12686,7 +12628,7 @@ impl RuntimeWorld {
     }
 
     fn pathway_distance(&self, from_location_id: u64, to_location_id: u64) -> u8 {
-        seed_content()
+        active_content()
             .exits
             .iter()
             .find(|exit| {
@@ -13251,7 +13193,7 @@ impl RuntimeWorld {
         from_location_id: u64,
         to_location_id: u64,
     ) -> Option<&'static SeedExitContent> {
-        seed_content().exits.iter().find(|exit| {
+        active_content().exits.iter().find(|exit| {
             exit.from_location_id == from_location_id && exit.to_location_id == to_location_id
         })
     }
@@ -13266,7 +13208,7 @@ impl RuntimeWorld {
     }
 
     fn seed_exit_candidate_for_search(&self, location_id: u64) -> Option<&'static SeedExitContent> {
-        let mut candidates = seed_content()
+        let mut candidates = active_content()
             .exits
             .iter()
             .filter(|exit| exit.from_location_id == location_id)
@@ -13297,7 +13239,7 @@ impl RuntimeWorld {
             })
             .collect::<Vec<_>>();
         hidden.sort_by_key(|item| {
-            let home_rank = seed_content()
+            let home_rank = active_content()
                 .items
                 .iter()
                 .find(|seed_item| seed_item.id == item.id)
@@ -13319,7 +13261,7 @@ impl RuntimeWorld {
     }
 
     fn hidden_exit_by_id(&self, hidden_exit_id: &str) -> Option<&'static SeedHiddenExitContent> {
-        seed_content()
+        active_content()
             .hidden_exits
             .iter()
             .find(|hidden_exit| hidden_exit.id == hidden_exit_id)
@@ -13339,7 +13281,7 @@ impl RuntimeWorld {
         from_location_id: u64,
         to_location_id: u64,
     ) -> Option<&'static SeedHiddenExitContent> {
-        seed_content().hidden_exits.iter().find(|hidden_exit| {
+        active_content().hidden_exits.iter().find(|hidden_exit| {
             (hidden_exit.from_location_id == from_location_id
                 && hidden_exit.to_location_id == to_location_id)
                 || (hidden_exit.from_location_id == to_location_id
@@ -13348,10 +13290,10 @@ impl RuntimeWorld {
     }
 
     fn location_discovered_by_search(&self, location_id: u64) -> bool {
-        seed_content().exits.iter().any(|exit| {
+        active_content().exits.iter().any(|exit| {
             (exit.from_location_id == location_id || exit.to_location_id == location_id)
                 && self.seed_exit_discovered(exit.from_location_id, exit.to_location_id)
-        }) || seed_content().hidden_exits.iter().any(|hidden_exit| {
+        }) || active_content().hidden_exits.iter().any(|hidden_exit| {
             (hidden_exit.from_location_id == location_id
                 || hidden_exit.to_location_id == location_id)
                 && self.hidden_exit_discovered(hidden_exit)
@@ -13376,7 +13318,7 @@ impl RuntimeWorld {
         location_id: u64,
         feature_key: &str,
     ) -> Option<&'static SeedHiddenExitContent> {
-        seed_content().hidden_exits.iter().find(|hidden_exit| {
+        active_content().hidden_exits.iter().find(|hidden_exit| {
             hidden_exit.from_location_id == location_id
                 && hidden_exit.feature_key == feature_key
                 && !self.hidden_exit_discovered(hidden_exit)
@@ -13387,7 +13329,7 @@ impl RuntimeWorld {
         &self,
         location_id: u64,
     ) -> Option<&'static SeedHiddenExitContent> {
-        seed_content().hidden_exits.iter().find(|hidden_exit| {
+        active_content().hidden_exits.iter().find(|hidden_exit| {
             hidden_exit.from_location_id == location_id && !self.hidden_exit_discovered(hidden_exit)
         })
     }
@@ -13727,14 +13669,14 @@ impl RuntimeWorld {
 
     fn avatar_hidden_until_discovered(&self, actor: CwActor) -> bool {
         if actor.kind != CW_ACTOR_NPC
-            || !seed_content()
+            || !active_content()
                 .actors
                 .iter()
                 .any(|seed_actor| seed_actor.id == actor.id)
         {
             return false;
         }
-        let hidden_location = seed_content()
+        let hidden_location = active_content()
             .hidden_exits
             .iter()
             .any(|hidden_exit| hidden_exit.to_location_id == actor.location_id);
@@ -13961,7 +13903,7 @@ impl RuntimeWorld {
     }
 
     fn recipe_by_id(&self, recipe_id: u64) -> Option<&'static SeedRecipeContent> {
-        seed_content()
+        active_content()
             .recipes
             .iter()
             .find(|recipe| recipe.id == recipe_id)
@@ -14029,7 +13971,7 @@ impl RuntimeWorld {
     }
 
     fn default_craft_recipe(&self, actor_id: u64) -> Option<&'static SeedRecipeContent> {
-        seed_content()
+        active_content()
             .recipes
             .iter()
             .find(|recipe| self.craft_action_for_recipe(actor_id, recipe.id).is_some())
@@ -14053,7 +13995,7 @@ impl RuntimeWorld {
         actor_id: u64,
         target_kind: &str,
     ) -> Vec<u64> {
-        seed_content()
+        active_content()
             .evolution_tracks
             .iter()
             .find(|track| track.actor_id == actor_id)
@@ -14083,7 +14025,7 @@ impl RuntimeWorld {
     }
 
     fn resident_personal_desires(&self, resident_id: u64) -> Vec<SeedResidentDesireContent> {
-        seed_content()
+        active_content()
             .actors
             .iter()
             .find(|actor| actor.id == resident_id)
@@ -14105,7 +14047,7 @@ impl RuntimeWorld {
         &self,
         resident_id: u64,
     ) -> Vec<SeedResidentAttachmentContent> {
-        seed_content()
+        active_content()
             .actors
             .iter()
             .find(|actor| actor.id == resident_id)
@@ -14805,7 +14747,7 @@ impl RuntimeWorld {
                 .or_else(|| opt_id(item.location_id))
                 .or_else(|| {
                     (item.charges > 0).then(|| {
-                        seed_content()
+                        active_content()
                             .items
                             .iter()
                             .find(|seed_item| seed_item.id == item_id)
@@ -16703,7 +16645,7 @@ impl RuntimeWorld {
     }
 
     fn exit_direction(&self, from_location_id: u64, to_location_id: u64) -> Option<String> {
-        if let Some(direction) = seed_content()
+        if let Some(direction) = active_content()
             .exits
             .iter()
             .find(|exit| {
@@ -16714,7 +16656,7 @@ impl RuntimeWorld {
         {
             return Some(direction.to_string());
         }
-        seed_content()
+        active_content()
             .hidden_exits
             .iter()
             .filter(|hidden_exit| self.hidden_exit_discovered(hidden_exit))
@@ -17909,7 +17851,7 @@ impl RuntimeWorld {
     }
 
     fn room_features(&self, location_id: u64) -> Vec<&'static SeedRoomFeatureContent> {
-        seed_content()
+        active_content()
             .room_features
             .iter()
             .filter(|feature| feature.location_id == location_id)
@@ -18309,7 +18251,7 @@ impl RuntimeWorld {
     }
 
     fn front_views(&self, location_id: u64) -> Vec<FrontView> {
-        seed_content()
+        active_content()
             .fronts
             .iter()
             .filter(|front| front.location_ids.contains(&location_id))
@@ -18567,7 +18509,7 @@ impl RuntimeWorld {
             .filter(|clock| clock.scope == "room" && clock.scope_id == location_id)
             .map(|clock| clock.id.clone())
             .collect();
-        seed_content()
+        active_content()
             .lifecycle_hooks
             .iter()
             .filter(|hook| match hook.target_kind.as_str() {
@@ -20888,7 +20830,7 @@ impl RuntimeWorld {
     }
 
     fn first_missing_evolution_item_name(&self, actor_id: u64) -> Option<String> {
-        let track = seed_content()
+        let track = active_content()
             .evolution_tracks
             .iter()
             .find(|track| track.actor_id == actor_id)?;
@@ -21003,7 +20945,7 @@ impl RuntimeWorld {
                 "Project goal: {} Stakes: {}{}",
                 job.premise, job.stakes, clock_note
             ));
-            if let Some(question) = seed_content()
+            if let Some(question) = active_content()
                 .fronts
                 .iter()
                 .find(|front| {
@@ -21014,7 +20956,7 @@ impl RuntimeWorld {
             {
                 goals.push(format!("Open story question: {question}"));
             }
-        } else if let Some(front) = seed_content()
+        } else if let Some(front) = active_content()
             .fronts
             .iter()
             .find(|front| front.status == "active" && front.location_ids.contains(&location_id))
@@ -21371,7 +21313,7 @@ impl RuntimeWorld {
             })
             .collect::<Vec<_>>();
         residents.sort_by_key(|actor| {
-            let dex = seed_content()
+            let dex = active_content()
                 .cards
                 .iter()
                 .position(|card| card.subject_kind == "actor" && card.subject_id == actor.id)
@@ -22600,7 +22542,7 @@ struct LocationAccessRule {
 }
 
 fn seed_entitlement_grant(grant_id: &str) -> Option<&'static SeedEntitlementGrant> {
-    seed_content()
+    active_content()
         .manifest
         .packs
         .iter()
@@ -22618,7 +22560,7 @@ fn entitlement_grant_asset_id(grant_id: &str) -> Option<&'static str> {
 }
 
 fn entitlement_grants_for_assets(asset_ids: &BTreeSet<String>) -> BTreeSet<String> {
-    seed_content()
+    active_content()
         .manifest
         .packs
         .iter()
@@ -22640,7 +22582,7 @@ fn non_empty_pack_id(pack_id: &str) -> Option<String> {
 }
 
 fn seed_pack_id_for_actor(actor_id: u64) -> Option<String> {
-    seed_content()
+    active_content()
         .actors
         .iter()
         .find(|actor| actor.id == actor_id)
@@ -22648,7 +22590,7 @@ fn seed_pack_id_for_actor(actor_id: u64) -> Option<String> {
 }
 
 fn seed_pack_id_for_item(item_id: u64) -> Option<String> {
-    seed_content()
+    active_content()
         .items
         .iter()
         .find(|item| item.id == item_id)
@@ -22656,7 +22598,7 @@ fn seed_pack_id_for_item(item_id: u64) -> Option<String> {
 }
 
 fn seed_pack_id_for_location(location_id: u64) -> Option<String> {
-    seed_content()
+    active_content()
         .locations
         .iter()
         .find(|location| location.id == location_id)
@@ -22664,7 +22606,7 @@ fn seed_pack_id_for_location(location_id: u64) -> Option<String> {
 }
 
 fn location_access_rule(location_id: u64) -> LocationAccessRule {
-    seed_content()
+    active_content()
         .access_gates
         .iter()
         .find(|gate| gate.location_id == location_id)
@@ -22699,7 +22641,7 @@ fn location_access_allowed(location_id: u64, access: &AccessContext) -> bool {
 }
 
 fn evolution_track_item_ids(actor_id: u64) -> Option<Vec<u64>> {
-    seed_content()
+    active_content()
         .evolution_tracks
         .iter()
         .find(|track| track.actor_id == actor_id)
@@ -22713,7 +22655,7 @@ fn evolution_track_item_ids(actor_id: u64) -> Option<Vec<u64>> {
 }
 
 fn seed_actor_allows_ambient_autonomy(actor_id: u64) -> bool {
-    seed_content()
+    active_content()
         .actors
         .iter()
         .find(|actor| actor.id == actor_id)
@@ -22729,7 +22671,7 @@ fn evolution_item_matches_resident(item_id: u64, actor_id: u64) -> bool {
 
 fn evolution_item_belongs_to_another_resident(item_id: u64, actor_id: u64) -> bool {
     !evolution_item_matches_resident(item_id, actor_id)
-        && seed_content().evolution_tracks.iter().any(|track| {
+        && active_content().evolution_tracks.iter().any(|track| {
             track
                 .requirements
                 .iter()
@@ -22775,7 +22717,7 @@ fn actor_location_from_overlap(
 }
 
 fn location_id_for_card_id(card_id: &str) -> Option<u64> {
-    seed_content()
+    active_content()
         .cards
         .iter()
         .find(|card| {
@@ -23012,7 +22954,7 @@ fn account_view(access: &AccessContext) -> AccountView {
 }
 
 fn owned_account_card(card_id: &str, access: &AccessContext) -> Option<CardView> {
-    let mut card = seed_content()
+    let mut card = active_content()
         .cards
         .iter()
         .find(|card| card.card_id == card_id || card.external_card_id.as_deref() == Some(card_id))
@@ -23297,7 +23239,7 @@ fn card_transaction_view(
 }
 
 fn seed_card_for_subject(subject_kind: &str, subject_id: u64) -> Option<CardView> {
-    seed_content()
+    active_content()
         .cards
         .iter()
         .find(|card| card.subject_kind == subject_kind && card.subject_id == subject_id)
@@ -23305,7 +23247,7 @@ fn seed_card_for_subject(subject_kind: &str, subject_id: u64) -> Option<CardView
 }
 
 fn seed_card_rarity_for_subject(subject_kind: &str, subject_id: u64) -> Option<&'static str> {
-    seed_content()
+    active_content()
         .cards
         .iter()
         .find(|card| card.subject_kind == subject_kind && card.subject_id == subject_id)
@@ -23410,13 +23352,7 @@ struct RubyHighCardSpec {
 }
 
 fn ruby_high_first_bell_catalog() -> &'static [RubyHighCardSpec] {
-    static CATALOG: OnceLock<Vec<RubyHighCardSpec>> = OnceLock::new();
-    CATALOG
-        .get_or_init(|| {
-            parse_seed_json("external_cards.json", SEED_EXTERNAL_CARDS_JSON)
-                .expect("embedded external card catalog must parse")
-        })
-        .as_slice()
+    content_registry().external_cards()
 }
 
 fn ruby_high_card_by_id(card_id: &str) -> Option<CardView> {
@@ -23626,13 +23562,13 @@ async fn meta(State(state): State<AppState>) -> Json<MetaResponse> {
             actions: ["attack", "dodge", "escape"],
         },
         worldpack: MetaWorldpack {
-            id: seed_content().manifest.id.clone(),
-            name: seed_content().manifest.name.clone(),
-            version: seed_content().manifest.version,
-            bundle_hash: seed_content().manifest.bundle_hash.clone(),
-            entry_location: seed_content().manifest.entry_location.clone(),
-            packs: seed_content().manifest.packs.clone(),
-            rules: seed_content()
+            id: active_content().manifest.id.clone(),
+            name: active_content().manifest.name.clone(),
+            version: active_content().manifest.version,
+            bundle_hash: active_content().manifest.bundle_hash.clone(),
+            entry_location: active_content().manifest.entry_location.clone(),
+            packs: active_content().manifest.packs.clone(),
+            rules: active_content()
                 .rules
                 .iter()
                 .map(|bundle| MetaRulesBundle {
@@ -23643,7 +23579,7 @@ async fn meta(State(state): State<AppState>) -> Json<MetaResponse> {
                     monster_seeds: bundle.resources.monster_seeds.len(),
                 })
                 .collect(),
-            attributions: seed_content().attributions.clone(),
+            attributions: active_content().attributions.clone(),
         },
         world: MetaWorldCounters {
             tick,
@@ -33075,7 +33011,8 @@ async fn generated_seed_card_asset(AxumPath(card_file): AxumPath<String>) -> imp
 async fn worldpack_asset(
     AxumPath((pack_id, asset_path)): AxumPath<(String, String)>,
 ) -> impl IntoResponse {
-    let Some(mount) = seed_asset_mounts()
+    let Some(mount) = content_registry()
+        .asset_mounts()
         .iter()
         .filter(|mount| {
             mount.pack_id == pack_id
@@ -33201,7 +33138,7 @@ fn generated_seed_card_bitmap_request(card_file: &str) -> Option<(&str, &'static
     {
         return None;
     }
-    if !seed_content()
+    if !active_content()
         .cards
         .iter()
         .any(|card| card.card_id == card_id)
@@ -33305,7 +33242,7 @@ struct SeedCardArtSpec {
 }
 
 fn seed_card_art_spec(card_id: &str) -> Option<SeedCardArtSpec> {
-    seed_content()
+    active_content()
         .cards
         .iter()
         .find(|card| card.card_id == card_id)
@@ -33550,7 +33487,7 @@ fn job_completion_orb_rewards(events: &[EventView]) -> Vec<AutomaticOrbReward> {
         .filter_map(|event| {
             let actor_id = event.actor_id?;
             let job_id = completed_job_id_from_event(event)?;
-            let job = seed_content().jobs.iter().find(|job| job.id == job_id)?;
+            let job = active_content().jobs.iter().find(|job| job.id == job_id)?;
             let orbs = job.reward.orbs();
             (orbs > 0).then(|| AutomaticOrbReward {
                 claim_key: format!("job_completed:{actor_id}:{job_id}:{}", event.seq),
@@ -33595,7 +33532,7 @@ fn lifecycle_hooks_for(
     target_kind: &str,
     target_id: &str,
 ) -> Vec<&'static SeedLifecycleHookContent> {
-    seed_content()
+    active_content()
         .lifecycle_hooks
         .iter()
         .filter(|hook| {
@@ -36514,7 +36451,7 @@ mod tests {
     }
 
     fn discover_all_seed_exits_for_test(runtime: &mut RuntimeWorld) {
-        for exit in &seed_content().exits {
+        for exit in &active_content().exits {
             discover_seed_exit_for_test(runtime, exit.from_location_id, exit.to_location_id);
         }
     }
@@ -46337,7 +46274,7 @@ mod tests {
             (63, "location-digital-realm"),
             (64, "location-darkest-ocean"),
         ] {
-            let name = seed_content()
+            let name = active_content()
                 .locations
                 .iter()
                 .find(|location| location.id == location_id)
@@ -46389,11 +46326,8 @@ mod tests {
 
     #[test]
     fn official_composition_omits_reference_only_srd_rule_packs() {
-        let rules: Vec<SeedRuleBundle> =
-            parse_seed_json("rules.json", SEED_RULES_JSON).expect("embedded rules parse");
-        let attributions: Vec<SeedAttribution> =
-            parse_seed_json("attributions.json", SEED_ATTRIBUTIONS_JSON)
-                .expect("embedded attributions parse");
+        let rules = &active_content().rules;
+        let attributions = &active_content().attributions;
 
         assert!(rules.is_empty());
         assert_eq!(attributions.len(), 1);
@@ -46409,7 +46343,7 @@ mod tests {
 
     #[test]
     fn seed_content_manifest_drives_runtime_metadata_and_evolution_tracks() {
-        let content = parse_seed_content(SEED_CONTENT_JSON).expect("seed content parses");
+        let content = active_content();
         assert_eq!(content.manifest.id, "cosyworld.official");
         assert_eq!(content.manifest.version, 1);
         assert_eq!(content.manifest.schema_version, 2);
@@ -46778,14 +46712,17 @@ mod tests {
         let runtime = load_snapshot_or_seed(Some(&path));
         let _ = fs::remove_file(path);
 
-        assert_eq!(runtime.world.location_count, seed_content().locations.len());
-        assert_eq!(runtime.world.actor_count, seed_content().actors.len());
+        assert_eq!(
+            runtime.world.location_count,
+            active_content().locations.len()
+        );
+        assert_eq!(runtime.world.actor_count, active_content().actors.len());
         assert_eq!(runtime.world.tick, RuntimeWorld::seeded().world.tick);
     }
 
     #[test]
     fn solar_abyss_factions_project_opposing_forces() {
-        let content = parse_seed_content(SEED_CONTENT_JSON).expect("seed content parses");
+        let content = active_content();
         let solar = content
             .factions
             .iter()
@@ -47292,7 +47229,7 @@ mod tests {
 
     #[tokio::test]
     async fn lonely_forest_source_characters_are_seeded_with_png_cards() {
-        let content = parse_seed_content(SEED_CONTENT_JSON).expect("seed content parses");
+        let content = active_content();
         let runtime = RuntimeWorld::seeded();
 
         let placed_seed_actors: Vec<&SeedActorContent> = content
@@ -47634,8 +47571,9 @@ mod tests {
 
     #[test]
     fn compiled_worldpack_asset_index_resolves_pack_mounts_safely() {
-        assert!(seed_asset_mounts().len() >= 3);
-        assert!(seed_asset_mounts()
+        assert!(content_registry().asset_mounts().len() >= 3);
+        assert!(content_registry()
+            .asset_mounts()
             .iter()
             .any(|mount| { mount.pack_id == "ruby-high.first-bell" && mount.mount == "cards" }));
         let card_path = seed_pack_asset_path(
@@ -54839,7 +54777,7 @@ mod tests {
     }
 
     #[test]
-    fn location_access_rules_are_loaded_from_seed_content() {
+    fn location_access_rules_are_loaded_from_content_registry() {
         let public = AccessContext::default();
         let homeroom_rule = location_access_rule(11);
         assert_eq!(homeroom_rule.required_card_id, Some("location-homeroom"));

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -1088,7 +1088,7 @@ impl RuntimeWorld {
                     self.default_craft_recipe(actor.id)
                 } else {
                     let query_key = command_key(rest);
-                    seed_content().recipes.iter().find(|recipe| {
+                    active_content().recipes.iter().find(|recipe| {
                         recipe.id.to_string() == query_key
                             || command_key(&recipe.key) == query_key
                             || command_key(&recipe.name) == query_key

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -261,6 +261,13 @@ const manifest = readJson("worldpack.json");
 if (!isObject(manifest)) {
   throw new Error("worldpack.json could not be parsed");
 }
+const registry = readJson("registry.json");
+if (!isObject(registry) || registry.schema_version !== 1) {
+  fail("registry.json must be a schema-version-1 object");
+}
+if (JSON.stringify(registry?.manifest) !== JSON.stringify(manifest)) {
+  fail("registry.json manifest does not match worldpack.json");
+}
 
 validateRequiredStrings("worldpack manifest", manifest, ["id", "name", "description"]);
 if (manifest.schema_version !== 2) {
@@ -395,8 +402,9 @@ if (
   || manifest.rules !== "rules.json"
   || manifest.attributions !== "attributions.json"
   || manifest.character_creation !== "character_creation.json"
+  || manifest.registry !== "registry.json"
 ) {
-  fail("worldpack manifest must map external_cards, assets, rules, attributions, and character_creation to compiled files");
+  fail("worldpack manifest must map the registry and compatibility artifacts to compiled files");
 }
 
 for (const [key, fileName] of Object.entries(expectedFiles)) {
@@ -420,8 +428,14 @@ for (const [key, fileName] of Object.entries(expectedFiles)) {
     }
   }
 }
+if (JSON.stringify(registry?.resources) !== JSON.stringify(content)) {
+  fail("registry.json resources do not match the compatibility resource files");
+}
 
 const externalCards = asArray("external_cards.json", readJson("external_cards.json"));
+if (JSON.stringify(registry?.external_cards) !== JSON.stringify(externalCards)) {
+  fail("registry.json external_cards do not match external_cards.json");
+}
 idSet("external cards", externalCards, (card) => card.card_id);
 for (const card of externalCards) {
   if (!isNonEmptyString(card.pack_id) || !has(packIds, card.pack_id)) {
@@ -448,6 +462,9 @@ for (const pack of packs) {
   }
 }
 const assetMounts = asArray("assets.json", readJson("assets.json"));
+if (JSON.stringify(registry?.assets) !== JSON.stringify(assetMounts)) {
+  fail("registry.json assets do not match assets.json");
+}
 idSet("asset mounts", assetMounts, (mount) => `${mount.pack_id}:${mount.mount}`);
 idSet("asset public prefixes", assetMounts, (mount) => mount.public_prefix);
 for (const mount of assetMounts) {
@@ -465,6 +482,9 @@ for (const mount of assetMounts) {
 }
 
 const ruleBundles = asArray("rules.json", readJson("rules.json"));
+if (JSON.stringify(registry?.rules) !== JSON.stringify(ruleBundles)) {
+  fail("registry.json rules do not match rules.json");
+}
 const rulePackIds = new Set();
 const ruleNamespaces = new Set();
 let ruleConditionCount = 0;
@@ -569,6 +589,9 @@ for (const pack of packs.filter((candidate) => candidate.kind === "rules")) {
 }
 
 const attributions = asArray("attributions.json", readJson("attributions.json"));
+if (JSON.stringify(registry?.attributions) !== JSON.stringify(attributions)) {
+  fail("registry.json attributions do not match attributions.json");
+}
 const attributedPackIds = idSet("attributions", attributions, (attribution) => attribution.pack_id);
 for (const attribution of attributions) {
   validateRequiredStrings("attribution", attribution, ["license", "source_name", "source_url", "text"]);
@@ -607,6 +630,9 @@ if (revisedSrdPack) {
 }
 
 const characterCreationBundles = asArray("character_creation.json", readJson("character_creation.json"));
+if (JSON.stringify(registry?.character_creation) !== JSON.stringify(characterCreationBundles)) {
+  fail("registry.json character_creation does not match character_creation.json");
+}
 const characterCreationPackIds = new Set();
 const characterCreationProfiles = [];
 for (const bundle of characterCreationBundles) {

--- a/v2/scripts/compile-worldpack.mjs
+++ b/v2/scripts/compile-worldpack.mjs
@@ -399,10 +399,23 @@ const manifest = {
   rules: "rules.json",
   attributions: "attributions.json",
   character_creation: "character_creation.json",
+  registry: "registry.json",
+};
+
+const registry = {
+  schema_version: 1,
+  manifest,
+  resources,
+  external_cards: externalCards,
+  assets,
+  rules: ruleBundles,
+  attributions,
+  character_creation: characterCreationBundles,
 };
 
 const outputs = new Map([
   ["worldpack.json", json(manifest)],
+  ["registry.json", json(registry)],
   ["external_cards.json", json(externalCards)],
   ["assets.json", json(assets)],
   ["rules.json", json(ruleBundles)],


### PR DESCRIPTION
Closes #22.

## What changed
- compile every resolved pack set into one deterministic `registry.json` while retaining the per-resource compatibility artifacts
- load the configured registry from `COSYWORLD_CONTENT_REGISTRY_PATH` (or the official content root) before world bootstrap
- add a Rust `ContentRegistry` that owns active content, pack/capability indexes, asset mounts, opaque reference resources, and deterministic dependency order
- validate registry schema, Manifest v1 contract, engine/dependency ranges, required capabilities, optional dependencies, duplicate packs/capabilities, and default rulesets before gameplay
- replace the fixed 22-file `include_str!` seed path and route runtime content/catalog/asset queries through the registry
- align the Rust service version with release 0.0.40 and document the mounted registry contract
- verify `registry.json` remains byte-equivalent to compiler compatibility outputs

## Verification
- `npm run check` (378 Node tests, worldpack validation, C kernel, 316 Rust tests, syntax)
- `npm run lint`
- `npm run check:version`
- `cargo fmt --check --manifest-path v2/orchestrator-rust/Cargo.toml`
- `git diff --check`
- local mounted-registry boot smoke: `/meta` returned 0.0.40, four packs, 33 locations, and bundle `sha256:abb0d1a95daeebaffa917369e9c73ddfe495f8861934c71e912da1417f27afdf`
- missing registry path exits before the listener opens