### PR TITLE
Make story-metric backfill atomic on AWS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.79",
+      "version": "0.0.80",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/story-metrics.md
+++ b/v2/docs/story-metrics.md
@@ -72,8 +72,9 @@ backfill therefore resolves to the same row and cannot inflate a count. Live
 metrics are written in the same SQLite transaction as the canonical journal;
 instrumentation errors are logged and fail open so analytics cannot block a
 world action. The versioned backfill derives supported signals from canonical
-events without copying event prose. Canonical events remain the repair source
-if metrics are lost.
+events without copying event prose and commits its first-run work in one
+rollback-safe SQLite savepoint. Canonical events remain the repair source if
+metrics are lost.
 
 Readers include only schema version 1. Rows with an unknown schema are excluded
 from every result and counted as `unsupported_schema_event_count`, making a

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.79"
+version = "0.0.80"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/story_metrics.rs
+++ b/v2/orchestrator-rust/src/story_metrics.rs
@@ -1432,6 +1432,23 @@ fn backfill_story_metrics_from_world_events(conn: &Connection) -> io::Result<()>
     if already_ran {
         return Ok(());
     }
+    conn.execute_batch("SAVEPOINT story_metrics_world_events_v1")
+        .map_err(sqlite_error)?;
+    match backfill_story_metric_rows(conn) {
+        Ok(()) => conn
+            .execute_batch("RELEASE story_metrics_world_events_v1")
+            .map_err(sqlite_error),
+        Err(error) => {
+            let _ = conn.execute_batch(
+                "ROLLBACK TO story_metrics_world_events_v1;
+                 RELEASE story_metrics_world_events_v1;",
+            );
+            Err(error)
+        }
+    }
+}
+
+fn backfill_story_metric_rows(conn: &Connection) -> io::Result<()> {
     let mut stmt = conn
         .prepare("SELECT payload_json, created_at_ms FROM world_events ORDER BY seq")
         .map_err(sqlite_error)?;
@@ -1764,6 +1781,98 @@ mod tests {
         assert!(!serialized.contains("raw private chat"));
         assert!(!serialized.contains("actor_id"));
         assert!(serialized.contains(&story_player_ref(5000)));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn backfill_is_atomic_and_retryable_after_an_insert_failure() {
+        let path = temp_story_db("backfill-atomicity");
+        let _ = fs::remove_file(&path);
+        let conn = Connection::open(&path).expect("open atomic backfill fixture");
+        conn.execute_batch(
+            "CREATE TABLE world_events (
+                seq INTEGER PRIMARY KEY,
+                event_type TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                created_at_ms INTEGER NOT NULL
+            );",
+        )
+        .expect("create atomic backfill world events");
+        init_story_metrics_store(&conn).expect("initialize empty story store");
+        conn.execute(
+            "DELETE FROM story_metric_backfills WHERE backfill_key = ?1",
+            params![STORY_METRICS_BACKFILL_KEY],
+        )
+        .unwrap();
+        let created = EventView {
+            seq: 1,
+            type_name: "actor.created".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            ..EventView::default()
+        };
+        let message = EventView {
+            seq: 2,
+            type_name: "message.created".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            ..EventView::default()
+        };
+        for event in [&created, &message] {
+            conn.execute(
+                "INSERT INTO world_events (seq, event_type, payload_json, created_at_ms)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    event.seq as i64,
+                    event.type_name,
+                    serde_json::to_string(event).unwrap(),
+                    1_000_i64 + event.seq as i64,
+                ],
+            )
+            .unwrap();
+        }
+        conn.execute_batch(
+            "CREATE TRIGGER reject_story_backfill
+             BEFORE INSERT ON story_metric_events
+             BEGIN
+               SELECT RAISE(ABORT, 'forced story backfill failure');
+             END;",
+        )
+        .unwrap();
+
+        let error = backfill_story_metrics_from_world_events(&conn).unwrap_err();
+        assert!(error.to_string().contains("forced story backfill failure"));
+        assert!(conn.is_autocommit());
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM story_metric_events", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM story_metric_backfills", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+
+        conn.execute_batch("DROP TRIGGER reject_story_backfill")
+            .unwrap();
+        backfill_story_metrics_from_world_events(&conn).expect("retry atomic backfill");
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM story_metric_events", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM story_metric_backfills", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
 
         let _ = fs::remove_file(path);
     }


### PR DESCRIPTION
Follow-up to #140.

## Incident

The tagged v0.0.79 workflow succeeded, and Fly booted cleanly, but AWS ECS task revision 37 failed its ELB health checks. ECS retained revision 36, so AWS stayed available on v0.0.78.

ECS retries later completed the deterministic partial backfill and revision 37 stabilized on v0.0.79. The hotfix is still required so a fresh or restored production store reaches readiness in one task rather than depending on repeated health-check failures for forward progress.

CloudWatch showed the new task did not begin listening until roughly four minutes after ECS start. The first-run story-metric derivation was using one SQLite autocommit per row; on the EFS-backed production event store, that exceeded the existing 90-second health grace period.

## Fix

- execute the entire versioned world-event backfill inside one rollback-safe SQLite savepoint
- retain deterministic `INSERT OR IGNORE` recovery from the partial rows written by revision 37
- add a forced-insert-failure fixture proving rows and the completion marker roll back together and the next retry succeeds
- bump the hotfix release to v0.0.80

## Verification

- story-metric tests: 6 passed
- full Rust suite: 380 passed
- release build: passed
- Rust format and diff checks: passed
- version bump check: passed
