### PR TITLE
Restore Lonely Forest deployment authorization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Deploy the same image to Lonely Forest
         run: flyctl deploy --config fly.lonelyforest.toml --image "${{ steps.image.outputs.ref }}" --ha=false
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
 
   github-release:
     name: Create GitHub release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.89",
+      "version": "0.0.90",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.89"
+version = "0.0.90"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.89"
+version = "0.0.90"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- use a dedicated `FLY_LONELYFOREST_API_TOKEN` for the secondary Fly deployment
- retain the existing primary-app token for `cosyworld`
- bump the repository version to `0.0.90`

The shared `FLY_API_TOKEN` is app-scoped: it successfully deploys `cosyworld` and resolves its image digest, but Fly rejects it when the same workflow deploys `cosyworld-lonelyforest`. A new one-year token scoped only to `cosyworld-lonelyforest` has been stored in the repository secret consumed by this change.

This restores least-privilege authorization while preserving the invariant that both installations deploy the exact same immutable image.

Closes #18

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'`
- `npm run check:version`
- `git diff --check`
- confirmed `FLY_LONELYFOREST_API_TOKEN` exists in repository Actions secrets
- confirmed the latest failed workflow completed the primary deployment and failed only at secondary-app authorization

## Review checklist

- [x] Workflow change is isolated from the mixed local gameplay worktree
- [x] Secondary token is app-scoped and was never printed
- [x] Existing primary deployment credentials are unchanged
- [x] Repository version is bumped