### PR TITLE
Prove hot-room migration and regional failover

### DIFF
--- a/docs/deployment/07-deployment.md
+++ b/docs/deployment/07-deployment.md
@@ -160,7 +160,8 @@ NODE_OPTIONS="--max-old-space-size=4096"
 ## Scaling Tips
 
 - Attach a persistent volume for SQLite and keep exactly one production task.
-- Multiple app instances require exact per-process routes and the remaining
-  hot-room migration/process-loss gate in #130. A load balancer alone is unsafe.
+- Hot-room handoff and regional failover are covered by the #130 chaos harness,
+  but multiple production instances still require exact per-task routes and a
+  successful release-specific operator drill. A load balancer alone is unsafe.
 - Redis cache
 - Containerize with Docker/Kubernetes

--- a/infra/aws-lonely-forest/README.md
+++ b/infra/aws-lonely-forest/README.md
@@ -16,11 +16,12 @@ archive/library site at `lonelyforestlibrary.com`.
   `sites/lonelyforestlibrary`.
 
 The ECS service is intentionally `desired_count = 1`. Shared journal fencing,
-cross-process routing, projection/presence convergence, invite rendezvous, and
-the pinned two-process harness are implemented, but ECS still lacks an exact
-per-task owner route and the #130 hot-room migration/failover gate. Do not
-increase it to obtain horizontal write capacity. Multi-process production must
-pass the remaining gates in
+cross-process routing, projection/presence convergence, invite rendezvous,
+atomic hot-room handoff, verified regional recovery, and both chaos harnesses
+are implemented. ECS still lacks an exact per-task owner route, and the first
+release-specific operator drill has not passed. Do not increase it to obtain
+horizontal write capacity. Multi-process production must pass the remaining
+infrastructure and operational gates in
 [`../../v2/docs/canonical-world.md`](../../v2/docs/canonical-world.md).
 
 `COSYWORLD_PROCESS_ID` labels this ECS capacity process in `/meta`.
@@ -32,6 +33,12 @@ persistent-state namespace.
 The task definition intentionally leaves `COSYWORLD_CANONICAL_ROUTE_URL` and
 `COSYWORLD_CANONICAL_ROUTER_TOKEN` unset. A normal ALB origin is not an exact
 task route and must not be placed in the process route registry.
+
+It also leaves the canonical region/recovery variables unset. A future
+multi-region task definition must set `COSYWORLD_CANONICAL_REGION_ID`, and its
+active source must configure both `COSYWORLD_CANONICAL_RECOVERY_DB_PATH` and
+`COSYWORLD_CANONICAL_RECOVERY_REGION_ID`. Promotion is allowed only after the
+source region is hard-fenced and the copied prefix hash is recorded externally.
 
 `deployment.auto.tfvars` captures the current deployed shape:
 

--- a/infra/aws-lonely-forest/variables.tf
+++ b/infra/aws-lonely-forest/variables.tf
@@ -94,11 +94,11 @@ variable "task_memory" {
 variable "desired_count" {
   type        = number
   default     = 1
-  description = "Number of orchestrator tasks. MUST remain 1 until exact ECS task routing and the #130 hot-room migration/failover gate are complete."
+  description = "Number of orchestrator tasks. MUST remain 1 until exact ECS task routing and a release-specific #130 recovery drill are complete."
 
   validation {
     condition     = var.desired_count == 1
-    error_message = "desired_count must remain 1 until exact task routing and the #130 hot-room migration/failover gate are implemented."
+    error_message = "desired_count must remain 1 until exact task routing and the release-specific hot-room/failover drill pass."
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.75",
+      "version": "0.0.76",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -44,11 +44,14 @@ shape still boots one orchestrator, backed by a durable fenced commit point:
 - The C kernel is built with fixed in-process capacities of 512 actors, 1024
   items, 256 locations, 1024 exits, 256 emitted events per kernel call, and 128
   evolution tracks. `/meta` exposes the live counters and these compiled caps.
-- Capacity processes can now register exact routes, forward canonical commands,
-  converge durable projections, relay ephemeral presence, and rendezvous stable
-  profile/invite references. Production remains one task until the hot-room
-  migration and failover gate in #130 passes. Starting isolated public-world
-  copies—or using a shared load balancer URL as an owner route—is forbidden.
+- Capacity processes can register exact routes, forward canonical commands,
+  converge durable projections, relay ephemeral presence, rendezvous stable
+  profile/invite references, atomically hand off hot rooms, checkpoint split
+  ownership ranges, and promote a hash-verified recovery prefix under higher
+  regional and partition fences. Production remains one task until AWS has
+  exact per-task routes and a release-specific recovery drill passes. Starting
+  isolated public-world copies—or using a shared load balancer URL as an owner
+  route—is forbidden. See `docs/canonical-world.md` for the operator contract.
 
 Seed world content:
 

--- a/v2/docs/canonical-world.md
+++ b/v2/docs/canonical-world.md
@@ -13,10 +13,15 @@ an exact boot-scoped route, forwards writes to the current fenced room owner,
 polls the durable suffix, and relays ephemeral presence without advancing the
 world cursor. The pinned two-process harness proves this convergence path.
 
-Production still keeps one task/machine. Hot-room ownership migration and the
-full process-loss/failover gate remain in #130, and a normal shared load
-balancer is not an exact process route. Passing the #127 harness does not by
-itself authorize raising production capacity.
+Atomic hot-room ownership handoff, range checkpoints, durable regional-prefix
+proofs, and fenced recovery promotion are now implemented. The #130 chaos
+harness exercises them under hot load, process loss, storage isolation,
+ownership splits, and source-region loss.
+
+Production still keeps one task/machine. AWS does not yet provide an exact
+per-task owner route, and the first live recovery drill has not been signed off.
+A normal shared load balancer is not an exact process route. Passing the
+software harnesses does not by itself authorize raising production capacity.
 
 The target separates five responsibilities without changing player identity:
 
@@ -163,6 +168,91 @@ view for active-room projections, and never insert it into replay history.
 Session affinity is therefore an optimization only, not a correctness
 requirement.
 
+## Ownership handoff and regional recovery
+
+Every durable store has one random `canonical_store_id`, pinned inside
+`canonical_store_identity`. Every lease acquisition and journal commit checks
+that identity and the active regional authority in the same SQLite transaction.
+If a mounted database disappears after boot, the replacement empty file has no
+identity and mutations fail closed instead of creating a mergeable fork.
+
+`COSYWORLD_CANONICAL_REGION_ID` labels the process region and defaults to
+`local`. `/meta.deployment` exposes `region_id`, `active_region_id`,
+`promotion_epoch`, and `canonical_store_id`. A standby must use the same copied
+store identity, a distinct region id, and the exact process-routing secret.
+
+Hot-room moves use the hidden, bearer-authenticated operator route:
+
+```text
+POST /internal/canonical/ownership/handoff
+{
+  "partition_keys": ["room:world://cosyworld/official/location/opaque-id"],
+  "target_owner_id": "process-b:boot-id",
+  "expected_world_seq": 92811,
+  "reason": "hot-room load rebalance"
+}
+```
+
+The target must have a live exact route in the active region. Storage compares
+the expected global cursor and every source owner/fence/expiry, increments all
+target fences, and writes one `canonical_ownership_checkpoints` row in one
+immediate transaction. A cursor move or stale source aborts the entire handoff.
+Read/SSE fan-out can continue from any converged process; only the fenced room
+owner commits writes.
+
+Regional recovery is opt-in and requires both
+`COSYWORLD_CANONICAL_RECOVERY_DB_PATH` and
+`COSYWORLD_CANONICAL_RECOVERY_REGION_ID`. The recovery path must differ from
+`COSYWORLD_V2_EVENT_DB_PATH`. An authenticated
+`POST /internal/canonical/regions/checkpoint` performs an online SQLite backup,
+hashes the exact committed world/event/journal/lease/entity prefix, and records
+the resulting `sha256:` proof on both copies. Checkpoints never regress.
+
+Promotion runs on the standby process, whose event database is that verified
+copy and whose `COSYWORLD_CANONICAL_REGION_ID` matches the checkpoint region:
+
+```text
+POST /internal/canonical/regions/promote
+{
+  "source_region_id": "us-east-1",
+  "expected_promotion_epoch": 3,
+  "expected_prefix_hash": "sha256:operator-recorded-proof"
+}
+```
+
+The transaction recomputes the proof, compares the store id, committed cursor,
+journal cursor, source region, and promotion epoch, then advances regional
+authority and every partition fence before accepting a target-region write.
+The source region must be hard-fenced from traffic and storage before this call.
+Its old database is quarantined permanently; it is never merged or restored as
+a writer. Rollback is another forward checkpoint/promotion from the current
+authority, not reuse of an older primary.
+
+### Operator drill and observability
+
+1. Record `/meta.deployment`, `/state.world_seq`, the target owner route, and
+   the current lease before a handoff.
+2. Keep synthetic writes running, submit the handoff at that exact cursor, and
+   confirm the logged checkpoint id, higher fence, monotonic entity versions,
+   gap-free event suffix, and zero duplicate intent receipts.
+3. Create a recovery checkpoint and retain its region, world/journal cursors,
+   store id, and prefix hash outside the source region.
+4. Stop source-region ingress and writers, revoke their write path, and prove
+   that no source task or scheduled writer remains. Do not promote on ambiguous
+   isolation.
+5. Start the standby against the copied database. Confirm its configured region
+   differs from `active_region_id`, then promote using the recorded hash and
+   epoch. Confirm the promotion log and higher fences in `/meta`/receipts.
+6. Reconnect clients through both regional edges and compare stable actor,
+   room, item, version, and ordered suffix state. Preserve the old storage as
+   read-only incident evidence.
+
+Alert on a process region differing from `active_region_id`, a promotion-epoch
+change, store-id disagreement, repeated `PermissionDenied` lease errors,
+checkpoint lag, event-store append failure/pending outbox growth, or an exact
+owner route nearing expiry. A failed step keeps traffic on the last confirmed
+authority; it never falls back to an isolated local save.
+
 ## Failure and migration gates
 
 | Gate | Pass condition |
@@ -195,9 +285,15 @@ client B to process B.
    B commits with a higher fence while preserving identity and history.
 
 The harness also proves cross-process session refresh and `seq: 0` presence
-fan-out. The remaining #130 failover suite adds ownership migration during an
-active hot room, stale-owner isolation at the append boundary, and promoted
-region recovery.
+fan-out.
+
+`hot_room_and_regional_chaos_preserve_one_committed_world` adds 16 alternating
+edge writes to one hot room, atomic owner handoff, stale-owner rejection,
+independent hot/cold range ownership, all-or-nothing cross-range mutation,
+empty-store isolation, owner-process loss, exact regional backup proof, source
+region loss, higher-fence promotion, and clients reconnecting through different
+regional edges. It asserts one gap-free suffix, unique event ids, exactly one
+copy of every acknowledged message, and no isolated mutation.
 
 ## Rollout order
 
@@ -207,9 +303,12 @@ region recovery.
    authority to durable multi-process storage. (Complete in #128.)
 3. Add stable routing, regional presence fan-out, invite rendezvous, and the
    pinned two-process harness. (Complete in #127.)
-4. Add partition handoff, hot-room fan-out, and process-loss tests.
-5. Add replicated regional recovery and prove the failover gate.
-6. Raise production capacity only after every gate passes.
+4. Add partition handoff, hot-room fan-out, and process-loss tests. (Complete in
+   #130.)
+5. Add replicated regional recovery and prove the failover gate. (Complete in
+   #130.)
+6. Add exact production per-task routes, pass the release-specific operator
+   drill, and only then raise production capacity.
 
 Rollback always returns traffic to one authoritative writer over the same
 committed journal. It never restores an isolated process save as a competing

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.75"
+version = "0.0.76"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.75"
+version = "0.0.76"
 edition = "2021"
 publish = false
 
@@ -18,7 +18,7 @@ rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["backup", "bundled"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/v2/orchestrator-rust/src/canonical_journal.rs
+++ b/v2/orchestrator-rust/src/canonical_journal.rs
@@ -1,8 +1,9 @@
-use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior, MAIN_DB};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet},
-    io,
+    fs, io,
     path::Path,
     time::Duration,
 };
@@ -54,6 +55,7 @@ pub(super) struct CanonicalReceiptRow<'a> {
 pub(super) struct CanonicalProcessRoute {
     pub(super) owner_id: String,
     pub(super) process_id: String,
+    pub(super) region_id: String,
     pub(super) base_url: String,
     pub(super) heartbeat_expires_at_ms: u64,
 }
@@ -69,6 +71,59 @@ pub(super) struct CanonicalInvite {
     pub(super) expires_at_ms: u64,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct CanonicalOwnershipTransfer {
+    pub(super) source: AuthorityLease,
+    pub(super) target_owner_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct CanonicalOwnershipCheckpoint {
+    pub(super) checkpoint_id: String,
+    pub(super) world_id: String,
+    pub(super) world_epoch: u64,
+    pub(super) world_seq: u64,
+    pub(super) leases: BTreeMap<String, AuthorityLease>,
+    pub(super) reason: String,
+    pub(super) created_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct CanonicalReplicaCheckpoint {
+    pub(super) world_id: String,
+    pub(super) world_epoch: u64,
+    pub(super) store_id: String,
+    pub(super) region_id: String,
+    pub(super) durable_world_seq: u64,
+    pub(super) action_journal_seq: u64,
+    pub(super) prefix_hash: String,
+    pub(super) created_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct CanonicalRegionAuthority {
+    pub(super) world_id: String,
+    pub(super) world_epoch: u64,
+    pub(super) active_region_id: String,
+    pub(super) promotion_epoch: u64,
+    pub(super) durable_world_seq: u64,
+    pub(super) updated_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct CanonicalRegionPromotion {
+    pub(super) promotion_id: String,
+    pub(super) world_id: String,
+    pub(super) world_epoch: u64,
+    pub(super) source_region_id: String,
+    pub(super) target_region_id: String,
+    pub(super) promotion_epoch: u64,
+    pub(super) durable_world_seq: u64,
+    pub(super) action_journal_seq: u64,
+    pub(super) prefix_hash: String,
+    pub(super) promoted_at_ms: u64,
+}
+
 pub(super) fn init_canonical_journal(
     conn: &Connection,
     world_id: &str,
@@ -81,6 +136,12 @@ pub(super) fn init_canonical_journal(
             committed_seq INTEGER NOT NULL,
             updated_at_ms INTEGER NOT NULL
         );
+        CREATE TABLE IF NOT EXISTS canonical_store_identity (
+            world_id TEXT PRIMARY KEY,
+            world_epoch INTEGER NOT NULL,
+            store_id TEXT NOT NULL UNIQUE,
+            created_at_ms INTEGER NOT NULL
+        );
         CREATE TABLE IF NOT EXISTS canonical_partition_leases (
             world_id TEXT NOT NULL,
             partition_key TEXT NOT NULL,
@@ -92,6 +153,17 @@ pub(super) fn init_canonical_journal(
         );
         CREATE INDEX IF NOT EXISTS idx_canonical_partition_leases_owner
             ON canonical_partition_leases(world_id, owner_id, lease_expires_at_ms);
+        CREATE TABLE IF NOT EXISTS canonical_ownership_checkpoints (
+            checkpoint_id TEXT PRIMARY KEY,
+            world_id TEXT NOT NULL,
+            world_epoch INTEGER NOT NULL,
+            world_seq INTEGER NOT NULL,
+            leases_json TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_canonical_ownership_checkpoints_world_seq
+            ON canonical_ownership_checkpoints(world_id, world_epoch, world_seq);
         CREATE TABLE IF NOT EXISTS canonical_entity_versions (
             world_id TEXT NOT NULL,
             entity_ref TEXT NOT NULL,
@@ -139,6 +211,39 @@ pub(super) fn init_canonical_journal(
         );
         CREATE INDEX IF NOT EXISTS idx_canonical_process_routes_live
             ON canonical_process_routes(world_id, heartbeat_expires_at_ms, process_id);
+        CREATE TABLE IF NOT EXISTS canonical_region_authority (
+            world_id TEXT PRIMARY KEY,
+            world_epoch INTEGER NOT NULL,
+            active_region_id TEXT NOT NULL,
+            promotion_epoch INTEGER NOT NULL,
+            durable_world_seq INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS canonical_region_replicas (
+            world_id TEXT NOT NULL,
+            world_epoch INTEGER NOT NULL,
+            region_id TEXT NOT NULL,
+            store_id TEXT NOT NULL,
+            durable_world_seq INTEGER NOT NULL,
+            action_journal_seq INTEGER NOT NULL,
+            prefix_hash TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            PRIMARY KEY (world_id, region_id)
+        );
+        CREATE TABLE IF NOT EXISTS canonical_region_promotions (
+            promotion_id TEXT PRIMARY KEY,
+            world_id TEXT NOT NULL,
+            world_epoch INTEGER NOT NULL,
+            source_region_id TEXT NOT NULL,
+            target_region_id TEXT NOT NULL,
+            promotion_epoch INTEGER NOT NULL,
+            durable_world_seq INTEGER NOT NULL,
+            action_journal_seq INTEGER NOT NULL,
+            prefix_hash TEXT NOT NULL,
+            promoted_at_ms INTEGER NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_canonical_region_promotions_epoch
+            ON canonical_region_promotions(world_id, promotion_epoch);
         CREATE TABLE IF NOT EXISTS canonical_invites (
             invite_id TEXT PRIMARY KEY,
             world_id TEXT NOT NULL,
@@ -152,6 +257,13 @@ pub(super) fn init_canonical_journal(
             ON canonical_invites(world_id, actor_ref, expires_at_ms);",
     )
     .map_err(sqlite_error)?;
+
+    ensure_column(
+        conn,
+        "canonical_process_routes",
+        "region_id",
+        "ALTER TABLE canonical_process_routes ADD COLUMN region_id TEXT NOT NULL DEFAULT 'local'",
+    )?;
 
     for (column, alter_sql) in [
         (
@@ -252,6 +364,787 @@ pub(super) fn init_canonical_journal(
     Ok(())
 }
 
+pub(super) fn ensure_canonical_store_identity(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    proposed_store_id: &str,
+    created_at_ms: u64,
+) -> io::Result<String> {
+    validate_storage_label(proposed_store_id, "canonical store id")?;
+    let mut conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
+    tx.execute(
+        "INSERT OR IGNORE INTO canonical_store_identity
+            (world_id, world_epoch, store_id, created_at_ms)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            world_id,
+            as_i64(world_epoch)?,
+            proposed_store_id,
+            as_i64(created_at_ms)?
+        ],
+    )
+    .map_err(sqlite_error)?;
+    let store_id = canonical_store_identity_in_connection(&tx, world_id, world_epoch)?;
+    tx.commit().map_err(sqlite_error)?;
+    Ok(store_id)
+}
+
+pub(super) fn validate_canonical_store_identity(
+    conn: &Connection,
+    world_id: &str,
+    world_epoch: u64,
+    expected_store_id: &str,
+) -> io::Result<()> {
+    let stored = canonical_store_identity_in_connection(conn, world_id, world_epoch)?;
+    if stored != expected_store_id {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "canonical store identity mismatch: expected {expected_store_id}, found {stored}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_store_identity_in_connection(
+    conn: &Connection,
+    world_id: &str,
+    world_epoch: u64,
+) -> io::Result<String> {
+    let stored = conn
+        .query_row(
+            "SELECT world_epoch, store_id
+             FROM canonical_store_identity
+             WHERE world_id = ?1",
+            params![world_id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()
+        .map_err(sqlite_error)?
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "canonical store identity is missing; refusing to create an isolated world fork",
+            )
+        })?;
+    if stored.0 != as_i64(world_epoch)? {
+        return Err(invalid_data(format!(
+            "canonical store epoch mismatch: storage has {}, runtime expects {world_epoch}",
+            stored.0
+        )));
+    }
+    validate_storage_label(&stored.1, "canonical store id")?;
+    Ok(stored.1)
+}
+
+pub(super) fn ensure_region_authority(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    initial_region_id: &str,
+    updated_at_ms: u64,
+) -> io::Result<CanonicalRegionAuthority> {
+    validate_storage_label(initial_region_id, "canonical region id")?;
+    let mut conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
+    let durable_world_seq = current_world_seq(&tx, world_id)?;
+    tx.execute(
+        "INSERT OR IGNORE INTO canonical_region_authority
+            (world_id, world_epoch, active_region_id, promotion_epoch,
+             durable_world_seq, updated_at_ms)
+         VALUES (?1, ?2, ?3, 1, ?4, ?5)",
+        params![
+            world_id,
+            as_i64(world_epoch)?,
+            initial_region_id,
+            as_i64(durable_world_seq)?,
+            as_i64(updated_at_ms)?
+        ],
+    )
+    .map_err(sqlite_error)?;
+    let authority = current_region_authority_in_connection(&tx, world_id, world_epoch)?;
+    tx.commit().map_err(sqlite_error)?;
+    Ok(authority)
+}
+
+pub(super) fn current_region_authority(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+) -> io::Result<CanonicalRegionAuthority> {
+    let conn = open_canonical_store(path)?;
+    current_region_authority_in_connection(&conn, world_id, world_epoch)
+}
+
+fn current_region_authority_in_connection(
+    conn: &Connection,
+    world_id: &str,
+    world_epoch: u64,
+) -> io::Result<CanonicalRegionAuthority> {
+    let row = conn
+        .query_row(
+            "SELECT world_epoch, active_region_id, promotion_epoch,
+                    durable_world_seq, updated_at_ms
+             FROM canonical_region_authority
+             WHERE world_id = ?1",
+            params![world_id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(sqlite_error)?
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "canonical region authority is missing",
+            )
+        })?;
+    if row.0 != as_i64(world_epoch)? {
+        return Err(invalid_data(format!(
+            "canonical region epoch mismatch: authority has {}, runtime expects {world_epoch}",
+            row.0
+        )));
+    }
+    Ok(CanonicalRegionAuthority {
+        world_id: world_id.to_string(),
+        world_epoch,
+        active_region_id: row.1,
+        promotion_epoch: as_u64(row.2, "promotion_epoch")?,
+        durable_world_seq: as_u64(row.3, "durable_world_seq")?,
+        updated_at_ms: as_u64(row.4, "updated_at_ms")?,
+    })
+}
+
+pub(super) fn validate_active_region(
+    conn: &Connection,
+    world_id: &str,
+    world_epoch: u64,
+    region_id: &str,
+) -> io::Result<CanonicalRegionAuthority> {
+    let authority = current_region_authority_in_connection(conn, world_id, world_epoch)?;
+    if authority.active_region_id != region_id {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "region {region_id} is fenced; active canonical region is {} at promotion epoch {}",
+                authority.active_region_id, authority.promotion_epoch
+            ),
+        ));
+    }
+    Ok(authority)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn acquire_partition_leases_for_region(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    expected_store_id: &str,
+    region_id: &str,
+    partition_keys: &BTreeSet<String>,
+    owner_id: &str,
+    now_ms: u64,
+    ttl_ms: u64,
+) -> io::Result<BTreeMap<String, AuthorityLease>> {
+    let mut conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
+    validate_canonical_store_identity(&tx, world_id, world_epoch, expected_store_id)?;
+    validate_active_region(&tx, world_id, world_epoch, region_id)?;
+    let mut leases = BTreeMap::new();
+    for partition_key in partition_keys {
+        let lease = acquire_partition_lease_in_transaction(
+            &tx,
+            world_id,
+            partition_key,
+            owner_id,
+            now_ms,
+            ttl_ms,
+        )?;
+        leases.insert(partition_key.clone(), lease);
+    }
+    tx.commit().map_err(sqlite_error)?;
+    Ok(leases)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn handoff_partition_leases(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    expected_store_id: &str,
+    region_id: &str,
+    transfers: &BTreeMap<String, CanonicalOwnershipTransfer>,
+    expected_world_seq: u64,
+    reason: &str,
+    now_ms: u64,
+    ttl_ms: u64,
+) -> io::Result<CanonicalOwnershipCheckpoint> {
+    if transfers.is_empty() {
+        return Err(invalid_data(
+            "ownership handoff requires at least one partition",
+        ));
+    }
+    if reason.trim().is_empty() || reason.chars().count() > 200 {
+        return Err(invalid_data(
+            "ownership handoff reason must be 1-200 characters",
+        ));
+    }
+    let mut conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
+    validate_canonical_store_identity(&tx, world_id, world_epoch, expected_store_id)?;
+    validate_active_region(&tx, world_id, world_epoch, region_id)?;
+    let committed_seq = current_world_seq(&tx, world_id)?;
+    if committed_seq != expected_world_seq {
+        return Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            format!(
+                "ownership handoff boundary moved: expected {expected_world_seq}, committed {committed_seq}"
+            ),
+        ));
+    }
+    let mut leases = BTreeMap::new();
+    let next_expiry = now_ms.saturating_add(ttl_ms.max(1));
+    for (partition_key, transfer) in transfers {
+        validate_storage_label(&transfer.target_owner_id, "target owner id")?;
+        if transfer.source.world_id != world_id || transfer.source.partition_key != *partition_key {
+            return Err(invalid_data(format!(
+                "ownership handoff source does not match partition {partition_key}"
+            )));
+        }
+        let target_fencing_epoch = transfer.source.fencing_epoch.saturating_add(1);
+        let changed = tx
+            .execute(
+                "UPDATE canonical_partition_leases
+                 SET owner_id = ?7, fencing_epoch = ?8,
+                     lease_expires_at_ms = ?9, updated_at_ms = ?6
+                 WHERE world_id = ?1 AND partition_key = ?2
+                   AND owner_id = ?3 AND fencing_epoch = ?4
+                   AND lease_expires_at_ms > ?5",
+                params![
+                    world_id,
+                    partition_key,
+                    transfer.source.owner_id,
+                    as_i64(transfer.source.fencing_epoch)?,
+                    as_i64(now_ms)?,
+                    as_i64(now_ms)?,
+                    transfer.target_owner_id,
+                    as_i64(target_fencing_epoch)?,
+                    as_i64(next_expiry)?
+                ],
+            )
+            .map_err(sqlite_error)?;
+        if changed != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("partition {partition_key} moved, expired, or was fenced before handoff"),
+            ));
+        }
+        leases.insert(
+            partition_key.clone(),
+            AuthorityLease {
+                world_id: world_id.to_string(),
+                partition_key: partition_key.clone(),
+                owner_id: transfer.target_owner_id.clone(),
+                fencing_epoch: target_fencing_epoch,
+                lease_expires_at_ms: next_expiry,
+            },
+        );
+    }
+    let checkpoint_id = format!(
+        "{}:ownership:{}:{}",
+        world_id,
+        expected_world_seq,
+        short_checkpoint_hash(&leases, now_ms)
+    );
+    let leases_json = serde_json::to_string(&leases)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    tx.execute(
+        "INSERT INTO canonical_ownership_checkpoints
+            (checkpoint_id, world_id, world_epoch, world_seq,
+             leases_json, reason, created_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            checkpoint_id,
+            world_id,
+            as_i64(world_epoch)?,
+            as_i64(expected_world_seq)?,
+            leases_json,
+            reason.trim(),
+            as_i64(now_ms)?
+        ],
+    )
+    .map_err(sqlite_error)?;
+    tx.commit().map_err(sqlite_error)?;
+    Ok(CanonicalOwnershipCheckpoint {
+        checkpoint_id,
+        world_id: world_id.to_string(),
+        world_epoch,
+        world_seq: expected_world_seq,
+        leases,
+        reason: reason.trim().to_string(),
+        created_at_ms: now_ms,
+    })
+}
+
+pub(super) fn canonical_replica_checkpoint(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    region_id: &str,
+    created_at_ms: u64,
+) -> io::Result<CanonicalReplicaCheckpoint> {
+    validate_storage_label(region_id, "canonical region id")?;
+    let conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    let store_id = canonical_store_identity_in_connection(&conn, world_id, world_epoch)?;
+    let durable_world_seq = current_world_seq(&conn, world_id)?;
+    let action_journal_seq = max_action_journal_seq(&conn)?;
+    let prefix_hash = canonical_prefix_hash(
+        &conn,
+        world_id,
+        world_epoch,
+        &store_id,
+        durable_world_seq,
+        action_journal_seq,
+    )?;
+    Ok(CanonicalReplicaCheckpoint {
+        world_id: world_id.to_string(),
+        world_epoch,
+        store_id,
+        region_id: region_id.to_string(),
+        durable_world_seq,
+        action_journal_seq,
+        prefix_hash,
+        created_at_ms,
+    })
+}
+
+pub(super) fn record_region_replica_checkpoint(
+    path: &Path,
+    checkpoint: &CanonicalReplicaCheckpoint,
+) -> io::Result<()> {
+    let mut conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, &checkpoint.world_id, checkpoint.world_epoch)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
+    validate_canonical_store_identity(
+        &tx,
+        &checkpoint.world_id,
+        checkpoint.world_epoch,
+        &checkpoint.store_id,
+    )?;
+    let committed = current_world_seq(&tx, &checkpoint.world_id)?;
+    if checkpoint.durable_world_seq > committed
+        || checkpoint.action_journal_seq > max_action_journal_seq(&tx)?
+    {
+        return Err(invalid_data(
+            "regional replica checkpoint is ahead of the durable canonical prefix",
+        ));
+    }
+    if !checkpoint.prefix_hash.starts_with("sha256:") || checkpoint.prefix_hash.len() != 71 {
+        return Err(invalid_data("regional replica checkpoint hash is invalid"));
+    }
+    let existing = tx
+        .query_row(
+            "SELECT durable_world_seq, action_journal_seq
+             FROM canonical_region_replicas
+             WHERE world_id = ?1 AND region_id = ?2",
+            params![checkpoint.world_id, checkpoint.region_id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()
+        .map_err(sqlite_error)?;
+    if existing.is_some_and(|(world_seq, journal_seq)| {
+        world_seq > checkpoint.durable_world_seq as i64
+            || journal_seq > checkpoint.action_journal_seq as i64
+    }) {
+        return Err(invalid_data("regional replica checkpoint cannot regress"));
+    }
+    tx.execute(
+        "INSERT INTO canonical_region_replicas
+            (world_id, world_epoch, region_id, store_id, durable_world_seq,
+             action_journal_seq, prefix_hash, created_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(world_id, region_id) DO UPDATE SET
+            world_epoch = excluded.world_epoch,
+            store_id = excluded.store_id,
+            durable_world_seq = excluded.durable_world_seq,
+            action_journal_seq = excluded.action_journal_seq,
+            prefix_hash = excluded.prefix_hash,
+            created_at_ms = excluded.created_at_ms",
+        params![
+            checkpoint.world_id,
+            as_i64(checkpoint.world_epoch)?,
+            checkpoint.region_id,
+            checkpoint.store_id,
+            as_i64(checkpoint.durable_world_seq)?,
+            as_i64(checkpoint.action_journal_seq)?,
+            checkpoint.prefix_hash,
+            as_i64(checkpoint.created_at_ms)?
+        ],
+    )
+    .map_err(sqlite_error)?;
+    tx.commit().map_err(sqlite_error)?;
+    Ok(())
+}
+
+pub(super) fn read_region_replica_checkpoint(
+    path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    region_id: &str,
+) -> io::Result<Option<CanonicalReplicaCheckpoint>> {
+    let conn = open_canonical_store(path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    conn.query_row(
+        "SELECT world_epoch, store_id, durable_world_seq,
+                action_journal_seq, prefix_hash, created_at_ms
+         FROM canonical_region_replicas
+         WHERE world_id = ?1 AND region_id = ?2",
+        params![world_id, region_id],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, i64>(5)?,
+            ))
+        },
+    )
+    .optional()
+    .map_err(sqlite_error)?
+    .map(
+        |(
+            stored_epoch,
+            store_id,
+            durable_world_seq,
+            action_journal_seq,
+            prefix_hash,
+            created_at_ms,
+        )| {
+            if stored_epoch != as_i64(world_epoch)? {
+                return Err(invalid_data("regional replica checkpoint epoch mismatch"));
+            }
+            Ok(CanonicalReplicaCheckpoint {
+                world_id: world_id.to_string(),
+                world_epoch,
+                store_id,
+                region_id: region_id.to_string(),
+                durable_world_seq: as_u64(durable_world_seq, "durable_world_seq")?,
+                action_journal_seq: as_u64(action_journal_seq, "action_journal_seq")?,
+                prefix_hash,
+                created_at_ms: as_u64(created_at_ms, "created_at_ms")?,
+            })
+        },
+    )
+    .transpose()
+}
+
+pub(super) fn replicate_canonical_store(
+    primary_path: &Path,
+    recovery_path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    recovery_region_id: &str,
+    created_at_ms: u64,
+) -> io::Result<CanonicalReplicaCheckpoint> {
+    if primary_path == recovery_path {
+        return Err(invalid_data(
+            "recovery replica path must differ from the primary",
+        ));
+    }
+    if let Some(parent) = recovery_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let primary = open_canonical_store(primary_path)?;
+    init_canonical_journal(&primary, world_id, world_epoch)?;
+    canonical_store_identity_in_connection(&primary, world_id, world_epoch)?;
+    primary
+        .backup(MAIN_DB, recovery_path, None)
+        .map_err(sqlite_error)?;
+    let checkpoint = canonical_replica_checkpoint(
+        recovery_path,
+        world_id,
+        world_epoch,
+        recovery_region_id,
+        created_at_ms,
+    )?;
+    record_region_replica_checkpoint(recovery_path, &checkpoint)?;
+    record_region_replica_checkpoint(primary_path, &checkpoint)?;
+    Ok(checkpoint)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn promote_recovery_region(
+    recovery_path: &Path,
+    world_id: &str,
+    world_epoch: u64,
+    expected_store_id: &str,
+    source_region_id: &str,
+    target_region_id: &str,
+    expected_promotion_epoch: u64,
+    checkpoint: &CanonicalReplicaCheckpoint,
+    promoted_at_ms: u64,
+) -> io::Result<CanonicalRegionPromotion> {
+    if source_region_id == target_region_id {
+        return Err(invalid_data(
+            "recovery promotion requires a different target region",
+        ));
+    }
+    let mut conn = open_canonical_store(recovery_path)?;
+    init_canonical_journal(&conn, world_id, world_epoch)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
+    validate_canonical_store_identity(&tx, world_id, world_epoch, expected_store_id)?;
+    let authority = current_region_authority_in_connection(&tx, world_id, world_epoch)?;
+    if authority.active_region_id != source_region_id
+        || authority.promotion_epoch != expected_promotion_epoch
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "regional authority moved before recovery promotion",
+        ));
+    }
+    let stored_checkpoint = tx
+        .query_row(
+            "SELECT world_epoch, store_id, durable_world_seq,
+                    action_journal_seq, prefix_hash
+             FROM canonical_region_replicas
+             WHERE world_id = ?1 AND region_id = ?2",
+            params![world_id, target_region_id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(sqlite_error)?
+        .ok_or_else(|| invalid_data("target region has no durable replica checkpoint"))?;
+    if checkpoint.world_id != world_id
+        || checkpoint.world_epoch != world_epoch
+        || checkpoint.region_id != target_region_id
+        || stored_checkpoint.0 != as_i64(world_epoch)?
+        || stored_checkpoint.1 != expected_store_id
+        || stored_checkpoint.2 != as_i64(checkpoint.durable_world_seq)?
+        || stored_checkpoint.3 != as_i64(checkpoint.action_journal_seq)?
+        || stored_checkpoint.4 != checkpoint.prefix_hash
+        || current_world_seq(&tx, world_id)? != checkpoint.durable_world_seq
+        || max_action_journal_seq(&tx)? != checkpoint.action_journal_seq
+    {
+        return Err(invalid_data(
+            "target region does not contain the exact durable committed prefix",
+        ));
+    }
+    let recomputed = canonical_prefix_hash(
+        &tx,
+        world_id,
+        world_epoch,
+        expected_store_id,
+        checkpoint.durable_world_seq,
+        checkpoint.action_journal_seq,
+    )?;
+    if recomputed != checkpoint.prefix_hash {
+        return Err(invalid_data(
+            "regional replica prefix proof does not match storage",
+        ));
+    }
+    let promotion_epoch = authority.promotion_epoch.saturating_add(1);
+    tx.execute(
+        "UPDATE canonical_partition_leases
+         SET fencing_epoch = fencing_epoch + 1,
+             lease_expires_at_ms = ?2,
+             updated_at_ms = ?2
+         WHERE world_id = ?1",
+        params![world_id, as_i64(promoted_at_ms)?],
+    )
+    .map_err(sqlite_error)?;
+    let changed = tx
+        .execute(
+            "UPDATE canonical_region_authority
+             SET active_region_id = ?4, promotion_epoch = ?5,
+                 durable_world_seq = ?6, updated_at_ms = ?7
+             WHERE world_id = ?1 AND world_epoch = ?2
+               AND active_region_id = ?3 AND promotion_epoch = ?8",
+            params![
+                world_id,
+                as_i64(world_epoch)?,
+                source_region_id,
+                target_region_id,
+                as_i64(promotion_epoch)?,
+                as_i64(checkpoint.durable_world_seq)?,
+                as_i64(promoted_at_ms)?,
+                as_i64(expected_promotion_epoch)?
+            ],
+        )
+        .map_err(sqlite_error)?;
+    if changed != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "regional authority was concurrently promoted",
+        ));
+    }
+    let promotion_id = format!("{world_id}:region-promotion:{promotion_epoch}");
+    tx.execute(
+        "INSERT INTO canonical_region_promotions
+            (promotion_id, world_id, world_epoch, source_region_id,
+             target_region_id, promotion_epoch, durable_world_seq,
+             action_journal_seq, prefix_hash, promoted_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        params![
+            promotion_id,
+            world_id,
+            as_i64(world_epoch)?,
+            source_region_id,
+            target_region_id,
+            as_i64(promotion_epoch)?,
+            as_i64(checkpoint.durable_world_seq)?,
+            as_i64(checkpoint.action_journal_seq)?,
+            checkpoint.prefix_hash,
+            as_i64(promoted_at_ms)?
+        ],
+    )
+    .map_err(sqlite_error)?;
+    tx.commit().map_err(sqlite_error)?;
+    Ok(CanonicalRegionPromotion {
+        promotion_id,
+        world_id: world_id.to_string(),
+        world_epoch,
+        source_region_id: source_region_id.to_string(),
+        target_region_id: target_region_id.to_string(),
+        promotion_epoch,
+        durable_world_seq: checkpoint.durable_world_seq,
+        action_journal_seq: checkpoint.action_journal_seq,
+        prefix_hash: checkpoint.prefix_hash.clone(),
+        promoted_at_ms,
+    })
+}
+
+fn max_action_journal_seq(conn: &Connection) -> io::Result<u64> {
+    let value = conn
+        .query_row(
+            "SELECT COALESCE(MAX(journal_seq), 0) FROM action_journal",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_error)?;
+    as_u64(value, "maximum action journal sequence")
+}
+
+fn canonical_prefix_hash(
+    conn: &Connection,
+    world_id: &str,
+    world_epoch: u64,
+    store_id: &str,
+    durable_world_seq: u64,
+    action_journal_seq: u64,
+) -> io::Result<String> {
+    let mut digest = Sha256::new();
+    for value in [
+        world_id.to_string(),
+        world_epoch.to_string(),
+        store_id.to_string(),
+        durable_world_seq.to_string(),
+        action_journal_seq.to_string(),
+    ] {
+        hash_piece(&mut digest, value.as_bytes());
+    }
+    for (sql, bound) in [
+        (
+            "SELECT journal_seq || ':' || record_json
+             FROM action_journal WHERE journal_seq <= ?1 ORDER BY journal_seq",
+            action_journal_seq,
+        ),
+        (
+            "SELECT seq || ':' || payload_json
+             FROM world_events WHERE seq <= ?1 ORDER BY seq",
+            durable_world_seq,
+        ),
+    ] {
+        let mut stmt = conn.prepare(sql).map_err(sqlite_error)?;
+        let rows = stmt
+            .query_map(params![as_i64(bound)?], |row| row.get::<_, String>(0))
+            .map_err(sqlite_error)?;
+        for row in rows {
+            hash_piece(&mut digest, row.map_err(sqlite_error)?.as_bytes());
+        }
+    }
+    for sql in [
+        "SELECT partition_key || ':' || owner_id || ':' || fencing_epoch
+         FROM canonical_partition_leases WHERE world_id = ?1 ORDER BY partition_key",
+        "SELECT entity_ref || ':' || entity_version
+         FROM canonical_entity_versions WHERE world_id = ?1 ORDER BY entity_ref",
+    ] {
+        let mut stmt = conn.prepare(sql).map_err(sqlite_error)?;
+        let rows = stmt
+            .query_map(params![world_id], |row| row.get::<_, String>(0))
+            .map_err(sqlite_error)?;
+        for row in rows {
+            hash_piece(&mut digest, row.map_err(sqlite_error)?.as_bytes());
+        }
+    }
+    Ok(format!("sha256:{:x}", digest.finalize()))
+}
+
+fn hash_piece(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_le_bytes());
+    digest.update(bytes);
+}
+
+fn short_checkpoint_hash(leases: &BTreeMap<String, AuthorityLease>, now_ms: u64) -> String {
+    let mut digest = Sha256::new();
+    digest.update(now_ms.to_le_bytes());
+    digest.update(serde_json::to_vec(leases).unwrap_or_default());
+    format!("{:x}", digest.finalize())[..16].to_string()
+}
+
+fn validate_storage_label(value: &str, field: &str) -> io::Result<()> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 160
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | ':' | '.'))
+    {
+        return Err(invalid_data(format!(
+            "{field} must be 1-160 ASCII letters, numbers, '-', '_', ':' or '.'"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 pub(super) fn acquire_partition_lease(
     path: &Path,
@@ -277,36 +1170,6 @@ pub(super) fn acquire_partition_lease(
     )?;
     tx.commit().map_err(sqlite_error)?;
     Ok(lease)
-}
-
-pub(super) fn acquire_partition_leases(
-    path: &Path,
-    world_id: &str,
-    world_epoch: u64,
-    partition_keys: &BTreeSet<String>,
-    owner_id: &str,
-    now_ms: u64,
-    ttl_ms: u64,
-) -> io::Result<BTreeMap<String, AuthorityLease>> {
-    let mut conn = open_canonical_store(path)?;
-    init_canonical_journal(&conn, world_id, world_epoch)?;
-    let tx = conn
-        .transaction_with_behavior(TransactionBehavior::Immediate)
-        .map_err(sqlite_error)?;
-    let mut leases = BTreeMap::new();
-    for partition_key in partition_keys {
-        let lease = acquire_partition_lease_in_transaction(
-            &tx,
-            world_id,
-            partition_key,
-            owner_id,
-            now_ms,
-            ttl_ms,
-        )?;
-        leases.insert(partition_key.clone(), lease);
-    }
-    tx.commit().map_err(sqlite_error)?;
-    Ok(leases)
 }
 
 pub(super) fn acquire_partition_lease_in_transaction(
@@ -428,10 +1291,11 @@ pub(super) fn upsert_process_route(
     init_canonical_journal(&conn, world_id, world_epoch)?;
     conn.execute(
         "INSERT INTO canonical_process_routes
-            (world_id, owner_id, process_id, base_url, heartbeat_expires_at_ms, updated_at_ms)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            (world_id, owner_id, process_id, region_id, base_url, heartbeat_expires_at_ms, updated_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
          ON CONFLICT(world_id, owner_id) DO UPDATE SET
             process_id = excluded.process_id,
+            region_id = excluded.region_id,
             base_url = excluded.base_url,
             heartbeat_expires_at_ms = excluded.heartbeat_expires_at_ms,
             updated_at_ms = excluded.updated_at_ms",
@@ -439,6 +1303,7 @@ pub(super) fn upsert_process_route(
             world_id,
             route.owner_id,
             route.process_id,
+            route.region_id,
             route.base_url,
             as_i64(route.heartbeat_expires_at_ms)?,
             as_i64(updated_at_ms)?
@@ -458,7 +1323,7 @@ pub(super) fn process_route_for_owner(
     let conn = open_canonical_store(path)?;
     init_canonical_journal(&conn, world_id, world_epoch)?;
     conn.query_row(
-        "SELECT owner_id, process_id, base_url, heartbeat_expires_at_ms
+        "SELECT owner_id, process_id, region_id, base_url, heartbeat_expires_at_ms
          FROM canonical_process_routes
          WHERE world_id = ?1 AND owner_id = ?2 AND heartbeat_expires_at_ms > ?3",
         params![world_id, owner_id, as_i64(now_ms)?],
@@ -467,17 +1332,19 @@ pub(super) fn process_route_for_owner(
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
-                row.get::<_, i64>(3)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
             ))
         },
     )
     .optional()
     .map_err(sqlite_error)?
     .map(
-        |(owner_id, process_id, base_url, heartbeat_expires_at_ms)| {
+        |(owner_id, process_id, region_id, base_url, heartbeat_expires_at_ms)| {
             Ok(CanonicalProcessRoute {
                 owner_id,
                 process_id,
+                region_id,
                 base_url,
                 heartbeat_expires_at_ms: as_u64(
                     heartbeat_expires_at_ms,
@@ -499,7 +1366,7 @@ pub(super) fn active_process_routes(
     init_canonical_journal(&conn, world_id, world_epoch)?;
     let mut stmt = conn
         .prepare(
-            "SELECT owner_id, process_id, base_url, heartbeat_expires_at_ms
+            "SELECT owner_id, process_id, region_id, base_url, heartbeat_expires_at_ms
              FROM canonical_process_routes
              WHERE world_id = ?1 AND heartbeat_expires_at_ms > ?2
              ORDER BY process_id, owner_id",
@@ -511,16 +1378,18 @@ pub(super) fn active_process_routes(
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
-                row.get::<_, i64>(3)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
             ))
         })
         .map_err(sqlite_error)?;
     rows.map(|row| {
-        let (owner_id, process_id, base_url, heartbeat_expires_at_ms) =
+        let (owner_id, process_id, region_id, base_url, heartbeat_expires_at_ms) =
             row.map_err(sqlite_error)?;
         Ok(CanonicalProcessRoute {
             owner_id,
             process_id,
+            region_id,
             base_url,
             heartbeat_expires_at_ms: as_u64(heartbeat_expires_at_ms, "heartbeat_expires_at_ms")?,
         })
@@ -731,6 +1600,13 @@ pub(super) fn advance_world_sequence(
             "canonical world sequence changed during commit",
         ));
     }
+    conn.execute(
+        "UPDATE canonical_region_authority
+         SET durable_world_seq = ?2, updated_at_ms = ?3
+         WHERE world_id = ?1 AND durable_world_seq <= ?2",
+        params![world_id, as_i64(next_seq)?, as_i64(updated_at_ms)?],
+    )
+    .map_err(sqlite_error)?;
     Ok(())
 }
 
@@ -1133,6 +2009,7 @@ mod tests {
         let route = CanonicalProcessRoute {
             owner_id: "process-a:boot-1".to_string(),
             process_id: "process-a".to_string(),
+            region_id: "region-a".to_string(),
             base_url: "http://127.0.0.1:4101".to_string(),
             heartbeat_expires_at_ms: 50,
         };

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -109,11 +109,14 @@ struct AppState {
     actor_chat_locks: Arc<StdMutex<BTreeSet<u64>>>,
     canonical_command_lock: Arc<Mutex<()>>,
     canonical_owner_id: Arc<String>,
+    canonical_store_id: Arc<String>,
+    canonical_region_id: Arc<String>,
     canonical_lease_ttl: Duration,
     canonical_applied_journal_seq: Arc<AtomicU64>,
     canonical_fanout_seq: Arc<AtomicU64>,
     canonical_fanout_lock: Arc<StdMutex<()>>,
     canonical_routing: Arc<CanonicalRoutingConfig>,
+    canonical_recovery: Arc<Option<CanonicalRecoveryConfig>>,
     regional_presence: Arc<StdMutex<BTreeMap<u64, RegionalPresence>>>,
     room_turns: Arc<StdMutex<RoomTurns>>,
     room_memory_cache: Arc<StdMutex<BTreeMap<u64, RoomMemoryCacheEntry>>>,
@@ -129,6 +132,7 @@ struct AppState {
 const CANONICAL_WORLD_PARTITION: &str = "world";
 const DEFAULT_CANONICAL_LEASE_TTL: Duration = Duration::from_secs(30);
 const DEFAULT_CANONICAL_CONVERGENCE_POLL: Duration = Duration::from_millis(100);
+const DEFAULT_CANONICAL_REGION_ID: &str = "local";
 const CANONICAL_ROUTE_HEARTBEAT_MULTIPLIER: u32 = 3;
 const CANONICAL_INVITE_TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
@@ -136,6 +140,12 @@ const CANONICAL_INVITE_TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 struct CanonicalRoutingConfig {
     base_url: Option<String>,
     token: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct CanonicalRecoveryConfig {
+    replica_path: PathBuf,
+    region_id: String,
 }
 
 impl CanonicalRoutingConfig {
@@ -161,6 +171,23 @@ struct ForwardedCanonicalCommand {
     source_process_id: String,
     client_addr: String,
     payload: CommandRequest,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CanonicalHandoffRequest {
+    partition_keys: Vec<String>,
+    target_owner_id: String,
+    expected_world_seq: u64,
+    reason: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CanonicalRecoveryPromotionRequest {
+    source_region_id: String,
+    expected_promotion_epoch: u64,
+    expected_prefix_hash: String,
 }
 
 struct CanonicalCommandCommitContext {
@@ -3090,6 +3117,38 @@ fn canonical_routing_config_from_env() -> io::Result<CanonicalRoutingConfig> {
     canonical_routing_config(base_url, token)
 }
 
+fn canonical_recovery_config_from_env(
+    event_store_path: Option<&Path>,
+) -> io::Result<Option<CanonicalRecoveryConfig>> {
+    let replica_path = std::env::var("COSYWORLD_CANONICAL_RECOVERY_DB_PATH")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let region_id = std::env::var("COSYWORLD_CANONICAL_RECOVERY_REGION_ID")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if replica_path.is_some() != region_id.is_some() {
+        return Err(deployment_config_error(
+            "COSYWORLD_CANONICAL_RECOVERY_DB_PATH and COSYWORLD_CANONICAL_RECOVERY_REGION_ID must be configured together",
+        ));
+    }
+    let (Some(replica_path), Some(region_id)) = (replica_path, region_id) else {
+        return Ok(None);
+    };
+    let region_id = normalize_process_id(&region_id, "COSYWORLD_CANONICAL_RECOVERY_REGION_ID")?;
+    if event_store_path.is_some_and(|primary| primary == replica_path.as_path()) {
+        return Err(deployment_config_error(
+            "COSYWORLD_CANONICAL_RECOVERY_DB_PATH must differ from COSYWORLD_V2_EVENT_DB_PATH",
+        ));
+    }
+    Ok(Some(CanonicalRecoveryConfig {
+        replica_path,
+        region_id,
+    }))
+}
+
 fn canonical_routing_config(
     base_url: Option<String>,
     token: Option<String>,
@@ -3127,6 +3186,15 @@ fn canonical_routing_config(
 fn canonical_route_heartbeat_expiry(now_ms: u64, lease_ttl: Duration) -> u64 {
     let ttl_ms = u64::try_from(lease_ttl.as_millis()).unwrap_or(u64::MAX);
     now_ms.saturating_add(ttl_ms.saturating_mul(u64::from(CANONICAL_ROUTE_HEARTBEAT_MULTIPLIER)))
+}
+
+fn canonical_region_id_from_env() -> io::Result<String> {
+    std::env::var("COSYWORLD_CANONICAL_REGION_ID")
+        .ok()
+        .as_deref()
+        .map(|value| normalize_process_id(value, "COSYWORLD_CANONICAL_REGION_ID"))
+        .transpose()
+        .map(|region| region.unwrap_or_else(|| DEFAULT_CANONICAL_REGION_ID.to_string()))
 }
 
 fn character_creation_views() -> Vec<CharacterCreationProfileView> {
@@ -4449,9 +4517,17 @@ impl AppState {
             resident_continuity_path_from_env(snapshot_path.as_deref()).map(Arc::new);
         let event_store_path = event_store_path_from_env().map(Arc::new);
         let canonical_routing = Arc::new(canonical_routing_config_from_env()?);
+        let canonical_recovery = Arc::new(canonical_recovery_config_from_env(
+            event_store_path.as_deref().map(PathBuf::as_path),
+        )?);
         if canonical_routing.enabled() && event_store_path.is_none() {
             return Err(deployment_config_error(
                 "canonical process routing requires COSYWORLD_V2_EVENT_DB_PATH",
+            ));
+        }
+        if canonical_recovery.is_some() && event_store_path.is_none() {
+            return Err(deployment_config_error(
+                "canonical regional recovery requires COSYWORLD_V2_EVENT_DB_PATH",
             ));
         }
         let fail_closed_on_continuity_error = deployment.profile.is_production();
@@ -4677,6 +4753,27 @@ impl AppState {
             }
         }
 
+        let canonical_region_id = Arc::new(canonical_region_id_from_env()?);
+        let canonical_store_id = Arc::new(if let Some(path) = event_store_path.as_deref() {
+            let store_id = ensure_canonical_store_identity(
+                path,
+                OFFICIAL_WORLD_ID,
+                OFFICIAL_WORLD_EPOCH,
+                &format!("store:{}", random_hex(16)),
+                now_millis(),
+            )?;
+            ensure_region_authority(
+                path,
+                OFFICIAL_WORLD_ID,
+                OFFICIAL_WORLD_EPOCH,
+                canonical_region_id.as_str(),
+                now_millis(),
+            )?;
+            store_id
+        } else {
+            format!("memory:{}", random_hex(16))
+        });
+
         let actor_sessions = event_store_path
             .as_deref()
             .map(|path| match load_actor_sessions(path) {
@@ -4746,6 +4843,7 @@ impl AppState {
                 &CanonicalProcessRoute {
                     owner_id: canonical_owner_id.as_ref().clone(),
                     process_id: deployment.process_id.clone(),
+                    region_id: canonical_region_id.as_ref().clone(),
                     base_url: base_url.to_string(),
                     heartbeat_expires_at_ms: canonical_route_heartbeat_expiry(
                         now,
@@ -4787,11 +4885,14 @@ impl AppState {
             actor_chat_locks: Arc::new(StdMutex::new(BTreeSet::new())),
             canonical_command_lock: Arc::new(Mutex::new(())),
             canonical_owner_id,
+            canonical_store_id,
+            canonical_region_id,
             canonical_lease_ttl,
             canonical_applied_journal_seq: Arc::new(AtomicU64::new(canonical_applied_journal_seq)),
             canonical_fanout_seq: Arc::new(AtomicU64::new(canonical_fanout_seq)),
             canonical_fanout_lock: Arc::new(StdMutex::new(())),
             canonical_routing,
+            canonical_recovery,
             regional_presence: Arc::new(StdMutex::new(BTreeMap::new())),
             room_turns: Arc::new(StdMutex::new(RoomTurns::default())),
             room_memory_cache: Arc::new(StdMutex::new(BTreeMap::new())),
@@ -20300,6 +20401,9 @@ async fn meta(State(state): State<AppState>) -> Json<MetaResponse> {
         .lock()
         .map(|health| health.clone())
         .unwrap_or_default();
+    let region_authority = state.event_store_path.as_deref().and_then(|path| {
+        current_region_authority(path, OFFICIAL_WORLD_ID, OFFICIAL_WORLD_EPOCH).ok()
+    });
 
     Json(MetaResponse {
         ok: true,
@@ -20316,8 +20420,22 @@ async fn meta(State(state): State<AppState>) -> Json<MetaResponse> {
             world_id: state.deployment.world_id.clone(),
             world_epoch: OFFICIAL_WORLD_EPOCH,
             process_id: state.deployment.process_id.clone(),
+            region_id: state.canonical_region_id.as_ref().clone(),
+            active_region_id: region_authority
+                .as_ref()
+                .map(|authority| authority.active_region_id.clone())
+                .unwrap_or_else(|| state.canonical_region_id.as_ref().clone()),
+            promotion_epoch: region_authority
+                .as_ref()
+                .map(|authority| authority.promotion_epoch)
+                .unwrap_or(1),
+            canonical_store_id: state.canonical_store_id.as_ref().clone(),
             shard_id: state.deployment.process_id.clone(),
-            shard_model: "single_process",
+            shard_model: if state.canonical_routing.enabled() {
+                "canonical_capacity"
+            } else {
+                "single_process"
+            },
         },
         features: MetaFeatureFlags {
             server_authored_chat: true,
@@ -23829,10 +23947,12 @@ async fn follow_canonical_invite_with_forwarding(
             events: Vec::new(),
         });
     }
-    let lease_result = acquire_partition_leases(
+    let lease_result = acquire_partition_leases_for_region(
         path,
         OFFICIAL_WORLD_ID,
         OFFICIAL_WORLD_EPOCH,
+        state.canonical_store_id.as_str(),
+        state.canonical_region_id.as_str(),
         &partitions,
         state.canonical_owner_id.as_str(),
         now_millis(),
@@ -23840,7 +23960,10 @@ async fn follow_canonical_invite_with_forwarding(
     );
     if let Err(error) = lease_result {
         if allow_forward
-            && error.kind() == io::ErrorKind::WouldBlock
+            && matches!(
+                error.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::PermissionDenied
+            )
             && state.canonical_routing.enabled()
         {
             match canonical_route_for_partitions(&state, &partitions) {
@@ -23992,10 +24115,12 @@ fn acquire_command_authority_leases(
             .collect());
     };
     init_event_store(path)?;
-    acquire_partition_leases(
+    acquire_partition_leases_for_region(
         path,
         OFFICIAL_WORLD_ID,
         OFFICIAL_WORLD_EPOCH,
+        state.canonical_store_id.as_str(),
+        state.canonical_region_id.as_str(),
         &partitions,
         state.canonical_owner_id.as_str(),
         now,
@@ -24313,7 +24438,10 @@ async fn command_with_forwarding(
         Ok(leases) => leases,
         Err(error) => {
             if allow_forward
-                && error.kind() == io::ErrorKind::WouldBlock
+                && matches!(
+                    error.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::PermissionDenied
+                )
                 && state.canonical_routing.enabled()
             {
                 match canonical_route_for_partitions(&state, &partitions) {
@@ -24580,6 +24708,269 @@ async fn internal_follow_canonical_invite(
     )
     .await;
     (StatusCode::OK, response).into_response()
+}
+
+fn canonical_internal_result<T: Serialize>(
+    result: io::Result<T>,
+    success_status: StatusCode,
+) -> Response {
+    match result {
+        Ok(value) => (
+            success_status,
+            Json(serde_json::json!({
+                "ok": true,
+                "result": value,
+            })),
+        )
+            .into_response(),
+        Err(error) => {
+            let status = match error.kind() {
+                io::ErrorKind::InvalidData | io::ErrorKind::InvalidInput => StatusCode::BAD_REQUEST,
+                io::ErrorKind::PermissionDenied => StatusCode::CONFLICT,
+                io::ErrorKind::WouldBlock => StatusCode::CONFLICT,
+                io::ErrorKind::NotFound => StatusCode::NOT_FOUND,
+                _ => StatusCode::SERVICE_UNAVAILABLE,
+            };
+            (
+                status,
+                Json(serde_json::json!({
+                    "ok": false,
+                    "error": error.to_string(),
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn internal_canonical_ownership_handoff(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Json(payload): Json<CanonicalHandoffRequest>,
+) -> Response {
+    if !canonical_internal_authorized(&state, &headers) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let Some(path) = state.event_store_path.as_deref() else {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    };
+    let partition_keys = payload
+        .partition_keys
+        .iter()
+        .map(|value| value.trim().to_string())
+        .collect::<BTreeSet<_>>();
+    if partition_keys.is_empty()
+        || partition_keys.len() != payload.partition_keys.len()
+        || partition_keys.len() > 64
+        || partition_keys.iter().any(|partition| {
+            partition.is_empty()
+                || partition.len() > 256
+                || !(partition == CANONICAL_WORLD_PARTITION || partition.starts_with("room:"))
+        })
+    {
+        return canonical_internal_result::<CanonicalOwnershipCheckpoint>(
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "partition_keys must contain 1-64 unique canonical room/world partitions",
+            )),
+            StatusCode::OK,
+        );
+    }
+    let now = now_millis();
+    let route = match process_route_for_owner(
+        path,
+        OFFICIAL_WORLD_ID,
+        OFFICIAL_WORLD_EPOCH,
+        payload.target_owner_id.trim(),
+        now,
+    ) {
+        Ok(Some(route)) if route.region_id == *state.canonical_region_id => route,
+        Ok(Some(_)) => {
+            return canonical_internal_result::<CanonicalOwnershipCheckpoint>(
+                Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "target owner is not in the active source region",
+                )),
+                StatusCode::OK,
+            );
+        }
+        Ok(None) => {
+            return canonical_internal_result::<CanonicalOwnershipCheckpoint>(
+                Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "target owner has no live exact process route",
+                )),
+                StatusCode::OK,
+            );
+        }
+        Err(error) => {
+            return canonical_internal_result::<CanonicalOwnershipCheckpoint>(
+                Err(error),
+                StatusCode::OK,
+            );
+        }
+    };
+    let transfers = partition_keys
+        .iter()
+        .map(|partition_key| {
+            let lease = current_partition_lease(
+                path,
+                OFFICIAL_WORLD_ID,
+                OFFICIAL_WORLD_EPOCH,
+                partition_key,
+                now,
+            )?
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    format!("partition {partition_key} has no live source owner"),
+                )
+            })?;
+            Ok((
+                partition_key.clone(),
+                CanonicalOwnershipTransfer {
+                    source: lease,
+                    target_owner_id: route.owner_id.clone(),
+                },
+            ))
+        })
+        .collect::<io::Result<BTreeMap<_, _>>>();
+    let result = transfers.and_then(|transfers| {
+        handoff_partition_leases(
+            path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            state.canonical_store_id.as_str(),
+            state.canonical_region_id.as_str(),
+            &transfers,
+            payload.expected_world_seq,
+            &payload.reason,
+            now,
+            authority_lease_ttl_ms(&state),
+        )
+    });
+    if let Ok(checkpoint) = &result {
+        info!(
+            checkpoint_id = %checkpoint.checkpoint_id,
+            world_seq = checkpoint.world_seq,
+            target_owner_id = %route.owner_id,
+            partition_count = checkpoint.leases.len(),
+            "committed canonical ownership handoff"
+        );
+    }
+    canonical_internal_result(result, StatusCode::OK)
+}
+
+async fn internal_canonical_region_checkpoint(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+) -> Response {
+    if !canonical_internal_authorized(&state, &headers) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let (Some(primary_path), Some(recovery)) = (
+        state.event_store_path.as_deref(),
+        state.canonical_recovery.as_ref().as_ref(),
+    ) else {
+        return canonical_internal_result::<CanonicalReplicaCheckpoint>(
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "canonical recovery replica is not configured",
+            )),
+            StatusCode::CREATED,
+        );
+    };
+    let authority = current_region_authority(primary_path, OFFICIAL_WORLD_ID, OFFICIAL_WORLD_EPOCH);
+    let result = authority.and_then(|authority| {
+        if authority.active_region_id != *state.canonical_region_id {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "only the active canonical region may checkpoint recovery storage",
+            ));
+        }
+        replicate_canonical_store(
+            primary_path,
+            &recovery.replica_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &recovery.region_id,
+            now_millis(),
+        )
+    });
+    if let Ok(checkpoint) = &result {
+        info!(
+            recovery_region_id = %checkpoint.region_id,
+            durable_world_seq = checkpoint.durable_world_seq,
+            action_journal_seq = checkpoint.action_journal_seq,
+            prefix_hash = %checkpoint.prefix_hash,
+            "checkpointed canonical recovery prefix"
+        );
+    }
+    canonical_internal_result(result, StatusCode::CREATED)
+}
+
+async fn internal_canonical_region_promote(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Json(payload): Json<CanonicalRecoveryPromotionRequest>,
+) -> Response {
+    if !canonical_internal_authorized(&state, &headers) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let Some(recovery_path) = state.event_store_path.as_deref() else {
+        return canonical_internal_result::<CanonicalRegionPromotion>(
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "canonical event storage is not configured",
+            )),
+            StatusCode::OK,
+        );
+    };
+    let result = read_region_replica_checkpoint(
+        recovery_path,
+        OFFICIAL_WORLD_ID,
+        OFFICIAL_WORLD_EPOCH,
+        state.canonical_region_id.as_str(),
+    )
+    .and_then(|checkpoint| {
+        checkpoint.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "recovery region has no durable checkpoint",
+            )
+        })
+    })
+    .and_then(|checkpoint| {
+        if checkpoint.prefix_hash != payload.expected_prefix_hash {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "recovery prefix hash does not match the operator-approved checkpoint",
+            ));
+        }
+        promote_recovery_region(
+            recovery_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            state.canonical_store_id.as_str(),
+            payload.source_region_id.trim(),
+            state.canonical_region_id.as_str(),
+            payload.expected_promotion_epoch,
+            &checkpoint,
+            now_millis(),
+        )
+    });
+    if let Ok(promotion) = &result {
+        warn!(
+            promotion_id = %promotion.promotion_id,
+            source_region_id = %promotion.source_region_id,
+            target_region_id = %promotion.target_region_id,
+            promotion_epoch = promotion.promotion_epoch,
+            durable_world_seq = promotion.durable_world_seq,
+            prefix_hash = %promotion.prefix_hash,
+            "promoted canonical recovery region"
+        );
+    }
+    canonical_internal_result(result, StatusCode::OK)
 }
 
 async fn command_inner(
@@ -25902,6 +26293,7 @@ fn refresh_canonical_process_route(state: &AppState) -> io::Result<()> {
         &CanonicalProcessRoute {
             owner_id: state.canonical_owner_id.as_ref().clone(),
             process_id: state.deployment.process_id.clone(),
+            region_id: state.canonical_region_id.as_ref().clone(),
             base_url: base_url.to_string(),
             heartbeat_expires_at_ms: canonical_route_heartbeat_expiry(
                 now,
@@ -32826,10 +33218,12 @@ fn acquire_record_authority_leases(
             })
             .collect());
     };
-    acquire_partition_leases(
+    acquire_partition_leases_for_region(
         path,
         OFFICIAL_WORLD_ID,
         OFFICIAL_WORLD_EPOCH,
+        state.canonical_store_id.as_str(),
+        state.canonical_region_id.as_str(),
         &partitions,
         state.canonical_owner_id.as_str(),
         now,
@@ -32961,6 +33355,18 @@ fn commit_journal_record(
         let committed = (|| -> io::Result<(u32, Vec<EventView>, bool, u64)> {
             let commit_time = now_millis();
             let lease_ttl = authority_lease_ttl_ms(state);
+            validate_canonical_store_identity(
+                &tx,
+                OFFICIAL_WORLD_ID,
+                OFFICIAL_WORLD_EPOCH,
+                state.canonical_store_id.as_str(),
+            )?;
+            validate_active_region(
+                &tx,
+                OFFICIAL_WORLD_ID,
+                OFFICIAL_WORLD_EPOCH,
+                state.canonical_region_id.as_str(),
+            )?;
             for lease in authority_leases.values_mut() {
                 *lease = validate_and_renew_partition_lease(&tx, lease, commit_time, lease_ttl)?;
             }
@@ -35516,6 +35922,29 @@ mod tests {
     fn test_app_state(runtime: RuntimeWorld, event_store_path: Option<PathBuf>) -> AppState {
         let (tx, _) = broadcast::channel(32);
         let canonical_fanout_seq = runtime.world.next_event_seq.saturating_sub(1);
+        let canonical_region_id = DEFAULT_CANONICAL_REGION_ID.to_string();
+        let canonical_store_id = if let Some(path) = event_store_path.as_deref() {
+            init_event_store(path).expect("initialize canonical test store");
+            let store_id = ensure_canonical_store_identity(
+                path,
+                OFFICIAL_WORLD_ID,
+                OFFICIAL_WORLD_EPOCH,
+                &format!("test-store:{}", random_hex(8)),
+                now_millis(),
+            )
+            .expect("canonical test store identity");
+            ensure_region_authority(
+                path,
+                OFFICIAL_WORLD_ID,
+                OFFICIAL_WORLD_EPOCH,
+                &canonical_region_id,
+                now_millis(),
+            )
+            .expect("canonical test region authority");
+            store_id
+        } else {
+            format!("test-memory:{}", random_hex(8))
+        };
         AppState {
             inner: Arc::new(Mutex::new(runtime)),
             tx,
@@ -35524,7 +35953,7 @@ mod tests {
             resident_continuity_path: None,
             event_store_path: event_store_path.clone().map(Arc::new),
             event_store_health: Arc::new(StdMutex::new(EventStoreHealth::default())),
-            account_auth: AccountAuth::for_test(event_store_path.map(Arc::new)),
+            account_auth: AccountAuth::for_test(event_store_path.clone().map(Arc::new)),
             ownership_index: Arc::new(RwLock::new(OwnershipIndex::default())),
             trust_client_card_ids: false,
             dev_reset_enabled: false,
@@ -35548,11 +35977,14 @@ mod tests {
             actor_chat_locks: Arc::new(StdMutex::new(BTreeSet::new())),
             canonical_command_lock: Arc::new(Mutex::new(())),
             canonical_owner_id: Arc::new(format!("test:{}", random_hex(8))),
+            canonical_store_id: Arc::new(canonical_store_id),
+            canonical_region_id: Arc::new(canonical_region_id),
             canonical_lease_ttl: DEFAULT_CANONICAL_LEASE_TTL,
             canonical_applied_journal_seq: Arc::new(AtomicU64::new(0)),
             canonical_fanout_seq: Arc::new(AtomicU64::new(canonical_fanout_seq)),
             canonical_fanout_lock: Arc::new(StdMutex::new(())),
             canonical_routing: Arc::new(CanonicalRoutingConfig::default()),
+            canonical_recovery: Arc::new(None),
             regional_presence: Arc::new(StdMutex::new(BTreeMap::new())),
             room_turns: Arc::new(StdMutex::new(RoomTurns::default())),
             room_memory_cache: Arc::new(StdMutex::new(BTreeMap::new())),
@@ -36425,6 +36857,755 @@ mod tests {
         server_b.abort();
         drop(client);
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn hot_room_and_regional_chaos_preserve_one_committed_world() {
+        std::thread::Builder::new()
+            .name("hot-room-regional-chaos".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .enable_all()
+                    .build()
+                    .expect("build hot-room regional chaos runtime")
+                    .block_on(run_hot_room_and_regional_chaos());
+            })
+            .expect("spawn hot-room regional chaos thread")
+            .join()
+            .expect("hot-room regional chaos thread");
+    }
+
+    async fn run_hot_room_and_regional_chaos() {
+        let primary_path = std::env::temp_dir().join(format!(
+            "cosyworld-hot-room-primary-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let recovery_path = std::env::temp_dir().join(format!(
+            "cosyworld-hot-room-recovery-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let quarantine_path = primary_path.with_extension("isolated.sqlite");
+        for path in [&primary_path, &recovery_path, &quarantine_path] {
+            let _ = fs::remove_file(path);
+        }
+
+        let listener_a = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind hot-room process A");
+        let listener_b = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind hot-room process B");
+        let addr_a = listener_a.local_addr().expect("hot-room process A address");
+        let addr_b = listener_b.local_addr().expect("hot-room process B address");
+        let url_a = format!("http://{addr_a}");
+        let url_b = format!("http://{addr_b}");
+        let router_token = "hot-room-regional-router-token";
+        let lease_ttl = Duration::from_millis(1_500);
+        let actor_hot = 5100;
+        let actor_cold = 5101;
+
+        let state_a = configure_capacity_test_state(
+            test_app_state(RuntimeWorld::seeded(), Some(primary_path.clone())),
+            "hot-a",
+            "hot-a:boot-a",
+            &url_a,
+            router_token,
+            lease_ttl,
+        );
+        let session_hot = commit_capacity_test_human(
+            &state_a,
+            actor_hot,
+            COSY_COTTAGE_LOCATION_ID,
+            "Hot Room Neighbour",
+        )
+        .await;
+        let session_cold = commit_capacity_test_human(
+            &state_a,
+            actor_cold,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Cold Room Neighbour",
+        )
+        .await;
+        let baseline_seq = current_world_seq(
+            &open_event_store(&primary_path).expect("hot-room baseline store"),
+            OFFICIAL_WORLD_ID,
+        )
+        .expect("hot-room baseline cursor");
+
+        let mut runtime_b =
+            RuntimeWorld::from_action_journal(&primary_path).expect("replay hot-room process B");
+        advance_runtime_next_event_seq_from_store(&mut runtime_b, &primary_path)
+            .expect("advance hot-room process B cursor");
+        let state_b = configure_capacity_test_state(
+            test_app_state(runtime_b, Some(primary_path.clone())),
+            "hot-b",
+            "hot-b:boot-b",
+            &url_b,
+            router_token,
+            lease_ttl,
+        );
+        let store_id = state_a.canonical_store_id.as_ref().clone();
+        assert_eq!(state_b.canonical_store_id.as_str(), store_id);
+
+        let app_a = routes::app_router(state_a.clone());
+        let app_b = routes::app_router(state_b.clone());
+        let server_a = tokio::spawn(async move {
+            axum::serve(
+                listener_a,
+                app_a.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("serve hot-room process A");
+        });
+        let server_b = tokio::spawn(async move {
+            axum::serve(
+                listener_b,
+                app_b.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("serve hot-room process B");
+        });
+        let convergence_a =
+            start_canonical_capacity_scheduler(state_a.clone()).expect("hot-room convergence A");
+        let convergence_b =
+            start_canonical_capacity_scheduler(state_b.clone()).expect("hot-room convergence B");
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("hot-room client");
+
+        let (actor_ref, hot_partition, cold_partition) = {
+            let runtime = state_a.inner.lock().await;
+            let actor_ref = runtime
+                .canonical_ref("actor", actor_hot)
+                .expect("hot actor ref")
+                .to_string();
+            let hot_location_ref = runtime
+                .canonical_ref("location", COSY_COTTAGE_LOCATION_ID)
+                .expect("hot location ref");
+            let cold_location_ref = runtime
+                .canonical_ref("location", RAIN_SOFT_GARDEN_LOCATION_ID)
+                .expect("cold location ref");
+            (
+                actor_ref,
+                canonical_room_partition_key(hot_location_ref),
+                canonical_room_partition_key(cold_location_ref),
+            )
+        };
+
+        // Hot-room load may enter through either edge, but one fenced owner
+        // serializes every effect and entity versions only move forward.
+        let mut actor_versions = Vec::new();
+        let mut hot_messages = Vec::new();
+        for index in 0..16_u64 {
+            converge_capacity_for_read(&state_a, Some(&session_hot)).await;
+            let content = format!("hot-room-load-{index}");
+            let request = {
+                let runtime = state_a.inner.lock().await;
+                canonical_test_command_request(
+                    &runtime,
+                    actor_hot,
+                    &session_hot,
+                    &format!("test:hot-room-load:{index}"),
+                    &format!("say {content}"),
+                )
+            };
+            let base = if index % 2 == 0 { &url_a } else { &url_b };
+            let response: CommandResponse = client
+                .post(format!("{base}/commands"))
+                .json(&request)
+                .send()
+                .await
+                .expect("hot-room load command")
+                .json()
+                .await
+                .expect("hot-room load response");
+            assert!(response.ok, "{response:?}");
+            converge_capacity_for_read(&state_a, Some(&session_hot)).await;
+            let version = state_a.inner.lock().await.entity_version(&actor_ref);
+            actor_versions.push(version);
+            hot_messages.push(content);
+        }
+        assert!(actor_versions.windows(2).all(|pair| pair[1] > pair[0]));
+
+        let source_hot_lease = current_partition_lease(
+            &primary_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &hot_partition,
+            now_millis(),
+        )
+        .expect("read hot-room source lease")
+        .expect("hot-room source owner");
+        assert_eq!(source_hot_lease.owner_id, "hot-a:boot-a");
+        let handoff_seq = current_world_seq(
+            &open_event_store(&primary_path).expect("handoff store"),
+            OFFICIAL_WORLD_ID,
+        )
+        .expect("handoff cursor");
+        let handoff = handoff_partition_leases(
+            &primary_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &store_id,
+            DEFAULT_CANONICAL_REGION_ID,
+            &BTreeMap::from([(
+                hot_partition.clone(),
+                CanonicalOwnershipTransfer {
+                    source: source_hot_lease.clone(),
+                    target_owner_id: "hot-b:boot-b".to_string(),
+                },
+            )]),
+            handoff_seq,
+            "hot-room load rebalance",
+            now_millis(),
+            authority_lease_ttl_ms(&state_a),
+        )
+        .expect("commit hot-room handoff");
+        let target_hot_lease = handoff
+            .leases
+            .get(&hot_partition)
+            .expect("target hot-room lease")
+            .clone();
+        assert_eq!(handoff.world_seq, handoff_seq);
+        assert_eq!(target_hot_lease.owner_id, "hot-b:boot-b");
+        assert_eq!(
+            target_hot_lease.fencing_epoch,
+            source_hot_lease.fencing_epoch + 1
+        );
+
+        let stale_rejected = {
+            let mut conn = open_event_store(&primary_path).expect("stale handoff store");
+            let tx = conn
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .expect("stale handoff transaction");
+            let result = validate_and_renew_partition_lease(
+                &tx,
+                &source_hot_lease,
+                now_millis(),
+                authority_lease_ttl_ms(&state_a),
+            );
+            tx.rollback().expect("rollback stale handoff probe");
+            result
+        };
+        assert_eq!(
+            stale_rejected
+                .expect_err("stale pre-handoff owner must fail")
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+
+        let post_handoff_request = {
+            let runtime = state_a.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_hot,
+                &session_hot,
+                "test:after-hot-room-handoff",
+                "say handoff stayed contiguous",
+            )
+        };
+        let post_handoff: CommandResponse = client
+            .post(format!("{url_a}/commands"))
+            .json(&post_handoff_request)
+            .send()
+            .await
+            .expect("post-handoff command through stale edge")
+            .json()
+            .await
+            .expect("post-handoff response");
+        assert!(post_handoff.ok, "{post_handoff:?}");
+        assert!(post_handoff
+            .receipt
+            .as_ref()
+            .is_some_and(|receipt| receipt.owner_fencing_epoch >= target_hot_lease.fencing_epoch));
+
+        // Refresh the cold room, then checkpoint two independently owned
+        // ranges at one exact global sequence boundary.
+        converge_capacity_for_read(&state_a, Some(&session_cold)).await;
+        let cold_request = {
+            let runtime = state_a.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_cold,
+                &session_cold,
+                "test:cold-range-checkpoint",
+                "say cold range is ready",
+            )
+        };
+        let cold_response: CommandResponse = client
+            .post(format!("{url_a}/commands"))
+            .json(&cold_request)
+            .send()
+            .await
+            .expect("cold range command")
+            .json()
+            .await
+            .expect("cold range response");
+        assert!(cold_response.ok, "{cold_response:?}");
+        let split_now = now_millis();
+        let hot_before_split = current_partition_lease(
+            &primary_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &hot_partition,
+            split_now,
+        )
+        .unwrap()
+        .expect("hot owner before split");
+        let cold_before_split = current_partition_lease(
+            &primary_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &cold_partition,
+            split_now,
+        )
+        .unwrap()
+        .expect("cold owner before split");
+        assert_ne!(hot_before_split.owner_id, cold_before_split.owner_id);
+        let split_seq =
+            current_world_seq(&open_event_store(&primary_path).unwrap(), OFFICIAL_WORLD_ID)
+                .unwrap();
+        let split = handoff_partition_leases(
+            &primary_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &store_id,
+            DEFAULT_CANONICAL_REGION_ID,
+            &BTreeMap::from([
+                (
+                    hot_partition.clone(),
+                    CanonicalOwnershipTransfer {
+                        target_owner_id: hot_before_split.owner_id.clone(),
+                        source: hot_before_split,
+                    },
+                ),
+                (
+                    cold_partition.clone(),
+                    CanonicalOwnershipTransfer {
+                        target_owner_id: cold_before_split.owner_id.clone(),
+                        source: cold_before_split,
+                    },
+                ),
+            ]),
+            split_seq,
+            "split hot and cold ownership ranges",
+            split_now,
+            authority_lease_ttl_ms(&state_a),
+        )
+        .expect("commit ownership split checkpoint");
+        assert_eq!(split.world_seq, split_seq);
+        assert_eq!(split.leases.len(), 2);
+        assert_ne!(
+            split.leases[&hot_partition].owner_id,
+            split.leases[&cold_partition].owner_id
+        );
+
+        // A cross-range mutation cannot partially apply while the children
+        // have different owners.
+        converge_capacity_for_read(&state_b, Some(&session_hot)).await;
+        let before_cross_seq = latest_action_journal_seq(&primary_path).unwrap();
+        let before_cross_location = state_b
+            .inner
+            .lock()
+            .await
+            .actor_by_id(actor_hot)
+            .unwrap()
+            .location_id;
+        let cross_result = {
+            let mut runtime = state_b.inner.lock().await;
+            let mut record = JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_NONE,
+                    actor_id: actor_hot,
+                    destination_location_id: RAIN_SOFT_GARDEN_LOCATION_ID,
+                    ..CwAction::default()
+                },
+                runtime.next_seed_value(),
+            );
+            record.source_location_id = Some(COSY_COTTAGE_LOCATION_ID);
+            record
+                .projection_mutations
+                .push(ProjectionMutation::RendezvousActor {
+                    actor_id: actor_hot,
+                    location_id: RAIN_SOFT_GARDEN_LOCATION_ID,
+                    invite_id: "test:split-range".to_string(),
+                });
+            commit_journal_record(&state_b, &mut runtime, record)
+        };
+        assert_eq!(
+            cross_result
+                .expect_err("cross-owner mutation must fail closed")
+                .kind(),
+            io::ErrorKind::WouldBlock
+        );
+        assert_eq!(
+            latest_action_journal_seq(&primary_path).unwrap(),
+            before_cross_seq
+        );
+        assert_eq!(
+            state_b
+                .inner
+                .lock()
+                .await
+                .actor_by_id(actor_hot)
+                .unwrap()
+                .location_id,
+            before_cross_location
+        );
+
+        // Network isolation cannot bootstrap a second world at the same path:
+        // a fresh file has no pinned store identity and every mutation rejects.
+        convergence_a.abort();
+        convergence_b.abort();
+        fs::rename(&primary_path, &quarantine_path).expect("isolate primary store");
+        let isolated_request = {
+            let runtime = state_b.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_hot,
+                &session_hot,
+                "test:network-isolation",
+                "say this must not fork",
+            )
+        };
+        let isolated: CommandResponse = client
+            .post(format!("{url_b}/commands"))
+            .json(&isolated_request)
+            .send()
+            .await
+            .expect("isolated command response")
+            .json()
+            .await
+            .expect("isolated command json");
+        assert!(!isolated.ok);
+        assert_eq!(isolated.status, 503);
+        let isolated_conn = open_event_store(&primary_path).expect("fresh isolated store");
+        let isolated_actions: i64 = isolated_conn
+            .query_row("SELECT COUNT(*) FROM action_journal", [], |row| row.get(0))
+            .unwrap();
+        let isolated_identity: i64 = isolated_conn
+            .query_row("SELECT COUNT(*) FROM canonical_store_identity", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!((isolated_actions, isolated_identity), (0, 0));
+        drop(isolated_conn);
+        fs::remove_file(&primary_path).expect("remove isolated empty store");
+        fs::rename(&quarantine_path, &primary_path).expect("restore primary store");
+        let convergence_a =
+            start_canonical_capacity_scheduler(state_a.clone()).expect("restart convergence A");
+        let convergence_b =
+            start_canonical_capacity_scheduler(state_b.clone()).expect("restart convergence B");
+        converge_capacity_for_read(&state_a, Some(&session_hot)).await;
+
+        // Kill the hot-room owner. The surviving process takes the expired
+        // range at a higher fence without changing actor identity or history.
+        convergence_b.abort();
+        server_b.abort();
+        tokio::time::sleep(lease_ttl + Duration::from_millis(250)).await;
+        let process_loss_request = {
+            let runtime = state_a.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_hot,
+                &session_hot,
+                "test:hot-owner-loss",
+                "say process loss kept one history",
+            )
+        };
+        let process_loss: CommandResponse = client
+            .post(format!("{url_a}/commands"))
+            .json(&process_loss_request)
+            .send()
+            .await
+            .expect("command after hot owner loss")
+            .json()
+            .await
+            .expect("process loss response");
+        assert!(process_loss.ok, "{process_loss:?}");
+        let process_loss_fence = process_loss
+            .receipt
+            .as_ref()
+            .expect("process loss receipt")
+            .owner_fencing_epoch;
+        assert!(process_loss_fence > split.leases[&hot_partition].fencing_epoch);
+
+        // Replicate one exact committed prefix, lose the source region, and
+        // promote only the verified copy under a higher regional epoch/fence.
+        let source_authority =
+            current_region_authority(&primary_path, OFFICIAL_WORLD_ID, OFFICIAL_WORLD_EPOCH)
+                .expect("source region authority");
+        assert_eq!(
+            source_authority.active_region_id,
+            DEFAULT_CANONICAL_REGION_ID
+        );
+        let pre_promotion_lease = current_partition_lease(
+            &primary_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &hot_partition,
+            now_millis(),
+        )
+        .unwrap()
+        .expect("pre-promotion hot lease");
+        let checkpoint = replicate_canonical_store(
+            &primary_path,
+            &recovery_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            "recovery",
+            now_millis(),
+        )
+        .expect("replicate recovery prefix");
+        assert_eq!(
+            checkpoint.durable_world_seq,
+            current_world_seq(&open_event_store(&primary_path).unwrap(), OFFICIAL_WORLD_ID)
+                .unwrap()
+        );
+        assert!(checkpoint.prefix_hash.starts_with("sha256:"));
+        convergence_a.abort();
+        server_a.abort();
+        let promotion = promote_recovery_region(
+            &recovery_path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &store_id,
+            DEFAULT_CANONICAL_REGION_ID,
+            "recovery",
+            source_authority.promotion_epoch,
+            &checkpoint,
+            now_millis(),
+        )
+        .expect("promote recovery region");
+        assert_eq!(
+            promotion.promotion_epoch,
+            source_authority.promotion_epoch + 1
+        );
+        assert_eq!(promotion.durable_world_seq, checkpoint.durable_world_seq);
+        assert_eq!(promotion.prefix_hash, checkpoint.prefix_hash);
+        let promoted_authority =
+            current_region_authority(&recovery_path, OFFICIAL_WORLD_ID, OFFICIAL_WORLD_EPOCH)
+                .unwrap();
+        assert_eq!(promoted_authority.active_region_id, "recovery");
+        let stale_region_rejected = {
+            let mut conn = open_event_store(&recovery_path).unwrap();
+            let tx = conn
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .unwrap();
+            let result = validate_and_renew_partition_lease(
+                &tx,
+                &pre_promotion_lease,
+                now_millis(),
+                authority_lease_ttl_ms(&state_a),
+            );
+            tx.rollback().unwrap();
+            result
+        };
+        assert_eq!(
+            stale_region_rejected
+                .expect_err("pre-promotion owner must be fenced")
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+
+        let listener_recovery = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind recovery writer");
+        let recovery_addr = listener_recovery.local_addr().unwrap();
+        let recovery_url = format!("http://{recovery_addr}");
+        let mut recovery_runtime =
+            RuntimeWorld::from_action_journal(&recovery_path).expect("replay recovery writer");
+        advance_runtime_next_event_seq_from_store(&mut recovery_runtime, &recovery_path).unwrap();
+        let mut recovery_state = test_app_state(recovery_runtime, Some(recovery_path.clone()));
+        recovery_state.canonical_region_id = Arc::new("recovery".to_string());
+        let recovery_state = configure_capacity_test_state(
+            recovery_state,
+            "recovery-writer",
+            "recovery-writer:boot-r",
+            &recovery_url,
+            router_token,
+            lease_ttl,
+        );
+        let recovery_app = routes::app_router(recovery_state.clone());
+        let recovery_server = tokio::spawn(async move {
+            axum::serve(
+                listener_recovery,
+                recovery_app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("serve recovery writer");
+        });
+        let recovery_convergence = start_canonical_capacity_scheduler(recovery_state.clone())
+            .expect("recovery convergence");
+        converge_capacity_for_read(&recovery_state, Some(&session_hot)).await;
+        let recovery_request = {
+            let runtime = recovery_state.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_hot,
+                &session_hot,
+                "test:regional-promotion",
+                "say recovery kept the committed prefix",
+            )
+        };
+        let recovery_response: CommandResponse = client
+            .post(format!("{recovery_url}/commands"))
+            .json(&recovery_request)
+            .send()
+            .await
+            .expect("recovery region command")
+            .json()
+            .await
+            .expect("recovery command response");
+        assert!(recovery_response.ok, "{recovery_response:?}");
+        assert!(
+            recovery_response.receipt.as_ref().is_some_and(
+                |receipt| receipt.owner_fencing_epoch > pre_promotion_lease.fencing_epoch
+            )
+        );
+
+        // A client reconnecting through the former region reads the promoted
+        // prefix and forwards writes to the active recovery owner.
+        let listener_reconnect = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind reconnect edge");
+        let reconnect_addr = listener_reconnect.local_addr().unwrap();
+        let reconnect_url = format!("http://{reconnect_addr}");
+        let mut reconnect_runtime =
+            RuntimeWorld::from_action_journal(&recovery_path).expect("replay reconnect edge");
+        advance_runtime_next_event_seq_from_store(&mut reconnect_runtime, &recovery_path).unwrap();
+        let reconnect_state = configure_capacity_test_state(
+            test_app_state(reconnect_runtime, Some(recovery_path.clone())),
+            "former-region-edge",
+            "former-region-edge:boot-e",
+            &reconnect_url,
+            router_token,
+            lease_ttl,
+        );
+        let reconnect_app = routes::app_router(reconnect_state.clone());
+        let reconnect_server = tokio::spawn(async move {
+            axum::serve(
+                listener_reconnect,
+                reconnect_app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("serve reconnect edge");
+        });
+        let reconnect_convergence = start_canonical_capacity_scheduler(reconnect_state.clone())
+            .expect("reconnect convergence");
+        converge_capacity_for_read(&reconnect_state, Some(&session_hot)).await;
+        let reconnect_request = {
+            let runtime = reconnect_state.inner.lock().await;
+            canonical_test_command_request(
+                &runtime,
+                actor_hot,
+                &session_hot,
+                "test:cross-region-reconnect",
+                "say both regions rejoined one world",
+            )
+        };
+        let reconnect_response: CommandResponse = client
+            .post(format!("{reconnect_url}/commands"))
+            .json(&reconnect_request)
+            .send()
+            .await
+            .expect("reconnected region command")
+            .json()
+            .await
+            .expect("reconnected command response");
+        assert!(reconnect_response.ok, "{reconnect_response:?}");
+        converge_capacity_for_read(&recovery_state, Some(&session_hot)).await;
+        converge_capacity_for_read(&reconnect_state, Some(&session_hot)).await;
+
+        let recovery_view: serde_json::Value = client
+            .get(format!("{recovery_url}/state"))
+            .query(&[
+                ("actor_id", actor_hot.to_string()),
+                ("actor_session", session_hot.clone()),
+            ])
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let reconnect_view: serde_json::Value = client
+            .get(format!("{reconnect_url}/state"))
+            .query(&[
+                ("actor_id", actor_hot.to_string()),
+                ("actor_session", session_hot.clone()),
+            ])
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        for field in ["world_seq", "location", "actors", "items", "action_hand"] {
+            assert_eq!(
+                recovery_view[field], reconnect_view[field],
+                "regional reconnect diverged at {field}"
+            );
+        }
+
+        let final_seq = current_world_seq(
+            &open_event_store(&recovery_path).unwrap(),
+            OFFICIAL_WORLD_ID,
+        )
+        .unwrap();
+        let suffix = read_event_store_forward_between(
+            &recovery_path,
+            baseline_seq,
+            final_seq,
+            MAX_EVENT_STORE_SCAN,
+        )
+        .expect("read regional recovery suffix");
+        assert!(suffix.windows(2).all(|pair| pair[1].seq == pair[0].seq + 1));
+        assert_eq!(
+            suffix
+                .iter()
+                .map(|event| event.seq)
+                .collect::<BTreeSet<_>>()
+                .len(),
+            suffix.len(),
+            "regional suffix contains duplicate event ids"
+        );
+        for content in hot_messages.iter().map(String::as_str).chain([
+            "handoff stayed contiguous",
+            "process loss kept one history",
+            "recovery kept the committed prefix",
+            "both regions rejoined one world",
+        ]) {
+            assert_eq!(
+                suffix
+                    .iter()
+                    .filter(|event| {
+                        event.type_name == "message.created"
+                            && event.content.as_deref() == Some(content)
+                    })
+                    .count(),
+                1,
+                "message {content:?} was lost or duplicated"
+            );
+        }
+        assert!(!suffix.iter().any(|event| {
+            event.type_name == "message.created"
+                && event.content.as_deref() == Some("this must not fork")
+        }));
+
+        recovery_convergence.abort();
+        reconnect_convergence.abort();
+        recovery_server.abort();
+        reconnect_server.abort();
+        drop(client);
+        for path in [&primary_path, &recovery_path, &quarantine_path] {
+            let _ = fs::remove_file(path);
+        }
     }
 
     #[tokio::test]
@@ -58014,11 +59195,14 @@ mod tests {
             actor_chat_locks: Arc::new(StdMutex::new(BTreeSet::new())),
             canonical_command_lock: Arc::new(Mutex::new(())),
             canonical_owner_id: Arc::new(format!("test:{}", random_hex(8))),
+            canonical_store_id: Arc::new(format!("test-memory:{}", random_hex(8))),
+            canonical_region_id: Arc::new(DEFAULT_CANONICAL_REGION_ID.to_string()),
             canonical_lease_ttl: DEFAULT_CANONICAL_LEASE_TTL,
             canonical_applied_journal_seq: Arc::new(AtomicU64::new(0)),
             canonical_fanout_seq: Arc::new(AtomicU64::new(canonical_fanout_seq)),
             canonical_fanout_lock: Arc::new(StdMutex::new(())),
             canonical_routing: Arc::new(CanonicalRoutingConfig::default()),
+            canonical_recovery: Arc::new(None),
             regional_presence: Arc::new(StdMutex::new(BTreeMap::new())),
             room_turns: Arc::new(StdMutex::new(RoomTurns::default())),
             room_memory_cache: Arc::new(StdMutex::new(BTreeMap::new())),
@@ -58447,6 +59631,10 @@ struct MetaDeployment {
     world_id: String,
     world_epoch: u64,
     process_id: String,
+    region_id: String,
+    active_region_id: String,
+    promotion_epoch: u64,
+    canonical_store_id: String,
     shard_id: String,
     shard_model: &'static str,
 }

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -147,6 +147,18 @@ pub(super) fn app_router(state: AppState) -> Router {
             "/internal/canonical/invites/follow",
             post(internal_follow_canonical_invite),
         )
+        .route(
+            "/internal/canonical/ownership/handoff",
+            post(internal_canonical_ownership_handoff),
+        )
+        .route(
+            "/internal/canonical/regions/checkpoint",
+            post(internal_canonical_region_checkpoint),
+        )
+        .route(
+            "/internal/canonical/regions/promote",
+            post(internal_canonical_region_promote),
+        )
         .route("/stream", get(stream))
         .layer(CompressionLayer::new())
         .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
## What changed

- pin one durable canonical store identity and active region authority into every lease acquisition and commit
- add atomic multi-partition ownership handoff at an exact committed sequence boundary
- add exact process-route region metadata and standby-aware forwarding
- create hash-verified SQLite recovery checkpoints and fenced regional promotion
- expose hidden bearer-authenticated handoff, checkpoint, and promotion operator routes
- add `/meta` store/region/promotion observability and a complete promotion/rollback drill
- keep AWS production capacity pinned to one until exact per-task routes and a release-specific drill pass
- bump the release to 0.0.76

## Why

A shared journal and exact owner routes proved divergent capacity processes could converge, but there was no atomic hot-room migration or durable recovery-region promotion boundary. Without those gates, increasing capacity or promoting a copied store could lose events, accept a stale owner, or fork the public world.

## Impact

Hot reads and SSE fan-out may be served by converged capacity processes while one fenced owner serializes room writes. Operators can move up to 64 ownership partitions atomically, checkpoint a durable prefix with a SHA-256 proof, and promote only that verified prefix under higher regional and partition fences. Production remains deliberately single-task until its infrastructure-specific gate is satisfied.

## Verification

- `cargo test`: 363 passed
- focused #127 two-process convergence harness: passed
- focused #130 hot-room/regional chaos harness: passed
- `npm test`: 418 passed
- ESLint: passed
- worldpack compositions + strict proof-world: passed
- C kernel tests: passed
- syntax and version checks: passed
- Rust release build: passed
- JavaScript production bundle and docs build: passed
- Terraform fmt and validate: passed
- regular clippy: completed with only 33 existing baseline warnings; #130 adds none

Closes #130