### PR TITLE
Replay retired quest acceptance records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.65",
+      "version": "0.0.66",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.65"
+version = "0.0.66"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -760,6 +760,11 @@ enum ProjectionMutation {
         status: String,
         reason: String,
     },
+    #[serde(rename = "accept_quest")]
+    LegacyAcceptQuest {
+        quest_id: String,
+        reason: String,
+    },
     BankVisitLedger {
         reason: String,
     },
@@ -7658,6 +7663,11 @@ impl RuntimeWorld {
                         action.actor_id,
                         reason,
                     ));
+                }
+                ProjectionMutation::LegacyAcceptQuest { .. } => {
+                    // The pre-worldpack prototype required explicit quest acceptance.
+                    // Mounted jobs are active by construction now, so replay only needs
+                    // to preserve this retired record's tick and causality.
                 }
                 ProjectionMutation::BankVisitLedger { reason } => {
                     if let Some(event) = self.bank_visit_ledger(action.actor_id, reason) {
@@ -36581,6 +36591,44 @@ mod tests {
                 COSY_COTTAGE_LOCATION_ID
             ),
         )));
+    }
+
+    #[test]
+    fn legacy_accept_quest_records_replay_as_an_explicit_retired_no_op() {
+        let runtime = RuntimeWorld::seeded();
+        let mut legacy_json = serde_json::to_value(JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: RATI_ACTOR_ID,
+                ..CwAction::default()
+            },
+            17633,
+        ))
+        .expect("serialize journal record");
+        legacy_json["projection_mutations"] = serde_json::json!([{
+            "kind": "accept_quest",
+            "quest_id": "quest",
+            "reason": "accepted",
+        }]);
+
+        let legacy: JournalRecord = serde_json::from_value(legacy_json.clone())
+            .expect("deserialize legacy accept quest record");
+        assert!(matches!(
+            legacy.projection_mutations.as_slice(),
+            [ProjectionMutation::LegacyAcceptQuest { quest_id, reason }]
+                if quest_id == "quest" && reason == "accepted"
+        ));
+
+        let mut replay = runtime;
+        let before = replay.world.tick;
+        let (status, events) = replay.apply_journal_record(&legacy);
+        assert_eq!(status, CW_OK);
+        assert_eq!(replay.world.tick, before);
+        assert!(events.is_empty());
+
+        legacy_json["projection_mutations"][0]["kind"] =
+            serde_json::json!("unknown_future_mutation");
+        assert!(serde_json::from_value::<JournalRecord>(legacy_json).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Continues #120 after the first real-volume replay in #121 exposed the next retired schema shape.

## What changed

- deserialize the pre-worldpack `accept_quest { quest_id, reason }` projection mutation explicitly
- replay it as a retired no-op because mounted jobs are active by construction in the current runtime
- retain fail-closed behavior for any genuinely unknown future mutation
- bump the recovery release to v0.0.66

## Production evidence

A schema-only audit performed on the Fly machine found exactly one removed mutation kind (`accept_quest`) across the durable journal. No database or player content was exported.

## Validation

- both legacy compatibility regressions pass
- all 335 Rust tests pass
- formatting, diff, and version checks pass
- the broader 414-test JavaScript, worldpack, kernel, syntax, and workflow gates passed on #121 and those surfaces are unchanged here