### PR TITLE
feat(v2): converge canonical capacity processes

### DIFF
--- a/docs/deployment/07-deployment.md
+++ b/docs/deployment/07-deployment.md
@@ -10,9 +10,10 @@ The Node service remains the companion service for admin pages, auth, integratio
 
 The official product has one canonical world. A process, AWS task, Fly machine,
 region, or room owner is capacity infrastructure and must not create a separate
-player history. The current SQLite deployment is intentionally one writer.
-Before increasing instance count, implement and pass the identity, durable
-journal, fenced ownership, routing, and failover gates in
+player history. The current SQLite deployment is intentionally one production
+task. Identity, durable journal, fencing, routing, presence fan-out, invite
+rendezvous, and the pinned two-process convergence harness are complete. Before
+increasing instance count, pass the hot-room migration and failover gates in
 [`../../v2/docs/canonical-world.md`](../../v2/docs/canonical-world.md). Never put
 multiple isolated SQLite saves behind a load balancer.
 
@@ -96,6 +97,11 @@ Create a `.env` file with:
   label shown in `/meta`. `COSYWORLD_V2_SHARD_ID` remains a matching legacy
   alias during migration. Neither may be used as a world, room, actor,
   invitation, claim, or save namespace.
+- **V2 Capacity Routing:** `COSYWORLD_CANONICAL_ROUTE_URL` and
+  `COSYWORLD_CANONICAL_ROUTER_TOKEN` are optional but must be set together. The
+  URL must target that exact process rather than the shared player load
+  balancer; the token must be a secret of at least 16 characters. Keep both
+  unset while AWS/Fly remains at one task/machine.
 
 ---
 
@@ -153,9 +159,8 @@ NODE_OPTIONS="--max-old-space-size=4096"
 
 ## Scaling Tips
 
-- Attach a persistent volume for SQLite and keep exactly one writer.
-- For multiple app instances, first provide a shared canonical journal,
-  versioned entities, fenced partition ownership, stable routing, and the
-  required two-process/failover test harness. A load balancer alone is unsafe.
+- Attach a persistent volume for SQLite and keep exactly one production task.
+- Multiple app instances require exact per-process routes and the remaining
+  hot-room migration/process-loss gate in #130. A load balancer alone is unsafe.
 - Redis cache
 - Containerize with Docker/Kubernetes

--- a/infra/aws-lonely-forest/README.md
+++ b/infra/aws-lonely-forest/README.md
@@ -15,11 +15,12 @@ archive/library site at `lonelyforestlibrary.com`.
 - S3 private bucket plus CloudFront distribution for the archive site in
   `sites/lonelyforestlibrary`.
 
-The ECS service is intentionally `desired_count = 1` because the app uses
-SQLite/EFS as the canonical event store. Do not increase it to obtain
-horizontal write capacity: two independently booted kernels can fork room
-history even when they see the same EFS path. Multi-process production requires
-the journal, fencing, routing, and failover gates in
+The ECS service is intentionally `desired_count = 1`. Shared journal fencing,
+cross-process routing, projection/presence convergence, invite rendezvous, and
+the pinned two-process harness are implemented, but ECS still lacks an exact
+per-task owner route and the #130 hot-room migration/failover gate. Do not
+increase it to obtain horizontal write capacity. Multi-process production must
+pass the remaining gates in
 [`../../v2/docs/canonical-world.md`](../../v2/docs/canonical-world.md).
 
 `COSYWORLD_PROCESS_ID` labels this ECS capacity process in `/meta`.
@@ -27,6 +28,10 @@ the journal, fencing, routing, and failover gates in
 the Terraform `process_id` input for new deployments; the older `shard_id`
 input remains the fallback. Neither label is the official world id or a valid
 persistent-state namespace.
+
+The task definition intentionally leaves `COSYWORLD_CANONICAL_ROUTE_URL` and
+`COSYWORLD_CANONICAL_ROUTER_TOKEN` unset. A normal ALB origin is not an exact
+task route and must not be placed in the process route registry.
 
 `deployment.auto.tfvars` captures the current deployed shape:
 

--- a/infra/aws-lonely-forest/variables.tf
+++ b/infra/aws-lonely-forest/variables.tf
@@ -94,11 +94,11 @@ variable "task_memory" {
 variable "desired_count" {
   type        = number
   default     = 1
-  description = "Number of orchestrator tasks. MUST remain 1 while SQLite/EFS is the event store; multiple isolated kernels would fork the canonical world."
+  description = "Number of orchestrator tasks. MUST remain 1 until exact ECS task routing and the #130 hot-room migration/failover gate are complete."
 
   validation {
     condition     = var.desired_count == 1
-    error_message = "desired_count must remain 1 until canonical journal, fenced ownership, and multi-process convergence gates are implemented."
+    error_message = "desired_count must remain 1 until exact task routing and the #130 hot-room migration/failover gate are implemented."
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.74",
+      "version": "0.0.75",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -44,11 +44,11 @@ shape still boots one orchestrator, backed by a durable fenced commit point:
 - The C kernel is built with fixed in-process capacities of 512 actors, 1024
   items, 256 locations, 1024 exits, 256 emitted events per kernel call, and 128
   evolution tracks. `/meta` exposes the live counters and these compiled caps.
-- Production remains one writer while routing and failover gates are unfinished.
-  The journal and room leases are now storage-fenced, but horizontal capacity
-  may be enabled only after stable routing plus the cross-process/failover tests
-  in [`docs/canonical-world.md`](docs/canonical-world.md). Starting isolated
-  public-world copies behind a load balancer is forbidden.
+- Capacity processes can now register exact routes, forward canonical commands,
+  converge durable projections, relay ephemeral presence, and rendezvous stable
+  profile/invite references. Production remains one task until the hot-room
+  migration and failover gate in #130 passes. Starting isolated public-world
+  copies—or using a shared load balancer URL as an owner route—is forbidden.
 
 Seed world content:
 
@@ -383,6 +383,14 @@ COSYWORLD_V2_EVENT_DB_PATH=off cargo run
 The canonical lease defaults to 30 seconds. Local failure tests may override it
 with `COSYWORLD_CANONICAL_LEASE_TTL_MS` (1000–300000). An expired or superseded
 owner is rejected by SQLite; mutations are never buffered for a later merge.
+
+Multi-process convergence additionally requires a shared event DB and both
+`COSYWORLD_CANONICAL_ROUTE_URL` and `COSYWORLD_CANONICAL_ROUTER_TOKEN`. The URL
+must be a directly targetable origin for that exact process, not the ordinary
+shared player load balancer; the token must be a shared secret of at least 16
+characters. Leave both unset for the supported one-task production shape. See
+[`docs/canonical-world.md`](docs/canonical-world.md) for the routing, invite,
+presence, and remaining scale gates.
 
 ## Play In A Terminal
 

--- a/v2/docs/canonical-world.md
+++ b/v2/docs/canonical-world.md
@@ -7,10 +7,16 @@ normative decision; this page turns it into rollout and test gates.
 
 ## Current and target shapes
 
-Today, one Rust orchestrator owns the in-memory C kernel and one SQLite event
-store. It is a valid single-writer seed of the canonical world, but it is not a
-horizontal multi-writer design. Production must keep one task/machine while
-this storage mode is active.
+The Rust orchestrator can now run divergent capacity processes over one shared
+SQLite journal. Each process keeps a replayable C-kernel projection, advertises
+an exact boot-scoped route, forwards writes to the current fenced room owner,
+polls the durable suffix, and relays ephemeral presence without advancing the
+world cursor. The pinned two-process harness proves this convergence path.
+
+Production still keeps one task/machine. Hot-room ownership migration and the
+full process-loss/failover gate remain in #130, and a normal shared load
+balancer is not an exact process route. Passing the #127 harness does not by
+itself authorize raising production capacity.
 
 The target separates five responsibilities without changing player identity:
 
@@ -124,15 +130,38 @@ the gap-free durable suffix ordered by `(world_epoch, world_seq)`.
 
 ## Routing and rendezvous
 
-- `/play`, profile, invite, and pact routes resolve stable canonical refs.
-- The router resolves the current owner; the URL never embeds an instance,
-  region, lease, or process id.
-- Two users may keep HTTP/SSE connections to different capacity processes and
-  still share one room projection and event cursor.
-- Reconnect sends the last acknowledged public cursor, replays committed
-  events, refreshes entity versions, and then accepts new commands.
-- Session affinity is an optimization only. Correctness tests must deliberately
-  disable it.
+Each routed process must set both of these values or neither:
+
+- `COSYWORLD_CANONICAL_ROUTE_URL`: an HTTP(S) origin that targets that exact
+  process, with no credentials, path, query, or fragment;
+- `COSYWORLD_CANONICAL_ROUTER_TOKEN`: a shared secret of at least 16 characters
+  used only for authenticated process-to-process requests.
+
+Routing also requires `COSYWORLD_V2_EVENT_DB_PATH`. A boot registers its exact
+`owner_id`, `process_id`, origin, and heartbeat expiry in
+`canonical_process_routes`. The current room lease names the owner; ingress
+looks up that owner's live route and forwards the original command envelope.
+Internal routes return `404` without the exact bearer secret. Do not configure
+the ordinary shared player load balancer as a process route: it can select the
+wrong owner and recurse into an unavailable write.
+
+Durable projections poll the shared action journal every 100 ms and also catch
+up before `/state`, `/inspect`, `/world`, `/events`, `/stream`, `/profiles`,
+invite, and command handling. Reconnect resumes from the caller's acknowledged
+event cursor. Stable actor lookups use `GET /profiles?actor_ref=...` and never
+derive identity from a process label.
+
+`POST /invites` creates a seven-day durable invite for an authenticated actor,
+`GET /invites/{invite_id}` resolves the inviter's current canonical profile,
+and `POST /invites/{invite_id}/follow` moves an authenticated follower to the
+inviter's current canonical location. The follow is fenced across origin and
+destination rooms and is forwarded to the current owner when necessary.
+
+Presence uses the same live route registry but remains explicitly ephemeral.
+Capacity processes relay `actor.presence` with `seq: 0`, keep a bounded regional
+view for active-room projections, and never insert it into replay history.
+Session affinity is therefore an optimization only, not a correctness
+requirement.
 
 ## Failure and migration gates
 
@@ -147,31 +176,28 @@ the gap-free durable suffix ordered by `(world_epoch, world_seq)`.
 | Pack migration | all writers change from old hash to new hash as one audited operation |
 | Save import | source is namespaced and hashed; rerun is idempotent; conflicts create no world mutation |
 
-## Two-process integration test plan
+## Two-process integration harness
 
-The required harness starts two API processes with different `process_id`
-values and one canonical test authority. It pins client A to process A and
-client B to process B, with affinity disabled.
+`divergent_capacity_processes_converge_without_affinity` starts two real
+loopback API servers with different `process_id` and boot-scoped owner values,
+one shared journal, and affinity disabled. It pins client A to process A and
+client B to process B.
 
 1. Both clients enter the same location and compare location/actor/item ids and
    versions.
 2. A takes the floor item; B observes the same disposition and ordered event.
 3. Both retry A’s `intent_id`; the journal contains one receipt and one effect.
-4. A moves while B acts in the origin room; the result is serialized without a
-   duplicated actor or half-moved item.
-5. Kill the owner between validation and append, then after append but before
-   response. Each case converges to zero or one committed effect.
-6. Isolate the old owner, grant a higher fence, and prove the old owner cannot
-   write.
-7. Reconnect both clients from earlier cursors and compare the full public event
-   suffix and projected action hands.
-8. Follow an invite generated on A through B and prove both clients rendezvous
-   in the same canonical location.
+4. An invite generated on A is resolved and followed through B; both profiles
+   rendezvous at the inviter's current stable location reference.
+5. Both clients compare location, actors, items, action hand, and the complete
+   ordered public suffix from an earlier cursor.
+6. The owner process and its convergence worker are killed; after lease expiry,
+   B commits with a higher fence while preserving identity and history.
 
-The failover suite repeats this with ownership migration, a hot room under SSE
-fan-out, and a promoted second region. It verifies monotonically increasing
-`world_seq` and `entity_version`, no duplicate identity, and no lost
-acknowledged event.
+The harness also proves cross-process session refresh and `seq: 0` presence
+fan-out. The remaining #130 failover suite adds ownership migration during an
+active hot room, stale-owner isolation at the append boundary, and promoted
+region recovery.
 
 ## Rollout order
 
@@ -179,8 +205,8 @@ acknowledged event.
    process. (Complete in #129.)
 2. Move the journal, idempotency receipts, entity versions, and fencing
    authority to durable multi-process storage. (Complete in #128.)
-3. Add stable routing, regional presence fan-out, invite rendezvous, and the pinned
-   two-process harness.
+3. Add stable routing, regional presence fan-out, invite rendezvous, and the
+   pinned two-process harness. (Complete in #127.)
 4. Add partition handoff, hot-room fan-out, and process-loss tests.
 5. Add replicated regional recovery and prove the failover gate.
 6. Raise production capacity only after every gate passes.

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.74"
+version = "0.0.75"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.74"
+version = "0.0.75"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/canonical_journal.rs
+++ b/v2/orchestrator-rust/src/canonical_journal.rs
@@ -4,7 +4,10 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     io,
     path::Path,
+    time::Duration,
 };
+
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(super) struct AuthorityLease {
@@ -45,6 +48,25 @@ pub(super) struct CanonicalReceiptRow<'a> {
     pub(super) owner_id: &'a str,
     pub(super) owner_fencing_epoch: u64,
     pub(super) created_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct CanonicalProcessRoute {
+    pub(super) owner_id: String,
+    pub(super) process_id: String,
+    pub(super) base_url: String,
+    pub(super) heartbeat_expires_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct CanonicalInvite {
+    pub(super) invite_id: String,
+    pub(super) world_id: String,
+    pub(super) actor_ref: String,
+    pub(super) created_location_ref: String,
+    pub(super) created_world_seq: u64,
+    pub(super) created_at_ms: u64,
+    pub(super) expires_at_ms: u64,
 }
 
 pub(super) fn init_canonical_journal(
@@ -105,7 +127,29 @@ pub(super) fn init_canonical_journal(
         CREATE INDEX IF NOT EXISTS idx_canonical_commits_world_seq
             ON canonical_commits(world_id, world_epoch, last_world_seq);
         CREATE INDEX IF NOT EXISTS idx_canonical_commits_intent
-            ON canonical_commits(world_id, intent_id);",
+            ON canonical_commits(world_id, intent_id);
+        CREATE TABLE IF NOT EXISTS canonical_process_routes (
+            world_id TEXT NOT NULL,
+            owner_id TEXT NOT NULL,
+            process_id TEXT NOT NULL,
+            base_url TEXT NOT NULL,
+            heartbeat_expires_at_ms INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL,
+            PRIMARY KEY (world_id, owner_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_canonical_process_routes_live
+            ON canonical_process_routes(world_id, heartbeat_expires_at_ms, process_id);
+        CREATE TABLE IF NOT EXISTS canonical_invites (
+            invite_id TEXT PRIMARY KEY,
+            world_id TEXT NOT NULL,
+            actor_ref TEXT NOT NULL,
+            created_location_ref TEXT NOT NULL,
+            created_world_seq INTEGER NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            expires_at_ms INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_canonical_invites_actor
+            ON canonical_invites(world_id, actor_ref, expires_at_ms);",
     )
     .map_err(sqlite_error)?;
 
@@ -161,11 +205,26 @@ pub(super) fn init_canonical_journal(
         params![world_id, as_i64(world_epoch)?, max_seq],
     )
     .map_err(sqlite_error)?;
-    let stored_epoch = conn
+    // Read the cursor, durable suffix, and commit count in one SQLite snapshot.
+    // Separate autocommit SELECTs can straddle another process's commit and
+    // briefly pair the new cursor with the old event maximum.
+    let (stored_epoch, committed_seq, durable_max_seq, commit_count) = conn
         .query_row(
-            "SELECT world_epoch FROM canonical_world_state WHERE world_id = ?1",
+            "SELECT state.world_epoch,
+                    state.committed_seq,
+                    (SELECT COALESCE(MAX(seq), 0) FROM world_events),
+                    (SELECT COUNT(*) FROM canonical_commits WHERE world_id = ?1)
+             FROM canonical_world_state AS state
+             WHERE state.world_id = ?1",
             params![world_id],
-            |row| row.get::<_, i64>(0),
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                ))
+            },
         )
         .map_err(sqlite_error)?;
     if stored_epoch != as_i64(world_epoch)? {
@@ -173,27 +232,20 @@ pub(super) fn init_canonical_journal(
             "canonical world epoch mismatch: storage has {stored_epoch}, runtime expects {world_epoch}"
         )));
     }
-    let commit_count = conn
-        .query_row(
-            "SELECT COUNT(*) FROM canonical_commits WHERE world_id = ?1",
-            params![world_id],
-            |row| row.get::<_, i64>(0),
-        )
-        .map_err(sqlite_error)?;
     if commit_count == 0 {
         conn.execute(
             "UPDATE canonical_world_state
              SET committed_seq = MAX(committed_seq, ?2)
              WHERE world_id = ?1",
-            params![world_id, max_seq],
+            params![world_id, durable_max_seq],
         )
         .map_err(sqlite_error)?;
     } else {
-        let committed_seq = current_world_seq(conn, world_id)?;
-        let max_seq = as_u64(max_seq, "maximum world event sequence")?;
-        if committed_seq != max_seq {
+        let committed_seq = as_u64(committed_seq, "committed world sequence")?;
+        let durable_max_seq = as_u64(durable_max_seq, "maximum world event sequence")?;
+        if committed_seq != durable_max_seq {
             return Err(invalid_data(format!(
-                "canonical world cursor {committed_seq} does not match durable event suffix {max_seq}"
+                "canonical world cursor {committed_seq} does not match durable event suffix {durable_max_seq}"
             )));
         }
     }
@@ -210,7 +262,7 @@ pub(super) fn acquire_partition_lease(
     now_ms: u64,
     ttl_ms: u64,
 ) -> io::Result<AuthorityLease> {
-    let mut conn = Connection::open(path).map_err(sqlite_error)?;
+    let mut conn = open_canonical_store(path)?;
     init_canonical_journal(&conn, world_id, world_epoch)?;
     let tx = conn
         .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -236,7 +288,7 @@ pub(super) fn acquire_partition_leases(
     now_ms: u64,
     ttl_ms: u64,
 ) -> io::Result<BTreeMap<String, AuthorityLease>> {
-    let mut conn = Connection::open(path).map_err(sqlite_error)?;
+    let mut conn = open_canonical_store(path)?;
     init_canonical_journal(&conn, world_id, world_epoch)?;
     let tx = conn
         .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -327,6 +379,233 @@ pub(super) fn acquire_partition_lease_in_transaction(
         fencing_epoch,
         lease_expires_at_ms: next_expiry,
     })
+}
+
+pub(super) fn current_partition_lease(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    partition_key: &str,
+    now_ms: u64,
+) -> io::Result<Option<AuthorityLease>> {
+    let conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    conn.query_row(
+        "SELECT owner_id, fencing_epoch, lease_expires_at_ms
+         FROM canonical_partition_leases
+         WHERE world_id = ?1 AND partition_key = ?2 AND lease_expires_at_ms > ?3",
+        params![world_id, partition_key, as_i64(now_ms)?],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(sqlite_error)?
+    .map(|(owner_id, fencing_epoch, lease_expires_at_ms)| {
+        Ok(AuthorityLease {
+            world_id: world_id.to_string(),
+            partition_key: partition_key.to_string(),
+            owner_id,
+            fencing_epoch: as_u64(fencing_epoch, "fencing_epoch")?,
+            lease_expires_at_ms: as_u64(lease_expires_at_ms, "lease_expires_at_ms")?,
+        })
+    })
+    .transpose()
+}
+
+pub(super) fn upsert_process_route(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    route: &CanonicalProcessRoute,
+    updated_at_ms: u64,
+) -> io::Result<()> {
+    let conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    conn.execute(
+        "INSERT INTO canonical_process_routes
+            (world_id, owner_id, process_id, base_url, heartbeat_expires_at_ms, updated_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(world_id, owner_id) DO UPDATE SET
+            process_id = excluded.process_id,
+            base_url = excluded.base_url,
+            heartbeat_expires_at_ms = excluded.heartbeat_expires_at_ms,
+            updated_at_ms = excluded.updated_at_ms",
+        params![
+            world_id,
+            route.owner_id,
+            route.process_id,
+            route.base_url,
+            as_i64(route.heartbeat_expires_at_ms)?,
+            as_i64(updated_at_ms)?
+        ],
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+pub(super) fn process_route_for_owner(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    owner_id: &str,
+    now_ms: u64,
+) -> io::Result<Option<CanonicalProcessRoute>> {
+    let conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    conn.query_row(
+        "SELECT owner_id, process_id, base_url, heartbeat_expires_at_ms
+         FROM canonical_process_routes
+         WHERE world_id = ?1 AND owner_id = ?2 AND heartbeat_expires_at_ms > ?3",
+        params![world_id, owner_id, as_i64(now_ms)?],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(sqlite_error)?
+    .map(
+        |(owner_id, process_id, base_url, heartbeat_expires_at_ms)| {
+            Ok(CanonicalProcessRoute {
+                owner_id,
+                process_id,
+                base_url,
+                heartbeat_expires_at_ms: as_u64(
+                    heartbeat_expires_at_ms,
+                    "heartbeat_expires_at_ms",
+                )?,
+            })
+        },
+    )
+    .transpose()
+}
+
+pub(super) fn active_process_routes(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    now_ms: u64,
+) -> io::Result<Vec<CanonicalProcessRoute>> {
+    let conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT owner_id, process_id, base_url, heartbeat_expires_at_ms
+             FROM canonical_process_routes
+             WHERE world_id = ?1 AND heartbeat_expires_at_ms > ?2
+             ORDER BY process_id, owner_id",
+        )
+        .map_err(sqlite_error)?;
+    let rows = stmt
+        .query_map(params![world_id, as_i64(now_ms)?], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })
+        .map_err(sqlite_error)?;
+    rows.map(|row| {
+        let (owner_id, process_id, base_url, heartbeat_expires_at_ms) =
+            row.map_err(sqlite_error)?;
+        Ok(CanonicalProcessRoute {
+            owner_id,
+            process_id,
+            base_url,
+            heartbeat_expires_at_ms: as_u64(heartbeat_expires_at_ms, "heartbeat_expires_at_ms")?,
+        })
+    })
+    .collect()
+}
+
+pub(super) fn insert_canonical_invite(
+    path: &Path,
+    world_epoch: u64,
+    invite: &CanonicalInvite,
+) -> io::Result<bool> {
+    let conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, &invite.world_id, world_epoch)?;
+    let inserted = conn
+        .execute(
+            "INSERT OR IGNORE INTO canonical_invites
+                (invite_id, world_id, actor_ref, created_location_ref,
+                 created_world_seq, created_at_ms, expires_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                invite.invite_id,
+                invite.world_id,
+                invite.actor_ref,
+                invite.created_location_ref,
+                as_i64(invite.created_world_seq)?,
+                as_i64(invite.created_at_ms)?,
+                as_i64(invite.expires_at_ms)?
+            ],
+        )
+        .map_err(sqlite_error)?;
+    Ok(inserted == 1)
+}
+
+pub(super) fn read_canonical_invite(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    invite_id: &str,
+    now_ms: u64,
+) -> io::Result<Option<CanonicalInvite>> {
+    let conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    conn.query_row(
+        "SELECT invite_id, world_id, actor_ref, created_location_ref,
+                created_world_seq, created_at_ms, expires_at_ms
+         FROM canonical_invites
+         WHERE invite_id = ?1 AND world_id = ?2 AND expires_at_ms > ?3",
+        params![invite_id, world_id, as_i64(now_ms)?],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, i64>(6)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(sqlite_error)?
+    .map(
+        |(
+            invite_id,
+            world_id,
+            actor_ref,
+            created_location_ref,
+            created_world_seq,
+            created_at_ms,
+            expires_at_ms,
+        )| {
+            Ok(CanonicalInvite {
+                invite_id,
+                world_id,
+                actor_ref,
+                created_location_ref,
+                created_world_seq: as_u64(created_world_seq, "created_world_seq")?,
+                created_at_ms: as_u64(created_at_ms, "created_at_ms")?,
+                expires_at_ms: as_u64(expires_at_ms, "expires_at_ms")?,
+            })
+        },
+    )
+    .transpose()
 }
 
 pub(super) fn validate_and_renew_partition_lease(
@@ -692,7 +971,7 @@ pub(super) fn finalize_atomic_command_receipt(
     world_seq: u64,
     updated_at_ms: u64,
 ) -> io::Result<bool> {
-    let conn = Connection::open(path).map_err(sqlite_error)?;
+    let conn = open_canonical_store(path)?;
     let updated = conn
         .execute(
             "UPDATE canonical_command_receipts
@@ -724,6 +1003,13 @@ fn ensure_column(conn: &Connection, table: &str, column: &str, alter_sql: &str) 
     }
     conn.execute(alter_sql, []).map_err(sqlite_error)?;
     Ok(())
+}
+
+fn open_canonical_store(path: &Path) -> io::Result<Connection> {
+    let conn = Connection::open(path).map_err(sqlite_error)?;
+    conn.busy_timeout(SQLITE_BUSY_TIMEOUT)
+        .map_err(sqlite_error)?;
+    Ok(conn)
 }
 
 fn as_i64(value: u64) -> io::Result<i64> {
@@ -836,6 +1122,65 @@ mod tests {
         assert_eq!(
             validate_next_world_sequence(&conn, "world://test", &[3, 4]).unwrap(),
             (3, 4)
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn process_routes_only_resolve_while_the_exact_owner_is_live() {
+        let path = temp_db("process-route");
+        initialize(&path);
+        let route = CanonicalProcessRoute {
+            owner_id: "process-a:boot-1".to_string(),
+            process_id: "process-a".to_string(),
+            base_url: "http://127.0.0.1:4101".to_string(),
+            heartbeat_expires_at_ms: 50,
+        };
+        upsert_process_route(&path, "world://test", 1, &route, 10).unwrap();
+
+        assert_eq!(
+            process_route_for_owner(&path, "world://test", 1, "process-a:boot-1", 49,).unwrap(),
+            Some(route.clone())
+        );
+        assert_eq!(
+            active_process_routes(&path, "world://test", 1, 49).unwrap(),
+            vec![route]
+        );
+        assert!(
+            process_route_for_owner(&path, "world://test", 1, "process-a:boot-1", 50,)
+                .unwrap()
+                .is_none()
+        );
+        assert!(active_process_routes(&path, "world://test", 1, 50)
+            .unwrap()
+            .is_empty());
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn canonical_invites_are_durable_unique_and_expire_at_the_boundary() {
+        let path = temp_db("invite");
+        initialize(&path);
+        let invite = CanonicalInvite {
+            invite_id: "cw_test_invite".to_string(),
+            world_id: "world://test".to_string(),
+            actor_ref: "world://test/actor/alice".to_string(),
+            created_location_ref: "world://test/location/cottage".to_string(),
+            created_world_seq: 42,
+            created_at_ms: 100,
+            expires_at_ms: 200,
+        };
+
+        assert!(insert_canonical_invite(&path, 1, &invite).unwrap());
+        assert!(!insert_canonical_invite(&path, 1, &invite).unwrap());
+        assert_eq!(
+            read_canonical_invite(&path, "world://test", 1, &invite.invite_id, 199).unwrap(),
+            Some(invite.clone())
+        );
+        assert!(
+            read_canonical_invite(&path, "world://test", 1, &invite.invite_id, 200)
+                .unwrap()
+                .is_none()
         );
         let _ = fs::remove_file(path);
     }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -58,7 +58,7 @@ use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicU8, Ordering as AtomicOrdering},
+        atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering},
         Arc, Mutex as StdMutex, OnceLock,
     },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -110,6 +110,11 @@ struct AppState {
     canonical_command_lock: Arc<Mutex<()>>,
     canonical_owner_id: Arc<String>,
     canonical_lease_ttl: Duration,
+    canonical_applied_journal_seq: Arc<AtomicU64>,
+    canonical_fanout_seq: Arc<AtomicU64>,
+    canonical_fanout_lock: Arc<StdMutex<()>>,
+    canonical_routing: Arc<CanonicalRoutingConfig>,
+    regional_presence: Arc<StdMutex<BTreeMap<u64, RegionalPresence>>>,
     room_turns: Arc<StdMutex<RoomTurns>>,
     room_memory_cache: Arc<StdMutex<BTreeMap<u64, RoomMemoryCacheEntry>>>,
     room_memory_jobs: Arc<StdMutex<BTreeSet<(u64, u64, u64)>>>,
@@ -123,6 +128,40 @@ struct AppState {
 
 const CANONICAL_WORLD_PARTITION: &str = "world";
 const DEFAULT_CANONICAL_LEASE_TTL: Duration = Duration::from_secs(30);
+const DEFAULT_CANONICAL_CONVERGENCE_POLL: Duration = Duration::from_millis(100);
+const CANONICAL_ROUTE_HEARTBEAT_MULTIPLIER: u32 = 3;
+const CANONICAL_INVITE_TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+#[derive(Clone, Debug, Default)]
+struct CanonicalRoutingConfig {
+    base_url: Option<String>,
+    token: Option<String>,
+}
+
+impl CanonicalRoutingConfig {
+    fn enabled(&self) -> bool {
+        self.base_url.is_some() && self.token.is_some()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RegionalPresence {
+    active: bool,
+    last_seen_at: Instant,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CanonicalPresenceRelay {
+    source_owner_id: String,
+    events: Vec<EventView>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ForwardedCanonicalCommand {
+    source_process_id: String,
+    client_addr: String,
+    payload: CommandRequest,
+}
 
 struct CanonicalCommandCommitContext {
     envelope: CanonicalCommandEnvelope,
@@ -753,6 +792,11 @@ enum ProjectionMutation {
         actor_id: u64,
         location_id: u64,
         reason: String,
+    },
+    RendezvousActor {
+        actor_id: u64,
+        location_id: u64,
+        invite_id: String,
     },
     JourneyTransition {
         pathway: GeneratedPathwayState,
@@ -1744,7 +1788,87 @@ struct EventsQuery {
     cards: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Debug, Deserialize)]
+struct CanonicalProfileQuery {
+    actor_ref: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct CanonicalProfileView {
+    world_id: String,
+    world_epoch: u64,
+    actor_ref: String,
+    actor_id: u64,
+    actor_version: u64,
+    name: String,
+    location_ref: String,
+    location_id: u64,
+    location_version: u64,
+    location_name: String,
+    through_seq: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CanonicalProfileResponse {
+    ok: bool,
+    status: u32,
+    process_id: String,
+    profile: Option<CanonicalProfileView>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CreateCanonicalInviteRequest {
+    actor_id: u64,
+    actor_session: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct FollowCanonicalInviteRequest {
+    actor_id: u64,
+    actor_session: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CanonicalInviteView {
+    invite_id: String,
+    invite_url: String,
+    world_id: String,
+    world_epoch: u64,
+    inviter: CanonicalProfileView,
+    created_location_ref: String,
+    created_world_seq: u64,
+    expires_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CanonicalInviteResponse {
+    ok: bool,
+    status: u32,
+    process_id: String,
+    invite: Option<CanonicalInviteView>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CanonicalInviteFollowResponse {
+    ok: bool,
+    status: u32,
+    process_id: String,
+    invite_id: String,
+    actor_ref: Option<String>,
+    rendezvous_location_ref: Option<String>,
+    through_seq: u64,
+    events: Vec<EventView>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ForwardedCanonicalInviteFollow {
+    source_process_id: String,
+    client_addr: String,
+    invite_id: String,
+    payload: FollowCanonicalInviteRequest,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct EventsResponse {
     world_id: String,
     world_epoch: u64,
@@ -2954,6 +3078,57 @@ fn deployment_config_error(message: impl Into<String>) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidInput, message.into())
 }
 
+fn canonical_routing_config_from_env() -> io::Result<CanonicalRoutingConfig> {
+    let base_url = std::env::var("COSYWORLD_CANONICAL_ROUTE_URL")
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty());
+    let token = std::env::var("COSYWORLD_CANONICAL_ROUTER_TOKEN")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    canonical_routing_config(base_url, token)
+}
+
+fn canonical_routing_config(
+    base_url: Option<String>,
+    token: Option<String>,
+) -> io::Result<CanonicalRoutingConfig> {
+    if base_url.is_some() != token.is_some() {
+        return Err(deployment_config_error(
+            "COSYWORLD_CANONICAL_ROUTE_URL and COSYWORLD_CANONICAL_ROUTER_TOKEN must be configured together",
+        ));
+    }
+    if let Some(base_url) = base_url.as_deref() {
+        let parsed = reqwest::Url::parse(base_url).map_err(|error| {
+            deployment_config_error(format!("COSYWORLD_CANONICAL_ROUTE_URL is invalid: {error}"))
+        })?;
+        if !matches!(parsed.scheme(), "http" | "https")
+            || parsed.host_str().is_none()
+            || !parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+            || parsed.path() != "/"
+        {
+            return Err(deployment_config_error(
+                "COSYWORLD_CANONICAL_ROUTE_URL must be an http(s) origin without credentials, path, query, or fragment",
+            ));
+        }
+    }
+    if token.as_deref().is_some_and(|token| token.len() < 16) {
+        return Err(deployment_config_error(
+            "COSYWORLD_CANONICAL_ROUTER_TOKEN must contain at least 16 characters",
+        ));
+    }
+    Ok(CanonicalRoutingConfig { base_url, token })
+}
+
+fn canonical_route_heartbeat_expiry(now_ms: u64, lease_ttl: Duration) -> u64 {
+    let ttl_ms = u64::try_from(lease_ttl.as_millis()).unwrap_or(u64::MAX);
+    now_ms.saturating_add(ttl_ms.saturating_mul(u64::from(CANONICAL_ROUTE_HEARTBEAT_MULTIPLIER)))
+}
+
 fn character_creation_views() -> Vec<CharacterCreationProfileView> {
     active_content()
         .character_creation
@@ -3516,6 +3691,17 @@ fn actor_is_suspended(state: &AppState, actor_id: u64) -> bool {
 
 fn active_actor_ids_for_state(state: &AppState) -> BTreeSet<u64> {
     let mut ids = active_actor_ids(&state.actor_sessions);
+    if let Ok(mut presence) = state.regional_presence.lock() {
+        let now = Instant::now();
+        presence.retain(|_, state| {
+            now.saturating_duration_since(state.last_seen_at) <= ACTIVE_ACTOR_WINDOW
+        });
+        ids.extend(
+            presence
+                .iter()
+                .filter_map(|(actor_id, state)| state.active.then_some(*actor_id)),
+        );
+    }
     if let Ok(suspensions) = state.actor_suspensions.lock() {
         ids.retain(|id| !suspensions.contains_key(id));
     }
@@ -4224,6 +4410,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     configured_content_registry().map_err(io::Error::other)?;
     let state = AppState::bootstrap().await?;
+    let _canonical_capacity_scheduler = start_canonical_capacity_scheduler(state.clone());
     start_actor_job_worker(state.clone());
     start_event_store_retry_scheduler(state.clone());
     start_ownership_refresh_scheduler(state.clone());
@@ -4261,6 +4448,12 @@ impl AppState {
         let resident_continuity_path =
             resident_continuity_path_from_env(snapshot_path.as_deref()).map(Arc::new);
         let event_store_path = event_store_path_from_env().map(Arc::new);
+        let canonical_routing = Arc::new(canonical_routing_config_from_env()?);
+        if canonical_routing.enabled() && event_store_path.is_none() {
+            return Err(deployment_config_error(
+                "canonical process routing requires COSYWORLD_V2_EVENT_DB_PATH",
+            ));
+        }
         let fail_closed_on_continuity_error = deployment.profile.is_production();
         let mut runtime = match event_store_path.as_deref() {
             Some(path) => {
@@ -4531,6 +4724,37 @@ impl AppState {
             deployment.profile.is_production(),
         )?);
         let canonical_owner_id = Arc::new(format!("{}:{}", deployment.process_id, random_hex(16)));
+        let canonical_lease_ttl = canonical_lease_ttl_from_env()?;
+        let (canonical_applied_journal_seq, canonical_fanout_seq) =
+            if let Some(path) = event_store_path.as_deref() {
+                (
+                    latest_action_journal_seq(path)?,
+                    current_world_seq(&open_event_store(path)?, OFFICIAL_WORLD_ID)?,
+                )
+            } else {
+                (0, runtime.world.next_event_seq.saturating_sub(1))
+            };
+        if let (Some(path), Some(base_url)) = (
+            event_store_path.as_deref(),
+            canonical_routing.base_url.as_deref(),
+        ) {
+            let now = now_millis();
+            upsert_process_route(
+                path,
+                OFFICIAL_WORLD_ID,
+                OFFICIAL_WORLD_EPOCH,
+                &CanonicalProcessRoute {
+                    owner_id: canonical_owner_id.as_ref().clone(),
+                    process_id: deployment.process_id.clone(),
+                    base_url: base_url.to_string(),
+                    heartbeat_expires_at_ms: canonical_route_heartbeat_expiry(
+                        now,
+                        canonical_lease_ttl,
+                    ),
+                },
+                now,
+            )?;
+        }
 
         Ok(Self {
             inner: Arc::new(Mutex::new(runtime)),
@@ -4563,7 +4787,12 @@ impl AppState {
             actor_chat_locks: Arc::new(StdMutex::new(BTreeSet::new())),
             canonical_command_lock: Arc::new(Mutex::new(())),
             canonical_owner_id,
-            canonical_lease_ttl: canonical_lease_ttl_from_env()?,
+            canonical_lease_ttl,
+            canonical_applied_journal_seq: Arc::new(AtomicU64::new(canonical_applied_journal_seq)),
+            canonical_fanout_seq: Arc::new(AtomicU64::new(canonical_fanout_seq)),
+            canonical_fanout_lock: Arc::new(StdMutex::new(())),
+            canonical_routing,
+            regional_presence: Arc::new(StdMutex::new(BTreeMap::new())),
             room_turns: Arc::new(StdMutex::new(RoomTurns::default())),
             room_memory_cache: Arc::new(StdMutex::new(BTreeMap::new())),
             room_memory_jobs: Arc::new(StdMutex::new(BTreeSet::new())),
@@ -5263,6 +5492,18 @@ impl RuntimeWorld {
             _ => None,
         }
         .map(String::as_str)
+    }
+
+    fn runtime_handle_for_canonical_ref(&self, kind: &str, canonical_ref: &str) -> Option<u64> {
+        let refs = match kind {
+            "actor" => &self.canonical_identities.actor_refs,
+            "item" => &self.canonical_identities.item_refs,
+            "location" => &self.canonical_identities.location_refs,
+            "journal" => &self.canonical_identities.journal_refs,
+            _ => return None,
+        };
+        refs.iter()
+            .find_map(|(runtime_handle, value)| (value == canonical_ref).then_some(*runtime_handle))
     }
 
     fn canonical_pact_ref(&self, bond_id: &str) -> Option<&str> {
@@ -7607,6 +7848,19 @@ impl RuntimeWorld {
                         actor.kind == CW_ACTOR_NPC && actor.status == CW_ACTOR_ACTIVE
                     });
                     if valid_resident {
+                        if let Some(event) =
+                            self.place_actor_location(*actor_id, *location_id, true)
+                        {
+                            events.push(event);
+                        }
+                    }
+                }
+                ProjectionMutation::RendezvousActor {
+                    actor_id,
+                    location_id,
+                    invite_id: _,
+                } => {
+                    if self.actor_by_id(*actor_id).is_some() {
                         if let Some(event) =
                             self.place_actor_location(*actor_id, *location_id, true)
                         {
@@ -21219,10 +21473,27 @@ async fn pack_open(
     }
 }
 
+async fn converge_capacity_for_read(state: &AppState, actor_session: Option<&str>) {
+    if let Some(token) = actor_session {
+        if let Err(error) = refresh_actor_session_from_store(state, token) {
+            warn!(
+                "failed to refresh actor session for canonical read: {}",
+                error
+            );
+        }
+    }
+    match sync_canonical_capacity_once(state).await {
+        Ok(events) if !events.is_empty() => broadcast_events(state, &events),
+        Ok(_) => {}
+        Err(error) => warn!("canonical read convergence failed: {}", error),
+    }
+}
+
 async fn state_view(
     State(state): State<AppState>,
     Query(query): Query<StateQuery>,
 ) -> Json<StateResponse> {
+    converge_capacity_for_read(&state, query.actor_session.as_deref()).await;
     let ownership = state.ownership_snapshot().await;
     let access = AccessContext::from_query(
         &query,
@@ -21283,6 +21554,7 @@ async fn inspect_view(
     State(state): State<AppState>,
     Query(query): Query<StateQuery>,
 ) -> Json<InspectorView> {
+    converge_capacity_for_read(&state, query.actor_session.as_deref()).await;
     let ownership = state.ownership_snapshot().await;
     let access = AccessContext::from_query(
         &query,
@@ -21320,6 +21592,7 @@ async fn world_view(
     State(state): State<AppState>,
     Query(query): Query<StateQuery>,
 ) -> Json<WorldResponse> {
+    converge_capacity_for_read(&state, query.actor_session.as_deref()).await;
     let ownership = state.ownership_snapshot().await;
     let access = AccessContext::from_query(
         &query,
@@ -21352,6 +21625,7 @@ async fn events_view(
     State(state): State<AppState>,
     Query(query): Query<EventsQuery>,
 ) -> Json<EventsResponse> {
+    converge_capacity_for_read(&state, query.actor_session.as_deref()).await;
     let replay_limit = event_replay_limit(query.limit);
     let ownership = state.ownership_snapshot().await;
     let access = AccessContext::from_events_query(
@@ -23208,6 +23482,467 @@ async fn submit_narrative_move(
     .await
 }
 
+fn canonical_profile_view(runtime: &RuntimeWorld, actor_ref: &str) -> Option<CanonicalProfileView> {
+    let actor_id = runtime.runtime_handle_for_canonical_ref("actor", actor_ref)?;
+    let actor = runtime.actor_by_id(actor_id)?;
+    let location_ref = runtime
+        .canonical_ref("location", actor.location_id)?
+        .to_string();
+    Some(CanonicalProfileView {
+        world_id: OFFICIAL_WORLD_ID.to_string(),
+        world_epoch: OFFICIAL_WORLD_EPOCH,
+        actor_ref: actor_ref.to_string(),
+        actor_id,
+        actor_version: runtime.entity_version(actor_ref),
+        name: runtime.actor_name(actor_id)?,
+        location_ref: location_ref.clone(),
+        location_id: actor.location_id,
+        location_version: runtime.entity_version(&location_ref),
+        location_name: runtime.location_name(actor.location_id)?,
+        through_seq: runtime.world.next_event_seq.saturating_sub(1),
+    })
+}
+
+fn canonical_profile_error(state: &AppState, status: u32) -> Json<CanonicalProfileResponse> {
+    Json(CanonicalProfileResponse {
+        ok: false,
+        status,
+        process_id: state.deployment.process_id.clone(),
+        profile: None,
+    })
+}
+
+async fn canonical_profile(
+    State(state): State<AppState>,
+    Query(query): Query<CanonicalProfileQuery>,
+) -> Json<CanonicalProfileResponse> {
+    converge_capacity_for_read(&state, None).await;
+    let actor_ref = query.actor_ref.trim();
+    if actor_ref.is_empty() || actor_ref.len() > 512 {
+        return canonical_profile_error(&state, 400);
+    }
+    let runtime = state.inner.lock().await;
+    let Some(profile) = canonical_profile_view(&runtime, actor_ref) else {
+        return canonical_profile_error(&state, 404);
+    };
+    Json(CanonicalProfileResponse {
+        ok: true,
+        status: 200,
+        process_id: state.deployment.process_id.clone(),
+        profile: Some(profile),
+    })
+}
+
+fn canonical_invite_response_error(state: &AppState, status: u32) -> Json<CanonicalInviteResponse> {
+    Json(CanonicalInviteResponse {
+        ok: false,
+        status,
+        process_id: state.deployment.process_id.clone(),
+        invite: None,
+    })
+}
+
+fn canonical_invite_id_valid(invite_id: &str) -> bool {
+    (8..=128).contains(&invite_id.len())
+        && invite_id
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+}
+
+fn canonical_invite_view(
+    runtime: &RuntimeWorld,
+    invite: &CanonicalInvite,
+) -> Option<CanonicalInviteView> {
+    Some(CanonicalInviteView {
+        invite_id: invite.invite_id.clone(),
+        invite_url: format!("/invites/{}", invite.invite_id),
+        world_id: invite.world_id.clone(),
+        world_epoch: OFFICIAL_WORLD_EPOCH,
+        inviter: canonical_profile_view(runtime, &invite.actor_ref)?,
+        created_location_ref: invite.created_location_ref.clone(),
+        created_world_seq: invite.created_world_seq,
+        expires_at_ms: invite.expires_at_ms,
+    })
+}
+
+async fn create_canonical_invite(
+    State(state): State<AppState>,
+    Json(payload): Json<CreateCanonicalInviteRequest>,
+) -> Json<CanonicalInviteResponse> {
+    converge_capacity_for_read(&state, Some(&payload.actor_session)).await;
+    let Some(path) = state.event_store_path.as_deref() else {
+        return canonical_invite_response_error(&state, 503);
+    };
+    let (actor_ref, location_ref, world_seq) = {
+        let runtime = state.inner.lock().await;
+        if !client_actor_session_matches_for_state(
+            &runtime,
+            &state,
+            payload.actor_id,
+            Some(&payload.actor_session),
+        ) {
+            return canonical_invite_response_error(&state, 403);
+        }
+        let Some(actor_ref) = runtime.canonical_ref("actor", payload.actor_id) else {
+            return canonical_invite_response_error(&state, 404);
+        };
+        let Some(location_ref) = runtime
+            .actor_by_id(payload.actor_id)
+            .and_then(|actor| runtime.canonical_ref("location", actor.location_id))
+        else {
+            return canonical_invite_response_error(&state, 404);
+        };
+        (
+            actor_ref.to_string(),
+            location_ref.to_string(),
+            runtime.world.next_event_seq.saturating_sub(1),
+        )
+    };
+    let now = now_millis();
+    let invite = CanonicalInvite {
+        invite_id: format!("cw_{}", random_hex(16)),
+        world_id: OFFICIAL_WORLD_ID.to_string(),
+        actor_ref,
+        created_location_ref: location_ref,
+        created_world_seq: world_seq,
+        created_at_ms: now,
+        expires_at_ms: now
+            .saturating_add(u64::try_from(CANONICAL_INVITE_TTL.as_millis()).unwrap_or(u64::MAX)),
+    };
+    match insert_canonical_invite(path, OFFICIAL_WORLD_EPOCH, &invite) {
+        Ok(true) => {}
+        Ok(false) => return canonical_invite_response_error(&state, 409),
+        Err(error) => {
+            warn!("failed to persist canonical invite: {}", error);
+            return canonical_invite_response_error(&state, 503);
+        }
+    }
+    let runtime = state.inner.lock().await;
+    let Some(invite) = canonical_invite_view(&runtime, &invite) else {
+        return canonical_invite_response_error(&state, 500);
+    };
+    Json(CanonicalInviteResponse {
+        ok: true,
+        status: 201,
+        process_id: state.deployment.process_id.clone(),
+        invite: Some(invite),
+    })
+}
+
+async fn canonical_invite(
+    State(state): State<AppState>,
+    AxumPath(invite_id): AxumPath<String>,
+) -> Json<CanonicalInviteResponse> {
+    converge_capacity_for_read(&state, None).await;
+    if !canonical_invite_id_valid(&invite_id) {
+        return canonical_invite_response_error(&state, 400);
+    }
+    let Some(path) = state.event_store_path.as_deref() else {
+        return canonical_invite_response_error(&state, 503);
+    };
+    let invite = match read_canonical_invite(
+        path,
+        OFFICIAL_WORLD_ID,
+        OFFICIAL_WORLD_EPOCH,
+        &invite_id,
+        now_millis(),
+    ) {
+        Ok(Some(invite)) => invite,
+        Ok(None) => return canonical_invite_response_error(&state, 404),
+        Err(error) => {
+            warn!("failed to read canonical invite: {}", error);
+            return canonical_invite_response_error(&state, 503);
+        }
+    };
+    let runtime = state.inner.lock().await;
+    let Some(invite) = canonical_invite_view(&runtime, &invite) else {
+        return canonical_invite_response_error(&state, 404);
+    };
+    Json(CanonicalInviteResponse {
+        ok: true,
+        status: 200,
+        process_id: state.deployment.process_id.clone(),
+        invite: Some(invite),
+    })
+}
+
+fn canonical_invite_follow_error(
+    state: &AppState,
+    invite_id: &str,
+    status: u32,
+) -> Json<CanonicalInviteFollowResponse> {
+    Json(CanonicalInviteFollowResponse {
+        ok: false,
+        status,
+        process_id: state.deployment.process_id.clone(),
+        invite_id: invite_id.to_string(),
+        actor_ref: None,
+        rendezvous_location_ref: None,
+        through_seq: 0,
+        events: Vec::new(),
+    })
+}
+
+async fn forward_canonical_invite_follow(
+    state: &AppState,
+    route: &CanonicalProcessRoute,
+    client_addr: SocketAddr,
+    invite_id: &str,
+    payload: &FollowCanonicalInviteRequest,
+) -> io::Result<CanonicalInviteFollowResponse> {
+    let token =
+        state.canonical_routing.token.as_deref().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::PermissionDenied, "router token missing")
+        })?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(io::Error::other)?;
+    let response = client
+        .post(format!(
+            "{}/internal/canonical/invites/follow",
+            route.base_url
+        ))
+        .bearer_auth(token)
+        .json(&ForwardedCanonicalInviteFollow {
+            source_process_id: state.deployment.process_id.clone(),
+            client_addr: client_addr.to_string(),
+            invite_id: invite_id.to_string(),
+            payload: payload.clone(),
+        })
+        .send()
+        .await
+        .map_err(io::Error::other)?;
+    if !response.status().is_success() {
+        return Err(io::Error::other(format!(
+            "canonical owner {} returned HTTP {}",
+            route.process_id,
+            response.status()
+        )));
+    }
+    response.json().await.map_err(io::Error::other)
+}
+
+async fn follow_canonical_invite(
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    AxumPath(invite_id): AxumPath<String>,
+    Json(payload): Json<FollowCanonicalInviteRequest>,
+) -> Json<CanonicalInviteFollowResponse> {
+    follow_canonical_invite_with_forwarding(client_addr, state, invite_id, payload, true).await
+}
+
+async fn follow_canonical_invite_with_forwarding(
+    client_addr: SocketAddr,
+    state: AppState,
+    invite_id: String,
+    payload: FollowCanonicalInviteRequest,
+    allow_forward: bool,
+) -> Json<CanonicalInviteFollowResponse> {
+    if !canonical_invite_id_valid(&invite_id) {
+        return canonical_invite_follow_error(&state, &invite_id, 400);
+    }
+    converge_capacity_for_read(&state, Some(&payload.actor_session)).await;
+    let _command_guard = state.canonical_command_lock.lock().await;
+    let Some(path) = state.event_store_path.as_deref() else {
+        return canonical_invite_follow_error(&state, &invite_id, 503);
+    };
+    let invite = match read_canonical_invite(
+        path,
+        OFFICIAL_WORLD_ID,
+        OFFICIAL_WORLD_EPOCH,
+        &invite_id,
+        now_millis(),
+    ) {
+        Ok(Some(invite)) => invite,
+        Ok(None) => return canonical_invite_follow_error(&state, &invite_id, 404),
+        Err(error) => {
+            warn!("failed to resolve canonical invite: {}", error);
+            return canonical_invite_follow_error(&state, &invite_id, 503);
+        }
+    };
+    let access = AccessContext::for_linked_actor_receipt(&state, payload.actor_id);
+    let (actor_ref, origin_location_id, target_location_id, target_location_ref, partitions) = {
+        let runtime = state.inner.lock().await;
+        if !client_actor_session_matches_for_state(
+            &runtime,
+            &state,
+            payload.actor_id,
+            Some(&payload.actor_session),
+        ) {
+            return canonical_invite_follow_error(&state, &invite_id, 403);
+        }
+        let Some(actor_ref) = runtime.canonical_ref("actor", payload.actor_id) else {
+            return canonical_invite_follow_error(&state, &invite_id, 404);
+        };
+        let Some(origin_location_id) = runtime
+            .actor_by_id(payload.actor_id)
+            .map(|actor| actor.location_id)
+        else {
+            return canonical_invite_follow_error(&state, &invite_id, 404);
+        };
+        let Some(inviter_id) = runtime.runtime_handle_for_canonical_ref("actor", &invite.actor_ref)
+        else {
+            return canonical_invite_follow_error(&state, &invite_id, 404);
+        };
+        let Some(target_location_id) = runtime
+            .actor_by_id(inviter_id)
+            .map(|actor| actor.location_id)
+        else {
+            return canonical_invite_follow_error(&state, &invite_id, 404);
+        };
+        if !location_access_allowed(target_location_id, &access) {
+            return canonical_invite_follow_error(&state, &invite_id, 403);
+        }
+        let Some(target_location_ref) = runtime.canonical_ref("location", target_location_id)
+        else {
+            return canonical_invite_follow_error(&state, &invite_id, 404);
+        };
+        (
+            actor_ref.to_string(),
+            origin_location_id,
+            target_location_id,
+            target_location_ref.to_string(),
+            canonical_partitions_for_location_ids(
+                &runtime,
+                [origin_location_id, target_location_id],
+            ),
+        )
+    };
+    if origin_location_id == target_location_id {
+        let through_seq = state
+            .inner
+            .lock()
+            .await
+            .world
+            .next_event_seq
+            .saturating_sub(1);
+        return Json(CanonicalInviteFollowResponse {
+            ok: true,
+            status: 200,
+            process_id: state.deployment.process_id.clone(),
+            invite_id,
+            actor_ref: Some(actor_ref),
+            rendezvous_location_ref: Some(target_location_ref),
+            through_seq,
+            events: Vec::new(),
+        });
+    }
+    let lease_result = acquire_partition_leases(
+        path,
+        OFFICIAL_WORLD_ID,
+        OFFICIAL_WORLD_EPOCH,
+        &partitions,
+        state.canonical_owner_id.as_str(),
+        now_millis(),
+        authority_lease_ttl_ms(&state),
+    );
+    if let Err(error) = lease_result {
+        if allow_forward
+            && error.kind() == io::ErrorKind::WouldBlock
+            && state.canonical_routing.enabled()
+        {
+            match canonical_route_for_partitions(&state, &partitions) {
+                Ok(Some(route)) => {
+                    match forward_canonical_invite_follow(
+                        &state,
+                        &route,
+                        client_addr,
+                        &invite_id,
+                        &payload,
+                    )
+                    .await
+                    {
+                        Ok(response) => {
+                            match sync_canonical_capacity_once(&state).await {
+                                Ok(events) if !events.is_empty() => {
+                                    broadcast_events(&state, &events)
+                                }
+                                Ok(_) => {}
+                                Err(sync_error) => warn!(
+                                    "invite rendezvous committed but local convergence failed: {}",
+                                    sync_error
+                                ),
+                            }
+                            return Json(response);
+                        }
+                        Err(route_error) => warn!(
+                            "failed to route invite rendezvous to {}: {}",
+                            route.process_id, route_error
+                        ),
+                    }
+                }
+                Ok(None) => {}
+                Err(route_error) => warn!("invite owner route lookup failed: {}", route_error),
+            }
+        }
+        warn!(
+            "canonical invite rendezvous authority unavailable: {}",
+            error
+        );
+        return canonical_invite_follow_error(&state, &invite_id, 503);
+    }
+
+    let (status, events, through_seq, rendezvous_location_ref) = {
+        let mut runtime = state.inner.lock().await;
+        let Some(inviter_id) = runtime.runtime_handle_for_canonical_ref("actor", &invite.actor_ref)
+        else {
+            return canonical_invite_follow_error(&state, &invite_id, 404);
+        };
+        let Some(current_target_location_id) = runtime
+            .actor_by_id(inviter_id)
+            .map(|actor| actor.location_id)
+        else {
+            return canonical_invite_follow_error(&state, &invite_id, 404);
+        };
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: payload.actor_id,
+                destination_location_id: current_target_location_id,
+                ..CwAction::default()
+            },
+            runtime.next_seed_value(),
+        );
+        record.source_location_id = Some(origin_location_id);
+        record
+            .projection_mutations
+            .push(ProjectionMutation::RendezvousActor {
+                actor_id: payload.actor_id,
+                location_id: current_target_location_id,
+                invite_id: invite_id.clone(),
+            });
+        let (status, events) = match commit_journal_record(&state, &mut runtime, record) {
+            Ok(committed) => committed,
+            Err(error) => {
+                warn!("canonical invite rendezvous commit failed: {}", error);
+                return canonical_invite_follow_error(&state, &invite_id, 503);
+            }
+        };
+        let rendezvous_location_ref = runtime
+            .canonical_ref("location", current_target_location_id)
+            .map(ToString::to_string);
+        (
+            status,
+            events,
+            runtime.world.next_event_seq.saturating_sub(1),
+            rendezvous_location_ref,
+        )
+    };
+    broadcast_events(&state, &events);
+    Json(CanonicalInviteFollowResponse {
+        ok: status == CW_OK,
+        status,
+        process_id: state.deployment.process_id.clone(),
+        invite_id,
+        actor_ref: Some(actor_ref),
+        rendezvous_location_ref,
+        through_seq,
+        events,
+    })
+}
+
 fn canonical_command_error(
     command: &str,
     status: u32,
@@ -23238,16 +23973,7 @@ fn acquire_command_authority_leases(
     runtime: &RuntimeWorld,
     actor_id: u64,
 ) -> io::Result<BTreeMap<String, AuthorityLease>> {
-    let mut partitions = BTreeSet::new();
-    if let Some(location_ref) = runtime
-        .actor_by_id(actor_id)
-        .and_then(|actor| runtime.canonical_ref("location", actor.location_id))
-    {
-        partitions.insert(canonical_room_partition_key(location_ref));
-    }
-    if partitions.is_empty() {
-        partitions.insert(CANONICAL_WORLD_PARTITION.to_string());
-    }
+    let partitions = canonical_command_partitions(runtime, actor_id);
     let now = now_millis();
     let ttl = authority_lease_ttl_ms(state);
     let Some(path) = state.event_store_path.as_deref() else {
@@ -23277,14 +24003,135 @@ fn acquire_command_authority_leases(
     )
 }
 
+fn canonical_command_partitions(runtime: &RuntimeWorld, actor_id: u64) -> BTreeSet<String> {
+    let mut partitions = BTreeSet::new();
+    if let Some(location_ref) = runtime
+        .actor_by_id(actor_id)
+        .and_then(|actor| runtime.canonical_ref("location", actor.location_id))
+    {
+        partitions.insert(canonical_room_partition_key(location_ref));
+    }
+    if partitions.is_empty() {
+        partitions.insert(CANONICAL_WORLD_PARTITION.to_string());
+    }
+    partitions
+}
+
+fn canonical_route_for_partitions(
+    state: &AppState,
+    partitions: &BTreeSet<String>,
+) -> io::Result<Option<CanonicalProcessRoute>> {
+    let Some(path) = state.event_store_path.as_deref() else {
+        return Ok(None);
+    };
+    let now = now_millis();
+    let mut owner_id = None;
+    for partition_key in partitions {
+        let Some(lease) = current_partition_lease(
+            path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            partition_key,
+            now,
+        )?
+        else {
+            continue;
+        };
+        if owner_id
+            .as_ref()
+            .is_some_and(|owner: &String| owner != &lease.owner_id)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "canonical partitions currently have different owners",
+            ));
+        }
+        owner_id = Some(lease.owner_id);
+    }
+    let Some(owner_id) = owner_id else {
+        return Ok(None);
+    };
+    if owner_id == *state.canonical_owner_id {
+        return Ok(None);
+    }
+    process_route_for_owner(
+        path,
+        OFFICIAL_WORLD_ID,
+        OFFICIAL_WORLD_EPOCH,
+        &owner_id,
+        now,
+    )
+}
+
+async fn forward_canonical_command(
+    state: &AppState,
+    route: &CanonicalProcessRoute,
+    client_addr: SocketAddr,
+    payload: &CommandRequest,
+) -> io::Result<CommandResponse> {
+    let token =
+        state.canonical_routing.token.as_deref().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::PermissionDenied, "router token missing")
+        })?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(io::Error::other)?;
+    let response = client
+        .post(format!("{}/internal/canonical/commands", route.base_url))
+        .bearer_auth(token)
+        .json(&ForwardedCanonicalCommand {
+            source_process_id: state.deployment.process_id.clone(),
+            client_addr: client_addr.to_string(),
+            payload: payload.clone(),
+        })
+        .send()
+        .await
+        .map_err(io::Error::other)?;
+    if !response.status().is_success() {
+        return Err(io::Error::other(format!(
+            "canonical owner {} returned HTTP {}",
+            route.process_id,
+            response.status()
+        )));
+    }
+    response.json().await.map_err(io::Error::other)
+}
+
 async fn command(
     ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
-    Json(mut payload): Json<CommandRequest>,
+    Json(payload): Json<CommandRequest>,
 ) -> Json<CommandResponse> {
-    // #128 moves this serialization and the receipt/event append into the
-    // durable authority. While production remains one process, this lock makes
-    // the canonical intent check and command execution one local critical section.
+    command_with_forwarding(client_addr, state, payload, true).await
+}
+
+async fn command_with_forwarding(
+    client_addr: SocketAddr,
+    state: AppState,
+    mut payload: CommandRequest,
+    allow_forward: bool,
+) -> Json<CommandResponse> {
+    match sync_canonical_capacity_once(&state).await {
+        Ok(events) if !events.is_empty() => broadcast_events(&state, &events),
+        Ok(_) => {}
+        Err(error) => {
+            warn!("canonical command convergence failed: {}", error);
+            return canonical_command_error(
+                &payload.command,
+                503,
+                "Canonical history is temporarily unavailable. Refresh and retry.",
+            );
+        }
+    }
+    if let Some(token) = payload.actor_session.as_deref() {
+        if let Err(error) = refresh_actor_session_from_store(&state, token) {
+            warn!("failed to refresh canonical actor session: {}", error);
+        }
+    }
+    // The local lock serializes validation for commands that route to this
+    // process. Cross-process serialization and idempotency live in SQLite.
     let _command_guard = state.canonical_command_lock.lock().await;
     let compatibility_envelope = payload.envelope.is_none();
     let envelope = {
@@ -23454,18 +24301,54 @@ async fn command(
         }
     }
 
-    let leases = {
+    payload.envelope = Some(envelope.clone());
+    let (partitions, lease_result) = {
         let runtime = state.inner.lock().await;
-        match acquire_command_authority_leases(&state, &runtime, payload.actor_id) {
-            Ok(leases) => leases,
-            Err(error) => {
-                warn!("canonical command authority is unavailable: {}", error);
-                return canonical_command_error(
-                    &payload.command,
-                    503,
-                    "Canonical write authority is unavailable. Refresh and retry.",
-                );
+        (
+            canonical_command_partitions(&runtime, payload.actor_id),
+            acquire_command_authority_leases(&state, &runtime, payload.actor_id),
+        )
+    };
+    let leases = match lease_result {
+        Ok(leases) => leases,
+        Err(error) => {
+            if allow_forward
+                && error.kind() == io::ErrorKind::WouldBlock
+                && state.canonical_routing.enabled()
+            {
+                match canonical_route_for_partitions(&state, &partitions) {
+                    Ok(Some(route)) => {
+                        match forward_canonical_command(&state, &route, client_addr, &payload).await
+                        {
+                            Ok(response) => {
+                                match sync_canonical_capacity_once(&state).await {
+                                    Ok(events) if !events.is_empty() => {
+                                        broadcast_events(&state, &events)
+                                    }
+                                    Ok(_) => {}
+                                    Err(sync_error) => warn!(
+                                        "forwarded command committed but local convergence failed: {}",
+                                        sync_error
+                                    ),
+                                }
+                                return Json(response);
+                            }
+                            Err(route_error) => warn!(
+                                "failed to route canonical command from {} to {}: {}",
+                                state.deployment.process_id, route.process_id, route_error
+                            ),
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(route_error) => warn!("canonical route lookup failed: {}", route_error),
+                }
             }
+            warn!("canonical command authority is unavailable: {}", error);
+            return canonical_command_error(
+                &payload.command,
+                503,
+                "Canonical write authority is unavailable. Refresh and retry.",
+            );
         }
     };
     let command_context = Arc::new(CanonicalCommandCommitContext {
@@ -23476,7 +24359,6 @@ async fn command(
         leases,
         phase: AtomicU8::new(0),
     });
-    payload.envelope = Some(envelope.clone());
     let Json(mut response) = CANONICAL_COMMAND_COMMIT_CONTEXT
         .scope(
             command_context.clone(),
@@ -23616,6 +24498,88 @@ async fn command(
         }
     }
     Json(response)
+}
+
+fn canonical_internal_authorized(state: &AppState, headers: &HeaderMap) -> bool {
+    let Some(expected) = state.canonical_routing.token.as_deref() else {
+        return false;
+    };
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|provided| provided == expected)
+}
+
+async fn internal_canonical_command(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Json(forwarded): Json<ForwardedCanonicalCommand>,
+) -> Response {
+    if !canonical_internal_authorized(&state, &headers) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let client_addr = forwarded
+        .client_addr
+        .parse::<SocketAddr>()
+        .unwrap_or_else(|_| "127.0.0.1:0".parse().expect("loopback socket"));
+    let response = command_with_forwarding(client_addr, state, forwarded.payload, false).await;
+    (StatusCode::OK, response).into_response()
+}
+
+async fn internal_canonical_presence(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Json(relay): Json<CanonicalPresenceRelay>,
+) -> Response {
+    if !canonical_internal_authorized(&state, &headers) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    if relay.source_owner_id == *state.canonical_owner_id
+        || relay.events.iter().any(|event| {
+            event.world_id != OFFICIAL_WORLD_ID
+                || event.world_epoch != OFFICIAL_WORLD_EPOCH
+                || event.seq != 0
+                || event.type_name != "actor.presence"
+        })
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    {
+        let mut runtime = state.inner.lock().await;
+        for event in &relay.events {
+            if let Some(actor_id) = event.actor_id {
+                runtime
+                    .presence_states
+                    .insert(actor_id, event.content.as_deref() == Some("active"));
+            }
+        }
+    }
+    broadcast_events_without_presence_relay(&state, &relay.events);
+    StatusCode::NO_CONTENT.into_response()
+}
+
+async fn internal_follow_canonical_invite(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Json(forwarded): Json<ForwardedCanonicalInviteFollow>,
+) -> Response {
+    if !canonical_internal_authorized(&state, &headers) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let client_addr = forwarded
+        .client_addr
+        .parse::<SocketAddr>()
+        .unwrap_or_else(|_| "127.0.0.1:0".parse().expect("loopback socket"));
+    let response = follow_canonical_invite_with_forwarding(
+        client_addr,
+        state,
+        forwarded.invite_id,
+        forwarded.payload,
+        false,
+    )
+    .await;
+    (StatusCode::OK, response).into_response()
 }
 
 async fn command_inner(
@@ -24921,6 +25885,96 @@ fn start_actor_job_worker(state: AppState) {
     tokio::spawn(async move {
         run_actor_job_worker(state, ACTOR_JOB_KIND_ORB_CHAT).await;
     });
+}
+
+fn refresh_canonical_process_route(state: &AppState) -> io::Result<()> {
+    let (Some(path), Some(base_url)) = (
+        state.event_store_path.as_deref(),
+        state.canonical_routing.base_url.as_deref(),
+    ) else {
+        return Ok(());
+    };
+    let now = now_millis();
+    upsert_process_route(
+        path,
+        OFFICIAL_WORLD_ID,
+        OFFICIAL_WORLD_EPOCH,
+        &CanonicalProcessRoute {
+            owner_id: state.canonical_owner_id.as_ref().clone(),
+            process_id: state.deployment.process_id.clone(),
+            base_url: base_url.to_string(),
+            heartbeat_expires_at_ms: canonical_route_heartbeat_expiry(
+                now,
+                state.canonical_lease_ttl,
+            ),
+        },
+        now,
+    )
+}
+
+async fn sync_canonical_capacity_once(state: &AppState) -> io::Result<Vec<EventView>> {
+    let Some(path) = state.event_store_path.as_deref() else {
+        return Ok(Vec::new());
+    };
+    let latest_journal_seq = latest_action_journal_seq(path)?;
+    if latest_journal_seq
+        > state
+            .canonical_applied_journal_seq
+            .load(AtomicOrdering::Acquire)
+    {
+        let mut runtime = state.inner.lock().await;
+        let applied = state
+            .canonical_applied_journal_seq
+            .load(AtomicOrdering::Acquire);
+        if latest_journal_seq > applied {
+            let presence_states = runtime.presence_states.clone();
+            restore_runtime_from_durable_state(state, &mut runtime, path)?;
+            runtime.presence_states = presence_states;
+            state
+                .canonical_applied_journal_seq
+                .store(latest_journal_seq, AtomicOrdering::Release);
+        }
+    }
+
+    let through_seq = current_world_seq(&open_event_store(path)?, OFFICIAL_WORLD_ID)?;
+    let after = state.canonical_fanout_seq.load(AtomicOrdering::Acquire);
+    if through_seq <= after {
+        return Ok(Vec::new());
+    }
+    let events = read_event_store_forward_between(path, after, through_seq, MAX_EVENT_STORE_SCAN)?;
+    Ok(events)
+}
+
+fn start_canonical_capacity_scheduler(state: AppState) -> Option<tokio::task::JoinHandle<()>> {
+    state.event_store_path.as_ref()?;
+    Some(tokio::spawn(async move {
+        let heartbeat_interval = state
+            .canonical_lease_ttl
+            .checked_div(2)
+            .unwrap_or(Duration::from_secs(1))
+            .max(Duration::from_secs(1));
+        let mut next_heartbeat = Instant::now();
+        loop {
+            if Instant::now() >= next_heartbeat {
+                if let Err(error) = refresh_canonical_process_route(&state) {
+                    warn!(
+                        "failed to refresh canonical route for process {}: {}",
+                        state.deployment.process_id, error
+                    );
+                }
+                next_heartbeat = Instant::now() + heartbeat_interval;
+            }
+            match sync_canonical_capacity_once(&state).await {
+                Ok(events) if !events.is_empty() => broadcast_events(&state, &events),
+                Ok(_) => {}
+                Err(error) => warn!(
+                    "canonical convergence poll failed for process {}: {}",
+                    state.deployment.process_id, error
+                ),
+            }
+            tokio::time::sleep(DEFAULT_CANONICAL_CONVERGENCE_POLL).await;
+        }
+    }))
 }
 
 fn start_event_store_retry_scheduler(state: AppState) {
@@ -29785,6 +30839,7 @@ async fn stream(
     State(state): State<AppState>,
     Query(query): Query<EventsQuery>,
 ) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    converge_capacity_for_read(&state, query.actor_session.as_deref()).await;
     let ownership = state.ownership_snapshot().await;
     let access = AccessContext::from_events_query(
         &query,
@@ -29949,12 +31004,101 @@ fn sse_gap_event(gap: EventReplayGap) -> Option<Result<Event, Infallible>> {
 }
 
 fn broadcast_events(state: &AppState, events: &[EventView]) {
+    broadcast_events_inner(state, events, true);
+}
+
+fn broadcast_events_without_presence_relay(state: &AppState, events: &[EventView]) {
+    broadcast_events_inner(state, events, false);
+}
+
+fn broadcast_events_inner(state: &AppState, events: &[EventView], relay_presence: bool) {
+    let _fanout_guard = state
+        .canonical_fanout_lock
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut presence_events = Vec::new();
     for event in events
         .iter()
         .filter(|event| event.type_name != "action.receipt")
     {
+        if event.seq > 0 {
+            let current = state.canonical_fanout_seq.load(AtomicOrdering::Acquire);
+            if event.seq <= current {
+                continue;
+            }
+            if event.seq != current.saturating_add(1) {
+                warn!(
+                    "delaying durable fan-out seq {} until process {} catches up from {}",
+                    event.seq, state.deployment.process_id, current
+                );
+                continue;
+            }
+            state
+                .canonical_fanout_seq
+                .store(event.seq, AtomicOrdering::Release);
+        } else if event.type_name == "actor.presence" {
+            if let Some(actor_id) = event.actor_id {
+                if let Ok(mut presence) = state.regional_presence.lock() {
+                    presence.insert(
+                        actor_id,
+                        RegionalPresence {
+                            active: event.content.as_deref() == Some("active"),
+                            last_seen_at: Instant::now(),
+                        },
+                    );
+                }
+            }
+            presence_events.push(event.clone());
+        }
         let _ = state.tx.send(event.clone());
     }
+    if relay_presence && !presence_events.is_empty() && state.canonical_routing.enabled() {
+        let state = state.clone();
+        tokio::spawn(async move {
+            if let Err(error) = fanout_capacity_presence(&state, presence_events).await {
+                warn!("canonical presence fan-out failed: {}", error);
+            }
+        });
+    }
+}
+
+async fn fanout_capacity_presence(state: &AppState, events: Vec<EventView>) -> io::Result<()> {
+    let Some(path) = state.event_store_path.as_deref() else {
+        return Ok(());
+    };
+    let Some(token) = state.canonical_routing.token.as_deref() else {
+        return Ok(());
+    };
+    let routes =
+        active_process_routes(path, OFFICIAL_WORLD_ID, OFFICIAL_WORLD_EPOCH, now_millis())?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+        .map_err(io::Error::other)?;
+    let payload = CanonicalPresenceRelay {
+        source_owner_id: state.canonical_owner_id.as_ref().clone(),
+        events,
+    };
+    for route in routes
+        .into_iter()
+        .filter(|route| route.owner_id != *state.canonical_owner_id)
+    {
+        let url = format!("{}/internal/canonical/presence", route.base_url);
+        if let Err(error) = client
+            .post(url)
+            .bearer_auth(token)
+            .json(&payload)
+            .send()
+            .await
+            .and_then(reqwest::Response::error_for_status)
+        {
+            warn!(
+                "presence relay from {} to {} failed: {}",
+                state.deployment.process_id, route.process_id, error
+            );
+        }
+    }
+    Ok(())
 }
 
 fn index_etag() -> &'static str {
@@ -31788,7 +32932,7 @@ fn commit_journal_record(
             }
         },
     };
-    let (status, events, _actor_job_inserted) = if let Some(path) =
+    let (status, events, _actor_job_inserted, _committed_journal_seq) = if let Some(path) =
         state.event_store_path.as_deref()
     {
         let mut conn = match open_event_store(path) {
@@ -31814,7 +32958,7 @@ fn commit_journal_record(
                 return Err(error);
             }
         };
-        let committed = (|| -> io::Result<(u32, Vec<EventView>, bool)> {
+        let committed = (|| -> io::Result<(u32, Vec<EventView>, bool, u64)> {
             let commit_time = now_millis();
             let lease_ttl = authority_lease_ttl_ms(state);
             for lease in authority_leases.values_mut() {
@@ -31999,6 +33143,7 @@ fn commit_journal_record(
                 status,
                 events,
                 observation_job_inserted || queued_job_inserted,
+                action_journal_seq,
             ))
         })();
         let committed = match committed {
@@ -32026,6 +33171,9 @@ fn commit_journal_record(
         if let Some(context) = command_context.as_ref() {
             context.finish_commit();
         }
+        state
+            .canonical_applied_journal_seq
+            .store(committed.3, AtomicOrdering::Release);
         state.record_event_store_append_success();
         committed
     } else {
@@ -32033,7 +33181,7 @@ fn commit_journal_record(
         if let Some(context) = command_context.as_ref() {
             context.finish_commit();
         }
-        (status, events, false)
+        (status, events, false, 0)
     };
     if !events.is_empty() {
         state.mark_activity();
@@ -32539,6 +33687,19 @@ fn action_journal_has_records(path: &Path) -> io::Result<bool> {
     Ok(count > 0)
 }
 
+fn latest_action_journal_seq(path: &Path) -> io::Result<u64> {
+    init_event_store(path)?;
+    let conn = open_event_store(path)?;
+    let value = conn
+        .query_row(
+            "SELECT COALESCE(MAX(journal_seq), 0) FROM action_journal",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_error)?;
+    u64::try_from(value).map_err(|_| snapshot_error("action journal returned a negative sequence"))
+}
+
 #[cfg(test)]
 fn append_action_journal(path: &Path, record: &JournalRecord) -> io::Result<()> {
     init_event_store(path)?;
@@ -32867,6 +34028,57 @@ fn load_actor_sessions(path: &Path) -> io::Result<ActorSessions> {
         );
     }
     Ok(sessions)
+}
+
+fn refresh_actor_session_from_store(state: &AppState, session_token: &str) -> io::Result<()> {
+    let token = session_token.trim();
+    if token.is_empty() {
+        return Ok(());
+    }
+    if state
+        .actor_sessions
+        .lock()
+        .map(|sessions| sessions.sessions.contains_key(token))
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+    let Some(path) = state.event_store_path.as_deref() else {
+        return Ok(());
+    };
+    init_event_store(path)?;
+    let conn = open_event_store(path)?;
+    let now_unix = now_unix_secs();
+    let stored = conn
+        .query_row(
+            "SELECT actor_id, expires_at_unix
+             FROM actor_sessions
+             WHERE session_token = ?1 AND expires_at_unix > ?2",
+            params![token, now_unix as i64],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()
+        .map_err(sqlite_error)?;
+    let Some((actor_id, expires_at_unix)) = stored else {
+        return Ok(());
+    };
+    if actor_id <= 0 || expires_at_unix <= now_unix as i64 {
+        return Ok(());
+    }
+    let now = Instant::now();
+    if let Ok(mut sessions) = state.actor_sessions.lock() {
+        sessions
+            .sessions
+            .entry(token.to_string())
+            .or_insert(ActorSession {
+                actor_id: actor_id as u64,
+                expires_at: now + Duration::from_secs(expires_at_unix as u64 - now_unix),
+                expires_at_unix: expires_at_unix as u64,
+                last_seen_at: inactive_presence_seen_at(now),
+                explicitly_inactive: true,
+            });
+    }
+    Ok(())
 }
 
 fn persist_actor_session(path: &Path, token: &str, session: &ActorSession) -> io::Result<()> {
@@ -34087,7 +35299,10 @@ fn read_economy_audit(path: &Path, limit: usize) -> io::Result<ModerationEconomy
 }
 
 fn open_event_store(path: &Path) -> io::Result<Connection> {
-    Connection::open(path).map_err(sqlite_error)
+    let conn = Connection::open(path).map_err(sqlite_error)?;
+    conn.busy_timeout(Duration::from_secs(5))
+        .map_err(sqlite_error)?;
+    Ok(conn)
 }
 
 fn canonical_command_receipt_key(world_id: &str, intent_id: &str) -> String {
@@ -34104,7 +35319,7 @@ fn read_canonical_command_response(
     conn.query_row(
         "SELECT request_hash, response_json
          FROM canonical_command_receipts
-         WHERE world_id = ?1 AND intent_id = ?2",
+         WHERE world_id = ?1 AND intent_id = ?2 AND finalized = 1",
         params![world_id, intent_id],
         |row| {
             Ok(StoredCommandResponse {
@@ -34300,6 +35515,7 @@ mod tests {
 
     fn test_app_state(runtime: RuntimeWorld, event_store_path: Option<PathBuf>) -> AppState {
         let (tx, _) = broadcast::channel(32);
+        let canonical_fanout_seq = runtime.world.next_event_seq.saturating_sub(1);
         AppState {
             inner: Arc::new(Mutex::new(runtime)),
             tx,
@@ -34333,6 +35549,11 @@ mod tests {
             canonical_command_lock: Arc::new(Mutex::new(())),
             canonical_owner_id: Arc::new(format!("test:{}", random_hex(8))),
             canonical_lease_ttl: DEFAULT_CANONICAL_LEASE_TTL,
+            canonical_applied_journal_seq: Arc::new(AtomicU64::new(0)),
+            canonical_fanout_seq: Arc::new(AtomicU64::new(canonical_fanout_seq)),
+            canonical_fanout_lock: Arc::new(StdMutex::new(())),
+            canonical_routing: Arc::new(CanonicalRoutingConfig::default()),
+            regional_presence: Arc::new(StdMutex::new(BTreeMap::new())),
             room_turns: Arc::new(StdMutex::new(RoomTurns::default())),
             room_memory_cache: Arc::new(StdMutex::new(BTreeMap::new())),
             room_memory_jobs: Arc::new(StdMutex::new(BTreeSet::new())),
@@ -34345,6 +35566,78 @@ mod tests {
             },
             allow_unsigned_wallet_claims: false,
         }
+    }
+
+    fn configure_capacity_test_state(
+        mut state: AppState,
+        process_id: &str,
+        owner_id: &str,
+        base_url: &str,
+        router_token: &str,
+        lease_ttl: Duration,
+    ) -> AppState {
+        state.deployment = DeploymentConfig {
+            profile: DeploymentProfile::Local,
+            world_id: OFFICIAL_WORLD_ID.to_string(),
+            process_id: process_id.to_string(),
+        };
+        state.canonical_owner_id = Arc::new(owner_id.to_string());
+        state.canonical_lease_ttl = lease_ttl;
+        state.canonical_routing = Arc::new(CanonicalRoutingConfig {
+            base_url: Some(base_url.to_string()),
+            token: Some(router_token.to_string()),
+        });
+        if let Some(path) = state.event_store_path.as_deref() {
+            state.canonical_applied_journal_seq.store(
+                latest_action_journal_seq(path).expect("capacity test journal sequence"),
+                AtomicOrdering::Release,
+            );
+            state.canonical_fanout_seq.store(
+                current_world_seq(
+                    &open_event_store(path).expect("capacity test store"),
+                    OFFICIAL_WORLD_ID,
+                )
+                .expect("capacity test world sequence"),
+                AtomicOrdering::Release,
+            );
+            state.actor_sessions = Arc::new(StdMutex::new(
+                load_actor_sessions(path).expect("capacity test actor sessions"),
+            ));
+        }
+        refresh_canonical_process_route(&state).expect("register capacity test route");
+        state
+    }
+
+    async fn commit_capacity_test_human(
+        state: &AppState,
+        actor_id: u64,
+        location_id: u64,
+        name: &str,
+    ) -> String {
+        let events = {
+            let mut runtime = state.inner.lock().await;
+            let mut create = CwAction::default();
+            create.kind = CW_ACTION_CREATE_ACTOR;
+            create.actor_id = actor_id;
+            create.location_id = location_id;
+            let mut record = JournalRecord::new(create, 90_000 + actor_id);
+            record.actor_meta_upserts.insert(
+                actor_id,
+                ActorMeta {
+                    name: name.to_string(),
+                    speech_mode: "prose".to_string(),
+                    title: "Capacity Test Avatar".to_string(),
+                    description: "A pinned client in the canonical convergence harness."
+                        .to_string(),
+                },
+            );
+            let (status, events) =
+                commit_journal_record(state, &mut runtime, record).expect("commit test avatar");
+            assert_eq!(status, CW_OK);
+            events
+        };
+        broadcast_events(state, &events);
+        issue_actor_session(state, actor_id).0
     }
 
     fn command_request(actor_id: u64, command: &str) -> CommandRequest {
@@ -34465,6 +35758,140 @@ mod tests {
         );
     }
 
+    #[test]
+    fn canonical_routing_requires_a_safe_origin_and_paired_secret() {
+        assert!(!canonical_routing_config(None, None).unwrap().enabled());
+        assert!(
+            canonical_routing_config(Some("https://capacity.example".to_string()), None,).is_err()
+        );
+        assert!(canonical_routing_config(
+            Some("https://capacity.example/internal".to_string()),
+            Some("0123456789abcdef".to_string()),
+        )
+        .is_err());
+        assert!(canonical_routing_config(
+            Some("https://capacity.example".to_string()),
+            Some("too-short".to_string()),
+        )
+        .is_err());
+
+        let config = canonical_routing_config(
+            Some("https://capacity.example".to_string()),
+            Some("0123456789abcdef".to_string()),
+        )
+        .unwrap();
+        assert!(config.enabled());
+        assert_eq!(config.base_url.as_deref(), Some("https://capacity.example"));
+    }
+
+    #[test]
+    fn canonical_internal_auth_is_hidden_without_the_exact_bearer_secret() {
+        let mut state = test_app_state(RuntimeWorld::seeded(), None);
+        state.canonical_routing = Arc::new(CanonicalRoutingConfig {
+            base_url: Some("http://127.0.0.1:4101".to_string()),
+            token: Some("0123456789abcdef".to_string()),
+        });
+        let mut headers = HeaderMap::new();
+        assert!(!canonical_internal_authorized(&state, &headers));
+        headers.insert(
+            header::AUTHORIZATION,
+            "Bearer wrong-secret".parse().unwrap(),
+        );
+        assert!(!canonical_internal_authorized(&state, &headers));
+        headers.insert(
+            header::AUTHORIZATION,
+            "Bearer 0123456789abcdef".parse().unwrap(),
+        );
+        assert!(canonical_internal_authorized(&state, &headers));
+    }
+
+    #[test]
+    fn provisional_atomic_command_receipts_are_not_client_visible() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-provisional-receipt-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        init_event_store(&path).expect("initialize receipt store");
+        let conn = open_event_store(&path).expect("open receipt store");
+        init_canonical_journal(&conn, OFFICIAL_WORLD_ID, OFFICIAL_WORLD_EPOCH)
+            .expect("initialize canonical receipt schema");
+        insert_atomic_command_receipt(
+            &conn,
+            &CanonicalReceiptRow {
+                world_id: OFFICIAL_WORLD_ID,
+                intent_id: "test:provisional",
+                request_hash: "hash",
+                response_json: r#"{"receipt":null}"#,
+                commit_id: "commit:1",
+                world_epoch: OFFICIAL_WORLD_EPOCH,
+                world_seq: 1,
+                owner_id: "process-a:boot-a",
+                owner_fencing_epoch: 1,
+                created_at_ms: 10,
+            },
+        )
+        .expect("insert provisional receipt");
+        drop(conn);
+
+        assert!(
+            read_canonical_command_response(&path, OFFICIAL_WORLD_ID, "test:provisional",)
+                .unwrap()
+                .is_none()
+        );
+        assert!(finalize_atomic_command_receipt(
+            &path,
+            OFFICIAL_WORLD_ID,
+            "test:provisional",
+            "hash",
+            r#"{"receipt":{"world_seq":1}}"#,
+            1,
+            11,
+        )
+        .unwrap());
+        assert_eq!(
+            read_canonical_command_response(&path, OFFICIAL_WORLD_ID, "test:provisional",)
+                .unwrap()
+                .map(|stored| stored.response_json),
+            Some(r#"{"receipt":{"world_seq":1}}"#.to_string())
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn durable_process_fanout_is_ordered_and_exactly_once() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Fanout Neighbour",
+        );
+        let event = runtime
+            .event_log
+            .iter()
+            .find(|event| event.seq > 0 && event.type_name != "action.receipt")
+            .cloned()
+            .expect("durable actor event");
+        let mut delayed = event.clone();
+        delayed.seq = event.seq + 1;
+        delayed.type_name = "test.delayed".to_string();
+        let state = test_app_state(runtime, None);
+        state
+            .canonical_fanout_seq
+            .store(event.seq.saturating_sub(1), AtomicOrdering::Release);
+        let mut receiver = state.tx.subscribe();
+
+        broadcast_events(&state, &[delayed.clone()]);
+        assert!(receiver.try_recv().is_err(), "a durable gap must wait");
+        broadcast_events(&state, &[event.clone(), delayed.clone()]);
+        assert_eq!(receiver.try_recv().unwrap().seq, event.seq);
+        assert_eq!(receiver.try_recv().unwrap().seq, delayed.seq);
+        broadcast_events(&state, &[event, delayed]);
+        assert!(receiver.try_recv().is_err(), "a durable retry must dedupe");
+    }
+
     #[tokio::test]
     async fn duplicate_canonical_intent_returns_the_same_receipt_and_one_effect() {
         let actor_id = 5000;
@@ -34524,6 +35951,480 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn divergent_capacity_processes_converge_without_affinity() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-capacity-convergence-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        init_event_store(&path).expect("initialize convergence store");
+
+        let listener_a = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind process A");
+        let listener_b = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind process B");
+        let addr_a = listener_a.local_addr().expect("process A address");
+        let addr_b = listener_b.local_addr().expect("process B address");
+        let url_a = format!("http://{addr_a}");
+        let url_b = format!("http://{addr_b}");
+        let router_token = "capacity-test-router-token";
+        let lease_ttl = Duration::from_secs(1);
+
+        let state_a = configure_capacity_test_state(
+            test_app_state(RuntimeWorld::seeded(), Some(path.clone())),
+            "process-a",
+            "process-a:boot-a",
+            &url_a,
+            router_token,
+            lease_ttl,
+        );
+        let actor_a = 5000;
+        let actor_b = 5001;
+        let session_a =
+            commit_capacity_test_human(&state_a, actor_a, COSY_COTTAGE_LOCATION_ID, "Pinned A")
+                .await;
+        let session_b =
+            commit_capacity_test_human(&state_a, actor_b, RAIN_SOFT_GARDEN_LOCATION_ID, "Pinned B")
+                .await;
+        let baseline_seq = current_world_seq(
+            &open_event_store(&path).expect("baseline store"),
+            OFFICIAL_WORLD_ID,
+        )
+        .expect("baseline cursor");
+
+        let mut runtime_b = RuntimeWorld::from_action_journal(&path).expect("replay process B");
+        advance_runtime_next_event_seq_from_store(&mut runtime_b, &path)
+            .expect("advance process B cursor");
+        let state_b = configure_capacity_test_state(
+            test_app_state(runtime_b, Some(path.clone())),
+            "process-b",
+            "process-b:boot-b",
+            &url_b,
+            router_token,
+            lease_ttl,
+        );
+
+        let app_a = routes::app_router(state_a.clone());
+        let app_b = routes::app_router(state_b.clone());
+        let server_a = tokio::spawn(async move {
+            axum::serve(
+                listener_a,
+                app_a.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("serve process A");
+        });
+        let server_b = tokio::spawn(async move {
+            axum::serve(
+                listener_b,
+                app_b.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("serve process B");
+        });
+        let convergence_a =
+            start_canonical_capacity_scheduler(state_a.clone()).expect("process A convergence");
+        let convergence_b =
+            start_canonical_capacity_scheduler(state_b.clone()).expect("process B convergence");
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("capacity test client");
+
+        // Presence crosses the real process routes but stays outside durable history.
+        let mut presence_rx_b = state_b.tx.subscribe();
+        let ping: serde_json::Value = client
+            .post(format!("{url_a}/presence/ping"))
+            .json(&serde_json::json!({
+                "actor_id": actor_a,
+                "actor_session": session_a,
+            }))
+            .send()
+            .await
+            .expect("ping through process A")
+            .json()
+            .await
+            .expect("presence response");
+        assert_eq!(ping["ok"], true);
+        let relayed_presence = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let event = presence_rx_b
+                    .recv()
+                    .await
+                    .expect("process B presence event");
+                if event.type_name == "actor.presence" && event.actor_id == Some(actor_a) {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("presence fan-out timeout");
+        assert_eq!(relayed_presence.seq, 0);
+        assert_eq!(relayed_presence.content.as_deref(), Some("active"));
+        assert_eq!(
+            current_world_seq(
+                &open_event_store(&path).expect("presence cursor store"),
+                OFFICIAL_WORLD_ID,
+            )
+            .expect("presence cursor"),
+            baseline_seq,
+            "presence must not advance canonical history"
+        );
+
+        // Refresh process A's room lease immediately before B follows the invite.
+        let warmup_request = {
+            let runtime = state_a.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_a,
+                &session_a,
+                "test:capacity-warmup",
+                "say the same hearth is ready",
+            )
+        };
+        let warmup: CommandResponse = client
+            .post(format!("{url_a}/commands"))
+            .json(&warmup_request)
+            .send()
+            .await
+            .expect("warmup command")
+            .json()
+            .await
+            .expect("warmup response");
+        assert!(warmup.ok, "{warmup:?}");
+
+        let invite: CanonicalInviteResponse = client
+            .post(format!("{url_a}/invites"))
+            .json(&CreateCanonicalInviteRequest {
+                actor_id: actor_a,
+                actor_session: session_a.clone(),
+            })
+            .send()
+            .await
+            .expect("create invite through A")
+            .json()
+            .await
+            .expect("invite response");
+        assert!(invite.ok, "{invite:?}");
+        assert_eq!(invite.process_id, "process-a");
+        let invite = invite.invite.expect("canonical invite");
+        let resolved_on_b: CanonicalInviteResponse = client
+            .get(format!("{url_b}/invites/{}", invite.invite_id))
+            .send()
+            .await
+            .expect("resolve invite through B")
+            .json()
+            .await
+            .expect("resolved invite response");
+        assert!(resolved_on_b.ok, "{resolved_on_b:?}");
+        assert_eq!(resolved_on_b.process_id, "process-b");
+        assert_eq!(
+            resolved_on_b
+                .invite
+                .as_ref()
+                .map(|view| view.inviter.actor_ref.as_str()),
+            Some(invite.inviter.actor_ref.as_str())
+        );
+
+        let followed: CanonicalInviteFollowResponse = client
+            .post(format!("{url_b}/invites/{}/follow", invite.invite_id))
+            .json(&FollowCanonicalInviteRequest {
+                actor_id: actor_b,
+                actor_session: session_b.clone(),
+            })
+            .send()
+            .await
+            .expect("follow invite through B")
+            .json()
+            .await
+            .expect("follow response");
+        assert!(followed.ok, "{followed:?}");
+        assert_eq!(
+            followed.rendezvous_location_ref.as_deref(),
+            Some(invite.inviter.location_ref.as_str())
+        );
+        assert!(followed.events.iter().any(|event| {
+            event.type_name == "actor.moved"
+                && event.actor_id == Some(actor_b)
+                && event.destination_location_id == Some(COSY_COTTAGE_LOCATION_ID)
+        }));
+
+        let actor_b_ref = followed.actor_ref.clone().expect("actor B canonical ref");
+        let profile_a: CanonicalProfileResponse = client
+            .get(format!("{url_a}/profiles"))
+            .query(&[("actor_ref", actor_b_ref.as_str())])
+            .send()
+            .await
+            .expect("profile through A")
+            .json()
+            .await
+            .expect("profile A response");
+        let profile_b: CanonicalProfileResponse = client
+            .get(format!("{url_b}/profiles"))
+            .query(&[("actor_ref", actor_b_ref.as_str())])
+            .send()
+            .await
+            .expect("profile through B")
+            .json()
+            .await
+            .expect("profile B response");
+        assert_eq!(profile_a.profile, profile_b.profile);
+        assert_eq!(
+            profile_b.profile.as_ref().map(|view| view.location_id),
+            Some(COSY_COTTAGE_LOCATION_ID)
+        );
+
+        // One intent enters through both processes concurrently and commits once.
+        let retry_request = {
+            let runtime = state_a.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_a,
+                &session_a,
+                "test:cross-process-retry",
+                "say this arrives exactly once",
+            )
+        };
+        let request_a = client
+            .post(format!("{url_a}/commands"))
+            .json(&retry_request)
+            .send();
+        let request_b = client
+            .post(format!("{url_b}/commands"))
+            .json(&retry_request)
+            .send();
+        let (response_a, response_b) = tokio::join!(request_a, request_b);
+        let response_a: CommandResponse = response_a
+            .expect("retry through A")
+            .json()
+            .await
+            .expect("retry A response");
+        let response_b: CommandResponse = response_b
+            .expect("retry through B")
+            .json()
+            .await
+            .expect("retry B response");
+        assert!(response_a.ok, "{response_a:?}");
+        assert!(response_b.ok, "{response_b:?}");
+        assert_eq!(response_a.receipt, response_b.receipt);
+        assert_eq!(
+            serde_json::to_value(&response_a).unwrap(),
+            serde_json::to_value(&response_b).unwrap()
+        );
+        let receipt_count = open_event_store(&path)
+            .expect("receipt store")
+            .query_row(
+                "SELECT COUNT(*) FROM canonical_command_receipts
+                 WHERE world_id = ?1 AND intent_id = ?2",
+                params![OFFICIAL_WORLD_ID, "test:cross-process-retry"],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("receipt count");
+        assert_eq!(receipt_count, 1);
+        for state in [&state_a, &state_b] {
+            converge_capacity_for_read(state, None).await;
+            assert_eq!(
+                state
+                    .inner
+                    .lock()
+                    .await
+                    .event_log
+                    .iter()
+                    .filter(|event| {
+                        event.type_name == "message.created"
+                            && event.actor_id == Some(actor_a)
+                            && event.content.as_deref() == Some("this arrives exactly once")
+                    })
+                    .count(),
+                1
+            );
+        }
+
+        // A command entering through B mutates the item once on A's fenced room.
+        let (loose_item_id, loose_item_name) = {
+            let runtime = state_a.inner.lock().await;
+            let item = runtime.world.items[..runtime.world.item_count]
+                .iter()
+                .find(|item| {
+                    item.location_id == COSY_COTTAGE_LOCATION_ID && item.holder_actor_id == 0
+                })
+                .copied()
+                .expect("loose cottage item");
+            (
+                item.id,
+                runtime.item_name(item.id).expect("loose item name"),
+            )
+        };
+        let take_request = {
+            let runtime = state_a.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_a,
+                &session_a,
+                "test:cross-process-item",
+                &format!("take {loose_item_name}"),
+            )
+        };
+        let take: CommandResponse = client
+            .post(format!("{url_b}/commands"))
+            .json(&take_request)
+            .send()
+            .await
+            .expect("take through B")
+            .json()
+            .await
+            .expect("take response");
+        assert!(take.ok, "{take:?}");
+        for state in [&state_a, &state_b] {
+            converge_capacity_for_read(state, None).await;
+            assert_eq!(
+                state
+                    .inner
+                    .lock()
+                    .await
+                    .item_by_id(loose_item_id)
+                    .map(|item| item.holder_actor_id),
+                Some(actor_a)
+            );
+        }
+
+        let state_url = |base: &str| format!("{base}/state");
+        let state_a_view: serde_json::Value = client
+            .get(state_url(&url_a))
+            .query(&[
+                ("actor_id", actor_b.to_string()),
+                ("actor_session", session_b.clone()),
+            ])
+            .send()
+            .await
+            .expect("state through A")
+            .json()
+            .await
+            .expect("state A json");
+        let state_b_view: serde_json::Value = client
+            .get(state_url(&url_b))
+            .query(&[
+                ("actor_id", actor_b.to_string()),
+                ("actor_session", session_b.clone()),
+            ])
+            .send()
+            .await
+            .expect("state through B")
+            .json()
+            .await
+            .expect("state B json");
+        for field in ["location", "actors", "items", "action_hand"] {
+            assert_eq!(
+                state_a_view[field], state_b_view[field],
+                "pinned clients diverged at {field}"
+            );
+        }
+
+        let events_a: EventsResponse = client
+            .get(format!("{url_a}/events"))
+            .query(&[
+                ("after", baseline_seq.to_string()),
+                ("limit", "500".to_string()),
+                ("actor_id", actor_b.to_string()),
+                ("actor_session", session_b.clone()),
+            ])
+            .send()
+            .await
+            .expect("events through A")
+            .json()
+            .await
+            .expect("events A response");
+        let events_b: EventsResponse = client
+            .get(format!("{url_b}/events"))
+            .query(&[
+                ("after", baseline_seq.to_string()),
+                ("limit", "500".to_string()),
+                ("actor_id", actor_b.to_string()),
+                ("actor_session", session_b.clone()),
+            ])
+            .send()
+            .await
+            .expect("events through B")
+            .json()
+            .await
+            .expect("events B response");
+        assert_eq!(
+            serde_json::to_value(&events_a.events).unwrap(),
+            serde_json::to_value(&events_b.events).unwrap()
+        );
+        assert!(events_a.caught_up && events_b.caught_up);
+        assert!(events_a
+            .events
+            .windows(2)
+            .all(|events| events[0].seq + 1 == events[1].seq));
+
+        // Kill the owner entrance. B waits for lease expiry, takes a higher fence,
+        // and continues from the same actor identity and committed prefix.
+        convergence_a.abort();
+        server_a.abort();
+        tokio::time::sleep(lease_ttl + Duration::from_millis(250)).await;
+        converge_capacity_for_read(&state_b, Some(&session_a)).await;
+        let failover_request = {
+            let runtime = state_b.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_a,
+                &session_a,
+                "test:owner-process-loss",
+                "say history stayed with us",
+            )
+        };
+        let failover: CommandResponse = client
+            .post(format!("{url_b}/commands"))
+            .json(&failover_request)
+            .send()
+            .await
+            .expect("command after owner loss")
+            .json()
+            .await
+            .expect("failover response");
+        assert!(failover.ok, "{failover:?}");
+        assert!(
+            failover
+                .receipt
+                .as_ref()
+                .map(|receipt| receipt.owner_fencing_epoch)
+                > response_a
+                    .receipt
+                    .as_ref()
+                    .map(|receipt| receipt.owner_fencing_epoch)
+        );
+        let profile_after_loss: CanonicalProfileResponse = client
+            .get(format!("{url_b}/profiles"))
+            .query(&[("actor_ref", invite.inviter.actor_ref.as_str())])
+            .send()
+            .await
+            .expect("profile after owner loss")
+            .json()
+            .await
+            .expect("profile after loss response");
+        assert_eq!(
+            profile_after_loss
+                .profile
+                .as_ref()
+                .map(|profile| profile.actor_ref.as_str()),
+            Some(invite.inviter.actor_ref.as_str())
+        );
+        assert!(state_b.inner.lock().await.event_log.iter().any(|event| {
+            event.type_name == "message.created"
+                && event.content.as_deref() == Some("this arrives exactly once")
+        }));
+
+        convergence_b.abort();
+        server_b.abort();
+        drop(client);
+        let _ = fs::remove_file(path);
     }
 
     #[tokio::test]
@@ -56078,6 +57979,7 @@ mod tests {
         let mut runtime = RuntimeWorld::seeded();
         runtime.apply_wallet_overlap_placements(&initial, 0);
         assert_eq!(runtime.actor_by_id(1001).unwrap().location_id, 1);
+        let canonical_fanout_seq = runtime.world.next_event_seq.saturating_sub(1);
 
         let (tx, _) = broadcast::channel(8);
         let state = AppState {
@@ -56113,6 +58015,11 @@ mod tests {
             canonical_command_lock: Arc::new(Mutex::new(())),
             canonical_owner_id: Arc::new(format!("test:{}", random_hex(8))),
             canonical_lease_ttl: DEFAULT_CANONICAL_LEASE_TTL,
+            canonical_applied_journal_seq: Arc::new(AtomicU64::new(0)),
+            canonical_fanout_seq: Arc::new(AtomicU64::new(canonical_fanout_seq)),
+            canonical_fanout_lock: Arc::new(StdMutex::new(())),
+            canonical_routing: Arc::new(CanonicalRoutingConfig::default()),
+            regional_presence: Arc::new(StdMutex::new(BTreeMap::new())),
             room_turns: Arc::new(StdMutex::new(RoomTurns::default())),
             room_memory_cache: Arc::new(StdMutex::new(BTreeMap::new())),
             room_memory_jobs: Arc::new(StdMutex::new(BTreeSet::new())),

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -17,7 +17,7 @@ pub(crate) struct CommandResponse {
     pub(crate) events: Vec<EventView>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct CommandRequest {
     pub(crate) actor_id: u64,
     pub(crate) actor_session: Option<String>,

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -75,6 +75,10 @@ pub(super) fn app_router(state: AppState) -> Router {
         .route("/inspect", get(inspect_view))
         .route("/world", get(world_view))
         .route("/events", get(events_view))
+        .route("/profiles", get(canonical_profile))
+        .route("/invites", post(create_canonical_invite))
+        .route("/invites/{invite_id}", get(canonical_invite))
+        .route("/invites/{invite_id}/follow", post(follow_canonical_invite))
         .route("/moderation/activation", get(activation_metrics_view))
         .route("/moderation/events", get(moderation_events_view))
         .route("/moderation/reports", get(moderation_reports_view))
@@ -131,6 +135,18 @@ pub(super) fn app_router(state: AppState) -> Router {
         .route("/actions/resolve-bond", post(resolve_bond))
         .route("/actions/flee", post(flee))
         .route("/commands", post(command))
+        .route(
+            "/internal/canonical/commands",
+            post(internal_canonical_command),
+        )
+        .route(
+            "/internal/canonical/presence",
+            post(internal_canonical_presence),
+        )
+        .route(
+            "/internal/canonical/invites/follow",
+            post(internal_follow_canonical_invite),
+        )
         .route("/stream", get(stream))
         .layer(CompressionLayer::new())
         .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
Closes #127

## Summary

- register boot-scoped process routes and forward canonical commands to the current fenced owner
- converge journal-backed projections and ordered durable SSE fanout across capacity processes while relaying presence as ephemeral `seq: 0` events
- add stable profile lookup plus durable invite creation, resolution, and fenced rendezvous
- refresh actor sessions on another process and preserve canonical identity/history through owner expiry and takeover
- keep AWS/Fly at one production task until the #130 hot-room migration/failover gate

## Convergence harness

The new real-loopback harness pins clients to divergent process ids with affinity disabled and proves:

- identical location, actors, items, action hand, and ordered replay
- one effect/receipt for the same intent through both processes
- cross-process profile/invite rendezvous
- item disposition convergence
- reconnect/session refresh
- owner-process loss, higher fencing epoch, and preserved identity/history
- presence fanout without advancing durable history

It also caught and now covers provisional receipt visibility, snapshot-consistent cursor validation, bounded SQLite contention, and ordered exactly-once per-process durable fanout.

## Verification

- `npm test` — 418 passed
- `cargo test` — 362 passed
- `npm run lint`
- `npm run check:version`
- `npm run v2:worldpack`
- `npm run v2:kernel`
- `npm run v2:syntax`
- `npm run build:js`
- `cargo check`
- `cargo build --release`
- `cargo fmt --all --check`
- `cargo clippy`
- `terraform fmt -check infra/aws-lonely-forest`
- `git diff --check`

Release candidate: `v0.0.75`.