### PR TITLE
Define the card entitlement boundary

### DIFF
--- a/docs/decisions/0001-cards-are-entitlements.md
+++ b/docs/decisions/0001-cards-are-entitlements.md
@@ -1,0 +1,110 @@
+# ADR 0001: cards are entitlements, never world entities
+
+- Status: Accepted
+- Date: 2026-07-16
+- Decision owners: CosyWorld maintainers
+- Related: #20, #23, #24, #25, #26, #27, #48, #51, #52
+
+## Context
+
+Rati has three legitimate owners. Core authors the resident who runs the Blue
+Cottage. Ruby High: First Bell minted a Rati collectible. Ruby High also adds
+school membership and vocabulary when it is mounted. Treating any one of these
+records as the other two would either make Core depend on an optional pack or
+let wallet state replace shared-shard truth.
+
+The same ambiguity applies to locations and items. A wallet can prove access or
+provenance, but it cannot authoritatively say that a shared NPC disappeared, a
+door moved, or a shard-local item changed hands.
+
+## Decision
+
+The chain records what a player is entitled to everywhere. The kernel records
+what is true in this shard. A card is an entitlement about an entity, never the
+entity itself.
+
+The persisted concepts are separate:
+
+| Concept | Canonical identity | Authoritative record | Lifetime |
+| --- | --- | --- | --- |
+| World entity | `pack://<authoring-pack>/<actor|item|location>/<local-id>` | compiled world resource plus shard snapshot | while its authoring pack is mounted |
+| External card | owning `pack_id` plus string `card_id` | pack card catalogue; wallet ownership feed projects possession | independent of a shard |
+| Actor facet | `pack://<applying-pack>/actor-facet/<facet-id>` | applying pack's `actor_facets` resource | only while the applying pack is mounted |
+| Entitlement grant | namespaced grant string such as `ruby-high.first-bell:location-homeroom` | pack manifest authority and grant declaration | dormant when no mounted resource consumes it |
+
+Numeric actor, item, and location ids remain runtime handles for the C kernel
+and legacy snapshots. They are not cross-pack identity. Saved snapshots carry
+their canonical mapping in `content_context.references`.
+
+`card_bindings` is the only card-to-entity association. The binding belongs to
+the pack that owns the external card and points at the authoring pack's
+canonical entity reference. One external card can describe at most one world
+entity, and one seed card can have at most one external binding. An entitlement
+grant may be consumed by more than one access gate, but it never binds an actor
+or facet directly. Facets are separate, removable rows and may condition their
+presence with `requires_packs`.
+
+World entity rows are a closed contract. Actor, item, and location resources
+cannot contain `card_id`, `external_card_id`, wallet, ownership, grant, or other
+undeclared fields. Those coordinates belong in external cards, `card_bindings`,
+and entitlement grants. The compiler, compiled-world checker, and Rust registry
+all fail closed on an attempted overlap.
+
+Items consequently have one plane at a time:
+
+- a world item is a numeric `items` resource projected into kernel/shard state;
+- a wallet keepsake is an asset from the ownership provider and is not inserted
+  into `world_items`;
+- moving between planes requires a typed, durable receipt that consumes the
+  source before creating the destination.
+
+Manifest v1 does not define arbitrary item materialization or crystallization.
+The Wooden Box burn/opening flow is the existing receipt pattern: verified burn
+state is persisted before the wallet box becomes a local pack entitlement. A
+future portable-item bridge must add its own typed receipt contract and prove
+that no wallet claim and live world item overlap; a card binding alone can
+never perform that transition.
+
+## Rati migration
+
+Rati remains `pack://cosyworld.core/actor/1001`. Core-only composition includes
+the actor and its generated/local card surface without an external card id.
+When Ruby High is mounted, Ruby contributes:
+
+- `rati-first-bell`, an actor facet targeting the Core canonical reference;
+- `rati-first-bell-card`, a binding from Ruby's external `rati` card to that
+  same Core actor.
+
+Ruby-only composition omits both dependency-conditioned rows. Removing Ruby
+therefore removes the school facet and external binding without changing Rati's
+world identity, location, dialogue authority, or Core availability.
+
+## Runtime and API projection
+
+- `registry.resources.actors`, `.items`, and `.locations` hold world truth and
+  retain their authoring `pack_id`.
+- `registry.external_cards`, `.resources.card_bindings`, and
+  `.resources.actor_facets` hold the three separate expansion records.
+- `/state.access.owned_card_ids` reports verified wallet cards and
+  `/state.access.granted_entitlement_ids` reports resolved grants. Neither is a
+  world-entity collection or actor-control list.
+- `/content-packs` reports mounted pack access and resource counts; mount state,
+  not wallet possession, decides whether a facet exists.
+- Server-authored shared-resident lines remain authoritative. A play-as license
+  can only apply in a separately instanced campaign shard that explicitly
+  creates its own actor state.
+
+## Consequences and follow-ups
+
+Core and Ruby extraction (#24 and #27) implement and test the migration above.
+Location-scoped rules (#26) must call the removable records *facets* and must
+not persist expansion membership into the Core actor. The action hand (#48)
+must call wallet-owned influences *keepsakes* or *passes*, not actors/items in
+the scene. The terminology work (#51) must reserve *action card* for a scene
+choice, *keepsake/pass* for an entitlement surface, *world item* for kernel
+state, and *world pack* for mounted content.
+
+The trade-off is deliberate indirection. Packs must declare bindings, facets,
+and grants instead of copying wallet coordinates onto entity rows. In return,
+optional packs can unmount safely, shared-world continuity cannot be bought or
+disconnected, and item portability cannot duplicate shard-local supply.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.56",
+      "version": "0.0.57",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/content-pack-contract.test.mjs
+++ b/test/v2/content-pack-contract.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   resolveContentPackGraph,
   validateContentPackManifest,
+  validateWorldEntityResource,
 } from "../../v2/scripts/content-pack-contract.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -157,6 +158,26 @@ describe("Content Pack Manifest v1", () => {
         authorities: [{ ...entitlements.authorities[0], provider: "fixture.other/entitlements" }],
       },
     }))).toThrow(/unavailable provider fixture\.other\/entitlements/);
+  });
+
+  it("keeps wallet identity fields out of authoritative world entities", () => {
+    expect(() => validateWorldEntityResource("fixture.world", "actors", {
+      id: 1,
+      name: "Ada",
+      speech_mode: "server_authored",
+      title: "Keeper",
+      description: "Keeps the local truth.",
+      external_card_id: "ada-wallet-card",
+    })).toThrow(/wallet cards and entitlements must use card_bindings/);
+    expect(() => validateWorldEntityResource("fixture.world", "items", {
+      id: 2,
+      name: "Brass Key",
+      description: "A shard-local key.",
+      kind: "keepsake",
+      charges: 1,
+      location_id: 1,
+      wallet_asset_id: "portable-key",
+    })).toThrow(/unknown field wallet_asset_id/);
   });
 
   it("resolves dependencies in deterministic topological order", () => {

--- a/test/v2/ruby-high-peer-pack.test.mjs
+++ b/test/v2/ruby-high-peer-pack.test.mjs
@@ -55,6 +55,9 @@ describe("Ruby High: First Bell peer pack", () => {
       external_card_id: "rati",
     })]);
     const coreRati = coreOnly.resources.cards.find((card) => card.card_id === "rati");
+    expect(coreOnly.resources.actors.find((actor) => actor.id === 1001)).toEqual(
+      expect.objectContaining({ pack_id: "cosyworld.core", name: "Rati" }),
+    );
     expect(coreRati.external_card_id).toBeUndefined();
     expect(coreRati.source).toBe("cosyworld_core");
   });

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -146,6 +146,36 @@ describe("worldpack Manifest v1 validation", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("has unavailable provider fixture.missing/entitlements");
   });
+
+  it("rejects wallet identity embedded in a world item", () => {
+    const root = worldpackFixture();
+    const items = JSON.parse(fs.readFileSync(path.join(root, "items.json"), "utf8"));
+    items[0].external_card_id = "wallet-copy-of-world-item";
+    writeJson(root, "items.json", items);
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("wallet cards and entitlements must use card_bindings");
+  });
+
+  it("allows one external card to describe only one world entity", () => {
+    const root = worldpackFixture();
+    const bindings = JSON.parse(fs.readFileSync(path.join(root, "card_bindings.json"), "utf8"));
+    bindings.push({
+      ...bindings[0],
+      id: "rati-card-duplicate-subject",
+      entity_ref: "pack://cosyworld.core/actor/1002",
+      subject_id: 1002,
+      seed_card_id: "cosy-whiskerwind",
+    });
+    writeJson(root, "card_bindings.json", bindings);
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("external card rati binds more than one world entity");
+  });
 });
 
 describe("worldpack authored relationships", () => {

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -102,6 +102,8 @@ use `requires_packs` when their entity lives in an optional dependency. In the
 official composition, First Bell binds its Rati card and school facet to
 `pack://cosyworld.core/actor/1001`; both resources disappear from the standalone
 Ruby registry, while Core's Rati remains valid and uses its local card surface.
+The accepted identity, cardinality, persistence, and one-plane item rules are
+recorded in [ADR 0001](../../docs/decisions/0001-cards-are-entitlements.md).
 
 Manifest v1 is fail-closed: unknown fields are rejected. Forward-compatible
 metadata must live under `extensions` with a namespaced `x-...` key. Adding a

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.56"
+version = "0.0.57"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -1126,6 +1126,49 @@ mod tests {
     }
 
     #[test]
+    fn runtime_rejects_wallet_identity_embedded_in_world_entity_state() {
+        let path = configured_content_root().join("official/registry.json");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(path).expect("compiled registry reads"))
+                .expect("compiled registry parses");
+        value["resources"]["items"][0]["external_card_id"] =
+            serde_json::json!("wallet-copy-of-world-item");
+
+        let error = ContentRegistry::from_json(&value.to_string(), env!("CARGO_PKG_VERSION"))
+            .expect_err("world entities must reject wallet identity fields");
+
+        assert!(
+            error.contains("unknown field `external_card_id`"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn runtime_allows_one_external_card_to_describe_only_one_world_entity() {
+        let path = configured_content_root().join("official/registry.json");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(path).expect("compiled registry reads"))
+                .expect("compiled registry parses");
+        let mut duplicate = value["resources"]["card_bindings"][0].clone();
+        duplicate["id"] = serde_json::json!("rati-card-duplicate-subject");
+        duplicate["entity_ref"] = serde_json::json!("pack://cosyworld.core/actor/1002");
+        duplicate["subject_id"] = serde_json::json!(1002);
+        duplicate["seed_card_id"] = serde_json::json!("cosy-whiskerwind");
+        value["resources"]["card_bindings"]
+            .as_array_mut()
+            .expect("card bindings are an array")
+            .push(duplicate);
+
+        let error = ContentRegistry::from_json(&value.to_string(), env!("CARGO_PKG_VERSION"))
+            .expect_err("one wallet card cannot describe two entities");
+
+        assert!(
+            error.contains("external card rati binds more than one world entity"),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn core_and_non_world_compositions_mount_without_implicit_packs() {
         let content_root = configured_content_root();
         let core = ContentRegistry::from_json(

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1395,6 +1395,7 @@ struct SeedFactionContent {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SeedActorContent {
     #[serde(default)]
     pack_id: String,
@@ -1453,6 +1454,7 @@ struct SeedStatBlockContent {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SeedItemContent {
     #[serde(default)]
     pack_id: String,
@@ -1465,6 +1467,7 @@ struct SeedItemContent {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SeedLocationContent {
     #[serde(default)]
     pack_id: String,
@@ -5233,6 +5236,7 @@ fn validate_seed_content(content: &SeedContent) -> Result<(), String> {
     }
     let mut card_binding_ids = BTreeSet::new();
     let mut bound_seed_cards = BTreeSet::new();
+    let mut bound_external_cards = BTreeSet::new();
     for binding in &content.card_bindings {
         let Some(seed_card) = content.cards.iter().find(|card| {
             card.card_id == binding.seed_card_id
@@ -5277,9 +5281,20 @@ fn validate_seed_content(content: &SeedContent) -> Result<(), String> {
             || expected_ref.as_deref() != Some(binding.entity_ref.as_str())
             || external_card.map(|card| card.pack_id.as_str()) != Some(binding.pack_id.as_str())
             || !card_binding_ids.insert(binding.id.as_str())
-            || !bound_seed_cards.insert(seed_card.card_id.as_str())
         {
             return Err(format!("invalid card binding {}", binding.id));
+        }
+        if !bound_seed_cards.insert(seed_card.card_id.as_str()) {
+            return Err(format!(
+                "seed card {} has more than one external binding",
+                seed_card.card_id
+            ));
+        }
+        if !bound_external_cards.insert(binding.external_card_id.as_str()) {
+            return Err(format!(
+                "external card {} binds more than one world entity",
+                binding.external_card_id
+            ));
         }
     }
 

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -6,6 +6,7 @@ import {
   CANONICAL_ID_MAPPING_VERSION,
   CONTENT_PACK_CONTRACT,
   resolveContentPackGraph,
+  validateWorldEntityResource,
 } from "./content-pack-contract.mjs";
 import {
   buildContentReferenceMapping,
@@ -993,6 +994,11 @@ for (const profile of characterCreationProfiles) {
 }
 
 for (const actor of actors) {
+  try {
+    validateWorldEntityResource(actor.pack_id, "actors", actor);
+  } catch (error) {
+    fail(error.message);
+  }
   validateRequiredStrings("actor", actor, ["name", "speech_mode", "title", "description"]);
   if (actor.ambient_autonomy !== undefined && typeof actor.ambient_autonomy !== "boolean") {
     fail(`actor ${actor.id} has invalid ambient_autonomy`);
@@ -1032,6 +1038,11 @@ for (const actor of actors) {
 }
 
 for (const item of items) {
+  try {
+    validateWorldEntityResource(item.pack_id, "items", item);
+  } catch (error) {
+    fail(error.message);
+  }
   validateRequiredStrings("item", item, ["name", "description", "kind"]);
   if (!["potion", "evolution", "keepsake"].includes(item.kind)) {
     fail(`item ${item.id} has invalid kind ${item.kind}`);
@@ -1046,6 +1057,11 @@ for (const item of items) {
 const itemById = new Map(items.map((item) => [item.id, item]));
 
 for (const location of locations) {
+  try {
+    validateWorldEntityResource(location.pack_id, "locations", location);
+  } catch (error) {
+    fail(error.message);
+  }
   validateRequiredStrings("location", location, ["name", "title", "description", "persona"]);
   if (!Array.isArray(location.memory) || location.memory.some((entry) => !isNonEmptyString(entry))) {
     fail(`location ${location.id} must have non-empty memory strings`);
@@ -1361,6 +1377,7 @@ for (const card of cards) {
 
 idSet("card bindings", cardBindings, (binding) => binding.id);
 const boundSeedCards = new Set();
+const boundExternalCards = new Set();
 for (const binding of cardBindings) {
   validateRequiredStrings("card binding", binding, [
     "id",
@@ -1393,6 +1410,8 @@ for (const binding of cardBindings) {
   }
   if (boundSeedCards.has(binding.seed_card_id)) fail(`seed card ${binding.seed_card_id} has more than one external binding`);
   boundSeedCards.add(binding.seed_card_id);
+  if (boundExternalCards.has(binding.external_card_id)) fail(`external card ${binding.external_card_id} binds more than one world entity`);
+  boundExternalCards.add(binding.external_card_id);
 }
 
 for (const gate of accessGates) {

--- a/v2/scripts/compile-worldpack.mjs
+++ b/v2/scripts/compile-worldpack.mjs
@@ -8,6 +8,7 @@ import {
   CONTENT_PACK_CONTRACT,
   resolveContentPackGraph,
   validateContentPackManifest,
+  validateWorldEntityResource,
 } from "./content-pack-contract.mjs";
 import {
   buildContentReferenceMapping,
@@ -363,6 +364,7 @@ for (const pack of packs) {
     assert(Array.isArray(rows), `pack ${pack.manifest.id} resource ${resource} must be an array`);
     for (const row of rows) {
       assert(row && typeof row === "object" && !Array.isArray(row), `pack ${pack.manifest.id} resource ${resource} contains a non-object row`);
+      validateWorldEntityResource(pack.manifest.id, resource, row);
       assert(!row.pack_id || row.pack_id === pack.manifest.id, `pack ${pack.manifest.id} resource ${resource} contains conflicting pack_id ${row.pack_id}`);
       const { requires_packs: requiresPacks = [], ...compiledRow } = row;
       assert(Array.isArray(requiresPacks), `pack ${pack.manifest.id} resource ${resource} requires_packs must be an array`);

--- a/v2/scripts/content-pack-contract.mjs
+++ b/v2/scripts/content-pack-contract.mjs
@@ -16,6 +16,46 @@ export const CAPABILITY_KINDS = Object.freeze([
   "reference",
 ]);
 
+const WORLD_ENTITY_FIELDS = Object.freeze({
+  actors: new Set([
+    "pack_id",
+    "requires_packs",
+    "id",
+    "name",
+    "speech_mode",
+    "title",
+    "description",
+    "ambient_autonomy",
+    "location_id",
+    "stats",
+    "desires",
+    "attachments",
+  ]),
+  items: new Set([
+    "pack_id",
+    "requires_packs",
+    "id",
+    "name",
+    "description",
+    "kind",
+    "charges",
+    "location_id",
+  ]),
+  locations: new Set([
+    "pack_id",
+    "requires_packs",
+    "id",
+    "name",
+    "title",
+    "description",
+    "persona",
+    "memory",
+    "biome",
+    "terrain",
+    "allow_combat",
+  ]),
+});
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const schemaPath = path.resolve(scriptDir, "../schemas/content-pack-manifest-v1.schema.json");
 const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
@@ -31,6 +71,23 @@ function formatSchemaErrors(errors) {
   return errors
     .map((error) => `${error.instancePath || "/"} ${error.message}`)
     .join("; ");
+}
+
+export function validateWorldEntityResource(packId, resource, row) {
+  const allowedFields = WORLD_ENTITY_FIELDS[resource];
+  if (!allowedFields) return row;
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    contractError(`pack ${packId} ${resource} resource must be an object`);
+  }
+  for (const field of Object.keys(row)) {
+    if (!allowedFields.has(field)) {
+      contractError(
+        `pack ${packId} ${resource} resource ${String(row.id ?? "unknown")} has unknown field ${field}; `
+        + "wallet cards and entitlements must use card_bindings and entitlement grants, not world entity state",
+      );
+    }
+  }
+  return row;
 }
 
 export function parseSemver(version, label = "version") {


### PR DESCRIPTION
## Summary

- record ADR 0001 for separate world entity, external card, actor facet, and entitlement identities
- make actor, item, and location resources fail closed on undeclared wallet/entitlement fields in the compiler, checker, and Rust registry
- require each external card and seed card to bind to at most one world entity
- lock the Rati Core/Ruby migration and one-plane item rule under regression tests
- bump the runtime release to 0.0.57

Closes #52.

## Validation

- complete Node suite with the matching Node 24 native ABI: 402 passed
- npm run v2:rust:test: 330 passed
- npm run v2:worldpack: official, Core-only, Ruby-only, and services-only passed
- cargo check
- cargo fmt --check
- npm run check:version
- git diff --cached --check

## Review checklist

- [x] Tests cover the changed behavior or the PR explains why no test applies.
- [x] Generated worldpack files and locks are refreshed when source content changes. No source content changed; deterministic checks pass.
- [x] Register review completed for changes under v2/content/** against v2/docs/writing-style.md (not applicable; no content changes).
- [x] Genre review completed: which kindness does any new horror enlarge? (not applicable; architecture and validation only).