### PR TITLE
Explain avatar defeat and simplify ability upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.58",
+      "version": "0.0.59",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.58"
+version = "0.0.59"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -684,6 +684,17 @@
     .arrival-scene::before {
       animation: arrival-glow 1.6s ease-in-out infinite;
     }
+    .defeat-scene {
+      border-color: rgba(255, 125, 125, 0.24);
+      background:
+        linear-gradient(180deg, rgba(255, 125, 125, 0.055), rgba(239, 201, 107, 0.025)),
+        rgba(8, 14, 10, 0.54);
+    }
+    .defeat-scene::before {
+      content: "◇";
+      color: var(--red);
+    }
+    .defeat-scene .room-scene-cue { color: var(--amber); }
     @keyframes arrival-glow {
       0%, 100% { opacity: 0.45; transform: translateX(-50%) scale(0.88); }
       50% { opacity: 1; transform: translateX(-50%) scale(1.08); }
@@ -2918,6 +2929,9 @@
     let firstTaleStageSeen = 0;
     let firstTaleCelebration = false;
     let firstTaleCompletionSeen = false;
+    const defeatTransitionStorageKey = "cosyworld.defeatTransition";
+    let defeatTransition = wantsReset ? null : loadDefeatTransition();
+    if (wantsReset) sessionStorage.removeItem(defeatTransitionStorageKey);
     const $ = (id) => document.getElementById(id);
     const modalReturnFocus = new Map();
     let walletAddress = bootParams.get("wallet") || bootParams.get("wallet_address") || localStorage.getItem("cosyworld.wallet") || "";
@@ -2939,6 +2953,48 @@
       localStorage.removeItem("cosyworld.actorId");
       localStorage.removeItem("cosyworld.actorSession");
       localStorage.removeItem("cosyworld.avatarGateVersion");
+    }
+
+    function loadDefeatTransition() {
+      try {
+        const stored = JSON.parse(sessionStorage.getItem(defeatTransitionStorageKey) || "null");
+        return stored && typeof stored === "object" ? stored : null;
+      } catch {
+        return null;
+      }
+    }
+
+    function saveDefeatTransition() {
+      try {
+        if (defeatTransition) {
+          sessionStorage.setItem(defeatTransitionStorageKey, JSON.stringify(defeatTransition));
+        } else {
+          sessionStorage.removeItem(defeatTransitionStorageKey);
+        }
+      } catch {
+        // The transition remains visible for this page even when storage is unavailable.
+      }
+    }
+
+    function clearDefeatTransition() {
+      defeatTransition = null;
+      saveDefeatTransition();
+    }
+
+    function captureDefeatTransition(event) {
+      if (
+        !["combat.knockout", "combat.death"].includes(String(event?.type || ""))
+        || !actorId
+        || Number(event.target_actor_id || 0) !== Number(actorId)
+      ) return false;
+      const defeated = actorForId(actorId);
+      defeatTransition = {
+        actorName: event.target_actor_name || defeated?.name || "Your avatar",
+        opponentName: event.actor_name || "the danger",
+        eventSeq: Number(event.seq || 0),
+      };
+      saveDefeatTransition();
+      return true;
     }
 
     function setModalBackgroundInert(inert) {
@@ -3232,6 +3288,7 @@
       localStorage.setItem("cosyworld.actorId", String(actorId));
       if (actorSession) localStorage.setItem("cosyworld.actorSession", actorSession);
       localStorage.setItem("cosyworld.avatarGateVersion", avatarGateVersion);
+      clearDefeatTransition();
       pushEvents(avatar.events || []);
       await pingPresence();
       handKeys = [];
@@ -3565,6 +3622,7 @@
 
     function buildActions(view) {
       if (view.primary_action?.kind === "create_avatar") {
+        const beginningAgain = Boolean(defeatTransition);
         const creationProfile = (view.character_creation || [])[0] || null;
         const creationChoices = creationProfile?.choices?.length
           ? creationProfile.choices.map((choice) => ({
@@ -3580,17 +3638,25 @@
         const defaultChoice = creationProfile?.default_choice_id || authoredCallingChoices[0].statement;
         const action = {
           kind: "avatar-arrival",
-          label: "begin",
-          detail: creationProfile ? `enter ${creationProfile.name}` : "choose what draws you in",
+          label: beginningAgain ? "begin again" : "begin",
+          detail: beginningAgain
+            ? "make a new avatar"
+            : (creationProfile ? `enter ${creationProfile.name}` : "choose what draws you in"),
           command: "create avatar",
           focusKey: "create-avatar",
           card: cardForLocation(view.location?.id),
           shape: "location",
-          modalTitle: creationProfile?.prompt || "what draws you in?",
-          modalSummary: creationProfile?.description || "Pick the sort of trouble your avatar can't resist.",
-          effect: creationProfile
-            ? `begins ${creationProfile.name}`
-            : "brings your new avatar into The Cosy Cottage",
+          modalTitle: beginningAgain
+            ? "begin another tale"
+            : (creationProfile?.prompt || "what draws you in?"),
+          modalSummary: beginningAgain
+            ? "Choose what draws your next avatar into the world."
+            : (creationProfile?.description || "Pick the sort of trouble your avatar can't resist."),
+          effect: beginningAgain
+            ? "starts a new avatar's tale"
+            : (creationProfile
+              ? `begins ${creationProfile.name}`
+              : "brings your new avatar into The Cosy Cottage"),
           choices: creationChoices,
           selectedChoice: defaultChoice,
           busyLabel: "arriving",
@@ -3665,7 +3731,7 @@
           card: cardForActor(actorId) || cardForLocation(view.location?.id),
           shape: "avatar",
           priority: currentRank > 0 && options.has("create_bond") ? 78 : 76,
-          modalTitle: oneAbility ? `practice ${firstAbility.label}` : "choose an ability to practice",
+          modalTitle: oneAbility ? `${firstAbility.label} +1` : "choose an ability",
           modalSummary: oneAbility
             ? `Add +1 to your training bonus for ${firstAbility.label} checks. The ability score itself does not change.`
             : "Choose which ability gets +1 to its check training bonus. The ability score itself does not change.",
@@ -3706,7 +3772,7 @@
         ].join(":");
         const practiceChoices = (practiceAction?.abilityCandidates || [])
           .map((ability) => ({
-            label: `practice ${ability.label}`,
+            label: `${ability.label} +1`,
             detail: `${ability.detail || "use what you learned"} · +1 training bonus to ${ability.label} checks`,
             value: `practice:${ability.id}`,
             card: practiceAction.card,
@@ -3737,7 +3803,7 @@
             ? "choose one of two lessons"
             : (growAction
               ? "from what you learned"
-              : (oneChoice ? "choose an ability to practice" : "choose one of two abilities")),
+              : (oneChoice ? `${(practiceAction?.abilityCandidates || [])[0]?.label || "ability"} +1` : "choose one of two abilities")),
           command: "evolve",
           focusKey: growAction?.focusKey || practiceAction?.focusKey || "evolve",
           focusKeys: [...new Set([
@@ -5667,6 +5733,7 @@
     function pushEvents(events) {
       let changed = false;
       for (const event of events) {
+        if (captureDefeatTransition(event)) changed = true;
         if (applyActionReceipt(event)) {
           changed = true;
           continue;
@@ -6698,13 +6765,14 @@
       const pendingConversation = pendingConversationHtml();
       const pendingChatReplies = pendingChatsHtml();
       const pendingArrival = pendingAvatarArrivalHtml();
+      const defeatScene = defeatTransitionHtml();
       const hasChat = visibleEvents.length > 0 || Boolean(pendingConversation) || Boolean(pendingChatReplies);
       const residentOnly = visibleEvents.length > 0 && visibleEvents.every(messageActorIsResident);
       log.classList.toggle("library-mode", Boolean(libraryPanel));
       log.classList.toggle("account-mode", !libraryPanel && Boolean(accountPanel));
       log.classList.toggle("chat-mode", !libraryPanel && !accountPanel && hasChat);
-      log.classList.toggle("room-mode", !libraryPanel && !accountPanel && !hasChat && !pendingArrival);
-      log.classList.toggle("arrival-mode", !libraryPanel && !accountPanel && Boolean(pendingArrival));
+      log.classList.toggle("room-mode", !libraryPanel && !accountPanel && !hasChat && !pendingArrival && !defeatScene);
+      log.classList.toggle("arrival-mode", !libraryPanel && !accountPanel && Boolean(pendingArrival || defeatScene));
       log.classList.toggle("quiet-mode", !libraryPanel && !accountPanel && residentOnly);
       const panelMode = libraryPanel ? "library" : (accountPanel ? "account" : "");
       document.querySelector(".terminal")?.classList.toggle("panel-open", Boolean(panelMode));
@@ -6727,6 +6795,11 @@
       }
       if (accountPanel) {
         log.innerHTML = accountPanel;
+        log.scrollTop = 0;
+        return;
+      }
+      if (defeatScene) {
+        log.innerHTML = defeatScene;
         log.scrollTop = 0;
         return;
       }
@@ -6898,6 +6971,17 @@
       const cue = `Drawn in by ${calling}. Someone here is getting ready to say hello.`;
       const aria = `${kicker}. ${text} ${cue}`;
       return `<div class="room-scene arrival-scene" role="status" aria-label="${escapeAttr(aria)}"><span class="room-scene-kicker">${escapeHtml(kicker)}</span><span class="room-scene-text">${escapeHtml(text)}</span><span class="room-scene-cue">${escapeHtml(cue)}</span></div>`;
+    }
+
+    function defeatTransitionHtml() {
+      if (!defeatTransition) return "";
+      const actor = defeatTransition.actorName || "Your avatar";
+      const opponent = defeatTransition.opponentName || "the danger";
+      const kicker = "this tale has ended";
+      const text = `${actor} was defeated by ${opponent}.`;
+      const cue = "This avatar is gone. Any linked account and keepsakes are still here. Choose begin again below when you are ready.";
+      const aria = `${kicker}. ${text} ${cue}`;
+      return `<div class="room-scene defeat-scene" role="alert" aria-label="${escapeAttr(aria)}"><span class="room-scene-kicker">${escapeHtml(kicker)}</span><span class="room-scene-text">${escapeHtml(text)}</span><span class="room-scene-cue">${escapeHtml(cue)}</span></div>`;
     }
 
     function quietRoomSceneHtml() {
@@ -8326,7 +8410,7 @@
       }
       if (["practice", "train"].includes(String(action?.label || "").toLowerCase()) && action?.choices?.length) {
         return [
-          ["Choose", "the ability you want to practice"],
+          ["Choose", "the ability that gets +1"],
           ["Then", "its check training bonus increases by +1"],
           ["Score", "the ability score itself does not change"],
         ];
@@ -8339,7 +8423,7 @@
             ? [
                 ["Choose", "one of two lessons"],
                 ["Keep it", "save this visit as growth you can use later"],
-                ["Practice it", "add +1 to that ability's check training bonus"],
+                ["Ability +1", "add +1 to that ability's check training bonus"],
                 ["Score", "the ability score itself does not change"],
               ]
             : [
@@ -8428,6 +8512,7 @@
 
     function actionConfirmLabel(action) {
       const label = String(action?.label || "").toLowerCase();
+      if (label === "begin again") return "begin again";
       if (String(action?.command || "").trim().toLowerCase() === "create avatar") return "begin";
       if (label === "grow" || label === "bank") return "grow";
       if (label === "evolve") return "evolve";

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -39980,7 +39980,11 @@ mod tests {
         assert!(INDEX_HTML.contains("arrive as"));
         assert!(INDEX_HTML.contains("What draws you in:"));
         assert!(INDEX_HTML.contains("`enter ${creationProfile.name}`"));
-        assert!(INDEX_HTML.contains("modalTitle: creationProfile?.prompt"));
+        assert!(INDEX_HTML.contains(": (creationProfile?.prompt || \"what draws you in?\")"));
+        assert!(INDEX_HTML.contains("function captureDefeatTransition"));
+        assert!(INDEX_HTML.contains("this tale has ended"));
+        assert!(INDEX_HTML.contains("Choose begin again below when you are ready."));
+        assert!(INDEX_HTML.contains("label: beginningAgain ? \"begin again\" : \"begin\""));
         assert!(INDEX_HTML.contains("character_creation_id"));
         assert!(INDEX_HTML.contains("character_choice_id"));
         assert!(INDEX_HTML.contains("accountRow(\"purpose\", purpose)"));
@@ -40048,6 +40052,8 @@ mod tests {
         assert!(INDEX_HTML.contains("choose how to evolve"));
         assert!(INDEX_HTML.contains("choose one of two lessons"));
         assert!(INDEX_HTML.contains("practiceChoices.slice(0, growAction ? 1 : 2)"));
+        assert!(INDEX_HTML.contains("label: `${ability.label} +1`"));
+        assert!(!INDEX_HTML.contains("label: `practice ${ability.label}`"));
         assert!(INDEX_HTML.contains("+1 training bonus to ${ability.label} checks"));
         assert!(INDEX_HTML.contains("action.evolveModes?.includes(\"practice\")"));
         assert!(INDEX_HTML.contains("/actions/create-bond"));

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -3073,23 +3073,77 @@ async function main() {
     assert(trainIndex < travelIndex, `train action should appear before wandering away with spendable progress: ${JSON.stringify(result)}`);
     assert(result.firstStep[trainIndex]?.detail === "choose one of two knacks", `Evolve should make its two dealt knack choices visible without token language: ${JSON.stringify(result)}`);
     assert(result.firstStep[trainIndex]?.title === "choose how to evolve" && result.firstStep[trainIndex]?.summary === "Choose one of two ways this lesson can strengthen your avatar.", `Evolve should explain the identity choice warmly: ${JSON.stringify(result)}`);
-    assert(result.firstStep[trainIndex]?.choices.length === 2 && result.firstStep[trainIndex]?.choices.every((choice) => choice.startsWith("practice ")), `Evolve should deal exactly two random trainable knacks inside one card: ${JSON.stringify(result)}`);
+    assert(result.firstStep[trainIndex]?.choices.length === 2 && result.firstStep[trainIndex]?.choices.every((choice) => /^(Strength|Dexterity|Constitution|Intelligence|Wisdom|Charisma) \+1$/.test(choice)), `Evolve should label each dealt ability as its exact +1 change: ${JSON.stringify(result)}`);
     assert(result.firstStep[trainIndex]?.choiceDetails.every((detail) => /\+1 to .+ checks/i.test(detail)), `each Evolve option should name the exact check bonus it changes: ${JSON.stringify(result)}`);
     assert(/^practice:/.test(result.firstStep[trainIndex]?.selectedChoice || ""), `Evolve should select one of its two dealt knacks by default: ${JSON.stringify(result)}`);
     const combinedIndex = result.combinedLesson.findIndex((action) => action.label === "evolve");
     assert(result.combinedLesson[combinedIndex]?.detail === "choose one of two lessons", `Learn and Evolve should surface as one two-choice card: ${JSON.stringify(result)}`);
-    assert(result.combinedLesson[combinedIndex]?.choices.length === 2 && result.combinedLesson[combinedIndex]?.choices.includes("keep the lesson") && result.combinedLesson[combinedIndex]?.choices.some((choice) => choice.startsWith("practice ")), `the combined card should keep the lesson beside one randomly dealt knack: ${JSON.stringify(result)}`);
+    assert(result.combinedLesson[combinedIndex]?.choices.length === 2 && result.combinedLesson[combinedIndex]?.choices.includes("keep the lesson") && result.combinedLesson[combinedIndex]?.choices.some((choice) => / \+1$/.test(choice)), `the combined card should keep the lesson beside one explicit ability increase: ${JSON.stringify(result)}`);
     const contextualIndex = result.contextual.findIndex((action) => action.label === "evolve");
     assert(contextualIndex >= 0, `contextual train action should use the offered skill: ${JSON.stringify(result)}`);
     assert(result.contextual[contextualIndex]?.choices.length === 2, `contextual Evolve should still deal only two choices: ${JSON.stringify(result)}`);
     const directPractice = result.onlyListening.find((action) => action.focusKey === "train-listening");
-    assert(directPractice?.label === "evolve" && directPractice?.detail === "choose a knack to practice" && directPractice?.command === "evolve", `a lone trainable knack should stay inside the unified Evolve card: ${JSON.stringify(result)}`);
+    assert(directPractice?.label === "evolve" && directPractice?.detail === "Wisdom +1" && directPractice?.command === "evolve", `a lone trainable ability should name its exact +1 change inside the unified Evolve card: ${JSON.stringify(result)}`);
     const repeatTrainIndex = result.repeatWithBond.findIndex((action) => action.label === "evolve");
     const bondIndex = result.repeatWithBond.findIndex((action) => action.focusKey === "bond:1001");
     assert(bondIndex >= 0 && repeatTrainIndex >= 0 && bondIndex < repeatTrainIndex, `growing closer should interrupt repeat practice when both are available: ${JSON.stringify(result)}`);
     assert(result.repeatWithBond[repeatTrainIndex]?.detail === "choose one of two knacks", `repeat Evolve should retain two dealt knack choices: ${JSON.stringify(result)}`);
     assert(!/one growth|growth spent/i.test(JSON.stringify(result)), `practice should not expose growth as a counted token: ${JSON.stringify(result)}`);
     assert(![...result.firstStep, ...result.contextual, ...result.onlyListening, ...result.repeatWithBond].some((action) => String(action.detail || "").includes(" / ")), `train copy should avoid slash-heavy detail: ${JSON.stringify(result)}`);
+  }
+
+  async function assertPlayerDefeatTransitionIsExplicit() {
+    const result = await page.evaluate(() => {
+      const previousState = state;
+      const previousActorId = actorId;
+      const previousTransition = defeatTransition;
+      const previousStoredTransition = sessionStorage.getItem(defeatTransitionStorageKey);
+      try {
+        actorId = 5000;
+        state = {
+          location: { id: 3, name: "Moonlit Trail" },
+          actors: [
+            { id: 5000, name: "Lantern Stitch", kind: "human", status: "active" },
+            { id: 1004, name: "Moonlit Echo", kind: "npc", status: "active" },
+          ],
+          primary_action: { kind: "attack", options: [{ kind: "attack" }] },
+          cards: { actors: {}, items: {}, locations: {} },
+        };
+        clearDefeatTransition();
+        const captured = captureDefeatTransition({
+          seq: 99,
+          type: "combat.knockout",
+          actor_id: 1004,
+          actor_name: "Moonlit Echo",
+          target_actor_id: 5000,
+          target_actor_name: "Lantern Stitch",
+        });
+        state = {
+          ...state,
+          primary_action: { kind: "create_avatar", options: [] },
+          character_creation: [],
+        };
+        const restart = buildActions(state)[0];
+        return {
+          captured,
+          html: defeatTransitionHtml(),
+          restartLabel: restart?.label || "",
+          restartDetail: restart?.detail || "",
+          restartTitle: restart?.modalTitle || "",
+          restartConfirm: actionConfirmLabel(restart),
+        };
+      } finally {
+        state = previousState;
+        actorId = previousActorId;
+        defeatTransition = previousTransition;
+        if (previousStoredTransition === null) sessionStorage.removeItem(defeatTransitionStorageKey);
+        else sessionStorage.setItem(defeatTransitionStorageKey, previousStoredTransition);
+      }
+    });
+    assert(result.captured, `the player's knockout should capture an explicit defeat transition: ${JSON.stringify(result)}`);
+    assert(/this tale has ended/i.test(result.html) && /Lantern Stitch was defeated by Moonlit Echo/i.test(result.html), `the defeat scene should name the outcome and both combatants: ${JSON.stringify(result)}`);
+    assert(/This avatar is gone/i.test(result.html) && /linked account and keepsakes are still here/i.test(result.html), `the defeat scene should explain what was lost and what remains: ${JSON.stringify(result)}`);
+    assert(result.restartLabel === "begin again" && result.restartDetail === "make a new avatar" && result.restartTitle === "begin another tale" && result.restartConfirm === "begin again", `the post-defeat action should be a deliberate restart rather than a silent reset: ${JSON.stringify(result)}`);
   }
 
   async function assertBondSurfacesAsCompactRelationshipAction() {
@@ -7760,6 +7814,7 @@ async function main() {
   await assertGiveTradeCanBeDrawnFromShuffledDeck();
   await assertBankLedgerSurfacesAsCompactProgressAction();
   await assertTrainSkillSurfacesAsCompactAdvancementAction();
+  await assertPlayerDefeatTransitionIsExplicit();
   await assertBondSurfacesAsCompactRelationshipAction();
   await assertMatureBondSurfacesAsCompactSettlementAction();
   await assertPreparedProgressLabelsAreRoomScoped();


### PR DESCRIPTION
## Summary
- show an explicit end-of-tale scene when the active avatar is defeated
- explain that the avatar is gone while the linked account and keepsakes remain
- make restarting deliberate with begin again copy
- label ability training choices as Intelligence +1, Wisdom +1, and so on
- bump the release version to 0.0.59

## Verification
- pnpm test: 406 passed
- cargo test: 330 passed
- cargo fmt --check
- pnpm v2:syntax
- pnpm check:version