### PR TITLE
Expose complete content pack licensing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.55",
+      "version": "0.0.56",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/content-pack-contract.test.mjs
+++ b/test/v2/content-pack-contract.test.mjs
@@ -20,10 +20,15 @@ function manifest(id, overrides = {}) {
     kind: "assets",
     description: `${id} fixture`,
     license: "MIT",
+    license_url: "https://opensource.org/license/mit",
     engine: ">=0.0.20 <0.1.0",
     capabilities: [{ id: `${id}/assets`, kind: "assets", version: "1.0.0" }],
     dependencies: [],
-    provenance: { source_name: "contract test" },
+    provenance: {
+      author: "Contract Test",
+      source_name: "contract test",
+      source_url: "https://example.com/contract-test",
+    },
     ...overrides,
   };
 }
@@ -54,11 +59,37 @@ describe("Content Pack Manifest v1", () => {
     expect(lock.canonical_id_mapping_version).toBe(1);
     expect(lock.dependency_order).toEqual(lock.packs.map((pack) => pack.id));
     expect(lock.license_records.map((record) => record.pack_id)).toEqual(lock.dependency_order);
+    expect(lock.license_records.every((record) => (
+      record.license_identifier
+      && record.license_url.startsWith("https://")
+      && record.provenance.author
+      && Array.isArray(record.notices)
+    ))).toBe(true);
+    const lantern = lock.license_records.find(
+      (record) => record.pack_id === "cosyworld.campaign.the-lantern-keeper",
+    );
+    expect(lantern.provenance.modification_notice).toMatch(/SRD 5\.1/);
+    expect(lantern.notices[0].text).toContain("System Reference Document 5.1");
+    expect(lantern.notices[0].text).toContain(
+      "creativecommons.org/licenses/by/4.0/legalcode",
+    );
     expect(lock.packs.every((pack) => (
       /^sha256:[0-9a-f]{64}$/.test(pack.integrity)
       && Array.isArray(pack.dependency_closure)
       && pack.capabilities.length > 0
     ))).toBe(true);
+  });
+
+  it("requires complete license and provenance coordinates", () => {
+    expect(() => validateContentPackManifest(manifest("fixture.no-license-url", {
+      license_url: undefined,
+    }))).toThrow(/license_url/);
+    expect(() => validateContentPackManifest(manifest("fixture.no-author", {
+      provenance: {
+        source_name: "contract test",
+        source_url: "https://example.com/contract-test",
+      },
+    }))).toThrow(/author/);
   });
 
   it("rejects unknown fields but preserves namespaced extensions", () => {

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -118,7 +118,7 @@ describe("worldpack Manifest v1 validation", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "requires missing capability cosyworld.core/missing from cosyworld.core@1.3.0",
+      "requires missing capability cosyworld.core/missing from cosyworld.core@1.3.1",
     );
   });
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -599,6 +599,8 @@ Dialogue prompts keep the latest 16 spoken lines per room in a bounded, snapshot
 
 - `GET /health`
 - `GET /meta`
+- `GET /licenses`
+- `GET /content-packs`
 - `GET /state`
 - `GET /state?actor_id=5000&actor_session=<session>`
 - `GET /state?actor_id=5000&actor_session=<session>&wallet_session=<wallet-session>`
@@ -647,7 +649,7 @@ journaled as append-only lifecycle events, and persisted in snapshots. See
 [`docs/combat-system.md`](docs/combat-system.md) for the exact SRD-compatible
 surface and deliberate exclusions.
 
-`/health` is intentionally minimal readiness. `/meta` is the deploy/smoke metadata endpoint: package version, debug/release build profile, deployment profile, shard id/model, non-secret feature flags such as server-authored Chat and enabled client-authored speech, persistence mode, moderation report retention, ownership-feed mode, current world counters, and compiled kernel capacities. `./v2/mvp.sh status` prints a one-line summary from it.
+`/health` is intentionally minimal readiness. `/meta` is the deploy/smoke metadata endpoint: package version, debug/release build profile, deployment profile, shard id/model, non-secret feature flags such as server-authored Chat and enabled client-authored speech, persistence mode, moderation report retention, ownership-feed mode, current world counters, compiled kernel capacities, and the mounted packs' exact license records. `GET /licenses` exposes those pack versions, license links, provenance, modification notices, and bundled attribution text without authentication. `./v2/mvp.sh status` prints a one-line summary from `/meta`.
 
 Protected operator audit routes require `Authorization: Bearer <COSYWORLD_MODERATION_TOKEN>`. `/moderation` serves a no-store operator console that stores the bearer token in local browser storage and uses the protected report endpoints; loading the page alone does not expose report data. The console can resolve reports, delete resolved reports, suspend the reporter attached to an open report, and suspend a reported target when that target is a human avatar. Report suspension actions also resolve the report with a suspension note, so the open queue reflects the operator action. Report details show current reporter/target suspension state and can unsuspend suspended human actors from open or resolved reports. `/moderation/events` returns bounded all-room event replay, `/moderation/reports` returns bounded player report queue entries, `/moderation/reports/{report_id}/resolve` closes a report with resolution metadata, `/moderation/reports/{report_id}/delete` removes a resolved report, `/moderation/activation` returns first-session and day-seven retention evidence from the activation event table, and `/moderation/economy` returns bounded Orb ledger, AI usage ledger, Wooden Box receipt, and avatar pack opening rows without exposing player OpenRouter keys.
 

--- a/v2/content/core-only/assets.json
+++ b/v2/content/core-only/assets.json
@@ -1,8 +1,8 @@
 [
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.0",
-    "pack_integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+    "pack_version": "1.3.1",
+    "pack_integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -14,8 +14,8 @@
   },
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.0",
-    "pack_integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+    "pack_version": "1.3.1",
+    "pack_integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/core-only/content_refs.json
+++ b/v2/content/core-only/content_refs.json
@@ -5,7 +5,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1001",
       "legacy_runtime_id": 1001,
@@ -14,7 +14,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1002",
       "legacy_runtime_id": 1002,
@@ -23,7 +23,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1003",
       "legacy_runtime_id": 1003,
@@ -32,7 +32,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1004",
       "legacy_runtime_id": 1004,
@@ -41,7 +41,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1005",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1005",
       "legacy_runtime_id": 1005,
@@ -50,7 +50,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1040",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1040",
       "legacy_runtime_id": 1040,
@@ -59,7 +59,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1041",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1041",
       "legacy_runtime_id": 1041,
@@ -68,7 +68,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1042",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1042",
       "legacy_runtime_id": 1042,
@@ -77,7 +77,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1043",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1043",
       "legacy_runtime_id": 1043,
@@ -86,7 +86,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1044",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1044",
       "legacy_runtime_id": 1044,
@@ -95,7 +95,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1045",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1045",
       "legacy_runtime_id": 1045,
@@ -104,7 +104,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1046",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1046",
       "legacy_runtime_id": 1046,
@@ -113,7 +113,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1047",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1047",
       "legacy_runtime_id": 1047,
@@ -122,7 +122,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1048",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1048",
       "legacy_runtime_id": 1048,
@@ -131,7 +131,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1049",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1049",
       "legacy_runtime_id": 1049,
@@ -140,7 +140,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1050",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1050",
       "legacy_runtime_id": 1050,
@@ -149,7 +149,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1051",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1051",
       "legacy_runtime_id": 1051,
@@ -158,7 +158,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1052",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1052",
       "legacy_runtime_id": 1052,
@@ -167,7 +167,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1053",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1053",
       "legacy_runtime_id": 1053,
@@ -176,7 +176,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1054",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1054",
       "legacy_runtime_id": 1054,
@@ -185,7 +185,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1055",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1055",
       "legacy_runtime_id": 1055,
@@ -194,7 +194,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1056",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1056",
       "legacy_runtime_id": 1056,
@@ -203,7 +203,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1057",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1057",
       "legacy_runtime_id": 1057,
@@ -212,7 +212,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1058",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1058",
       "legacy_runtime_id": 1058,
@@ -221,7 +221,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1059",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1059",
       "legacy_runtime_id": 1059,
@@ -230,7 +230,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1060",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1060",
       "legacy_runtime_id": 1060,
@@ -239,7 +239,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1061",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1061",
       "legacy_runtime_id": 1061,
@@ -248,7 +248,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1062",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1062",
       "legacy_runtime_id": 1062,
@@ -257,7 +257,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1063",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1063",
       "legacy_runtime_id": 1063,
@@ -266,7 +266,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1064",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1064",
       "legacy_runtime_id": 1064,
@@ -275,7 +275,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1065",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1065",
       "legacy_runtime_id": 1065,
@@ -284,7 +284,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1066",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1066",
       "legacy_runtime_id": 1066,
@@ -293,7 +293,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1067",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1067",
       "legacy_runtime_id": 1067,
@@ -302,7 +302,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1068",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1068",
       "legacy_runtime_id": 1068,
@@ -311,7 +311,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1069",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1069",
       "legacy_runtime_id": 1069,
@@ -320,7 +320,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1070",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1070",
       "legacy_runtime_id": 1070,
@@ -329,7 +329,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-abbey-bookmark",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-abbey-bookmark",
       "runtime_handle": 138956494956560
@@ -337,7 +337,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-azazoth",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-azazoth",
       "runtime_handle": 2742827434789688
@@ -345,7 +345,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-cottage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-cottage",
       "runtime_handle": 3679023710615970
@@ -353,7 +353,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-dewbright-button",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-dewbright-button",
       "runtime_handle": 7543879359126606
@@ -361,7 +361,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-hearth-tonic",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-hearth-tonic",
       "runtime_handle": 6099844187041316
@@ -369,7 +369,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-hearthstone-tag",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-hearthstone-tag",
       "runtime_handle": 445803431082645
@@ -377,7 +377,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-echo",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-moonlit-echo",
       "runtime_handle": 3701779326615881
@@ -385,7 +385,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-trail",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-moonlit-trail",
       "runtime_handle": 3706559719582066
@@ -393,7 +393,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonwool-thread",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-moonwool-thread",
       "runtime_handle": 3248987744606910
@@ -401,7 +401,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-mossglass-bead",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-mossglass-bead",
       "runtime_handle": 406732117808934
@@ -409,7 +409,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-old-oak",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-old-oak",
       "runtime_handle": 6806929065153819
@@ -417,7 +417,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-pearl-deep-resident",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-pearl-deep-resident",
       "runtime_handle": 8634483881055898
@@ -425,7 +425,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-rain-soft-garden",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-rain-soft-garden",
       "runtime_handle": 8636127016066734
@@ -433,7 +433,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-skull",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-skull",
       "runtime_handle": 8174630967825761
@@ -441,7 +441,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-story-button",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-story-button",
       "runtime_handle": 3151408643854036
@@ -449,7 +449,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-threadbare-map-scrap",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-threadbare-map-scrap",
       "runtime_handle": 4482891498418887
@@ -457,7 +457,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-vowbright-angel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-vowbright-angel",
       "runtime_handle": 7966555082684141
@@ -465,7 +465,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-watch-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-watch-bell",
       "runtime_handle": 6205526622615328
@@ -473,7 +473,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-whiskerwind",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-whiskerwind",
       "runtime_handle": 5669444972898140
@@ -481,7 +481,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-wolfprint-charm",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-wolfprint-charm",
       "runtime_handle": 915703357568385
@@ -489,7 +489,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-zadkiel-dark-angel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-zadkiel-dark-angel",
       "runtime_handle": 8315124370132858
@@ -497,7 +497,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-armored-winged-hero",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-armored-winged-hero",
       "runtime_handle": 6600128378329146
@@ -505,7 +505,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-badger-cub",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-badger-cub",
       "runtime_handle": 3524217422483260
@@ -513,7 +513,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-beetle-armor",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-beetle-armor",
       "runtime_handle": 7880939887467250
@@ -521,7 +521,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-blue-shadow-man",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-blue-shadow-man",
       "runtime_handle": 3755993660754793
@@ -529,7 +529,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-blue-squirrel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-blue-squirrel",
       "runtime_handle": 3374679645864704
@@ -537,7 +537,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-cloaked-mouse-reader",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-cloaked-mouse-reader",
       "runtime_handle": 3997082335066109
@@ -545,7 +545,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-forest-dryad",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-forest-dryad",
       "runtime_handle": 8662818472079145
@@ -553,7 +553,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-garden-rabbit",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-garden-rabbit",
       "runtime_handle": 2730391876987516
@@ -561,7 +561,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-golden-squirrel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-golden-squirrel",
       "runtime_handle": 162503682361987
@@ -569,7 +569,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-golden-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-golden-winged-boy",
       "runtime_handle": 4342854739894551
@@ -577,7 +577,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-grey-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-grey-winged-boy",
       "runtime_handle": 1250802238685798
@@ -585,7 +585,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-llama-scholar",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-llama-scholar",
       "runtime_handle": 6908093676132939
@@ -593,7 +593,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-mouse-wanderer",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-mouse-wanderer",
       "runtime_handle": 4601206403124060
@@ -601,7 +601,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-neon-tiger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-neon-tiger",
       "runtime_handle": 6229971572743818
@@ -609,7 +609,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-rabbit-scribe",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-rabbit-scribe",
       "runtime_handle": 8634110685852129
@@ -617,7 +617,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-red-shadow-figure",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-red-shadow-figure",
       "runtime_handle": 3112884101630158
@@ -625,7 +625,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-shadow-wolf",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-shadow-wolf",
       "runtime_handle": 4273988789998875
@@ -633,7 +633,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-steampunk-mouse",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-steampunk-mouse",
       "runtime_handle": 4441668646189737
@@ -641,7 +641,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-sunlit-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-sunlit-winged-boy",
       "runtime_handle": 8615932867192302
@@ -649,7 +649,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-tavern-blond-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-tavern-blond-boy",
       "runtime_handle": 1835702442135722
@@ -657,7 +657,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-veiled-forest-ghost",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-veiled-forest-ghost",
       "runtime_handle": 4799858469869419
@@ -665,7 +665,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-white-ferret-noble",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-white-ferret-noble",
       "runtime_handle": 5084247526999701
@@ -673,7 +673,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-wolf-pup",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-wolf-pup",
       "runtime_handle": 236437027581609
@@ -681,7 +681,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-woodland-bear",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-woodland-bear",
       "runtime_handle": 9000656934868850
@@ -689,7 +689,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-alpine-forest",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-alpine-forest",
       "runtime_handle": 8242458519360113
@@ -697,7 +697,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-circle-of-the-moon",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-circle-of-the-moon",
       "runtime_handle": 1930856172148870
@@ -705,7 +705,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-dark-abyss",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-dark-abyss",
       "runtime_handle": 7382677506125331
@@ -713,7 +713,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-darkest-ocean",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-darkest-ocean",
       "runtime_handle": 5061075064260629
@@ -721,7 +721,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-digital-realm",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-digital-realm",
       "runtime_handle": 5887686546418438
@@ -729,7 +729,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-endless-ocean",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-endless-ocean",
       "runtime_handle": 5401754774320525
@@ -737,7 +737,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-flower-meadow",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-flower-meadow",
       "runtime_handle": 7614022144101722
@@ -745,7 +745,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-goblin-cave",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-goblin-cave",
       "runtime_handle": 3499001612672709
@@ -753,7 +753,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-great-library",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-great-library",
       "runtime_handle": 7328586258800562
@@ -761,7 +761,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-haunted-mansion",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-haunted-mansion",
       "runtime_handle": 7484239537948286
@@ -769,7 +769,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-lofty-peak",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-lofty-peak",
       "runtime_handle": 2456240765655012
@@ -777,7 +777,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-lost-woods",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-lost-woods",
       "runtime_handle": 6580883718503069
@@ -785,7 +785,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-old-oak-tree",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-old-oak-tree",
       "runtime_handle": 2838379433219254
@@ -793,7 +793,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-quiet-abbey",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-quiet-abbey",
       "runtime_handle": 4838231888638100
@@ -801,7 +801,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-solar-temple",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-solar-temple",
       "runtime_handle": 450219611871818
@@ -809,7 +809,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-summit-trail",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-summit-trail",
       "runtime_handle": 8064929121549612
@@ -817,7 +817,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-the-heavens",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-the-heavens",
       "runtime_handle": 6396411156616223
@@ -825,7 +825,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-turgid-swamp",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-turgid-swamp",
       "runtime_handle": 6935773679641332
@@ -833,7 +833,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-wilting-jungle",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-wilting-jungle",
       "runtime_handle": 5897394732936641
@@ -841,7 +841,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/rati",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "rati",
       "runtime_handle": 1392254580257493
@@ -849,7 +849,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.fair-bargain",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "goblin-cave.fair-bargain",
       "runtime_handle": 8054949801377040
@@ -857,7 +857,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.leverage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "goblin-cave.leverage",
       "runtime_handle": 1065707925425919
@@ -865,7 +865,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "haunted-mansion.threshold",
       "runtime_handle": 4535315091897137
@@ -873,7 +873,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.warden-rage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "haunted-mansion.warden-rage",
       "runtime_handle": 6257115991159330
@@ -881,7 +881,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.danger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "moonlit-trail.danger",
       "runtime_handle": 257345026365457
@@ -889,7 +889,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.progress",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "moonlit-trail.progress",
       "runtime_handle": 6085238183587093
@@ -897,7 +897,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.drowned-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "solar-abyss.drowned-bell",
       "runtime_handle": 3555240757788262
@@ -905,7 +905,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.schism",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "solar-abyss.schism",
       "runtime_handle": 4589004266308223
@@ -913,7 +913,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.amends",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "turgid-swamp.amends",
       "runtime_handle": 4432023342275341
@@ -921,7 +921,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.old-grudge",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "turgid-swamp.old-grudge",
       "runtime_handle": 8536373757408084
@@ -929,7 +929,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/abyssal_residents",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "abyssal_residents",
       "runtime_handle": 1688333275188302
@@ -937,7 +937,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/digital_strays",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "digital_strays",
       "runtime_handle": 5048545454289654
@@ -945,7 +945,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/farthest_mists",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "farthest_mists",
       "runtime_handle": 350962558801960
@@ -953,7 +953,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/goblin_market",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "goblin_market",
       "runtime_handle": 3490418888358082
@@ -961,7 +961,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/great_library",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "great_library",
       "runtime_handle": 991170045564473
@@ -969,7 +969,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/haunted_remnants",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "haunted_remnants",
       "runtime_handle": 4900866309718573
@@ -977,7 +977,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/hearthbound",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "hearthbound",
       "runtime_handle": 4046513959484943
@@ -985,7 +985,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/lonely_forest_court",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "lonely_forest_court",
       "runtime_handle": 5495209280499345
@@ -993,7 +993,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/moon_circle",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "moon_circle",
       "runtime_handle": 3594504273910135
@@ -1001,7 +1001,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/quiet_abbey",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "quiet_abbey",
       "runtime_handle": 7894097855005461
@@ -1009,7 +1009,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/solar_temple",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "solar_temple",
       "runtime_handle": 2642136344425509
@@ -1017,7 +1017,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/goblin-cave%3Amarket-leverage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "goblin-cave:market-leverage",
       "runtime_handle": 5093973293074428
@@ -1025,7 +1025,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/haunted-mansion%3Abarred-threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "haunted-mansion:barred-threshold",
       "runtime_handle": 6295078661322495
@@ -1033,7 +1033,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/moonlit-trail%3Aecho-front",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "moonlit-trail:echo-front",
       "runtime_handle": 3643385637336037
@@ -1041,7 +1041,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/solar-abyss%3Abell-front",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "solar-abyss:bell-front",
       "runtime_handle": 591496292254136
@@ -1049,7 +1049,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/turgid-swamp%3Aold-grudge",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "turgid-swamp:old-grudge",
       "runtime_handle": 5644962986267984
@@ -1057,7 +1057,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/hidden-exit/darkest-ocean%3Adark-abyss",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "hidden-exit",
       "local_id": "darkest-ocean:dark-abyss",
       "runtime_handle": 456562266146446
@@ -1065,7 +1065,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2001",
       "legacy_runtime_id": 2001,
@@ -1074,7 +1074,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2002",
       "legacy_runtime_id": 2002,
@@ -1083,7 +1083,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2003",
       "legacy_runtime_id": 2003,
@@ -1092,7 +1092,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2004",
       "legacy_runtime_id": 2004,
@@ -1101,7 +1101,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2005",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2005",
       "legacy_runtime_id": 2005,
@@ -1110,7 +1110,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2006",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2006",
       "legacy_runtime_id": 2006,
@@ -1119,7 +1119,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2007",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2007",
       "legacy_runtime_id": 2007,
@@ -1128,7 +1128,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2008",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2008",
       "legacy_runtime_id": 2008,
@@ -1137,7 +1137,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2009",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2009",
       "legacy_runtime_id": 2009,
@@ -1146,7 +1146,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2010",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2010",
       "legacy_runtime_id": 2010,
@@ -1155,7 +1155,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/goblin-cave%3Aname-the-price",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "goblin-cave:name-the-price",
       "runtime_handle": 3094113202720990
@@ -1163,7 +1163,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/haunted-mansion%3Aearn-the-threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "haunted-mansion:earn-the-threshold",
       "runtime_handle": 7833342030263292
@@ -1171,7 +1171,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/moonlit-trail%3Aquiet-the-echo",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "moonlit-trail:quiet-the-echo",
       "runtime_handle": 3184352149003600
@@ -1179,7 +1179,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/solar-abyss%3Adrowned-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "solar-abyss:drowned-bell",
       "runtime_handle": 681263158451131
@@ -1187,7 +1187,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/turgid-swamp%3Aamend-the-ledger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "turgid-swamp:amend-the-ledger",
       "runtime_handle": 477973030695414
@@ -1195,7 +1195,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/1",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "1",
       "legacy_runtime_id": 1,
@@ -1204,7 +1204,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/2",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "2",
       "legacy_runtime_id": 2,
@@ -1213,7 +1213,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/3",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "3",
       "legacy_runtime_id": 3,
@@ -1222,7 +1222,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/30",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "30",
       "legacy_runtime_id": 30,
@@ -1231,7 +1231,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/31",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "31",
       "legacy_runtime_id": 31,
@@ -1240,7 +1240,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/32",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "32",
       "legacy_runtime_id": 32,
@@ -1249,7 +1249,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/33",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "33",
       "legacy_runtime_id": 33,
@@ -1258,7 +1258,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/34",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "34",
       "legacy_runtime_id": 34,
@@ -1267,7 +1267,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/35",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "35",
       "legacy_runtime_id": 35,
@@ -1276,7 +1276,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/36",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "36",
       "legacy_runtime_id": 36,
@@ -1285,7 +1285,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/40",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "40",
       "legacy_runtime_id": 40,
@@ -1294,7 +1294,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/41",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "41",
       "legacy_runtime_id": 41,
@@ -1303,7 +1303,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/42",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "42",
       "legacy_runtime_id": 42,
@@ -1312,7 +1312,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/43",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "43",
       "legacy_runtime_id": 43,
@@ -1321,7 +1321,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/44",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "44",
       "legacy_runtime_id": 44,
@@ -1330,7 +1330,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/50",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "50",
       "legacy_runtime_id": 50,
@@ -1339,7 +1339,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/60",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "60",
       "legacy_runtime_id": 60,
@@ -1348,7 +1348,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/61",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "61",
       "legacy_runtime_id": 61,
@@ -1357,7 +1357,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/62",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "62",
       "legacy_runtime_id": 62,
@@ -1366,7 +1366,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/63",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "63",
       "legacy_runtime_id": 63,
@@ -1375,7 +1375,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/64",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "64",
       "legacy_runtime_id": 64,
@@ -1384,7 +1384,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/65",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "65",
       "legacy_runtime_id": 65,
@@ -1393,7 +1393,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "recipe",
       "local_id": "3001",
       "runtime_handle": 828439639934659
@@ -1401,7 +1401,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A1",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:1",
       "runtime_handle": 3639178970696137
@@ -1409,7 +1409,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A2",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:2",
       "runtime_handle": 4328625160851383
@@ -1417,7 +1417,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A3",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:3",
       "runtime_handle": 272728635448160
@@ -1425,7 +1425,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A30",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:30",
       "runtime_handle": 4949881785988127
@@ -1433,7 +1433,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A31",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:31",
       "runtime_handle": 12158853449275
@@ -1441,7 +1441,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A32",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:32",
       "runtime_handle": 3065031734117441
@@ -1449,7 +1449,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A33",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:33",
       "runtime_handle": 8635481635081203
@@ -1457,7 +1457,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A34",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:34",
       "runtime_handle": 3415405010788251
@@ -1465,7 +1465,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A35",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:35",
       "runtime_handle": 8268805670112054
@@ -1473,7 +1473,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A36",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:36",
       "runtime_handle": 1278082739662403
@@ -1481,7 +1481,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A40",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:40",
       "runtime_handle": 2373835638704337
@@ -1489,7 +1489,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A41",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:41",
       "runtime_handle": 302978963504637
@@ -1497,7 +1497,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A42",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:42",
       "runtime_handle": 4669140359619141
@@ -1505,7 +1505,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A43",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:43",
       "runtime_handle": 3577060339822743
@@ -1513,7 +1513,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A44",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:44",
       "runtime_handle": 4396167510730171
@@ -1521,7 +1521,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A50",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:50",
       "runtime_handle": 1673766510642920
@@ -1529,7 +1529,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A60",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:60",
       "runtime_handle": 5586350793250546
@@ -1537,7 +1537,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A61",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:61",
       "runtime_handle": 6162116676111910
@@ -1545,7 +1545,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A62",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:62",
       "runtime_handle": 897159537111265
@@ -1553,7 +1553,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A63",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:63",
       "runtime_handle": 7446099757621175
@@ -1561,7 +1561,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A64",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:64",
       "runtime_handle": 4767551281449957
@@ -1569,7 +1569,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A65",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:65",
       "runtime_handle": 389717939014779

--- a/v2/content/core-only/licenses.json
+++ b/v2/content/core-only/licenses.json
@@ -1,0 +1,15 @@
+[
+  {
+    "pack_id": "cosyworld.core",
+    "name": "CosyWorld Core",
+    "version": "1.3.1",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
+  }
+]

--- a/v2/content/core-only/registry.json
+++ b/v2/content/core-only/registry.json
@@ -9,15 +9,16 @@
     "version": 1,
     "description": "The first-party cosy exploration experience with no expansion packs mounted.",
     "entry_location": "cosyworld.core:location/1",
-    "bundle_hash": "sha256:33bd77b88583110f8156e3376eaf8478a4a03ac0716fb3144b88798c41b0476e",
+    "bundle_hash": "sha256:446069c94b9ca2c05217f41575d06b06e23d29fb1d1c280bb53985a7c22f3810",
     "packs": [
       {
         "id": "cosyworld.core",
         "name": "CosyWorld Core",
         "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
-        "version": "1.3.0",
+        "version": "1.3.1",
         "kind": "world",
         "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
         "engine": ">=0.0.20 <0.1.0",
         "capabilities": [
           {
@@ -47,6 +48,7 @@
           }
         ],
         "provenance": {
+          "author": "Cenetex",
           "source_name": "CosyWorld",
           "source_url": "https://github.com/cenetex/cosyworld"
         },
@@ -79,7 +81,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68"
+        "integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4"
       }
     ],
     "files": {
@@ -107,6 +109,7 @@
     "assets": "assets.json",
     "rules": "rules.json",
     "attributions": "attributions.json",
+    "licenses": "licenses.json",
     "character_creation": "character_creation.json",
     "content_references": "content_refs.json",
     "registry": "registry.json"
@@ -5370,8 +5373,8 @@
   "assets": [
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
-      "pack_integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+      "pack_version": "1.3.1",
+      "pack_integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -5383,8 +5386,8 @@
     },
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
-      "pack_integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+      "pack_version": "1.3.1",
+      "pack_integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",
@@ -5397,6 +5400,21 @@
   ],
   "rules": [],
   "attributions": [],
+  "licenses": [
+    {
+      "pack_id": "cosyworld.core",
+      "name": "CosyWorld Core",
+      "version": "1.3.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    }
+  ],
   "character_creation": [],
   "content_references": {
     "schema_version": 1,
@@ -5405,7 +5423,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1001",
         "legacy_runtime_id": 1001,
@@ -5414,7 +5432,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1002",
         "legacy_runtime_id": 1002,
@@ -5423,7 +5441,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1003",
         "legacy_runtime_id": 1003,
@@ -5432,7 +5450,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1004",
         "legacy_runtime_id": 1004,
@@ -5441,7 +5459,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1005",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1005",
         "legacy_runtime_id": 1005,
@@ -5450,7 +5468,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1040",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1040",
         "legacy_runtime_id": 1040,
@@ -5459,7 +5477,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1041",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1041",
         "legacy_runtime_id": 1041,
@@ -5468,7 +5486,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1042",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1042",
         "legacy_runtime_id": 1042,
@@ -5477,7 +5495,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1043",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1043",
         "legacy_runtime_id": 1043,
@@ -5486,7 +5504,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1044",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1044",
         "legacy_runtime_id": 1044,
@@ -5495,7 +5513,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1045",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1045",
         "legacy_runtime_id": 1045,
@@ -5504,7 +5522,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1046",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1046",
         "legacy_runtime_id": 1046,
@@ -5513,7 +5531,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1047",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1047",
         "legacy_runtime_id": 1047,
@@ -5522,7 +5540,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1048",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1048",
         "legacy_runtime_id": 1048,
@@ -5531,7 +5549,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1049",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1049",
         "legacy_runtime_id": 1049,
@@ -5540,7 +5558,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1050",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1050",
         "legacy_runtime_id": 1050,
@@ -5549,7 +5567,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1051",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1051",
         "legacy_runtime_id": 1051,
@@ -5558,7 +5576,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1052",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1052",
         "legacy_runtime_id": 1052,
@@ -5567,7 +5585,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1053",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1053",
         "legacy_runtime_id": 1053,
@@ -5576,7 +5594,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1054",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1054",
         "legacy_runtime_id": 1054,
@@ -5585,7 +5603,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1055",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1055",
         "legacy_runtime_id": 1055,
@@ -5594,7 +5612,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1056",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1056",
         "legacy_runtime_id": 1056,
@@ -5603,7 +5621,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1057",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1057",
         "legacy_runtime_id": 1057,
@@ -5612,7 +5630,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1058",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1058",
         "legacy_runtime_id": 1058,
@@ -5621,7 +5639,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1059",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1059",
         "legacy_runtime_id": 1059,
@@ -5630,7 +5648,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1060",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1060",
         "legacy_runtime_id": 1060,
@@ -5639,7 +5657,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1061",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1061",
         "legacy_runtime_id": 1061,
@@ -5648,7 +5666,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1062",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1062",
         "legacy_runtime_id": 1062,
@@ -5657,7 +5675,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1063",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1063",
         "legacy_runtime_id": 1063,
@@ -5666,7 +5684,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1064",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1064",
         "legacy_runtime_id": 1064,
@@ -5675,7 +5693,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1065",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1065",
         "legacy_runtime_id": 1065,
@@ -5684,7 +5702,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1066",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1066",
         "legacy_runtime_id": 1066,
@@ -5693,7 +5711,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1067",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1067",
         "legacy_runtime_id": 1067,
@@ -5702,7 +5720,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1068",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1068",
         "legacy_runtime_id": 1068,
@@ -5711,7 +5729,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1069",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1069",
         "legacy_runtime_id": 1069,
@@ -5720,7 +5738,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1070",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1070",
         "legacy_runtime_id": 1070,
@@ -5729,7 +5747,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-abbey-bookmark",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-abbey-bookmark",
         "runtime_handle": 138956494956560
@@ -5737,7 +5755,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-azazoth",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-azazoth",
         "runtime_handle": 2742827434789688
@@ -5745,7 +5763,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-cottage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-cottage",
         "runtime_handle": 3679023710615970
@@ -5753,7 +5771,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-dewbright-button",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-dewbright-button",
         "runtime_handle": 7543879359126606
@@ -5761,7 +5779,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-hearth-tonic",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-hearth-tonic",
         "runtime_handle": 6099844187041316
@@ -5769,7 +5787,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-hearthstone-tag",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-hearthstone-tag",
         "runtime_handle": 445803431082645
@@ -5777,7 +5795,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-echo",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-moonlit-echo",
         "runtime_handle": 3701779326615881
@@ -5785,7 +5803,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-trail",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-moonlit-trail",
         "runtime_handle": 3706559719582066
@@ -5793,7 +5811,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonwool-thread",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-moonwool-thread",
         "runtime_handle": 3248987744606910
@@ -5801,7 +5819,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-mossglass-bead",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-mossglass-bead",
         "runtime_handle": 406732117808934
@@ -5809,7 +5827,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-old-oak",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-old-oak",
         "runtime_handle": 6806929065153819
@@ -5817,7 +5835,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-pearl-deep-resident",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-pearl-deep-resident",
         "runtime_handle": 8634483881055898
@@ -5825,7 +5843,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-rain-soft-garden",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-rain-soft-garden",
         "runtime_handle": 8636127016066734
@@ -5833,7 +5851,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-skull",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-skull",
         "runtime_handle": 8174630967825761
@@ -5841,7 +5859,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-story-button",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-story-button",
         "runtime_handle": 3151408643854036
@@ -5849,7 +5867,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-threadbare-map-scrap",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-threadbare-map-scrap",
         "runtime_handle": 4482891498418887
@@ -5857,7 +5875,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-vowbright-angel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-vowbright-angel",
         "runtime_handle": 7966555082684141
@@ -5865,7 +5883,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-watch-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-watch-bell",
         "runtime_handle": 6205526622615328
@@ -5873,7 +5891,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-whiskerwind",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-whiskerwind",
         "runtime_handle": 5669444972898140
@@ -5881,7 +5899,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-wolfprint-charm",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-wolfprint-charm",
         "runtime_handle": 915703357568385
@@ -5889,7 +5907,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-zadkiel-dark-angel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-zadkiel-dark-angel",
         "runtime_handle": 8315124370132858
@@ -5897,7 +5915,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-armored-winged-hero",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-armored-winged-hero",
         "runtime_handle": 6600128378329146
@@ -5905,7 +5923,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-badger-cub",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-badger-cub",
         "runtime_handle": 3524217422483260
@@ -5913,7 +5931,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-beetle-armor",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-beetle-armor",
         "runtime_handle": 7880939887467250
@@ -5921,7 +5939,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-blue-shadow-man",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-blue-shadow-man",
         "runtime_handle": 3755993660754793
@@ -5929,7 +5947,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-blue-squirrel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-blue-squirrel",
         "runtime_handle": 3374679645864704
@@ -5937,7 +5955,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-cloaked-mouse-reader",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-cloaked-mouse-reader",
         "runtime_handle": 3997082335066109
@@ -5945,7 +5963,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-forest-dryad",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-forest-dryad",
         "runtime_handle": 8662818472079145
@@ -5953,7 +5971,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-garden-rabbit",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-garden-rabbit",
         "runtime_handle": 2730391876987516
@@ -5961,7 +5979,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-golden-squirrel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-golden-squirrel",
         "runtime_handle": 162503682361987
@@ -5969,7 +5987,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-golden-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-golden-winged-boy",
         "runtime_handle": 4342854739894551
@@ -5977,7 +5995,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-grey-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-grey-winged-boy",
         "runtime_handle": 1250802238685798
@@ -5985,7 +6003,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-llama-scholar",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-llama-scholar",
         "runtime_handle": 6908093676132939
@@ -5993,7 +6011,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-mouse-wanderer",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-mouse-wanderer",
         "runtime_handle": 4601206403124060
@@ -6001,7 +6019,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-neon-tiger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-neon-tiger",
         "runtime_handle": 6229971572743818
@@ -6009,7 +6027,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-rabbit-scribe",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-rabbit-scribe",
         "runtime_handle": 8634110685852129
@@ -6017,7 +6035,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-red-shadow-figure",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-red-shadow-figure",
         "runtime_handle": 3112884101630158
@@ -6025,7 +6043,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-shadow-wolf",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-shadow-wolf",
         "runtime_handle": 4273988789998875
@@ -6033,7 +6051,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-steampunk-mouse",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-steampunk-mouse",
         "runtime_handle": 4441668646189737
@@ -6041,7 +6059,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-sunlit-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-sunlit-winged-boy",
         "runtime_handle": 8615932867192302
@@ -6049,7 +6067,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-tavern-blond-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-tavern-blond-boy",
         "runtime_handle": 1835702442135722
@@ -6057,7 +6075,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-veiled-forest-ghost",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-veiled-forest-ghost",
         "runtime_handle": 4799858469869419
@@ -6065,7 +6083,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-white-ferret-noble",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-white-ferret-noble",
         "runtime_handle": 5084247526999701
@@ -6073,7 +6091,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-wolf-pup",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-wolf-pup",
         "runtime_handle": 236437027581609
@@ -6081,7 +6099,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-woodland-bear",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-woodland-bear",
         "runtime_handle": 9000656934868850
@@ -6089,7 +6107,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-alpine-forest",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-alpine-forest",
         "runtime_handle": 8242458519360113
@@ -6097,7 +6115,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-circle-of-the-moon",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-circle-of-the-moon",
         "runtime_handle": 1930856172148870
@@ -6105,7 +6123,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-dark-abyss",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-dark-abyss",
         "runtime_handle": 7382677506125331
@@ -6113,7 +6131,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-darkest-ocean",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-darkest-ocean",
         "runtime_handle": 5061075064260629
@@ -6121,7 +6139,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-digital-realm",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-digital-realm",
         "runtime_handle": 5887686546418438
@@ -6129,7 +6147,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-endless-ocean",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-endless-ocean",
         "runtime_handle": 5401754774320525
@@ -6137,7 +6155,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-flower-meadow",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-flower-meadow",
         "runtime_handle": 7614022144101722
@@ -6145,7 +6163,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-goblin-cave",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-goblin-cave",
         "runtime_handle": 3499001612672709
@@ -6153,7 +6171,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-great-library",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-great-library",
         "runtime_handle": 7328586258800562
@@ -6161,7 +6179,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-haunted-mansion",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-haunted-mansion",
         "runtime_handle": 7484239537948286
@@ -6169,7 +6187,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-lofty-peak",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-lofty-peak",
         "runtime_handle": 2456240765655012
@@ -6177,7 +6195,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-lost-woods",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-lost-woods",
         "runtime_handle": 6580883718503069
@@ -6185,7 +6203,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-old-oak-tree",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-old-oak-tree",
         "runtime_handle": 2838379433219254
@@ -6193,7 +6211,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-quiet-abbey",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-quiet-abbey",
         "runtime_handle": 4838231888638100
@@ -6201,7 +6219,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-solar-temple",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-solar-temple",
         "runtime_handle": 450219611871818
@@ -6209,7 +6227,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-summit-trail",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-summit-trail",
         "runtime_handle": 8064929121549612
@@ -6217,7 +6235,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-the-heavens",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-the-heavens",
         "runtime_handle": 6396411156616223
@@ -6225,7 +6243,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-turgid-swamp",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-turgid-swamp",
         "runtime_handle": 6935773679641332
@@ -6233,7 +6251,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-wilting-jungle",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-wilting-jungle",
         "runtime_handle": 5897394732936641
@@ -6241,7 +6259,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/rati",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "rati",
         "runtime_handle": 1392254580257493
@@ -6249,7 +6267,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.fair-bargain",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "goblin-cave.fair-bargain",
         "runtime_handle": 8054949801377040
@@ -6257,7 +6275,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.leverage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "goblin-cave.leverage",
         "runtime_handle": 1065707925425919
@@ -6265,7 +6283,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "haunted-mansion.threshold",
         "runtime_handle": 4535315091897137
@@ -6273,7 +6291,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.warden-rage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "haunted-mansion.warden-rage",
         "runtime_handle": 6257115991159330
@@ -6281,7 +6299,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.danger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "moonlit-trail.danger",
         "runtime_handle": 257345026365457
@@ -6289,7 +6307,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.progress",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "moonlit-trail.progress",
         "runtime_handle": 6085238183587093
@@ -6297,7 +6315,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.drowned-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "solar-abyss.drowned-bell",
         "runtime_handle": 3555240757788262
@@ -6305,7 +6323,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.schism",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "solar-abyss.schism",
         "runtime_handle": 4589004266308223
@@ -6313,7 +6331,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.amends",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "turgid-swamp.amends",
         "runtime_handle": 4432023342275341
@@ -6321,7 +6339,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.old-grudge",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "turgid-swamp.old-grudge",
         "runtime_handle": 8536373757408084
@@ -6329,7 +6347,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/abyssal_residents",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "abyssal_residents",
         "runtime_handle": 1688333275188302
@@ -6337,7 +6355,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/digital_strays",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "digital_strays",
         "runtime_handle": 5048545454289654
@@ -6345,7 +6363,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/farthest_mists",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "farthest_mists",
         "runtime_handle": 350962558801960
@@ -6353,7 +6371,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/goblin_market",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "goblin_market",
         "runtime_handle": 3490418888358082
@@ -6361,7 +6379,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/great_library",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "great_library",
         "runtime_handle": 991170045564473
@@ -6369,7 +6387,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/haunted_remnants",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "haunted_remnants",
         "runtime_handle": 4900866309718573
@@ -6377,7 +6395,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/hearthbound",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "hearthbound",
         "runtime_handle": 4046513959484943
@@ -6385,7 +6403,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/lonely_forest_court",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "lonely_forest_court",
         "runtime_handle": 5495209280499345
@@ -6393,7 +6411,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/moon_circle",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "moon_circle",
         "runtime_handle": 3594504273910135
@@ -6401,7 +6419,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/quiet_abbey",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "quiet_abbey",
         "runtime_handle": 7894097855005461
@@ -6409,7 +6427,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/solar_temple",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "solar_temple",
         "runtime_handle": 2642136344425509
@@ -6417,7 +6435,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/goblin-cave%3Amarket-leverage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "goblin-cave:market-leverage",
         "runtime_handle": 5093973293074428
@@ -6425,7 +6443,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/haunted-mansion%3Abarred-threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "haunted-mansion:barred-threshold",
         "runtime_handle": 6295078661322495
@@ -6433,7 +6451,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/moonlit-trail%3Aecho-front",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "moonlit-trail:echo-front",
         "runtime_handle": 3643385637336037
@@ -6441,7 +6459,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/solar-abyss%3Abell-front",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "solar-abyss:bell-front",
         "runtime_handle": 591496292254136
@@ -6449,7 +6467,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/turgid-swamp%3Aold-grudge",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "turgid-swamp:old-grudge",
         "runtime_handle": 5644962986267984
@@ -6457,7 +6475,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/hidden-exit/darkest-ocean%3Adark-abyss",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "hidden-exit",
         "local_id": "darkest-ocean:dark-abyss",
         "runtime_handle": 456562266146446
@@ -6465,7 +6483,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2001",
         "legacy_runtime_id": 2001,
@@ -6474,7 +6492,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2002",
         "legacy_runtime_id": 2002,
@@ -6483,7 +6501,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2003",
         "legacy_runtime_id": 2003,
@@ -6492,7 +6510,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2004",
         "legacy_runtime_id": 2004,
@@ -6501,7 +6519,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2005",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2005",
         "legacy_runtime_id": 2005,
@@ -6510,7 +6528,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2006",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2006",
         "legacy_runtime_id": 2006,
@@ -6519,7 +6537,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2007",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2007",
         "legacy_runtime_id": 2007,
@@ -6528,7 +6546,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2008",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2008",
         "legacy_runtime_id": 2008,
@@ -6537,7 +6555,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2009",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2009",
         "legacy_runtime_id": 2009,
@@ -6546,7 +6564,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2010",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2010",
         "legacy_runtime_id": 2010,
@@ -6555,7 +6573,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/goblin-cave%3Aname-the-price",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "goblin-cave:name-the-price",
         "runtime_handle": 3094113202720990
@@ -6563,7 +6581,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/haunted-mansion%3Aearn-the-threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "haunted-mansion:earn-the-threshold",
         "runtime_handle": 7833342030263292
@@ -6571,7 +6589,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/moonlit-trail%3Aquiet-the-echo",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "moonlit-trail:quiet-the-echo",
         "runtime_handle": 3184352149003600
@@ -6579,7 +6597,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/solar-abyss%3Adrowned-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "solar-abyss:drowned-bell",
         "runtime_handle": 681263158451131
@@ -6587,7 +6605,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/turgid-swamp%3Aamend-the-ledger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "turgid-swamp:amend-the-ledger",
         "runtime_handle": 477973030695414
@@ -6595,7 +6613,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/1",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "1",
         "legacy_runtime_id": 1,
@@ -6604,7 +6622,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/2",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "2",
         "legacy_runtime_id": 2,
@@ -6613,7 +6631,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/3",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "3",
         "legacy_runtime_id": 3,
@@ -6622,7 +6640,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/30",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "30",
         "legacy_runtime_id": 30,
@@ -6631,7 +6649,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/31",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "31",
         "legacy_runtime_id": 31,
@@ -6640,7 +6658,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/32",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "32",
         "legacy_runtime_id": 32,
@@ -6649,7 +6667,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/33",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "33",
         "legacy_runtime_id": 33,
@@ -6658,7 +6676,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/34",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "34",
         "legacy_runtime_id": 34,
@@ -6667,7 +6685,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/35",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "35",
         "legacy_runtime_id": 35,
@@ -6676,7 +6694,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/36",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "36",
         "legacy_runtime_id": 36,
@@ -6685,7 +6703,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/40",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "40",
         "legacy_runtime_id": 40,
@@ -6694,7 +6712,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/41",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "41",
         "legacy_runtime_id": 41,
@@ -6703,7 +6721,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/42",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "42",
         "legacy_runtime_id": 42,
@@ -6712,7 +6730,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/43",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "43",
         "legacy_runtime_id": 43,
@@ -6721,7 +6739,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/44",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "44",
         "legacy_runtime_id": 44,
@@ -6730,7 +6748,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/50",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "50",
         "legacy_runtime_id": 50,
@@ -6739,7 +6757,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/60",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "60",
         "legacy_runtime_id": 60,
@@ -6748,7 +6766,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/61",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "61",
         "legacy_runtime_id": 61,
@@ -6757,7 +6775,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/62",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "62",
         "legacy_runtime_id": 62,
@@ -6766,7 +6784,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/63",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "63",
         "legacy_runtime_id": 63,
@@ -6775,7 +6793,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/64",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "64",
         "legacy_runtime_id": 64,
@@ -6784,7 +6802,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/65",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "65",
         "legacy_runtime_id": 65,
@@ -6793,7 +6811,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "recipe",
         "local_id": "3001",
         "runtime_handle": 828439639934659
@@ -6801,7 +6819,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A1",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:1",
         "runtime_handle": 3639178970696137
@@ -6809,7 +6827,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A2",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:2",
         "runtime_handle": 4328625160851383
@@ -6817,7 +6835,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A3",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:3",
         "runtime_handle": 272728635448160
@@ -6825,7 +6843,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A30",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:30",
         "runtime_handle": 4949881785988127
@@ -6833,7 +6851,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A31",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:31",
         "runtime_handle": 12158853449275
@@ -6841,7 +6859,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A32",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:32",
         "runtime_handle": 3065031734117441
@@ -6849,7 +6867,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A33",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:33",
         "runtime_handle": 8635481635081203
@@ -6857,7 +6875,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A34",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:34",
         "runtime_handle": 3415405010788251
@@ -6865,7 +6883,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A35",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:35",
         "runtime_handle": 8268805670112054
@@ -6873,7 +6891,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A36",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:36",
         "runtime_handle": 1278082739662403
@@ -6881,7 +6899,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A40",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:40",
         "runtime_handle": 2373835638704337
@@ -6889,7 +6907,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A41",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:41",
         "runtime_handle": 302978963504637
@@ -6897,7 +6915,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A42",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:42",
         "runtime_handle": 4669140359619141
@@ -6905,7 +6923,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A43",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:43",
         "runtime_handle": 3577060339822743
@@ -6913,7 +6931,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A44",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:44",
         "runtime_handle": 4396167510730171
@@ -6921,7 +6939,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A50",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:50",
         "runtime_handle": 1673766510642920
@@ -6929,7 +6947,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A60",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:60",
         "runtime_handle": 5586350793250546
@@ -6937,7 +6955,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A61",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:61",
         "runtime_handle": 6162116676111910
@@ -6945,7 +6963,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A62",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:62",
         "runtime_handle": 897159537111265
@@ -6953,7 +6971,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A63",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:63",
         "runtime_handle": 7446099757621175
@@ -6961,7 +6979,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A64",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:64",
         "runtime_handle": 4767551281449957
@@ -6969,7 +6987,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A65",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:65",
         "runtime_handle": 389717939014779

--- a/v2/content/core-only/worldpack.json
+++ b/v2/content/core-only/worldpack.json
@@ -7,15 +7,16 @@
   "version": 1,
   "description": "The first-party cosy exploration experience with no expansion packs mounted.",
   "entry_location": "cosyworld.core:location/1",
-  "bundle_hash": "sha256:33bd77b88583110f8156e3376eaf8478a4a03ac0716fb3144b88798c41b0476e",
+  "bundle_hash": "sha256:446069c94b9ca2c05217f41575d06b06e23d29fb1d1c280bb53985a7c22f3810",
   "packs": [
     {
       "id": "cosyworld.core",
       "name": "CosyWorld Core",
       "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "kind": "world",
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "engine": ">=0.0.20 <0.1.0",
       "capabilities": [
         {
@@ -45,6 +46,7 @@
         }
       ],
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld",
         "source_url": "https://github.com/cenetex/cosyworld"
       },
@@ -77,7 +79,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68"
+      "integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4"
     }
   ],
   "files": {
@@ -105,6 +107,7 @@
   "assets": "assets.json",
   "rules": "rules.json",
   "attributions": "attributions.json",
+  "licenses": "licenses.json",
   "character_creation": "character_creation.json",
   "content_references": "content_refs.json",
   "registry": "registry.json"

--- a/v2/content/core/pack.json
+++ b/v2/content/core/pack.json
@@ -2,10 +2,11 @@
   "schema_version": 1,
   "id": "cosyworld.core",
   "name": "CosyWorld Core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "kind": "world",
   "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
   "license": "MIT",
+  "license_url": "https://opensource.org/license/mit",
   "engine": ">=0.0.20 <0.1.0",
   "capabilities": [
     {
@@ -33,6 +34,7 @@
     }
   ],
   "provenance": {
+    "author": "Cenetex",
     "source_name": "CosyWorld",
     "source_url": "https://github.com/cenetex/cosyworld"
   },

--- a/v2/content/lonely-forest/pack.json
+++ b/v2/content/lonely-forest/pack.json
@@ -2,10 +2,11 @@
   "schema_version": 1,
   "id": "cosyworld.lonely-forest.characters",
   "name": "Lonely Forest Character Art",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "kind": "assets",
   "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
   "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+  "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
   "engine": ">=0.0.20 <0.1.0",
   "capabilities": [
     {
@@ -30,6 +31,7 @@
     }
   ],
   "provenance": {
+    "author": "Cenetex",
     "source_name": "Cenetex Lonely Forest character art",
     "source_url": "https://github.com/cenetex/cosyworld"
   },

--- a/v2/content/official/assets.json
+++ b/v2/content/official/assets.json
@@ -1,8 +1,8 @@
 [
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.0",
-    "pack_integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+    "pack_version": "1.3.1",
+    "pack_integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -14,8 +14,8 @@
   },
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.0",
-    "pack_integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+    "pack_version": "1.3.1",
+    "pack_integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",
@@ -27,8 +27,8 @@
   },
   {
     "pack_id": "cosyworld.lonely-forest.characters",
-    "pack_version": "1.1.0",
-    "pack_integrity": "sha256:a5d1a25b1070d070411bdd7cf7a8eeab5a4be8f9a4943ba0c84ae55fdf0ba4e6",
+    "pack_version": "1.1.1",
+    "pack_integrity": "sha256:b3ff30dbc1809a84d150ffc12a9cf00ed1d8a57e518584de0ce8a91c7e4f4132",
     "provider": "cosyworld.lonely-forest.characters/assets",
     "mount": "characters",
     "root": "lonely-forest",
@@ -40,8 +40,8 @@
   },
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.0",
-    "pack_integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216",
+    "pack_version": "1.3.1",
+    "pack_integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
     "provider": "ruby-high.first-bell/assets",
     "mount": "cards",
     "root": "ruby-high-first-bell",

--- a/v2/content/official/character_creation.json
+++ b/v2/content/official/character_creation.json
@@ -1,7 +1,7 @@
 [
   {
     "pack_id": "cosyworld.campaign.the-lantern-keeper",
-    "pack_version": "0.1.0",
+    "pack_version": "0.1.1",
     "profiles": [
       {
         "schema_version": 1,

--- a/v2/content/official/content_refs.json
+++ b/v2/content/official/content_refs.json
@@ -5,7 +5,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8301",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "actor",
       "local_id": "8301",
       "legacy_runtime_id": 8301,
@@ -14,7 +14,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8302",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "actor",
       "local_id": "8302",
       "legacy_runtime_id": 8302,
@@ -23,7 +23,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8303",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "actor",
       "local_id": "8303",
       "legacy_runtime_id": 8303,
@@ -32,7 +32,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8304",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "actor",
       "local_id": "8304",
       "legacy_runtime_id": 8304,
@@ -41,7 +41,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-barrow",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-barrow",
       "runtime_handle": 2693745143565876
@@ -49,7 +49,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-chapel",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-chapel",
       "runtime_handle": 485182594396993
@@ -57,7 +57,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-dawn-oil",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-dawn-oil",
       "runtime_handle": 2918403238373891
@@ -65,7 +65,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-ember",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-ember",
       "runtime_handle": 6023960511621204
@@ -73,7 +73,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-inn",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-inn",
       "runtime_handle": 2167662595818650
@@ -81,7 +81,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-key",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-key",
       "runtime_handle": 8905115040499656
@@ -89,7 +89,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-knight",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-knight",
       "runtime_handle": 7581163987072796
@@ -97,7 +97,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mara",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-mara",
       "runtime_handle": 2237714680835428
@@ -105,7 +105,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothglass",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-mothglass",
       "runtime_handle": 5170986584558554
@@ -113,7 +113,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothwood",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-mothwood",
       "runtime_handle": 1673786737892201
@@ -121,7 +121,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-pip",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-pip",
       "runtime_handle": 6288898560895936
@@ -129,7 +129,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-rowan",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-rowan",
       "runtime_handle": 1658308598845697
@@ -137,7 +137,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-tower",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "card",
       "local_id": "lantern-keeper-tower",
       "runtime_handle": 5850818207762215
@@ -145,7 +145,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/character-profile/the-lantern-keeper",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "character-profile",
       "local_id": "the-lantern-keeper",
       "runtime_handle": 6074007409727657
@@ -153,7 +153,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.darkness",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "clock",
       "local_id": "lantern-keeper.darkness",
       "runtime_handle": 3497107257475399
@@ -161,7 +161,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.light",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "clock",
       "local_id": "lantern-keeper.light",
       "runtime_handle": 1743073783466389
@@ -169,7 +169,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/front/lantern-keeper%3Ahollow-light",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "front",
       "local_id": "lantern-keeper:hollow-light",
       "runtime_handle": 8897349519357189
@@ -177,7 +177,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8401",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "item",
       "local_id": "8401",
       "legacy_runtime_id": 8401,
@@ -186,7 +186,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8402",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "item",
       "local_id": "8402",
       "legacy_runtime_id": 8402,
@@ -195,7 +195,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8403",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "item",
       "local_id": "8403",
       "legacy_runtime_id": 8403,
@@ -204,7 +204,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8404",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "item",
       "local_id": "8404",
       "legacy_runtime_id": 8404,
@@ -213,7 +213,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/job/lantern-keeper%3Arekindle-the-beacon",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "job",
       "local_id": "lantern-keeper:rekindle-the-beacon",
       "runtime_handle": 3517284423041433
@@ -221,7 +221,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/800",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "location",
       "local_id": "800",
       "legacy_runtime_id": 800,
@@ -230,7 +230,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/801",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "location",
       "local_id": "801",
       "legacy_runtime_id": 801,
@@ -239,7 +239,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/802",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "location",
       "local_id": "802",
       "legacy_runtime_id": 802,
@@ -248,7 +248,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/803",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "location",
       "local_id": "803",
       "legacy_runtime_id": 803,
@@ -257,7 +257,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/804",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "location",
       "local_id": "804",
       "legacy_runtime_id": 804,
@@ -266,7 +266,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A800",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "room-sheet",
       "local_id": "room:800",
       "runtime_handle": 485005815750293
@@ -274,7 +274,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A801",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "room-sheet",
       "local_id": "room:801",
       "runtime_handle": 5114262777545579
@@ -282,7 +282,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A802",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "room-sheet",
       "local_id": "room:802",
       "runtime_handle": 3932833224947827
@@ -290,7 +290,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A803",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "room-sheet",
       "local_id": "room:803",
       "runtime_handle": 7094111250995550
@@ -298,7 +298,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A804",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "kind": "room-sheet",
       "local_id": "room:804",
       "runtime_handle": 112964325215682
@@ -306,7 +306,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1001",
       "legacy_runtime_id": 1001,
@@ -315,7 +315,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1002",
       "legacy_runtime_id": 1002,
@@ -324,7 +324,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1003",
       "legacy_runtime_id": 1003,
@@ -333,7 +333,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1004",
       "legacy_runtime_id": 1004,
@@ -342,7 +342,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1005",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1005",
       "legacy_runtime_id": 1005,
@@ -351,7 +351,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1040",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1040",
       "legacy_runtime_id": 1040,
@@ -360,7 +360,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1041",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1041",
       "legacy_runtime_id": 1041,
@@ -369,7 +369,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1042",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1042",
       "legacy_runtime_id": 1042,
@@ -378,7 +378,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1043",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1043",
       "legacy_runtime_id": 1043,
@@ -387,7 +387,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1044",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1044",
       "legacy_runtime_id": 1044,
@@ -396,7 +396,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1045",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1045",
       "legacy_runtime_id": 1045,
@@ -405,7 +405,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1046",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1046",
       "legacy_runtime_id": 1046,
@@ -414,7 +414,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1047",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1047",
       "legacy_runtime_id": 1047,
@@ -423,7 +423,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1048",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1048",
       "legacy_runtime_id": 1048,
@@ -432,7 +432,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1049",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1049",
       "legacy_runtime_id": 1049,
@@ -441,7 +441,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1050",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1050",
       "legacy_runtime_id": 1050,
@@ -450,7 +450,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1051",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1051",
       "legacy_runtime_id": 1051,
@@ -459,7 +459,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1052",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1052",
       "legacy_runtime_id": 1052,
@@ -468,7 +468,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1053",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1053",
       "legacy_runtime_id": 1053,
@@ -477,7 +477,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1054",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1054",
       "legacy_runtime_id": 1054,
@@ -486,7 +486,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1055",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1055",
       "legacy_runtime_id": 1055,
@@ -495,7 +495,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1056",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1056",
       "legacy_runtime_id": 1056,
@@ -504,7 +504,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1057",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1057",
       "legacy_runtime_id": 1057,
@@ -513,7 +513,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1058",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1058",
       "legacy_runtime_id": 1058,
@@ -522,7 +522,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1059",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1059",
       "legacy_runtime_id": 1059,
@@ -531,7 +531,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1060",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1060",
       "legacy_runtime_id": 1060,
@@ -540,7 +540,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1061",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1061",
       "legacy_runtime_id": 1061,
@@ -549,7 +549,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1062",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1062",
       "legacy_runtime_id": 1062,
@@ -558,7 +558,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1063",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1063",
       "legacy_runtime_id": 1063,
@@ -567,7 +567,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1064",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1064",
       "legacy_runtime_id": 1064,
@@ -576,7 +576,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1065",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1065",
       "legacy_runtime_id": 1065,
@@ -585,7 +585,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1066",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1066",
       "legacy_runtime_id": 1066,
@@ -594,7 +594,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1067",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1067",
       "legacy_runtime_id": 1067,
@@ -603,7 +603,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1068",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1068",
       "legacy_runtime_id": 1068,
@@ -612,7 +612,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1069",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1069",
       "legacy_runtime_id": 1069,
@@ -621,7 +621,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1070",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor",
       "local_id": "1070",
       "legacy_runtime_id": 1070,
@@ -630,7 +630,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-abbey-bookmark",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-abbey-bookmark",
       "runtime_handle": 138956494956560
@@ -638,7 +638,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-azazoth",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-azazoth",
       "runtime_handle": 2742827434789688
@@ -646,7 +646,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-cottage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-cottage",
       "runtime_handle": 3679023710615970
@@ -654,7 +654,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-dewbright-button",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-dewbright-button",
       "runtime_handle": 7543879359126606
@@ -662,7 +662,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-hearth-tonic",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-hearth-tonic",
       "runtime_handle": 6099844187041316
@@ -670,7 +670,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-hearthstone-tag",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-hearthstone-tag",
       "runtime_handle": 445803431082645
@@ -678,7 +678,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-echo",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-moonlit-echo",
       "runtime_handle": 3701779326615881
@@ -686,7 +686,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-trail",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-moonlit-trail",
       "runtime_handle": 3706559719582066
@@ -694,7 +694,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonwool-thread",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-moonwool-thread",
       "runtime_handle": 3248987744606910
@@ -702,7 +702,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-mossglass-bead",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-mossglass-bead",
       "runtime_handle": 406732117808934
@@ -710,7 +710,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-old-oak",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-old-oak",
       "runtime_handle": 6806929065153819
@@ -718,7 +718,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-pearl-deep-resident",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-pearl-deep-resident",
       "runtime_handle": 8634483881055898
@@ -726,7 +726,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-rain-soft-garden",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-rain-soft-garden",
       "runtime_handle": 8636127016066734
@@ -734,7 +734,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-skull",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-skull",
       "runtime_handle": 8174630967825761
@@ -742,7 +742,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-story-button",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-story-button",
       "runtime_handle": 3151408643854036
@@ -750,7 +750,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-threadbare-map-scrap",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-threadbare-map-scrap",
       "runtime_handle": 4482891498418887
@@ -758,7 +758,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-vowbright-angel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-vowbright-angel",
       "runtime_handle": 7966555082684141
@@ -766,7 +766,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-watch-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-watch-bell",
       "runtime_handle": 6205526622615328
@@ -774,7 +774,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-whiskerwind",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-whiskerwind",
       "runtime_handle": 5669444972898140
@@ -782,7 +782,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-wolfprint-charm",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-wolfprint-charm",
       "runtime_handle": 915703357568385
@@ -790,7 +790,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-zadkiel-dark-angel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "cosy-zadkiel-dark-angel",
       "runtime_handle": 8315124370132858
@@ -798,7 +798,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-armored-winged-hero",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-armored-winged-hero",
       "runtime_handle": 6600128378329146
@@ -806,7 +806,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-badger-cub",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-badger-cub",
       "runtime_handle": 3524217422483260
@@ -814,7 +814,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-beetle-armor",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-beetle-armor",
       "runtime_handle": 7880939887467250
@@ -822,7 +822,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-blue-shadow-man",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-blue-shadow-man",
       "runtime_handle": 3755993660754793
@@ -830,7 +830,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-blue-squirrel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-blue-squirrel",
       "runtime_handle": 3374679645864704
@@ -838,7 +838,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-cloaked-mouse-reader",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-cloaked-mouse-reader",
       "runtime_handle": 3997082335066109
@@ -846,7 +846,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-forest-dryad",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-forest-dryad",
       "runtime_handle": 8662818472079145
@@ -854,7 +854,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-garden-rabbit",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-garden-rabbit",
       "runtime_handle": 2730391876987516
@@ -862,7 +862,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-golden-squirrel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-golden-squirrel",
       "runtime_handle": 162503682361987
@@ -870,7 +870,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-golden-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-golden-winged-boy",
       "runtime_handle": 4342854739894551
@@ -878,7 +878,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-grey-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-grey-winged-boy",
       "runtime_handle": 1250802238685798
@@ -886,7 +886,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-llama-scholar",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-llama-scholar",
       "runtime_handle": 6908093676132939
@@ -894,7 +894,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-mouse-wanderer",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-mouse-wanderer",
       "runtime_handle": 4601206403124060
@@ -902,7 +902,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-neon-tiger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-neon-tiger",
       "runtime_handle": 6229971572743818
@@ -910,7 +910,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-rabbit-scribe",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-rabbit-scribe",
       "runtime_handle": 8634110685852129
@@ -918,7 +918,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-red-shadow-figure",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-red-shadow-figure",
       "runtime_handle": 3112884101630158
@@ -926,7 +926,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-shadow-wolf",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-shadow-wolf",
       "runtime_handle": 4273988789998875
@@ -934,7 +934,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-steampunk-mouse",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-steampunk-mouse",
       "runtime_handle": 4441668646189737
@@ -942,7 +942,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-sunlit-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-sunlit-winged-boy",
       "runtime_handle": 8615932867192302
@@ -950,7 +950,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-tavern-blond-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-tavern-blond-boy",
       "runtime_handle": 1835702442135722
@@ -958,7 +958,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-veiled-forest-ghost",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-veiled-forest-ghost",
       "runtime_handle": 4799858469869419
@@ -966,7 +966,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-white-ferret-noble",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-white-ferret-noble",
       "runtime_handle": 5084247526999701
@@ -974,7 +974,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-wolf-pup",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-wolf-pup",
       "runtime_handle": 236437027581609
@@ -982,7 +982,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-woodland-bear",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "lf-woodland-bear",
       "runtime_handle": 9000656934868850
@@ -990,7 +990,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-alpine-forest",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-alpine-forest",
       "runtime_handle": 8242458519360113
@@ -998,7 +998,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-circle-of-the-moon",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-circle-of-the-moon",
       "runtime_handle": 1930856172148870
@@ -1006,7 +1006,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-dark-abyss",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-dark-abyss",
       "runtime_handle": 7382677506125331
@@ -1014,7 +1014,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-darkest-ocean",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-darkest-ocean",
       "runtime_handle": 5061075064260629
@@ -1022,7 +1022,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-digital-realm",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-digital-realm",
       "runtime_handle": 5887686546418438
@@ -1030,7 +1030,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-endless-ocean",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-endless-ocean",
       "runtime_handle": 5401754774320525
@@ -1038,7 +1038,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-flower-meadow",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-flower-meadow",
       "runtime_handle": 7614022144101722
@@ -1046,7 +1046,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-goblin-cave",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-goblin-cave",
       "runtime_handle": 3499001612672709
@@ -1054,7 +1054,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-great-library",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-great-library",
       "runtime_handle": 7328586258800562
@@ -1062,7 +1062,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-haunted-mansion",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-haunted-mansion",
       "runtime_handle": 7484239537948286
@@ -1070,7 +1070,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-lofty-peak",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-lofty-peak",
       "runtime_handle": 2456240765655012
@@ -1078,7 +1078,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-lost-woods",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-lost-woods",
       "runtime_handle": 6580883718503069
@@ -1086,7 +1086,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-old-oak-tree",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-old-oak-tree",
       "runtime_handle": 2838379433219254
@@ -1094,7 +1094,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-quiet-abbey",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-quiet-abbey",
       "runtime_handle": 4838231888638100
@@ -1102,7 +1102,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-solar-temple",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-solar-temple",
       "runtime_handle": 450219611871818
@@ -1110,7 +1110,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-summit-trail",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-summit-trail",
       "runtime_handle": 8064929121549612
@@ -1118,7 +1118,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-the-heavens",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-the-heavens",
       "runtime_handle": 6396411156616223
@@ -1126,7 +1126,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-turgid-swamp",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-turgid-swamp",
       "runtime_handle": 6935773679641332
@@ -1134,7 +1134,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-wilting-jungle",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-wilting-jungle",
       "runtime_handle": 5897394732936641
@@ -1142,7 +1142,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/rati",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "rati",
       "runtime_handle": 1392254580257493
@@ -1150,7 +1150,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.fair-bargain",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "goblin-cave.fair-bargain",
       "runtime_handle": 8054949801377040
@@ -1158,7 +1158,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.leverage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "goblin-cave.leverage",
       "runtime_handle": 1065707925425919
@@ -1166,7 +1166,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "haunted-mansion.threshold",
       "runtime_handle": 4535315091897137
@@ -1174,7 +1174,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.warden-rage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "haunted-mansion.warden-rage",
       "runtime_handle": 6257115991159330
@@ -1182,7 +1182,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.danger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "moonlit-trail.danger",
       "runtime_handle": 257345026365457
@@ -1190,7 +1190,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.progress",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "moonlit-trail.progress",
       "runtime_handle": 6085238183587093
@@ -1198,7 +1198,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.drowned-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "solar-abyss.drowned-bell",
       "runtime_handle": 3555240757788262
@@ -1206,7 +1206,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.schism",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "solar-abyss.schism",
       "runtime_handle": 4589004266308223
@@ -1214,7 +1214,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.amends",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "turgid-swamp.amends",
       "runtime_handle": 4432023342275341
@@ -1222,7 +1222,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.old-grudge",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "clock",
       "local_id": "turgid-swamp.old-grudge",
       "runtime_handle": 8536373757408084
@@ -1230,7 +1230,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/abyssal_residents",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "abyssal_residents",
       "runtime_handle": 1688333275188302
@@ -1238,7 +1238,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/digital_strays",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "digital_strays",
       "runtime_handle": 5048545454289654
@@ -1246,7 +1246,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/farthest_mists",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "farthest_mists",
       "runtime_handle": 350962558801960
@@ -1254,7 +1254,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/goblin_market",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "goblin_market",
       "runtime_handle": 3490418888358082
@@ -1262,7 +1262,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/great_library",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "great_library",
       "runtime_handle": 991170045564473
@@ -1270,7 +1270,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/haunted_remnants",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "haunted_remnants",
       "runtime_handle": 4900866309718573
@@ -1278,7 +1278,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/hearthbound",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "hearthbound",
       "runtime_handle": 4046513959484943
@@ -1286,7 +1286,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/lonely_forest_court",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "lonely_forest_court",
       "runtime_handle": 5495209280499345
@@ -1294,7 +1294,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/moon_circle",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "moon_circle",
       "runtime_handle": 3594504273910135
@@ -1302,7 +1302,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/quiet_abbey",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "quiet_abbey",
       "runtime_handle": 7894097855005461
@@ -1310,7 +1310,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/solar_temple",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "solar_temple",
       "runtime_handle": 2642136344425509
@@ -1318,7 +1318,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/goblin-cave%3Amarket-leverage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "goblin-cave:market-leverage",
       "runtime_handle": 5093973293074428
@@ -1326,7 +1326,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/haunted-mansion%3Abarred-threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "haunted-mansion:barred-threshold",
       "runtime_handle": 6295078661322495
@@ -1334,7 +1334,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/moonlit-trail%3Aecho-front",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "moonlit-trail:echo-front",
       "runtime_handle": 3643385637336037
@@ -1342,7 +1342,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/solar-abyss%3Abell-front",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "solar-abyss:bell-front",
       "runtime_handle": 591496292254136
@@ -1350,7 +1350,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/turgid-swamp%3Aold-grudge",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "front",
       "local_id": "turgid-swamp:old-grudge",
       "runtime_handle": 5644962986267984
@@ -1358,7 +1358,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/hidden-exit/darkest-ocean%3Adark-abyss",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "hidden-exit",
       "local_id": "darkest-ocean:dark-abyss",
       "runtime_handle": 456562266146446
@@ -1366,7 +1366,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2001",
       "legacy_runtime_id": 2001,
@@ -1375,7 +1375,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2002",
       "legacy_runtime_id": 2002,
@@ -1384,7 +1384,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2003",
       "legacy_runtime_id": 2003,
@@ -1393,7 +1393,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2004",
       "legacy_runtime_id": 2004,
@@ -1402,7 +1402,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2005",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2005",
       "legacy_runtime_id": 2005,
@@ -1411,7 +1411,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2006",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2006",
       "legacy_runtime_id": 2006,
@@ -1420,7 +1420,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2007",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2007",
       "legacy_runtime_id": 2007,
@@ -1429,7 +1429,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2008",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2008",
       "legacy_runtime_id": 2008,
@@ -1438,7 +1438,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2009",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2009",
       "legacy_runtime_id": 2009,
@@ -1447,7 +1447,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2010",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "item",
       "local_id": "2010",
       "legacy_runtime_id": 2010,
@@ -1456,7 +1456,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/goblin-cave%3Aname-the-price",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "goblin-cave:name-the-price",
       "runtime_handle": 3094113202720990
@@ -1464,7 +1464,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/haunted-mansion%3Aearn-the-threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "haunted-mansion:earn-the-threshold",
       "runtime_handle": 7833342030263292
@@ -1472,7 +1472,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/moonlit-trail%3Aquiet-the-echo",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "moonlit-trail:quiet-the-echo",
       "runtime_handle": 3184352149003600
@@ -1480,7 +1480,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/solar-abyss%3Adrowned-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "solar-abyss:drowned-bell",
       "runtime_handle": 681263158451131
@@ -1488,7 +1488,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/turgid-swamp%3Aamend-the-ledger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "job",
       "local_id": "turgid-swamp:amend-the-ledger",
       "runtime_handle": 477973030695414
@@ -1496,7 +1496,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/1",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "1",
       "legacy_runtime_id": 1,
@@ -1505,7 +1505,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/2",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "2",
       "legacy_runtime_id": 2,
@@ -1514,7 +1514,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/3",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "3",
       "legacy_runtime_id": 3,
@@ -1523,7 +1523,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/30",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "30",
       "legacy_runtime_id": 30,
@@ -1532,7 +1532,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/31",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "31",
       "legacy_runtime_id": 31,
@@ -1541,7 +1541,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/32",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "32",
       "legacy_runtime_id": 32,
@@ -1550,7 +1550,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/33",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "33",
       "legacy_runtime_id": 33,
@@ -1559,7 +1559,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/34",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "34",
       "legacy_runtime_id": 34,
@@ -1568,7 +1568,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/35",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "35",
       "legacy_runtime_id": 35,
@@ -1577,7 +1577,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/36",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "36",
       "legacy_runtime_id": 36,
@@ -1586,7 +1586,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/40",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "40",
       "legacy_runtime_id": 40,
@@ -1595,7 +1595,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/41",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "41",
       "legacy_runtime_id": 41,
@@ -1604,7 +1604,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/42",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "42",
       "legacy_runtime_id": 42,
@@ -1613,7 +1613,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/43",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "43",
       "legacy_runtime_id": 43,
@@ -1622,7 +1622,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/44",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "44",
       "legacy_runtime_id": 44,
@@ -1631,7 +1631,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/50",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "50",
       "legacy_runtime_id": 50,
@@ -1640,7 +1640,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/60",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "60",
       "legacy_runtime_id": 60,
@@ -1649,7 +1649,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/61",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "61",
       "legacy_runtime_id": 61,
@@ -1658,7 +1658,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/62",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "62",
       "legacy_runtime_id": 62,
@@ -1667,7 +1667,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/63",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "63",
       "legacy_runtime_id": 63,
@@ -1676,7 +1676,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/64",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "64",
       "legacy_runtime_id": 64,
@@ -1685,7 +1685,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/65",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "65",
       "legacy_runtime_id": 65,
@@ -1694,7 +1694,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "recipe",
       "local_id": "3001",
       "runtime_handle": 828439639934659
@@ -1702,7 +1702,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A1",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:1",
       "runtime_handle": 3639178970696137
@@ -1710,7 +1710,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A2",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:2",
       "runtime_handle": 4328625160851383
@@ -1718,7 +1718,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A3",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:3",
       "runtime_handle": 272728635448160
@@ -1726,7 +1726,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A30",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:30",
       "runtime_handle": 4949881785988127
@@ -1734,7 +1734,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A31",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:31",
       "runtime_handle": 12158853449275
@@ -1742,7 +1742,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A32",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:32",
       "runtime_handle": 3065031734117441
@@ -1750,7 +1750,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A33",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:33",
       "runtime_handle": 8635481635081203
@@ -1758,7 +1758,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A34",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:34",
       "runtime_handle": 3415405010788251
@@ -1766,7 +1766,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A35",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:35",
       "runtime_handle": 8268805670112054
@@ -1774,7 +1774,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A36",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:36",
       "runtime_handle": 1278082739662403
@@ -1782,7 +1782,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A40",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:40",
       "runtime_handle": 2373835638704337
@@ -1790,7 +1790,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A41",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:41",
       "runtime_handle": 302978963504637
@@ -1798,7 +1798,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A42",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:42",
       "runtime_handle": 4669140359619141
@@ -1806,7 +1806,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A43",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:43",
       "runtime_handle": 3577060339822743
@@ -1814,7 +1814,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A44",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:44",
       "runtime_handle": 4396167510730171
@@ -1822,7 +1822,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A50",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:50",
       "runtime_handle": 1673766510642920
@@ -1830,7 +1830,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A60",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:60",
       "runtime_handle": 5586350793250546
@@ -1838,7 +1838,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A61",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:61",
       "runtime_handle": 6162116676111910
@@ -1846,7 +1846,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A62",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:62",
       "runtime_handle": 897159537111265
@@ -1854,7 +1854,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A63",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:63",
       "runtime_handle": 7446099757621175
@@ -1862,7 +1862,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A64",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:64",
       "runtime_handle": 4767551281449957
@@ -1870,7 +1870,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A65",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:65",
       "runtime_handle": 389717939014779
@@ -1878,7 +1878,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/actor-facet/rati-first-bell",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "actor-facet",
       "local_id": "rati-first-bell",
       "runtime_handle": 1038687835420516
@@ -1886,7 +1886,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card-binding/rati-first-bell-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card-binding",
       "local_id": "rati-first-bell-card",
       "runtime_handle": 3116738573256863
@@ -1894,7 +1894,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-cafeteria",
       "runtime_handle": 3107528363911865
@@ -1902,7 +1902,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-courtyard",
       "runtime_handle": 4782402674832957
@@ -1910,7 +1910,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-greenhouse",
       "runtime_handle": 3662976131116729
@@ -1918,7 +1918,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-homeroom",
       "runtime_handle": 7084902207358373
@@ -1926,7 +1926,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-library",
       "runtime_handle": 6785800264541047
@@ -1934,7 +1934,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-science-lab",
       "runtime_handle": 8201462675675638
@@ -1942,7 +1942,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "captain-null",
       "runtime_handle": 3843573141933674
@@ -1950,7 +1950,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "eliza",
       "runtime_handle": 4124553834845258
@@ -1958,7 +1958,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "indra",
       "runtime_handle": 8687099168741216
@@ -1966,7 +1966,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-flashcards",
       "runtime_handle": 6148366931632609
@@ -1974,7 +1974,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-hall-pass",
       "runtime_handle": 6154026517662833
@@ -1982,7 +1982,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-lab-flask",
       "runtime_handle": 7444186363202775
@@ -1990,7 +1990,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-library-card",
       "runtime_handle": 27821797810153
@@ -1998,7 +1998,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-lunch-tray",
       "runtime_handle": 3064948555071770
@@ -2006,7 +2006,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-notebook",
       "runtime_handle": 5906680647268123
@@ -2014,7 +2014,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-cafeteria",
       "runtime_handle": 232928798345453
@@ -2022,7 +2022,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-courtyard",
       "runtime_handle": 1017422828753302
@@ -2030,7 +2030,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-greenhouse",
       "runtime_handle": 1874830250433117
@@ -2038,7 +2038,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-homeroom",
       "runtime_handle": 6928775784641985
@@ -2046,7 +2046,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-library",
       "runtime_handle": 8204365461548708
@@ -2054,7 +2054,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-science-lab",
       "runtime_handle": 57115334800243
@@ -2062,7 +2062,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "lyra",
       "runtime_handle": 7094866015162716
@@ -2070,7 +2070,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "mika",
       "runtime_handle": 4809241939115652
@@ -2078,7 +2078,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "noor",
       "runtime_handle": 6643976235743711
@@ -2086,7 +2086,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "professor-edward",
       "runtime_handle": 1211962163801060
@@ -2094,7 +2094,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "rati",
       "runtime_handle": 8508280633539606
@@ -2102,7 +2102,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "ravi",
       "runtime_handle": 3914282740523084
@@ -2110,7 +2110,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "ruby",
       "runtime_handle": 442578259385801
@@ -2118,7 +2118,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "sally-science",
       "runtime_handle": 692877066368845
@@ -2126,7 +2126,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "sami",
       "runtime_handle": 5798756249869747
@@ -2134,7 +2134,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "ruby_high",
       "runtime_handle": 2919627811514647
@@ -2142,7 +2142,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "10",
       "legacy_runtime_id": 10,
@@ -2151,7 +2151,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "11",
       "legacy_runtime_id": 11,
@@ -2160,7 +2160,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "12",
       "legacy_runtime_id": 12,
@@ -2169,7 +2169,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "13",
       "legacy_runtime_id": 13,
@@ -2178,7 +2178,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "14",
       "legacy_runtime_id": 14,
@@ -2187,7 +2187,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "15",
       "legacy_runtime_id": 15,
@@ -2196,7 +2196,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:10",
       "runtime_handle": 2574024258005683
@@ -2204,7 +2204,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:11",
       "runtime_handle": 944777926762018
@@ -2212,7 +2212,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:12",
       "runtime_handle": 8925253377010016
@@ -2220,7 +2220,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:13",
       "runtime_handle": 1954150505527197
@@ -2228,7 +2228,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:14",
       "runtime_handle": 9002247914113905
@@ -2236,7 +2236,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:15",
       "runtime_handle": 8772787069788936

--- a/v2/content/official/licenses.json
+++ b/v2/content/official/licenses.json
@@ -1,0 +1,64 @@
+[
+  {
+    "pack_id": "cosyworld.core",
+    "name": "CosyWorld Core",
+    "version": "1.3.1",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
+  },
+  {
+    "pack_id": "cosyworld.campaign.the-lantern-keeper",
+    "name": "The Lantern Keeper",
+    "version": "0.1.1",
+    "license_identifier": "CC-BY-4.0",
+    "license_url": "https://creativecommons.org/licenses/by/4.0/",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld and System Reference Document 5.1",
+      "source_url": "https://github.com/cenetex/cosyworld",
+      "modification_notice": "Original CosyWorld campaign material adapts selected SRD 5.1 rules references."
+    },
+    "notices": [
+      {
+        "kind": "attribution",
+        "title": "System Reference Document 5.1 attribution",
+        "file": "ATTRIBUTION.md",
+        "source_name": "System Reference Document 5.1",
+        "source_url": "https://www.dndbeyond.com/srd",
+        "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
+      }
+    ]
+  },
+  {
+    "pack_id": "cosyworld.lonely-forest.characters",
+    "name": "Lonely Forest Character Art",
+    "version": "1.1.1",
+    "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+    "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "Cenetex Lonely Forest character art",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
+  },
+  {
+    "pack_id": "ruby-high.first-bell",
+    "name": "Ruby High: First Bell",
+    "version": "1.3.1",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Ruby High",
+      "source_name": "Ruby High: First Bell",
+      "source_url": "https://ruby-high.ai"
+    },
+    "notices": []
+  }
+]

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -9,15 +9,16 @@
     "version": 1,
     "description": "The reproducible seed world for the official CosyWorld shard.",
     "entry_location": "cosyworld.core:location/1",
-    "bundle_hash": "sha256:609b2c2ab823e073450c2477cbc885d8d2c327c7cf443bc8c772a20c9f43b101",
+    "bundle_hash": "sha256:34532454b0edb8612a14e5c4ba9a9acd99c14eeac0544eccc44c38255c467a4b",
     "packs": [
       {
         "id": "cosyworld.core",
         "name": "CosyWorld Core",
         "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
-        "version": "1.3.0",
+        "version": "1.3.1",
         "kind": "world",
         "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
         "engine": ">=0.0.20 <0.1.0",
         "capabilities": [
           {
@@ -47,6 +48,7 @@
           }
         ],
         "provenance": {
+          "author": "Cenetex",
           "source_name": "CosyWorld",
           "source_url": "https://github.com/cenetex/cosyworld"
         },
@@ -79,15 +81,16 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68"
+        "integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4"
       },
       {
         "id": "cosyworld.campaign.the-lantern-keeper",
         "name": "The Lantern Keeper",
         "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
-        "version": "0.1.0",
+        "version": "0.1.1",
         "kind": "campaign",
         "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
         "engine": ">=0.0.20 <0.1.0",
         "capabilities": [
           {
@@ -123,9 +126,10 @@
           }
         ],
         "provenance": {
+          "author": "Cenetex",
           "source_name": "CosyWorld and System Reference Document 5.1",
           "source_url": "https://github.com/cenetex/cosyworld",
-          "license_notice": "SRD-derived references are attributed in ATTRIBUTION.md."
+          "modification_notice": "Original CosyWorld campaign material adapts selected SRD 5.1 rules references."
         },
         "resource_counts": {
           "actors": 4,
@@ -156,15 +160,16 @@
           "type": "workspace",
           "path": "../../content/the-lantern-keeper"
         },
-        "integrity": "sha256:91198689bfa981b3faac2ad1bb5a5806b68a0fcc52a688ea37cc3e0eb5f8576e"
+        "integrity": "sha256:8dc3f02c0c407cf828b1acee48eab50a4e0c17d5fe3e41bf9ed9dfd7f88c3f48"
       },
       {
         "id": "cosyworld.lonely-forest.characters",
         "name": "Lonely Forest Character Art",
         "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
-        "version": "1.1.0",
+        "version": "1.1.1",
         "kind": "assets",
         "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+        "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
         "engine": ">=0.0.20 <0.1.0",
         "capabilities": [
           {
@@ -196,6 +201,7 @@
           }
         ],
         "provenance": {
+          "author": "Cenetex",
           "source_name": "Cenetex Lonely Forest character art",
           "source_url": "https://github.com/cenetex/cosyworld"
         },
@@ -228,15 +234,16 @@
           "type": "workspace",
           "path": "../../content/lonely-forest"
         },
-        "integrity": "sha256:a5d1a25b1070d070411bdd7cf7a8eeab5a4be8f9a4943ba0c84ae55fdf0ba4e6"
+        "integrity": "sha256:b3ff30dbc1809a84d150ffc12a9cf00ed1d8a57e518584de0ce8a91c7e4f4132"
       },
       {
         "id": "ruby-high.first-bell",
         "name": "Ruby High: First Bell",
         "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-        "version": "1.3.0",
+        "version": "1.3.1",
         "kind": "world",
         "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
         "engine": ">=0.0.20 <0.1.0",
         "capabilities": [
           {
@@ -297,6 +304,7 @@
           }
         ],
         "provenance": {
+          "author": "Ruby High",
           "source_name": "Ruby High: First Bell",
           "source_url": "https://ruby-high.ai"
         },
@@ -412,7 +420,7 @@
           "type": "workspace",
           "path": "../../content/ruby-high-first-bell"
         },
-        "integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216"
+        "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e"
       }
     ],
     "files": {
@@ -440,6 +448,7 @@
     "assets": "assets.json",
     "rules": "rules.json",
     "attributions": "attributions.json",
+    "licenses": "licenses.json",
     "character_creation": "character_creation.json",
     "content_references": "content_refs.json",
     "registry": "registry.json"
@@ -7644,8 +7653,8 @@
   "assets": [
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
-      "pack_integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+      "pack_version": "1.3.1",
+      "pack_integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -7657,8 +7666,8 @@
     },
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.0",
-      "pack_integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+      "pack_version": "1.3.1",
+      "pack_integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",
@@ -7670,8 +7679,8 @@
     },
     {
       "pack_id": "cosyworld.lonely-forest.characters",
-      "pack_version": "1.1.0",
-      "pack_integrity": "sha256:a5d1a25b1070d070411bdd7cf7a8eeab5a4be8f9a4943ba0c84ae55fdf0ba4e6",
+      "pack_version": "1.1.1",
+      "pack_integrity": "sha256:b3ff30dbc1809a84d150ffc12a9cf00ed1d8a57e518584de0ce8a91c7e4f4132",
       "provider": "cosyworld.lonely-forest.characters/assets",
       "mount": "characters",
       "root": "lonely-forest",
@@ -7683,8 +7692,8 @@
     },
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
-      "pack_integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216",
+      "pack_version": "1.3.1",
+      "pack_integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
       "provider": "ruby-high.first-bell/assets",
       "mount": "cards",
       "root": "ruby-high-first-bell",
@@ -7705,10 +7714,74 @@
       "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
     }
   ],
+  "licenses": [
+    {
+      "pack_id": "cosyworld.core",
+      "name": "CosyWorld Core",
+      "version": "1.3.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.campaign.the-lantern-keeper",
+      "name": "The Lantern Keeper",
+      "version": "0.1.1",
+      "license_identifier": "CC-BY-4.0",
+      "license_url": "https://creativecommons.org/licenses/by/4.0/",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld and System Reference Document 5.1",
+        "source_url": "https://github.com/cenetex/cosyworld",
+        "modification_notice": "Original CosyWorld campaign material adapts selected SRD 5.1 rules references."
+      },
+      "notices": [
+        {
+          "kind": "attribution",
+          "title": "System Reference Document 5.1 attribution",
+          "file": "ATTRIBUTION.md",
+          "source_name": "System Reference Document 5.1",
+          "source_url": "https://www.dndbeyond.com/srd",
+          "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
+        }
+      ]
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "version": "1.1.1",
+      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "ruby-high.first-bell",
+      "name": "Ruby High: First Bell",
+      "version": "1.3.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Ruby High",
+        "source_name": "Ruby High: First Bell",
+        "source_url": "https://ruby-high.ai"
+      },
+      "notices": []
+    }
+  ],
   "character_creation": [
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.0",
+      "pack_version": "0.1.1",
       "profiles": [
         {
           "schema_version": 1,
@@ -7767,7 +7840,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8301",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "actor",
         "local_id": "8301",
         "legacy_runtime_id": 8301,
@@ -7776,7 +7849,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8302",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "actor",
         "local_id": "8302",
         "legacy_runtime_id": 8302,
@@ -7785,7 +7858,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8303",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "actor",
         "local_id": "8303",
         "legacy_runtime_id": 8303,
@@ -7794,7 +7867,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8304",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "actor",
         "local_id": "8304",
         "legacy_runtime_id": 8304,
@@ -7803,7 +7876,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-barrow",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-barrow",
         "runtime_handle": 2693745143565876
@@ -7811,7 +7884,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-chapel",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-chapel",
         "runtime_handle": 485182594396993
@@ -7819,7 +7892,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-dawn-oil",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-dawn-oil",
         "runtime_handle": 2918403238373891
@@ -7827,7 +7900,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-ember",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-ember",
         "runtime_handle": 6023960511621204
@@ -7835,7 +7908,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-inn",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-inn",
         "runtime_handle": 2167662595818650
@@ -7843,7 +7916,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-key",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-key",
         "runtime_handle": 8905115040499656
@@ -7851,7 +7924,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-knight",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-knight",
         "runtime_handle": 7581163987072796
@@ -7859,7 +7932,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mara",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-mara",
         "runtime_handle": 2237714680835428
@@ -7867,7 +7940,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothglass",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-mothglass",
         "runtime_handle": 5170986584558554
@@ -7875,7 +7948,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothwood",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-mothwood",
         "runtime_handle": 1673786737892201
@@ -7883,7 +7956,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-pip",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-pip",
         "runtime_handle": 6288898560895936
@@ -7891,7 +7964,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-rowan",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-rowan",
         "runtime_handle": 1658308598845697
@@ -7899,7 +7972,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-tower",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "card",
         "local_id": "lantern-keeper-tower",
         "runtime_handle": 5850818207762215
@@ -7907,7 +7980,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/character-profile/the-lantern-keeper",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "character-profile",
         "local_id": "the-lantern-keeper",
         "runtime_handle": 6074007409727657
@@ -7915,7 +7988,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.darkness",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "clock",
         "local_id": "lantern-keeper.darkness",
         "runtime_handle": 3497107257475399
@@ -7923,7 +7996,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.light",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "clock",
         "local_id": "lantern-keeper.light",
         "runtime_handle": 1743073783466389
@@ -7931,7 +8004,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/front/lantern-keeper%3Ahollow-light",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "front",
         "local_id": "lantern-keeper:hollow-light",
         "runtime_handle": 8897349519357189
@@ -7939,7 +8012,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8401",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "item",
         "local_id": "8401",
         "legacy_runtime_id": 8401,
@@ -7948,7 +8021,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8402",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "item",
         "local_id": "8402",
         "legacy_runtime_id": 8402,
@@ -7957,7 +8030,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8403",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "item",
         "local_id": "8403",
         "legacy_runtime_id": 8403,
@@ -7966,7 +8039,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8404",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "item",
         "local_id": "8404",
         "legacy_runtime_id": 8404,
@@ -7975,7 +8048,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/job/lantern-keeper%3Arekindle-the-beacon",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "job",
         "local_id": "lantern-keeper:rekindle-the-beacon",
         "runtime_handle": 3517284423041433
@@ -7983,7 +8056,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/800",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "location",
         "local_id": "800",
         "legacy_runtime_id": 800,
@@ -7992,7 +8065,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/801",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "location",
         "local_id": "801",
         "legacy_runtime_id": 801,
@@ -8001,7 +8074,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/802",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "location",
         "local_id": "802",
         "legacy_runtime_id": 802,
@@ -8010,7 +8083,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/803",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "location",
         "local_id": "803",
         "legacy_runtime_id": 803,
@@ -8019,7 +8092,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/804",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "location",
         "local_id": "804",
         "legacy_runtime_id": 804,
@@ -8028,7 +8101,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A800",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "room-sheet",
         "local_id": "room:800",
         "runtime_handle": 485005815750293
@@ -8036,7 +8109,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A801",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "room-sheet",
         "local_id": "room:801",
         "runtime_handle": 5114262777545579
@@ -8044,7 +8117,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A802",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "room-sheet",
         "local_id": "room:802",
         "runtime_handle": 3932833224947827
@@ -8052,7 +8125,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A803",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "room-sheet",
         "local_id": "room:803",
         "runtime_handle": 7094111250995550
@@ -8060,7 +8133,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A804",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.0",
+        "pack_version": "0.1.1",
         "kind": "room-sheet",
         "local_id": "room:804",
         "runtime_handle": 112964325215682
@@ -8068,7 +8141,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1001",
         "legacy_runtime_id": 1001,
@@ -8077,7 +8150,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1002",
         "legacy_runtime_id": 1002,
@@ -8086,7 +8159,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1003",
         "legacy_runtime_id": 1003,
@@ -8095,7 +8168,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1004",
         "legacy_runtime_id": 1004,
@@ -8104,7 +8177,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1005",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1005",
         "legacy_runtime_id": 1005,
@@ -8113,7 +8186,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1040",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1040",
         "legacy_runtime_id": 1040,
@@ -8122,7 +8195,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1041",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1041",
         "legacy_runtime_id": 1041,
@@ -8131,7 +8204,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1042",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1042",
         "legacy_runtime_id": 1042,
@@ -8140,7 +8213,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1043",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1043",
         "legacy_runtime_id": 1043,
@@ -8149,7 +8222,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1044",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1044",
         "legacy_runtime_id": 1044,
@@ -8158,7 +8231,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1045",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1045",
         "legacy_runtime_id": 1045,
@@ -8167,7 +8240,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1046",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1046",
         "legacy_runtime_id": 1046,
@@ -8176,7 +8249,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1047",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1047",
         "legacy_runtime_id": 1047,
@@ -8185,7 +8258,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1048",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1048",
         "legacy_runtime_id": 1048,
@@ -8194,7 +8267,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1049",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1049",
         "legacy_runtime_id": 1049,
@@ -8203,7 +8276,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1050",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1050",
         "legacy_runtime_id": 1050,
@@ -8212,7 +8285,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1051",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1051",
         "legacy_runtime_id": 1051,
@@ -8221,7 +8294,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1052",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1052",
         "legacy_runtime_id": 1052,
@@ -8230,7 +8303,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1053",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1053",
         "legacy_runtime_id": 1053,
@@ -8239,7 +8312,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1054",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1054",
         "legacy_runtime_id": 1054,
@@ -8248,7 +8321,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1055",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1055",
         "legacy_runtime_id": 1055,
@@ -8257,7 +8330,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1056",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1056",
         "legacy_runtime_id": 1056,
@@ -8266,7 +8339,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1057",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1057",
         "legacy_runtime_id": 1057,
@@ -8275,7 +8348,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1058",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1058",
         "legacy_runtime_id": 1058,
@@ -8284,7 +8357,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1059",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1059",
         "legacy_runtime_id": 1059,
@@ -8293,7 +8366,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1060",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1060",
         "legacy_runtime_id": 1060,
@@ -8302,7 +8375,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1061",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1061",
         "legacy_runtime_id": 1061,
@@ -8311,7 +8384,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1062",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1062",
         "legacy_runtime_id": 1062,
@@ -8320,7 +8393,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1063",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1063",
         "legacy_runtime_id": 1063,
@@ -8329,7 +8402,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1064",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1064",
         "legacy_runtime_id": 1064,
@@ -8338,7 +8411,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1065",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1065",
         "legacy_runtime_id": 1065,
@@ -8347,7 +8420,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1066",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1066",
         "legacy_runtime_id": 1066,
@@ -8356,7 +8429,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1067",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1067",
         "legacy_runtime_id": 1067,
@@ -8365,7 +8438,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1068",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1068",
         "legacy_runtime_id": 1068,
@@ -8374,7 +8447,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1069",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1069",
         "legacy_runtime_id": 1069,
@@ -8383,7 +8456,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1070",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor",
         "local_id": "1070",
         "legacy_runtime_id": 1070,
@@ -8392,7 +8465,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-abbey-bookmark",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-abbey-bookmark",
         "runtime_handle": 138956494956560
@@ -8400,7 +8473,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-azazoth",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-azazoth",
         "runtime_handle": 2742827434789688
@@ -8408,7 +8481,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-cottage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-cottage",
         "runtime_handle": 3679023710615970
@@ -8416,7 +8489,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-dewbright-button",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-dewbright-button",
         "runtime_handle": 7543879359126606
@@ -8424,7 +8497,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-hearth-tonic",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-hearth-tonic",
         "runtime_handle": 6099844187041316
@@ -8432,7 +8505,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-hearthstone-tag",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-hearthstone-tag",
         "runtime_handle": 445803431082645
@@ -8440,7 +8513,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-echo",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-moonlit-echo",
         "runtime_handle": 3701779326615881
@@ -8448,7 +8521,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-trail",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-moonlit-trail",
         "runtime_handle": 3706559719582066
@@ -8456,7 +8529,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonwool-thread",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-moonwool-thread",
         "runtime_handle": 3248987744606910
@@ -8464,7 +8537,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-mossglass-bead",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-mossglass-bead",
         "runtime_handle": 406732117808934
@@ -8472,7 +8545,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-old-oak",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-old-oak",
         "runtime_handle": 6806929065153819
@@ -8480,7 +8553,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-pearl-deep-resident",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-pearl-deep-resident",
         "runtime_handle": 8634483881055898
@@ -8488,7 +8561,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-rain-soft-garden",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-rain-soft-garden",
         "runtime_handle": 8636127016066734
@@ -8496,7 +8569,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-skull",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-skull",
         "runtime_handle": 8174630967825761
@@ -8504,7 +8577,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-story-button",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-story-button",
         "runtime_handle": 3151408643854036
@@ -8512,7 +8585,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-threadbare-map-scrap",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-threadbare-map-scrap",
         "runtime_handle": 4482891498418887
@@ -8520,7 +8593,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-vowbright-angel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-vowbright-angel",
         "runtime_handle": 7966555082684141
@@ -8528,7 +8601,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-watch-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-watch-bell",
         "runtime_handle": 6205526622615328
@@ -8536,7 +8609,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-whiskerwind",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-whiskerwind",
         "runtime_handle": 5669444972898140
@@ -8544,7 +8617,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-wolfprint-charm",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-wolfprint-charm",
         "runtime_handle": 915703357568385
@@ -8552,7 +8625,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-zadkiel-dark-angel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "cosy-zadkiel-dark-angel",
         "runtime_handle": 8315124370132858
@@ -8560,7 +8633,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-armored-winged-hero",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-armored-winged-hero",
         "runtime_handle": 6600128378329146
@@ -8568,7 +8641,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-badger-cub",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-badger-cub",
         "runtime_handle": 3524217422483260
@@ -8576,7 +8649,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-beetle-armor",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-beetle-armor",
         "runtime_handle": 7880939887467250
@@ -8584,7 +8657,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-blue-shadow-man",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-blue-shadow-man",
         "runtime_handle": 3755993660754793
@@ -8592,7 +8665,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-blue-squirrel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-blue-squirrel",
         "runtime_handle": 3374679645864704
@@ -8600,7 +8673,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-cloaked-mouse-reader",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-cloaked-mouse-reader",
         "runtime_handle": 3997082335066109
@@ -8608,7 +8681,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-forest-dryad",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-forest-dryad",
         "runtime_handle": 8662818472079145
@@ -8616,7 +8689,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-garden-rabbit",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-garden-rabbit",
         "runtime_handle": 2730391876987516
@@ -8624,7 +8697,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-golden-squirrel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-golden-squirrel",
         "runtime_handle": 162503682361987
@@ -8632,7 +8705,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-golden-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-golden-winged-boy",
         "runtime_handle": 4342854739894551
@@ -8640,7 +8713,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-grey-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-grey-winged-boy",
         "runtime_handle": 1250802238685798
@@ -8648,7 +8721,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-llama-scholar",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-llama-scholar",
         "runtime_handle": 6908093676132939
@@ -8656,7 +8729,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-mouse-wanderer",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-mouse-wanderer",
         "runtime_handle": 4601206403124060
@@ -8664,7 +8737,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-neon-tiger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-neon-tiger",
         "runtime_handle": 6229971572743818
@@ -8672,7 +8745,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-rabbit-scribe",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-rabbit-scribe",
         "runtime_handle": 8634110685852129
@@ -8680,7 +8753,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-red-shadow-figure",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-red-shadow-figure",
         "runtime_handle": 3112884101630158
@@ -8688,7 +8761,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-shadow-wolf",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-shadow-wolf",
         "runtime_handle": 4273988789998875
@@ -8696,7 +8769,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-steampunk-mouse",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-steampunk-mouse",
         "runtime_handle": 4441668646189737
@@ -8704,7 +8777,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-sunlit-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-sunlit-winged-boy",
         "runtime_handle": 8615932867192302
@@ -8712,7 +8785,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-tavern-blond-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-tavern-blond-boy",
         "runtime_handle": 1835702442135722
@@ -8720,7 +8793,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-veiled-forest-ghost",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-veiled-forest-ghost",
         "runtime_handle": 4799858469869419
@@ -8728,7 +8801,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-white-ferret-noble",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-white-ferret-noble",
         "runtime_handle": 5084247526999701
@@ -8736,7 +8809,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-wolf-pup",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-wolf-pup",
         "runtime_handle": 236437027581609
@@ -8744,7 +8817,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-woodland-bear",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "lf-woodland-bear",
         "runtime_handle": 9000656934868850
@@ -8752,7 +8825,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-alpine-forest",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-alpine-forest",
         "runtime_handle": 8242458519360113
@@ -8760,7 +8833,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-circle-of-the-moon",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-circle-of-the-moon",
         "runtime_handle": 1930856172148870
@@ -8768,7 +8841,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-dark-abyss",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-dark-abyss",
         "runtime_handle": 7382677506125331
@@ -8776,7 +8849,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-darkest-ocean",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-darkest-ocean",
         "runtime_handle": 5061075064260629
@@ -8784,7 +8857,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-digital-realm",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-digital-realm",
         "runtime_handle": 5887686546418438
@@ -8792,7 +8865,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-endless-ocean",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-endless-ocean",
         "runtime_handle": 5401754774320525
@@ -8800,7 +8873,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-flower-meadow",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-flower-meadow",
         "runtime_handle": 7614022144101722
@@ -8808,7 +8881,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-goblin-cave",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-goblin-cave",
         "runtime_handle": 3499001612672709
@@ -8816,7 +8889,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-great-library",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-great-library",
         "runtime_handle": 7328586258800562
@@ -8824,7 +8897,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-haunted-mansion",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-haunted-mansion",
         "runtime_handle": 7484239537948286
@@ -8832,7 +8905,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-lofty-peak",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-lofty-peak",
         "runtime_handle": 2456240765655012
@@ -8840,7 +8913,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-lost-woods",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-lost-woods",
         "runtime_handle": 6580883718503069
@@ -8848,7 +8921,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-old-oak-tree",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-old-oak-tree",
         "runtime_handle": 2838379433219254
@@ -8856,7 +8929,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-quiet-abbey",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-quiet-abbey",
         "runtime_handle": 4838231888638100
@@ -8864,7 +8937,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-solar-temple",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-solar-temple",
         "runtime_handle": 450219611871818
@@ -8872,7 +8945,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-summit-trail",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-summit-trail",
         "runtime_handle": 8064929121549612
@@ -8880,7 +8953,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-the-heavens",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-the-heavens",
         "runtime_handle": 6396411156616223
@@ -8888,7 +8961,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-turgid-swamp",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-turgid-swamp",
         "runtime_handle": 6935773679641332
@@ -8896,7 +8969,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-wilting-jungle",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-wilting-jungle",
         "runtime_handle": 5897394732936641
@@ -8904,7 +8977,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/rati",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "rati",
         "runtime_handle": 1392254580257493
@@ -8912,7 +8985,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.fair-bargain",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "goblin-cave.fair-bargain",
         "runtime_handle": 8054949801377040
@@ -8920,7 +8993,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.leverage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "goblin-cave.leverage",
         "runtime_handle": 1065707925425919
@@ -8928,7 +9001,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "haunted-mansion.threshold",
         "runtime_handle": 4535315091897137
@@ -8936,7 +9009,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.warden-rage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "haunted-mansion.warden-rage",
         "runtime_handle": 6257115991159330
@@ -8944,7 +9017,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.danger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "moonlit-trail.danger",
         "runtime_handle": 257345026365457
@@ -8952,7 +9025,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.progress",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "moonlit-trail.progress",
         "runtime_handle": 6085238183587093
@@ -8960,7 +9033,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.drowned-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "solar-abyss.drowned-bell",
         "runtime_handle": 3555240757788262
@@ -8968,7 +9041,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.schism",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "solar-abyss.schism",
         "runtime_handle": 4589004266308223
@@ -8976,7 +9049,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.amends",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "turgid-swamp.amends",
         "runtime_handle": 4432023342275341
@@ -8984,7 +9057,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.old-grudge",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "clock",
         "local_id": "turgid-swamp.old-grudge",
         "runtime_handle": 8536373757408084
@@ -8992,7 +9065,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/abyssal_residents",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "abyssal_residents",
         "runtime_handle": 1688333275188302
@@ -9000,7 +9073,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/digital_strays",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "digital_strays",
         "runtime_handle": 5048545454289654
@@ -9008,7 +9081,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/farthest_mists",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "farthest_mists",
         "runtime_handle": 350962558801960
@@ -9016,7 +9089,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/goblin_market",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "goblin_market",
         "runtime_handle": 3490418888358082
@@ -9024,7 +9097,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/great_library",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "great_library",
         "runtime_handle": 991170045564473
@@ -9032,7 +9105,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/haunted_remnants",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "haunted_remnants",
         "runtime_handle": 4900866309718573
@@ -9040,7 +9113,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/hearthbound",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "hearthbound",
         "runtime_handle": 4046513959484943
@@ -9048,7 +9121,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/lonely_forest_court",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "lonely_forest_court",
         "runtime_handle": 5495209280499345
@@ -9056,7 +9129,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/moon_circle",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "moon_circle",
         "runtime_handle": 3594504273910135
@@ -9064,7 +9137,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/quiet_abbey",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "quiet_abbey",
         "runtime_handle": 7894097855005461
@@ -9072,7 +9145,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/solar_temple",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "solar_temple",
         "runtime_handle": 2642136344425509
@@ -9080,7 +9153,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/goblin-cave%3Amarket-leverage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "goblin-cave:market-leverage",
         "runtime_handle": 5093973293074428
@@ -9088,7 +9161,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/haunted-mansion%3Abarred-threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "haunted-mansion:barred-threshold",
         "runtime_handle": 6295078661322495
@@ -9096,7 +9169,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/moonlit-trail%3Aecho-front",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "moonlit-trail:echo-front",
         "runtime_handle": 3643385637336037
@@ -9104,7 +9177,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/solar-abyss%3Abell-front",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "solar-abyss:bell-front",
         "runtime_handle": 591496292254136
@@ -9112,7 +9185,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/turgid-swamp%3Aold-grudge",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "front",
         "local_id": "turgid-swamp:old-grudge",
         "runtime_handle": 5644962986267984
@@ -9120,7 +9193,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/hidden-exit/darkest-ocean%3Adark-abyss",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "hidden-exit",
         "local_id": "darkest-ocean:dark-abyss",
         "runtime_handle": 456562266146446
@@ -9128,7 +9201,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2001",
         "legacy_runtime_id": 2001,
@@ -9137,7 +9210,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2002",
         "legacy_runtime_id": 2002,
@@ -9146,7 +9219,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2003",
         "legacy_runtime_id": 2003,
@@ -9155,7 +9228,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2004",
         "legacy_runtime_id": 2004,
@@ -9164,7 +9237,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2005",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2005",
         "legacy_runtime_id": 2005,
@@ -9173,7 +9246,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2006",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2006",
         "legacy_runtime_id": 2006,
@@ -9182,7 +9255,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2007",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2007",
         "legacy_runtime_id": 2007,
@@ -9191,7 +9264,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2008",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2008",
         "legacy_runtime_id": 2008,
@@ -9200,7 +9273,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2009",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2009",
         "legacy_runtime_id": 2009,
@@ -9209,7 +9282,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2010",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "item",
         "local_id": "2010",
         "legacy_runtime_id": 2010,
@@ -9218,7 +9291,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/goblin-cave%3Aname-the-price",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "goblin-cave:name-the-price",
         "runtime_handle": 3094113202720990
@@ -9226,7 +9299,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/haunted-mansion%3Aearn-the-threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "haunted-mansion:earn-the-threshold",
         "runtime_handle": 7833342030263292
@@ -9234,7 +9307,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/moonlit-trail%3Aquiet-the-echo",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "moonlit-trail:quiet-the-echo",
         "runtime_handle": 3184352149003600
@@ -9242,7 +9315,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/solar-abyss%3Adrowned-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "solar-abyss:drowned-bell",
         "runtime_handle": 681263158451131
@@ -9250,7 +9323,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/turgid-swamp%3Aamend-the-ledger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "job",
         "local_id": "turgid-swamp:amend-the-ledger",
         "runtime_handle": 477973030695414
@@ -9258,7 +9331,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/1",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "1",
         "legacy_runtime_id": 1,
@@ -9267,7 +9340,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/2",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "2",
         "legacy_runtime_id": 2,
@@ -9276,7 +9349,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/3",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "3",
         "legacy_runtime_id": 3,
@@ -9285,7 +9358,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/30",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "30",
         "legacy_runtime_id": 30,
@@ -9294,7 +9367,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/31",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "31",
         "legacy_runtime_id": 31,
@@ -9303,7 +9376,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/32",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "32",
         "legacy_runtime_id": 32,
@@ -9312,7 +9385,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/33",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "33",
         "legacy_runtime_id": 33,
@@ -9321,7 +9394,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/34",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "34",
         "legacy_runtime_id": 34,
@@ -9330,7 +9403,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/35",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "35",
         "legacy_runtime_id": 35,
@@ -9339,7 +9412,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/36",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "36",
         "legacy_runtime_id": 36,
@@ -9348,7 +9421,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/40",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "40",
         "legacy_runtime_id": 40,
@@ -9357,7 +9430,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/41",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "41",
         "legacy_runtime_id": 41,
@@ -9366,7 +9439,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/42",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "42",
         "legacy_runtime_id": 42,
@@ -9375,7 +9448,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/43",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "43",
         "legacy_runtime_id": 43,
@@ -9384,7 +9457,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/44",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "44",
         "legacy_runtime_id": 44,
@@ -9393,7 +9466,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/50",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "50",
         "legacy_runtime_id": 50,
@@ -9402,7 +9475,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/60",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "60",
         "legacy_runtime_id": 60,
@@ -9411,7 +9484,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/61",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "61",
         "legacy_runtime_id": 61,
@@ -9420,7 +9493,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/62",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "62",
         "legacy_runtime_id": 62,
@@ -9429,7 +9502,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/63",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "63",
         "legacy_runtime_id": 63,
@@ -9438,7 +9511,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/64",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "64",
         "legacy_runtime_id": 64,
@@ -9447,7 +9520,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/65",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "65",
         "legacy_runtime_id": 65,
@@ -9456,7 +9529,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "recipe",
         "local_id": "3001",
         "runtime_handle": 828439639934659
@@ -9464,7 +9537,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A1",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:1",
         "runtime_handle": 3639178970696137
@@ -9472,7 +9545,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A2",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:2",
         "runtime_handle": 4328625160851383
@@ -9480,7 +9553,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A3",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:3",
         "runtime_handle": 272728635448160
@@ -9488,7 +9561,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A30",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:30",
         "runtime_handle": 4949881785988127
@@ -9496,7 +9569,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A31",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:31",
         "runtime_handle": 12158853449275
@@ -9504,7 +9577,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A32",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:32",
         "runtime_handle": 3065031734117441
@@ -9512,7 +9585,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A33",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:33",
         "runtime_handle": 8635481635081203
@@ -9520,7 +9593,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A34",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:34",
         "runtime_handle": 3415405010788251
@@ -9528,7 +9601,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A35",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:35",
         "runtime_handle": 8268805670112054
@@ -9536,7 +9609,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A36",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:36",
         "runtime_handle": 1278082739662403
@@ -9544,7 +9617,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A40",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:40",
         "runtime_handle": 2373835638704337
@@ -9552,7 +9625,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A41",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:41",
         "runtime_handle": 302978963504637
@@ -9560,7 +9633,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A42",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:42",
         "runtime_handle": 4669140359619141
@@ -9568,7 +9641,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A43",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:43",
         "runtime_handle": 3577060339822743
@@ -9576,7 +9649,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A44",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:44",
         "runtime_handle": 4396167510730171
@@ -9584,7 +9657,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A50",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:50",
         "runtime_handle": 1673766510642920
@@ -9592,7 +9665,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A60",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:60",
         "runtime_handle": 5586350793250546
@@ -9600,7 +9673,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A61",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:61",
         "runtime_handle": 6162116676111910
@@ -9608,7 +9681,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A62",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:62",
         "runtime_handle": 897159537111265
@@ -9616,7 +9689,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A63",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:63",
         "runtime_handle": 7446099757621175
@@ -9624,7 +9697,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A64",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:64",
         "runtime_handle": 4767551281449957
@@ -9632,7 +9705,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A65",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:65",
         "runtime_handle": 389717939014779
@@ -9640,7 +9713,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/actor-facet/rati-first-bell",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "actor-facet",
         "local_id": "rati-first-bell",
         "runtime_handle": 1038687835420516
@@ -9648,7 +9721,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card-binding/rati-first-bell-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card-binding",
         "local_id": "rati-first-bell-card",
         "runtime_handle": 3116738573256863
@@ -9656,7 +9729,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-cafeteria",
         "runtime_handle": 3107528363911865
@@ -9664,7 +9737,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-courtyard",
         "runtime_handle": 4782402674832957
@@ -9672,7 +9745,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-greenhouse",
         "runtime_handle": 3662976131116729
@@ -9680,7 +9753,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-homeroom",
         "runtime_handle": 7084902207358373
@@ -9688,7 +9761,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-library",
         "runtime_handle": 6785800264541047
@@ -9696,7 +9769,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-science-lab",
         "runtime_handle": 8201462675675638
@@ -9704,7 +9777,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "captain-null",
         "runtime_handle": 3843573141933674
@@ -9712,7 +9785,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "eliza",
         "runtime_handle": 4124553834845258
@@ -9720,7 +9793,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "indra",
         "runtime_handle": 8687099168741216
@@ -9728,7 +9801,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-flashcards",
         "runtime_handle": 6148366931632609
@@ -9736,7 +9809,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-hall-pass",
         "runtime_handle": 6154026517662833
@@ -9744,7 +9817,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-lab-flask",
         "runtime_handle": 7444186363202775
@@ -9752,7 +9825,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-library-card",
         "runtime_handle": 27821797810153
@@ -9760,7 +9833,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-lunch-tray",
         "runtime_handle": 3064948555071770
@@ -9768,7 +9841,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-notebook",
         "runtime_handle": 5906680647268123
@@ -9776,7 +9849,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-cafeteria",
         "runtime_handle": 232928798345453
@@ -9784,7 +9857,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-courtyard",
         "runtime_handle": 1017422828753302
@@ -9792,7 +9865,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-greenhouse",
         "runtime_handle": 1874830250433117
@@ -9800,7 +9873,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-homeroom",
         "runtime_handle": 6928775784641985
@@ -9808,7 +9881,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-library",
         "runtime_handle": 8204365461548708
@@ -9816,7 +9889,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-science-lab",
         "runtime_handle": 57115334800243
@@ -9824,7 +9897,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "lyra",
         "runtime_handle": 7094866015162716
@@ -9832,7 +9905,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "mika",
         "runtime_handle": 4809241939115652
@@ -9840,7 +9913,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "noor",
         "runtime_handle": 6643976235743711
@@ -9848,7 +9921,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "professor-edward",
         "runtime_handle": 1211962163801060
@@ -9856,7 +9929,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "rati",
         "runtime_handle": 8508280633539606
@@ -9864,7 +9937,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "ravi",
         "runtime_handle": 3914282740523084
@@ -9872,7 +9945,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "ruby",
         "runtime_handle": 442578259385801
@@ -9880,7 +9953,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "sally-science",
         "runtime_handle": 692877066368845
@@ -9888,7 +9961,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "sami",
         "runtime_handle": 5798756249869747
@@ -9896,7 +9969,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "ruby_high",
         "runtime_handle": 2919627811514647
@@ -9904,7 +9977,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "10",
         "legacy_runtime_id": 10,
@@ -9913,7 +9986,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "11",
         "legacy_runtime_id": 11,
@@ -9922,7 +9995,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "12",
         "legacy_runtime_id": 12,
@@ -9931,7 +10004,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "13",
         "legacy_runtime_id": 13,
@@ -9940,7 +10013,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "14",
         "legacy_runtime_id": 14,
@@ -9949,7 +10022,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "15",
         "legacy_runtime_id": 15,
@@ -9958,7 +10031,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:10",
         "runtime_handle": 2574024258005683
@@ -9966,7 +10039,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:11",
         "runtime_handle": 944777926762018
@@ -9974,7 +10047,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:12",
         "runtime_handle": 8925253377010016
@@ -9982,7 +10055,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:13",
         "runtime_handle": 1954150505527197
@@ -9990,7 +10063,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:14",
         "runtime_handle": 9002247914113905
@@ -9998,7 +10071,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:15",
         "runtime_handle": 8772787069788936

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -7,15 +7,16 @@
   "version": 1,
   "description": "The reproducible seed world for the official CosyWorld shard.",
   "entry_location": "cosyworld.core:location/1",
-  "bundle_hash": "sha256:609b2c2ab823e073450c2477cbc885d8d2c327c7cf443bc8c772a20c9f43b101",
+  "bundle_hash": "sha256:34532454b0edb8612a14e5c4ba9a9acd99c14eeac0544eccc44c38255c467a4b",
   "packs": [
     {
       "id": "cosyworld.core",
       "name": "CosyWorld Core",
       "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "kind": "world",
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "engine": ">=0.0.20 <0.1.0",
       "capabilities": [
         {
@@ -45,6 +46,7 @@
         }
       ],
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld",
         "source_url": "https://github.com/cenetex/cosyworld"
       },
@@ -77,15 +79,16 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68"
+      "integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4"
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
       "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "kind": "campaign",
       "license": "CC-BY-4.0",
+      "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "engine": ">=0.0.20 <0.1.0",
       "capabilities": [
         {
@@ -121,9 +124,10 @@
         }
       ],
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld and System Reference Document 5.1",
         "source_url": "https://github.com/cenetex/cosyworld",
-        "license_notice": "SRD-derived references are attributed in ATTRIBUTION.md."
+        "modification_notice": "Original CosyWorld campaign material adapts selected SRD 5.1 rules references."
       },
       "resource_counts": {
         "actors": 4,
@@ -154,15 +158,16 @@
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:91198689bfa981b3faac2ad1bb5a5806b68a0fcc52a688ea37cc3e0eb5f8576e"
+      "integrity": "sha256:8dc3f02c0c407cf828b1acee48eab50a4e0c17d5fe3e41bf9ed9dfd7f88c3f48"
     },
     {
       "id": "cosyworld.lonely-forest.characters",
       "name": "Lonely Forest Character Art",
       "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "kind": "assets",
       "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
       "engine": ">=0.0.20 <0.1.0",
       "capabilities": [
         {
@@ -194,6 +199,7 @@
         }
       ],
       "provenance": {
+        "author": "Cenetex",
         "source_name": "Cenetex Lonely Forest character art",
         "source_url": "https://github.com/cenetex/cosyworld"
       },
@@ -226,15 +232,16 @@
         "type": "workspace",
         "path": "../../content/lonely-forest"
       },
-      "integrity": "sha256:a5d1a25b1070d070411bdd7cf7a8eeab5a4be8f9a4943ba0c84ae55fdf0ba4e6"
+      "integrity": "sha256:b3ff30dbc1809a84d150ffc12a9cf00ed1d8a57e518584de0ce8a91c7e4f4132"
     },
     {
       "id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
       "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "kind": "world",
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "engine": ">=0.0.20 <0.1.0",
       "capabilities": [
         {
@@ -295,6 +302,7 @@
         }
       ],
       "provenance": {
+        "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
       },
@@ -410,7 +418,7 @@
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216"
+      "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e"
     }
   ],
   "files": {
@@ -438,6 +446,7 @@
   "assets": "assets.json",
   "rules": "rules.json",
   "attributions": "attributions.json",
+  "licenses": "licenses.json",
   "character_creation": "character_creation.json",
   "content_references": "content_refs.json",
   "registry": "registry.json"

--- a/v2/content/ruby-high-first-bell/pack.json
+++ b/v2/content/ruby-high-first-bell/pack.json
@@ -2,10 +2,11 @@
   "schema_version": 1,
   "id": "ruby-high.first-bell",
   "name": "Ruby High: First Bell",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "kind": "world",
   "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
   "license": "MIT",
+  "license_url": "https://opensource.org/license/mit",
   "engine": ">=0.0.20 <0.1.0",
   "capabilities": [
     {
@@ -59,6 +60,7 @@
     }
   ],
   "provenance": {
+    "author": "Ruby High",
     "source_name": "Ruby High: First Bell",
     "source_url": "https://ruby-high.ai"
   },

--- a/v2/content/ruby-high-only/assets.json
+++ b/v2/content/ruby-high-only/assets.json
@@ -1,8 +1,8 @@
 [
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.0",
-    "pack_integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216",
+    "pack_version": "1.3.1",
+    "pack_integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
     "provider": "ruby-high.first-bell/assets",
     "mount": "cards",
     "root": "ruby-high-first-bell",

--- a/v2/content/ruby-high-only/content_refs.json
+++ b/v2/content/ruby-high-only/content_refs.json
@@ -5,7 +5,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-cafeteria",
       "runtime_handle": 3107528363911865
@@ -13,7 +13,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-courtyard",
       "runtime_handle": 4782402674832957
@@ -21,7 +21,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-greenhouse",
       "runtime_handle": 3662976131116729
@@ -29,7 +29,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-homeroom",
       "runtime_handle": 7084902207358373
@@ -37,7 +37,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-library",
       "runtime_handle": 6785800264541047
@@ -45,7 +45,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "card",
       "local_id": "location-science-lab",
       "runtime_handle": 8201462675675638
@@ -53,7 +53,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "captain-null",
       "runtime_handle": 3843573141933674
@@ -61,7 +61,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "eliza",
       "runtime_handle": 4124553834845258
@@ -69,7 +69,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "indra",
       "runtime_handle": 8687099168741216
@@ -77,7 +77,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-flashcards",
       "runtime_handle": 6148366931632609
@@ -85,7 +85,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-hall-pass",
       "runtime_handle": 6154026517662833
@@ -93,7 +93,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-lab-flask",
       "runtime_handle": 7444186363202775
@@ -101,7 +101,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-library-card",
       "runtime_handle": 27821797810153
@@ -109,7 +109,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-lunch-tray",
       "runtime_handle": 3064948555071770
@@ -117,7 +117,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "item-notebook",
       "runtime_handle": 5906680647268123
@@ -125,7 +125,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-cafeteria",
       "runtime_handle": 232928798345453
@@ -133,7 +133,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-courtyard",
       "runtime_handle": 1017422828753302
@@ -141,7 +141,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-greenhouse",
       "runtime_handle": 1874830250433117
@@ -149,7 +149,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-homeroom",
       "runtime_handle": 6928775784641985
@@ -157,7 +157,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-library",
       "runtime_handle": 8204365461548708
@@ -165,7 +165,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "location-science-lab",
       "runtime_handle": 57115334800243
@@ -173,7 +173,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "lyra",
       "runtime_handle": 7094866015162716
@@ -181,7 +181,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "mika",
       "runtime_handle": 4809241939115652
@@ -189,7 +189,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "noor",
       "runtime_handle": 6643976235743711
@@ -197,7 +197,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "professor-edward",
       "runtime_handle": 1211962163801060
@@ -205,7 +205,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "rati",
       "runtime_handle": 8508280633539606
@@ -213,7 +213,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "ravi",
       "runtime_handle": 3914282740523084
@@ -221,7 +221,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "ruby",
       "runtime_handle": 442578259385801
@@ -229,7 +229,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "sally-science",
       "runtime_handle": 692877066368845
@@ -237,7 +237,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "external-card",
       "local_id": "sami",
       "runtime_handle": 5798756249869747
@@ -245,7 +245,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "faction",
       "local_id": "ruby_high",
       "runtime_handle": 2919627811514647
@@ -253,7 +253,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "10",
       "legacy_runtime_id": 10,
@@ -262,7 +262,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "11",
       "legacy_runtime_id": 11,
@@ -271,7 +271,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "12",
       "legacy_runtime_id": 12,
@@ -280,7 +280,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "13",
       "legacy_runtime_id": 13,
@@ -289,7 +289,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "14",
       "legacy_runtime_id": 14,
@@ -298,7 +298,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "location",
       "local_id": "15",
       "legacy_runtime_id": 15,
@@ -307,7 +307,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:10",
       "runtime_handle": 2574024258005683
@@ -315,7 +315,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:11",
       "runtime_handle": 944777926762018
@@ -323,7 +323,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:12",
       "runtime_handle": 8925253377010016
@@ -331,7 +331,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:13",
       "runtime_handle": 1954150505527197
@@ -339,7 +339,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:14",
       "runtime_handle": 9002247914113905
@@ -347,7 +347,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
+      "pack_version": "1.3.1",
       "kind": "room-sheet",
       "local_id": "room:15",
       "runtime_handle": 8772787069788936

--- a/v2/content/ruby-high-only/licenses.json
+++ b/v2/content/ruby-high-only/licenses.json
@@ -1,0 +1,15 @@
+[
+  {
+    "pack_id": "ruby-high.first-bell",
+    "name": "Ruby High: First Bell",
+    "version": "1.3.1",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Ruby High",
+      "source_name": "Ruby High: First Bell",
+      "source_url": "https://ruby-high.ai"
+    },
+    "notices": []
+  }
+]

--- a/v2/content/ruby-high-only/registry.json
+++ b/v2/content/ruby-high-only/registry.json
@@ -10,15 +10,16 @@
     "description": "A standalone First Bell boot fixture with no CosyWorld Core pack mounted.",
     "entry_location": "ruby-high.first-bell:location/11",
     "entry_grant_id": "ruby-high.first-bell:location-homeroom",
-    "bundle_hash": "sha256:d345555f23cc25aa708642dc928ed74f304d105d379243054de94fe984c4d2dd",
+    "bundle_hash": "sha256:fdf45cd5b2c99a0f0c8b113bee55acbcfc375a826cdedab11fb717b425483c93",
     "packs": [
       {
         "id": "ruby-high.first-bell",
         "name": "Ruby High: First Bell",
         "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-        "version": "1.3.0",
+        "version": "1.3.1",
         "kind": "world",
         "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
         "engine": ">=0.0.20 <0.1.0",
         "capabilities": [
           {
@@ -77,6 +78,7 @@
           }
         ],
         "provenance": {
+          "author": "Ruby High",
           "source_name": "Ruby High: First Bell",
           "source_url": "https://ruby-high.ai"
         },
@@ -192,7 +194,7 @@
           "type": "workspace",
           "path": "../../content/ruby-high-first-bell"
         },
-        "integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216"
+        "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e"
       }
     ],
     "files": {
@@ -220,6 +222,7 @@
     "assets": "assets.json",
     "rules": "rules.json",
     "attributions": "attributions.json",
+    "licenses": "licenses.json",
     "character_creation": "character_creation.json",
     "content_references": "content_refs.json",
     "registry": "registry.json"
@@ -1195,8 +1198,8 @@
   "assets": [
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.0",
-      "pack_integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216",
+      "pack_version": "1.3.1",
+      "pack_integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
       "provider": "ruby-high.first-bell/assets",
       "mount": "cards",
       "root": "ruby-high-first-bell",
@@ -1209,6 +1212,21 @@
   ],
   "rules": [],
   "attributions": [],
+  "licenses": [
+    {
+      "pack_id": "ruby-high.first-bell",
+      "name": "Ruby High: First Bell",
+      "version": "1.3.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Ruby High",
+        "source_name": "Ruby High: First Bell",
+        "source_url": "https://ruby-high.ai"
+      },
+      "notices": []
+    }
+  ],
   "character_creation": [],
   "content_references": {
     "schema_version": 1,
@@ -1217,7 +1235,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-cafeteria",
         "runtime_handle": 3107528363911865
@@ -1225,7 +1243,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-courtyard",
         "runtime_handle": 4782402674832957
@@ -1233,7 +1251,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-greenhouse",
         "runtime_handle": 3662976131116729
@@ -1241,7 +1259,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-homeroom",
         "runtime_handle": 7084902207358373
@@ -1249,7 +1267,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-library",
         "runtime_handle": 6785800264541047
@@ -1257,7 +1275,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "card",
         "local_id": "location-science-lab",
         "runtime_handle": 8201462675675638
@@ -1265,7 +1283,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "captain-null",
         "runtime_handle": 3843573141933674
@@ -1273,7 +1291,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "eliza",
         "runtime_handle": 4124553834845258
@@ -1281,7 +1299,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "indra",
         "runtime_handle": 8687099168741216
@@ -1289,7 +1307,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-flashcards",
         "runtime_handle": 6148366931632609
@@ -1297,7 +1315,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-hall-pass",
         "runtime_handle": 6154026517662833
@@ -1305,7 +1323,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-lab-flask",
         "runtime_handle": 7444186363202775
@@ -1313,7 +1331,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-library-card",
         "runtime_handle": 27821797810153
@@ -1321,7 +1339,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-lunch-tray",
         "runtime_handle": 3064948555071770
@@ -1329,7 +1347,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "item-notebook",
         "runtime_handle": 5906680647268123
@@ -1337,7 +1355,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-cafeteria",
         "runtime_handle": 232928798345453
@@ -1345,7 +1363,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-courtyard",
         "runtime_handle": 1017422828753302
@@ -1353,7 +1371,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-greenhouse",
         "runtime_handle": 1874830250433117
@@ -1361,7 +1379,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-homeroom",
         "runtime_handle": 6928775784641985
@@ -1369,7 +1387,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-library",
         "runtime_handle": 8204365461548708
@@ -1377,7 +1395,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "location-science-lab",
         "runtime_handle": 57115334800243
@@ -1385,7 +1403,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "lyra",
         "runtime_handle": 7094866015162716
@@ -1393,7 +1411,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "mika",
         "runtime_handle": 4809241939115652
@@ -1401,7 +1419,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "noor",
         "runtime_handle": 6643976235743711
@@ -1409,7 +1427,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "professor-edward",
         "runtime_handle": 1211962163801060
@@ -1417,7 +1435,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "rati",
         "runtime_handle": 8508280633539606
@@ -1425,7 +1443,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "ravi",
         "runtime_handle": 3914282740523084
@@ -1433,7 +1451,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "ruby",
         "runtime_handle": 442578259385801
@@ -1441,7 +1459,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "sally-science",
         "runtime_handle": 692877066368845
@@ -1449,7 +1467,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "external-card",
         "local_id": "sami",
         "runtime_handle": 5798756249869747
@@ -1457,7 +1475,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "faction",
         "local_id": "ruby_high",
         "runtime_handle": 2919627811514647
@@ -1465,7 +1483,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "10",
         "legacy_runtime_id": 10,
@@ -1474,7 +1492,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "11",
         "legacy_runtime_id": 11,
@@ -1483,7 +1501,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "12",
         "legacy_runtime_id": 12,
@@ -1492,7 +1510,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "13",
         "legacy_runtime_id": 13,
@@ -1501,7 +1519,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "14",
         "legacy_runtime_id": 14,
@@ -1510,7 +1528,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "location",
         "local_id": "15",
         "legacy_runtime_id": 15,
@@ -1519,7 +1537,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:10",
         "runtime_handle": 2574024258005683
@@ -1527,7 +1545,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:11",
         "runtime_handle": 944777926762018
@@ -1535,7 +1553,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:12",
         "runtime_handle": 8925253377010016
@@ -1543,7 +1561,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:13",
         "runtime_handle": 1954150505527197
@@ -1551,7 +1569,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:14",
         "runtime_handle": 9002247914113905
@@ -1559,7 +1577,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.0",
+        "pack_version": "1.3.1",
         "kind": "room-sheet",
         "local_id": "room:15",
         "runtime_handle": 8772787069788936

--- a/v2/content/ruby-high-only/worldpack.json
+++ b/v2/content/ruby-high-only/worldpack.json
@@ -8,15 +8,16 @@
   "description": "A standalone First Bell boot fixture with no CosyWorld Core pack mounted.",
   "entry_location": "ruby-high.first-bell:location/11",
   "entry_grant_id": "ruby-high.first-bell:location-homeroom",
-  "bundle_hash": "sha256:d345555f23cc25aa708642dc928ed74f304d105d379243054de94fe984c4d2dd",
+  "bundle_hash": "sha256:fdf45cd5b2c99a0f0c8b113bee55acbcfc375a826cdedab11fb717b425483c93",
   "packs": [
     {
       "id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
       "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "kind": "world",
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "engine": ">=0.0.20 <0.1.0",
       "capabilities": [
         {
@@ -75,6 +76,7 @@
         }
       ],
       "provenance": {
+        "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
       },
@@ -190,7 +192,7 @@
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216"
+      "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e"
     }
   ],
   "files": {
@@ -218,6 +220,7 @@
   "assets": "assets.json",
   "rules": "rules.json",
   "attributions": "attributions.json",
+  "licenses": "licenses.json",
   "character_creation": "character_creation.json",
   "content_references": "content_refs.json",
   "registry": "registry.json"

--- a/v2/content/rules-srd-5.1/pack.json
+++ b/v2/content/rules-srd-5.1/pack.json
@@ -2,10 +2,11 @@
   "schema_version": 1,
   "id": "cosyworld.rules-srd-5.1",
   "name": "CosyWorld Rules: SRD 5.1",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "kind": "rules",
   "description": "An attributed, non-authoritative SRD 5.1 adapter pack for CosyWorld conversion seeds.",
   "license": "CC-BY-4.0",
+  "license_url": "https://creativecommons.org/licenses/by/4.0/",
   "engine": ">=0.0.20 <0.1.0",
   "capabilities": [
     {
@@ -27,9 +28,10 @@
     }
   ],
   "provenance": {
+    "author": "Wizards of the Coast LLC",
     "source_name": "System Reference Document 5.1",
     "source_url": "https://www.dndbeyond.com/srd",
-    "license_notice": "CC-BY-4.0 attribution is carried in ATTRIBUTION.md."
+    "modification_notice": "Selected rules references are adapted into CosyWorld's non-authoritative conversion schema."
   },
   "rules_adapter": "cosyworld.rules/1",
   "rules_namespace": "srd5.1",

--- a/v2/content/rules-srd-5.2.1/pack.json
+++ b/v2/content/rules-srd-5.2.1/pack.json
@@ -2,10 +2,11 @@
   "schema_version": 1,
   "id": "cosyworld.rules-srd-5.2.1",
   "name": "CosyWorld Rules: SRD 5.2.1",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "kind": "rules",
   "description": "An attributed, non-authoritative SRD 5.2.1 adapter pack for CosyWorld conversion seeds.",
   "license": "CC-BY-4.0",
+  "license_url": "https://creativecommons.org/licenses/by/4.0/",
   "engine": ">=0.0.20 <0.1.0",
   "capabilities": [
     {
@@ -27,9 +28,10 @@
     }
   ],
   "provenance": {
+    "author": "Wizards of the Coast LLC",
     "source_name": "System Reference Document 5.2.1",
     "source_url": "https://www.dndbeyond.com/srd",
-    "license_notice": "CC-BY-4.0 attribution is carried in ATTRIBUTION.md."
+    "modification_notice": "Selected rules references are adapted into CosyWorld's non-authoritative conversion schema."
   },
   "rules_adapter": "cosyworld.rules/1",
   "rules_namespace": "srd5.2.1",

--- a/v2/content/services-fixture/pack.json
+++ b/v2/content/services-fixture/pack.json
@@ -2,10 +2,11 @@
   "schema_version": 1,
   "id": "cosyworld.services-fixture",
   "name": "CosyWorld Services Fixture",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "kind": "catalog",
   "description": "A content-free fixture proving engine services do not require a world pack.",
   "license": "MIT",
+  "license_url": "https://opensource.org/license/mit",
   "engine": ">=0.0.20 <0.1.0",
   "capabilities": [
     {
@@ -18,6 +19,7 @@
   "default_ruleset": null,
   "entry_points": [],
   "provenance": {
+    "author": "Cenetex",
     "source_name": "CosyWorld test fixtures",
     "source_url": "https://github.com/cenetex/cosyworld"
   },

--- a/v2/content/services-only/licenses.json
+++ b/v2/content/services-only/licenses.json
@@ -1,0 +1,15 @@
+[
+  {
+    "pack_id": "cosyworld.services-fixture",
+    "name": "CosyWorld Services Fixture",
+    "version": "1.0.1",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld test fixtures",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
+  }
+]

--- a/v2/content/services-only/registry.json
+++ b/v2/content/services-only/registry.json
@@ -8,15 +8,16 @@
     "name": "CosyWorld Services Only",
     "version": 1,
     "description": "A non-world composition for health, metadata, identity, and moderation services.",
-    "bundle_hash": "sha256:897cae42c89bb31ba177649077f4c0273110c9b2b9bc4a587a92ba31aeb85281",
+    "bundle_hash": "sha256:cc112c288ecb34aa44ada803a167d2194857f52de3d257044a63f533e651fc75",
     "packs": [
       {
         "id": "cosyworld.services-fixture",
         "name": "CosyWorld Services Fixture",
         "description": "A content-free fixture proving engine services do not require a world pack.",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "kind": "catalog",
         "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
         "engine": ">=0.0.20 <0.1.0",
         "capabilities": [
           {
@@ -31,6 +32,7 @@
         "default_ruleset": null,
         "entry_points": [],
         "provenance": {
+          "author": "Cenetex",
           "source_name": "CosyWorld test fixtures",
           "source_url": "https://github.com/cenetex/cosyworld"
         },
@@ -63,7 +65,7 @@
           "type": "workspace",
           "path": "../../content/services-fixture"
         },
-        "integrity": "sha256:c3aecc47979c68ba0b77a407d83d9eb043c5b676d92dacf3148d5a4df052a9e2"
+        "integrity": "sha256:cf8cbdacd4ecaccf03a5245c4e6edf71e52cbfbb7469c1366c2740378100be39"
       }
     ],
     "files": {
@@ -91,6 +93,7 @@
     "assets": "assets.json",
     "rules": "rules.json",
     "attributions": "attributions.json",
+    "licenses": "licenses.json",
     "character_creation": "character_creation.json",
     "content_references": "content_refs.json",
     "registry": "registry.json"
@@ -120,6 +123,21 @@
   "assets": [],
   "rules": [],
   "attributions": [],
+  "licenses": [
+    {
+      "pack_id": "cosyworld.services-fixture",
+      "name": "CosyWorld Services Fixture",
+      "version": "1.0.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld test fixtures",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    }
+  ],
   "character_creation": [],
   "content_references": {
     "schema_version": 1,

--- a/v2/content/services-only/worldpack.json
+++ b/v2/content/services-only/worldpack.json
@@ -6,15 +6,16 @@
   "name": "CosyWorld Services Only",
   "version": 1,
   "description": "A non-world composition for health, metadata, identity, and moderation services.",
-  "bundle_hash": "sha256:897cae42c89bb31ba177649077f4c0273110c9b2b9bc4a587a92ba31aeb85281",
+  "bundle_hash": "sha256:cc112c288ecb34aa44ada803a167d2194857f52de3d257044a63f533e651fc75",
   "packs": [
     {
       "id": "cosyworld.services-fixture",
       "name": "CosyWorld Services Fixture",
       "description": "A content-free fixture proving engine services do not require a world pack.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "kind": "catalog",
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "engine": ">=0.0.20 <0.1.0",
       "capabilities": [
         {
@@ -29,6 +30,7 @@
       "default_ruleset": null,
       "entry_points": [],
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld test fixtures",
         "source_url": "https://github.com/cenetex/cosyworld"
       },
@@ -61,7 +63,7 @@
         "type": "workspace",
         "path": "../../content/services-fixture"
       },
-      "integrity": "sha256:c3aecc47979c68ba0b77a407d83d9eb043c5b676d92dacf3148d5a4df052a9e2"
+      "integrity": "sha256:cf8cbdacd4ecaccf03a5245c4e6edf71e52cbfbb7469c1366c2740378100be39"
     }
   ],
   "files": {
@@ -89,6 +91,7 @@
   "assets": "assets.json",
   "rules": "rules.json",
   "attributions": "attributions.json",
+  "licenses": "licenses.json",
   "character_creation": "character_creation.json",
   "content_references": "content_refs.json",
   "registry": "registry.json"

--- a/v2/content/the-holy-land/pack.json
+++ b/v2/content/the-holy-land/pack.json
@@ -2,10 +2,11 @@
   "schema_version": 1,
   "id": "cosyworld.the-holy-land",
   "name": "The Holy Land",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "kind": "world",
   "description": "A watercolor pilgrimage through Gospel-associated places with the Twelve and generative wayside supplicants; Jesus is not depicted as an actor or collectible card.",
   "license": "MIT",
+  "license_url": "https://opensource.org/license/mit",
   "engine": ">=0.0.20 <0.1.0",
   "capabilities": [
     {
@@ -40,6 +41,7 @@
     }
   ],
   "provenance": {
+    "author": "Cenetex",
     "source_name": "CosyWorld: The Holy Land",
     "source_url": "https://github.com/cenetex/cosyworld"
   },

--- a/v2/content/the-lantern-keeper/pack.json
+++ b/v2/content/the-lantern-keeper/pack.json
@@ -2,10 +2,11 @@
   "schema_version": 1,
   "id": "cosyworld.campaign.the-lantern-keeper",
   "name": "The Lantern Keeper",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "kind": "campaign",
   "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
   "license": "CC-BY-4.0",
+  "license_url": "https://creativecommons.org/licenses/by/4.0/",
   "engine": ">=0.0.20 <0.1.0",
   "capabilities": [
     {
@@ -35,9 +36,10 @@
     }
   ],
   "provenance": {
+    "author": "Cenetex",
     "source_name": "CosyWorld and System Reference Document 5.1",
     "source_url": "https://github.com/cenetex/cosyworld",
-    "license_notice": "SRD-derived references are attributed in ATTRIBUTION.md."
+    "modification_notice": "Original CosyWorld campaign material adapts selected SRD 5.1 rules references."
   },
   "character_creation": "character_creation.json",
   "attribution": {

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -78,7 +78,10 @@ Each manifest declares:
 - dependencies with a pack version range and the exact capabilities required
   from that pack;
 - optional default-ruleset and typed entry-point references;
-- license and provenance metadata; and
+- a license identifier and canonical license URL;
+- provenance with author, source name, source URL, and a modification notice
+  whenever source material was adapted;
+- an attribution file plus any additional bundled license/notice files; and
 - resources, assets, entitlement providers, and attribution where applicable.
 
 The compiler accepts selected packs in any order and emits one deterministic
@@ -120,7 +123,8 @@ closed engine contract; it is not a plugin entry point.
 `pack.lock.json` is the reproducibility record used alongside saved-world bundle
 identity. For each pack it records the exact semantic version, complete content
 hash, materialized source, declared capabilities, direct requirements,
-transitive dependency closure, license, and provenance. The lock also records
+transitive dependency closure, license identifier/URL, provenance, and the exact
+text of every bundled notice. The lock also records
 the canonical-ID mapping version and deterministic dependency order. Given the
 locked sources, the compiler emits byte-identical files and bundle identity for
 identical inputs.
@@ -255,6 +259,13 @@ composition. The endpoint does not dynamically install packs or interpret a
 payment rail. Packs declare content and access surfaces; verified claims
 determine the current player's entitlement projection.
 
+`GET /licenses` is the unauthenticated attribution surface. It returns one
+record for every mounted pack with its pinned version, license identifier and
+URL, author/source/modification provenance, and the exact text of each bundled
+notice. `/meta.worldpack.licenses` carries the same records for administrative
+diagnostics. Both surfaces are compiled from the lock inputs; they never read a
+mutable source checkout at request time.
+
 ### Asset providers
 
 Every authored asset mount names an `assets` capability declared by the same
@@ -367,6 +378,13 @@ carried into `attributions.json`.
 The official world includes both packs as reference data. Neither pack adds
 world entities, gains authority over monster behavior, or overlays the other
 pack's namespace. See `docs/rules-adapter.md` for the mapping boundary.
+
+SRD-derived product copy may say **“5E compatible.”** It must not describe the
+product as official, affiliated with, sponsored by, or endorsed by Wizards of
+the Coast. Every SRD-derived manifest must use `CC-BY-4.0`, link the canonical
+license URL, name Wizards of the Coast LLC as the source author, describe its
+modifications, and bundle the version-appropriate attribution statement. The
+compiler and runtime registry reject an incomplete record.
 
 ## Campaign packs
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.55"
+version = "0.0.56"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_packs.rs
+++ b/v2/orchestrator-rust/src/content_packs.rs
@@ -7,6 +7,28 @@ pub(super) struct ContentPacksResponse {
     packs: Vec<ContentPackView>,
 }
 
+#[derive(Debug, Serialize)]
+pub(super) struct LicensesResponse {
+    worldpack_id: String,
+    bundle_hash: String,
+    compatibility_notice: &'static str,
+    packs: Vec<SeedLicenseRecord>,
+}
+
+pub(super) fn licenses_response() -> LicensesResponse {
+    LicensesResponse {
+        worldpack_id: active_content().manifest.id.clone(),
+        bundle_hash: active_content().manifest.bundle_hash.clone(),
+        compatibility_notice:
+            "5E compatible. Not affiliated with or endorsed by Wizards of the Coast.",
+        packs: active_content().licenses.clone(),
+    }
+}
+
+pub(super) async fn licenses_view() -> Json<LicensesResponse> {
+    Json(licenses_response())
+}
+
 #[derive(Clone, Debug, Serialize)]
 struct ContentPackView {
     id: String,
@@ -291,6 +313,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn public_licenses_include_every_mounted_pack_and_exact_srd_notice() {
+        let response = licenses_response();
+        assert_eq!(response.packs.len(), active_content().manifest.packs.len());
+        let lantern = response
+            .packs
+            .iter()
+            .find(|pack| pack.pack_id == "cosyworld.campaign.the-lantern-keeper")
+            .expect("Lantern Keeper license record");
+        assert_eq!(lantern.license_identifier, "CC-BY-4.0");
+        assert_eq!(
+            lantern.license_url,
+            "https://creativecommons.org/licenses/by/4.0/"
+        );
+        assert!(lantern.notices.iter().any(|notice| {
+            notice.kind == "attribution"
+                && notice.text.contains("System Reference Document 5.1")
+                && notice
+                    .text
+                    .contains("creativecommons.org/licenses/by/4.0/legalcode")
+        }));
+    }
+
+    #[test]
     fn catalog_projects_public_locked_partial_and_entitled_access() {
         let public = content_packs_response(&AccessContext::default());
         assert_eq!(public.packs.len(), 4);
@@ -305,7 +350,7 @@ mod tests {
         assert_eq!(core.asset_providers.len(), 2);
         assert!(core.asset_providers.iter().all(|provider| {
             provider.provider == "cosyworld.core/assets"
-                && provider.cache_namespace.contains("cosyworld.core@1.3.0")
+                && provider.cache_namespace.contains("cosyworld.core@1.3.1")
                 && provider.content_hash.starts_with("sha256:")
         }));
 

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -67,6 +67,8 @@ struct CompiledContentRegistry {
     #[serde(default)]
     attributions: Vec<SeedAttribution>,
     #[serde(default)]
+    licenses: Vec<SeedLicenseRecord>,
+    #[serde(default)]
     character_creation: Vec<SeedCharacterCreationBundle>,
     content_references: ContentReferenceDocument,
 }
@@ -137,6 +139,7 @@ impl ContentRegistry {
             recipes: take_resource(&mut resources, "recipes")?,
             rules: document.rules,
             attributions: document.attributions,
+            licenses: document.licenses,
             character_creation: document.character_creation,
             external_cards: document.external_cards,
             asset_mounts: document.assets,
@@ -693,7 +696,11 @@ fn resolve_pack_graph(
                 pack.id, pack.version, pack.engine, engine_version
             ));
         }
-        if pack.capabilities.is_empty() || !pack.provenance.is_object() {
+        if pack.capabilities.is_empty()
+            || pack.provenance.author.trim().is_empty()
+            || pack.provenance.source_name.trim().is_empty()
+            || pack.provenance.source_url.trim().is_empty()
+        {
             return Err(format!(
                 "pack {}@{} is missing capabilities or provenance",
                 pack.id, pack.version
@@ -879,6 +886,7 @@ mod tests {
             version: "1.0.0".to_string(),
             kind: "world".to_string(),
             license: "MIT".to_string(),
+            license_url: "https://opensource.org/license/mit".to_string(),
             integrity: format!("sha256:{}", "0".repeat(64)),
             engine: ">=0.1.0 <1.0.0".to_string(),
             capabilities: vec![capability(&format!("{id}.world"))],
@@ -890,7 +898,12 @@ mod tests {
             dependency_closure: Vec::new(),
             default_ruleset: None,
             entry_points: Vec::new(),
-            provenance: serde_json::json!({"source":"test"}),
+            provenance: SeedPackProvenance {
+                author: "Fixture Author".to_string(),
+                source_name: "Fixture Source".to_string(),
+                source_url: "https://example.com/fixture".to_string(),
+                modification_notice: None,
+            },
             resource_counts: BTreeMap::new(),
             distribution: None,
             entitlements: None,
@@ -904,6 +917,18 @@ mod tests {
         let has_world_pack = packs
             .iter()
             .any(|pack| matches!(pack.kind.as_str(), "world" | "campaign"));
+        let licenses = packs
+            .iter()
+            .map(|pack| SeedLicenseRecord {
+                pack_id: pack.id.clone(),
+                name: pack.name.clone(),
+                version: pack.version.clone(),
+                license_identifier: pack.license.clone(),
+                license_url: pack.license_url.clone(),
+                provenance: pack.provenance.clone(),
+                notices: Vec::new(),
+            })
+            .collect::<Vec<_>>();
         let mut value = serde_json::json!({
             "schema_version": 1,
             "manifest": {
@@ -917,13 +942,15 @@ mod tests {
                 "bundle_hash": format!("sha256:{}", "0".repeat(64)),
                 "packs": packs,
                 "registry": "registry.json",
-                "content_references": "content_refs.json"
+                "content_references": "content_refs.json",
+                "licenses": "licenses.json"
             },
             "resources": {},
             "external_cards": [],
             "assets": [],
             "rules": [],
             "attributions": [],
+            "licenses": licenses,
             "character_creation": [],
             "content_references": {
                 "schema_version": 1,
@@ -1052,7 +1079,7 @@ mod tests {
         )
         .expect("official registry loads");
         assert_eq!(registry.content().locations.len(), 33);
-        assert_eq!(registry.pack("cosyworld.core").unwrap().version, "1.3.0");
+        assert_eq!(registry.pack("cosyworld.core").unwrap().version, "1.3.1");
         assert_eq!(
             registry.capability_provider("cosyworld.core/world"),
             Some("cosyworld.core")

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1042,6 +1042,7 @@ struct SeedContent {
     recipes: Vec<SeedRecipeContent>,
     rules: Vec<SeedRuleBundle>,
     attributions: Vec<SeedAttribution>,
+    licenses: Vec<SeedLicenseRecord>,
     character_creation: Vec<SeedCharacterCreationBundle>,
     external_cards: Vec<ExternalCardSpec>,
     asset_mounts: Vec<SeedAssetMount>,
@@ -1073,6 +1074,8 @@ struct SeedWorldpackManifest {
     registry: String,
     #[serde(default)]
     content_references: String,
+    #[serde(default)]
+    licenses: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1084,6 +1087,7 @@ struct SeedWorldpackPack {
     version: String,
     kind: String,
     license: String,
+    license_url: String,
     integrity: String,
     #[serde(default)]
     engine: String,
@@ -1099,8 +1103,7 @@ struct SeedWorldpackPack {
     default_ruleset: Option<String>,
     #[serde(default)]
     entry_points: Vec<serde_json::Value>,
-    #[serde(default)]
-    provenance: serde_json::Value,
+    provenance: SeedPackProvenance,
     #[serde(default)]
     resource_counts: BTreeMap<String, usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1258,6 +1261,38 @@ struct SeedAttribution {
     source_name: String,
     source_url: String,
     text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SeedPackProvenance {
+    author: String,
+    source_name: String,
+    source_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    modification_notice: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SeedLicenseNotice {
+    kind: String,
+    title: String,
+    file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_url: Option<String>,
+    text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SeedLicenseRecord {
+    pack_id: String,
+    name: String,
+    version: String,
+    license_identifier: String,
+    license_url: String,
+    provenance: SeedPackProvenance,
+    notices: Vec<SeedLicenseNotice>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -2154,6 +2189,7 @@ struct MetaWorldpack {
     packs: Vec<SeedWorldpackPack>,
     rules: Vec<MetaRulesBundle>,
     attributions: Vec<SeedAttribution>,
+    licenses: Vec<SeedLicenseRecord>,
 }
 
 #[derive(Debug, Serialize)]
@@ -4231,6 +4267,10 @@ fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> Result<(), S
                 "world" | "campaign" | "catalog" | "assets" | "rules"
             )
             || pack.license.trim().is_empty()
+            || !pack.license_url.starts_with("https://")
+            || pack.provenance.author.trim().is_empty()
+            || pack.provenance.source_name.trim().is_empty()
+            || !pack.provenance.source_url.starts_with("https://")
             || !valid_sha256_digest(&pack.integrity)
             || !pack_ids.insert(pack.id.as_str())
         {
@@ -4246,7 +4286,10 @@ fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> Result<(), S
             return Err(format!("invalid rules pack metadata for {}", pack.id));
         }
     }
-    if manifest.registry != "registry.json" || manifest.content_references != "content_refs.json" {
+    if manifest.registry != "registry.json"
+        || manifest.content_references != "content_refs.json"
+        || manifest.licenses != "licenses.json"
+    {
         return Err(
             "worldpack manifest does not identify its compiled registry and content references"
                 .to_string(),
@@ -4271,6 +4314,70 @@ fn validate_seed_content(content: &SeedContent) -> Result<(), String> {
         .iter()
         .map(|pack| (pack.id.as_str(), pack))
         .collect::<BTreeMap<_, _>>();
+    let mut licensed_pack_ids = BTreeSet::new();
+    for record in &content.licenses {
+        let Some(pack) = packs_by_id.get(record.pack_id.as_str()) else {
+            return Err(format!(
+                "license record {} references an unknown pack",
+                record.pack_id
+            ));
+        };
+        if record.name != pack.name
+            || record.version != pack.version
+            || record.license_identifier != pack.license
+            || record.license_url != pack.license_url
+            || record.provenance.author != pack.provenance.author
+            || record.provenance.source_name != pack.provenance.source_name
+            || record.provenance.source_url != pack.provenance.source_url
+            || record.provenance.modification_notice != pack.provenance.modification_notice
+            || !licensed_pack_ids.insert(record.pack_id.as_str())
+        {
+            return Err(format!("invalid license record for {}", record.pack_id));
+        }
+        for notice in &record.notices {
+            if !matches!(notice.kind.as_str(), "attribution" | "license" | "notice")
+                || notice.title.trim().is_empty()
+                || notice.file.trim().is_empty()
+                || notice.text.trim().is_empty()
+                || notice
+                    .source_url
+                    .as_deref()
+                    .is_some_and(|url| !url.starts_with("https://"))
+            {
+                return Err(format!("invalid bundled notice for {}", record.pack_id));
+            }
+        }
+        let source = format!(
+            "{} {}",
+            record.provenance.source_name,
+            record
+                .notices
+                .iter()
+                .filter_map(|notice| notice.source_name.as_deref())
+                .collect::<Vec<_>>()
+                .join(" ")
+        )
+        .to_ascii_lowercase();
+        if (source.contains("system reference document") || source.contains("srd"))
+            && (record.license_identifier != "CC-BY-4.0"
+                || record.provenance.modification_notice.is_none()
+                || !record.notices.iter().any(|notice| {
+                    notice.kind == "attribution"
+                        && notice.text.contains("Wizards of the Coast LLC")
+                        && notice
+                            .text
+                            .contains("creativecommons.org/licenses/by/4.0/legalcode")
+                }))
+        {
+            return Err(format!(
+                "SRD-derived pack {} has incomplete attribution",
+                record.pack_id
+            ));
+        }
+    }
+    if licensed_pack_ids.len() != content.manifest.packs.len() {
+        return Err("not every mounted pack has a license record".to_string());
+    }
     let mut entitlement_grant_ids = BTreeSet::new();
     for pack in &content.manifest.packs {
         if let Some(distribution) = pack.distribution.as_ref() {
@@ -24148,6 +24255,7 @@ async fn meta(State(state): State<AppState>) -> Json<MetaResponse> {
                 })
                 .collect(),
             attributions: active_content().attributions.clone(),
+            licenses: active_content().licenses.clone(),
         },
         world: MetaWorldCounters {
             tick,
@@ -40643,7 +40751,7 @@ mod tests {
             .iter()
             .find(|reference| reference.canonical_ref == "pack://cosyworld.core/location/1")
             .expect("journal persists its canonical location reference");
-        assert_eq!(location_reference.pack_version, "1.3.0");
+        assert_eq!(location_reference.pack_version, "1.3.1");
         assert_eq!(location_reference.legacy_runtime_id, Some(1));
 
         let replayed = RuntimeWorld::from_action_journal(&path).expect("replay runtime");

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -35,6 +35,7 @@ pub(super) fn app_router(state: AppState) -> Router {
         .route("/assets/{*asset_path}", get(public_pack_asset))
         .route("/health", get(health))
         .route("/meta", get(meta))
+        .route("/licenses", get(licenses_view))
         .route("/content-packs", get(content_packs_view))
         .route("/auth/account", get(account_identity))
         .route("/auth/logout", post(account_logout))

--- a/v2/schemas/content-pack-manifest-v1.schema.json
+++ b/v2/schemas/content-pack-manifest-v1.schema.json
@@ -13,6 +13,7 @@
     "kind",
     "description",
     "license",
+    "license_url",
     "engine",
     "capabilities",
     "dependencies",
@@ -28,6 +29,7 @@
     },
     "description": { "$ref": "#/definitions/nonEmptyString" },
     "license": { "$ref": "#/definitions/nonEmptyString" },
+    "license_url": { "type": "string", "format": "uri" },
     "engine": { "$ref": "#/definitions/versionRange" },
     "capabilities": {
       "type": "array",
@@ -67,6 +69,10 @@
       "additionalProperties": { "$ref": "#/definitions/relativePath" }
     },
     "attribution": { "$ref": "#/definitions/attribution" },
+    "notices": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/bundledNotice" }
+    },
     "character_creation": { "$ref": "#/definitions/relativePath" },
     "extensions": {
       "description": "Namespaced forward-compatible metadata ignored by Manifest v1 runtimes.",
@@ -144,11 +150,12 @@
     "provenance": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["source_name"],
+      "required": ["author", "source_name", "source_url"],
       "properties": {
+        "author": { "$ref": "#/definitions/nonEmptyString" },
         "source_name": { "$ref": "#/definitions/nonEmptyString" },
         "source_url": { "type": "string", "format": "uri" },
-        "license_notice": { "$ref": "#/definitions/nonEmptyString" }
+        "modification_notice": { "$ref": "#/definitions/nonEmptyString" }
       }
     },
     "assetMount": {
@@ -235,6 +242,16 @@
         "file": { "$ref": "#/definitions/relativePath" },
         "source_name": { "$ref": "#/definitions/nonEmptyString" },
         "source_url": { "type": "string", "format": "uri" }
+      }
+    },
+    "bundledNotice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "title", "file"],
+      "properties": {
+        "kind": { "enum": ["attribution", "license", "notice"] },
+        "title": { "$ref": "#/definitions/nonEmptyString" },
+        "file": { "$ref": "#/definitions/relativePath" }
       }
     }
   }

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -393,6 +393,10 @@ for (const pack of packs) {
     || !Array.isArray(pack.dependency_closure)
     || !Array.isArray(pack.entry_points)
     || !isObject(pack.provenance)
+    || !isNonEmptyString(pack.license_url)
+    || !isNonEmptyString(pack.provenance.author)
+    || !isNonEmptyString(pack.provenance.source_name)
+    || !isNonEmptyString(pack.provenance.source_url)
   ) {
     fail(`worldpack pack ${pack.id} is missing Manifest v1 contract metadata`);
   }
@@ -446,6 +450,7 @@ try {
       kind: pack.kind,
       description: pack.description,
       license: pack.license,
+      license_url: pack.license_url,
       engine: pack.engine,
       capabilities: pack.capabilities,
       dependencies: pack.dependency_requirements,
@@ -478,6 +483,7 @@ if (
   || manifest.assets !== "assets.json"
   || manifest.rules !== "rules.json"
   || manifest.attributions !== "attributions.json"
+  || manifest.licenses !== "licenses.json"
   || manifest.character_creation !== "character_creation.json"
   || manifest.content_references !== "content_refs.json"
   || manifest.registry !== "registry.json"
@@ -702,6 +708,70 @@ for (const attribution of attributions) {
 }
 for (const pack of packs.filter((candidate) => candidate.kind === "rules")) {
   if (!has(attributedPackIds, pack.id)) fail(`rules pack ${pack.id} has no compiled attribution`);
+}
+
+const licenses = asArray("licenses.json", readJson("licenses.json"));
+if (JSON.stringify(registry?.licenses) !== JSON.stringify(licenses)) {
+  fail("registry.json licenses do not match licenses.json");
+}
+const licensedPackIds = idSet("license records", licenses, (record) => record.pack_id);
+for (const record of licenses) {
+  validateRequiredStrings("license record", record, [
+    "name",
+    "version",
+    "license_identifier",
+    "license_url",
+  ]);
+  const pack = packs.find((candidate) => candidate.id === record.pack_id);
+  if (!pack) {
+    fail(`license record references pack outside this bundle: ${record.pack_id}`);
+    continue;
+  }
+  if (
+    record.name !== pack.name
+    || record.version !== pack.version
+    || record.license_identifier !== pack.license
+    || record.license_url !== pack.license_url
+    || JSON.stringify(record.provenance) !== JSON.stringify(pack.provenance)
+  ) {
+    fail(`license record does not match mounted pack ${record.pack_id}`);
+  }
+  validateRequiredStrings(`license record ${record.pack_id} provenance`, record.provenance, [
+    "author",
+    "source_name",
+    "source_url",
+  ]);
+  const notices = asArray(`license record ${record.pack_id} notices`, record.notices);
+  for (const notice of notices) {
+    validateRequiredStrings(`license record ${record.pack_id} notice`, notice, [
+      "kind",
+      "title",
+      "file",
+      "text",
+    ]);
+    if (!["attribution", "license", "notice"].includes(notice.kind)) {
+      fail(`license record ${record.pack_id} has unsupported notice kind ${notice.kind}`);
+    }
+  }
+  const sourceNames = [
+    record.provenance?.source_name,
+    ...notices.map((notice) => notice.source_name),
+  ].filter(Boolean).join(" ");
+  if (/(?:system reference document|\bsrd\b)/i.test(sourceNames)) {
+    const requiredAttribution = notices.find((notice) => notice.kind === "attribution");
+    if (
+      record.license_identifier !== "CC-BY-4.0"
+      || record.license_url !== "https://creativecommons.org/licenses/by/4.0/"
+      || !isNonEmptyString(record.provenance?.modification_notice)
+      || !requiredAttribution?.text?.includes("Wizards of the Coast LLC")
+      || !requiredAttribution?.text?.includes("creativecommons.org/licenses/by/4.0/legalcode")
+    ) {
+      fail(`SRD-derived pack ${record.pack_id} has incomplete license or attribution metadata`);
+    }
+  }
+}
+for (const pack of packs) {
+  if (!has(licensedPackIds, pack.id)) fail(`pack ${pack.id} has no compiled license record`);
 }
 const srdPack = packs.find((pack) => pack.id === "cosyworld.rules-srd-5.1");
 if (srdPack) {

--- a/v2/scripts/compile-worldpack.mjs
+++ b/v2/scripts/compile-worldpack.mjs
@@ -103,12 +103,48 @@ function declaredPackFiles(packRoot, manifest) {
   }
   if (manifest.character_creation) files.push(path.join(packRoot, manifest.character_creation));
   if (manifest.attribution?.file) files.push(path.join(packRoot, manifest.attribution.file));
+  for (const notice of manifest.notices ?? []) files.push(path.join(packRoot, notice.file));
   if (manifest.external_cards) files.push(path.join(packRoot, manifest.external_cards));
   for (const mount of manifest.assets ?? []) {
     if (mount.manifest) files.push(path.join(packRoot, mount.manifest));
     files.push(...filesBelow(path.join(packRoot, mount.directory)));
   }
   return [...new Set(files)].sort();
+}
+
+function bundledNotices(packRoot, manifest) {
+  const notices = [];
+  if (manifest.attribution) {
+    notices.push({
+      kind: "attribution",
+      title: `${manifest.attribution.source_name} attribution`,
+      file: manifest.attribution.file,
+      source_name: manifest.attribution.source_name,
+      source_url: manifest.attribution.source_url,
+      text: fs.readFileSync(path.join(packRoot, manifest.attribution.file), "utf8").trim(),
+    });
+  }
+  for (const notice of manifest.notices ?? []) {
+    notices.push({
+      kind: notice.kind,
+      title: notice.title,
+      file: notice.file,
+      text: fs.readFileSync(path.join(packRoot, notice.file), "utf8").trim(),
+    });
+  }
+  return notices;
+}
+
+function licenseRecord(packRoot, manifest) {
+  return {
+    pack_id: manifest.id,
+    name: manifest.name,
+    version: manifest.version,
+    license_identifier: manifest.license,
+    license_url: manifest.license_url,
+    provenance: manifest.provenance,
+    notices: bundledNotices(packRoot, manifest),
+  };
 }
 
 function packIntegrity(packRoot, manifest) {
@@ -236,6 +272,18 @@ for (const packId of world.packs) {
   } else {
     assert(!manifest.rules, `only rules packs may declare rules resources (${packId})`);
   }
+  const srdDerived = /(?:system reference document|\bsrd\b)/i.test(
+    `${manifest.provenance.source_name} ${manifest.attribution?.source_name ?? ""}`,
+  );
+  if (srdDerived) {
+    assert(manifest.license === "CC-BY-4.0", `SRD-derived pack ${packId} must use CC-BY-4.0`);
+    assert(manifest.license_url === "https://creativecommons.org/licenses/by/4.0/", `SRD-derived pack ${packId} has the wrong license URL`);
+    assert(manifest.attribution?.file, `SRD-derived pack ${packId} must bundle its required attribution`);
+    assert(manifest.provenance.modification_notice, `SRD-derived pack ${packId} must identify its modifications`);
+    const attributionText = fs.readFileSync(path.join(packRoot, manifest.attribution.file), "utf8");
+    assert(attributionText.includes("Wizards of the Coast LLC"), `SRD-derived pack ${packId} attribution is missing the source author`);
+    assert(attributionText.includes("creativecommons.org/licenses/by/4.0/legalcode"), `SRD-derived pack ${packId} attribution is missing the CC-BY-4.0 legal-code URL`);
+  }
   if (manifest.kind === "campaign") {
     assert(manifest.character_creation, `campaign pack ${packId} must declare character_creation`);
   }
@@ -277,14 +325,10 @@ const nextLock = {
     dependency_closure: resolved.dependencyClosure.get(manifest.id),
     capabilities: manifest.capabilities,
     license: manifest.license,
+    license_url: manifest.license_url,
     provenance: manifest.provenance,
   })),
-  license_records: packs.map(({ manifest }) => ({
-    pack_id: manifest.id,
-    version: manifest.version,
-    license: manifest.license,
-    provenance: manifest.provenance,
-  })),
+  license_records: packs.map(({ manifest, packRoot }) => licenseRecord(packRoot, manifest)),
 };
 
 if (writeLock) {
@@ -301,6 +345,7 @@ const externalCards = [];
 const assets = [];
 const ruleBundles = [];
 const attributions = [];
+const licenseRecords = [];
 const characterCreationBundles = [];
 const resourceCountsByPack = new Map();
 const selectedPackIds = new Set(packs.map((pack) => pack.manifest.id));
@@ -311,6 +356,7 @@ for (const pack of packs) {
   resourceCounts.rules = 0;
   resourceCounts.character_creation = 0;
   resourceCountsByPack.set(pack.manifest.id, resourceCounts);
+  licenseRecords.push(licenseRecord(pack.packRoot, pack.manifest));
   for (const [resource, relativePath] of Object.entries(pack.manifest.resources ?? {})) {
     assert(resource in resources, `pack ${pack.manifest.id} declares unknown resource ${resource}`);
     const rows = readJson(path.join(pack.packRoot, relativePath));
@@ -408,6 +454,7 @@ const packSummary = packs.map(({ locked, manifest, integrity }) => ({
   version: manifest.version,
   kind: manifest.kind,
   license: manifest.license,
+  license_url: manifest.license_url,
   engine: manifest.engine,
   capabilities: manifest.capabilities,
   dependencies: manifest.dependencies.map((dependency) => dependency.id),
@@ -443,6 +490,7 @@ const bundleHash = sha256([
   json(assets),
   json(ruleBundles),
   json(attributions),
+  json(licenseRecords),
   json(characterCreationBundles),
   json(contentReferences),
 ]);
@@ -463,6 +511,7 @@ const manifest = {
   assets: "assets.json",
   rules: "rules.json",
   attributions: "attributions.json",
+  licenses: "licenses.json",
   character_creation: "character_creation.json",
   content_references: "content_refs.json",
   registry: "registry.json",
@@ -476,6 +525,7 @@ const registry = {
   assets,
   rules: ruleBundles,
   attributions,
+  licenses: licenseRecords,
   character_creation: characterCreationBundles,
   content_references: contentReferences,
 };
@@ -487,6 +537,7 @@ const outputs = new Map([
   ["assets.json", json(assets)],
   ["rules.json", json(ruleBundles)],
   ["attributions.json", json(attributions)],
+  ["licenses.json", json(licenseRecords)],
   ["character_creation.json", json(characterCreationBundles)],
   ["content_refs.json", json(contentReferences)],
   ...Object.entries(resourceFiles).map(([resource, fileName]) => [fileName, json(resources[resource])]),

--- a/v2/scripts/import-srd-5.2.1.mjs
+++ b/v2/scripts/import-srd-5.2.1.mjs
@@ -53,6 +53,8 @@ function writeOrCheck(fileName, value) {
 }
 
 const source = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+const packManifest = JSON.parse(fs.readFileSync(path.join(packRoot, "pack.json"), "utf8"));
+const packAttribution = fs.readFileSync(path.join(packRoot, "ATTRIBUTION.md"), "utf8");
 if (
   source.document !== "System Reference Document 5.2.1"
   || source.source_url !== "https://www.dndbeyond.com/srd"
@@ -60,6 +62,18 @@ if (
   || !source.attribution?.includes("creativecommons.org/licenses/by/4.0/legalcode")
 ) {
   throw new Error("SRD 5.2.1 selected source metadata is invalid");
+}
+if (
+  packManifest.license !== "CC-BY-4.0"
+  || packManifest.license_url !== "https://creativecommons.org/licenses/by/4.0/"
+  || packManifest.provenance?.author !== "Wizards of the Coast LLC"
+  || !packManifest.provenance?.modification_notice
+  || packManifest.attribution?.file !== "ATTRIBUTION.md"
+  || !packAttribution.includes("System Reference Document 5.2.1")
+  || !packAttribution.includes("Wizards of the Coast LLC")
+  || !packAttribution.includes("creativecommons.org/licenses/by/4.0/legalcode")
+) {
+  throw new Error("SRD 5.2.1 pack is missing its required CC-BY-4.0 attribution record");
 }
 
 const conditions = conditionNames.map((name) => {

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -166,6 +166,7 @@ async function assertSignedWalletAvatarRecovery(signedWallet) {
 async function assertRuntimeMeta() {
   const baseUrl = new URL(targetUrl).origin;
   const meta = await fetch(`${baseUrl}/meta`).then((response) => response.json());
+  const licenses = await fetch(`${baseUrl}/licenses`).then((response) => response.json());
   assert(meta.ok === true, `runtime meta should be ok: ${JSON.stringify(meta)}`);
   assert(meta.service === "cosyworld-orchestrator", `runtime meta should name the service: ${JSON.stringify(meta)}`);
   assert(typeof meta.version === "string" && meta.version.length > 0, `runtime meta should expose package version: ${JSON.stringify(meta)}`);
@@ -185,6 +186,24 @@ async function assertRuntimeMeta() {
   assert(typeof meta.ownership_feed?.wallet_count === "number", `runtime meta should expose ownership wallet count: ${JSON.stringify(meta.ownership_feed)}`);
   assert((meta.world?.actor_count || 0) >= 4, `runtime meta should expose seeded world counters: ${JSON.stringify(meta.world)}`);
   assert((meta.world?.location_count || 0) >= 3, `runtime meta should expose location counters: ${JSON.stringify(meta.world)}`);
+  assert(
+    licenses.worldpack_id === meta.worldpack?.id
+      && licenses.bundle_hash === meta.worldpack?.bundle_hash
+      && licenses.packs?.length === meta.worldpack?.packs?.length,
+    `public licenses should cover every mounted pack: ${JSON.stringify(licenses)}`,
+  );
+  assert(
+    JSON.stringify(licenses.packs) === JSON.stringify(meta.worldpack?.licenses),
+    "public licenses and administrative diagnostics should expose the same pinned records",
+  );
+  assert(
+    licenses.packs.every((pack) => (
+      pack.license_identifier
+        && pack.license_url?.startsWith("https://")
+        && pack.provenance?.author
+    )),
+    `public licenses should expose complete coordinates: ${JSON.stringify(licenses.packs)}`,
+  );
   return meta;
 }
 

--- a/v2/worlds/core-only/pack.lock.json
+++ b/v2/worlds/core-only/pack.lock.json
@@ -9,12 +9,12 @@
   "packs": [
     {
       "id": "cosyworld.core",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "source": {
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+      "integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
       "dependencies": [],
       "dependency_closure": [],
       "capabilities": [
@@ -35,7 +35,9 @@
         }
       ],
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld",
         "source_url": "https://github.com/cenetex/cosyworld"
       }
@@ -44,12 +46,16 @@
   "license_records": [
     {
       "pack_id": "cosyworld.core",
-      "version": "1.3.0",
-      "license": "MIT",
+      "name": "CosyWorld Core",
+      "version": "1.3.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld",
         "source_url": "https://github.com/cenetex/cosyworld"
-      }
+      },
+      "notices": []
     }
   ]
 }

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -12,12 +12,12 @@
   "packs": [
     {
       "id": "cosyworld.core",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "source": {
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:e4c109b6397a158c0fc8d18a617228affe01952ecdde1633d0e4cecbb5027f68",
+      "integrity": "sha256:4378427a9546711626a295637ce843759f15da47eda028104f55b7b5e02477f4",
       "dependencies": [],
       "dependency_closure": [],
       "capabilities": [
@@ -38,19 +38,21 @@
         }
       ],
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld",
         "source_url": "https://github.com/cenetex/cosyworld"
       }
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "source": {
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:91198689bfa981b3faac2ad1bb5a5806b68a0fcc52a688ea37cc3e0eb5f8576e",
+      "integrity": "sha256:8dc3f02c0c407cf828b1acee48eab50a4e0c17d5fe3e41bf9ed9dfd7f88c3f48",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -71,20 +73,22 @@
         }
       ],
       "license": "CC-BY-4.0",
+      "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld and System Reference Document 5.1",
         "source_url": "https://github.com/cenetex/cosyworld",
-        "license_notice": "SRD-derived references are attributed in ATTRIBUTION.md."
+        "modification_notice": "Original CosyWorld campaign material adapts selected SRD 5.1 rules references."
       }
     },
     {
       "id": "cosyworld.lonely-forest.characters",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "source": {
         "type": "workspace",
         "path": "../../content/lonely-forest"
       },
-      "integrity": "sha256:a5d1a25b1070d070411bdd7cf7a8eeab5a4be8f9a4943ba0c84ae55fdf0ba4e6",
+      "integrity": "sha256:b3ff30dbc1809a84d150ffc12a9cf00ed1d8a57e518584de0ce8a91c7e4f4132",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -105,19 +109,21 @@
         }
       ],
       "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "Cenetex Lonely Forest character art",
         "source_url": "https://github.com/cenetex/cosyworld"
       }
     },
     {
       "id": "ruby-high.first-bell",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "source": {
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216",
+      "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -159,7 +165,9 @@
         }
       ],
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
       }
@@ -168,40 +176,65 @@
   "license_records": [
     {
       "pack_id": "cosyworld.core",
-      "version": "1.3.0",
-      "license": "MIT",
+      "name": "CosyWorld Core",
+      "version": "1.3.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld",
         "source_url": "https://github.com/cenetex/cosyworld"
-      }
+      },
+      "notices": []
     },
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "version": "0.1.0",
-      "license": "CC-BY-4.0",
+      "name": "The Lantern Keeper",
+      "version": "0.1.1",
+      "license_identifier": "CC-BY-4.0",
+      "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld and System Reference Document 5.1",
         "source_url": "https://github.com/cenetex/cosyworld",
-        "license_notice": "SRD-derived references are attributed in ATTRIBUTION.md."
-      }
+        "modification_notice": "Original CosyWorld campaign material adapts selected SRD 5.1 rules references."
+      },
+      "notices": [
+        {
+          "kind": "attribution",
+          "title": "System Reference Document 5.1 attribution",
+          "file": "ATTRIBUTION.md",
+          "source_name": "System Reference Document 5.1",
+          "source_url": "https://www.dndbeyond.com/srd",
+          "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
+        }
+      ]
     },
     {
       "pack_id": "cosyworld.lonely-forest.characters",
-      "version": "1.1.0",
-      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "name": "Lonely Forest Character Art",
+      "version": "1.1.1",
+      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "Cenetex Lonely Forest character art",
         "source_url": "https://github.com/cenetex/cosyworld"
-      }
+      },
+      "notices": []
     },
     {
       "pack_id": "ruby-high.first-bell",
-      "version": "1.3.0",
-      "license": "MIT",
+      "name": "Ruby High: First Bell",
+      "version": "1.3.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
-      }
+      },
+      "notices": []
     }
   ]
 }

--- a/v2/worlds/ruby-high-only/pack.lock.json
+++ b/v2/worlds/ruby-high-only/pack.lock.json
@@ -9,12 +9,12 @@
   "packs": [
     {
       "id": "ruby-high.first-bell",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "source": {
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:e26e2923a1dbe049ed4d35a6ca8ca475e27d58dad8bc5882ff5b38103303a216",
+      "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -54,7 +54,9 @@
         }
       ],
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
       }
@@ -63,12 +65,16 @@
   "license_records": [
     {
       "pack_id": "ruby-high.first-bell",
-      "version": "1.3.0",
-      "license": "MIT",
+      "name": "Ruby High: First Bell",
+      "version": "1.3.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
-      }
+      },
+      "notices": []
     }
   ]
 }

--- a/v2/worlds/services-only/pack.lock.json
+++ b/v2/worlds/services-only/pack.lock.json
@@ -9,12 +9,12 @@
   "packs": [
     {
       "id": "cosyworld.services-fixture",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "source": {
         "type": "workspace",
         "path": "../../content/services-fixture"
       },
-      "integrity": "sha256:c3aecc47979c68ba0b77a407d83d9eb043c5b676d92dacf3148d5a4df052a9e2",
+      "integrity": "sha256:cf8cbdacd4ecaccf03a5245c4e6edf71e52cbfbb7469c1366c2740378100be39",
       "dependencies": [],
       "dependency_closure": [],
       "capabilities": [
@@ -25,7 +25,9 @@
         }
       ],
       "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld test fixtures",
         "source_url": "https://github.com/cenetex/cosyworld"
       }
@@ -34,12 +36,16 @@
   "license_records": [
     {
       "pack_id": "cosyworld.services-fixture",
-      "version": "1.0.0",
-      "license": "MIT",
+      "name": "CosyWorld Services Fixture",
+      "version": "1.0.1",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
       "provenance": {
+        "author": "Cenetex",
         "source_name": "CosyWorld test fixtures",
         "source_url": "https://github.com/cenetex/cosyworld"
-      }
+      },
+      "notices": []
     }
   ]
 }


### PR DESCRIPTION
## Summary
- require structured author, source, license URL, modification, and bundled-notice metadata for content packs
- pin exact notice text in pack locks and compiled `licenses.json` artifacts across every composition
- expose unauthenticated `GET /licenses` records and the same data in `/meta.worldpack.licenses`
- reject incomplete SRD-derived records and enforce the SRD 5.2.1 attribution/5E-compatible wording contract

Closes #29

## Validation
- `npm test` — 399 passed
- `npm run v2:worldpack` — official and all three standalone compositions passed
- `npm run v2:rust:test` — 328 passed
- `cargo test --manifest-path v2/orchestrator-rust/Cargo.toml public_licenses_include_every_mounted_pack_and_exact_srd_notice -- --nocapture` — passed
- `npm run check:version` — passed
- `git diff --check` — passed
- live unauthenticated `/licenses` and `/meta` comparison — 4/4 complete mounted-pack records and exact Lantern Keeper notice
- `npm run v2:check` — worldpack, kernel, AI-model, 328 Rust tests, build, and production-profile smoke passed; browser phase reached the AI-authored welcome assertion but the isolated worktree has no untracked AI configuration (`inference_unconfigured`), so no forbidden fallback line was emitted

## Compatibility and generated files
- bumps package/orchestrator to 0.0.56 and pack patch versions
- regenerates all four pack locks and compiled registries through `compile-worldpack.mjs --write-lock`
- bundle identities change with the newly pinned pack versions and exact license records
- stable HTTP endpoints and gameplay behavior are unchanged

## Review checklist
- [x] authored manifests, locks, compiled registries, runtime projection, tests, and docs agree
- [x] generated artifacts contain only expected version/license/context churn
- [x] no secrets or runtime files are included
