### PR TITLE
Cache ARM64 release builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,8 @@ jobs:
           tags: |
             ${{ steps.ecr.outputs.registry }}/${{ env.AWS_ECR_REPOSITORY }}:${{ github.ref_name }}
             ${{ steps.ecr.outputs.registry }}/${{ env.AWS_ECR_REPOSITORY }}:latest
+          cache-from: type=registry,ref=${{ steps.ecr.outputs.registry }}/${{ env.AWS_ECR_REPOSITORY }}:buildcache
+          cache-to: type=registry,ref=${{ steps.ecr.outputs.registry }}/${{ env.AWS_ECR_REPOSITORY }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
-FROM rust:1-bookworm AS build
-
-WORKDIR /app
-
-COPY v2/core-c ./v2/core-c
-COPY v2/content ./v2/content
-COPY v2/ai-model-rust ./v2/ai-model-rust
-COPY v2/orchestrator-rust ./v2/orchestrator-rust
-COPY src/services/web/public/images/cosy-cottage.png ./src/services/web/public/images/cosy-cottage.png
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1-bookworm AS chef
 
 WORKDIR /app/v2/orchestrator-rust
+
+FROM chef AS planner
+
+COPY v2/core-c /app/v2/core-c
+COPY v2/ai-model-rust /app/v2/ai-model-rust
+COPY v2/orchestrator-rust /app/v2/orchestrator-rust
+
+RUN cargo chef prepare --recipe-path /app/recipe.json
+
+FROM chef AS build
+
+COPY --from=planner /app/recipe.json /app/recipe.json
+COPY v2/core-c /app/v2/core-c
+
+# Keep third-party Rust dependencies in a layer that application source edits do
+# not invalidate. The release workflow persists this layer in ECR.
+RUN cargo chef cook --release --recipe-path /app/recipe.json
+
+COPY v2/core-c /app/v2/core-c
+COPY v2/content /app/v2/content
+COPY v2/ai-model-rust /app/v2/ai-model-rust
+COPY v2/orchestrator-rust /app/v2/orchestrator-rust
+COPY src/services/web/public/images/cosy-cottage.png /app/src/services/web/public/images/cosy-cottage.png
+
 RUN cargo build --release
 
 FROM debian:bookworm-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM chef AS build
 
 COPY --from=planner /app/recipe.json /app/recipe.json
 COPY v2/core-c /app/v2/core-c
+COPY v2/ai-model-rust /app/v2/ai-model-rust
 
 # Keep third-party Rust dependencies in a layer that application source edits do
 # not invalidate. The release workflow persists this layer in ECR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.49",
+      "version": "0.0.50",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.49"
+version = "0.0.50"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What changed

- builds Rust dependencies through a pinned `cargo-chef` planning/cook layer
- persists BuildKit cache layers in the existing ECR repository under the `buildcache` tag
- includes the local `cosyworld-ai-model` crate in the dependency-planning stage
- bumps the release version to 0.0.50

## Why

AWS ARM64 release builds were recompiling the Rust dependency graph on ephemeral runners. Keeping the dependency layer stable and persisting it in ECR lets application-only edits reuse compiled third-party dependencies.

## Impact

The first build still populates the cache. Later releases with unchanged Rust manifests should avoid most dependency recompilation. Quest and knowledge changes from superseded PR #36 are intentionally excluded.

## Validation

- `actionlint .github/workflows/deploy.yml`
- `npm run check:version`
- `git diff --check origin/main...HEAD`
- Docker BuildKit static validation was attempted, but the local Podman/Docker daemon is not running; GitHub CI is the build validation gate.