### PR TITLE
fix: relock core-only composition after asset prompt re-sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.45",
+      "version": "0.0.46",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/core-only/registry.json
+++ b/v2/content/core-only/registry.json
@@ -9,7 +9,7 @@
     "version": 1,
     "description": "The first-party cosy exploration experience with no expansion packs mounted.",
     "entry_location": "cosyworld.core:location/1",
-    "bundle_hash": "sha256:226f9f2dd1cdc5a0cd54b3d8c4b50fc5e6dbf5d0bfa901033fb5e35db9ed00ca",
+    "bundle_hash": "sha256:ffbbce375c279bfd704768457c1175d5e10e96321d4e7dd9a4d99f8763a83fa6",
     "packs": [
       {
         "id": "cosyworld.core",
@@ -77,7 +77,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:ebd032bcb69990ab02056b45f8c8ba36600f596a3e47c3258f1bd5ff8f4f475a"
+        "integrity": "sha256:581d6088938ddd258dcefca2b586a88095554e45f0d607a3844e4dabc17936f8"
       }
     ],
     "files": {

--- a/v2/content/core-only/worldpack.json
+++ b/v2/content/core-only/worldpack.json
@@ -7,7 +7,7 @@
   "version": 1,
   "description": "The first-party cosy exploration experience with no expansion packs mounted.",
   "entry_location": "cosyworld.core:location/1",
-  "bundle_hash": "sha256:226f9f2dd1cdc5a0cd54b3d8c4b50fc5e6dbf5d0bfa901033fb5e35db9ed00ca",
+  "bundle_hash": "sha256:ffbbce375c279bfd704768457c1175d5e10e96321d4e7dd9a4d99f8763a83fa6",
   "packs": [
     {
       "id": "cosyworld.core",
@@ -75,7 +75,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:ebd032bcb69990ab02056b45f8c8ba36600f596a3e47c3258f1bd5ff8f4f475a"
+      "integrity": "sha256:581d6088938ddd258dcefca2b586a88095554e45f0d607a3844e4dabc17936f8"
     }
   ],
   "files": {

--- a/v2/worlds/core-only/pack.lock.json
+++ b/v2/worlds/core-only/pack.lock.json
@@ -14,7 +14,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:ebd032bcb69990ab02056b45f8c8ba36600f596a3e47c3258f1bd5ff8f4f475a",
+      "integrity": "sha256:581d6088938ddd258dcefca2b586a88095554e45f0d607a3844e4dabc17936f8",
       "dependencies": [],
       "dependency_closure": [],
       "capabilities": [


### PR DESCRIPTION
Completes #84: the core-only/services-only compositions added by #82 carry their own pack locks, still referencing pre-#83 core integrity — this is what kept main red after #84. All compositions and the contract test verified green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)