### PR TITLE
fix: recompile official bundle after asset prompt re-sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.44",
+      "version": "0.0.45",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -9,7 +9,7 @@
     "version": 1,
     "description": "The reproducible seed world for the official CosyWorld shard.",
     "entry_location": "cosyworld.core:location/1",
-    "bundle_hash": "sha256:fb08c711c0167919f262baeeabdb435bac249eb690824e1b031241af756b343c",
+    "bundle_hash": "sha256:df3a8fe0ca6121203d868ea8e49126f38438efb937eb730447dd8121e0f4b81f",
     "packs": [
       {
         "id": "cosyworld.core",
@@ -77,7 +77,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:ebd032bcb69990ab02056b45f8c8ba36600f596a3e47c3258f1bd5ff8f4f475a"
+        "integrity": "sha256:581d6088938ddd258dcefca2b586a88095554e45f0d607a3844e4dabc17936f8"
       },
       {
         "id": "cosyworld.campaign.the-lantern-keeper",

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -7,7 +7,7 @@
   "version": 1,
   "description": "The reproducible seed world for the official CosyWorld shard.",
   "entry_location": "cosyworld.core:location/1",
-  "bundle_hash": "sha256:fb08c711c0167919f262baeeabdb435bac249eb690824e1b031241af756b343c",
+  "bundle_hash": "sha256:df3a8fe0ca6121203d868ea8e49126f38438efb937eb730447dd8121e0f4b81f",
   "packs": [
     {
       "id": "cosyworld.core",
@@ -75,7 +75,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:ebd032bcb69990ab02056b45f8c8ba36600f596a3e47c3258f1bd5ff8f4f475a"
+      "integrity": "sha256:581d6088938ddd258dcefca2b586a88095554e45f0d607a3844e4dabc17936f8"
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -17,7 +17,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:ebd032bcb69990ab02056b45f8c8ba36600f596a3e47c3258f1bd5ff8f4f475a",
+      "integrity": "sha256:581d6088938ddd258dcefca2b586a88095554e45f0d607a3844e4dabc17936f8",
       "dependencies": [],
       "dependency_closure": [],
       "capabilities": [


### PR DESCRIPTION
Main CI is red at content-pack-contract.test.mjs (byte-identical digests): #83 changed core asset prompts without regenerating the official bundle artifacts. This regenerates registry.json, worldpack.json, and pack.lock.json and bumps to 0.0.45. Contract test verified green locally (9/9); worldpack check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)