### PR TITLE
Fix production worldpack continuity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.63",
+      "version": "0.0.64",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/content-pack-contract.test.mjs
+++ b/test/v2/content-pack-contract.test.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -279,5 +280,53 @@ describe("Content Pack Manifest v1", () => {
     expect(second.status, second.stderr).toBe(0);
     expect(first.stdout).toBe(second.stdout);
     expect(first.stdout).toMatch(/artifact digest sha256:[0-9a-f]{64}/);
+  });
+
+  it("keeps persistence migration policy outside the content bundle identity", () => {
+    const officialWorldDir = path.join(repoRoot, "v2/worlds/official");
+    const authoredWorld = JSON.parse(fs.readFileSync(
+      path.join(officialWorldDir, "world.json"),
+      "utf8",
+    ));
+    const authoredLock = JSON.parse(fs.readFileSync(
+      path.join(officialWorldDir, "pack.lock.json"),
+      "utf8",
+    ));
+    const compile = (world) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "cosyworld-persistence-policy-"));
+      const worldDir = path.join(root, "world");
+      const outputDir = path.join(root, "output");
+      fs.mkdirSync(worldDir, { recursive: true });
+      const lock = structuredClone(authoredLock);
+      for (const pack of lock.packs) {
+        pack.source.path = path.resolve(officialWorldDir, pack.source.path);
+      }
+      fs.writeFileSync(path.join(worldDir, "world.json"), JSON.stringify(world, null, 2));
+      fs.writeFileSync(path.join(worldDir, "pack.lock.json"), JSON.stringify(lock, null, 2));
+      const result = spawnSync(process.execPath, [
+        compilerPath,
+        "--world-dir",
+        worldDir,
+        "--output-dir",
+        outputDir,
+      ], { cwd: repoRoot, encoding: "utf8" });
+      expect(result.status, result.stderr).toBe(0);
+      const compiled = JSON.parse(fs.readFileSync(
+        path.join(outputDir, "worldpack.json"),
+        "utf8",
+      ));
+      fs.rmSync(root, { recursive: true, force: true });
+      return compiled;
+    };
+
+    const withoutPolicy = structuredClone(authoredWorld);
+    delete withoutPolicy.persistence_compatibility;
+    const baseline = compile(withoutPolicy);
+    const withPolicy = compile(authoredWorld);
+
+    expect(withPolicy.bundle_hash).toBe(baseline.bundle_hash);
+    expect(withPolicy.persistence_compatibility).toEqual(
+      authoredWorld.persistence_compatibility,
+    );
   });
 });

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -9,6 +9,15 @@
     "version": 1,
     "description": "The reproducible seed world for the official CosyWorld shard.",
     "entry_location": "cosyworld.core:location/1",
+    "persistence_compatibility": {
+      "schema_version": 1,
+      "replay_compatible_bundle_hashes": [
+        "sha256:f97d77e008a46d79d9c9d83e607b257a16ef66d591b037297495b99f21fdafa5",
+        "sha256:3bcecba1646a5fd6c0d1c2c0c435a35b58f1910ac50a0ea3422245fe78a22802",
+        "sha256:338f4d9a5eefc75d832f7cc48c40600263dc49c89a2e6aa7365ea0d6a361d960",
+        "sha256:499302d175bf38df6eadf7810afea8f98b039bead76cc27f0383c490ae668672"
+      ]
+    },
     "bundle_hash": "sha256:3a06264db7ff974bf3ff94cb60bc74e5e9e7dd3e52dfc82024140d81b0d2d997",
     "packs": [
       {

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -7,6 +7,15 @@
   "version": 1,
   "description": "The reproducible seed world for the official CosyWorld shard.",
   "entry_location": "cosyworld.core:location/1",
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:f97d77e008a46d79d9c9d83e607b257a16ef66d591b037297495b99f21fdafa5",
+      "sha256:3bcecba1646a5fd6c0d1c2c0c435a35b58f1910ac50a0ea3422245fe78a22802",
+      "sha256:338f4d9a5eefc75d832f7cc48c40600263dc49c89a2e6aa7365ea0d6a361d960",
+      "sha256:499302d175bf38df6eadf7810afea8f98b039bead76cc27f0383c490ae668672"
+    ]
+  },
   "bundle_hash": "sha256:3a06264db7ff974bf3ff94cb60bc74e5e9e7dd3e52dfc82024140d81b0d2d997",
   "packs": [
     {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.63"
+version = "0.0.64"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -51,6 +51,8 @@ pub(super) struct SeedWorldpackManifest {
     #[serde(default)]
     pub(super) bundle_hash: String,
     #[serde(default)]
+    pub(super) persistence_compatibility: SeedPersistenceCompatibility,
+    #[serde(default)]
     pub(super) packs: Vec<SeedWorldpackPack>,
     #[serde(default)]
     pub(super) registry: String,
@@ -58,6 +60,14 @@ pub(super) struct SeedWorldpackManifest {
     pub(super) content_references: String,
     #[serde(default)]
     pub(super) licenses: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(super) struct SeedPersistenceCompatibility {
+    #[serde(default)]
+    pub(super) schema_version: u32,
+    #[serde(default)]
+    pub(super) replay_compatible_bundle_hashes: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -742,6 +752,24 @@ pub(super) fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> R
             "worldpack manifest does not identify its compiled registry and content references"
                 .to_string(),
         );
+    }
+    let compatibility = &manifest.persistence_compatibility;
+    if compatibility.schema_version == 0 {
+        if !compatibility.replay_compatible_bundle_hashes.is_empty() {
+            return Err(
+                "worldpack persistence compatibility hashes require schema version 1".to_string(),
+            );
+        }
+    } else {
+        let mut compatible_hashes = BTreeSet::new();
+        if compatibility.schema_version != 1
+            || compatibility
+                .replay_compatible_bundle_hashes
+                .iter()
+                .any(|hash| !valid_sha256_digest(hash) || !compatible_hashes.insert(hash.as_str()))
+        {
+            return Err("invalid worldpack persistence compatibility policy".to_string());
+        }
     }
     Ok(())
 }

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -337,6 +337,26 @@ impl ContentRegistry {
         }
     }
 
+    pub(super) fn inspect_content_reference_for_declared_migration(
+        &self,
+        persisted: &ContentReferenceEntry,
+    ) -> ContentReferenceStatus {
+        if self.pack(&persisted.pack_id).is_none() {
+            return ContentReferenceStatus::MissingPack;
+        }
+        let Some(current) = self
+            .content_references_by_canonical
+            .get(&persisted.canonical_ref)
+        else {
+            return ContentReferenceStatus::UnknownReference;
+        };
+        if current.runtime_handle != persisted.runtime_handle {
+            ContentReferenceStatus::Remapped
+        } else {
+            ContentReferenceStatus::Available
+        }
+    }
+
     #[cfg(test)]
     fn additional_resource(&self, kind: &str) -> Option<&serde_json::Value> {
         self.additional_resources.get(kind)

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -2258,9 +2258,10 @@ fn action_content_handles(action: &CwAction) -> Vec<(&'static str, u64)> {
     handles
 }
 
-fn validate_persisted_content_context(
+fn validate_persisted_content_context_for_replay(
     context: &ContentReferenceContext,
     label: &str,
+    declared_worldpack_migration: bool,
 ) -> io::Result<()> {
     if context.mapping_version == 0 {
         return Ok(());
@@ -2273,7 +2274,11 @@ fn validate_persisted_content_context(
         )));
     }
     for reference in &context.references {
-        let status = content_registry().inspect_content_reference(reference);
+        let status = if declared_worldpack_migration {
+            content_registry().inspect_content_reference_for_declared_migration(reference)
+        } else {
+            content_registry().inspect_content_reference(reference)
+        };
         if status != ContentReferenceStatus::Available {
             return Err(snapshot_error(format!(
                 "{label} content reference {} is not replayable: {status:?}",
@@ -2282,6 +2287,38 @@ fn validate_persisted_content_context(
         }
     }
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorldpackReplayCompatibility {
+    LegacyUnversioned,
+    Exact,
+    DeclaredMigration,
+}
+
+fn persisted_worldpack_replay_compatibility(
+    persisted_bundle_hash: &str,
+    label: &str,
+) -> io::Result<WorldpackReplayCompatibility> {
+    let active_bundle_hash = active_content().manifest.bundle_hash.as_str();
+    if persisted_bundle_hash.is_empty() {
+        return Ok(WorldpackReplayCompatibility::LegacyUnversioned);
+    }
+    if persisted_bundle_hash == active_bundle_hash {
+        return Ok(WorldpackReplayCompatibility::Exact);
+    }
+    if active_content()
+        .manifest
+        .persistence_compatibility
+        .replay_compatible_bundle_hashes
+        .iter()
+        .any(|hash| hash == persisted_bundle_hash)
+    {
+        return Ok(WorldpackReplayCompatibility::DeclaredMigration);
+    }
+    Err(snapshot_error(format!(
+        "{label} worldpack {persisted_bundle_hash} does not match active worldpack {active_bundle_hash} and is not declared replay-compatible"
+    )))
 }
 
 #[derive(Debug, Serialize)]
@@ -4071,33 +4108,69 @@ impl AppState {
         let resident_continuity_path =
             resident_continuity_path_from_env(snapshot_path.as_deref()).map(Arc::new);
         let event_store_path = event_store_path_from_env().map(Arc::new);
+        let fail_closed_on_continuity_error = deployment.profile.is_production();
         let mut runtime = match event_store_path.as_deref() {
-            Some(path) => match init_event_store(path)
-                .and_then(|_| action_journal_has_records(path))
-                .and_then(|has_records| {
-                    if has_records {
-                        RuntimeWorld::from_action_journal(path)
-                    } else {
-                        Err(snapshot_error("action journal is empty"))
+            Some(path) => {
+                match init_event_store(path).and_then(|_| action_journal_has_records(path)) {
+                    Ok(true) => match RuntimeWorld::from_action_journal(path) {
+                        Ok(runtime) => {
+                            info!(
+                                "replayed CosyWorld v2 action journal from {}",
+                                path.display()
+                            );
+                            runtime
+                        }
+                        Err(error) if fail_closed_on_continuity_error => {
+                            return Err(io::Error::new(
+                                error.kind(),
+                                format!(
+                                "production continuity cannot replay action journal {}: {error}",
+                                path.display()
+                            ),
+                            ));
+                        }
+                        Err(error) => {
+                            warn!(
+                            "action journal unavailable at {}; falling back to snapshot/seed: {}",
+                            path.display(),
+                            error
+                        );
+                            load_snapshot_or_seed_with_policy(
+                                snapshot_path.as_deref(),
+                                fail_closed_on_continuity_error,
+                            )?
+                        }
+                    },
+                    Ok(false) => load_snapshot_or_seed_with_policy(
+                        snapshot_path.as_deref(),
+                        fail_closed_on_continuity_error,
+                    )?,
+                    Err(error) if fail_closed_on_continuity_error => {
+                        return Err(io::Error::new(
+                            error.kind(),
+                            format!(
+                                "production continuity cannot read action journal {}: {error}",
+                                path.display()
+                            ),
+                        ));
                     }
-                }) {
-                Ok(runtime) => {
-                    info!(
-                        "replayed CosyWorld v2 action journal from {}",
-                        path.display()
-                    );
-                    runtime
+                    Err(error) => {
+                        warn!(
+                            "action journal unavailable at {}; falling back to snapshot/seed: {}",
+                            path.display(),
+                            error
+                        );
+                        load_snapshot_or_seed_with_policy(
+                            snapshot_path.as_deref(),
+                            fail_closed_on_continuity_error,
+                        )?
+                    }
                 }
-                Err(error) => {
-                    warn!(
-                        "action journal unavailable at {}; falling back to snapshot/seed: {}",
-                        path.display(),
-                        error
-                    );
-                    load_snapshot_or_seed(snapshot_path.as_deref())
-                }
-            },
-            None => load_snapshot_or_seed(snapshot_path.as_deref()),
+            }
+            None => load_snapshot_or_seed_with_policy(
+                snapshot_path.as_deref(),
+                fail_closed_on_continuity_error,
+            )?,
         };
         if let Some(path) = event_store_path.as_deref() {
             if let Err(error) = advance_runtime_next_event_seq_from_store(&mut runtime, path) {
@@ -4732,16 +4805,20 @@ impl RuntimeSnapshot {
     }
 
     fn into_runtime(self) -> io::Result<RuntimeWorld> {
-        if !self.worldpack_bundle_hash.is_empty()
-            && self.worldpack_bundle_hash != active_content().manifest.bundle_hash
-        {
-            return Err(snapshot_error(format!(
-                "snapshot worldpack {} does not match active worldpack {}",
+        let compatibility =
+            persisted_worldpack_replay_compatibility(&self.worldpack_bundle_hash, "snapshot")?;
+        if compatibility == WorldpackReplayCompatibility::DeclaredMigration {
+            warn!(
+                "loading snapshot through declared worldpack migration: {} -> {}",
                 self.worldpack_bundle_hash,
                 active_content().manifest.bundle_hash
-            )));
+            );
         }
-        validate_persisted_content_context(&self.content_context, "snapshot")?;
+        validate_persisted_content_context_for_replay(
+            &self.content_context,
+            "snapshot",
+            compatibility == WorldpackReplayCompatibility::DeclaredMigration,
+        )?;
         if self.world_actors.len() > CW_MAX_ACTORS {
             return Err(snapshot_error("too many actors in snapshot"));
         }
@@ -4930,18 +5007,31 @@ impl RuntimeWorld {
     fn from_action_journal(path: &Path) -> io::Result<Self> {
         let mut runtime = Self::seeded();
         let records = read_action_journal(path)?;
+        let mut migrated_bundle_hashes = BTreeSet::new();
         for record in records {
-            if !record.worldpack_bundle_hash.is_empty()
-                && record.worldpack_bundle_hash != active_content().manifest.bundle_hash
-            {
-                return Err(snapshot_error(format!(
-                    "action journal worldpack {} does not match active worldpack {}",
-                    record.worldpack_bundle_hash,
-                    active_content().manifest.bundle_hash
-                )));
+            let compatibility = persisted_worldpack_replay_compatibility(
+                &record.worldpack_bundle_hash,
+                "action journal",
+            )?;
+            if compatibility == WorldpackReplayCompatibility::DeclaredMigration {
+                migrated_bundle_hashes.insert(record.worldpack_bundle_hash.clone());
             }
-            validate_persisted_content_context(&record.content_context, "action journal")?;
+            validate_persisted_content_context_for_replay(
+                &record.content_context,
+                "action journal",
+                compatibility == WorldpackReplayCompatibility::DeclaredMigration,
+            )?;
             let _ = runtime.apply_journal_record(&record);
+        }
+        if !migrated_bundle_hashes.is_empty() {
+            warn!(
+                "replayed action journal through declared worldpack migration(s) from [{}] to {}",
+                migrated_bundle_hashes
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                active_content().manifest.bundle_hash
+            );
         }
         runtime.recompute_counters();
         runtime.ensure_seed_topology();
@@ -6837,14 +6927,16 @@ impl RuntimeWorld {
                 "unsupported resident continuity snapshot version",
             ));
         }
-        if !snapshot.worldpack_bundle_hash.is_empty()
-            && snapshot.worldpack_bundle_hash != active_content().manifest.bundle_hash
-        {
-            return Err(snapshot_error(format!(
-                "resident continuity worldpack {} does not match active worldpack {}",
+        let compatibility = persisted_worldpack_replay_compatibility(
+            &snapshot.worldpack_bundle_hash,
+            "resident continuity",
+        )?;
+        if compatibility == WorldpackReplayCompatibility::DeclaredMigration {
+            warn!(
+                "loading resident continuity through declared worldpack migration: {} -> {}",
                 snapshot.worldpack_bundle_hash,
                 active_content().manifest.bundle_hash
-            )));
+            );
         }
         Ok(self.apply_resident_continuity_snapshot(snapshot))
     }
@@ -30181,23 +30273,40 @@ fn default_resident_continuity_path(snapshot_path: Option<&PathBuf>) -> PathBuf 
     snapshot_path.with_file_name(format!("{base}-resident-continuity.json"))
 }
 
+#[cfg(test)]
 fn load_snapshot_or_seed(snapshot_path: Option<&PathBuf>) -> RuntimeWorld {
+    load_snapshot_or_seed_with_policy(snapshot_path, false)
+        .expect("local snapshot fallback must always seed on failure")
+}
+
+fn load_snapshot_or_seed_with_policy(
+    snapshot_path: Option<&PathBuf>,
+    fail_closed_on_continuity_error: bool,
+) -> io::Result<RuntimeWorld> {
     match snapshot_path {
         Some(path) => match RuntimeWorld::load_snapshot(path) {
             Ok(runtime) => {
                 info!("loaded CosyWorld v2 snapshot from {}", path.display());
-                runtime
+                Ok(runtime)
             }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(RuntimeWorld::seeded()),
+            Err(error) if fail_closed_on_continuity_error => Err(io::Error::new(
+                error.kind(),
+                format!(
+                    "production continuity cannot load snapshot {}: {error}",
+                    path.display()
+                ),
+            )),
             Err(error) => {
                 warn!(
                     "starting fresh CosyWorld v2 world; failed to load snapshot {}: {}",
                     path.display(),
                     error
                 );
-                RuntimeWorld::seeded()
+                Ok(RuntimeWorld::seeded())
             }
         },
-        None => RuntimeWorld::seeded(),
+        None => Ok(RuntimeWorld::seeded()),
     }
 }
 
@@ -35536,6 +35645,69 @@ mod tests {
             .event_log
             .iter()
             .any(|event| event.type_name == "message.created" && event.content_id == Some(9001)));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn action_journal_replays_declared_worldpack_epochs_in_order() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-migrated-journal-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        let compatible_hashes = &active_content()
+            .manifest
+            .persistence_compatibility
+            .replay_compatible_bundle_hashes;
+
+        let mut create = CwAction::default();
+        create.kind = CW_ACTION_CREATE_ACTOR;
+        create.actor_id = 5000;
+        create.location_id = COSY_COTTAGE_LOCATION_ID;
+        let mut create_record = JournalRecord::new(create, 9911);
+        create_record.worldpack_bundle_hash = compatible_hashes[0].clone();
+        for reference in &mut create_record.content_context.references {
+            if reference.pack_id == "cosyworld.core" {
+                reference.pack_version = "1.0.0".to_string();
+            }
+        }
+        create_record.actor_meta_upserts.insert(
+            5000,
+            ActorMeta {
+                name: "Migrated Traveler".to_string(),
+                speech_mode: "prose".to_string(),
+                title: "Epoch Walker".to_string(),
+                description: "A continuity migration fixture.".to_string(),
+            },
+        );
+
+        let mut say = CwAction::default();
+        say.kind = CW_ACTION_SAY;
+        say.actor_id = 5000;
+        say.content_id = 9001;
+        let mut say_record = JournalRecord::new(say, 9912);
+        say_record.worldpack_bundle_hash = compatible_hashes[1].clone();
+        say_record.content_context = ContentReferenceContext::default();
+        say_record
+            .content_upserts
+            .insert(9001, "hello across worldpack epochs".to_string());
+
+        append_action_journal(&path, &create_record).expect("append migrated create");
+        append_action_journal(&path, &say_record).expect("append migrated speech");
+
+        let replayed = RuntimeWorld::from_action_journal(&path)
+            .expect("declared journal epochs replay against current content");
+        assert_eq!(
+            replayed.actor_name(5000).as_deref(),
+            Some("Migrated Traveler")
+        );
+        assert_eq!(
+            replayed.content.get(&9001).map(String::as_str),
+            Some("hello across worldpack epochs")
+        );
+        assert!(replayed.actor_by_id(5000).is_some());
 
         let _ = fs::remove_file(path);
     }
@@ -42614,6 +42786,33 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_accepts_an_explicitly_declared_worldpack_migration() {
+        let compatible_hashes = &active_content()
+            .manifest
+            .persistence_compatibility
+            .replay_compatible_bundle_hashes;
+        assert_eq!(compatible_hashes.len(), 4);
+        assert!(!compatible_hashes.contains(&active_content().manifest.bundle_hash));
+
+        let mut snapshot = RuntimeSnapshot::from_runtime(&RuntimeWorld::seeded());
+        snapshot.version = 1;
+        snapshot.worldpack_bundle_hash = compatible_hashes[0].clone();
+        snapshot.content_context = ContentReferenceContext::default();
+        snapshot.tick = 57;
+        snapshot.next_event_seq = 736;
+
+        let runtime = snapshot
+            .into_runtime()
+            .expect("declared production snapshot epoch migrates");
+        assert_eq!(runtime.world.tick, 57);
+        assert_eq!(runtime.world.next_event_seq, 736);
+        assert_eq!(
+            runtime.world.location_count,
+            active_content().locations.len()
+        );
+    }
+
+    #[test]
     fn prelaunch_bundle_change_falls_back_to_a_fresh_seed() {
         let path = std::env::temp_dir().join(format!(
             "cosyworld-worldpack-mismatch-{}-{}.json",
@@ -42637,6 +42836,31 @@ mod tests {
         );
         assert_eq!(runtime.world.actor_count, active_content().actors.len());
         assert_eq!(runtime.world.tick, RuntimeWorld::seeded().world.tick);
+    }
+
+    #[test]
+    fn production_bundle_change_fails_closed_instead_of_seeding() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-production-worldpack-mismatch-{}-{}.json",
+            std::process::id(),
+            now_seed()
+        ));
+        let mut snapshot = RuntimeSnapshot::from_runtime(&RuntimeWorld::seeded());
+        snapshot.worldpack_bundle_hash = format!("sha256:{}", "0".repeat(64));
+        fs::write(
+            &path,
+            serde_json::to_vec(&snapshot).expect("snapshot serializes"),
+        )
+        .expect("mismatched snapshot writes");
+
+        let error = load_snapshot_or_seed_with_policy(Some(&path), true)
+            .expect_err("production continuity must fail closed");
+        let _ = fs::remove_file(path);
+
+        assert!(error
+            .to_string()
+            .contains("production continuity cannot load snapshot"));
+        assert!(error.to_string().contains("not declared replay-compatible"));
     }
 
     #[test]

--- a/v2/scripts/compile-worldpack.mjs
+++ b/v2/scripts/compile-worldpack.mjs
@@ -231,6 +231,28 @@ assert(lock.world_id === world.id, "pack lock does not belong to the official wo
 assert(Array.isArray(world.packs) && world.packs.length > 0, "world composition has no packs");
 assert(Array.isArray(lock.packs), "world composition pack lock has no packs array");
 assert(new Set(world.packs).size === world.packs.length, "world composition has duplicate pack ids");
+const persistenceCompatibility = world.persistence_compatibility ?? null;
+if (persistenceCompatibility) {
+  assert(
+    persistenceCompatibility.schema_version === 1,
+    "world persistence compatibility schema_version must be 1",
+  );
+  assert(
+    Array.isArray(persistenceCompatibility.replay_compatible_bundle_hashes),
+    "world persistence compatibility must declare replay_compatible_bundle_hashes",
+  );
+  assert(
+    persistenceCompatibility.replay_compatible_bundle_hashes.every(
+      (value) => /^sha256:[0-9a-f]{64}$/.test(value),
+    ),
+    "world persistence compatibility contains an invalid bundle hash",
+  );
+  assert(
+    new Set(persistenceCompatibility.replay_compatible_bundle_hashes).size
+      === persistenceCompatibility.replay_compatible_bundle_hashes.length,
+    "world persistence compatibility contains duplicate bundle hashes",
+  );
+}
 
 const lockById = new Map(lock.packs.map((entry) => [entry.id, entry]));
 assert(lockById.size === lock.packs.length, "pack lock has duplicate pack ids");
@@ -484,8 +506,9 @@ const contentReferences = buildContentReferenceMapping(
   }),
   CANONICAL_ID_MAPPING_VERSION,
 );
+const { persistence_compatibility: _persistenceCompatibility, ...worldIdentity } = world;
 const bundleHash = sha256([
-  json(world),
+  json(worldIdentity),
   json(packSummary),
   ...Object.values(resources).map(json),
   json(externalCards),
@@ -496,6 +519,10 @@ const bundleHash = sha256([
   json(characterCreationBundles),
   json(contentReferences),
 ]);
+assert(
+  !persistenceCompatibility?.replay_compatible_bundle_hashes.includes(bundleHash),
+  "world persistence compatibility must not list the active bundle hash",
+);
 const manifest = {
   schema_version: 2,
   pack_contract: CONTENT_PACK_CONTRACT,
@@ -506,6 +533,7 @@ const manifest = {
   description: world.description,
   entry_location: world.entry_location,
   ...(world.entry_grant_id ? { entry_grant_id: world.entry_grant_id } : {}),
+  ...(persistenceCompatibility ? { persistence_compatibility: persistenceCompatibility } : {}),
   bundle_hash: bundleHash,
   packs: packSummary,
   files: resourceFiles,

--- a/v2/worlds/official/world.json
+++ b/v2/worlds/official/world.json
@@ -5,6 +5,15 @@
   "version": 1,
   "description": "The reproducible seed world for the official CosyWorld shard.",
   "entry_location": "cosyworld.core:location/1",
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:f97d77e008a46d79d9c9d83e607b257a16ef66d591b037297495b99f21fdafa5",
+      "sha256:3bcecba1646a5fd6c0d1c2c0c435a35b58f1910ac50a0ea3422245fe78a22802",
+      "sha256:338f4d9a5eefc75d832f7cc48c40600263dc49c89a2e6aa7365ea0d6a361d960",
+      "sha256:499302d175bf38df6eadf7810afea8f98b039bead76cc27f0383c490ae668672"
+    ]
+  },
   "packs": [
     "cosyworld.core",
     "cosyworld.campaign.the-lantern-keeper",


### PR DESCRIPTION
## Summary

- declare the four production worldpack epochs observed in the persisted journal as explicitly replay-compatible
- keep the migration policy outside the deterministic content bundle identity
- validate canonical content references and stable runtime handles while replaying declared migrations
- fail closed in production when persisted continuity cannot be read or replayed, instead of silently seeding a fresh world
- bump the release to v0.0.64

Closes #118

## Validation

- `npm run check:version`
- `node v2/scripts/compile-worldpack.mjs --check --artifact-digest`
- `cargo fmt --check`
- `cargo check`
- `cargo test` — 333 passed
- `npm test` — 412 passed
- `npm run check:local` — compiler, kernel, Rust, production-profile, ownership-feed, and burn smoke checks passed; final browser wallet-connect harness hit the repository's existing 10-second timeout
