### PR TITLE
Reset room transcript after live travel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.50"
+version = "0.0.51"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5638,6 +5638,7 @@
       try {
         const receipt = JSON.parse(event.content);
         if (!receipt?.state) return false;
+        const previousLocationId = state?.location?.id || null;
         const previousAccess = state?.access || null;
         const previousAccount = state?.account || null;
         state = receipt.state;
@@ -5648,6 +5649,11 @@
         }
         if (previousAccount && !state.account?.authenticated) {
           state.account = previousAccount;
+        }
+        const locationChanged = previousLocationId && previousLocationId !== state.location?.id;
+        if (locationChanged) {
+          pendingChats = [];
+          rebuildLog([...(state.recent_events || [])].reverse());
         }
         actions = buildActions(state);
         return true;

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4352,6 +4352,9 @@ async function main() {
       const previousSeen = new Set(seenSeq);
       const previousActorId = actorId;
       const previousAccountPanelPinned = accountPanelPinned;
+      const previousState = state;
+      const previousActions = actions;
+      const previousPendingChats = pendingChats.slice();
       const message = (seq, actorIdValue, actorName, content) => ({
         seq,
         type: "message.created",
@@ -4438,6 +4441,36 @@ async function main() {
         const acceptsForwardTimeline = !transcriptTimelineRewound({
           recent_events: [message(93, 5000, "Moss Stitch", "new history")],
         }, 92);
+        const oldRoomLine = message(300, 5000, "Moss Stitch", "old room history");
+        const newRoomLine = {
+          ...message(301, 5000, "Moss Stitch", "new room history"),
+          location_id: 2,
+          location_name: "New Room",
+        };
+        state = {
+          ...state,
+          location: { ...(state?.location || {}), id: 1, name: "Old Room" },
+          recent_events: [oldRoomLine],
+        };
+        logEvents = [oldRoomLine];
+        pendingChats = [{ id: "pending-old-room-chat" }];
+        const travelReceiptApplied = applyActionReceipt({
+          type: "action.receipt",
+          content: JSON.stringify({
+            state: {
+              ...state,
+              location: { ...state.location, id: 2, name: "New Room" },
+              recent_events: [newRoomLine],
+            },
+            world_tick: 12,
+            state_revision: 34,
+          }),
+        });
+        const afterTravelReceipt = {
+          applied: travelReceiptApplied,
+          pendingCount: pendingChats.length,
+          events: logEvents.map((event) => ({ seq: event.seq, content: event.content })),
+        };
         return {
           collapsed,
           collapsedHtml,
@@ -4454,6 +4487,7 @@ async function main() {
           afterReplayReset,
           detectsServerTimelineRewind,
           acceptsForwardTimeline,
+          afterTravelReceipt,
         };
       } finally {
         logEvents = previousLogEvents;
@@ -4461,6 +4495,9 @@ async function main() {
         for (const seq of previousSeen) seenSeq.add(seq);
         actorId = previousActorId;
         accountPanelPinned = previousAccountPanelPinned;
+        state = previousState;
+        actions = previousActions;
+        pendingChats = previousPendingChats;
         renderTimelines();
       }
     });
@@ -4478,6 +4515,7 @@ async function main() {
     assert(result.afterLiveReset.length === 1 && result.afterLiveReset[0]?.content === "*the new room begins quietly*", `a live world reset should clear the previous transcript: ${JSON.stringify(result)}`);
     assert(result.afterReplayReset.length === 1 && result.afterReplayReset[0]?.content === "fresh firelight", `rebuilding replay should keep only unique chat after the latest world reset: ${JSON.stringify(result)}`);
     assert(result.detectsServerTimelineRewind && result.acceptsForwardTimeline, `a reconnect should replace rewound server history without mistaking a forward timeline for a reset: ${JSON.stringify(result)}`);
+    assert(result.afterTravelReceipt?.applied && result.afterTravelReceipt.pendingCount === 0 && result.afterTravelReceipt.events.length === 1 && result.afterTravelReceipt.events[0]?.content === "new room history", `a live travel receipt should clear pending chat and replace the old room transcript: ${JSON.stringify(result)}`);
   }
 
   async function assertCardBeatsStayInSceneAndBookkeepingStaysOut() {


### PR DESCRIPTION
## What changed

- detects location changes delivered through live `action.receipt` events
- clears pending chat from the previous room and rebuilds the transcript from the destination room's recent events
- adds a browser smoke regression covering pending-chat removal and transcript replacement
- aligns Node and Rust release versions at 0.0.51

## Why

Regular state refreshes already rebuilt room history after travel, but live action receipts replaced state without clearing the old room transcript. A player could briefly retain stale room lines and pending chat after moving.

## Impact

Live travel now has the same room-boundary behavior as a normal refresh: the destination transcript replaces the old room history and pending chat cannot leak across rooms.

## Validation

- focused Playwright regression against a locally built server
- `npm run check:version`
- `npm run v2:syntax`
- `cargo test content_registry::tests::official_registry_exposes_pack_aware_indexes`
- `git diff --check`