### PR TITLE
Disambiguate player-facing card and pack nouns

### DIFF
--- a/docs/decisions/0001-cards-are-entitlements.md
+++ b/docs/decisions/0001-cards-are-entitlements.md
@@ -100,9 +100,10 @@ Core and Ruby extraction (#24 and #27) implement and test the migration above.
 Location-scoped rules (#26) must call the removable records *facets* and must
 not persist expansion membership into the Core actor. The action hand (#48)
 must call wallet-owned influences *keepsakes* or *passes*, not actors/items in
-the scene. The terminology work (#51) must reserve *action card* for a scene
-choice, *keepsake/pass* for an entitlement surface, *world item* for kernel
-state, and *world pack* for mounted content.
+the scene. The [player lexicon](../../v2/docs/player-lexicon.md) reserves
+*action* for a scene choice, *keepsake/pass* for collection and entitlement
+surfaces, *world item* for kernel state, *bundle* for a collectible reveal, and
+*world pack* for mounted content.
 
 The trade-off is deliberate indirection. Packs must declare bindings, facets,
 and grants instead of copying wallet coordinates onto entity rows. In return,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.57",
+      "version": "0.0.58",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/player-lexicon.test.mjs
+++ b/test/v2/player-lexicon.test.mjs
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+const index = read("v2/orchestrator-rust/src/index.html");
+const gates = read("v2/content/ruby-high-first-bell/access_gates.json");
+const glossary = read("v2/docs/player-lexicon.md");
+
+describe("player-facing action, keepsake, pass, bundle, and world-pack lexicon", () => {
+  it("passes the five-task comprehension copy contract", () => {
+    const tasks = [
+      {
+        task: "make the avatar do something now",
+        concept: 'data-player-concept="action"',
+        cue: "Choose an action below. Someone here will answer.",
+        analytics: 'data-analytics-event="action.select"',
+      },
+      {
+        task: "inspect or keep a collected memory close",
+        concept: 'data-player-concept="keepsake"',
+        cue: "your keepsakes",
+        analytics: 'data-analytics-event="keepsake.open"',
+      },
+      {
+        task: "explain why a school room is locked",
+        concept: 'data-player-concept="pass"',
+        cue: "pass required",
+      },
+      {
+        task: "reveal the contents produced by a Box",
+        concept: 'data-player-concept="bundle"',
+        cue: "open bundle",
+        analytics: 'data-analytics-event="bundle.open"',
+      },
+      {
+        task: "find mounted experience content",
+        concept: 'data-player-concept="world-pack"',
+        cue: "world packs mounted",
+        analytics: 'data-analytics-event="world_pack.library.open"',
+      },
+    ];
+
+    for (const task of tasks) {
+      expect(index, task.task).toContain(task.concept);
+      expect(`${index}\n${gates}`, task.task).toContain(task.cue);
+      if (task.analytics) expect(index, task.task).toContain(task.analytics);
+    }
+  });
+
+  it("uses the same distinctions in accessibility labels and collection copy", () => {
+    expect(index).toContain('aria-label="Open current location keepsake"');
+    expect(index).toContain('aria-label="Close keepsake details"');
+    expect(index).toContain("Open ${escapeAttr(cardName)} keepsake details");
+    expect(index).toContain("Keep a few keepsakes close—up to three.");
+    expect(index).toContain("Opened avatar bundle:");
+    expect(gates).toContain("Ruby High: First Bell location pass required.");
+  });
+
+  it("removes the former ambiguous player copy while preserving API compatibility", () => {
+    for (const ambiguous of [
+      "Choose a card below",
+      "Your next cards are ready",
+      "location card required",
+      "Opened pack",
+      "Avatar Pack",
+      "your first card",
+      "Keep a few cards close",
+      "The card passes the room turn",
+      "fresh pack of avatar cards",
+    ]) {
+      expect(`${index}\n${gates}`).not.toContain(ambiguous);
+    }
+
+    expect(index).toContain('${otherCardCount === 1 ? "action" : "actions"}');
+    expect(index).toContain('${packs === 1 ? "bundle" : "bundles"}');
+    expect(index).toContain('/nft/packs/open');
+    expect(index).toContain("data-account-open-pack");
+    expect(index).toContain("required_card_id");
+  });
+
+  it("checks in ownership, lifecycle, affordance, accessibility, and analytics guidance", () => {
+    for (const section of [
+      "## Canonical concepts",
+      "Ownership and authority",
+      "Lifecycle",
+      "Primary affordance",
+      "## Accessibility and analytics",
+      "## Five-task comprehension check",
+      "## Architecture relationship",
+    ]) {
+      expect(glossary).toContain(section);
+    }
+    for (const noun of ["**action**", "**keepsake**", "**pass**", "**bundle**", "**world pack**"]) {
+      expect(glossary).toContain(noun);
+    }
+  });
+});

--- a/v2/content/official/access_gates.json
+++ b/v2/content/official/access_gates.json
@@ -3,42 +3,42 @@
     "location_id": 10,
     "required_grant_id": "ruby-high.first-bell:location-science-lab",
     "required_card_id": "location-science-lab",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 11,
     "required_grant_id": "ruby-high.first-bell:location-homeroom",
     "required_card_id": "location-homeroom",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 12,
     "required_grant_id": "ruby-high.first-bell:location-library",
     "required_card_id": "location-library",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 13,
     "required_grant_id": "ruby-high.first-bell:location-cafeteria",
     "required_card_id": "location-cafeteria",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 14,
     "required_grant_id": "ruby-high.first-bell:location-greenhouse",
     "required_card_id": "location-greenhouse",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 15,
     "required_grant_id": "ruby-high.first-bell:location-courtyard",
     "required_card_id": "location-courtyard",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   }
 ]

--- a/v2/content/official/assets.json
+++ b/v2/content/official/assets.json
@@ -40,8 +40,8 @@
   },
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.1",
-    "pack_integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
+    "pack_version": "1.3.2",
+    "pack_integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab",
     "provider": "ruby-high.first-bell/assets",
     "mount": "cards",
     "root": "ruby-high-first-bell",

--- a/v2/content/official/content_refs.json
+++ b/v2/content/official/content_refs.json
@@ -1878,7 +1878,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/actor-facet/rati-first-bell",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "actor-facet",
       "local_id": "rati-first-bell",
       "runtime_handle": 1038687835420516
@@ -1886,7 +1886,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card-binding/rati-first-bell-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card-binding",
       "local_id": "rati-first-bell-card",
       "runtime_handle": 3116738573256863
@@ -1894,7 +1894,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-cafeteria",
       "runtime_handle": 3107528363911865
@@ -1902,7 +1902,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-courtyard",
       "runtime_handle": 4782402674832957
@@ -1910,7 +1910,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-greenhouse",
       "runtime_handle": 3662976131116729
@@ -1918,7 +1918,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-homeroom",
       "runtime_handle": 7084902207358373
@@ -1926,7 +1926,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-library",
       "runtime_handle": 6785800264541047
@@ -1934,7 +1934,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-science-lab",
       "runtime_handle": 8201462675675638
@@ -1942,7 +1942,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "captain-null",
       "runtime_handle": 3843573141933674
@@ -1950,7 +1950,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "eliza",
       "runtime_handle": 4124553834845258
@@ -1958,7 +1958,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "indra",
       "runtime_handle": 8687099168741216
@@ -1966,7 +1966,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-flashcards",
       "runtime_handle": 6148366931632609
@@ -1974,7 +1974,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-hall-pass",
       "runtime_handle": 6154026517662833
@@ -1982,7 +1982,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-lab-flask",
       "runtime_handle": 7444186363202775
@@ -1990,7 +1990,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-library-card",
       "runtime_handle": 27821797810153
@@ -1998,7 +1998,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-lunch-tray",
       "runtime_handle": 3064948555071770
@@ -2006,7 +2006,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-notebook",
       "runtime_handle": 5906680647268123
@@ -2014,7 +2014,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-cafeteria",
       "runtime_handle": 232928798345453
@@ -2022,7 +2022,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-courtyard",
       "runtime_handle": 1017422828753302
@@ -2030,7 +2030,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-greenhouse",
       "runtime_handle": 1874830250433117
@@ -2038,7 +2038,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-homeroom",
       "runtime_handle": 6928775784641985
@@ -2046,7 +2046,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-library",
       "runtime_handle": 8204365461548708
@@ -2054,7 +2054,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-science-lab",
       "runtime_handle": 57115334800243
@@ -2062,7 +2062,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "lyra",
       "runtime_handle": 7094866015162716
@@ -2070,7 +2070,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "mika",
       "runtime_handle": 4809241939115652
@@ -2078,7 +2078,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "noor",
       "runtime_handle": 6643976235743711
@@ -2086,7 +2086,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "professor-edward",
       "runtime_handle": 1211962163801060
@@ -2094,7 +2094,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "rati",
       "runtime_handle": 8508280633539606
@@ -2102,7 +2102,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "ravi",
       "runtime_handle": 3914282740523084
@@ -2110,7 +2110,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "ruby",
       "runtime_handle": 442578259385801
@@ -2118,7 +2118,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "sally-science",
       "runtime_handle": 692877066368845
@@ -2126,7 +2126,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "sami",
       "runtime_handle": 5798756249869747
@@ -2134,7 +2134,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "faction",
       "local_id": "ruby_high",
       "runtime_handle": 2919627811514647
@@ -2142,7 +2142,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "10",
       "legacy_runtime_id": 10,
@@ -2151,7 +2151,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "11",
       "legacy_runtime_id": 11,
@@ -2160,7 +2160,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "12",
       "legacy_runtime_id": 12,
@@ -2169,7 +2169,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "13",
       "legacy_runtime_id": 13,
@@ -2178,7 +2178,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "14",
       "legacy_runtime_id": 14,
@@ -2187,7 +2187,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "15",
       "legacy_runtime_id": 15,
@@ -2196,7 +2196,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:10",
       "runtime_handle": 2574024258005683
@@ -2204,7 +2204,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:11",
       "runtime_handle": 944777926762018
@@ -2212,7 +2212,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:12",
       "runtime_handle": 8925253377010016
@@ -2220,7 +2220,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:13",
       "runtime_handle": 1954150505527197
@@ -2228,7 +2228,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:14",
       "runtime_handle": 9002247914113905
@@ -2236,7 +2236,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:15",
       "runtime_handle": 8772787069788936

--- a/v2/content/official/licenses.json
+++ b/v2/content/official/licenses.json
@@ -51,7 +51,7 @@
   {
     "pack_id": "ruby-high.first-bell",
     "name": "Ruby High: First Bell",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -9,7 +9,7 @@
     "version": 1,
     "description": "The reproducible seed world for the official CosyWorld shard.",
     "entry_location": "cosyworld.core:location/1",
-    "bundle_hash": "sha256:34532454b0edb8612a14e5c4ba9a9acd99c14eeac0544eccc44c38255c467a4b",
+    "bundle_hash": "sha256:499302d175bf38df6eadf7810afea8f98b039bead76cc27f0383c490ae668672",
     "packs": [
       {
         "id": "cosyworld.core",
@@ -240,7 +240,7 @@
         "id": "ruby-high.first-bell",
         "name": "Ruby High: First Bell",
         "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-        "version": "1.3.1",
+        "version": "1.3.2",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit",
@@ -420,7 +420,7 @@
           "type": "workspace",
           "path": "../../content/ruby-high-first-bell"
         },
-        "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e"
+        "integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab"
       }
     ],
     "files": {
@@ -1524,42 +1524,42 @@
         "location_id": 10,
         "required_grant_id": "ruby-high.first-bell:location-science-lab",
         "required_card_id": "location-science-lab",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 11,
         "required_grant_id": "ruby-high.first-bell:location-homeroom",
         "required_card_id": "location-homeroom",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 12,
         "required_grant_id": "ruby-high.first-bell:location-library",
         "required_card_id": "location-library",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 13,
         "required_grant_id": "ruby-high.first-bell:location-cafeteria",
         "required_card_id": "location-cafeteria",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 14,
         "required_grant_id": "ruby-high.first-bell:location-greenhouse",
         "required_card_id": "location-greenhouse",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 15,
         "required_grant_id": "ruby-high.first-bell:location-courtyard",
         "required_card_id": "location-courtyard",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       }
     ],
@@ -7692,8 +7692,8 @@
     },
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
-      "pack_integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
+      "pack_version": "1.3.2",
+      "pack_integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab",
       "provider": "ruby-high.first-bell/assets",
       "mount": "cards",
       "root": "ruby-high-first-bell",
@@ -7767,7 +7767,7 @@
     {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
@@ -9713,7 +9713,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/actor-facet/rati-first-bell",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "actor-facet",
         "local_id": "rati-first-bell",
         "runtime_handle": 1038687835420516
@@ -9721,7 +9721,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card-binding/rati-first-bell-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card-binding",
         "local_id": "rati-first-bell-card",
         "runtime_handle": 3116738573256863
@@ -9729,7 +9729,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-cafeteria",
         "runtime_handle": 3107528363911865
@@ -9737,7 +9737,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-courtyard",
         "runtime_handle": 4782402674832957
@@ -9745,7 +9745,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-greenhouse",
         "runtime_handle": 3662976131116729
@@ -9753,7 +9753,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-homeroom",
         "runtime_handle": 7084902207358373
@@ -9761,7 +9761,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-library",
         "runtime_handle": 6785800264541047
@@ -9769,7 +9769,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-science-lab",
         "runtime_handle": 8201462675675638
@@ -9777,7 +9777,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "captain-null",
         "runtime_handle": 3843573141933674
@@ -9785,7 +9785,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "eliza",
         "runtime_handle": 4124553834845258
@@ -9793,7 +9793,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "indra",
         "runtime_handle": 8687099168741216
@@ -9801,7 +9801,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-flashcards",
         "runtime_handle": 6148366931632609
@@ -9809,7 +9809,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-hall-pass",
         "runtime_handle": 6154026517662833
@@ -9817,7 +9817,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-lab-flask",
         "runtime_handle": 7444186363202775
@@ -9825,7 +9825,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-library-card",
         "runtime_handle": 27821797810153
@@ -9833,7 +9833,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-lunch-tray",
         "runtime_handle": 3064948555071770
@@ -9841,7 +9841,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-notebook",
         "runtime_handle": 5906680647268123
@@ -9849,7 +9849,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-cafeteria",
         "runtime_handle": 232928798345453
@@ -9857,7 +9857,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-courtyard",
         "runtime_handle": 1017422828753302
@@ -9865,7 +9865,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-greenhouse",
         "runtime_handle": 1874830250433117
@@ -9873,7 +9873,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-homeroom",
         "runtime_handle": 6928775784641985
@@ -9881,7 +9881,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-library",
         "runtime_handle": 8204365461548708
@@ -9889,7 +9889,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-science-lab",
         "runtime_handle": 57115334800243
@@ -9897,7 +9897,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "lyra",
         "runtime_handle": 7094866015162716
@@ -9905,7 +9905,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "mika",
         "runtime_handle": 4809241939115652
@@ -9913,7 +9913,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "noor",
         "runtime_handle": 6643976235743711
@@ -9921,7 +9921,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "professor-edward",
         "runtime_handle": 1211962163801060
@@ -9929,7 +9929,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "rati",
         "runtime_handle": 8508280633539606
@@ -9937,7 +9937,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "ravi",
         "runtime_handle": 3914282740523084
@@ -9945,7 +9945,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "ruby",
         "runtime_handle": 442578259385801
@@ -9953,7 +9953,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "sally-science",
         "runtime_handle": 692877066368845
@@ -9961,7 +9961,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "sami",
         "runtime_handle": 5798756249869747
@@ -9969,7 +9969,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "faction",
         "local_id": "ruby_high",
         "runtime_handle": 2919627811514647
@@ -9977,7 +9977,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "10",
         "legacy_runtime_id": 10,
@@ -9986,7 +9986,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "11",
         "legacy_runtime_id": 11,
@@ -9995,7 +9995,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "12",
         "legacy_runtime_id": 12,
@@ -10004,7 +10004,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "13",
         "legacy_runtime_id": 13,
@@ -10013,7 +10013,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "14",
         "legacy_runtime_id": 14,
@@ -10022,7 +10022,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "15",
         "legacy_runtime_id": 15,
@@ -10031,7 +10031,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:10",
         "runtime_handle": 2574024258005683
@@ -10039,7 +10039,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:11",
         "runtime_handle": 944777926762018
@@ -10047,7 +10047,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:12",
         "runtime_handle": 8925253377010016
@@ -10055,7 +10055,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:13",
         "runtime_handle": 1954150505527197
@@ -10063,7 +10063,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:14",
         "runtime_handle": 9002247914113905
@@ -10071,7 +10071,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:15",
         "runtime_handle": 8772787069788936

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -7,7 +7,7 @@
   "version": 1,
   "description": "The reproducible seed world for the official CosyWorld shard.",
   "entry_location": "cosyworld.core:location/1",
-  "bundle_hash": "sha256:34532454b0edb8612a14e5c4ba9a9acd99c14eeac0544eccc44c38255c467a4b",
+  "bundle_hash": "sha256:499302d175bf38df6eadf7810afea8f98b039bead76cc27f0383c490ae668672",
   "packs": [
     {
       "id": "cosyworld.core",
@@ -238,7 +238,7 @@
       "id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
       "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit",
@@ -418,7 +418,7 @@
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e"
+      "integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab"
     }
   ],
   "files": {

--- a/v2/content/ruby-high-first-bell/access_gates.json
+++ b/v2/content/ruby-high-first-bell/access_gates.json
@@ -3,36 +3,36 @@
     "location_id": 10,
     "required_grant_id": "ruby-high.first-bell:location-science-lab",
     "required_card_id": "location-science-lab",
-    "reason": "Ruby High: First Bell location card required."
+    "reason": "Ruby High: First Bell location pass required."
   },
   {
     "location_id": 11,
     "required_grant_id": "ruby-high.first-bell:location-homeroom",
     "required_card_id": "location-homeroom",
-    "reason": "Ruby High: First Bell location card required."
+    "reason": "Ruby High: First Bell location pass required."
   },
   {
     "location_id": 12,
     "required_grant_id": "ruby-high.first-bell:location-library",
     "required_card_id": "location-library",
-    "reason": "Ruby High: First Bell location card required."
+    "reason": "Ruby High: First Bell location pass required."
   },
   {
     "location_id": 13,
     "required_grant_id": "ruby-high.first-bell:location-cafeteria",
     "required_card_id": "location-cafeteria",
-    "reason": "Ruby High: First Bell location card required."
+    "reason": "Ruby High: First Bell location pass required."
   },
   {
     "location_id": 14,
     "required_grant_id": "ruby-high.first-bell:location-greenhouse",
     "required_card_id": "location-greenhouse",
-    "reason": "Ruby High: First Bell location card required."
+    "reason": "Ruby High: First Bell location pass required."
   },
   {
     "location_id": 15,
     "required_grant_id": "ruby-high.first-bell:location-courtyard",
     "required_card_id": "location-courtyard",
-    "reason": "Ruby High: First Bell location card required."
+    "reason": "Ruby High: First Bell location pass required."
   }
 ]

--- a/v2/content/ruby-high-first-bell/pack.json
+++ b/v2/content/ruby-high-first-bell/pack.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "ruby-high.first-bell",
   "name": "Ruby High: First Bell",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "kind": "world",
   "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
   "license": "MIT",

--- a/v2/content/ruby-high-only/access_gates.json
+++ b/v2/content/ruby-high-only/access_gates.json
@@ -3,42 +3,42 @@
     "location_id": 10,
     "required_grant_id": "ruby-high.first-bell:location-science-lab",
     "required_card_id": "location-science-lab",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 11,
     "required_grant_id": "ruby-high.first-bell:location-homeroom",
     "required_card_id": "location-homeroom",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 12,
     "required_grant_id": "ruby-high.first-bell:location-library",
     "required_card_id": "location-library",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 13,
     "required_grant_id": "ruby-high.first-bell:location-cafeteria",
     "required_card_id": "location-cafeteria",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 14,
     "required_grant_id": "ruby-high.first-bell:location-greenhouse",
     "required_card_id": "location-greenhouse",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   },
   {
     "location_id": 15,
     "required_grant_id": "ruby-high.first-bell:location-courtyard",
     "required_card_id": "location-courtyard",
-    "reason": "Ruby High: First Bell location card required.",
+    "reason": "Ruby High: First Bell location pass required.",
     "pack_id": "ruby-high.first-bell"
   }
 ]

--- a/v2/content/ruby-high-only/assets.json
+++ b/v2/content/ruby-high-only/assets.json
@@ -1,8 +1,8 @@
 [
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.1",
-    "pack_integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
+    "pack_version": "1.3.2",
+    "pack_integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab",
     "provider": "ruby-high.first-bell/assets",
     "mount": "cards",
     "root": "ruby-high-first-bell",

--- a/v2/content/ruby-high-only/content_refs.json
+++ b/v2/content/ruby-high-only/content_refs.json
@@ -5,7 +5,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-cafeteria",
       "runtime_handle": 3107528363911865
@@ -13,7 +13,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-courtyard",
       "runtime_handle": 4782402674832957
@@ -21,7 +21,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-greenhouse",
       "runtime_handle": 3662976131116729
@@ -29,7 +29,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-homeroom",
       "runtime_handle": 7084902207358373
@@ -37,7 +37,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-library",
       "runtime_handle": 6785800264541047
@@ -45,7 +45,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "card",
       "local_id": "location-science-lab",
       "runtime_handle": 8201462675675638
@@ -53,7 +53,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "captain-null",
       "runtime_handle": 3843573141933674
@@ -61,7 +61,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "eliza",
       "runtime_handle": 4124553834845258
@@ -69,7 +69,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "indra",
       "runtime_handle": 8687099168741216
@@ -77,7 +77,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-flashcards",
       "runtime_handle": 6148366931632609
@@ -85,7 +85,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-hall-pass",
       "runtime_handle": 6154026517662833
@@ -93,7 +93,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-lab-flask",
       "runtime_handle": 7444186363202775
@@ -101,7 +101,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-library-card",
       "runtime_handle": 27821797810153
@@ -109,7 +109,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-lunch-tray",
       "runtime_handle": 3064948555071770
@@ -117,7 +117,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "item-notebook",
       "runtime_handle": 5906680647268123
@@ -125,7 +125,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-cafeteria",
       "runtime_handle": 232928798345453
@@ -133,7 +133,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-courtyard",
       "runtime_handle": 1017422828753302
@@ -141,7 +141,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-greenhouse",
       "runtime_handle": 1874830250433117
@@ -149,7 +149,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-homeroom",
       "runtime_handle": 6928775784641985
@@ -157,7 +157,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-library",
       "runtime_handle": 8204365461548708
@@ -165,7 +165,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "location-science-lab",
       "runtime_handle": 57115334800243
@@ -173,7 +173,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "lyra",
       "runtime_handle": 7094866015162716
@@ -181,7 +181,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "mika",
       "runtime_handle": 4809241939115652
@@ -189,7 +189,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "noor",
       "runtime_handle": 6643976235743711
@@ -197,7 +197,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "professor-edward",
       "runtime_handle": 1211962163801060
@@ -205,7 +205,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "rati",
       "runtime_handle": 8508280633539606
@@ -213,7 +213,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "ravi",
       "runtime_handle": 3914282740523084
@@ -221,7 +221,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "ruby",
       "runtime_handle": 442578259385801
@@ -229,7 +229,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "sally-science",
       "runtime_handle": 692877066368845
@@ -237,7 +237,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "external-card",
       "local_id": "sami",
       "runtime_handle": 5798756249869747
@@ -245,7 +245,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "faction",
       "local_id": "ruby_high",
       "runtime_handle": 2919627811514647
@@ -253,7 +253,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "10",
       "legacy_runtime_id": 10,
@@ -262,7 +262,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "11",
       "legacy_runtime_id": 11,
@@ -271,7 +271,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "12",
       "legacy_runtime_id": 12,
@@ -280,7 +280,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "13",
       "legacy_runtime_id": 13,
@@ -289,7 +289,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "14",
       "legacy_runtime_id": 14,
@@ -298,7 +298,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "location",
       "local_id": "15",
       "legacy_runtime_id": 15,
@@ -307,7 +307,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:10",
       "runtime_handle": 2574024258005683
@@ -315,7 +315,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:11",
       "runtime_handle": 944777926762018
@@ -323,7 +323,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:12",
       "runtime_handle": 8925253377010016
@@ -331,7 +331,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:13",
       "runtime_handle": 1954150505527197
@@ -339,7 +339,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:14",
       "runtime_handle": 9002247914113905
@@ -347,7 +347,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
+      "pack_version": "1.3.2",
       "kind": "room-sheet",
       "local_id": "room:15",
       "runtime_handle": 8772787069788936

--- a/v2/content/ruby-high-only/licenses.json
+++ b/v2/content/ruby-high-only/licenses.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "ruby-high.first-bell",
     "name": "Ruby High: First Bell",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {

--- a/v2/content/ruby-high-only/registry.json
+++ b/v2/content/ruby-high-only/registry.json
@@ -10,13 +10,13 @@
     "description": "A standalone First Bell boot fixture with no CosyWorld Core pack mounted.",
     "entry_location": "ruby-high.first-bell:location/11",
     "entry_grant_id": "ruby-high.first-bell:location-homeroom",
-    "bundle_hash": "sha256:fdf45cd5b2c99a0f0c8b113bee55acbcfc375a826cdedab11fb717b425483c93",
+    "bundle_hash": "sha256:e397518d998e7e32fee655897d45bd407486392c31969380001c7306f38cf47f",
     "packs": [
       {
         "id": "ruby-high.first-bell",
         "name": "Ruby High: First Bell",
         "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-        "version": "1.3.1",
+        "version": "1.3.2",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit",
@@ -194,7 +194,7 @@
           "type": "workspace",
           "path": "../../content/ruby-high-first-bell"
         },
-        "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e"
+        "integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab"
       }
     ],
     "files": {
@@ -235,42 +235,42 @@
         "location_id": 10,
         "required_grant_id": "ruby-high.first-bell:location-science-lab",
         "required_card_id": "location-science-lab",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 11,
         "required_grant_id": "ruby-high.first-bell:location-homeroom",
         "required_card_id": "location-homeroom",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 12,
         "required_grant_id": "ruby-high.first-bell:location-library",
         "required_card_id": "location-library",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 13,
         "required_grant_id": "ruby-high.first-bell:location-cafeteria",
         "required_card_id": "location-cafeteria",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 14,
         "required_grant_id": "ruby-high.first-bell:location-greenhouse",
         "required_card_id": "location-greenhouse",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       },
       {
         "location_id": 15,
         "required_grant_id": "ruby-high.first-bell:location-courtyard",
         "required_card_id": "location-courtyard",
-        "reason": "Ruby High: First Bell location card required.",
+        "reason": "Ruby High: First Bell location pass required.",
         "pack_id": "ruby-high.first-bell"
       }
     ],
@@ -1198,8 +1198,8 @@
   "assets": [
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.1",
-      "pack_integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
+      "pack_version": "1.3.2",
+      "pack_integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab",
       "provider": "ruby-high.first-bell/assets",
       "mount": "cards",
       "root": "ruby-high-first-bell",
@@ -1216,7 +1216,7 @@
     {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
@@ -1235,7 +1235,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-cafeteria",
         "runtime_handle": 3107528363911865
@@ -1243,7 +1243,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-courtyard",
         "runtime_handle": 4782402674832957
@@ -1251,7 +1251,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-greenhouse",
         "runtime_handle": 3662976131116729
@@ -1259,7 +1259,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-homeroom",
         "runtime_handle": 7084902207358373
@@ -1267,7 +1267,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-library",
         "runtime_handle": 6785800264541047
@@ -1275,7 +1275,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "card",
         "local_id": "location-science-lab",
         "runtime_handle": 8201462675675638
@@ -1283,7 +1283,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "captain-null",
         "runtime_handle": 3843573141933674
@@ -1291,7 +1291,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "eliza",
         "runtime_handle": 4124553834845258
@@ -1299,7 +1299,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "indra",
         "runtime_handle": 8687099168741216
@@ -1307,7 +1307,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-flashcards",
         "runtime_handle": 6148366931632609
@@ -1315,7 +1315,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-hall-pass",
         "runtime_handle": 6154026517662833
@@ -1323,7 +1323,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-lab-flask",
         "runtime_handle": 7444186363202775
@@ -1331,7 +1331,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-library-card",
         "runtime_handle": 27821797810153
@@ -1339,7 +1339,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-lunch-tray",
         "runtime_handle": 3064948555071770
@@ -1347,7 +1347,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "item-notebook",
         "runtime_handle": 5906680647268123
@@ -1355,7 +1355,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-cafeteria",
         "runtime_handle": 232928798345453
@@ -1363,7 +1363,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-courtyard",
         "runtime_handle": 1017422828753302
@@ -1371,7 +1371,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-greenhouse",
         "runtime_handle": 1874830250433117
@@ -1379,7 +1379,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-homeroom",
         "runtime_handle": 6928775784641985
@@ -1387,7 +1387,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-library",
         "runtime_handle": 8204365461548708
@@ -1395,7 +1395,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "location-science-lab",
         "runtime_handle": 57115334800243
@@ -1403,7 +1403,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "lyra",
         "runtime_handle": 7094866015162716
@@ -1411,7 +1411,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "mika",
         "runtime_handle": 4809241939115652
@@ -1419,7 +1419,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "noor",
         "runtime_handle": 6643976235743711
@@ -1427,7 +1427,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "professor-edward",
         "runtime_handle": 1211962163801060
@@ -1435,7 +1435,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "rati",
         "runtime_handle": 8508280633539606
@@ -1443,7 +1443,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "ravi",
         "runtime_handle": 3914282740523084
@@ -1451,7 +1451,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "ruby",
         "runtime_handle": 442578259385801
@@ -1459,7 +1459,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "sally-science",
         "runtime_handle": 692877066368845
@@ -1467,7 +1467,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "external-card",
         "local_id": "sami",
         "runtime_handle": 5798756249869747
@@ -1475,7 +1475,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "faction",
         "local_id": "ruby_high",
         "runtime_handle": 2919627811514647
@@ -1483,7 +1483,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "10",
         "legacy_runtime_id": 10,
@@ -1492,7 +1492,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "11",
         "legacy_runtime_id": 11,
@@ -1501,7 +1501,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "12",
         "legacy_runtime_id": 12,
@@ -1510,7 +1510,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "13",
         "legacy_runtime_id": 13,
@@ -1519,7 +1519,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "14",
         "legacy_runtime_id": 14,
@@ -1528,7 +1528,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "location",
         "local_id": "15",
         "legacy_runtime_id": 15,
@@ -1537,7 +1537,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:10",
         "runtime_handle": 2574024258005683
@@ -1545,7 +1545,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:11",
         "runtime_handle": 944777926762018
@@ -1553,7 +1553,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:12",
         "runtime_handle": 8925253377010016
@@ -1561,7 +1561,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:13",
         "runtime_handle": 1954150505527197
@@ -1569,7 +1569,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:14",
         "runtime_handle": 9002247914113905
@@ -1577,7 +1577,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.1",
+        "pack_version": "1.3.2",
         "kind": "room-sheet",
         "local_id": "room:15",
         "runtime_handle": 8772787069788936

--- a/v2/content/ruby-high-only/worldpack.json
+++ b/v2/content/ruby-high-only/worldpack.json
@@ -8,13 +8,13 @@
   "description": "A standalone First Bell boot fixture with no CosyWorld Core pack mounted.",
   "entry_location": "ruby-high.first-bell:location/11",
   "entry_grant_id": "ruby-high.first-bell:location-homeroom",
-  "bundle_hash": "sha256:fdf45cd5b2c99a0f0c8b113bee55acbcfc375a826cdedab11fb717b425483c93",
+  "bundle_hash": "sha256:e397518d998e7e32fee655897d45bd407486392c31969380001c7306f38cf47f",
   "packs": [
     {
       "id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
       "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit",
@@ -192,7 +192,7 @@
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e"
+      "integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab"
     }
   ],
   "files": {

--- a/v2/docs/player-lexicon.md
+++ b/v2/docs/player-lexicon.md
@@ -1,0 +1,80 @@
+# Player lexicon
+
+CosyWorld uses different nouns for a choice, a collectible memory, access, a
+collection reveal, and installed world content. Internal schemas retain their
+stable `card_*`, `*_card_ids`, and `pack_*` fields; this glossary governs
+player-facing copy, accessibility labels, and analytics names.
+
+## Canonical concepts
+
+| Concept | Player-facing noun | Ownership and authority | Lifecycle | Primary affordance |
+| --- | --- | --- | --- | --- |
+| A verb offered in the three-choice hand | **action** | The engine deals legal actions from authoritative room state. A player chooses one; it is not owned or collected. | Replaced after a choice or redeal. | Command-shaped action button in the hand; `data-player-concept="action"`. |
+| An actor, item, or location representation in the collection | **keepsake** | A wallet or local collection may hold the representation. It can influence which actions appear, but never replaces the world entity. | Persists in the collection; up to three may be kept close. | Illustrated collection tile and details dialog; `data-player-concept="keepsake"`. |
+| Permission to enter a gated place | **pass** or **access** | A mounted world pack declares the grant; a verified entitlement provider proves it. The kernel receives only allowed/denied movement. | Dormant if its consuming world pack is unmounted; does not alter world state. | Locked-place badge reading “pass required”; `data-player-concept="pass"`. |
+| A revealable group of keepsakes | **bundle** | A verified Box receipt or trusted ownership feed associates the unopened bundle with an account. | Opened once; yields keepsakes and leaves a durable receipt. | Avatar Bundle tile and “open bundle” action; `data-player-concept="bundle"`. |
+| Installable or mounted experience content | **world pack** | The shard composition owns the mount decision; wallet possession cannot mount code or content. | Installed, mounted, unmounted, and version-locked by operators. | World Library entry; `data-player-concept="world-pack"`. |
+
+A **Box** keeps its proper name. It is the on-chain object consumed by the
+receipted flow that creates an Avatar Bundle; it is neither the bundle nor a
+world pack.
+
+## Copy rules
+
+- Use **action** in hand instructions, turn cues, and action accessibility
+  labels. “Action card” is acceptable only in developer documentation that is
+  explicitly discussing the deck/hand implementation.
+- Use **keepsake** for collection tiles, entity art/details, and the “kept
+  close” loadout. Owning a keepsake never means owning the shared entity.
+- Use **pass** when the missing entitlement corresponds to a location. Use
+  **access** when no player-facing pass representation exists.
+- Use **bundle** for the one-time group revealed by the Box flow. Do not call it
+  a pack in player copy.
+- Use **world pack** in the World Library and content architecture. Do not use
+  bare “pack” when a bundle could be meant.
+
+The internal API remains compatible: `cards`, `card_id`, `required_card_id`,
+`unopened_pack_ids`, `/nft/packs/open`, and related database names do not change.
+Adapters may also continue to recognize legacy error text such as “card
+required,” but new player-visible errors use this glossary.
+
+## Accessibility and analytics
+
+Interactive surfaces expose the same concept nouns through
+`data-player-concept`. Analytics hooks use namespaced event names rather than a
+generic `card.click` or `pack.open`:
+
+| Event | Meaning |
+| --- | --- |
+| `action.select`, `action.confirm`, `action.redeal` | choose, confirm, or replace a hand action |
+| `keepsake.collection.open`, `keepsake.open`, `keepsake.toggle` | inspect the collection, inspect a keepsake, or change the kept-close loadout |
+| `bundle.open` | reveal one Avatar Bundle |
+| `world_pack.library.open` | open the mounted World Library |
+
+Pass requirements are currently read-only badges, so they expose a concept but
+do not emit a click event. If a pass-purchase or claim flow is added, its event
+namespace is `pass.*`.
+
+## Five-task comprehension check
+
+The UI copy contract answers these five tasks without relying on art or layout:
+
+| Task | The player should choose or identify | Required cue |
+| --- | --- | --- |
+| Make the avatar do something now | an **action** | “Choose an action below” and action-labelled hand buttons |
+| Inspect or keep a collected memory close | a **keepsake** | “your keepsakes,” “keepsake details,” and “keep close” |
+| Explain why a school room is locked | a **pass** | “Ruby High: First Bell location pass required” |
+| Reveal the contents produced by a Box | an Avatar **Bundle** | “open bundle” and “Opened avatar bundle” |
+| Find or inspect mounted experience content | a **world pack** | the World Library count and world-pack entries |
+
+Regression tests check all five cues together and reject the former ambiguous
+phrases. A future moderated usability study can add human evidence without
+changing these baseline nouns.
+
+## Architecture relationship
+
+This is the player-facing layer of
+[ADR 0001](../../docs/decisions/0001-cards-are-entitlements.md). The ADR defines
+world entity, external card, facet, and entitlement identity. This glossary
+names how those records appear to players. World-pack compilation and API
+fields are documented separately in [Worldpacks](worldpacks.md).

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -104,6 +104,10 @@ official composition, First Bell binds its Rati card and school facet to
 Ruby registry, while Core's Rati remains valid and uses its local card surface.
 The accepted identity, cardinality, persistence, and one-plane item rules are
 recorded in [ADR 0001](../../docs/decisions/0001-cards-are-entitlements.md).
+Player copy calls these collection representations **keepsakes**, location
+entitlements **passes**, collectible reveals **bundles**, and mounted content
+**world packs**; see the [player lexicon](player-lexicon.md). Stable manifest
+and API fields retain their existing `card` and `pack` names.
 
 Manifest v1 is fail-closed: unknown fields are rejected. Forward-compatible
 metadata must live under `extensions` with a namespaced `x-...` key. Adding a

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.57"
+version = "0.0.58"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2702,8 +2702,8 @@
 <body>
   <div class="shell">
     <header class="topbar">
-      <button class="brand" id="brand" type="button" aria-label="Open World Library" aria-expanded="false" aria-controls="log">world library</button>
-      <button class="economy" id="economy" type="button" aria-label="Open your collection" aria-expanded="false" aria-controls="log"></button>
+      <button class="brand" id="brand" type="button" aria-label="Open World Library" aria-expanded="false" aria-controls="log" data-player-concept="world-pack" data-analytics-event="world_pack.library.open">world library</button>
+      <button class="economy" id="economy" type="button" aria-label="Open your keepsake collection" aria-expanded="false" aria-controls="log" data-player-concept="keepsake" data-analytics-event="keepsake.collection.open"></button>
       <button class="location-pill" type="button" aria-label="Focus current location">
         <img id="location-image" alt="" />
         <span id="subtitle">booting</span>
@@ -2712,7 +2712,7 @@
     <main class="terminal">
       <section class="room">
         <div class="room-hero" id="room-hero">
-          <button class="room-hero-card" id="room-hero-card" type="button" aria-label="Open current location card">
+          <button class="room-hero-card" id="room-hero-card" type="button" aria-label="Open current location keepsake" data-player-concept="keepsake" data-analytics-event="keepsake.open">
             <img id="room-hero-image" alt="" />
           </button>
           <div class="room-avatar-rail" id="room-avatar-rail" aria-label="Avatars in this location"></div>
@@ -2732,10 +2732,10 @@
     <footer class="prompt">
       <div class="turn-ping-pill" id="turn-ping-pill" aria-live="assertive" hidden></div>
       <div class="caret">&gt;</div>
-      <button class="cmd primary" id="primary"></button>
-      <button class="cmd secondary" id="secondary"></button>
-      <button class="cmd secondary" id="tertiary"></button>
-      <button class="cmd shuffle" id="shuffle" type="button"></button>
+      <button class="cmd primary" id="primary" data-player-concept="action" data-analytics-event="action.select"></button>
+      <button class="cmd secondary" id="secondary" data-player-concept="action" data-analytics-event="action.select"></button>
+      <button class="cmd secondary" id="tertiary" data-player-concept="action" data-analytics-event="action.select"></button>
+      <button class="cmd shuffle" id="shuffle" type="button" data-player-concept="action" data-analytics-event="action.redeal"></button>
     </footer>
   </div>
   <div class="command-palette" id="command-palette" hidden>
@@ -2745,8 +2745,8 @@
     </form>
   </div>
   <div class="card-modal" id="card-modal" hidden>
-    <section class="card-dialog" role="dialog" aria-modal="true" aria-labelledby="card-modal-name" tabindex="-1">
-      <button class="card-close" type="button" data-card-close aria-label="Close card">x</button>
+    <section class="card-dialog" role="dialog" aria-modal="true" aria-labelledby="card-modal-name" tabindex="-1" data-player-concept="keepsake">
+      <button class="card-close" type="button" data-card-close aria-label="Close keepsake details">x</button>
       <div class="card-art"><img id="card-modal-image" alt="" /></div>
       <div class="card-copy">
         <h2 class="card-name" id="card-modal-name"></h2>
@@ -2759,13 +2759,13 @@
     </section>
   </div>
   <div class="action-modal" id="action-modal" hidden>
-    <section class="action-dialog" role="dialog" aria-modal="true" aria-labelledby="action-modal-title" tabindex="-1">
+    <section class="action-dialog" role="dialog" aria-modal="true" aria-labelledby="action-modal-title" tabindex="-1" data-player-concept="action">
       <div class="action-art"><img id="action-modal-image" alt="" /></div>
       <h2 class="action-title" id="action-modal-title"></h2>
       <div class="action-summary" id="action-modal-summary"></div>
       <div class="action-meta" id="action-modal-meta"></div>
       <div class="action-choice-list" id="action-modal-choices" hidden></div>
-      <button class="action-confirm" id="action-modal-confirm" type="button">confirm</button>
+      <button class="action-confirm" id="action-modal-confirm" type="button" data-analytics-event="action.confirm">confirm</button>
       <button class="action-cancel" type="button" data-action-close>cancel</button>
     </section>
   </div>
@@ -3818,8 +3818,8 @@
           targetName: oneChat ? firstTargetName : "",
           orbCost: chatUsesOrbs ? chatCostValue : 0,
           modalSummary: oneChat
-            ? `Play Chat to start a short conversation with ${firstTargetName}. The card passes the room turn immediately while the conversation unfolds.`
-            : "Choose someone nearby, then play Chat. The card passes the room turn immediately while the conversation unfolds.",
+            ? `Play Chat to start a short conversation with ${firstTargetName}. The action passes the room turn immediately while the conversation unfolds.`
+            : "Choose someone nearby, then play Chat. The action passes the room turn immediately while the conversation unfolds.",
           effect: oneChat
             ? `you and ${firstTargetName} trade a few lines after the room turn passes`
             : "the chosen conversation unfolds after the room turn passes",
@@ -5258,7 +5258,7 @@
           }
           packId = confirmed.receipt?.pack_id || packId;
         }
-        if (!packId) throw new Error("Box did not create a pack.");
+        if (!packId) throw new Error("Box did not create an avatar bundle.");
         await openPack(packId);
       } finally {
         openingBoxId = "";
@@ -5270,21 +5270,21 @@
       if (!walletSession) {
         const connected = await connectWallet();
         if (!connected) {
-          setError("Connect a wallet to open this pack.");
+          setError("Connect a wallet to open this avatar bundle.");
           return;
         }
       }
       setError("");
-      setStatus("Opening pack...", "ok");
+      setStatus("Opening avatar bundle...", "ok");
       const opened = await post("/nft/packs/open", {
         wallet_session: walletSession,
         pack_id: packId,
       });
       if (!opened.ok) {
-        throw new Error(opened.error || "Pack could not be opened.");
+        throw new Error(opened.error || "Avatar bundle could not be opened.");
       }
       const cards = opened.opening?.card_ids || [];
-      setStatus(cards.length ? `Opened pack: ${cards.join(", ")}` : "Opened pack.", "ok");
+      setStatus(cards.length ? `Opened avatar bundle: ${cards.join(", ")}` : "Opened avatar bundle.", "ok");
       focusIndex = 0;
       focusedKey = "";
       accountPanelPinned = true;
@@ -5986,7 +5986,7 @@
       const roomHeroImage = $("room-hero-image");
       roomHeroImage.src = locationArt;
       roomHeroImage.alt = locationCard?.display_name || location.name || "";
-      roomHeroCard.setAttribute("aria-label", `Open ${locationCard?.display_name || location.name || "current location"} card`);
+      roomHeroCard.setAttribute("aria-label", `Open ${locationCard?.display_name || location.name || "current location"} keepsake`);
       setCardTarget(roomHeroCard, locationCard);
       $("room-avatar-rail").innerHTML = roomAvatarRailHtml(state);
       $("subtitle").textContent = location.name || "Unknown";
@@ -6022,7 +6022,7 @@
       }
       if (!compact) {
         if (boxes) parts.push(`${boxes} ${boxes === 1 ? "box" : "boxes"}`);
-        if (packs) parts.push(`${packs} ${packs === 1 ? "pack" : "packs"}`);
+        if (packs) parts.push(`${packs} ${packs === 1 ? "bundle" : "bundles"}`);
       }
       parts.push(accountPanelPinned ? "close" : "account");
       const economyNode = $("economy");
@@ -6030,8 +6030,8 @@
       economyNode.setAttribute(
         "aria-label",
         accountPanelPinned
-          ? "Close your collection and return to room chat"
-          : `Open your collection: ${orbs} Orbs, ${boxes} Boxes, and ${packs} unopened packs`
+          ? "Close your keepsake collection and return to room chat"
+          : `Open your keepsake collection: ${orbs} Orbs, ${boxes} Boxes, and ${packs} unopened avatar bundles`
       );
       economyNode.setAttribute("aria-expanded", accountPanelPinned ? "true" : "false");
       economyNode.classList.toggle("focused", Boolean(accountPanelPinned));
@@ -6072,7 +6072,11 @@
         exit.access_reason,
         exit.kicker,
       ].map((value) => String(value || "").trim().toLowerCase()).filter(Boolean).join(" ");
-      return text.includes("card locked") || text.includes("wallet needed") || text.includes("card required");
+      return text.includes("pass required")
+        || text.includes("access required")
+        || text.includes("card locked")
+        || text.includes("wallet needed")
+        || text.includes("card required");
     }
 
     function cardForLocationInView(view, id) {
@@ -6097,7 +6101,7 @@
         const you = actor.id === actorId;
         const evolved = Number(actor.stats?.level || 1) > 1;
         const label = you ? `${actorLabel(actor)} (you)` : actorLabel(actor);
-        return `<button class="room-avatar-pfp${you ? " you" : ""}${evolved ? " evolved" : ""}" type="button"${cardDataAttr(card)} title="${escapeAttr(label)}" aria-label="Open ${escapeAttr(label)} card"${backgroundImageStyle(image)}></button>`;
+        return `<button class="room-avatar-pfp${you ? " you" : ""}${evolved ? " evolved" : ""}" type="button"${cardDataAttr(card)} title="${escapeAttr(label)}" aria-label="Open ${escapeAttr(label)} keepsake" data-player-concept="keepsake" data-analytics-event="keepsake.open"${backgroundImageStyle(image)}></button>`;
       });
       const remaining = actors.length - visible.length;
       if (remaining > 0) {
@@ -6484,7 +6488,7 @@
         return finishSentence(actor ? `${actor}: ${text}` : text);
       }
       if (kind === "hand") {
-        if (/^new cards$/i.test(text)) return "A fresh hand of cards is ready.";
+        if (/^new cards$/i.test(text)) return "A fresh hand of actions is ready.";
         return finishSentence(text);
       }
       if (kind === "search") {
@@ -6598,7 +6602,7 @@
         return { kind: "move", label: "locked", text: event.destination_location_name || "path blocked" };
       }
       if (event.type === "hand.shuffled") {
-        return { kind: "hand", label: "hand", text: "new cards" };
+        return { kind: "hand", label: "hand", text: "new actions" };
       }
       if (event.type === "turn.ping_started") {
         const actor = event.actor_name || "someone";
@@ -6761,7 +6765,7 @@
       const bundleDetails = bundle
         ? `<details class="library-technical"><summary>bundle details</summary><code>${escapeHtml(bundle)}</code></details>`
         : "";
-      return `<section class="account-panel library-panel" aria-labelledby="world-library-title"><div class="library-heading"><h2 id="world-library-title">world library</h2><small>${escapeHtml(`${packs.length} worlds and packs`)}</small></div><div class="library-intro">See where your story can travel. Open worlds are ready now; locked places show the card or collection that will let you enter.</div>${worldChronicleHtml()}<div class="library-grid">${cards}</div>${bundleDetails}</section>`;
+      return `<section class="account-panel library-panel" aria-labelledby="world-library-title"><div class="library-heading"><h2 id="world-library-title">world library</h2><small>${escapeHtml(`${packs.length} world packs mounted`)}</small></div><div class="library-intro">See where your story can travel. Open worlds are ready now; locked places name the pass or access they need.</div>${worldChronicleHtml()}<div class="library-grid">${cards}</div>${bundleDetails}</section>`;
     }
 
     function worldChronicleHtml() {
@@ -6798,8 +6802,11 @@
       const locations = Array.isArray(pack.locations) ? pack.locations : [];
       const shownLocations = locations.slice(0, 6).map((location) => {
         const open = location.accessible !== false;
-        const stateLabel = open ? "open" : (location.required_card_id ? "card required" : "access required");
-        return `<div class="library-location${open ? " accessible" : ""}"><span>${escapeHtml(location.name || `Location ${location.id}`)}</span><span class="library-location-state">${escapeHtml(stateLabel)}</span></div>`;
+        const stateLabel = open ? "open" : (location.required_card_id ? "pass required" : "access required");
+        const conceptAttr = open
+          ? 'data-player-concept="world-pack"'
+          : 'data-player-concept="pass"';
+        return `<div class="library-location${open ? " accessible" : ""}" ${conceptAttr}><span>${escapeHtml(location.name || `Location ${location.id}`)}</span><span class="library-location-state">${escapeHtml(stateLabel)}</span></div>`;
       }).join("");
       const remaining = Math.max(0, locations.length - 6);
       const locationList = shownLocations
@@ -6811,13 +6818,13 @@
       const authority = libraryPackAuthoritySummary(pack);
       const badgeLabel = stateName === "partial" ? "some open" : (stateName === "included" ? "included" : stateName);
       const technical = [
-        `${pack.kind || "pack"} · v${pack.version || "?"} · ${pack.license || "unlicensed"}${dependencies}`,
+        `${pack.kind || "world pack"} · v${pack.version || "?"} · ${pack.license || "unlicensed"}${dependencies}`,
         authority,
       ].filter(Boolean).join(" · ");
       const technicalDetails = technical
         ? `<details class="library-technical"><summary>technical details</summary><div>${escapeHtml(technical)}</div></details>`
         : "";
-      return `<article class="library-pack"><div class="library-pack-top"><div><div class="library-pack-name">${escapeHtml(pack.name || pack.id)}</div><div class="library-pack-meta">${escapeHtml(pack.kind || "pack")}</div></div><span class="library-access-badge ${escapeAttr(stateName)}">${escapeHtml(badgeLabel)}</span></div><div class="library-pack-copy">${escapeHtml(pack.description || "No description yet.")}</div><div class="library-pack-counts">${escapeHtml(libraryPackCountSummary(pack.resource_counts || {}))}</div><div class="library-pack-access">${escapeHtml(pack.access_summary || "Included with this world.")}</div>${locationList}${technicalDetails}</article>`;
+      return `<article class="library-pack" data-player-concept="world-pack"><div class="library-pack-top"><div><div class="library-pack-name">${escapeHtml(pack.name || pack.id)}</div><div class="library-pack-meta">${escapeHtml(pack.kind || "world pack")}</div></div><span class="library-access-badge ${escapeAttr(stateName)}">${escapeHtml(badgeLabel)}</span></div><div class="library-pack-copy">${escapeHtml(pack.description || "No description yet.")}</div><div class="library-pack-counts">${escapeHtml(libraryPackCountSummary(pack.resource_counts || {}))}</div><div class="library-pack-access">${escapeHtml(pack.access_summary || "Included with this world.")}</div>${locationList}${technicalDetails}</article>`;
     }
 
     function libraryPackAuthoritySummary(pack) {
@@ -6847,8 +6854,8 @@
         ["locations", "places"],
         ["actors", "residents"],
         ["items", "items"],
-        ["cards", "cards"],
-        ["external_cards", "catalog cards"],
+        ["cards", "keepsakes"],
+        ["external_cards", "catalog keepsakes"],
         ["character_creation", "character paths"],
         ["rules", "rules references"],
         ["assets", "asset collections"],
@@ -6857,7 +6864,7 @@
         .map(([key, label]) => [Number(counts[key] || 0), label])
         .filter(([count]) => count > 0)
         .map(([count, label]) => `${count} ${label}`);
-      return visible.length ? visible.join(" · ") : "metadata-only pack";
+      return visible.length ? visible.join(" · ") : "metadata-only world pack";
     }
 
     function pendingConversationHtml() {
@@ -6877,7 +6884,7 @@
       if (actionBusy && pendingAction?.kind === "orb-chat") return "";
       return pendingChats.map((chat) => {
         const speaker = chat.targetName || "Someone nearby";
-        const aria = `${speaker} is finding the thread. Your next cards are ready while the conversation unfolds.`;
+        const aria = `${speaker} is finding the thread. Your next actions are ready while the conversation unfolds.`;
         return `<div class="line chat npc pending" role="status" aria-label="${escapeAttr(aria)}">${chatPfpHtml({ actor_id: chat.targetActorId }, speaker)}<span class="speaker">${escapeHtml(speaker)}</span><span class="text" aria-hidden="true"><span class="chat-thinking-dots"><i></i><i></i><i></i></span>finding the thread…</span></div>`;
       }).join("");
     }
@@ -6898,7 +6905,7 @@
       const hasAvatar = Boolean(actorId && state?.primary_action?.kind !== "create_avatar");
       const kicker = hasAvatar ? "the room is listening" : "a new tale is waiting";
       const cue = hasAvatar
-        ? "Choose a card below. Someone here will answer."
+        ? "Choose an action below. Someone here will answer."
         : "Begin with the trouble you can't resist.";
       const aria = `${kicker}. ${beat} ${cue}`;
       return `<div class="room-scene" role="note" aria-label="${escapeAttr(aria)}"><span class="room-scene-kicker">${escapeHtml(kicker)}</span><span class="room-scene-text">${escapeHtml(beat)}</span><span class="room-scene-cue">${escapeHtml(cue)}</span></div>`;
@@ -6944,16 +6951,16 @@
             ? "all three kept close"
             : `room for ${smallNumberWord(keepsakeCapacity - equippedCardIds.length)} more`}`
           : "choose a few to keep close"),
-        accountRow("cards", ownedCards.length ? `${smallNumberWord(ownedCards.length)} in your collection` : "waiting to be found"),
+        accountRow("collection", ownedCards.length ? `${smallNumberWord(ownedCards.length)} keepsakes gathered` : "waiting to be found"),
         accountRow("boxes", boxes.length ? `${smallNumberWord(boxes.length)} waiting to open` : "a wooden box may turn up"),
-        accountRow("packs", packs.length ? `${smallNumberWord(packs.length)} waiting to open` : "an avatar pack may turn up"),
+        accountRow("bundles", packs.length ? `${smallNumberWord(packs.length)} waiting to open` : "an avatar bundle may turn up"),
       ];
       for (const receipt of receipts.slice(0, 3)) {
-        inventoryRows.push(accountRow("opened box", "a wooden box became an avatar pack"));
+        inventoryRows.push(accountRow("opened box", "a wooden box became an avatar bundle"));
       }
       for (const opening of openings.slice(0, 3)) {
         const cards = (opening.card_ids || []).map(cardDisplayName).join(", ");
-        inventoryRows.push(accountRow("opened pack", cards || "a few new cards"));
+        inventoryRows.push(accountRow("opened bundle", cards || "a few new keepsakes"));
       }
       const actions = [];
       if (signed) {
@@ -6961,15 +6968,15 @@
           actions.push(`<button class="account-button secondary" type="button" data-account-open-box="first">open box</button>`);
         }
         if (packs.length) {
-          actions.push(`<button class="account-button secondary" type="button" data-account-open-pack="first">open pack</button>`);
+          actions.push(`<button class="account-button secondary" type="button" data-account-open-pack="first" data-player-concept="bundle" data-analytics-event="bundle.open">open bundle</button>`);
         }
       }
       const inventory = assets.length
         ? `<div class="account-assets">${assets.join("")}</div>`
-        : `<div class="account-empty">your collection is waiting for its first card</div>`;
+        : `<div class="account-empty">your collection is waiting for its first keepsake</div>`;
       const accountActions = actions.length ? `<div class="account-actions">${actions.join("")}</div>` : "";
       const keepsakeNote = ownedCards.length
-        ? `<div class="keepsake-note">Keep a few cards close—up to three. They help the choices they care about turn up sooner in your hand.</div>`
+        ? `<div class="keepsake-note">Keep a few keepsakes close—up to three. They help the choices they care about turn up sooner in your hand.</div>`
         : "";
       const accountName = identity?.authenticated
         ? "CosyWorld account"
@@ -7005,7 +7012,7 @@
       const avatarBlurb = String(avatarCard?.blurb || avatar?.description || "").trim();
       const avatarImage = cardImage(avatarCard);
       const portrait = avatarImage
-        ? `<button class="account-portrait" type="button"${cardDataAttr(avatarCard)} aria-label="Open ${escapeAttr(avatarName)} card"><img src="${escapeAttr(avatarImage)}" alt="" /></button>`
+        ? `<button class="account-portrait" type="button"${cardDataAttr(avatarCard)} aria-label="Open ${escapeAttr(avatarName)} keepsake" data-player-concept="keepsake" data-analytics-event="keepsake.open"><img src="${escapeAttr(avatarImage)}" alt="" /></button>`
         : "";
       const identity = `<div class="account-identity${portrait ? "" : " no-portrait"}">${portrait}<div class="account-identity-copy"><span class="account-identity-name">${escapeHtml(avatarName)}</span>${avatarTitle ? `<span class="account-identity-title">${escapeHtml(avatarTitle)}</span>` : ""}${avatarBlurb ? `<span class="account-identity-blurb">${escapeHtml(avatarBlurb)}</span>` : ""}</div></div>`;
       const purpose = String(state?.calling?.statement || "").trim() || "still choosing what trouble to get into";
@@ -7048,8 +7055,8 @@
     }
 
     function accountPackCard(packId) {
-      const image = fallbackCardImage(accountCard("Avatar Pack"));
-      return `<div class="account-asset"><img src="${escapeAttr(image)}" alt="Avatar Pack" data-card-key="pack:${escapeAttr(packId)}" /><div class="account-asset-title">${emojiHtml("🎴")}Avatar Pack</div><div class="account-asset-subtitle">${escapeHtml(compactAssetId(packId))}</div><button class="account-button secondary" type="button" data-account-open-pack="${escapeAttr(packId)}">open pack</button></div>`;
+      const image = fallbackCardImage(accountCard("Avatar Bundle"));
+      return `<div class="account-asset" data-player-concept="bundle"><img src="${escapeAttr(image)}" alt="Avatar Bundle" data-card-key="pack:${escapeAttr(packId)}" /><div class="account-asset-title">${emojiHtml("🎴")}Avatar Bundle</div><div class="account-asset-subtitle">${escapeHtml(compactAssetId(packId))}</div><button class="account-button secondary" type="button" data-account-open-pack="${escapeAttr(packId)}" data-analytics-event="bundle.open">open bundle</button></div>`;
     }
 
     function accountOwnedCard(card) {
@@ -7059,9 +7066,9 @@
       const full = equippedCardIds.length >= keepsakeCapacity;
       const rarity = friendlyCardRarity(card.rarity);
       const buttonLabel = equipped ? "put away" : "keep close";
-      const cardName = card.display_name || card.card_id || "Owned card";
+      const cardName = card.display_name || card.card_id || "Owned keepsake";
       const cardNameHtml = `${emojiHtml(cardEmoji(card, shape))}${escapeHtml(cardName)}`;
-      return `<div class="account-asset owned-card ${escapeAttr(shape)}${equipped ? " kept-close" : ""}"><button class="account-card-open" type="button"${cardDataAttr(card)} aria-label="Open ${escapeAttr(cardName)} card details"><img src="${escapeAttr(image)}" alt="" /></button><div class="account-asset-title">${cardNameHtml}</div><div class="account-asset-subtitle">${escapeHtml(rarity)} · ${escapeHtml(card.title || card.role || "card")}</div><div class="account-asset-effect"><span>when kept close</span>${escapeHtml(keepsakePromise(card))}</div><button class="account-button secondary" type="button" data-account-toggle-keepsake="${escapeAttr(card.card_id || "")}"${!equipped && full ? " disabled" : ""}>${buttonLabel}</button></div>`;
+      return `<div class="account-asset owned-card ${escapeAttr(shape)}${equipped ? " kept-close" : ""}" data-player-concept="keepsake"><button class="account-card-open" type="button"${cardDataAttr(card)} aria-label="Open ${escapeAttr(cardName)} keepsake details" data-analytics-event="keepsake.open"><img src="${escapeAttr(image)}" alt="" /></button><div class="account-asset-title">${cardNameHtml}</div><div class="account-asset-subtitle">${escapeHtml(rarity)} · ${escapeHtml(card.title || card.role || "keepsake")}</div><div class="account-asset-effect"><span>when kept close</span>${escapeHtml(keepsakePromise(card))}</div><button class="account-button secondary" type="button" data-account-toggle-keepsake="${escapeAttr(card.card_id || "")}" data-analytics-event="keepsake.toggle"${!equipped && full ? " disabled" : ""}>${buttonLabel}</button></div>`;
     }
 
     function boxImageUrl(boxId, stateName = "closed") {
@@ -7072,7 +7079,7 @@
       const empty = [
         "waiting to be found",
         "a wooden box may turn up",
-        "an avatar pack may turn up",
+        "an avatar bundle may turn up",
         "your first little moment is waiting",
         "ability training will grow here",
         "someone new is waiting to meet you",
@@ -7742,7 +7749,7 @@
           card_id: boxId,
           display_name: "Intricately Carved Wooden Box",
           title: "sealed world seed",
-          blurb: "A little wooden box with a fresh pack of avatar cards tucked inside.",
+          blurb: "A little wooden box with a fresh bundle of avatar keepsakes tucked inside.",
           rarity: "mystery",
           role: "item",
           aspect: "square",
@@ -7755,15 +7762,15 @@
         const packId = key.slice(5);
         return {
           card_id: packId,
-          display_name: "Avatar Pack",
-          title: "unopened card pack",
-          blurb: "A fresh pack of avatar cards waiting to be opened.",
+          display_name: "Avatar Bundle",
+          title: "unopened keepsake bundle",
+          blurb: "A fresh bundle of avatar keepsakes waiting to be opened.",
           rarity: "pack",
           role: "item",
           aspect: "square",
           source: "cosyworld_pack",
           owned: true,
-          image_url: fallbackCardImage(accountCard("Avatar Pack")),
+          image_url: fallbackCardImage(accountCard("Avatar Bundle")),
         };
       }
       for (const group of [state?.cards?.actors, state?.cards?.items, state?.cards?.locations, state?.account?.owned_cards]) {
@@ -7987,8 +7994,8 @@
       const dialog = $("card-modal").querySelector(".card-dialog");
       dialog?.classList.toggle("portrait-card", shapeForCard(card) === "avatar");
       $("card-modal-image").src = image;
-      $("card-modal-image").alt = card.display_name || "CosyWorld card";
-      $("card-modal-name").innerHTML = `${emojiHtml(cardEmoji(card))}${escapeHtml(card.display_name || "CosyWorld Card")}`;
+      $("card-modal-image").alt = card.display_name || "CosyWorld keepsake";
+      $("card-modal-name").innerHTML = `${emojiHtml(cardEmoji(card))}${escapeHtml(card.display_name || "CosyWorld Keepsake")}`;
       $("card-modal-title").textContent = card.title || card.role || "";
       $("card-modal-blurb").textContent = card.blurb || "";
       const meta = [
@@ -8059,7 +8066,7 @@
 
     function keepsakePromise(card) {
       if (["cosyworld_box", "cosyworld_pack"].includes(card?.source)) return "";
-      const name = String(card?.display_name || card?.card_id || "This card").trim();
+      const name = String(card?.display_name || card?.card_id || "This keepsake").trim();
       if (shapeForCard(card) === "avatar") {
         return `${name} and other chats, friendships, and trades turn up sooner.`;
       }
@@ -8514,7 +8521,7 @@
         : role === "item"
           ? "<circle cx='160' cy='88' r='44' fill='#efc96b' opacity='.28'/><path d='M121 99 C134 65 186 65 199 99 C183 116 137 116 121 99 Z' fill='#d8f7dc' opacity='.72'/><circle cx='160' cy='91' r='18' fill='#efc96b' opacity='.82'/>"
           : "<circle cx='160' cy='74' r='36' fill='#d8f7dc' opacity='.72'/><path d='M88 150 C102 108 128 95 160 95 C192 95 218 108 232 150 Z' fill='#65e68a' opacity='.38'/><path d='M112 78 C130 45 190 45 208 78' fill='none' stroke='#efc96b' stroke-width='8' stroke-linecap='round' opacity='.82'/>";
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180" role="img" aria-label="CosyWorld mini card art"><defs><radialGradient id="glow" cx="50%" cy="35%" r="65%"><stop offset="0" stop-color="#efc96b" stop-opacity=".24"/><stop offset="1" stop-color="${color}" stop-opacity="0"/></radialGradient></defs><rect width="320" height="180" fill="${color}"/><rect width="320" height="180" fill="url(#glow)"/><rect x="10" y="10" width="300" height="160" fill="none" stroke="#efc96b" stroke-width="4" opacity=".82"/>${motif}</svg>`;
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180" role="img" aria-label="CosyWorld keepsake art"><defs><radialGradient id="glow" cx="50%" cy="35%" r="65%"><stop offset="0" stop-color="#efc96b" stop-opacity=".24"/><stop offset="1" stop-color="${color}" stop-opacity="0"/></radialGradient></defs><rect width="320" height="180" fill="${color}"/><rect width="320" height="180" fill="url(#glow)"/><rect x="10" y="10" width="300" height="160" fill="none" stroke="#efc96b" stroke-width="4" opacity=".82"/>${motif}</svg>`;
       return `data:image/svg+xml,${encodeURIComponent(svg).replaceAll("'", "%27")}`;
     }
 
@@ -9091,7 +9098,7 @@
       return {
         label: "more",
         detail: actorId
-          ? `${otherCardCount} other ${otherCardCount === 1 ? "card" : "cards"}`
+          ? `${otherCardCount} other ${otherCardCount === 1 ? "action" : "actions"}`
           : "after avatar",
         focusKey: "shuffle-hand",
         cardType: "shuffle",
@@ -9157,7 +9164,7 @@
         if (canShowShuffleAction()) {
           renderButton("shuffle", {
             label: "more",
-            detail: "new cards",
+            detail: "new actions",
             cardType: "shuffle",
             busy: true,
           });
@@ -9416,7 +9423,7 @@
         event.preventDefault();
         const cardId = keepsake.getAttribute("data-account-toggle-keepsake") || "";
         if (!toggleKeepsakeCard(cardId)) {
-          setError(`Keep at most ${keepsakeCapacity} cards close.`);
+          setError(`Keep at most ${keepsakeCapacity} keepsakes close.`);
         } else {
           setError("");
         }
@@ -9448,8 +9455,8 @@
           card: cardByKey(`box:${boxId}`),
           shape: "item",
           modalTitle: "burn this Box?",
-          modalSummary: "This permanently destroys the on-chain Box. After confirmation, it becomes one avatar-card pack.",
-          effect: "one unopened avatar-card pack joins this account",
+          modalSummary: "This permanently destroys the on-chain Box. After confirmation, it becomes one avatar keepsake bundle.",
+          effect: "one unopened avatar keepsake bundle joins this account",
           risk: "the Box burn is irreversible",
           run: () => openBox(boxId),
         });
@@ -9463,7 +9470,7 @@
         if (!packId) return;
         accountPanelPinned = true;
         runAction({
-          label: "open pack",
+          label: "open bundle",
           detail: compactAssetId(packId),
           card: cardByKey(`pack:${packId}`),
           shape: "item",

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -10843,7 +10843,7 @@ impl RuntimeWorld {
                         if let Some(ledger_event) = self.mark_visit_ledger(
                             action.actor_id,
                             "feature",
-                            "You recorded a card observation.",
+                            "You recorded a room detail.",
                             event.seq,
                             &format!("feature_search:{location_id}:{feature_key}"),
                         ) {
@@ -10900,7 +10900,7 @@ impl RuntimeWorld {
                         if let Some(ledger_event) = self.mark_visit_ledger(
                             action.actor_id,
                             "location",
-                            "You observed the location card.",
+                            "You noticed what this place keeps.",
                             event.seq,
                             &format!("location_search:{location_id}"),
                         ) {
@@ -21928,7 +21928,7 @@ impl RuntimeWorld {
             "tag.cleared" if event.tag_label.as_deref() == Some("tired") => {
                 format!("{actor_name} took a proper breath.")
             }
-            _ => format!("{actor_name} played a card and changed the room a little."),
+            _ => format!("{actor_name} chose an action and changed the room a little."),
         }
     }
 
@@ -25197,7 +25197,7 @@ async fn pack_open(
             ok: false,
             status: 503,
             opening: None,
-            error: Some("event store is required for pack opening".to_string()),
+            error: Some("event store is required for avatar bundle opening".to_string()),
         });
     };
     let Some(wallet_address) = payload
@@ -25217,7 +25217,7 @@ async fn pack_open(
             ok: false,
             status: 400,
             opening: None,
-            error: Some("pack id is required".to_string()),
+            error: Some("avatar bundle id is required".to_string()),
         });
     };
 
@@ -25238,7 +25238,7 @@ async fn pack_open(
                 ok: false,
                 status: 409,
                 opening: None,
-                error: Some("pack already opened by another wallet".to_string()),
+                error: Some("avatar bundle already opened by another wallet".to_string()),
             });
         }
         Ok(None) => {}
@@ -25273,7 +25273,7 @@ async fn pack_open(
                 ok: false,
                 status: 403,
                 opening: None,
-                error: Some("pack receipt belongs to another wallet".to_string()),
+                error: Some("avatar bundle receipt belongs to another wallet".to_string()),
             });
         }
         if receipt.status != "burned" {
@@ -25281,7 +25281,7 @@ async fn pack_open(
                 ok: false,
                 status: 409,
                 opening: None,
-                error: Some("pack is not unopened".to_string()),
+                error: Some("avatar bundle is not unopened".to_string()),
             });
         }
     } else if !trusted_pack {
@@ -25289,7 +25289,7 @@ async fn pack_open(
             ok: false,
             status: 403,
             opening: None,
-            error: Some("pack is not active in the trusted ownership feed".to_string()),
+            error: Some("avatar bundle is not active in the trusted ownership feed".to_string()),
         });
     }
 
@@ -30768,7 +30768,7 @@ fn resident_system_prompt(plan: &ResidentReplyPlan) -> String {
         .starts_with("This is the player avatar's own immediate")
     {
         return format!(
-            "You are {}, the player avatar in CosyWorld. Write their immediate first-person in-character response to the card they just played. React to the concrete outcome instead of narrating the rules or inventing another action. Keep it under 34 words. {base}",
+            "You are {}, the player avatar in CosyWorld. Write their immediate first-person in-character response to the action they just chose. React to the concrete outcome instead of narrating the rules or inventing another action. Keep it under 34 words. {base}",
             plan.npc_name
         );
     }
@@ -33808,7 +33808,7 @@ fn optional_asset_placeholder(mount: &SeedAssetMount, relative_path: &str) -> Re
         mount.provider, mount.public_prefix, relative_path
     );
     let svg = format!(
-        "<svg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400' role='img' aria-label='Missing pack asset'><rect width='640' height='400' fill='#161d22'/><rect x='18' y='18' width='604' height='364' rx='22' fill='none' stroke='#efc96b' stroke-width='4'/><text x='320' y='178' text-anchor='middle' font-family='ui-monospace,monospace' font-size='28' fill='#efc96b'>PACK ASSET UNAVAILABLE</text><text x='320' y='224' text-anchor='middle' font-family='ui-monospace,monospace' font-size='16' fill='#d8f7dc'>{}</text></svg>",
+        "<svg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400' role='img' aria-label='Missing world pack asset'><rect width='640' height='400' fill='#161d22'/><rect x='18' y='18' width='604' height='364' rx='22' fill='none' stroke='#efc96b' stroke-width='4'/><text x='320' y='178' text-anchor='middle' font-family='ui-monospace,monospace' font-size='28' fill='#efc96b'>WORLD PACK ASSET UNAVAILABLE</text><text x='320' y='224' text-anchor='middle' font-family='ui-monospace,monospace' font-size='16' fill='#d8f7dc'>{}</text></svg>",
         escape_xml(&format!("{}: {}", mount.pack_id, relative_path))
     );
     (
@@ -33829,7 +33829,7 @@ fn optional_asset_placeholder(mount: &SeedAssetMount, relative_path: &str) -> Re
 fn unavailable_asset_provider_placeholder(public_path: &str) -> Response {
     let diagnostic = format!("no active asset provider for {public_path}");
     let svg = format!(
-        "<svg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400' role='img' aria-label='Unavailable pack asset provider'><rect width='640' height='400' fill='#161d22'/><rect x='18' y='18' width='604' height='364' rx='22' fill='none' stroke='#efc96b' stroke-width='4'/><text x='320' y='178' text-anchor='middle' font-family='ui-monospace,monospace' font-size='25' fill='#efc96b'>ASSET PROVIDER NOT MOUNTED</text><text x='320' y='224' text-anchor='middle' font-family='ui-monospace,monospace' font-size='14' fill='#d8f7dc'>{}</text></svg>",
+        "<svg xmlns='http://www.w3.org/2000/svg' width='640' height='400' viewBox='0 0 640 400' role='img' aria-label='Unavailable world pack asset provider'><rect width='640' height='400' fill='#161d22'/><rect x='18' y='18' width='604' height='364' rx='22' fill='none' stroke='#efc96b' stroke-width='4'/><text x='320' y='178' text-anchor='middle' font-family='ui-monospace,monospace' font-size='25' fill='#efc96b'>WORLD PACK PROVIDER NOT MOUNTED</text><text x='320' y='224' text-anchor='middle' font-family='ui-monospace,monospace' font-size='14' fill='#d8f7dc'>{}</text></svg>",
         escape_xml(public_path)
     );
     (
@@ -34185,7 +34185,7 @@ fn generated_seed_card_svg(spec: &SeedCardArtSpec) -> String {
     let card_id = escape_xml(&spec.card_id);
 
     format!(
-        "<svg xmlns='http://www.w3.org/2000/svg' width='{width}' height='{height}' viewBox='0 0 {width} {height}' role='img' aria-label='{label} seed card art' data-card-id='{card_id}'><defs><radialGradient id='glow' cx='50%' cy='26%' r='62%'><stop offset='0' stop-color='{accent}' stop-opacity='.36'/><stop offset='1' stop-color='{bg}' stop-opacity='0'/></radialGradient><pattern id='grain' width='12' height='12' patternUnits='userSpaceOnUse'><path d='M0 12L12 0' stroke='{ink}' stroke-opacity='.045' stroke-width='2'/></pattern></defs><rect width='{width}' height='{height}' rx='18' fill='{bg}'/><rect width='{width}' height='{height}' fill='url(#glow)'/><rect width='{width}' height='{height}' fill='url(#grain)'/><rect x='10' y='10' width='{inner_w}' height='{inner_h}' rx='14' fill='none' stroke='{accent}' stroke-width='4' opacity='.78'/><circle cx='{mid_x}' cy='{mid_y}' r='{circle_r}' fill='{accent}' opacity='.16'/><circle cx='{mid_x}' cy='{mid_y}' r='{circle_r2}' fill='none' stroke='{accent}' stroke-width='5' opacity='.75'/><text x='{mid_x}' y='{glyph_y}' text-anchor='middle' font-family='ui-monospace, SFMono-Regular, Menlo, monospace' font-size='{glyph_size}' font-weight='900' fill='{ink}'>{glyph}</text><text x='{mid_x}' y='{label_y}' text-anchor='middle' font-family='ui-monospace, SFMono-Regular, Menlo, monospace' font-size='22' font-weight='850' fill='{accent}'>{label}</text><text x='22' y='34' font-family='ui-monospace, SFMono-Regular, Menlo, monospace' font-size='14' font-weight='800' fill='{ink}' opacity='.72'>{role}</text></svg>",
+        "<svg xmlns='http://www.w3.org/2000/svg' width='{width}' height='{height}' viewBox='0 0 {width} {height}' role='img' aria-label='{label} keepsake art' data-card-id='{card_id}'><defs><radialGradient id='glow' cx='50%' cy='26%' r='62%'><stop offset='0' stop-color='{accent}' stop-opacity='.36'/><stop offset='1' stop-color='{bg}' stop-opacity='0'/></radialGradient><pattern id='grain' width='12' height='12' patternUnits='userSpaceOnUse'><path d='M0 12L12 0' stroke='{ink}' stroke-opacity='.045' stroke-width='2'/></pattern></defs><rect width='{width}' height='{height}' rx='18' fill='{bg}'/><rect width='{width}' height='{height}' fill='url(#glow)'/><rect width='{width}' height='{height}' fill='url(#grain)'/><rect x='10' y='10' width='{inner_w}' height='{inner_h}' rx='14' fill='none' stroke='{accent}' stroke-width='4' opacity='.78'/><circle cx='{mid_x}' cy='{mid_y}' r='{circle_r}' fill='{accent}' opacity='.16'/><circle cx='{mid_x}' cy='{mid_y}' r='{circle_r2}' fill='none' stroke='{accent}' stroke-width='5' opacity='.75'/><text x='{mid_x}' y='{glyph_y}' text-anchor='middle' font-family='ui-monospace, SFMono-Regular, Menlo, monospace' font-size='{glyph_size}' font-weight='900' fill='{ink}'>{glyph}</text><text x='{mid_x}' y='{label_y}' text-anchor='middle' font-family='ui-monospace, SFMono-Regular, Menlo, monospace' font-size='22' font-weight='850' fill='{accent}'>{label}</text><text x='22' y='34' font-family='ui-monospace, SFMono-Regular, Menlo, monospace' font-size='14' font-weight='800' fill='{ink}' opacity='.72'>{role}</text></svg>",
         inner_w = width - 20,
         inner_h = height - 20,
         circle_r = width.min(height) / 4,
@@ -36915,7 +36915,7 @@ fn record_economy_reconciliation(
                 asset_id: asset_id.clone(),
                 external_wallet_address: owners.iter().cloned().collect::<Vec<_>>().join(","),
                 local_wallet_address: None,
-                detail: "The trusted snapshot reports one unopened pack under multiple wallets."
+                detail: "The trusted snapshot reports one unopened avatar bundle under multiple wallets."
                     .to_string(),
             });
         }
@@ -36926,7 +36926,7 @@ fn record_economy_reconciliation(
                 external_wallet_address: owners.iter().next().cloned().unwrap_or_default(),
                 local_wallet_address: Some(local_owner.clone()),
                 detail:
-                    "A pack with a durable opening record is still unopened in the trusted snapshot."
+                    "An avatar bundle with a durable opening record is still unopened in the trusted snapshot."
                         .to_string(),
             });
         }
@@ -39803,7 +39803,7 @@ mod tests {
         assert!(INDEX_HTML.contains("the world beyond"));
         assert!(INDEX_HTML.contains("function localWorldConditionBeat"));
         assert!(INDEX_HTML.contains("accountPanelPinned ? \"close\" : \"account\""));
-        assert!(INDEX_HTML.contains("Close your collection and return to room chat"));
+        assert!(INDEX_HTML.contains("Close your keepsake collection and return to room chat"));
         assert!(INDEX_HTML.contains("accountPanelPinned && event.key === \"Escape\""));
         assert!(!INDEX_HTML.contains("connect ai"));
         assert!(!INDEX_HTML.contains("openrouter_api_key"));
@@ -39882,7 +39882,7 @@ mod tests {
         assert!(INDEX_HTML.contains("if (!actorId || action?.kind !== \"orb-chat\") return 0;"));
         assert!(!INDEX_HTML.contains("reacting to your card…"));
         assert!(!INDEX_HTML.contains("responding to your card…"));
-        assert!(INDEX_HTML.contains("Your next cards are ready while"));
+        assert!(INDEX_HTML.contains("Your next actions are ready while"));
         assert!(INDEX_HTML.contains("return [...(events || [])].slice(-24);"));
         assert!(INDEX_HTML.contains("const tailChanged = chatTailKey !== renderedChatTailKey;"));
         assert!(INDEX_HTML.contains("tailChanged || wasAtBottom"));
@@ -39901,7 +39901,7 @@ mod tests {
         assert!(INDEX_HTML.contains("function quietRoomSceneHtml"));
         assert!(INDEX_HTML.contains("the room is listening"));
         assert!(INDEX_HTML.contains("a new tale is waiting"));
-        assert!(INDEX_HTML.contains("Choose a card below. Someone here will answer."));
+        assert!(INDEX_HTML.contains("Choose an action below. Someone here will answer."));
         assert!(INDEX_HTML.contains("options.has(\"check\") || listenKnownUnattempted"));
         assert!(INDEX_HTML.contains("data-story-guide"));
         assert!(INDEX_HTML.contains("const storyGuideLabel"));
@@ -39958,7 +39958,7 @@ mod tests {
         assert!(INDEX_HTML.contains("button.classList.add(\"has-copy\");"));
         assert!(INDEX_HTML.contains("<span class=\"cmd-copy\"><span class=\"cmd-label\">"));
         assert!(INDEX_HTML.contains("cardImage(card) || fallbackCardImage(fallback)"));
-        assert!(INDEX_HTML.contains("CosyWorld mini card art"));
+        assert!(INDEX_HTML.contains("CosyWorld keepsake art"));
         assert!(INDEX_HTML.contains("function gardenHasDewbright"));
         assert!(INDEX_HTML.contains("A small pearled button catches the light."));
         assert!(INDEX_HTML.contains("where something pearled was lifted away"));
@@ -56184,7 +56184,7 @@ mod tests {
         assert_eq!(homeroom_rule.required_card_id, Some("location-homeroom"));
         assert_eq!(
             homeroom_rule.reason,
-            Some("Ruby High: First Bell location card required.")
+            Some("Ruby High: First Bell location pass required.")
         );
         assert!(!location_access_allowed(11, &public));
         assert!(location_access_allowed(2, &public));
@@ -56247,7 +56247,7 @@ mod tests {
         assert!(!state.cards.locations[&11].accessible);
         assert_eq!(
             state.cards.locations[&11].access_reason.as_deref(),
-            Some("Ruby High: First Bell location card required.")
+            Some("Ruby High: First Bell location pass required.")
         );
 
         let world = runtime.world_response(None, &no_wallet);

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -1938,12 +1938,12 @@ async function main() {
     assert(result.multiResident?.length === 1, `nearby residents should share one choice-bearing Chat card: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.detail === "choose someone · one Orb", `multi-resident Chat should advertise its in-card choice and whole-conversation cost: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.title === "choose someone to talk with", `multi-resident Chat should open a clear target picker: ${JSON.stringify(result)}`);
-    assert(result.multiResident[0]?.summary === "Choose someone nearby, then play Chat. The card passes the room turn immediately while the conversation unfolds.", `multi-resident Chat should explain the card commit and asynchronous conversation: ${JSON.stringify(result)}`);
+    assert(result.multiResident[0]?.summary === "Choose someone nearby, then play Chat. The action passes the room turn immediately while the conversation unfolds.", `multi-resident Chat should explain the action commit and asynchronous conversation: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.choices?.map((choice) => choice.label).join(",") === "Rati,Skull", `the Chat card should carry every eligible resident choice: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.alternateTargetId === 1003, `confirming an alternate Chat choice should address that resident: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.focusKeys?.includes("actor:1001") && result.multiResident[0]?.focusKeys?.includes("actor:1003"), `one Chat card should retain affinity for every resident it can reach: ${JSON.stringify(result)}`);
     assert(result.serverPaid?.title === "talk with Skull", `chat confirmation should name the conversation partner: ${JSON.stringify(result)}`);
-    assert(result.serverPaid?.summary === "Play Chat to start a short conversation with Skull. The card passes the room turn immediately while the conversation unfolds.", `chat confirmation should explain the ordinary card and asynchronous conversation: ${JSON.stringify(result)}`);
+    assert(result.serverPaid?.summary === "Play Chat to start a short conversation with Skull. The action passes the room turn immediately while the conversation unfolds.", `chat confirmation should explain the ordinary action and asynchronous conversation: ${JSON.stringify(result)}`);
     assert(result.serverPaid?.rows?.some((row) => row[0] === "Costs" && row[1] === "one Orb for the whole exchange"), `chat confirmation should spell out the single cost for every line: ${JSON.stringify(result)}`);
     assert(result.serverPaid?.rows?.some((row) => row[0] === "Conversation" && row[1].includes("one more line")), `chat confirmation should explain the back-and-forth cadence: ${JSON.stringify(result)}`);
     assert(!/reply hook|authors a line|-[0-9]+ Orb/i.test(JSON.stringify(result.serverPaid)), `chat confirmation should hide implementation and subtraction jargon: ${JSON.stringify(result)}`);
@@ -2440,7 +2440,7 @@ async function main() {
         .every((promise) => result.cardPromises.some((copy) => copy.includes(promise))),
       `each Avatar, Item, and Location should explain its own keepsake promise: ${JSON.stringify(result)}`,
     );
-    assert(result.modalPromise.includes("Homeroom, nearby paths, clues, and shared work turn up sooner"), `card details should repeat the keepsake promise: ${JSON.stringify(result)}`);
+    assert(result.modalPromise.includes("Homeroom, nearby paths, clues, and shared work turn up sooner"), `keepsake details should repeat the keepsake promise: ${JSON.stringify(result)}`);
     assert(
       result.guidedButton.highlighted
         && result.guidedButton.guide === "Gust"
@@ -2452,7 +2452,7 @@ async function main() {
     assert(
       result.cardButtons.length === 4
         && result.cardButtons.every((button) => button.tag === "BUTTON" && button.type === "button" && button.label.startsWith("Open ") && button.imageAlt === ""),
-      `owned card art should be a labelled button with decorative nested art: ${JSON.stringify(result)}`,
+      `owned keepsake art should be a labelled button with decorative nested art: ${JSON.stringify(result)}`,
     );
   }
 
@@ -4139,8 +4139,8 @@ async function main() {
     await page.locator("#location-image[data-card-key]").click();
     await page.waitForSelector("#card-modal:not([hidden])");
     const locationCardName = await page.locator("#card-modal-name").innerText();
-    assert(locationCardName.includes("Cosy Cottage"), `location image should open location card modal: ${locationCardName}`);
-    steps.push({ label: "location card modal", card: locationCardName });
+    assert(locationCardName.includes("Cosy Cottage"), `location image should open location keepsake details: ${locationCardName}`);
+    steps.push({ label: "location keepsake details", card: locationCardName });
     await closeCardModal();
 
     await page.locator(".room-avatar-pfp[data-card-key]").first().click();
@@ -5239,7 +5239,7 @@ async function main() {
     });
     const pendingCopy = await page.locator("#log .line.chat.pending").getAttribute("aria-label");
     assert(
-      /is finding the thread\. Your next cards are ready while the conversation unfolds\./.test(pendingCopy || ""),
+      /is finding the thread\. Your next actions are ready while the conversation unfolds\./.test(pendingCopy || ""),
       `queued Orb Chat should announce that play can continue: ${pendingCopy}`,
     );
     steps.push({ label, pending: "queued", cards: "ready" });
@@ -7138,7 +7138,7 @@ async function main() {
       `an empty avatar sheet should point warmly toward what comes next: ${guestSheetText}`,
     );
     assert(!/quiet for now|nothing yet|no one yet|\bnone\b|\b\d+ of \d+\b|dev-wallet/i.test(guestSheetText), `avatar sheet should avoid cold empty-state and account shorthand: ${guestSheetText}`);
-    assert(guestSheetText.includes("a wooden box may turn up") && guestSheetText.includes("an avatar pack may turn up"), `empty collection slots should suggest possibility instead of absence: ${guestSheetText}`);
+    assert(guestSheetText.includes("a wooden box may turn up") && guestSheetText.includes("an avatar bundle may turn up"), `empty collection slots should suggest possibility instead of absence: ${guestSheetText}`);
     assert(guestSheetText.includes("local tale") && guestSheetText.includes("choose a few to keep close"), `local tale and empty keepsake capacity should read naturally: ${guestSheetText}`);
     assert(guestSheetText.includes("purpose") && !guestSheetText.includes("calling"), `avatar sheet should use purpose rather than Calling terminology: ${guestSheetText}`);
     assert(guestSheetText.indexOf("purpose") < guestSheetText.indexOf("link account"), `character identity should appear before account controls: ${guestSheetText}`);
@@ -7160,7 +7160,7 @@ async function main() {
     await page.keyboard.press("Enter");
     await page.waitForFunction(() => document.querySelector("#economy")?.getAttribute("aria-expanded") === "true");
     assert((await page.locator("#economy").innerText()).toLowerCase().includes("close"), "open collection toggle should visibly say close");
-    assert((await page.locator("#economy").getAttribute("aria-label")) === "Close your collection and return to room chat", "open collection toggle should announce its close action");
+    assert((await page.locator("#economy").getAttribute("aria-label")) === "Close your keepsake collection and return to room chat", "open keepsake collection toggle should announce its close action");
     await page.keyboard.press("Escape");
     await page.waitForFunction(() => document.querySelector("#economy")?.getAttribute("aria-expanded") === "false");
     assert(await page.evaluate(() => document.activeElement?.id === "economy"), "Escape should close the collection and return focus to its toggle");
@@ -7207,8 +7207,8 @@ async function main() {
     ));
     await focusAccountInventory();
     const signedCollectionText = await page.locator(".account-panel").innerText();
-    assert(signedCollectionText.includes("Homeroom") && signedCollectionText.includes("Library"), `signed collection should show owned location cards before their paths are found: ${signedCollectionText}`);
-    assert(await page.locator(".account-panel .owned-card .account-card-open[data-card-key]").count() >= 2, "signed collection should render owned card art as detail buttons");
+    assert(signedCollectionText.includes("Homeroom") && signedCollectionText.includes("Library"), `signed collection should show owned location keepsakes before their paths are found: ${signedCollectionText}`);
+    assert(await page.locator(".account-panel .owned-card .account-card-open[data-card-key]").count() >= 2, "signed collection should render owned keepsake art as detail buttons");
     assert(await page.locator(".account-panel .owned-card .account-asset-effect").count() >= 2, "signed collection should explain what each kept-close card changes");
     await page.evaluate(() => {
       localStorage.removeItem("cosyworld.wallet");
@@ -7265,7 +7265,7 @@ async function main() {
       accountBeforeText.includes("box-smoke-1") && accountBeforeText.toLowerCase().includes("intricately carved wooden box"),
       `account panel should show active Box before opening: ${accountBeforeText}`,
     );
-    assert(accountBeforeText.includes("Homeroom") && accountBeforeText.includes("Library"), `account panel should show signed location cards alongside the Box: ${accountBeforeText}`);
+    assert(accountBeforeText.includes("Homeroom") && accountBeforeText.includes("Library"), `account panel should show signed location keepsakes alongside the Box: ${accountBeforeText}`);
     const boxArtProbe = await page.evaluate(async () => {
       const image = document.querySelector(".account-panel [data-card-key^='box:']");
       const response = await fetch(image?.getAttribute("src") || "");
@@ -7283,7 +7283,7 @@ async function main() {
     await page.locator(".account-panel [data-account-open-box='box-smoke-1']").click();
     await page.waitForFunction(() => {
       const status = document.querySelector("#error");
-      return status?.classList.contains("ok") && status.textContent.includes("Opened pack");
+      return status?.classList.contains("ok") && status.textContent.includes("Opened avatar bundle");
     });
     await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
     await page.waitForSelector(".account-panel", { state: "visible" });
@@ -7293,7 +7293,7 @@ async function main() {
       return fetch(`/state?wallet_session=${encodeURIComponent(walletSession)}`).then((response) => response.json());
     });
     assert(!(afterBoxOpen.access?.owned_box_ids || []).includes("box-smoke-1"), `opened Box should leave trusted access: ${JSON.stringify(afterBoxOpen.access)}`);
-    assert((afterBoxOpen.access?.unopened_pack_ids || []).length === 0, `opened pack should not remain unopened: ${JSON.stringify(afterBoxOpen.access)}`);
+    assert((afterBoxOpen.access?.unopened_pack_ids || []).length === 0, `opened bundle should not remain unopened: ${JSON.stringify(afterBoxOpen.access)}`);
     assert(
       (afterBoxOpen.access?.owned_card_ids || []).length > (beforeBoxOpen.access?.owned_card_ids || []).length,
       `pack opening should grant avatar cards: ${JSON.stringify({ before: beforeBoxOpen.access, after: afterBoxOpen.access })}`,
@@ -7304,7 +7304,7 @@ async function main() {
       .filter((card) => newlyGrantedIds.includes(card.card_id))
       .map((card) => card.display_name || card.card_id);
     assert(
-      accountAfterText.toLowerCase().includes("opened pack")
+      accountAfterText.toLowerCase().includes("opened bundle")
         && newlyGrantedNames.length === 3
         && newlyGrantedNames.every((name) => accountAfterText.includes(name)),
       `account panel should show every card the weighted pack held: ${JSON.stringify({ newlyGrantedIds, newlyGrantedNames, accountAfterText })}`,

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -118,12 +118,12 @@
     },
     {
       "id": "ruby-high.first-bell",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "source": {
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
+      "integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -226,7 +226,7 @@
     {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {

--- a/v2/worlds/ruby-high-only/pack.lock.json
+++ b/v2/worlds/ruby-high-only/pack.lock.json
@@ -9,12 +9,12 @@
   "packs": [
     {
       "id": "ruby-high.first-bell",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "source": {
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c5ae11c98841738ded0d4516f2496911bf9b1982fd5b756b693afa8d91ed305e",
+      "integrity": "sha256:dcdf2f0ad7394df1e74a36d881c84369aac5de73e6e12f8d41ac7530500da0ab",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -66,7 +66,7 @@
     {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {


### PR DESCRIPTION
## Summary

- define the canonical player lexicon for actions, keepsakes, passes, bundles, and world packs
- apply distinct UI copy, accessibility labels, analytics hooks, entitlement errors, and developer documentation while preserving stable APIs
- add a five-task comprehension regression and regenerate the versioned Ruby/official world-pack artifacts

## Validation

- 406 Node tests passed
- 330 Rust tests passed
- `npm run v2:worldpack`
- `npm run check:version`
- `cargo fmt --check`
- `node --check v2/scripts/smoke-browser.mjs`
- `git diff --check`

## Review checklist

- [x] Player-facing surfaces avoid ambiguous bare card/pack terminology
- [x] Internal identifiers and endpoints remain backward compatible
- [x] Generated world-pack locks and registries are current
- [x] Root and Rust versions are synchronized at 0.0.58

Closes #51