### PR TITLE
Restore legacy journal deployment continuity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy-${{ github.repository }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -40,7 +40,6 @@ jobs:
     name: Deploy tagged version to AWS
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: fly
     permissions:
       contents: read
       id-token: write

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.64",
+      "version": "0.0.65",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  new URL('../../.github/workflows/deploy.yml', import.meta.url),
+  'utf8'
+);
+
+const job = (name, nextName) => {
+  const start = workflow.indexOf(`\n  ${name}:`);
+  const end = nextName ? workflow.indexOf(`\n  ${nextName}:`, start + 1) : workflow.length;
+  return workflow.slice(start, end);
+};
+
+describe('deploy workflow', () => {
+  it('serializes deployments across branch and tag refs', () => {
+    expect(workflow).toContain('group: deploy-${{ github.repository }}');
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow).not.toContain('group: deploy-${{ github.ref }}');
+  });
+
+  it('lets tagged AWS deployments finish independently of Fly', () => {
+    expect(job('aws', 'github-release')).not.toMatch(/^\s+needs:\s*fly\s*$/m);
+    expect(job('github-release')).toContain('needs: [fly, aws]');
+  });
+});

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.64"
+version = "0.0.65"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.64"
+version = "0.0.65"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -737,6 +737,7 @@ enum ProjectionMutation {
     UseFeature {
         item_id: u64,
         location_id: u64,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
         feature_key: String,
         content: String,
         reason: String,
@@ -7597,6 +7598,9 @@ impl RuntimeWorld {
                         reason,
                     );
                     events.push(event.clone());
+                    if feature_key.is_empty() {
+                        continue;
+                    }
                     let item_name = self
                         .item_name(*item_id)
                         .unwrap_or_else(|| format!("Item {item_id}"));
@@ -36515,6 +36519,68 @@ mod tests {
         let before = replay.world.tick;
         assert_eq!(replay.apply_journal_record(&legacy).0, CW_OK);
         assert_eq!(replay.world.tick, before + 1);
+    }
+
+    #[test]
+    fn legacy_use_feature_records_replay_without_inventing_a_feature_identity() {
+        let runtime = RuntimeWorld::seeded();
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: RATI_ACTOR_ID,
+                ..CwAction::default()
+            },
+            17632,
+        );
+        record
+            .projection_mutations
+            .push(ProjectionMutation::UseFeature {
+                item_id: WATCH_BELL_ITEM_ID,
+                location_id: COSY_COTTAGE_LOCATION_ID,
+                feature_key: LOW_DOORWAY_FEATURE_KEY.to_string(),
+                content: "The Watch Bell answered the room.".to_string(),
+                reason: "use_feature".to_string(),
+            });
+
+        let mut legacy_json = serde_json::to_value(record).expect("serialize journal record");
+        let mutations = legacy_json
+            .get_mut("projection_mutations")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("projection mutation array");
+        mutations[0]
+            .as_object_mut()
+            .expect("use feature mutation")
+            .remove("feature_key");
+
+        let legacy: JournalRecord =
+            serde_json::from_value(legacy_json).expect("deserialize legacy use feature record");
+        assert!(matches!(
+            legacy.projection_mutations.as_slice(),
+            [ProjectionMutation::UseFeature { feature_key, .. }] if feature_key.is_empty()
+        ));
+
+        let mut replay = runtime;
+        let (status, events) = replay.apply_journal_record(&legacy);
+        assert_eq!(status, CW_OK);
+        assert!(events.iter().any(|event| {
+            event.type_name == "item.used"
+                && event.actor_id == Some(RATI_ACTOR_ID)
+                && event.item_id == Some(WATCH_BELL_ITEM_ID)
+        }));
+        assert!(!replay.tags.contains_key(&feature_use_tag_id(
+            RATI_ACTOR_ID,
+            COSY_COTTAGE_LOCATION_ID,
+            "",
+            WATCH_BELL_ITEM_ID,
+        )));
+        assert!(!replay.ledger_marks.contains_key(&visit_ledger_mark_id(
+            RATI_ACTOR_ID,
+            "feature",
+            &format!(
+                "feature_use:{}::{WATCH_BELL_ITEM_ID}",
+                COSY_COTTAGE_LOCATION_ID
+            ),
+        )));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #120.

## What changed

- accept pre-July `use_feature` journal mutations that do not contain `feature_key`
- replay their historical `item.used` event without fabricating a modern feature identity, tag, or ledger claim
- serialize branch and tag deploy workflows repository-wide
- let tagged AWS deployment proceed independently if Fly fails
- bump the release version to v0.0.65

## Root cause

The v0.0.64 Fly machine mounted a durable action journal containing `UseFeature` mutations written before `feature_key` became required. Direct Serde deserialization failed on the first legacy record and the process exited. At the same time, main and tag deploy workflows used ref-specific concurrency groups, so they raced for Fly's machine lease, and the tagged AWS job depended on Fly.

## Validation

- 414 JavaScript tests pass
- 334 Rust tests pass
- exact legacy mutation regression passes
- official/core-only/Ruby High/services worldpack checks pass
- strict proof-world check passes
- kernel and syntax checks pass
- `actionlint`, formatting, version, and diff checks pass