### PR TITLE
fix(v2): restore fast canonical card writes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,15 @@ jobs:
           cache-from: type=registry,ref=${{ steps.ecr.outputs.registry }}/${{ env.AWS_ECR_REPOSITORY }}:buildcache
           cache-to: type=registry,ref=${{ steps.ecr.outputs.registry }}/${{ env.AWS_ECR_REPOSITORY }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
+      # The arm64 image build can outlive the initial one-hour OIDC session.
+      # Re-assume the deployer role before Terraform touches the remote state.
+      - name: Refresh AWS credentials for Terraform
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          unset-current-credentials: true
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.84",
+      "version": "0.0.85",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.84"
+version = "0.0.85"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.84"
+version = "0.0.85"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/canonical_journal.rs
+++ b/v2/orchestrator-rust/src/canonical_journal.rs
@@ -1847,6 +1847,30 @@ pub(super) fn load_canonical_claims(
     Ok(claims)
 }
 
+pub(super) fn load_canonical_entity_versions(
+    path: &Path,
+    world_id: &str,
+) -> io::Result<BTreeMap<String, u64>> {
+    let conn = open_canonical_store(path)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT entity_ref, entity_version FROM canonical_entity_versions
+             WHERE world_id = ?1 ORDER BY entity_ref",
+        )
+        .map_err(sqlite_error)?;
+    let rows = stmt
+        .query_map(params![world_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })
+        .map_err(sqlite_error)?;
+    let mut versions = BTreeMap::new();
+    for row in rows {
+        let (entity_ref, entity_version) = row.map_err(sqlite_error)?;
+        versions.insert(entity_ref, as_u64(entity_version, "entity_version")?);
+    }
+    Ok(versions)
+}
+
 pub(super) fn insert_canonical_commit(
     conn: &Connection,
     row: &CanonicalCommitRow<'_>,

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1677,19 +1677,29 @@
       width: 100%;
       flex-basis: auto;
     }
-    .cmd.has-copy .thumb,
-    .cmd.has-copy .thumb.location {
+    .cmd.has-copy .thumb {
       width: 46px;
       flex: 0 0 46px;
-      min-height: 40px;
-      height: auto;
-      align-self: stretch;
+      min-height: 0;
+      height: 46px;
+      align-self: center;
+    }
+    .cmd.has-copy .thumb.avatar {
+      width: 36px;
+      flex-basis: 36px;
+      height: 48px;
+    }
+    .cmd.has-copy .thumb.location {
+      width: 58px;
+      flex-basis: 58px;
+      height: 34px;
     }
     .cmd .thumb.action-mini-card,
     .cmd .thumb.action-mini-card.avatar,
     .cmd .thumb.action-mini-card.item,
     .cmd .thumb.action-mini-card.location {
-      background-size: cover;
+      background-size: contain;
+      background-repeat: no-repeat;
       background-position: center;
       border-radius: 3px;
     }
@@ -2536,13 +2546,22 @@
         width: 100%;
         flex-basis: auto;
       }
-      .cmd.has-copy .thumb,
-      .cmd.has-copy .thumb.location {
+      .cmd.has-copy .thumb {
         width: 40px;
         flex: 0 0 40px;
-        min-height: 36px;
-        height: auto;
-        align-self: stretch;
+        min-height: 0;
+        height: 40px;
+        align-self: center;
+      }
+      .cmd.has-copy .thumb.avatar {
+        width: 32px;
+        flex-basis: 32px;
+        height: 44px;
+      }
+      .cmd.has-copy .thumb.location {
+        width: 52px;
+        flex-basis: 52px;
+        height: 32px;
       }
     }
 
@@ -3009,6 +3028,8 @@
     let refreshInFlight = null;
     let refreshQueued = false;
     let actionBusy = false;
+    let actionSlow = false;
+    let actionSlowTimer = null;
     let pendingAction = null;
     let pendingChats = [];
     let nextPendingChatId = 1;
@@ -8803,9 +8824,10 @@
         aspect: shape === "location" ? "wide" : (shape === "avatar" ? "tall" : "square"),
       };
       const image = cardImage(card) || fallbackCardImage(fallback);
+      const imageEmoji = cardImage(card) ? "" : emojiHtml(cardEmoji(fallback, shape));
       const dataAttr = interactive && card ? cardDataAttr(card) : "";
       const className = ["thumb", extraClass, shape].filter(Boolean).join(" ");
-      return `<span class="${escapeAttr(className)}"${dataAttr} aria-hidden="true" style="background-image:url('${escapeAttr(image)}')">${emojiHtml(cardEmoji(fallback, shape))}</span>`;
+      return `<span class="${escapeAttr(className)}"${dataAttr} aria-hidden="true" style="background-image:url('${escapeAttr(image)}')">${imageEmoji}</span>`;
     }
 
     function actionImage(action) {
@@ -9996,10 +10018,12 @@
         const busyDetail = typeof pendingAction?.busyDetail === "function"
           ? pendingAction.busyDetail()
           : pendingAction?.busyDetail;
-        const detail = busyDetail || pendingAction?.detail || pendingAction?.label || "working";
+        const detail = actionSlow
+          ? "saving safely — this is taking longer than usual"
+          : (busyDetail || pendingAction?.detail || pendingAction?.label || "working");
         renderButton("primary", {
           ...(pendingAction || {}),
-          label: pendingAction?.busyLabel || "working",
+          label: actionSlow ? "still working" : (pendingAction?.busyLabel || "working"),
           detail,
           busy: true,
         });
@@ -10091,7 +10115,14 @@
     async function runAction(action) {
       if (actionBusy) return;
       actionBusy = true;
+      actionSlow = false;
       pendingAction = action;
+      clearTimeout(actionSlowTimer);
+      actionSlowTimer = setTimeout(() => {
+        if (!actionBusy || pendingAction !== action) return;
+        actionSlow = true;
+        renderCommands();
+      }, 3000);
       const pendingChatId = beginPendingChat(action);
       renderCommands();
       renderLog();
@@ -10106,7 +10137,10 @@
         cancelPendingChat(pendingChatId);
         setError(String(error.message || error));
       } finally {
+        clearTimeout(actionSlowTimer);
+        actionSlowTimer = null;
         actionBusy = false;
+        actionSlow = false;
         pendingAction = null;
         render();
       }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -4902,8 +4902,7 @@ impl AppState {
                     error
                 );
             }
-            let canonical_claims = load_canonical_claims(path, OFFICIAL_WORLD_ID)?;
-            merge_runtime_canonical_claims(&mut runtime, &canonical_claims);
+            hydrate_runtime_canonical_state(&mut runtime, path)?;
         }
 
         let ownership_feed = OwnershipFeedConfig::from_env();
@@ -36797,6 +36796,25 @@ fn merge_runtime_canonical_claims(
     }
 }
 
+fn merge_runtime_canonical_entity_versions(
+    runtime: &mut RuntimeWorld,
+    versions: &BTreeMap<String, u64>,
+) {
+    runtime.canonical_identities.entity_versions.extend(
+        versions
+            .iter()
+            .map(|(entity_ref, version)| (entity_ref.clone(), *version)),
+    );
+}
+
+fn hydrate_runtime_canonical_state(runtime: &mut RuntimeWorld, path: &Path) -> io::Result<()> {
+    let versions = load_canonical_entity_versions(path, OFFICIAL_WORLD_ID)?;
+    merge_runtime_canonical_entity_versions(runtime, &versions);
+    let claims = load_canonical_claims(path, OFFICIAL_WORLD_ID)?;
+    merge_runtime_canonical_claims(runtime, &claims);
+    Ok(())
+}
+
 fn canonical_partitions_for_location_ids(
     runtime: &RuntimeWorld,
     location_ids: impl IntoIterator<Item = u64>,
@@ -37029,6 +37047,7 @@ fn commit_journal_record(
                 return Err(error);
             }
         };
+        let runtime_before_commit = runtime.clone();
         let committed = (|| -> io::Result<(u32, Vec<EventView>, bool, u64)> {
             let commit_time = now_millis();
             let lease_ttl = authority_lease_ttl_ms(state);
@@ -37274,11 +37293,20 @@ fn commit_journal_record(
             Ok(committed) => committed,
             Err(error) => {
                 let rollback_error = tx.rollback().map_err(sqlite_error).err();
-                let restore_error = restore_runtime_from_durable_state(state, runtime, path).err();
+                let restore_error = if rollback_error.is_none() {
+                    *runtime = runtime_before_commit;
+                    None
+                } else {
+                    restore_runtime_from_durable_state(state, runtime, path).err()
+                };
                 let error = journal_commit_recovery_error(error, rollback_error, restore_error);
                 if let Some(context) = command_context.as_ref() {
                     context.abort_commit();
                 }
+                warn!(
+                    "canonical journal commit failed for actor {} action {}: {}",
+                    record.action.actor_id, record.action.kind, error
+                );
                 state.record_event_store_append_failure(&error);
                 return Err(error);
             }
@@ -37289,6 +37317,10 @@ fn commit_journal_record(
             if let Some(context) = command_context.as_ref() {
                 context.abort_commit();
             }
+            warn!(
+                "canonical journal transaction commit failed for actor {} action {}: {}",
+                record.action.actor_id, record.action.kind, error
+            );
             state.record_event_store_append_failure(&error);
             return Err(error);
         }
@@ -37321,6 +37353,7 @@ fn restore_runtime_from_durable_state(
 ) -> io::Result<()> {
     let mut restored = RuntimeWorld::from_action_journal(event_store_path)?;
     advance_runtime_next_event_seq_from_store(&mut restored, event_store_path)?;
+    hydrate_runtime_canonical_state(&mut restored, event_store_path)?;
     if let Some(path) = state.resident_continuity_path.as_deref() {
         match restored.load_resident_continuity_snapshot(path) {
             Ok(_) => {}
@@ -47045,6 +47078,122 @@ mod tests {
     }
 
     #[test]
+    fn durable_entity_versions_rehydrate_replayed_runtime_before_next_write() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-canonical-version-rehydrate-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        let actor_id = 5000;
+        let state = test_app_state(RuntimeWorld::seeded(), Some(path.clone()));
+        {
+            let mut runtime = state.inner.blocking_lock();
+            let mut create = JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_CREATE_ACTOR,
+                    actor_id,
+                    location_id: COSY_COTTAGE_LOCATION_ID,
+                    ..CwAction::default()
+                },
+                71_200,
+            );
+            create.actor_meta_upserts.insert(
+                actor_id,
+                ActorMeta {
+                    name: "Version Traveller".to_string(),
+                    speech_mode: "prose".to_string(),
+                    title: "Recovery Tester".to_string(),
+                    description: "A test avatar crossing a worldpack version boundary.".to_string(),
+                },
+            );
+            assert_eq!(
+                commit_journal_record(&state, &mut runtime, create)
+                    .expect("commit versioned actor")
+                    .0,
+                CW_OK
+            );
+        }
+        let actor_ref = state
+            .inner
+            .blocking_lock()
+            .canonical_ref("actor", actor_id)
+            .expect("actor canonical ref")
+            .to_string();
+        let durable_version = {
+            let conn = open_event_store(&path).expect("open canonical versions");
+            let current = conn
+                .query_row(
+                    "SELECT entity_version FROM canonical_entity_versions
+                     WHERE world_id = ?1 AND entity_ref = ?2",
+                    params![OFFICIAL_WORLD_ID, &actor_ref],
+                    |row| row.get::<_, i64>(0),
+                )
+                .expect("durable actor version") as u64;
+            let advanced = current.saturating_add(10);
+            conn.execute(
+                "UPDATE canonical_entity_versions SET entity_version = ?3
+                 WHERE world_id = ?1 AND entity_ref = ?2",
+                params![OFFICIAL_WORLD_ID, &actor_ref, advanced as i64],
+            )
+            .expect("simulate a durable version ahead of replay");
+            advanced
+        };
+
+        {
+            let mut runtime = state.inner.blocking_lock();
+            restore_runtime_from_durable_state(&state, &mut runtime, &path)
+                .expect("rehydrate replayed runtime");
+            assert_eq!(runtime.entity_version(&actor_ref), durable_version);
+
+            let content_id = runtime.next_content_id;
+            runtime.next_content_id = runtime.next_content_id.saturating_add(1);
+            let mut say = JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_SAY,
+                    actor_id,
+                    content_id,
+                    ..CwAction::default()
+                },
+                71_201,
+            );
+            say.content_upserts.insert(
+                content_id,
+                "the durable version is authoritative".to_string(),
+            );
+            assert_eq!(
+                commit_journal_record(&state, &mut runtime, say)
+                    .expect("commit after canonical rehydration")
+                    .0,
+                CW_OK
+            );
+            assert_eq!(
+                runtime.entity_version(&actor_ref),
+                durable_version.saturating_add(1)
+            );
+        }
+        let stored_after = open_event_store(&path)
+            .expect("reopen canonical versions")
+            .query_row(
+                "SELECT entity_version FROM canonical_entity_versions
+                 WHERE world_id = ?1 AND entity_ref = ?2",
+                params![OFFICIAL_WORLD_ID, &actor_ref],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("advanced durable actor version") as u64;
+        assert_eq!(stored_after, durable_version.saturating_add(1));
+        assert_eq!(
+            state
+                .event_store_health
+                .lock()
+                .expect("event store health")
+                .consecutive_append_failures,
+            0
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
     fn actor_outbox_keeps_every_player_card_turn_in_order() {
         let path = std::env::temp_dir().join(format!(
             "cosyworld-v2-actor-outbox-order-{}-{}.sqlite",
@@ -47186,6 +47335,12 @@ mod tests {
              BEGIN SELECT RAISE(ABORT, 'injected actor outbox failure'); END;",
         )
         .expect("install failure injection");
+        conn.execute(
+            "UPDATE action_journal SET record_json = '{broken replay'
+             WHERE journal_seq = (SELECT MIN(journal_seq) FROM action_journal)",
+            [],
+        )
+        .expect("make full replay unavailable after rollback");
         drop(conn);
         let baseline_counts = {
             let conn = open_event_store(&path).expect("count rollback baseline rows");
@@ -47229,7 +47384,10 @@ mod tests {
                 reason: "actor_outbox_rollback_test".to_string(),
             });
 
-        assert!(commit_journal_record(&state, &mut runtime, record).is_err());
+        let error = commit_journal_record(&state, &mut runtime, record)
+            .expect_err("injected actor outbox failure");
+        assert!(error.to_string().contains("injected actor outbox failure"));
+        assert!(!error.to_string().contains("runtime restore failed"));
         assert_eq!(runtime.world.tick, before_tick);
         assert_eq!(runtime.world.next_event_seq, before_next_event_seq);
         assert!(!runtime.tags.contains_key("test:outbox:rollback"));


### PR DESCRIPTION
## Summary

- hydrate replayed runtime identity versions and claims from the authoritative canonical store
- restore the in-memory snapshot after a successful SQLite rollback, retaining fail-closed durable replay for ambiguous commit/rollback failures
- preserve card-art aspect ratios, avoid duplicate emoji overlays, and show honest slow-save feedback after three seconds
- refresh AWS OIDC credentials before Terraform after potentially long arm64 builds
- release as 0.0.85

## Root cause

The worldpack migration replay reconstructed runtime entity versions below the durable canonical version table. Every card write then failed compare-and-swap validation. Recovery synchronously replayed roughly 20,000 journal entries while holding the world lock, producing the long “working” state. The action-card CSS also stretched the thumbnail box and used `cover` on square full-card art, causing the cropped mobile image.

The prior tag deployment also exposed a separate release bug: its arm64 image build exceeded the initial one-hour AWS OIDC session, so Terraform started with expired credentials.

## Verification

- Rust: 393 tests passed
- JavaScript: 418 tests passed
- kernel, syntax, build, proof-world strict, official/composed worldpack checks passed
- production-profile smoke passed
- actionlint and YAML validation passed
- mobile browser at 393×700: correct 52×32 location art, `contain`, no emoji overlay, no console errors; two real actions completed in about 270 ms
