### PR TITLE
Make avatar affordances and room replies controller-neutral

### DIFF
--- a/docs/actor-action-surface.md
+++ b/docs/actor-action-surface.md
@@ -1,0 +1,57 @@
+# Shared actor action surface
+
+CosyWorld composes one scene-local legal action surface for every active
+avatar. `kind` is retained only as content provenance and snapshot
+compatibility; it does not create a player/NPC mechanics boundary.
+
+Every avatar with the same facets in the same scene receives the same candidate
+verbs and targets. `control_mode` decides which intelligence chooses from that
+surface:
+
+- `direct_input`: a person selects one of the certified buttons;
+- `reactive_ai`, `local_ai`, `roaming_ai`, or `delegated_ai`: an inference
+  controller selects one of those same buttons.
+
+Changing a controller never changes the avatar's legal verbs, targets, costs,
+checks, inventory rules, bonds, combat participation, evolution, or deed
+projection. Session ownership decides who may submit a direct choice; it is an
+authorization boundary, not an RPG rule.
+
+Room-card reactions rotate through every present active avatar in stable card
+order. An inference controller may speak and update its own continuity. A
+generated line for a `direct_input` avatar is public proxy speech on that
+player's behalf: it cannot create a private belief, promise, desire, pending
+intent, or extra mechanical action.
+
+The surface includes Notice/Search, Study, Scout, Travel, Craft, Prepare,
+Work/Help, Take, Set Down, Give, Use, Trade, Influence, Rest, Defend/Flee, and
+bounded Attack when their authoritative targets exist. Kernel offers, room
+state, authored content, inventory, clocks, combat state, and access rules
+certify candidates. Gifts may target any co-located avatar that can carry the
+item; an authored request ranks a gift but does not make it legal. Trades use
+the same transfer rule but require the recipient controller's acceptance
+policy. No controller may add an action or target.
+
+Inference-controller selection is deterministic. Safety, recovery, active
+projects, represented delivery needs, witnessed item memories, possessed
+recipe inputs, and relationship context provide the main score. An established
+practice contributes only a one-point tie-breaker. Authored titles and
+aspirations contribute no legality or score.
+
+Each inferred action stores a versioned trace with the full candidate set,
+bindings, target, factors, eligibility or rejection, chosen offer, seed, state
+revision, outcome, and committed event sequence IDs. Proposed actions outside
+the certified set fail closed. If no candidate survives grounding and cooldown
+checks, the controller produces no world mutation.
+
+Every meaningful outcome uses the same journal and projection path regardless
+of controller. It can reveal a route through canonical Search/Scout, create
+typed craft output, contribute to a project, and complete a physical delivery.
+Repeat-pair, repeat-item, repeated-craft, and immediate-return checks prevent
+gift, trade, pickup/drop, craft, and movement loops.
+
+Compatibility is deliberately one-way during the migration. Persisted
+`control_mode: "human"` values load as `direct_input`, while new snapshots and
+public state serialize the canonical `direct_input` value. Legacy `kind`
+remains readable and may identify authored provenance, but clients and rules
+must not use it to decide what an avatar may do or how prominently it appears.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.91",
+      "version": "0.0.92",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -882,8 +882,7 @@ static cw_status apply_theft(cw_world *world, const cw_action *action, uint64_t 
   if (status != CW_OK) return status;
   cw_actor *target = find_actor(world, action->target_actor_id);
   cw_item *item = find_item(world, action->item_id);
-  if (!target || !actor_is_active(target) || target->kind != CW_ACTOR_NPC
-      || target->id == actor->id) {
+  if (!target || !actor_is_active(target) || target->id == actor->id) {
     return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
   }
   if (target->location_id != actor->location_id) {
@@ -957,7 +956,7 @@ static void maybe_evolve_after_placement(cw_world *world, cw_id source_actor_id,
   for (size_t i = 0; i < world->evolution_track_count; ++i) {
     const cw_evolution_track *track = &world->evolution_tracks[i];
     cw_actor *target = find_actor(world, track->actor_id);
-    if (!target || target->kind != CW_ACTOR_NPC || target->stats.level >= 2) continue;
+    if (!target || !actor_is_active(target) || target->stats.level >= 2) continue;
     if (!evolution_track_satisfied(world, track)) continue;
 
     target->stats.level = 2;
@@ -980,14 +979,10 @@ static cw_status apply_give_item(cw_world *world, const cw_action *action, cw_ev
   cw_actor *actor = 0;
   cw_status status = require_active_actor(world, action, out_events, &actor);
   if (status != CW_OK) return status;
-  if (actor->kind != CW_ACTOR_HUMAN && actor->kind != CW_ACTOR_NPC) {
-    return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
-  }
-
   cw_actor *target = find_actor(world, action->target_actor_id);
   if (!target) return reject(world, out_events, action, CW_REASON_TARGET_NOT_FOUND);
   if (!actor_is_active(target)) return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
-  if (target->kind != CW_ACTOR_NPC) return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
+  if (target->id == actor->id) return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
   if (target->location_id != actor->location_id) return reject(world, out_events, action, CW_REASON_NOT_SAME_LOCATION);
 
   cw_item *item = find_item(world, action->item_id);
@@ -1038,9 +1033,6 @@ static cw_status apply_trade_item(cw_world *world, const cw_action *action, cw_e
   cw_actor *actor = 0;
   cw_status status = require_active_actor(world, action, out_events, &actor);
   if (status != CW_OK) return status;
-  if (actor->kind != CW_ACTOR_HUMAN && actor->kind != CW_ACTOR_NPC) {
-    return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
-  }
   if (!action->item_id || !action->target_item_id || action->item_id == action->target_item_id) {
     return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
   }
@@ -1048,7 +1040,6 @@ static cw_status apply_trade_item(cw_world *world, const cw_action *action, cw_e
   cw_actor *target = find_actor(world, action->target_actor_id);
   if (!target) return reject(world, out_events, action, CW_REASON_TARGET_NOT_FOUND);
   if (!actor_is_active(target)) return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
-  if (target->kind != CW_ACTOR_NPC) return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
   if (target->id == actor->id) return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
   if (target->location_id != actor->location_id) return reject(world, out_events, action, CW_REASON_NOT_SAME_LOCATION);
 
@@ -1503,12 +1494,12 @@ static cw_status apply_combat_start(cw_world *world, const cw_action *action, ui
   cw_actor *actor = 0;
   cw_status status = require_active_actor(world, action, out_events, &actor);
   if (status != CW_OK) return status;
-  if (actor->kind != CW_ACTOR_HUMAN || action->actor_id == action->target_actor_id) {
+  if (action->actor_id == action->target_actor_id) {
     return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
   }
   cw_actor *target = find_actor(world, action->target_actor_id);
   if (!target) return reject(world, out_events, action, CW_REASON_TARGET_NOT_FOUND);
-  if (!actor_is_active(target) || target->kind != CW_ACTOR_NPC) {
+  if (!actor_is_active(target)) {
     return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
   }
   if (target->location_id != actor->location_id) {
@@ -1612,7 +1603,9 @@ static cw_status apply_combat_join(cw_world *world, const cw_action *action, uin
   cw_combat_participant *participant = &encounter->participants[encounter->participant_count++];
   memset(participant, 0, sizeof(*participant));
   participant->actor_id = actor->id;
-  participant->side = actor->kind == CW_ACTOR_HUMAN ? 1 : 2;
+  /* Controller provenance is not a combat faction. Callers may choose side 2
+     explicitly; otherwise a joining actor joins the initiating side. */
+  participant->side = action->modifier == 2 ? 2 : 1;
   participant->initiative = (int16_t)(raw + ability_modifier(actor->stats.dexterity));
   sort_combat_participants(encounter);
   for (size_t i = 0; i < encounter->participant_count; ++i) {
@@ -1981,14 +1974,14 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
   }
 
   int actor_has_held_item = 0;
-  int room_npc_has_held_item = 0;
-  int room_has_active_npc = 0;
+  int room_actor_has_held_item = 0;
+  int room_has_active_actor = 0;
   int room_has_loose_item = 0;
   int hidden_search_item_available = 0;
   for (size_t i = 0; i < world->actor_count; ++i) {
     const cw_actor *other = &world->actors[i];
-    if (other->id != actor->id && other->kind == CW_ACTOR_NPC && actor_is_active(other) && other->location_id == actor->location_id) {
-      room_has_active_npc = 1;
+    if (other->id != actor->id && actor_is_active(other) && other->location_id == actor->location_id) {
+      room_has_active_actor = 1;
       break;
     }
   }
@@ -2013,12 +2006,12 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
     }
     if (item->holder_actor_id && item->holder_actor_id != actor->id) {
       const cw_actor *holder = find_actor_const(world, item->holder_actor_id);
-      if (holder && holder->kind == CW_ACTOR_NPC && actor_is_active(holder) && holder->location_id == actor->location_id) {
-        room_npc_has_held_item = 1;
+      if (holder && actor_is_active(holder) && holder->location_id == actor->location_id) {
+        room_actor_has_held_item = 1;
       }
     }
   }
-  if (actor_has_held_item && room_has_active_npc) {
+  if (actor_has_held_item && room_has_active_actor) {
     out_offers->option_flags |= CW_OFFER_GIVE_ITEM;
   }
   if (actor_has_held_item && !room_has_loose_item) {
@@ -2030,9 +2023,7 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
   if (actor_has_held_item && room_has_loose_item) {
     out_offers->option_flags |= CW_OFFER_CRAFT;
   }
-  if ((actor->kind == CW_ACTOR_HUMAN || actor->kind == CW_ACTOR_NPC)
-      && actor_has_held_item
-      && room_npc_has_held_item) {
+  if (actor_has_held_item && room_actor_has_held_item) {
     out_offers->option_flags |= CW_OFFER_TRADE_ITEM;
   }
 

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -859,6 +859,95 @@ static void test_npc_give_items(void) {
   assert(world.actors[1].stats.level == 2);
 }
 
+static void test_actor_affordances_do_not_depend_on_controller_provenance(void) {
+  cw_world world;
+  cw_event_buffer events;
+  cw_world_init(&world);
+  assert(cw_seed_cosy_cottage(&world, &events) == CW_OK);
+
+  cw_action create = {0};
+  create.kind = CW_ACTION_CREATE_ACTOR;
+  create.location_id = 1;
+  create.actor_id = 5001;
+  assert(cw_world_apply(&world, &create, 801, &events) == CW_OK);
+  create.actor_id = 5002;
+  assert(cw_world_apply(&world, &create, 802, &events) == CW_OK);
+
+  cw_item *tonic = test_find_item(&world, 2001);
+  cw_item *button = test_find_item(&world, 2005);
+  assert(tonic);
+  assert(button);
+  tonic->holder_actor_id = 5001;
+  tonic->location_id = 0;
+  button->holder_actor_id = 5002;
+  button->location_id = 0;
+
+  cw_action_offers offers = {0};
+  assert(cw_get_action_offers(&world, 5001, &offers) == CW_OK);
+  assert(offers.option_flags & CW_OFFER_GIVE_ITEM);
+  assert(offers.option_flags & CW_OFFER_TRADE_ITEM);
+
+  cw_action trade = {0};
+  trade.kind = CW_ACTION_TRADE_ITEM;
+  trade.actor_id = 5001;
+  trade.target_actor_id = 5002;
+  trade.item_id = tonic->id;
+  trade.target_item_id = button->id;
+  assert(cw_world_apply(&world, &trade, 803, &events) == CW_OK);
+  assert(events.events[0].type == CW_EVENT_ITEM_TRADED);
+  assert(tonic->holder_actor_id == 5002);
+  assert(button->holder_actor_id == 5001);
+
+  const cw_evolution_requirement human_requirement = {
+    2005, CW_PLACEMENT_ACTOR_HAND, {0}, 5002
+  };
+  assert(cw_world_set_evolution_track(&world, 5002, &human_requirement, 1) == CW_OK);
+  cw_action give = {0};
+  give.kind = CW_ACTION_GIVE_ITEM;
+  give.actor_id = 5001;
+  give.target_actor_id = 5002;
+  give.item_id = button->id;
+  assert(cw_world_apply(&world, &give, 804, &events) == CW_OK);
+  assert(events.count == 2);
+  assert(events.events[0].type == CW_EVENT_ITEM_GIVEN);
+  assert(events.events[1].type == CW_EVENT_AVATAR_EVOLVED);
+  assert(events.events[1].target_actor_id == 5002);
+
+  cw_actor *thief = 0;
+  for (size_t i = 0; i < world.actor_count; ++i) {
+    if (world.actors[i].id == 5001) thief = &world.actors[i];
+  }
+  assert(thief);
+  thief->stats.dexterity = 20;
+  cw_action theft = {0};
+  theft.kind = CW_ACTION_THEFT;
+  theft.actor_id = 5001;
+  theft.target_actor_id = 5002;
+  theft.item_id = button->id;
+  theft.dc = 1;
+  assert(cw_world_apply(&world, &theft, 805, &events) == CW_OK);
+  assert(events.count == 2);
+  assert(events.events[0].type == CW_EVENT_ITEM_THEFT_ATTEMPT);
+  assert(events.events[1].type == CW_EVENT_ITEM_STOLEN);
+  assert(button->holder_actor_id == 5001);
+
+  cw_actor *combat_target = 0;
+  for (size_t i = 0; i < world.actor_count; ++i) {
+    if (world.actors[i].id == 5002) combat_target = &world.actors[i];
+  }
+  assert(combat_target);
+  thief->location_id = 3;
+  combat_target->location_id = 3;
+  cw_action combat = {0};
+  combat.kind = CW_ACTION_COMBAT_START;
+  combat.actor_id = 5001;
+  combat.target_actor_id = 5002;
+  combat.content_id = 9801;
+  assert(cw_world_apply(&world, &combat, 806, &events) == CW_OK);
+  assert(events.events[0].type == CW_EVENT_COMBAT_ENCOUNTER_STARTED);
+  assert(world.combat_encounters[0].participant_count == 2);
+}
+
 static void test_give_can_exchange_an_item_to_make_weight_capacity(void) {
   cw_world world;
   cw_event_buffer events;
@@ -1175,6 +1264,7 @@ int main(void) {
   test_maximum_evolution_burst_fits_event_buffer();
   test_npc_trade_items();
   test_npc_give_items();
+  test_actor_affordances_do_not_depend_on_controller_provenance();
   test_give_can_exchange_an_item_to_make_weight_capacity();
   test_npc_pickup_can_evolve_self();
   test_inventory_uses_weight_and_container_capacity();

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.91"
+version = "0.0.92"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.91"
+version = "0.0.92"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -131,8 +131,7 @@ impl RuntimeWorld {
                     })
                     .find(|target_id| {
                         self.actor_by_id(*target_id).is_some_and(|target| {
-                            target.kind == CW_ACTOR_NPC
-                                && target.status == CW_ACTOR_ACTIVE
+                            Self::actor_is_active_avatar(target)
                                 && target.location_id == actor.location_id
                         })
                     })
@@ -204,6 +203,21 @@ impl RuntimeWorld {
             .map(|target| target.id)
     }
 
+    pub(super) fn combat_actors_share_side(&self, left_actor_id: u64, right_actor_id: u64) -> bool {
+        let Some(encounter) = self.active_combat_encounter_for_actor(left_actor_id) else {
+            return false;
+        };
+        let participant_side = |actor_id| {
+            encounter.participants[..encounter.participant_count]
+                .iter()
+                .find(|participant| participant.actor_id == actor_id)
+                .map(|participant| participant.side)
+        };
+        participant_side(left_actor_id)
+            .zip(participant_side(right_actor_id))
+            .is_some_and(|(left, right)| left == right)
+    }
+
     pub(super) fn combat_job_id_for_encounter(&self, encounter_id: u64) -> Option<String> {
         self.jobs
             .keys()
@@ -241,8 +255,7 @@ impl RuntimeWorld {
                     .unwrap_or(true);
                 actor_can_act
                     && self.actor_by_id(target_id).is_some_and(|target| {
-                        target.kind == CW_ACTOR_NPC
-                            && target.status == CW_ACTOR_ACTIVE
+                        Self::actor_is_active_avatar(target)
                             && target.location_id == actor.location_id
                             && self.actor_visible_in_projection(target, Some(actor_id), None)
                     })
@@ -265,7 +278,7 @@ impl RuntimeWorld {
     }
 }
 
-fn drive_combat_npc_turns(
+fn drive_combat_inference_turns(
     state: &AppState,
     runtime: &mut RuntimeWorld,
     encounter_id: u64,
@@ -278,7 +291,7 @@ fn drive_combat_npc_turns(
         let Some(actor) = runtime.actor_by_id(actor_id) else {
             return Ok(CW_OK);
         };
-        if actor.kind != CW_ACTOR_NPC {
+        if !runtime.actor_uses_inference(actor.id) {
             return Ok(CW_OK);
         }
         let Some(target_actor_id) = runtime.combat_target_for_actor(encounter_id, actor_id) else {
@@ -295,8 +308,8 @@ fn drive_combat_npc_turns(
             runtime.next_seed_value(),
         )
         .into_system();
-        let (status, npc_events) = commit_journal_record(state, runtime, record)?;
-        events.extend(npc_events);
+        let (status, inference_events) = commit_journal_record(state, runtime, record)?;
+        events.extend(inference_events);
         if status != CW_OK {
             return Ok(status);
         }
@@ -317,7 +330,7 @@ pub(super) async fn apply_combat_choice(
     if !client_actor_authorized_for_state(&runtime, &state, actor_id, actor_session) {
         return client_actor_rejected_response();
     }
-    let released_events = release_inactive_human_inventory_locked(&state, &mut runtime);
+    let released_events = release_inactive_direct_inventory_locked(&state, &mut runtime);
     let Some(actor) = runtime.actor_by_id(actor_id) else {
         drop(runtime);
         broadcast_events(&state, &released_events);
@@ -327,7 +340,7 @@ pub(super) async fn apply_combat_choice(
             events: Vec::new(),
         });
     };
-    if actor.kind != CW_ACTOR_HUMAN || actor.status != CW_ACTOR_ACTIVE {
+    if !RuntimeWorld::actor_is_active_avatar(actor) {
         drop(runtime);
         broadcast_events(&state, &released_events);
         return Json(ActionResponse {
@@ -421,17 +434,18 @@ pub(super) async fn apply_combat_choice(
         }
     }
 
-    let npc_status = match drive_combat_npc_turns(&state, &mut runtime, encounter_id, &mut events) {
-        Ok(status) => status,
-        Err(_) => 500,
-    };
-    if npc_status != CW_OK {
+    let inference_status =
+        match drive_combat_inference_turns(&state, &mut runtime, encounter_id, &mut events) {
+            Ok(status) => status,
+            Err(_) => 500,
+        };
+    if inference_status != CW_OK {
         drop(runtime);
         broadcast_events(&state, &released_events);
         broadcast_events(&state, &events);
         return Json(ActionResponse {
             ok: false,
-            status: npc_status,
+            status: inference_status,
             events,
         });
     }
@@ -504,8 +518,9 @@ pub(super) async fn apply_combat_choice(
     };
     events.extend(player_events);
     if status == CW_OK {
-        status = match drive_combat_npc_turns(&state, &mut runtime, encounter_id, &mut events) {
-            Ok(npc_status) => npc_status,
+        status = match drive_combat_inference_turns(&state, &mut runtime, encounter_id, &mut events)
+        {
+            Ok(inference_status) => inference_status,
             Err(_) => 500,
         };
     }

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -417,13 +417,15 @@
       align-items: center;
       gap: 7px;
       min-width: 0;
-      pointer-events: none;
+      overflow-x: auto;
+      overscroll-behavior-inline: contain;
+      scrollbar-width: thin;
+      pointer-events: auto;
     }
     .room-avatar-rail:empty {
       display: none;
     }
-    .room-avatar-pfp,
-    .room-avatar-more {
+    .room-avatar-pfp {
       width: 42px;
       height: 42px;
       flex: 0 0 42px;
@@ -444,14 +446,6 @@
     }
     .room-avatar-pfp.evolved {
       border-color: rgba(239, 201, 107, 0.95);
-    }
-    .room-avatar-more {
-      display: grid;
-      place-items: center;
-      color: var(--amber);
-      font-size: 12px;
-      font-weight: 900;
-      pointer-events: none;
     }
     .room-tags {
       display: flex;
@@ -738,7 +732,7 @@
       align-items: start;
       background: linear-gradient(90deg, rgba(139, 183, 255, 0.05), transparent 58%);
     }
-    .line.chat.npc {
+    .line.chat.avatar {
       border-left-color: rgba(239, 201, 107, 0.4);
       background: linear-gradient(90deg, rgba(239, 201, 107, 0.05), transparent 58%);
     }
@@ -796,7 +790,7 @@
       box-shadow: 0 0 0 1px rgba(5, 8, 6, 0.86), 0 4px 14px rgba(0,0,0,0.32);
       overflow: hidden;
     }
-    .line.npc .chat-pfp {
+    .line.avatar .chat-pfp {
       border-color: rgba(239, 201, 107, 0.64);
     }
     .line.world .chat-pfp {
@@ -854,7 +848,7 @@
     .speaker::before { content: "["; color: var(--line-strong); }
     .speaker::after { content: "]"; color: var(--line-strong); }
     .line.you .speaker { color: var(--blue); }
-    .line.npc .speaker { color: var(--amber); }
+    .line.avatar .speaker { color: var(--amber); }
     .line.world .speaker { color: var(--green); }
     .text {
       display: block;
@@ -2361,8 +2355,7 @@
         bottom: 8px;
         gap: 5px;
       }
-      .room-avatar-pfp,
-      .room-avatar-more {
+      .room-avatar-pfp {
         width: 34px;
         height: 34px;
         flex-basis: 34px;
@@ -4138,7 +4131,7 @@
         if (!options.has("create_bond") || Number(ledger.advancement_points || 0) <= 0) return null;
         const chatOffer = offerFor("create_bond");
         const offeredTargetId = Number(chatOffer?.target?.id || 0);
-        const chatCandidates = residentTargets
+        const chatCandidates = actorTargets
           .filter((actor) => !activeBondTargetIds.has(actor.id))
           .sort((left, right) => (
             Number(right.id === offeredTargetId) - Number(left.id === offeredTargetId)
@@ -4316,7 +4309,6 @@
         .map((participant) => Number(participant.actor_id)));
       const attackTargetIds = new Set(options.has("attack") ? (view.actors || [])
         .filter((actor) => actor.id !== actorId
-          && actor.kind === "npc"
           && actor.status === "active"
           && (offeredAttackTargetId > 0
             ? actor.id === offeredAttackTargetId
@@ -4324,9 +4316,11 @@
         .map((actor) => actor.id) : []);
       const usableTargets = (view.actors || []).filter((actor) => (
         actorNeedsHealing(actor)
-        && !(actor.kind === "npc" && attackTargetIds.has(actor.id))
+        && !attackTargetIds.has(actor.id)
       ));
-      const residentTargets = (view.actors || []).filter((actor) => actor.id !== actorId && actor.kind === "npc" && actor.status === "active");
+      const actorTargets = (view.actors || []).filter((actor) => (
+        actor.id !== actorId && actor.status === "active"
+      ));
       const progressAmountFromOffer = (offer, fallback) => {
         const structured = Number(offer?.progress || 0);
         if (Number.isFinite(structured) && structured > 0) return structured;
@@ -4381,12 +4375,12 @@
           const targetName = actorLabel(target).toLowerCase();
           const mentionedItem = heldItems.find((held) => giveOfferText.includes(String(held.name || "").toLowerCase()));
           if (mentionedItem && (!giveOfferText || giveOfferText.includes(targetName))) return mentionedItem;
-          if (!offeredTargetId && residentTargets.length === 1 && heldItems.length === 1) return heldItems[0];
+          if (!offeredTargetId && actorTargets.length === 1 && heldItems.length === 1) return heldItems[0];
           if (offeredTargetId === Number(target.id || 0) && heldItems.length === 1) return heldItems[0];
           return null;
         };
-        for (const target of residentTargets) {
-          const request = target.resident_economy?.request || null;
+        for (const target of actorTargets) {
+          const request = target.economy?.request || null;
           const requestedItemId = Number(request?.item_id || 0);
           const item = requestedItemId
             ? heldItems.find((held) => Number(held.id || 0) === requestedItemId)
@@ -4438,7 +4432,7 @@
             requestedGift: giftCandidates.some((candidate) => candidate.requested),
             effect: oneChoice
               ? (firstGift.reason || `${actorLabel(firstGift.target)} keeps ${firstGift.item.name} and may use, trade, or treasure it`)
-              : "the chosen resident keeps the chosen item",
+              : "the chosen avatar keeps the chosen item",
             ...(oneChoice ? {
               modalSummary: `Pass ${firstGift.item.name} to ${actorLabel(firstGift.target)}.`,
             } : {
@@ -4471,9 +4465,9 @@
         const defaultTradeItemId = Number(tradeOfferDefault?.target?.id || 0);
         const itemById = (itemId) => (view.items || []).find((item) => Number(item.id || 0) === Number(itemId || 0));
         const tradeCandidates = [];
-        for (const target of residentTargets) {
-          const request = target.resident_economy?.request || null;
-          const tradeOffer = target.resident_economy?.trade_offer || null;
+        for (const target of actorTargets) {
+          const request = target.economy?.request || null;
+          const tradeOffer = target.economy?.trade_offer || null;
           if (!tradeOffer) continue;
           const offeredItem = itemById(tradeOffer.offered_item_id);
           const targetItem = itemById(tradeOffer.requested_item_id);
@@ -4827,7 +4821,7 @@
         const useCandidates = [];
         for (const item of heldUsableItems) {
           usableTargets.forEach((target) => {
-            const request = target.resident_economy?.request || null;
+            const request = target.economy?.request || null;
             const requested = Number(request?.item_id || 0) === Number(item.id || 0);
             useCandidates.push({
               key: `${item.id}:${target.id}`,
@@ -5051,13 +5045,13 @@
           && helpOffer.project.progress_clock_id === contributionProject?.progress_clock_id
           && String(helpOffer?.target?.label || "").trim()) {
         const helpVerb = offerVerb(helpOffer, "Help");
-        const residentName = String(helpOffer.target.label).trim();
+        const avatarName = String(helpOffer.target.label).trim();
         const relationshipEffect = /deepens Bond|brings you closer/i.test(String(helpOffer?.effect || ""))
           ? "first contribution strengthens the relationship"
-          : "contribute alongside a resident";
+          : "contribute alongside another avatar";
         contributionStrategies.push({
           key: "help",
-          label: `${helpVerb} ${residentName} with ${projectLabel}`,
+          label: `${helpVerb} ${avatarName} with ${projectLabel}`,
           detail: [
             `+${helpProgressPreview} progress`,
             relationshipEffect,
@@ -5166,7 +5160,7 @@
         const targetId = Number(influenceOffer?.target?.id || 0);
         if (targetId) built.push({
           label: influenceOffer?.label || "influence",
-          detail: influenceOffer?.target?.label || "a nearby resident",
+          detail: influenceOffer?.target?.label || "a nearby avatar",
           command: influenceOffer?.command || "ask for a local lead",
           focusKey: `influence:${targetId}`,
           card: cardForActor(targetId),
@@ -5210,7 +5204,7 @@
           .filter((bond) => Number(bond.strength || 0) >= 2 && String(bond.status || "active") === "active")
           .map((bond) => ({
             bond,
-            target: residentTargets.find((actor) => actor.id === Number(bond.target_actor_id || 0)),
+            target: actorTargets.find((actor) => actor.id === Number(bond.target_actor_id || 0)),
           }))
           .filter((candidate) => candidate.target)
           .sort((left, right) => (
@@ -6062,25 +6056,25 @@
       return `${event.type}:${location}:${target}`;
     }
 
-    function residentMessageCollapseKey(event) {
-      if (!messageActorIsResident(event)) return "";
+    function inferredMessageCollapseKey(event) {
+      if (!messageActorUsesInference(event)) return "";
       const numericActorId = Number(event.actor_id || 0);
       const content = cleanStatusText(event.content).toLowerCase();
       if (!content) return "";
       return `${numericActorId}:${Number(event.location_id || 0)}:${content}`;
     }
 
-    function messageActorIsResident(event) {
+    function messageActorUsesInference(event) {
       if (event?.type !== "message.created") return false;
       const numericActorId = Number(event.actor_id || 0);
       const actor = actorForId(numericActorId);
-      return actor?.kind === "npc" || (numericActorId > 0 && numericActorId < 5000);
+      return event.source_world_tick != null || actor?.control_mode !== "direct_input";
     }
 
     function pacedChatTranscriptEvents(events) {
-      // Exact duplicate resident lines are already collapsed when events enter
+      // Exact duplicate avatar lines are already collapsed when events enter
       // the transcript. Keep distinct replies here so consecutive card plays do
-      // not erase one another just because the same resident answered them.
+      // not erase one another just because the same avatar answered them.
       return [...(events || [])].slice(-24);
     }
 
@@ -6148,15 +6142,15 @@
     }
 
     function appendLogEvent(event) {
-      const messageKey = residentMessageCollapseKey(event);
+      const messageKey = inferredMessageCollapseKey(event);
       if (messageKey) {
-        let residentMessagesSeen = 0;
+        let inferredMessagesSeen = 0;
         for (let index = logEvents.length - 1; index >= 0; index -= 1) {
           const prior = logEvents[index];
           if (prior?.type !== "message.created") continue;
-          if (!residentMessageCollapseKey(prior)) break;
-          residentMessagesSeen += 1;
-          if (residentMessageCollapseKey(prior) === messageKey) {
+          if (!inferredMessageCollapseKey(prior)) break;
+          inferredMessagesSeen += 1;
+          if (inferredMessageCollapseKey(prior) === messageKey) {
             const collapsed = {
               ...event,
               first_seq: prior.first_seq ?? prior.seq,
@@ -6166,7 +6160,7 @@
             logEvents.push(collapsed);
             return;
           }
-          if (residentMessagesSeen >= 4) break;
+          if (inferredMessagesSeen >= 4) break;
         }
       }
       const key = logEventCollapseKey(event);
@@ -6249,21 +6243,20 @@
           selectedTargetId = 0;
         }
       }
-      const residents = (state?.actors || []).filter((actor) => (
-        actor.kind === "npc"
-        && actor.status === "active"
+      const avatars = (state?.actors || []).filter((actor) => (
+        actor.status === "active"
         && Number(actor.location_id || state?.location?.id || 0) === Number(state?.location?.id || 0)
       ));
-      const selected = residents.find((actor) => Number(actor.id) === selectedTargetId);
+      const selected = avatars.find((actor) => Number(actor.id) === selectedTargetId);
       if (selected) return selected;
-      if (!residents.length) return actorForId(actorId);
-      const latestResidentId = [...logEvents].reverse().find((event) => (
+      if (!avatars.length) return actorForId(actorId);
+      const latestAvatarId = [...logEvents].reverse().find((event) => (
         event?.type === "message.created"
-        && residents.some((actor) => Number(actor.id) === Number(event.actor_id))
+        && avatars.some((actor) => Number(actor.id) === Number(event.actor_id))
       ))?.actor_id;
-      if (!latestResidentId) return residents[0];
-      const latestIndex = residents.findIndex((actor) => Number(actor.id) === Number(latestResidentId));
-      return residents[(latestIndex + 1) % residents.length];
+      if (!latestAvatarId) return avatars[0];
+      const latestIndex = avatars.findIndex((actor) => Number(actor.id) === Number(latestAvatarId));
+      return avatars[(latestIndex + 1) % avatars.length];
     }
 
     function beginPendingChat(action) {
@@ -6738,8 +6731,7 @@
         if (b.id === actorId) return 1;
         return String(a.name || "").localeCompare(String(b.name || ""));
       });
-      const visible = actors.slice(0, 7);
-      const portraits = visible.map((actor) => {
+      return actors.map((actor) => {
         const card = cardForActor(actor.id);
         const fallback = card || {
           display_name: actor.name || "Avatar",
@@ -6751,12 +6743,7 @@
         const evolved = Number(actor.stats?.level || 1) > 1;
         const label = you ? `${actorLabel(actor)} (you)` : actorLabel(actor);
         return `<button class="room-avatar-pfp${you ? " you" : ""}${evolved ? " evolved" : ""}" type="button"${cardDataAttr(card)} title="${escapeAttr(label)}" aria-label="Open ${escapeAttr(label)} keepsake" data-player-concept="keepsake" data-analytics-event="keepsake.open"${backgroundImageStyle(image)}></button>`;
-      });
-      const remaining = actors.length - visible.length;
-      if (remaining > 0) {
-        portraits.push(`<span class="room-avatar-more" title="${escapeAttr(`${remaining} more`)}">+${remaining}</span>`);
-      }
-      return portraits.join("");
+      }).join("");
     }
 
     function renderTimelines() {
@@ -6841,7 +6828,7 @@
         const gift = String(give.detail || "").match(/^(.+?)\s+to\s+(.+)$/i);
         return makeThread(
           give,
-          gift ? `${gift[2]} is waiting for ${gift[1]}` : "A nearby resident is hoping for one of your keepsakes",
+          gift ? `${gift[2]} is waiting for ${gift[1]}` : "A nearby avatar is hoping for one of your keepsakes",
           "gift",
         );
       }
@@ -7360,13 +7347,13 @@
       const pendingArrival = pendingAvatarArrivalHtml();
       const defeatScene = defeatTransitionHtml();
       const hasChat = visibleEvents.length > 0 || Boolean(pendingConversation) || Boolean(pendingChatReplies);
-      const residentOnly = visibleEvents.length > 0 && visibleEvents.every(messageActorIsResident);
+      const inferredOnly = visibleEvents.length > 0 && visibleEvents.every(messageActorUsesInference);
       log.classList.toggle("library-mode", Boolean(libraryPanel));
       log.classList.toggle("account-mode", !libraryPanel && Boolean(accountPanel));
       log.classList.toggle("chat-mode", !libraryPanel && !accountPanel && hasChat);
       log.classList.toggle("room-mode", !libraryPanel && !accountPanel && !hasChat && !pendingArrival && !defeatScene);
       log.classList.toggle("arrival-mode", !libraryPanel && !accountPanel && Boolean(pendingArrival || defeatScene));
-      log.classList.toggle("quiet-mode", !libraryPanel && !accountPanel && residentOnly);
+      log.classList.toggle("quiet-mode", !libraryPanel && !accountPanel && inferredOnly);
       const panelMode = libraryPanel ? "library" : (accountPanel ? "account" : "");
       document.querySelector(".terminal")?.classList.toggle("panel-open", Boolean(panelMode));
       document.querySelector(".prompt").hidden = Boolean(panelMode);
@@ -7621,7 +7608,7 @@
     function libraryPackCountSummary(counts) {
       const entries = [
         ["locations", "places"],
-        ["actors", "residents"],
+        ["actors", "avatars"],
         ["items", "items"],
         ["cards", "keepsakes"],
         ["external_cards", "catalog keepsakes"],
@@ -7646,7 +7633,7 @@
       const target = actorForId(targetId);
       const speaker = target ? actorLabel(target) : (pendingAction.targetName || "A neighbour");
       const aria = `${speaker} is finding the thread. Your conversation is unfolding.`;
-      return `<div class="line chat npc pending" role="status" aria-label="${escapeAttr(aria)}">${chatPfpHtml({ actor_id: targetId }, speaker)}<span class="speaker">${escapeHtml(speaker)}</span><span class="text" aria-hidden="true"><span class="chat-thinking-dots"><i></i><i></i><i></i></span>finding the thread…</span></div>`;
+      return `<div class="line chat avatar pending" role="status" aria-label="${escapeAttr(aria)}">${chatPfpHtml({ actor_id: targetId }, speaker)}<span class="speaker">${escapeHtml(speaker)}</span><span class="text" aria-hidden="true"><span class="chat-thinking-dots"><i></i><i></i><i></i></span>finding the thread…</span></div>`;
     }
 
     function pendingChatsHtml() {
@@ -7654,7 +7641,7 @@
       return pendingChats.map((chat) => {
         const speaker = chat.targetName || "Someone nearby";
         const aria = `${speaker} is finding the thread. Your next actions are ready while the conversation unfolds.`;
-        return `<div class="line chat npc pending" role="status" aria-label="${escapeAttr(aria)}">${chatPfpHtml({ actor_id: chat.targetActorId }, speaker)}<span class="speaker">${escapeHtml(speaker)}</span><span class="text" aria-hidden="true"><span class="chat-thinking-dots"><i></i><i></i><i></i></span>finding the thread…</span></div>`;
+        return `<div class="line chat avatar pending" role="status" aria-label="${escapeAttr(aria)}">${chatPfpHtml({ actor_id: chat.targetActorId }, speaker)}<span class="speaker">${escapeHtml(speaker)}</span><span class="text" aria-hidden="true"><span class="chat-thinking-dots"><i></i><i></i><i></i></span>finding the thread…</span></div>`;
       }).join("");
     }
 
@@ -8189,7 +8176,7 @@
     function messageHtml(event) {
       const speaker = event.actor_name || "CosyWorld";
       const body = eventText(event);
-      const kind = event.actor_id === actorId ? "you" : event.actor_id ? "npc" : "world";
+      const kind = event.actor_id === actorId ? "you" : event.actor_id ? "avatar" : "world";
       const repeat = Math.max(1, Number(event.repeat_count || 1));
       const baseAriaLabel = eventAriaLabel(event, speaker, body);
       const label = repeat > 1
@@ -8568,7 +8555,7 @@
 
     function actorNameForId(id) {
       const actor = actorForId(id);
-      return actor ? actorLabel(actor) : `Resident ${id}`;
+      return actor ? actorLabel(actor) : `Avatar ${id}`;
     }
 
     function accountCard(displayName) {
@@ -8695,8 +8682,8 @@
       return `<div class="economy-row"><span>level ${level} image</span><strong>${escapeHtml(detail)}</strong></div><button class="account-button" type="button" data-fund-community-image="${escapeAttr(subject.kind)}:${subject.id}"${disabled ? " disabled" : ""}>${escapeHtml(buttonLabel)}</button>`;
     }
 
-    function residentEconomyTitle(actor) {
-      const economy = actor?.resident_economy || null;
+    function actorEconomyTitle(actor) {
+      const economy = actor?.economy || null;
       if (!economy) return actorLabel(actor);
       const parts = [];
       const motive = String(economy.motive || "").trim();
@@ -8838,10 +8825,23 @@
       return `<span class="card-economy-main">${escapeHtml(itemName)}</span>${economyTagsHtml(tags)}`;
     }
 
-    function residentEconomyPanelHtml(actor) {
-      const economy = actor?.resident_economy || null;
-      if (!economy) return "";
+    function actorControlModeLabel(actor) {
+      return {
+        direct_input: "player choice",
+        reactive_ai: "reactive inference",
+        local_ai: "local inference",
+        roaming_ai: "roaming inference",
+        delegated_ai: "delegated inference",
+      }[String(actor?.control_mode || "")] || "";
+    }
+
+    function actorEconomyPanelHtml(actor) {
+      if (!actor) return "";
       const rows = [];
+      const controller = actorControlModeLabel(actor);
+      if (controller) rows.push(economyRowHtml("controller", escapeHtml(controller)));
+      const economy = actor?.economy || null;
+      if (!economy) return rows.join("");
       const motive = economyMotiveSummary(actor, economy);
       if (motive && !economyMotiveRepeatsRows(actor, economy, motive)) {
         rows.push(economyRowHtml("today", escapeHtml(motive)));
@@ -8910,7 +8910,7 @@
       $("card-modal-keepsake").innerHTML = promise
         ? `<span>when kept close</span>${escapeHtml(promise)}`
         : "";
-      $("card-modal-economy").innerHTML = `${residentEconomyPanelHtml(actor)}${communityArtPanelHtml(card)}`;
+      $("card-modal-economy").innerHTML = `${actorEconomyPanelHtml(actor)}${communityArtPanelHtml(card)}`;
       openModal("card-modal", $("card-modal").querySelector(".card-close"));
       if (dialog) dialog.scrollTop = 0;
       const copy = dialog?.querySelector(".card-copy");
@@ -9228,7 +9228,7 @@
       }
       if (String(action?.label || "").toLowerCase() === "trade" && action?.choices?.length) {
         return [
-          ["Choose", "the resident and keepsake swap"],
+          ["Choose", "the avatar and keepsake swap"],
           ["Then", "both keepsakes change hands"],
         ];
       }
@@ -9562,7 +9562,7 @@
         .replace(/\sand finishes progress clock\s+.+?\s+by\s+([1-9]\d*)/gi, " and finishes the work")
         .replace(/\sand sets up \+([1-9]\d*) progress/gi, " and makes the next try count")
         .replace(/^marks you\s+/i, "")
-        .replace(/^helps a resident and\s+/i, "")
+        .replace(/^helps (?:a resident|an avatar) and\s+/i, "")
         .trim();
     }
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -811,7 +811,7 @@ enum ProjectionMutation {
     },
     UpdateResidentContinuity {
         resident_id: u64,
-        proposal: ResidentIntentProposal,
+        proposal: AvatarIntentProposal,
         reason: String,
     },
     PlaceResident {
@@ -1139,7 +1139,7 @@ struct ResidentContinuityState {
     #[serde(default)]
     refusals: Vec<ResidentContinuityNote>,
     #[serde(default)]
-    pending_action: Option<ResidentProposedAction>,
+    pending_action: Option<AvatarProposedAction>,
     open_obligations: Vec<String>,
     current_intent: Option<String>,
     last_observed_event_seq: u64,
@@ -1183,7 +1183,7 @@ impl ResidentContinuityState {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct ResidentIntentProposal {
+struct AvatarIntentProposal {
     speech: String,
     #[serde(default)]
     intent: Option<String>,
@@ -1196,18 +1196,29 @@ struct ResidentIntentProposal {
     #[serde(default)]
     refusal: Option<String>,
     #[serde(default)]
-    proposed_action: Option<ResidentProposedAction>,
+    proposed_action: Option<AvatarProposedAction>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 enum ActorControlMode {
     #[default]
-    Human,
+    #[serde(alias = "human")]
+    DirectInput,
     ReactiveAi,
     LocalAi,
     RoamingAi,
     DelegatedAi,
+}
+
+impl ActorControlMode {
+    fn is_direct_input(self) -> bool {
+        self == Self::DirectInput
+    }
+
+    fn uses_inference(self) -> bool {
+        !self.is_direct_input()
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -1226,7 +1237,7 @@ struct ActorAutonomyState {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct ResidentProposedAction {
+struct AvatarProposedAction {
     kind: String,
     #[serde(default)]
     target_actor_id: Option<u64>,
@@ -1958,7 +1969,7 @@ struct MetaWorldCounters {
     next_event_seq: u64,
     actor_count: usize,
     actor_capacity: usize,
-    human_actor_count: usize,
+    direct_input_actor_count: usize,
     item_count: usize,
     item_capacity: usize,
     location_count: usize,
@@ -2335,7 +2346,6 @@ struct ResidentGiftCandidate {
 struct ResidentPlayerGiftCandidate {
     offered_item: CwItem,
     target: CwActor,
-    request: ResidentRequestView,
 }
 
 #[derive(Clone, Debug)]
@@ -4497,7 +4507,7 @@ fn schedule_avatar_identity_refinement(
             let mut runtime = state.inner.lock().await;
             let valid_actor = runtime
                 .actor_by_id(actor_id)
-                .is_some_and(|actor| actor.kind == CW_ACTOR_HUMAN);
+                .is_some_and(RuntimeWorld::actor_is_active_avatar);
             if !valid_actor {
                 return;
             }
@@ -7155,12 +7165,17 @@ impl RuntimeWorld {
     }
 
     fn backfill_generated_avatar_flavor(&mut self) {
-        let human_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
+        let generated_actor_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
             .iter()
-            .filter(|actor| actor.kind == CW_ACTOR_HUMAN)
+            .filter(|actor| {
+                !active_content()
+                    .actors
+                    .iter()
+                    .any(|authored| authored.id == actor.id)
+            })
             .map(|actor| actor.id)
             .collect();
-        for actor_id in human_ids {
+        for actor_id in generated_actor_ids {
             self.orb_balances.entry(actor_id).or_insert(STARTING_ORBS);
             let Some(meta) = self.actors.get_mut(&actor_id) else {
                 continue;
@@ -8675,7 +8690,7 @@ impl RuntimeWorld {
             let Some(resident) = self.actor_by_id(resident_id) else {
                 continue;
             };
-            if resident.kind != CW_ACTOR_NPC || resident.status != CW_ACTOR_ACTIVE {
+            if !Self::actor_is_active_avatar(resident) {
                 continue;
             }
             let current_seq = self
@@ -9048,10 +9063,10 @@ impl RuntimeWorld {
                     location_id,
                     reason: _,
                 } => {
-                    let valid_resident = self.actor_by_id(*actor_id).is_some_and(|actor| {
-                        actor.kind == CW_ACTOR_NPC && actor.status == CW_ACTOR_ACTIVE
-                    });
-                    if valid_resident {
+                    let valid_actor = self
+                        .actor_by_id(*actor_id)
+                        .is_some_and(Self::actor_is_active_avatar);
+                    if valid_actor {
                         if let Some(event) =
                             self.place_actor_location(*actor_id, *location_id, true)
                         {
@@ -9871,7 +9886,7 @@ impl RuntimeWorld {
         let Some(actor) = self.actor_by_id(action.actor_id) else {
             return Vec::new();
         };
-        if actor.kind != CW_ACTOR_HUMAN {
+        if !Self::actor_is_active_avatar(actor) {
             return Vec::new();
         }
         if let (Some(profile_id), Some(species_id), Some(origin_id)) = (
@@ -10005,14 +10020,9 @@ impl RuntimeWorld {
         if !valid_identity {
             return Vec::new();
         }
-        let Some(actor_index) =
-            self.world.actors[..self.world.actor_count]
-                .iter()
-                .position(|actor| {
-                    actor.id == actor_id
-                        && actor.kind == CW_ACTOR_HUMAN
-                        && actor.status == CW_ACTOR_ACTIVE
-                })
+        let Some(actor_index) = self.world.actors[..self.world.actor_count]
+            .iter()
+            .position(|actor| actor.id == actor_id && Self::actor_is_active_avatar(*actor))
         else {
             return Vec::new();
         };
@@ -10157,7 +10167,7 @@ impl RuntimeWorld {
             let Some(actor) = self.actor_by_id(actor_id) else {
                 continue;
             };
-            if actor.kind != CW_ACTOR_HUMAN {
+            if !Self::actor_is_active_avatar(actor) {
                 continue;
             }
             let from_location_id = event.location_id.unwrap_or(0);
@@ -10193,13 +10203,16 @@ impl RuntimeWorld {
         event_reason: &str,
         ledger_reason: &str,
     ) -> Vec<EventView> {
-        let Some(actor_kind) = self.actor_by_id(actor_id).map(|actor| actor.kind) else {
+        let Some(actor) = self.actor_by_id(actor_id) else {
             return Vec::new();
         };
-        let Some(target_kind) = self.actor_by_id(target_actor_id).map(|actor| actor.kind) else {
+        let Some(target) = self.actor_by_id(target_actor_id) else {
             return Vec::new();
         };
-        if actor_kind != CW_ACTOR_HUMAN || target_kind != CW_ACTOR_NPC {
+        if !Self::actor_is_active_avatar(actor)
+            || !Self::actor_is_active_avatar(target)
+            || actor.id == target.id
+        {
             return Vec::new();
         }
         if !self.rpg_claims.insert(claim_key) {
@@ -10309,9 +10322,7 @@ impl RuntimeWorld {
             let witness_actor_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
                 .iter()
                 .filter(|actor| {
-                    actor.kind == CW_ACTOR_HUMAN
-                        && actor.status == CW_ACTOR_ACTIVE
-                        && actor.location_id == location_id
+                    Self::actor_is_active_avatar(**actor) && actor.location_id == location_id
                 })
                 .map(|actor| actor.id)
                 .collect();
@@ -10335,7 +10346,7 @@ impl RuntimeWorld {
             "item.picked_up" => {
                 let resident_id = event.actor_id?;
                 let resident = self.actor_by_id(resident_id)?;
-                if resident.kind != CW_ACTOR_NPC {
+                if !Self::actor_is_active_avatar(resident) {
                     return None;
                 }
                 let item_id = event.item_id?;
@@ -10363,12 +10374,12 @@ impl RuntimeWorld {
             "avatar.evolved" => {
                 let source_actor_id = event.actor_id?;
                 let source = self.actor_by_id(source_actor_id)?;
-                if source.kind != CW_ACTOR_NPC {
+                if !Self::actor_is_active_avatar(source) {
                     return None;
                 }
                 let resident_id = event.target_actor_id?;
                 let resident = self.actor_by_id(resident_id)?;
-                if resident.kind != CW_ACTOR_NPC {
+                if !Self::actor_is_active_avatar(resident) {
                     return None;
                 }
                 let location_id = event.location_id.or(Some(resident.location_id))?;
@@ -10533,7 +10544,7 @@ impl RuntimeWorld {
         let Some(target) = self.actor_by_id(action.target_actor_id) else {
             return Vec::new();
         };
-        if target.kind != CW_ACTOR_NPC {
+        if !Self::actor_is_active_avatar(target) {
             return Vec::new();
         }
         let Some(check) = events.iter().find(|event| {
@@ -11790,10 +11801,10 @@ impl RuntimeWorld {
         let actor = self.actor_by_id(event.actor_id)?;
         let target = self.actor_by_id(event.target_actor_id)?;
         let mut parts = Vec::new();
-        if actor.kind == CW_ACTOR_NPC && event.target_item_id != 0 {
+        if Self::actor_is_active_avatar(actor) && event.target_item_id != 0 {
             parts.push(self.resident_gained_item_reason(actor, event.target_item_id));
         }
-        if target.kind == CW_ACTOR_NPC && event.item_id != 0 {
+        if Self::actor_is_active_avatar(target) && event.item_id != 0 {
             parts.push(self.resident_gained_item_reason(target, event.item_id));
         }
         (!parts.is_empty()).then(|| format!("{}.", parts.join("; ")))
@@ -11802,7 +11813,7 @@ impl RuntimeWorld {
     fn give_event_context(&self, event: &CwEvent) -> Option<String> {
         let actor = self.actor_by_id(event.actor_id)?;
         let target = self.actor_by_id(event.target_actor_id)?;
-        if event.item_id == 0 || target.kind != CW_ACTOR_NPC {
+        if event.item_id == 0 || !Self::actor_is_active_avatar(target) {
             return None;
         }
         let item_name = self
@@ -11831,7 +11842,7 @@ impl RuntimeWorld {
 
     fn pickup_event_context(&self, event: &CwEvent) -> Option<String> {
         let actor = self.actor_by_id(event.actor_id)?;
-        if actor.kind != CW_ACTOR_NPC || event.item_id == 0 {
+        if !Self::actor_is_active_avatar(actor) || event.item_id == 0 {
             return None;
         }
         Some(format!(
@@ -11842,7 +11853,7 @@ impl RuntimeWorld {
 
     fn drop_event_context(&self, event: &CwEvent) -> Option<String> {
         let actor = self.actor_by_id(event.actor_id)?;
-        if actor.kind != CW_ACTOR_NPC || event.item_id == 0 {
+        if !Self::actor_is_active_avatar(actor) || event.item_id == 0 {
             return None;
         }
         let actor_name = self
@@ -11863,7 +11874,7 @@ impl RuntimeWorld {
 
     fn use_event_context(&self, event: &CwEvent) -> Option<String> {
         let actor = self.actor_by_id(event.actor_id)?;
-        if actor.kind != CW_ACTOR_NPC || event.item_id == 0 || event.damage >= 0 {
+        if !Self::actor_is_active_avatar(actor) || event.item_id == 0 || event.damage >= 0 {
             return None;
         }
         let actor_name = self
@@ -11885,7 +11896,7 @@ impl RuntimeWorld {
 
     fn move_event_context(&self, event: &CwEvent) -> Option<String> {
         let actor = self.actor_by_id(event.actor_id)?;
-        if actor.kind != CW_ACTOR_NPC {
+        if !Self::actor_is_active_avatar(actor) {
             return None;
         }
         let from_location_id = event.location_id;
@@ -12557,23 +12568,38 @@ impl RuntimeWorld {
             .find(|actor| actor.id == actor_id)
     }
 
+    fn actor_is_active_avatar(actor: CwActor) -> bool {
+        matches!(actor.kind, CW_ACTOR_HUMAN | CW_ACTOR_NPC) && actor.status == CW_ACTOR_ACTIVE
+    }
+
+    fn actor_control_mode(&self, actor_id: u64) -> ActorControlMode {
+        self.actor_autonomy
+            .get(&actor_id)
+            .map(|autonomy| autonomy.control_mode)
+            .unwrap_or_default()
+    }
+
+    fn actor_uses_inference(&self, actor_id: u64) -> bool {
+        self.actor_control_mode(actor_id).uses_inference()
+    }
+
     fn client_actor_can_submit(&self, actor_id: u64) -> bool {
         self.actor_by_id(actor_id)
-            .map(|actor| actor.kind == CW_ACTOR_HUMAN && actor.status == CW_ACTOR_ACTIVE)
-            .unwrap_or(false)
+            .is_some_and(Self::actor_is_active_avatar)
+            && self.actor_control_mode(actor_id).is_direct_input()
     }
 
     fn actor_visible_in_projection(
         &self,
         actor: CwActor,
         client_actor_id: Option<u64>,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> bool {
-        if actor.kind == CW_ACTOR_HUMAN {
+        if !self.actor_uses_inference(actor.id) {
             if Some(actor.id) == client_actor_id {
                 return true;
             }
-            return active_human_actor_ids
+            return active_direct_actor_ids
                 .map(|ids| ids.contains(&actor.id))
                 .unwrap_or(true);
         }
@@ -13089,9 +13115,7 @@ impl RuntimeWorld {
             .iter()
             .copied()
             .filter(|actor| {
-                actor.location_id == location_id
-                    && actor.status == CW_ACTOR_ACTIVE
-                    && (actor.kind == CW_ACTOR_HUMAN || actor.kind == CW_ACTOR_NPC)
+                actor.location_id == location_id && Self::actor_is_active_avatar(*actor)
             })
             .map(|actor| actor.id)
             .collect::<Vec<_>>();
@@ -13141,9 +13165,7 @@ impl RuntimeWorld {
         let Some(actor) = self.actor_by_id(actor_id) else {
             return;
         };
-        if actor.status != CW_ACTOR_ACTIVE
-            || (actor.kind != CW_ACTOR_HUMAN && actor.kind != CW_ACTOR_NPC)
-        {
+        if !Self::actor_is_active_avatar(actor) {
             return;
         }
         let id = Self::search_memory_id(actor_id, kind, location_id, subject_key);
@@ -13318,7 +13340,7 @@ impl RuntimeWorld {
     }
 
     fn avatar_hidden_until_discovered(&self, actor: CwActor) -> bool {
-        if actor.kind != CW_ACTOR_NPC
+        if !Self::actor_is_active_avatar(actor)
             || !active_content()
                 .actors
                 .iter()
@@ -13340,8 +13362,7 @@ impl RuntimeWorld {
         let mut candidates = self.world.actors[..self.world.actor_count]
             .iter()
             .copied()
-            .filter(|actor| actor.kind == CW_ACTOR_NPC)
-            .filter(|actor| actor.status == CW_ACTOR_ACTIVE)
+            .filter(|actor| Self::actor_is_active_avatar(*actor))
             .filter(|actor| actor.location_id == location_id)
             .filter(|actor| self.avatar_hidden_until_discovered(*actor))
             .filter(|actor| !self.avatar_discovered(actor.id))
@@ -13661,14 +13682,14 @@ impl RuntimeWorld {
     }
 
     fn resident_calling_desired_item_ids(&self, resident: CwActor) -> Vec<u64> {
-        if resident.kind != CW_ACTOR_NPC || resident.stats.level >= 2 {
+        if !Self::actor_is_active_avatar(resident) || resident.stats.level >= 2 {
             return Vec::new();
         }
         self.resident_evolution_item_ids(resident.id)
     }
 
     fn resident_calling_sought_item_ids(&self, resident: CwActor) -> Vec<u64> {
-        if resident.kind != CW_ACTOR_NPC || resident.stats.level >= 2 {
+        if !Self::actor_is_active_avatar(resident) || resident.stats.level >= 2 {
             return Vec::new();
         }
         self.resident_evolution_item_ids_for_target_kind(resident.id, "actor_hand")
@@ -13716,7 +13737,7 @@ impl RuntimeWorld {
     }
 
     fn resident_attachment_item_ids(&self, resident: CwActor) -> Vec<u64> {
-        if resident.kind != CW_ACTOR_NPC {
+        if !Self::actor_is_active_avatar(resident) {
             return Vec::new();
         }
         self.resident_personal_attachments(resident.id)
@@ -13726,7 +13747,7 @@ impl RuntimeWorld {
     }
 
     fn resident_desired_item_ids(&self, resident: CwActor) -> Vec<u64> {
-        if resident.kind != CW_ACTOR_NPC {
+        if !Self::actor_is_active_avatar(resident) {
             return Vec::new();
         }
         let mut item_ids = self.resident_calling_desired_item_ids(resident);
@@ -13746,7 +13767,7 @@ impl RuntimeWorld {
     }
 
     fn resident_healing_target(&self, resident: CwActor) -> Option<CwActor> {
-        if resident.kind != CW_ACTOR_NPC || resident.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(resident) {
             return None;
         }
         self.world.actors[..self.world.actor_count]
@@ -13761,13 +13782,7 @@ impl RuntimeWorld {
                             resident.location_id,
                         ))
             })
-            .min_by_key(|target| {
-                (
-                    target.id != resident.id,
-                    target.kind != CW_ACTOR_NPC,
-                    target.id,
-                )
-            })
+            .min_by_key(|target| (target.id != resident.id, target.id))
     }
 
     fn resident_held_healing_item_for_target(
@@ -13800,7 +13815,7 @@ impl RuntimeWorld {
         resident: CwActor,
         item_id: u64,
     ) -> Option<ResidentFeatureUseCandidate> {
-        if resident.kind != CW_ACTOR_NPC || resident.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(resident) {
             return None;
         }
         self.room_features(resident.location_id)
@@ -13835,7 +13850,7 @@ impl RuntimeWorld {
     }
 
     fn resident_local_feature_item_ids(&self, resident: CwActor) -> Vec<u64> {
-        if resident.kind != CW_ACTOR_NPC || resident.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(resident) {
             return Vec::new();
         }
         let mut item_ids: Vec<u64> = self
@@ -14358,8 +14373,8 @@ impl RuntimeWorld {
             .iter()
             .copied()
             .filter(|actor| {
-                actor.kind == CW_ACTOR_HUMAN
-                    && actor.status == CW_ACTOR_ACTIVE
+                Self::actor_is_active_avatar(*actor)
+                    && actor.id != resident.id
                     && actor.location_id == resident.location_id
             })
             .any(|actor| {
@@ -14374,7 +14389,7 @@ impl RuntimeWorld {
         client_actor_id: Option<u64>,
     ) -> String {
         let Some(economy) = self.resident_economy_view(resident, client_actor_id) else {
-            return "Resident economy: no resident item economy is active.".to_string();
+            return "Actor economy: no item economy is active.".to_string();
         };
 
         let mut parts = Vec::new();
@@ -14471,7 +14486,7 @@ impl RuntimeWorld {
     #[cfg(test)]
     fn resident_reply_text_for_committed_action(&self, action: &CwAction) -> Option<(u64, String)> {
         let target = self.actor_by_id(action.target_actor_id)?;
-        if target.kind != CW_ACTOR_NPC || target.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(target) {
             return None;
         }
         match action.kind {
@@ -14505,7 +14520,7 @@ impl RuntimeWorld {
     fn direct_observation_reply_plan(
         &self,
         observation: &PlayerTickObservation,
-    ) -> Option<ResidentReplyPlan> {
+    ) -> Option<AvatarReplyPlan> {
         let event = observation.source_events.iter().find(|event| {
             event.success
                 && event.actor_id == Some(observation.source_actor_id)
@@ -14572,20 +14587,20 @@ impl RuntimeWorld {
         )
     }
 
-    fn resident_economy_action_reply_plan(&self, action: &CwAction) -> Option<ResidentReplyPlan> {
+    fn resident_economy_action_reply_plan(&self, action: &CwAction) -> Option<AvatarReplyPlan> {
         let actor = self.actor_by_id(action.actor_id)?;
-        if actor.kind != CW_ACTOR_NPC || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) || !self.actor_uses_inference(actor.id) {
             return None;
         }
         let user_text = self.resident_economy_action_reply_seed(actor, action)?;
-        let npc_meta = self.actors.get(&actor.id);
+        let actor_meta = self.actors.get(&actor.id);
         let location_meta = self.location_meta_for(actor.location_id);
-        Some(ResidentReplyPlan {
-            npc_actor_id: actor.id,
-            npc_name: self
+        Some(AvatarReplyPlan {
+            speaker_actor_id: actor.id,
+            speaker_name: self
                 .actor_name(actor.id)
                 .unwrap_or_else(|| format!("Actor {}", actor.id)),
-            speech_mode: npc_meta
+            speech_mode: actor_meta
                 .map(|meta| meta.speech_mode.clone())
                 .unwrap_or_else(|| "prose".to_string()),
             resident_continuity: self.resident_continuity_for(actor),
@@ -14808,7 +14823,7 @@ impl RuntimeWorld {
             self.resident_continuities.remove(&resident_id);
             return;
         };
-        if resident.kind != CW_ACTOR_NPC || resident.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(resident) {
             self.resident_continuities.remove(&resident_id);
             return;
         }
@@ -14819,7 +14834,8 @@ impl RuntimeWorld {
     fn refresh_all_resident_continuities(&mut self) {
         let resident_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
             .iter()
-            .filter(|actor| actor.kind == CW_ACTOR_NPC && actor.status == CW_ACTOR_ACTIVE)
+            .copied()
+            .filter(|actor| Self::actor_is_active_avatar(*actor))
             .map(|actor| actor.id)
             .collect();
         for resident_id in resident_ids {
@@ -14833,29 +14849,21 @@ impl RuntimeWorld {
         self.actor_autonomy
             .retain(|actor_id, _| active_ids.contains(actor_id));
         for actor in actors {
-            let default_mode = if actor.kind == CW_ACTOR_HUMAN {
-                ActorControlMode::Human
-            } else if seed_actor_allows_ambient_autonomy(actor.id) {
-                ActorControlMode::LocalAi
-            } else {
-                ActorControlMode::ReactiveAi
-            };
+            let default_mode = seed_actor_default_control_mode(actor.id);
             let desires = self
                 .resident_continuities
                 .get(&actor.id)
                 .map(|continuity| continuity.open_obligations.clone())
                 .unwrap_or_default();
-            let autonomy = self.actor_autonomy.entry(actor.id).or_default();
-            if actor.kind == CW_ACTOR_HUMAN
-                && !matches!(autonomy.control_mode, ActorControlMode::DelegatedAi)
-            {
-                autonomy.control_mode = ActorControlMode::Human;
-            } else if actor.kind == CW_ACTOR_NPC && autonomy.control_mode == ActorControlMode::Human
-            {
-                autonomy.control_mode = default_mode;
-            }
+            let autonomy =
+                self.actor_autonomy
+                    .entry(actor.id)
+                    .or_insert_with(|| ActorAutonomyState {
+                        control_mode: default_mode,
+                        ..ActorAutonomyState::default()
+                    });
             autonomy.current_desires = desires;
-            if actor.kind == CW_ACTOR_NPC && autonomy.attention_credits == 0 {
+            if autonomy.control_mode.uses_inference() && autonomy.attention_credits == 0 {
                 autonomy.attention_credits = 1;
             }
         }
@@ -14875,9 +14883,9 @@ impl RuntimeWorld {
             })
             .unwrap_or_else(|| observation.source_location_id.into_iter().collect());
         for actor in &self.world.actors[..self.world.actor_count] {
-            if actor.kind != CW_ACTOR_NPC
-                || actor.status != CW_ACTOR_ACTIVE
+            if !Self::actor_is_active_avatar(*actor)
                 || !affected_locations.contains(&actor.location_id)
+                || !self.actor_uses_inference(actor.id)
             {
                 continue;
             }
@@ -14901,7 +14909,7 @@ impl RuntimeWorld {
             return false;
         }
         match autonomy.control_mode {
-            ActorControlMode::Human => false,
+            ActorControlMode::DirectInput => false,
             ActorControlMode::ReactiveAi => action_kind == CW_ACTION_SAY,
             ActorControlMode::LocalAi => action_kind != CW_ACTION_FLEE,
             ActorControlMode::RoamingAi | ActorControlMode::DelegatedAi => true,
@@ -14939,7 +14947,7 @@ impl RuntimeWorld {
         let Some(autonomy) = self.actor_autonomy.get_mut(&record.action.actor_id) else {
             return;
         };
-        if autonomy.control_mode == ActorControlMode::Human {
+        if autonomy.control_mode.is_direct_input() {
             return;
         }
         autonomy.last_acted_tick = record.source_world_tick.unwrap_or(self.world.tick);
@@ -14949,15 +14957,18 @@ impl RuntimeWorld {
 
     fn player_tick_already_has_autonomous_result(&self, source_world_tick: u64) -> bool {
         self.actor_autonomy.values().any(|autonomy| {
-            autonomy.control_mode != ActorControlMode::Human
-                && autonomy.last_acted_tick >= source_world_tick
+            autonomy.control_mode.uses_inference() && autonomy.last_acted_tick >= source_world_tick
+        }) || self.event_log.iter().rev().any(|event| {
+            event.success
+                && event.type_name == "message.created"
+                && event.source_world_tick == Some(source_world_tick)
         })
     }
 
     fn apply_resident_intent_projection(
         &mut self,
         resident_id: u64,
-        proposal: &ResidentIntentProposal,
+        proposal: &AvatarIntentProposal,
         reason: &str,
     ) {
         self.refresh_resident_continuity(resident_id);
@@ -15370,7 +15381,7 @@ impl RuntimeWorld {
         let Some(carrier) = self.actor_by_id(carrier_actor_id) else {
             return;
         };
-        if carrier.kind != CW_ACTOR_NPC || carrier.status != CW_ACTOR_ACTIVE || location_id == 0 {
+        if !Self::actor_is_active_avatar(carrier) || location_id == 0 {
             return;
         }
 
@@ -15577,10 +15588,7 @@ impl RuntimeWorld {
         let Some(resident) = self.actor_by_id(resident_id) else {
             return;
         };
-        if resident.kind != CW_ACTOR_NPC
-            || resident.status != CW_ACTOR_ACTIVE
-            || resident.location_id != location_id
-        {
+        if !Self::actor_is_active_avatar(resident) || resident.location_id != location_id {
             return;
         }
 
@@ -15636,7 +15644,7 @@ impl RuntimeWorld {
         let resident_ids_with_desires: Vec<CwActor> = actor_ids
             .iter()
             .filter_map(|actor_id| self.actor_by_id(*actor_id))
-            .filter(|actor| actor.kind == CW_ACTOR_NPC)
+            .filter(|actor| Self::actor_is_active_avatar(*actor))
             .collect();
         for actor in resident_ids_with_desires {
             let sought_item_ids: BTreeSet<_> =
@@ -15686,9 +15694,7 @@ impl RuntimeWorld {
         let resident_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
             .iter()
             .filter(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
-                    && actor.location_id == location_id
+                Self::actor_is_active_avatar(**actor) && actor.location_id == location_id
             })
             .map(|actor| actor.id)
             .collect();
@@ -15701,9 +15707,7 @@ impl RuntimeWorld {
         let resident_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
             .iter()
             .filter(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
-                    && actor.location_id == location_id
+                Self::actor_is_active_avatar(**actor) && actor.location_id == location_id
             })
             .map(|actor| actor.id)
             .collect();
@@ -15773,8 +15777,7 @@ impl RuntimeWorld {
                         .iter()
                         .filter(|actor| {
                             actor.id != actor_id
-                                && actor.kind == CW_ACTOR_NPC
-                                && actor.status == CW_ACTOR_ACTIVE
+                                && Self::actor_is_active_avatar(**actor)
                                 && actor.location_id == from_location_id
                         })
                         .map(|actor| actor.id)
@@ -15814,7 +15817,7 @@ impl RuntimeWorld {
         }
 
         if let Some(actor) = self.actor_by_id(action.actor_id) {
-            if actor.kind == CW_ACTOR_NPC && actor.status == CW_ACTOR_ACTIVE {
+            if Self::actor_is_active_avatar(actor) {
                 locations.insert(actor.location_id);
             }
         }
@@ -15825,9 +15828,7 @@ impl RuntimeWorld {
             let resident_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
                 .iter()
                 .filter(|actor| {
-                    actor.kind == CW_ACTOR_NPC
-                        && actor.status == CW_ACTOR_ACTIVE
-                        && actor.location_id == location_id
+                    Self::actor_is_active_avatar(**actor) && actor.location_id == location_id
                 })
                 .map(|actor| actor.id)
                 .collect();
@@ -15889,7 +15890,7 @@ impl RuntimeWorld {
 
     #[cfg(test)]
     fn resident_expendable_item_for_pickup(&self, resident: CwActor) -> Option<CwItem> {
-        if resident.kind != CW_ACTOR_NPC || !self.actor_inventory_full(resident.id) {
+        if !Self::actor_is_active_avatar(resident) || !self.actor_inventory_full(resident.id) {
             return None;
         }
         self.resident_exchange_item_for_pickup(resident, None)
@@ -15900,7 +15901,7 @@ impl RuntimeWorld {
         resident: CwActor,
         incoming_item: Option<CwItem>,
     ) -> Option<CwItem> {
-        if resident.kind != CW_ACTOR_NPC {
+        if !Self::actor_is_active_avatar(resident) {
             return None;
         }
         let mut candidates: Vec<_> = self
@@ -15934,7 +15935,7 @@ impl RuntimeWorld {
                 accepted: false,
                 score: i16::MIN,
                 willingness: "refuses",
-                reason: "That resident is not here.".to_string(),
+                reason: "That avatar is not here.".to_string(),
             };
         };
         let offered_score = self.resident_item_offer_score(resident, offered_item);
@@ -15942,7 +15943,7 @@ impl RuntimeWorld {
         let score = offered_score.saturating_sub(requested_score);
         let resident_name = self
             .actor_name(resident.id)
-            .unwrap_or_else(|| format!("Resident {}", resident.id));
+            .unwrap_or_else(|| format!("Avatar {}", resident.id));
         let offered_name = self
             .item_name(offered_item.id)
             .unwrap_or_else(|| format!("Item {}", offered_item.id));
@@ -16066,7 +16067,9 @@ impl RuntimeWorld {
         target: CwActor,
         offered_item: CwItem,
     ) -> Option<CwItem> {
-        if target.kind != CW_ACTOR_NPC || self.actor_can_receive_item(target, offered_item.id) {
+        if !Self::actor_is_active_avatar(target)
+            || self.actor_can_receive_item(target, offered_item.id)
+        {
             return None;
         }
         let return_item = self.resident_exchange_item_for_pickup(target, Some(offered_item))?;
@@ -16311,8 +16314,7 @@ impl RuntimeWorld {
                 .iter()
                 .any(|other| {
                     other.id != actor_id
-                        && other.kind == CW_ACTOR_NPC
-                        && other.status == CW_ACTOR_ACTIVE
+                        && Self::actor_is_active_avatar(*other)
                         && other.location_id == actor.location_id
                         && self.actor_visible_in_projection(*other, Some(actor_id), None)
                 })
@@ -16440,8 +16442,7 @@ impl RuntimeWorld {
         let Some(actor) = self.actor_by_id(action.actor_id) else {
             return Vec::new();
         };
-        if actor.kind != CW_ACTOR_HUMAN
-            || actor.status != CW_ACTOR_ACTIVE
+        if !Self::actor_is_active_avatar(actor)
             || !source_events
                 .iter()
                 .any(|event| event.actor_id == Some(action.actor_id))
@@ -16610,7 +16611,7 @@ impl RuntimeWorld {
     ) -> Vec<EventView> {
         if !self
             .actor_by_id(action.actor_id)
-            .is_some_and(|actor| actor.kind == CW_ACTOR_HUMAN && actor.status == CW_ACTOR_ACTIVE)
+            .is_some_and(Self::actor_is_active_avatar)
         {
             return Vec::new();
         }
@@ -16767,7 +16768,7 @@ impl RuntimeWorld {
         for participant_id in &job.participant_ids {
             if let Some(actor) = self.world.actors[..actor_count]
                 .iter_mut()
-                .find(|actor| actor.id == *participant_id && actor.kind == CW_ACTOR_NPC)
+                .find(|actor| actor.id == *participant_id)
             {
                 actor.status = CW_ACTOR_ACTIVE;
                 actor.damage = 0;
@@ -17017,7 +17018,7 @@ impl RuntimeWorld {
         actor_id: u64,
     ) -> Option<PlayerFeatureUseCandidate> {
         let actor = self.actor_by_id(actor_id)?;
-        if actor.kind != CW_ACTOR_HUMAN || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) {
             return None;
         }
         let held_item_ids: BTreeSet<u64> = self
@@ -17228,8 +17229,7 @@ impl RuntimeWorld {
             .copied()
             .find(|target| {
                 target.id != actor_id
-                    && target.kind == CW_ACTOR_NPC
-                    && target.status == CW_ACTOR_ACTIVE
+                    && Self::actor_is_active_avatar(*target)
                     && target.location_id == actor.location_id
                     && self.actor_visible_in_projection(*target, Some(actor_id), None)
                     && self.active_bond(actor_id, target.id).is_none()
@@ -17253,8 +17253,7 @@ impl RuntimeWorld {
                     && self
                         .actor_by_id(bond.target_actor_id)
                         .is_some_and(|target| {
-                            target.kind == CW_ACTOR_NPC
-                                && target.status == CW_ACTOR_ACTIVE
+                            Self::actor_is_active_avatar(target)
                                 && target.location_id == actor.location_id
                         })
             })
@@ -17565,7 +17564,7 @@ impl RuntimeWorld {
     ) -> Result<CommunityArtPlan, String> {
         let contributor = self
             .actor_by_id(contributor_actor_id)
-            .filter(|actor| actor.kind == CW_ACTOR_HUMAN && actor.status == CW_ACTOR_ACTIVE)
+            .filter(|actor| Self::actor_is_active_avatar(*actor))
             .ok_or_else(|| "The contributing avatar is no longer active.".to_string())?;
         let level = self
             .community_art_subject_level(subject_kind, subject_id)
@@ -17926,7 +17925,7 @@ impl RuntimeWorld {
                 .2
                 .is_empty();
         let has_combat_target = self.has_active_combat_target(actor_id);
-        let has_resident_gift = self.has_resident_gift(actor_id);
+        let has_actor_gift = self.has_actor_gift(actor_id);
         let can_trade_item = self.default_item_trade(actor_id).is_some();
         let can_attempt_theft = self.default_theft_candidate(actor_id).is_some();
         let can_prepare = self.prepare_available(actor_id);
@@ -18038,7 +18037,7 @@ impl RuntimeWorld {
                 });
             }
         }
-        if offers.option_flags & CW_OFFER_GIVE_ITEM != 0 && has_resident_gift {
+        if offers.option_flags & CW_OFFER_GIVE_ITEM != 0 && has_actor_gift {
             options.push(ActionOption {
                 kind: "give_item".to_string(),
                 label: "Give Item".to_string(),
@@ -18722,15 +18721,12 @@ impl RuntimeWorld {
                         .unwrap_or_else(|| format!("Item {}", item.id));
                     (item.id, name)
                 }),
-            "give_item" => self
-                .default_resident_gift_candidate(actor_id)
-                .map(|candidate| {
-                    let item = candidate.offered_item;
-                    let name = self
-                        .item_name(item.id)
-                        .unwrap_or_else(|| format!("Item {}", item.id));
-                    (item.id, name)
-                }),
+            "give_item" => self.actor_give_candidate(actor_id).map(|(item, _)| {
+                let name = self
+                    .item_name(item.id)
+                    .unwrap_or_else(|| format!("Item {}", item.id));
+                (item.id, name)
+            }),
             "trade_item" => self
                 .default_item_trade_candidate(actor_id)
                 .map(|candidate| {
@@ -19115,16 +19111,16 @@ impl RuntimeWorld {
                     label: self.actor_name(target.id),
                 }),
             "give_item" => self
-                .default_resident_gift_candidate(actor_id)
-                .map(|candidate| ActionTargetView {
+                .actor_give_candidate(actor_id)
+                .map(|(offered_item, target)| ActionTargetView {
                     kind: "actor".to_string(),
-                    id: Some(candidate.target.id),
+                    id: Some(target.id),
                     label: Some(format!(
                         "{} to {}",
-                        self.item_name(candidate.offered_item.id)
-                            .unwrap_or_else(|| format!("Item {}", candidate.offered_item.id)),
-                        self.actor_name(candidate.target.id)
-                            .unwrap_or_else(|| format!("Resident {}", candidate.target.id))
+                        self.item_name(offered_item.id)
+                            .unwrap_or_else(|| format!("Item {}", offered_item.id)),
+                        self.actor_name(target.id)
+                            .unwrap_or_else(|| format!("Avatar {}", target.id))
                     )),
                 }),
             "trade_item" => self
@@ -19464,19 +19460,23 @@ impl RuntimeWorld {
                     .map(|name| format!("keeps what mattered with {name}; leaves you something to remember"))
             }),
             "give_item" => self
-                .default_resident_gift_candidate(actor_id)
-                .map(|candidate| {
+                .actor_give_candidate(actor_id)
+                .map(|(offered_item, target)| {
                     let item_name = self
-                        .item_name(candidate.offered_item.id)
-                        .unwrap_or_else(|| format!("Item {}", candidate.offered_item.id));
+                        .item_name(offered_item.id)
+                        .unwrap_or_else(|| format!("Item {}", offered_item.id));
                     let target_name = self
-                        .actor_name(candidate.target.id)
-                        .unwrap_or_else(|| format!("Resident {}", candidate.target.id));
-                    let reason = candidate.request.reason.trim_end_matches('.');
-                    if let Some(return_item) = self.resident_player_gift_return_item(
-                        candidate.target,
-                        candidate.offered_item,
-                    ) {
+                        .actor_name(target.id)
+                        .unwrap_or_else(|| format!("Avatar {}", target.id));
+                    let request_reason = self
+                        .resident_request_for_holder(target, actor_id)
+                        .filter(|request| request.item_id == offered_item.id)
+                        .map(|request| request.reason)
+                        .unwrap_or_else(|| format!("{target_name} can receive {item_name}"));
+                    let reason = request_reason.trim_end_matches('.');
+                    if let Some(return_item) =
+                        self.resident_player_gift_return_item(target, offered_item)
+                    {
                         let return_name = self
                             .item_name(return_item.id)
                             .unwrap_or_else(|| format!("Item {}", return_item.id));
@@ -19586,8 +19586,7 @@ impl RuntimeWorld {
             .copied()
             .filter(|target| {
                 target.id != actor_id
-                    && target.kind == CW_ACTOR_NPC
-                    && target.status == CW_ACTOR_ACTIVE
+                    && Self::actor_is_active_avatar(*target)
                     && target.location_id == actor.location_id
                     && self.actor_visible_in_projection(*target, Some(actor_id), None)
             })
@@ -19623,16 +19622,37 @@ impl RuntimeWorld {
             })
     }
 
-    fn has_resident_gift(&self, actor_id: u64) -> bool {
-        self.default_resident_gift_candidate(actor_id).is_some()
+    fn has_actor_gift(&self, actor_id: u64) -> bool {
+        self.actor_give_candidate(actor_id).is_some()
     }
 
-    fn default_resident_gift_candidate(
-        &self,
-        actor_id: u64,
-    ) -> Option<ResidentPlayerGiftCandidate> {
+    fn actor_give_candidate(&self, actor_id: u64) -> Option<(CwItem, CwActor)> {
         let actor = self.actor_by_id(actor_id)?;
-        if actor.kind != CW_ACTOR_HUMAN || actor.status != CW_ACTOR_ACTIVE {
+        Self::actor_is_active_avatar(actor).then_some(())?;
+        self.default_actor_gift_candidate(actor_id)
+            .map(|candidate| (candidate.offered_item, candidate.target))
+            .or_else(|| {
+                self.resident_gift_candidate(actor)
+                    .map(|candidate| (candidate.actor_item, candidate.target))
+            })
+            .or_else(|| {
+                let mut held_items = self.actor_held_items(actor_id);
+                held_items.sort_by_key(|item| item.id);
+                let mut targets = self.active_chat_targets(actor_id);
+                targets.sort_by_key(|target| target.id);
+                held_items.into_iter().find_map(|item| {
+                    targets
+                        .iter()
+                        .copied()
+                        .find(|target| self.actor_can_receive_item(*target, item.id))
+                        .map(|target| (item, target))
+                })
+            })
+    }
+
+    fn default_actor_gift_candidate(&self, actor_id: u64) -> Option<ResidentPlayerGiftCandidate> {
+        let actor = self.actor_by_id(actor_id)?;
+        if !Self::actor_is_active_avatar(actor) {
             return None;
         }
 
@@ -19661,7 +19681,6 @@ impl RuntimeWorld {
             candidates.push(ResidentPlayerGiftCandidate {
                 offered_item,
                 target,
-                request,
             });
         }
         candidates.sort_by_key(|candidate| {
@@ -19676,7 +19695,7 @@ impl RuntimeWorld {
         candidates.into_iter().next()
     }
 
-    fn resident_gift_is_willing(
+    fn actor_gift_is_legal(
         &self,
         actor_id: u64,
         target_actor_id: u64,
@@ -19685,17 +19704,17 @@ impl RuntimeWorld {
         let actor = self
             .actor_by_id(actor_id)
             .ok_or_else(|| "That avatar is not here.".to_string())?;
-        if actor.kind != CW_ACTOR_HUMAN || actor.status != CW_ACTOR_ACTIVE {
-            return Err("Only an active player avatar can give items.".to_string());
+        if !Self::actor_is_active_avatar(actor) {
+            return Err("Only an active avatar can give items.".to_string());
         }
         let target = self
             .actor_by_id(target_actor_id)
-            .ok_or_else(|| "That resident is not here.".to_string())?;
-        if target.kind != CW_ACTOR_NPC
-            || target.status != CW_ACTOR_ACTIVE
+            .ok_or_else(|| "That avatar is not here.".to_string())?;
+        if target.id == actor.id
+            || !Self::actor_is_active_avatar(target)
             || target.location_id != actor.location_id
         {
-            return Err("That resident is not close enough to receive an item.".to_string());
+            return Err("That avatar is not close enough to receive an item.".to_string());
         }
         let offered_item = self.world.items[..self.world.item_count]
             .iter()
@@ -19705,32 +19724,19 @@ impl RuntimeWorld {
         if offered_item.holder_actor_id != actor_id {
             return Err("You are not holding that item.".to_string());
         }
-        let Some(request) = self.resident_request_for_holder(target, actor_id) else {
-            let target_name = self
-                .actor_name(target.id)
-                .unwrap_or_else(|| format!("Resident {}", target.id));
-            return Err(format!(
-                "{target_name} is not asking for that item right now."
-            ));
+        let requested = self
+            .resident_request_for_holder(target, actor_id)
+            .is_some_and(|request| request.item_id == item_id);
+        let can_receive = if requested {
+            self.resident_can_accept_player_gift(target, offered_item)
+        } else {
+            self.actor_can_receive_item(target, offered_item.id)
         };
-        if request.item_id != item_id {
+        if !can_receive {
             let target_name = self
                 .actor_name(target.id)
-                .unwrap_or_else(|| format!("Resident {}", target.id));
-            let item_name = self
-                .item_name(offered_item.id)
-                .unwrap_or_else(|| format!("Item {}", offered_item.id));
-            return Err(format!(
-                "{target_name} is not seeking {item_name} right now."
-            ));
-        }
-        if !self.resident_can_accept_player_gift(target, offered_item) {
-            let target_name = self
-                .actor_name(target.id)
-                .unwrap_or_else(|| format!("Resident {}", target.id));
-            return Err(format!(
-                "{target_name} has no free paw and cannot part with what they carry."
-            ));
+                .unwrap_or_else(|| format!("Avatar {}", target.id));
+            return Err(format!("{target_name} cannot carry that item right now."));
         }
         Ok(())
     }
@@ -19773,7 +19779,7 @@ impl RuntimeWorld {
         let Some(actor) = self.actor_by_id(actor_id) else {
             return Vec::new();
         };
-        if actor.kind != CW_ACTOR_HUMAN || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) {
             return Vec::new();
         }
         let offered_items = self.actor_held_items(actor_id);
@@ -19815,7 +19821,7 @@ impl RuntimeWorld {
         &self,
         actor: CwActor,
     ) -> Option<ResidentMutualTradeCandidate> {
-        if actor.kind != CW_ACTOR_NPC || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) {
             return None;
         }
         let actor_items = self.actor_held_items(actor.id);
@@ -19828,8 +19834,7 @@ impl RuntimeWorld {
             .copied()
             .filter(|target| {
                 target.id != actor.id
-                    && target.kind == CW_ACTOR_NPC
-                    && target.status == CW_ACTOR_ACTIVE
+                    && Self::actor_is_active_avatar(*target)
                     && target.location_id == actor.location_id
                     && self.resident_remembers_actor_at(actor.id, target.id, actor.location_id)
             })
@@ -19906,7 +19911,7 @@ impl RuntimeWorld {
     }
 
     fn resident_gift_candidate(&self, actor: CwActor) -> Option<ResidentGiftCandidate> {
-        if actor.kind != CW_ACTOR_NPC || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) {
             return None;
         }
         let actor_items = self.actor_held_items(actor.id);
@@ -19919,8 +19924,7 @@ impl RuntimeWorld {
             .copied()
             .filter(|target| {
                 target.id != actor.id
-                    && target.kind == CW_ACTOR_NPC
-                    && target.status == CW_ACTOR_ACTIVE
+                    && Self::actor_is_active_avatar(*target)
                     && target.location_id == actor.location_id
                     && self.resident_remembers_actor_at(actor.id, target.id, actor.location_id)
             })
@@ -19963,7 +19967,7 @@ impl RuntimeWorld {
     }
 
     fn resident_delivery_candidate(&self, actor: CwActor) -> Option<ResidentDeliveryCandidate> {
-        if actor.kind != CW_ACTOR_NPC || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) {
             return None;
         }
         let actor_items = self.actor_held_items(actor.id);
@@ -19991,7 +19995,7 @@ impl RuntimeWorld {
                 let Some(target) = self.actor_by_id(memory.subject_id) else {
                     continue;
                 };
-                if target.kind != CW_ACTOR_NPC || target.status != CW_ACTOR_ACTIVE {
+                if !Self::actor_is_active_avatar(target) {
                     continue;
                 }
                 let Some(desire_memory) =
@@ -20046,17 +20050,14 @@ impl RuntimeWorld {
         let actor = self
             .actor_by_id(actor_id)
             .ok_or_else(|| "That avatar is not here.".to_string())?;
-        if actor.kind != CW_ACTOR_HUMAN || actor.status != CW_ACTOR_ACTIVE {
-            return Err("Only an active player avatar can trade.".to_string());
+        if !Self::actor_is_active_avatar(actor) {
+            return Err("Only an active avatar can trade.".to_string());
         }
         let target = self
             .actor_by_id(target_actor_id)
-            .ok_or_else(|| "That resident is not here.".to_string())?;
-        if target.kind != CW_ACTOR_NPC
-            || target.status != CW_ACTOR_ACTIVE
-            || target.location_id != actor.location_id
-        {
-            return Err("That resident is not close enough to trade.".to_string());
+            .ok_or_else(|| "That avatar is not here.".to_string())?;
+        if !Self::actor_is_active_avatar(target) || target.location_id != actor.location_id {
+            return Err("That avatar is not close enough to trade.".to_string());
         }
         let offered_item = self.world.items[..self.world.item_count]
             .iter()
@@ -20106,7 +20107,8 @@ impl RuntimeWorld {
         if target.id == actor.id {
             return true;
         }
-        !(target.kind == CW_ACTOR_NPC && self.location_has_unresolved_combat(actor.location_id))
+        !self.location_has_unresolved_combat(actor.location_id)
+            || self.combat_actors_share_side(actor.id, target.id)
     }
 
     #[cfg(test)]
@@ -20145,8 +20147,9 @@ impl RuntimeWorld {
     fn dialogue_branch_for(&self, actor_id: u64, target_actor_id: u64) -> Option<DialogueBranch> {
         let actor = self.actor_by_id(actor_id)?;
         let target = self.actor_by_id(target_actor_id)?;
-        if actor.kind != CW_ACTOR_HUMAN
-            || target.kind != CW_ACTOR_NPC
+        if !Self::actor_is_active_avatar(actor)
+            || !Self::actor_is_active_avatar(target)
+            || actor.id == target.id
             || actor.location_id != target.location_id
         {
             return None;
@@ -20305,33 +20308,35 @@ impl RuntimeWorld {
             .collect()
     }
 
-    fn has_active_resident_at(&self, location_id: u64) -> bool {
+    fn has_active_inference_actor_at(&self, location_id: u64) -> bool {
         self.world.actors[..self.world.actor_count]
             .iter()
+            .copied()
             .any(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
+                Self::actor_is_active_avatar(actor)
+                    && self.actor_uses_inference(actor.id)
                     && actor.location_id == location_id
             })
     }
 
     fn welcome_host_for(&self, location_id: u64) -> Option<CwActor> {
-        if let Some(rati) = self
-            .actor_by_id(RATI_ACTOR_ID)
-            .filter(|actor| actor.kind == CW_ACTOR_NPC && actor.status == CW_ACTOR_ACTIVE)
-        {
+        if let Some(rati) = self.actor_by_id(RATI_ACTOR_ID).filter(|actor| {
+            Self::actor_is_active_avatar(*actor) && self.actor_uses_inference(actor.id)
+        }) {
             if rati.location_id != location_id {
                 return Some(rati);
             }
             return None;
         }
-        if self.has_active_resident_at(location_id) {
+        if self.has_active_inference_actor_at(location_id) {
             return None;
         }
         self.world.actors[..self.world.actor_count]
             .iter()
             .copied()
-            .filter(|actor| actor.kind == CW_ACTOR_NPC && actor.status == CW_ACTOR_ACTIVE)
+            .filter(|actor| {
+                Self::actor_is_active_avatar(*actor) && self.actor_uses_inference(actor.id)
+            })
             .min_by_key(|actor| actor.id)
     }
 
@@ -20447,10 +20452,9 @@ impl RuntimeWorld {
     fn avatar_chat_plan_for(&self, actor_id: u64, target_actor_id: u64) -> Option<AvatarChatPlan> {
         let actor = self.actor_by_id(actor_id)?;
         let target = self.actor_by_id(target_actor_id)?;
-        if actor.kind != CW_ACTOR_HUMAN
-            || actor.status != CW_ACTOR_ACTIVE
-            || target.kind != CW_ACTOR_NPC
-            || target.status != CW_ACTOR_ACTIVE
+        if !Self::actor_is_active_avatar(actor)
+            || !Self::actor_is_active_avatar(target)
+            || actor.id == target.id
             || actor.location_id != target.location_id
         {
             return None;
@@ -20512,11 +20516,11 @@ impl RuntimeWorld {
         speaker_actor_id: u64,
         target_actor_id: u64,
         text: &str,
-    ) -> Option<ResidentReplyPlan> {
+    ) -> Option<AvatarReplyPlan> {
         self.resident_reply_plan_for_target_with_context(speaker_actor_id, target_actor_id, text)
     }
 
-    fn conversation_subject(&self, text: &str, npc_actor_id: u64) -> Option<String> {
+    fn conversation_subject(&self, text: &str, speaker_actor_id: u64) -> Option<String> {
         let lowered = text.to_lowercase();
         let longest_match = |values: Vec<String>| {
             values
@@ -20534,7 +20538,7 @@ impl RuntimeWorld {
                 longest_match(
                     self.actors
                         .iter()
-                        .filter(|(actor_id, _)| **actor_id != npc_actor_id)
+                        .filter(|(actor_id, _)| **actor_id != speaker_actor_id)
                         .map(|(_, actor)| actor.name.clone())
                         .collect(),
                 )
@@ -20736,11 +20740,21 @@ impl RuntimeWorld {
         }
     }
 
+    #[cfg(test)]
     fn next_resident_card_reaction_plan(
         &self,
         speaker_actor_id: u64,
         events: &[EventView],
-    ) -> Option<ResidentReplyPlan> {
+    ) -> Option<AvatarReplyPlan> {
+        self.next_room_card_reaction_plan(speaker_actor_id, events, None)
+    }
+
+    fn next_room_card_reaction_plan(
+        &self,
+        speaker_actor_id: u64,
+        events: &[EventView],
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
+    ) -> Option<AvatarReplyPlan> {
         if events.iter().any(|event| {
             matches!(
                 event.type_name.as_str(),
@@ -20750,7 +20764,7 @@ impl RuntimeWorld {
             return None;
         }
         let speaker = self.actor_by_id(speaker_actor_id)?;
-        if speaker.kind != CW_ACTOR_HUMAN || speaker.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(speaker) {
             return None;
         }
         let actor_name = self
@@ -20758,16 +20772,18 @@ impl RuntimeWorld {
             .unwrap_or_else(|| "The visitor".to_string());
         let reaction_event = self.card_reaction_event(speaker_actor_id, events)?;
         let action_text = self.card_reaction_action_text(&actor_name, reaction_event);
-        let mut residents = self.world.actors[..self.world.actor_count]
+        let mut responders = self.world.actors[..self.world.actor_count]
             .iter()
             .copied()
             .filter(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
+                Self::actor_is_active_avatar(*actor)
                     && actor.location_id == speaker.location_id
+                    && (self.actor_uses_inference(actor.id)
+                        || active_direct_actor_ids
+                            .is_none_or(|active_ids| active_ids.contains(&actor.id)))
             })
             .collect::<Vec<_>>();
-        residents.sort_by_key(|actor| {
+        responders.sort_by_key(|actor| {
             let dex = active_content()
                 .cards
                 .iter()
@@ -20775,24 +20791,23 @@ impl RuntimeWorld {
                 .unwrap_or(usize::MAX);
             (dex, actor.id)
         });
-        if residents.is_empty() {
+        if responders.is_empty() {
             return None;
         }
-        let latest_resident_speaker = self.event_log.iter().rev().find_map(|event| {
+        let latest_room_speaker = self.event_log.iter().rev().find_map(|event| {
             if event.type_name != "message.created"
                 || event.location_id != Some(speaker.location_id)
             {
                 return None;
             }
-            event.actor_id.filter(|actor_id| {
-                self.actor_by_id(*actor_id)
-                    .is_some_and(|actor| actor.kind == CW_ACTOR_NPC)
-            })
+            event
+                .actor_id
+                .filter(|actor_id| responders.iter().any(|actor| actor.id == *actor_id))
         });
-        let target = latest_resident_speaker
-            .and_then(|actor_id| residents.iter().position(|actor| actor.id == actor_id))
-            .map(|index| residents[(index + 1) % residents.len()])
-            .unwrap_or(residents[0]);
+        let target = latest_room_speaker
+            .and_then(|actor_id| responders.iter().position(|actor| actor.id == actor_id))
+            .map(|index| responders[(index + 1) % responders.len()])
+            .unwrap_or(responders[0]);
         self.resident_reply_plan_for_target_with_context(speaker_actor_id, target.id, &action_text)
     }
 
@@ -20801,41 +20816,46 @@ impl RuntimeWorld {
         speaker_actor_id: u64,
         target_actor_id: u64,
         text: &str,
-    ) -> Option<ResidentReplyPlan> {
+    ) -> Option<AvatarReplyPlan> {
         let speaker = self.actor_by_id(speaker_actor_id)?;
-        let npc = self.actor_by_id(target_actor_id)?;
-        if speaker.kind != CW_ACTOR_HUMAN
-            || speaker.status != CW_ACTOR_ACTIVE
-            || npc.kind != CW_ACTOR_NPC
-            || npc.status != CW_ACTOR_ACTIVE
-            || speaker.location_id != npc.location_id
+        let responder = self.actor_by_id(target_actor_id)?;
+        if !Self::actor_is_active_avatar(speaker)
+            || !Self::actor_is_active_avatar(responder)
+            || speaker.location_id != responder.location_id
         {
             return None;
         }
-        let npc_meta = self.actors.get(&target_actor_id);
-        let location_meta = self.location_meta_for(npc.location_id);
-        let economy_note = self.resident_economy_prompt_note(npc, Some(speaker_actor_id));
-        Some(ResidentReplyPlan {
-            npc_actor_id: target_actor_id,
-            npc_name: self
+        let responder_meta = self.actors.get(&target_actor_id);
+        let location_meta = self.location_meta_for(responder.location_id);
+        let economy_note =
+            if !self.actor_uses_inference(responder.id) && responder.id == speaker_actor_id {
+                DIRECTLY_CONTROLLED_SELF_REACTION_CONTEXT.to_string()
+            } else if !self.actor_uses_inference(responder.id) {
+                DIRECTLY_CONTROLLED_REACTION_CONTEXT.to_string()
+            } else {
+                self.resident_economy_prompt_note(responder, Some(speaker_actor_id))
+            };
+        Some(AvatarReplyPlan {
+            speaker_actor_id: target_actor_id,
+            speaker_name: self
                 .actor_name(target_actor_id)
                 .unwrap_or_else(|| format!("Actor {target_actor_id}")),
-            speech_mode: npc_meta
+            speech_mode: responder_meta
                 .map(|meta| meta.speech_mode.clone())
                 .unwrap_or_else(|| "prose".to_string()),
-            resident_continuity: self.resident_continuity_for(npc),
+            resident_continuity: self.resident_continuity_for(responder),
             economy_note,
-            goals: self.narrative_goal_lines(Some(speaker_actor_id), npc.location_id),
+            goals: self.narrative_goal_lines(Some(target_actor_id), responder.location_id),
             location_name: self
-                .location_name(npc.location_id)
+                .location_name(responder.location_id)
                 .unwrap_or_else(|| "Unknown Location".to_string()),
             location_title: location_meta.title,
             location_description: location_meta.description,
             location_persona: location_meta.persona,
             location_memory: location_meta.memory,
-            cast: self.room_cast_names(npc.location_id),
-            recent_lines: self.recent_room_lines(npc.location_id, 8),
-            recent_activity: self.recent_room_activity(npc.location_id, 10),
+            cast: self.room_cast_names(responder.location_id),
+            recent_lines: self.recent_room_lines(responder.location_id, 8),
+            recent_activity: self.recent_room_activity(responder.location_id, 10),
             user_text: text.to_string(),
             caused_by_event_seq: None,
             source_world_tick: None,
@@ -20851,7 +20871,7 @@ impl RuntimeWorld {
         events: &[EventView],
     ) -> Option<RippleContext> {
         let source_actor = self.actor_by_id(source_actor_id)?;
-        if source_actor.kind != CW_ACTOR_HUMAN || source_actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(source_actor) {
             return None;
         }
 
@@ -20923,31 +20943,18 @@ impl RuntimeWorld {
         })
     }
 
-    fn resident_ripple_actor(&self, context: &RippleContext) -> Option<CwActor> {
-        let candidates: Vec<CwActor> = self.world.actors[..self.world.actor_count]
-            .iter()
-            .copied()
-            .filter(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
-                    && context.affected_location_ids.contains(&actor.location_id)
-            })
-            .collect();
-        if candidates.is_empty() {
-            return None;
-        }
-
-        Some(candidates[(self.world.tick as usize) % candidates.len()])
-    }
-
     #[cfg(test)]
     fn ambient_actor(&self) -> Option<CwActor> {
-        let human_locations: BTreeSet<u64> = self.world.actors[..self.world.actor_count]
+        let directly_controlled_locations: BTreeSet<u64> = self.world.actors
+            [..self.world.actor_count]
             .iter()
-            .filter(|actor| actor.kind == CW_ACTOR_HUMAN && actor.status == CW_ACTOR_ACTIVE)
+            .copied()
+            .filter(|actor| {
+                Self::actor_is_active_avatar(*actor) && !self.actor_uses_inference(actor.id)
+            })
             .map(|actor| actor.location_id)
             .collect();
-        if human_locations.is_empty() {
+        if directly_controlled_locations.is_empty() {
             return None;
         }
 
@@ -20955,10 +20962,9 @@ impl RuntimeWorld {
             .iter()
             .copied()
             .filter(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
-                    && seed_actor_allows_ambient_autonomy(actor.id)
-                    && human_locations.contains(&actor.location_id)
+                Self::actor_is_active_avatar(*actor)
+                    && self.actor_uses_inference(actor.id)
+                    && directly_controlled_locations.contains(&actor.location_id)
             })
             .collect();
         if candidates.is_empty() {
@@ -20969,14 +20975,14 @@ impl RuntimeWorld {
     }
 
     #[cfg(test)]
-    fn ambient_reply_plan(&self) -> Option<ResidentReplyPlan> {
+    fn ambient_reply_plan(&self) -> Option<AvatarReplyPlan> {
         let npc = self.ambient_actor()?;
         let npc_meta = self.actors.get(&npc.id);
         let location_meta = self.location_meta_for(npc.location_id);
         let economy_note = self.resident_economy_prompt_note(npc, None);
-        Some(ResidentReplyPlan {
-            npc_actor_id: npc.id,
-            npc_name: self
+        Some(AvatarReplyPlan {
+            speaker_actor_id: npc.id,
+            speaker_name: self
                 .actor_name(npc.id)
                 .unwrap_or_else(|| format!("Actor {}", npc.id)),
             speech_mode: npc_meta
@@ -21037,7 +21043,7 @@ impl RuntimeWorld {
     }
 
     fn resident_economy_autonomy_action(&self, actor: CwActor) -> Option<CwAction> {
-        if actor.kind != CW_ACTOR_NPC || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) || !self.actor_uses_inference(actor.id) {
             return None;
         }
         let waiting_for_player_gift = self.resident_waits_for_player_gift(actor);
@@ -21175,7 +21181,9 @@ impl RuntimeWorld {
     }
 
     fn fresh_resident_autonomy_action(&self, actor: CwActor, action: CwAction) -> Option<CwAction> {
-        (!self.resident_autonomy_action_repeats_recent_event(actor, &action)).then_some(action)
+        (!self.resident_autonomy_action_repeats_recent_event(actor, &action)
+            && self.kernel_offer_allows_action(&action))
+        .then_some(action)
     }
 
     fn resident_reply_repeats_recent_event(
@@ -21215,15 +21223,15 @@ impl RuntimeWorld {
 
     fn collision_safe_resident_proposal(
         &self,
-        plan: &ResidentReplyPlan,
-        proposal: ResidentIntentProposal,
-    ) -> Option<ResidentIntentProposal> {
+        plan: &AvatarReplyPlan,
+        proposal: AvatarIntentProposal,
+    ) -> Option<AvatarIntentProposal> {
         let location_id = self
-            .actor_by_id(plan.npc_actor_id)
+            .actor_by_id(plan.speaker_actor_id)
             .map(|actor| actor.location_id)
             .unwrap_or_default();
         if !self.resident_reply_repeats_recent_event(
-            plan.npc_actor_id,
+            plan.speaker_actor_id,
             location_id,
             &proposal.speech,
         ) {
@@ -21438,7 +21446,7 @@ impl RuntimeWorld {
     }
 
     fn resident_economy_autonomy_record(&self, actor: CwActor, seed: u64) -> Option<JournalRecord> {
-        if actor.kind != CW_ACTOR_NPC || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) || !self.actor_uses_inference(actor.id) {
             return None;
         }
         if self.resident_held_healing_item(actor).is_none() {
@@ -21452,53 +21460,6 @@ impl RuntimeWorld {
             self.append_resident_autonomy_intent_projection(actor, &mut record);
             record
         })
-    }
-
-    fn resident_wander_action(&self, actor: CwActor) -> Option<CwAction> {
-        if actor.kind != CW_ACTOR_NPC || actor.status != CW_ACTOR_ACTIVE {
-            return None;
-        }
-        if self.resident_waits_for_player_gift(actor) || self.resident_stays_with_active_job(actor)
-        {
-            return None;
-        }
-        let mut exits = self.world.exits[..self.world.exit_count]
-            .iter()
-            .copied()
-            .filter(|exit| exit.from_location_id == actor.location_id)
-            .filter(|exit| exit.flags & CW_EXIT_LOCKED == 0)
-            .filter(|exit| {
-                let rule = location_access_rule(exit.to_location_id);
-                rule.required_grant_id.is_none() && rule.required_card_id.is_none()
-            })
-            .filter(|exit| self.location_name(exit.to_location_id).is_some())
-            .collect::<Vec<_>>();
-        exits.sort_by_key(|exit| exit.to_location_id);
-        if exits.is_empty() {
-            return None;
-        }
-        let start = (self.world.tick as usize + actor.id as usize) % exits.len();
-        for offset in 0..exits.len() {
-            let exit = exits[(start + offset) % exits.len()];
-            let action = CwAction {
-                kind: CW_ACTION_MOVE,
-                actor_id: actor.id,
-                destination_location_id: exit.to_location_id,
-                ..CwAction::default()
-            };
-            if let Some(action) = self.fresh_resident_autonomy_action(actor, action) {
-                return Some(action);
-            }
-        }
-        None
-    }
-
-    fn resident_wander_record(&self, actor: CwActor, seed: u64) -> Option<JournalRecord> {
-        let action = self.resident_wander_action(actor)?;
-        let mut record =
-            JournalRecord::new(action, seed).into_actor_consequence(self.world.tick, None);
-        self.append_resident_autonomy_intent_projection(actor, &mut record);
-        Some(record)
     }
 
     fn append_resident_autonomy_intent_projection(
@@ -21520,12 +21481,12 @@ impl RuntimeWorld {
         &self,
         actor: CwActor,
         record: &JournalRecord,
-    ) -> ResidentIntentProposal {
+    ) -> AvatarIntentProposal {
         let action = &record.action;
         let actor_name = self
             .actor_name(actor.id)
             .unwrap_or_else(|| format!("Resident {}", actor.id));
-        let mut proposed_action = ResidentProposedAction {
+        let mut proposed_action = AvatarProposedAction {
             kind: "wait".to_string(),
             target_actor_id: None,
             item_id: None,
@@ -21624,7 +21585,7 @@ impl RuntimeWorld {
             _ => format!("{actor_name} intends to wait and observe."),
         };
         proposed_action.reason = Some(intent.clone());
-        ResidentIntentProposal {
+        AvatarIntentProposal {
             // Autonomy continuity is not visible dialogue. Spoken reactions are
             // generated separately through the resident inference path.
             speech: intent.clone(),
@@ -21639,7 +21600,7 @@ impl RuntimeWorld {
 
     fn prepare_resident_local_memories(&mut self, actor_id: u64) -> Option<CwActor> {
         let actor = self.actor_by_id(actor_id)?;
-        if actor.kind != CW_ACTOR_NPC || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) || !self.actor_uses_inference(actor.id) {
             return None;
         }
         self.observe_room_for_resident(actor.id, actor.location_id);
@@ -21653,9 +21614,7 @@ impl RuntimeWorld {
             .iter()
             .copied()
             .filter(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
-                    && seed_actor_allows_ambient_autonomy(actor.id)
+                Self::actor_is_active_avatar(*actor) && self.actor_uses_inference(actor.id)
             })
             .collect();
         if candidates.is_empty() {
@@ -21672,8 +21631,8 @@ impl RuntimeWorld {
             .iter()
             .copied()
             .filter(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
+                Self::actor_is_active_avatar(*actor)
+                    && self.actor_uses_inference(actor.id)
                     && context.affected_location_ids.contains(&actor.location_id)
             })
             .collect();
@@ -21856,8 +21815,8 @@ impl RuntimeWorld {
         self.world.actors[..self.world.actor_count]
             .iter()
             .filter(|actor| {
-                actor.kind == CW_ACTOR_NPC
-                    && actor.status == CW_ACTOR_ACTIVE
+                Self::actor_is_active_avatar(**actor)
+                    && self.actor_uses_inference(actor.id)
                     && actor.location_id == player.location_id
             })
             .take(2)
@@ -21938,27 +21897,13 @@ impl RuntimeWorld {
     #[cfg(test)]
     fn ambient_autonomy_action(&mut self) -> Option<CwAction> {
         self.refresh_resident_memories_for_autonomy();
-        if let Some(action) = self.resident_economy_autonomy_action_by_priority() {
-            return Some(action);
-        }
-        let actor = self.ambient_actor()?;
-        if let Some(action) = self.resident_wander_action(actor) {
-            return Some(action);
-        }
-        None
+        self.resident_economy_autonomy_action_by_priority()
     }
 
     #[cfg(test)]
     fn ambient_autonomy_record(&mut self, seed: u64) -> Option<JournalRecord> {
         self.refresh_resident_memories_for_autonomy();
-        if let Some(record) = self.resident_economy_autonomy_record_for_seed(seed) {
-            return Some(record);
-        }
-        let actor = self.ambient_actor()?;
-        if let Some(record) = self.resident_wander_record(actor, seed) {
-            return Some(record);
-        }
-        None
+        self.resident_economy_autonomy_record_for_seed(seed)
     }
 
     fn ripple_record_for_player_turn(
@@ -21976,19 +21921,6 @@ impl RuntimeWorld {
             record.caused_by_event_seq = context.source_event_seqs.iter().copied().max();
             record.ripple_source = Some(context.to_source());
             return Some(record);
-        }
-        if context.budget.allow_wander {
-            let actor = self.resident_ripple_actor(context)?;
-            if let Some(mut record) = self.resident_wander_record(actor, seed) {
-                if !self.ripple_move_keeps_player_company(context, &record.action) {
-                    return None;
-                }
-                record.origin = JournalOrigin::ActorConsequence;
-                record.source_world_tick = Some(self.world.tick);
-                record.caused_by_event_seq = context.source_event_seqs.iter().copied().max();
-                record.ripple_source = Some(context.to_source());
-                return Some(record);
-            }
         }
         None
     }
@@ -22716,13 +22648,16 @@ fn evolution_track_item_ids(actor_id: u64) -> Option<Vec<u64>> {
         })
 }
 
-fn seed_actor_allows_ambient_autonomy(actor_id: u64) -> bool {
-    active_content()
+fn seed_actor_default_control_mode(actor_id: u64) -> ActorControlMode {
+    match active_content()
         .actors
         .iter()
         .find(|actor| actor.id == actor_id)
-        .and_then(|actor| actor.ambient_autonomy)
-        .unwrap_or(true)
+    {
+        Some(actor) if actor.ambient_autonomy.unwrap_or(true) => ActorControlMode::LocalAi,
+        Some(_) => ActorControlMode::ReactiveAi,
+        None => ActorControlMode::DirectInput,
+    }
 }
 
 fn evolution_item_matches_resident(item_id: u64, actor_id: u64) -> bool {
@@ -23554,9 +23489,9 @@ async fn meta(State(state): State<AppState>) -> Json<MetaResponse> {
     let tick = runtime.world.tick;
     let next_event_seq = runtime.world.next_event_seq;
     let actor_count = runtime.world.actor_count;
-    let human_actor_count = runtime.world.actors[..runtime.world.actor_count]
+    let direct_input_actor_count = runtime.world.actors[..runtime.world.actor_count]
         .iter()
-        .filter(|actor| actor.kind == CW_ACTOR_HUMAN)
+        .filter(|actor| runtime.actor_control_mode(actor.id).is_direct_input())
         .count();
     let item_count = runtime.world.item_count;
     let location_count = runtime.world.location_count;
@@ -23734,7 +23669,7 @@ async fn meta(State(state): State<AppState>) -> Json<MetaResponse> {
             next_event_seq,
             actor_count,
             actor_capacity: CW_MAX_ACTORS,
-            human_actor_count,
+            direct_input_actor_count,
             item_count,
             item_capacity: CW_MAX_ITEMS,
             location_count,
@@ -24848,11 +24783,11 @@ async fn state_view(
     if let Some(actor_id) = actor_id {
         record_daily_visit(&state, actor_id);
     }
-    let active_humans = active_actor_ids_for_state(&state);
+    let active_direct_actors = active_actor_ids_for_state(&state);
     let mut response = runtime.state_response_with_presence(
         actor_id,
         &access,
-        Some(&active_humans),
+        Some(&active_direct_actors),
         query_openrouter_connected(query.openrouter_connected.as_deref()),
     );
     let turn_humans = active_turn_actor_ids_for_state(&state);
@@ -25014,11 +24949,11 @@ async fn inspect_view(
             &access,
         )
     });
-    let active_humans = active_actor_ids_for_state(&state);
+    let active_direct_actors = active_actor_ids_for_state(&state);
     let response = runtime.state_response_with_presence(
         actor_id,
         &access,
-        Some(&active_humans),
+        Some(&active_direct_actors),
         query_openrouter_connected(query.openrouter_connected.as_deref()),
     );
     drop(runtime);
@@ -25048,8 +24983,9 @@ async fn world_view(
             &access,
         )
     });
-    let active_humans = active_actor_ids_for_state(&state);
-    let response = runtime.world_response_with_presence(actor_id, &access, Some(&active_humans));
+    let active_direct_actors = active_actor_ids_for_state(&state);
+    let response =
+        runtime.world_response_with_presence(actor_id, &access, Some(&active_direct_actors));
     drop(runtime);
     Json(response)
 }
@@ -25339,7 +25275,7 @@ async fn create_avatar(
             let runtime = state.inner.lock().await;
             if let Some(actor) = runtime
                 .actor_by_id(actor_id)
-                .filter(|actor| actor.kind == CW_ACTOR_HUMAN && actor.status == CW_ACTOR_ACTIVE)
+                .filter(|actor| runtime.client_actor_can_submit(actor.id))
                 .map(|actor| runtime.actor_view(actor))
             {
                 drop(runtime);
@@ -25660,26 +25596,27 @@ async fn commit_presence_event(state: &AppState, actor_id: u64, active: bool) ->
     events
 }
 
-fn release_inactive_human_inventory_locked(
+fn release_inactive_direct_inventory_locked(
     state: &AppState,
     runtime: &mut RuntimeWorld,
 ) -> Vec<EventView> {
     let active_actor_ids = active_actor_ids_for_state(state);
-    let inactive_human_actor_ids = runtime.world.actors[..runtime.world.actor_count]
+    let inactive_direct_actor_ids = runtime.world.actors[..runtime.world.actor_count]
         .iter()
+        .copied()
         .filter(|actor| {
-            actor.kind == CW_ACTOR_HUMAN
-                && actor.status == CW_ACTOR_ACTIVE
+            RuntimeWorld::actor_is_active_avatar(*actor)
+                && !runtime.actor_uses_inference(actor.id)
                 && !active_actor_ids.contains(&actor.id)
         })
         .map(|actor| actor.id)
         .collect::<BTreeSet<_>>();
-    if inactive_human_actor_ids.is_empty() {
+    if inactive_direct_actor_ids.is_empty() {
         return Vec::new();
     }
     let drops = runtime.world.items[..runtime.world.item_count]
         .iter()
-        .filter(|item| inactive_human_actor_ids.contains(&item.holder_actor_id))
+        .filter(|item| inactive_direct_actor_ids.contains(&item.holder_actor_id))
         .filter_map(|item| {
             runtime
                 .actor_by_id(item.holder_actor_id)
@@ -25822,7 +25759,7 @@ async fn leave_presence(
     if ok {
         let released_events = {
             let mut runtime = state.inner.lock().await;
-            release_inactive_human_inventory_locked(&state, &mut runtime)
+            release_inactive_direct_inventory_locked(&state, &mut runtime)
         };
         if !released_events.is_empty() {
             broadcast_events(&state, &released_events);
@@ -26675,7 +26612,7 @@ async fn report_actor(
         );
     };
 
-    let active_humans = active_actor_ids_for_state(&state);
+    let active_direct_actors = active_actor_ids_for_state(&state);
     let report = {
         let runtime = state.inner.lock().await;
         if !client_actor_authorized_for_state(
@@ -26699,7 +26636,11 @@ async fn report_actor(
         };
         if reporter.id == target.id
             || reporter.location_id != target.location_id
-            || !runtime.actor_visible_in_projection(target, Some(reporter.id), Some(&active_humans))
+            || !runtime.actor_visible_in_projection(
+                target,
+                Some(reporter.id),
+                Some(&active_direct_actors),
+            )
         {
             return report_response(false, 404, None, "Reported actor must be nearby.");
         }
@@ -28795,8 +28736,8 @@ async fn command_inner(
                 events: Vec::new(),
             });
         }
-        let active_humans = active_actor_ids_for_state(&state);
-        runtime.resolve_command_with_presence(&payload, &access, Some(&active_humans))
+        let active_direct_actors = active_actor_ids_for_state(&state);
+        runtime.resolve_command_with_presence(&payload, &access, Some(&active_direct_actors))
     };
 
     let presence_events = if was_active {
@@ -29694,8 +29635,8 @@ async fn command_inner(
     }
 }
 
-async fn complete_resident_reply(state: &AppState, plan: ResidentReplyPlan) -> Result<(), String> {
-    let proposal = match resident_reply_intent(state.ai_config.as_ref().as_ref(), &plan).await {
+async fn complete_avatar_reply(state: &AppState, plan: AvatarReplyPlan) -> Result<(), String> {
+    let proposal = match avatar_reply_intent(state.ai_config.as_ref().as_ref(), &plan).await {
         Ok(proposal) => proposal,
         Err(error) => {
             warn!("AI resident inference failed; skipping dialogue: {}", error);
@@ -29715,10 +29656,10 @@ async fn complete_orb_chat_exchange(
     state: &AppState,
     actor_id: u64,
     target_actor_id: u64,
-    first_reply_plan: ResidentReplyPlan,
+    first_reply_plan: AvatarReplyPlan,
 ) {
     let first_proposal =
-        match resident_reply_intent(state.ai_config.as_ref().as_ref(), &first_reply_plan).await {
+        match avatar_reply_intent(state.ai_config.as_ref().as_ref(), &first_reply_plan).await {
             Ok(proposal) => proposal,
             Err(error) => {
                 warn!(
@@ -29827,7 +29768,7 @@ async fn complete_orb_chat_exchange(
         return;
     };
     let closing_proposal =
-        match resident_reply_intent(state.ai_config.as_ref().as_ref(), &closing_plan).await {
+        match avatar_reply_intent(state.ai_config.as_ref().as_ref(), &closing_plan).await {
             Ok(proposal) => proposal,
             Err(error) => {
                 warn!(
@@ -29849,23 +29790,23 @@ async fn complete_orb_chat_exchange(
 fn commit_resident_reply_record(
     state: &AppState,
     runtime: &mut RuntimeWorld,
-    plan: &ResidentReplyPlan,
-    mut proposal: ResidentIntentProposal,
+    plan: &AvatarReplyPlan,
+    mut proposal: AvatarIntentProposal,
 ) -> Option<Vec<EventView>> {
-    let speaker = runtime.actor_by_id(plan.npc_actor_id)?;
-    if speaker.status != CW_ACTOR_ACTIVE || !matches!(speaker.kind, CW_ACTOR_NPC | CW_ACTOR_HUMAN) {
+    let speaker = runtime.actor_by_id(plan.speaker_actor_id)?;
+    if !RuntimeWorld::actor_is_active_avatar(speaker) {
         return None;
     }
-    if speaker.kind == CW_ACTOR_NPC {
+    if runtime.actor_uses_inference(speaker.id) {
         proposal = runtime.collision_safe_resident_proposal(plan, proposal)?;
     } else {
         proposal.speech =
-            runtime.collision_safe_avatar_followup(plan.npc_actor_id, &proposal.speech)?;
+            runtime.collision_safe_avatar_followup(plan.speaker_actor_id, &proposal.speech)?;
     }
     let content_id = runtime.next_content_id_value();
     let action = CwAction {
         kind: CW_ACTION_SAY,
-        actor_id: plan.npc_actor_id,
+        actor_id: plan.speaker_actor_id,
         content_id,
         ..CwAction::default()
     };
@@ -29877,11 +29818,11 @@ fn commit_resident_reply_record(
     record
         .content_upserts
         .insert(content_id, proposal.speech.clone());
-    if speaker.kind == CW_ACTOR_NPC {
+    if runtime.actor_uses_inference(speaker.id) {
         record
             .projection_mutations
             .push(ProjectionMutation::UpdateResidentContinuity {
-                resident_id: plan.npc_actor_id,
+                resident_id: plan.speaker_actor_id,
                 proposal,
                 reason: "resident_intent".to_string(),
             });
@@ -29915,10 +29856,14 @@ fn append_action_receipt(
     events: &mut Vec<EventView>,
 ) {
     let access = AccessContext::for_linked_actor_receipt(state, actor_id);
-    let active_humans = active_turn_actor_ids_for_state(state);
-    let mut next_state =
-        runtime.state_response_with_presence(Some(actor_id), &access, Some(&active_humans), false);
-    next_state.turn = actor_room_turn_view(state, runtime, actor_id, &active_humans)
+    let active_direct_actors = active_turn_actor_ids_for_state(state);
+    let mut next_state = runtime.state_response_with_presence(
+        Some(actor_id),
+        &access,
+        Some(&active_direct_actors),
+        false,
+    );
+    next_state.turn = actor_room_turn_view(state, runtime, actor_id, &active_direct_actors)
         .unwrap_or_else(|| RoomTurnView::idle(next_state.location.id));
     let Ok(content) = serde_json::to_string(&serde_json::json!({
         "world_tick": runtime.world.tick,
@@ -29996,7 +29941,8 @@ fn player_tick_observation(
 async fn complete_player_tick_observation(
     state: &AppState,
     observation: PlayerTickObservation,
-) -> Result<Option<ResidentReplyPlan>, String> {
+) -> Result<Option<AvatarReplyPlan>, String> {
+    let active_direct_actor_ids = active_actor_ids_for_state(state);
     let (ripple_events, reply_plan) = {
         let mut runtime = state.inner.lock().await;
         // A worker may be reclaimed after its reaction committed but before the
@@ -30008,20 +29954,26 @@ async fn complete_player_tick_observation(
         runtime.observe_player_tick_for_autonomy(&observation);
         let card_reaction_plan = if observation.allow_ordinary_speech {
             runtime
-                .next_resident_card_reaction_plan(
+                .next_room_card_reaction_plan(
                     observation.source_actor_id,
                     &observation.source_events,
+                    Some(&active_direct_actor_ids),
                 )
                 .map(|plan| plan.with_observation(&observation))
         } else {
             runtime.direct_observation_reply_plan(&observation)
         }
         .filter(|plan| {
-            runtime.autonomy_allows_action(
-                plan.npc_actor_id,
-                CW_ACTION_SAY,
-                observation.source_world_tick,
-            )
+            runtime
+                .actor_by_id(plan.speaker_actor_id)
+                .is_some_and(|actor| {
+                    !runtime.actor_uses_inference(actor.id)
+                        || runtime.autonomy_allows_action(
+                            plan.speaker_actor_id,
+                            CW_ACTION_SAY,
+                            observation.source_world_tick,
+                        )
+                })
         });
         let source_action_kind = observation
             .ripple_source
@@ -30067,17 +30019,7 @@ async fn complete_player_tick_observation(
                             .then(|| runtime.resident_economy_action_reply_plan(&action))
                             .flatten()
                             .map(|plan| plan.with_observation(&observation));
-                        let player_was_only_available_speaker =
-                            card_reaction_plan.as_ref().is_some_and(|plan| {
-                                runtime
-                                    .actor_by_id(plan.npc_actor_id)
-                                    .is_some_and(|actor| actor.kind == CW_ACTOR_HUMAN)
-                            });
-                        let reply = if player_was_only_available_speaker {
-                            ripple_reply_plan.or(card_reaction_plan)
-                        } else {
-                            card_reaction_plan.or(ripple_reply_plan)
-                        };
+                        let reply = card_reaction_plan.or(ripple_reply_plan);
                         (events, reply)
                     }
                     Ok((_status, _events)) => (Vec::new(), card_reaction_plan),
@@ -30122,7 +30064,7 @@ fn schedule_player_tick_observation(state: &AppState, observation: PlayerTickObs
         tokio::time::sleep(Duration::from_millis(CARD_REACTION_HEARTBEAT_DELAY_MS)).await;
         match complete_player_tick_observation(&state, observation).await {
             Ok(Some(plan)) => {
-                if let Err(error) = complete_resident_reply(&state, plan).await {
+                if let Err(error) = complete_avatar_reply(&state, plan).await {
                     warn!("asynchronous resident dialogue failed: {}", error);
                 }
             }
@@ -30269,7 +30211,7 @@ async fn run_actor_job_worker(state: AppState, claimed_kind: &'static str) {
                                 let reply_path = path.to_path_buf();
                                 let reply_job = job.clone();
                                 tokio::spawn(async move {
-                                    match complete_resident_reply(&reply_state, plan).await {
+                                    match complete_avatar_reply(&reply_state, plan).await {
                                         Ok(()) => {
                                             if let Err(error) =
                                                 complete_actor_job(&reply_path, reply_job.id)
@@ -30461,7 +30403,7 @@ async fn maybe_emit_ambient_event(state: AppState) {
             broadcast_events(&state, &events);
         }
         if let Some(plan) = reply_plan {
-            let _ = complete_resident_reply(&state, plan).await;
+            let _ = complete_avatar_reply(&state, plan).await;
         }
         return;
     }
@@ -30473,7 +30415,7 @@ async fn maybe_emit_ambient_event(state: AppState) {
     };
     drop(runtime);
 
-    let proposal = match request_ai_resident_intent(&config, &plan).await {
+    let proposal = match request_ai_avatar_intent(&config, &plan).await {
         Ok(proposal) => proposal,
         Err(error) => {
             warn!(
@@ -30488,15 +30430,15 @@ async fn maybe_emit_ambient_event(state: AppState) {
     if state.quiet_for() < state.ambient.quiet_after {
         return;
     }
-    let Some(npc) = runtime.actor_by_id(plan.npc_actor_id) else {
+    let Some(speaker) = runtime.actor_by_id(plan.speaker_actor_id) else {
         return;
     };
-    if npc.kind != CW_ACTOR_NPC || npc.status != CW_ACTOR_ACTIVE {
+    if !RuntimeWorld::actor_is_active_avatar(speaker) || !runtime.actor_uses_inference(speaker.id) {
         return;
     }
     if runtime.resident_reply_repeats_recent_event(
-        plan.npc_actor_id,
-        npc.location_id,
+        plan.speaker_actor_id,
+        speaker.location_id,
         &proposal.speech,
     ) {
         return;
@@ -30504,7 +30446,7 @@ async fn maybe_emit_ambient_event(state: AppState) {
     let content_id = runtime.next_content_id_value();
     let action = CwAction {
         kind: CW_ACTION_SAY,
-        actor_id: plan.npc_actor_id,
+        actor_id: plan.speaker_actor_id,
         content_id,
         ..CwAction::default()
     };
@@ -30515,7 +30457,7 @@ async fn maybe_emit_ambient_event(state: AppState) {
     record
         .projection_mutations
         .push(ProjectionMutation::UpdateResidentContinuity {
-            resident_id: plan.npc_actor_id,
+            resident_id: plan.speaker_actor_id,
             proposal,
             reason: "resident_ambient_intent".to_string(),
         });
@@ -32003,7 +31945,7 @@ fn push_resident_continuity_note(
     notes.truncate(8);
 }
 
-fn resident_proposed_action_intent(action: &ResidentProposedAction) -> Option<String> {
+fn resident_proposed_action_intent(action: &AvatarProposedAction) -> Option<String> {
     let kind = sanitize_continuity_note_text(Some(&action.kind))?;
     let mut parts = vec![format!("propose {kind}")];
     if let Some(target_actor_id) = action.target_actor_id {
@@ -32025,10 +31967,7 @@ fn sanitize_avatar_chat(text: &str) -> Option<String> {
     cosyworld_ai_model::sanitize_avatar_chat(text)
 }
 
-fn parse_resident_intent_json(
-    text: &str,
-    plan: &ResidentReplyPlan,
-) -> Option<ResidentIntentProposal> {
+fn parse_resident_intent_json(text: &str, plan: &AvatarReplyPlan) -> Option<AvatarIntentProposal> {
     let cleaned = text
         .trim()
         .trim_start_matches("```json")
@@ -32048,13 +31987,13 @@ fn parse_resident_intent_json(
 
 fn resident_intent_from_json_value(
     value: &serde_json::Value,
-    plan: &ResidentReplyPlan,
-) -> Option<ResidentIntentProposal> {
+    plan: &AvatarReplyPlan,
+) -> Option<AvatarIntentProposal> {
     let speech = value
         .get("speech")
         .and_then(|value| value.as_str())
         .and_then(|speech| sanitize_resident_reply(plan, speech))?;
-    Some(ResidentIntentProposal {
+    Some(AvatarIntentProposal {
         speech,
         intent: sanitize_continuity_note_text(value.get("intent").and_then(|value| value.as_str())),
         belief: sanitize_continuity_note_text(value.get("belief").and_then(|value| value.as_str())),
@@ -32073,7 +32012,7 @@ fn resident_intent_from_json_value(
 
 fn resident_proposed_action_from_json_value(
     value: &serde_json::Value,
-) -> Option<ResidentProposedAction> {
+) -> Option<AvatarProposedAction> {
     if value.is_null() {
         return None;
     }
@@ -32094,7 +32033,7 @@ fn resident_proposed_action_from_json_value(
     ) {
         return None;
     }
-    Some(ResidentProposedAction {
+    Some(AvatarProposedAction {
         kind,
         target_actor_id: value
             .get("target_actor_id")
@@ -32107,11 +32046,11 @@ fn resident_proposed_action_from_json_value(
     })
 }
 
-fn sanitize_resident_reply(plan: &ResidentReplyPlan, text: &str) -> Option<String> {
+fn sanitize_resident_reply(plan: &AvatarReplyPlan, text: &str) -> Option<String> {
     cosyworld_ai_model::sanitize_resident_reply(
         &ResidentReplyModelInput {
-            npc_actor_id: plan.npc_actor_id,
-            npc_name: plan.npc_name.clone(),
+            npc_actor_id: plan.speaker_actor_id,
+            npc_name: plan.speaker_name.clone(),
             speech_mode: plan.speech_mode.clone(),
             user_text: plan.user_text.clone(),
         },
@@ -32980,8 +32919,7 @@ async fn influence(
         runtime
             .actor_by_id(payload.target_actor_id)
             .is_some_and(|target| {
-                target.kind == CW_ACTOR_NPC
-                    && target.status == CW_ACTOR_ACTIVE
+                RuntimeWorld::actor_is_active_avatar(target)
                     && target.location_id == actor.location_id
                     && runtime
                         .default_chat_target(payload.actor_id)
@@ -33148,7 +33086,7 @@ async fn give_item(
             return client_actor_rejected_response();
         }
         if runtime
-            .resident_gift_is_willing(
+            .actor_gift_is_legal(
                 payload.actor_id,
                 payload.target_actor_id.unwrap_or(0),
                 payload.item_id,
@@ -34875,8 +34813,8 @@ async fn create_bond(
             events: Vec::new(),
         });
     };
-    if target.kind != CW_ACTOR_NPC
-        || target.status != CW_ACTOR_ACTIVE
+    if target.id == actor.id
+        || !RuntimeWorld::actor_is_active_avatar(target)
         || target.location_id != actor.location_id
         || runtime
             .active_bond(payload.actor_id, payload.target_actor_id)
@@ -34987,8 +34925,8 @@ async fn revise_bond(
             events: Vec::new(),
         });
     };
-    if target.kind != CW_ACTOR_NPC
-        || target.status != CW_ACTOR_ACTIVE
+    if target.id == actor.id
+        || !RuntimeWorld::actor_is_active_avatar(target)
         || target.location_id != actor.location_id
     {
         return Json(ActionResponse {
@@ -35114,8 +35052,8 @@ async fn resolve_bond(
             events: Vec::new(),
         });
     };
-    if target.kind != CW_ACTOR_NPC
-        || target.status != CW_ACTOR_ACTIVE
+    if target.id == actor.id
+        || !RuntimeWorld::actor_is_active_avatar(target)
         || target.location_id != actor.location_id
         || active_bond.strength < BOND_SETTLE_MIN_STRENGTH
     {
@@ -35227,7 +35165,7 @@ async fn apply_journey_transition_with_hosted_access(
     if !client_actor_authorized_for_state(&runtime, &state, actor_id, actor_session) {
         return client_actor_rejected_response();
     }
-    let released_events = release_inactive_human_inventory_locked(&state, &mut runtime);
+    let released_events = release_inactive_direct_inventory_locked(&state, &mut runtime);
     let turn_location_id = runtime.actor_by_id(actor_id).map(|actor| actor.location_id);
     let turn_action = CwAction {
         kind: turn_action_kind,
@@ -35310,7 +35248,7 @@ async fn apply_and_broadcast_with_resident_reply_and_hosted_access(
             events: Vec::new(),
         });
     }
-    let released_events = release_inactive_human_inventory_locked(&state, &mut runtime);
+    let released_events = release_inactive_direct_inventory_locked(&state, &mut runtime);
     let turn_location_id = runtime.actor_by_id(actor_id).map(|actor| actor.location_id);
     if let Some(response) = actor_action_turn_rejection(&state, &runtime, &action) {
         drop(runtime);
@@ -37597,13 +37535,13 @@ fn commit_journal_record(
                 let actor_location_id = runtime
                     .actor_by_id(record.action.actor_id)
                     .map(|actor| actor.location_id);
-                let co_present_human_count = actor_location_id
+                let co_present_direct_actor_count = actor_location_id
                     .map(|location_id| {
                         runtime.world.actors[..runtime.world.actor_count]
                             .iter()
                             .filter(|actor| {
-                                actor.kind == CW_ACTOR_HUMAN
-                                    && actor.status == CW_ACTOR_ACTIVE
+                                RuntimeWorld::actor_is_active_avatar(**actor)
+                                    && !runtime.actor_uses_inference(actor.id)
                                     && actor.location_id == location_id
                                     && active_actor_ids.contains(&actor.id)
                             })
@@ -37615,7 +37553,7 @@ fn commit_journal_record(
                     runtime,
                     &record,
                     &events,
-                    co_present_human_count,
+                    co_present_direct_actor_count,
                     commit_time,
                 ) {
                     warn!(
@@ -45487,7 +45425,7 @@ mod tests {
         assert!(INDEX_HTML.contains("your friendship with ${firstTargetName} begins"));
         assert!(INDEX_HTML.contains("const giftCandidates = []"));
         assert!(INDEX_HTML.contains("Choose who receives"));
-        assert!(INDEX_HTML.contains("the chosen resident keeps the chosen item"));
+        assert!(INDEX_HTML.contains("the chosen avatar keeps the chosen item"));
         assert!(INDEX_HTML.contains("giveAction.selectedPayload"));
         assert!(INDEX_HTML.contains("function mergeDuplicateUseCards"));
         assert!(INDEX_HTML.contains("useChoiceKind: \"mixed\""));
@@ -45499,11 +45437,15 @@ mod tests {
         assert!(INDEX_HTML.contains("card: cardForLocation(exit.destination_location_id)"));
         assert!(INDEX_HTML
             .contains("card: cardForItem(candidate.item.id) || cardForActor(candidate.target.id)"));
-        assert!(INDEX_HTML.contains("target.resident_economy?.request"));
-        assert!(INDEX_HTML.contains("target.resident_economy?.trade_offer"));
+        assert!(INDEX_HTML.contains("target.economy?.request"));
+        assert!(INDEX_HTML.contains("target.economy?.trade_offer"));
         assert!(INDEX_HTML.contains("economy.trade_stance"));
-        assert!(INDEX_HTML.contains("function residentEconomyPanelHtml"));
-        assert!(INDEX_HTML.contains("actor?.resident_economy"));
+        assert!(INDEX_HTML.contains("function actorEconomyPanelHtml"));
+        assert!(INDEX_HTML.contains("actor?.economy"));
+        assert!(INDEX_HTML.contains("function actorControlModeLabel"));
+        assert!(INDEX_HTML.contains("controller\", escapeHtml(controller)"));
+        assert!(INDEX_HTML.contains("return actors.map((actor) =>"));
+        assert!(!INDEX_HTML.contains("room-avatar-more"));
         assert!(INDEX_HTML.contains("economy.inventory_count"));
         assert!(INDEX_HTML.contains("economy.carrying_capacity_tenths"));
         assert!(INDEX_HTML.contains("economy.held_items"));
@@ -46203,7 +46145,7 @@ mod tests {
             Some("moderation bearer token required")
         );
 
-        let non_human_suspend = moderation_suspend_actor(
+        let inference_controlled_suspend = moderation_suspend_actor(
             headers.clone(),
             State(state.clone()),
             AxumPath(1001),
@@ -46213,11 +46155,11 @@ mod tests {
         )
         .await
         .0;
-        assert!(!non_human_suspend.ok);
-        assert_eq!(non_human_suspend.status, 404);
+        assert!(!inference_controlled_suspend.ok);
+        assert_eq!(inference_controlled_suspend.status, 404);
         assert_eq!(
-            non_human_suspend.error.as_deref(),
-            Some("actor was not found or is not a human avatar")
+            inference_controlled_suspend.error.as_deref(),
+            Some("actor was not found or is not directly controlled")
         );
 
         let suspended = moderation_suspend_actor(
@@ -46798,7 +46740,7 @@ mod tests {
 
         let state = test_app_state(runtime, None);
         let mut runtime = state.inner.lock().await;
-        let events = release_inactive_human_inventory_locked(&state, &mut runtime);
+        let events = release_inactive_direct_inventory_locked(&state, &mut runtime);
 
         assert!(events.iter().any(|event| {
             event.type_name == "item.dropped"
@@ -46930,7 +46872,7 @@ mod tests {
         drop(conn);
 
         let mut runtime = state.inner.lock().await;
-        let events = release_inactive_human_inventory_locked(&state, &mut runtime);
+        let events = release_inactive_direct_inventory_locked(&state, &mut runtime);
 
         assert!(events.is_empty());
         assert!(runtime.world.items[..runtime.world.item_count]
@@ -48338,7 +48280,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resident_gameplay_turn_waits_for_the_card_heartbeat_not_ai_speech() {
+    async fn inference_gameplay_turn_waits_for_the_card_heartbeat_not_ai_speech() {
         let mut runtime = RuntimeWorld::seeded();
         hide_seed_items(&mut runtime);
         let mut create = CwAction::default();
@@ -48356,6 +48298,24 @@ mod tests {
             },
         );
         assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+        runtime.resident_memories.clear();
+        let sought_item_id =
+            evolution_track_item_ids(RATI_ACTOR_ID).expect("Rati has evolution items")[0];
+        for item in &mut runtime.world.items[..runtime.world.item_count] {
+            if item.id == sought_item_id {
+                item.location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
+                item.holder_actor_id = 0;
+            }
+        }
+        runtime.remember_resident_memory(
+            RATI_ACTOR_ID,
+            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            sought_item_id,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
+            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            Some(RATI_ACTOR_ID),
+        );
 
         let state = test_app_state(runtime, None);
         let (actor_session, _) = issue_actor_session(&state, 5000);
@@ -48391,7 +48351,7 @@ mod tests {
                                 | "item.used"
                         )
                 }),
-                "resident consequence should wait for the next room heartbeat"
+                "inference consequence should wait for the next room heartbeat"
             );
         }
         let resident_action = tokio::time::timeout(Duration::from_secs(5), async {
@@ -48420,7 +48380,7 @@ mod tests {
             }
         })
         .await
-        .expect("resident gameplay should follow the delayed heartbeat without waiting on AI");
+        .expect("inference gameplay should follow the delayed heartbeat without waiting on AI");
         assert!(resident_action.is_some());
         assert!(!response.events.iter().any(|event| {
             event.type_name == "message.created"
@@ -48430,9 +48390,15 @@ mod tests {
     }
 
     #[test]
-    fn card_reactions_cycle_through_resident_card_order() {
+    fn card_reactions_cycle_through_present_avatar_card_order() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Card Player");
+        create_test_human(
+            &mut runtime,
+            5001,
+            COSY_COTTAGE_LOCATION_ID,
+            "Neighbour Player",
+        );
         runtime.event_log.push(EventView {
             seq: 700,
             type_name: "item.picked_up".to_string(),
@@ -48455,7 +48421,7 @@ mod tests {
         let first = runtime
             .next_resident_card_reaction_plan(5000, &card_events)
             .expect("a resident should react to the card");
-        assert_eq!(first.npc_actor_id, RATI_ACTOR_ID);
+        assert_eq!(first.speaker_actor_id, RATI_ACTOR_ID);
         assert!(first.user_text.contains("searched"));
         assert!(
             first
@@ -48476,7 +48442,7 @@ mod tests {
         let second = runtime
             .next_resident_card_reaction_plan(5000, &card_events)
             .expect("the next resident should react");
-        assert_eq!(second.npc_actor_id, WHISKERWIND_ACTOR_ID);
+        assert_eq!(second.speaker_actor_id, WHISKERWIND_ACTOR_ID);
         assert_eq!(second.speech_mode, "emoji_only");
 
         runtime.event_log.push(EventView {
@@ -48489,15 +48455,52 @@ mod tests {
         });
         let third = runtime
             .next_resident_card_reaction_plan(5000, &card_events)
-            .expect("resident card order should continue");
-        assert_eq!(third.npc_actor_id, SKULL_ACTOR_ID);
+            .expect("avatar card order should continue");
+        assert_eq!(third.speaker_actor_id, SKULL_ACTOR_ID);
         assert_eq!(third.user_text, first.user_text);
+
+        runtime.event_log.push(EventView {
+            type_name: "message.created".to_string(),
+            success: true,
+            actor_id: Some(SKULL_ACTOR_ID),
+            location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            content: Some("Skull reacts.".to_string()),
+            ..EventView::default()
+        });
+        let fourth = runtime
+            .next_resident_card_reaction_plan(5000, &card_events)
+            .expect("the acting direct avatar should join the rotation");
+        assert_eq!(fourth.speaker_actor_id, 5000);
+        assert_eq!(
+            fourth.economy_note,
+            DIRECTLY_CONTROLLED_SELF_REACTION_CONTEXT
+        );
+
+        runtime.event_log.push(EventView {
+            type_name: "message.created".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            content: Some("Card Player reacts.".to_string()),
+            ..EventView::default()
+        });
+        let fifth = runtime
+            .next_resident_card_reaction_plan(5000, &card_events)
+            .expect("the other direct avatar should join the rotation");
+        assert_eq!(fifth.speaker_actor_id, 5001);
+        assert_eq!(fifth.economy_note, DIRECTLY_CONTROLLED_REACTION_CONTEXT);
     }
 
     #[test]
-    fn human_control_mode_never_speaks_for_the_player_avatar() {
+    fn present_direct_avatars_can_speak_for_players_on_room_heartbeat() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Card Player");
+        create_test_human(
+            &mut runtime,
+            5001,
+            COSY_COTTAGE_LOCATION_ID,
+            "Neighbour Player",
+        );
         for actor in &mut runtime.world.actors[..runtime.world.actor_count] {
             if actor.kind == CW_ACTOR_NPC && actor.location_id == COSY_COTTAGE_LOCATION_ID {
                 actor.location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
@@ -48512,9 +48515,36 @@ mod tests {
             ..EventView::default()
         }];
 
-        assert!(runtime
-            .next_resident_card_reaction_plan(5000, &card_events)
-            .is_none());
+        let active_direct_actors = BTreeSet::from([5000, 5001]);
+        let acting_avatar = runtime
+            .next_room_card_reaction_plan(5000, &card_events, Some(&active_direct_actors))
+            .expect("the acting avatar should answer");
+        assert_eq!(acting_avatar.speaker_actor_id, 5000);
+        assert_eq!(
+            acting_avatar.economy_note,
+            DIRECTLY_CONTROLLED_SELF_REACTION_CONTEXT
+        );
+        assert!(resident_system_prompt(&acting_avatar).contains("Speak briefly on behalf"));
+
+        runtime.event_log.push(EventView {
+            type_name: "message.created".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            content: Some("I heard it too.".to_string()),
+            ..EventView::default()
+        });
+        let other_avatar = runtime
+            .next_room_card_reaction_plan(5000, &card_events, Some(&active_direct_actors))
+            .expect("the other present direct avatar should answer next");
+        assert_eq!(other_avatar.speaker_actor_id, 5001);
+        assert_eq!(
+            other_avatar.economy_note,
+            DIRECTLY_CONTROLLED_REACTION_CONTEXT
+        );
+        assert!(
+            resident_system_prompt(&other_avatar).contains("Do not impersonate the acting avatar")
+        );
     }
 
     #[test]
@@ -48633,7 +48663,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_resident_follows_a_player_into_an_empty_adjacent_room() {
+    async fn inference_does_not_invent_an_off_surface_follow_move() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Path Player");
         hide_seed_items(&mut runtime);
@@ -48692,15 +48722,10 @@ mod tests {
         assert_eq!(
             runtime
                 .actor_by_id(RATI_ACTOR_ID)
-                .expect("Rati followed the path asynchronously")
+                .expect("Rati remains governed by the shared action surface")
                 .location_id,
-            RAIN_SOFT_GARDEN_LOCATION_ID
+            COSY_COTTAGE_LOCATION_ID
         );
-        assert!(runtime.event_log.iter().any(|event| {
-            event.type_name == "actor.moved"
-                && event.actor_id == Some(RATI_ACTOR_ID)
-                && event.destination_location_id == Some(RAIN_SOFT_GARDEN_LOCATION_ID)
-        }));
         assert_eq!(
             runtime
                 .event_log
@@ -48711,8 +48736,8 @@ mod tests {
                         && event.destination_location_id == Some(RAIN_SOFT_GARDEN_LOCATION_ID)
                 })
                 .count(),
-            1,
-            "reclaiming the same observation must not repeat its consequence"
+            0,
+            "an inference controller cannot add a follow move outside the shared candidates"
         );
     }
 
@@ -48757,7 +48782,7 @@ mod tests {
             let reply = runtime
                 .next_resident_card_reaction_plan(5000, &events)
                 .unwrap_or_else(|| panic!("{type_name} should promise a resident reaction"));
-            assert_eq!(reply.npc_actor_id, RATI_ACTOR_ID, "{type_name}");
+            assert_eq!(reply.speaker_actor_id, RATI_ACTOR_ID, "{type_name}");
         }
     }
 
@@ -49049,7 +49074,7 @@ mod tests {
                 actor.location_id = OLD_OAK_TREE_LOCATION_ID;
             }
         }
-        assert!(!runtime.has_active_resident_at(COSY_COTTAGE_LOCATION_ID));
+        assert!(!runtime.has_active_inference_actor_at(COSY_COTTAGE_LOCATION_ID));
         let state = test_app_state(runtime, None);
         let mut broadcasts = state.tx.subscribe();
 
@@ -49100,7 +49125,7 @@ mod tests {
     async fn avatar_creation_brings_rati_home_even_when_other_hosts_are_present() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.force_actor_location(RATI_ACTOR_ID, 10);
-        assert!(runtime.has_active_resident_at(COSY_COTTAGE_LOCATION_ID));
+        assert!(runtime.has_active_inference_actor_at(COSY_COTTAGE_LOCATION_ID));
         assert_eq!(
             runtime
                 .welcome_host_for(COSY_COTTAGE_LOCATION_ID)
@@ -49162,7 +49187,7 @@ mod tests {
         let gift = runtime
             .resident_reply_plan_for_target(5000, RATI_ACTOR_ID, "I gave you Story Button.")
             .expect("gift target can reply");
-        assert_eq!(gift.npc_actor_id, RATI_ACTOR_ID);
+        assert_eq!(gift.speaker_actor_id, RATI_ACTOR_ID);
         assert!(gift.user_text.contains("Story Button"));
 
         let contextual_reply = runtime
@@ -49554,7 +49579,7 @@ mod tests {
     }
 
     #[test]
-    fn active_presence_filters_stale_humans_without_hiding_residents() {
+    fn active_presence_filters_stale_direct_avatars_without_hiding_inference_avatars() {
         let mut runtime = RuntimeWorld::seeded();
         for (actor_id, name) in [(5000, "Active Guest"), (5001, "Gone Guest")] {
             let mut create = CwAction::default();
@@ -49574,11 +49599,11 @@ mod tests {
             assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
         }
 
-        let active_humans = BTreeSet::from([5000]);
+        let active_direct_actors = BTreeSet::from([5000]);
         let state = runtime.state_response_with_presence(
             Some(5000),
             &AccessContext::default(),
-            Some(&active_humans),
+            Some(&active_direct_actors),
             false,
         );
         assert!(state.actors.iter().any(|actor| actor.id == 5000));
@@ -49589,7 +49614,7 @@ mod tests {
             .resolve_command_with_presence(
                 &command_request(5000, "who"),
                 &AccessContext::default(),
-                Some(&active_humans),
+                Some(&active_direct_actors),
             )
             .expect("who resolves with live presence");
         match who.dispatch {
@@ -49607,7 +49632,7 @@ mod tests {
             .resolve_command_with_presence(
                 &command_request(5000, "look"),
                 &AccessContext::default(),
-                Some(&active_humans),
+                Some(&active_direct_actors),
             )
             .expect("look resolves with live presence");
         match look.dispatch {
@@ -49623,23 +49648,23 @@ mod tests {
             .resolve_command_with_presence(
                 &command_request(5000, "report Gone Guest: stale session"),
                 &AccessContext::default(),
-                Some(&active_humans),
+                Some(&active_direct_actors),
             )
-            .expect_err("stale humans are not visible report targets");
+            .expect_err("stale direct avatars are not visible report targets");
         assert_eq!(stale_report.status, 404);
 
         let world = runtime.world_response_with_presence(
             Some(5000),
             &AccessContext::default(),
-            Some(&active_humans),
+            Some(&active_direct_actors),
         );
         let cottage = world
             .locations
             .iter()
             .find(|location| location.id == 1)
             .expect("cottage location");
-        assert_eq!(cottage.human_count, 1);
-        assert!(cottage.resident_count >= 1);
+        assert_eq!(cottage.actor_count, cottage.actors.len());
+        assert!(cottage.actor_count >= 2);
         assert!(cottage.actors.iter().any(|actor| actor.id == 5000));
         assert!(!cottage.actors.iter().any(|actor| actor.id == 5001));
     }
@@ -54834,13 +54859,13 @@ mod tests {
 
         let (current_actor_id, waiting_actor_id, round, before_tick) = {
             let runtime = state.inner.lock().await;
-            let active_humans = active_turn_actor_ids_for_state(&state);
+            let active_direct_actors = active_turn_actor_ids_for_state(&state);
             let turn = room_turn_view_for_runtime(
                 &state,
                 &runtime,
                 COSY_COTTAGE_LOCATION_ID,
                 Some(5000),
-                &active_humans,
+                &active_direct_actors,
             );
             let current_actor_id = turn.current_actor_id.expect("room has a current actor");
             let waiting_actor_id = if current_actor_id == 5000 { 5001 } else { 5000 };
@@ -54908,13 +54933,13 @@ mod tests {
             .expect("Chat returns the next turn before the room heartbeat");
 
         let runtime = state.inner.lock().await;
-        let active_humans = active_turn_actor_ids_for_state(&state);
+        let active_direct_actors = active_turn_actor_ids_for_state(&state);
         let turn = room_turn_view_for_runtime(
             &state,
             &runtime,
             COSY_COTTAGE_LOCATION_ID,
             Some(current_actor_id),
-            &active_humans,
+            &active_direct_actors,
         );
         let after_card_tick = before_tick + 1;
         assert_eq!(runtime.world.tick, after_card_tick);
@@ -56953,7 +56978,7 @@ mod tests {
         );
         let garden = runtime.state_response(Some(5000), &access);
         assert_eq!(garden.location.name, "Rain-Soft Garden");
-        assert_eq!(garden.ledger.unbanked_count, 1);
+        assert!(garden.ledger.unbanked_count >= 1);
         assert!(garden
             .ledger
             .unbanked_marks
@@ -57026,8 +57051,7 @@ mod tests {
         discover_seed_exit_pair_for_test(&mut runtime, MOONLIT_TRAIL_LOCATION_ID, 2);
         let trail = runtime.state_response(Some(5000), &access);
         assert_eq!(trail.location.name, "Moonlit Trail");
-        assert_eq!(trail.primary_action.kind, "pick_up");
-        assert!(!trail
+        assert!(trail
             .primary_action
             .options
             .iter()
@@ -57083,6 +57107,11 @@ mod tests {
             .options
             .iter()
             .any(|option| option.kind == "flee"));
+        assert!(!resolved
+            .primary_action
+            .options
+            .iter()
+            .any(|option| option.kind == "give_item"));
     }
 
     #[test]
@@ -57673,7 +57702,7 @@ mod tests {
         assert!(request.reason.contains("tiny rain engine"));
         assert!(economy.motive.contains("tiny rain engine"));
         assert!(runtime
-            .resident_gift_is_willing(5000, STEAMPUNK_MOUSE_ACTOR_ID, DEWBRIGHT_BUTTON_ITEM_ID)
+            .actor_gift_is_legal(5000, STEAMPUNK_MOUSE_ACTOR_ID, DEWBRIGHT_BUTTON_ITEM_ID)
             .is_ok());
     }
 
@@ -57836,6 +57865,148 @@ mod tests {
     }
 
     #[test]
+    fn direct_avatars_share_actor_targets_and_gift_affordances() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, 2, "Button Giver");
+        create_test_human(&mut runtime, 5001, 2, "Button Receiver");
+        let item = runtime
+            .world
+            .items
+            .iter_mut()
+            .find(|item| item.id == STORY_BUTTON_ITEM_ID)
+            .expect("Story Button exists");
+        item.location_id = 0;
+        item.holder_actor_id = 5000;
+        item.held_since_tick = runtime.world.tick;
+        for (item_id, holder_actor_id) in [(2001, 5000), (DEWBRIGHT_BUTTON_ITEM_ID, 5001)] {
+            let item = runtime
+                .world
+                .items
+                .iter_mut()
+                .find(|item| item.id == item_id)
+                .expect("trade item exists");
+            item.location_id = 0;
+            item.holder_actor_id = holder_actor_id;
+            item.held_since_tick = runtime.world.tick;
+        }
+
+        let targets = runtime.active_chat_targets(5000);
+        assert_eq!(
+            targets.iter().map(|target| target.id).collect::<Vec<_>>(),
+            vec![5001]
+        );
+        let (offered_item, target) = runtime
+            .actor_give_candidate(5000)
+            .expect("a legal gift does not require a resident request");
+        assert_eq!(offered_item.holder_actor_id, 5000);
+        assert_eq!(target.id, 5001);
+        runtime
+            .actor_gift_is_legal(5000, 5001, STORY_BUTTON_ITEM_ID)
+            .expect("directly controlled avatars use the same gift rule");
+        assert!(runtime
+            .item_trade_candidates(5000)
+            .iter()
+            .any(|candidate| candidate.target.id == 5001));
+
+        let (trade_status, trade_events) = runtime.apply_journal_record(&JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_TRADE_ITEM,
+                actor_id: 5000,
+                target_actor_id: 5001,
+                item_id: 2001,
+                target_item_id: DEWBRIGHT_BUTTON_ITEM_ID,
+                ..CwAction::default()
+            },
+            78_330,
+        ));
+        assert_eq!(trade_status, CW_OK);
+        assert!(trade_events.iter().any(|event| {
+            event.type_name == "item.traded"
+                && event.actor_id == Some(5000)
+                && event.target_actor_id == Some(5001)
+        }));
+
+        let state = runtime.state_response(Some(5000), &AccessContext::default());
+        let give_offer = state
+            .action_offers
+            .iter()
+            .find(|offer| offer.kind == "give_item")
+            .expect("the shared action surface includes Give");
+        assert_eq!(
+            give_offer.target.as_ref().and_then(|target| target.id),
+            Some(5001)
+        );
+        let receiver = state
+            .actors
+            .iter()
+            .find(|actor| actor.id == 5001)
+            .expect("the other direct avatar is visible");
+        let receiver_json = serde_json::to_value(receiver).expect("actor view serializes");
+        assert_eq!(receiver_json["control_mode"], "direct_input");
+        assert!(receiver_json.get("economy").is_some());
+        assert!(receiver_json.get("resident_economy").is_none());
+
+        let (status, events) = runtime.apply_journal_record(&JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_GIVE_ITEM,
+                actor_id: 5000,
+                target_actor_id: 5001,
+                item_id: STORY_BUTTON_ITEM_ID,
+                ..CwAction::default()
+            },
+            78_331,
+        ));
+        assert_eq!(status, CW_OK);
+        assert!(events.iter().any(|event| {
+            event.type_name == "item.given"
+                && event.actor_id == Some(5000)
+                && event.target_actor_id == Some(5001)
+        }));
+    }
+
+    #[test]
+    fn controller_mode_not_actor_kind_selects_the_intelligence() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Switchable Avatar",
+        );
+        assert!(!runtime.actor_uses_inference(5000));
+        assert!(runtime.actor_uses_inference(RATI_ACTOR_ID));
+
+        runtime.ensure_actor_autonomy();
+        runtime
+            .actor_autonomy
+            .get_mut(&5000)
+            .expect("generated actor has a controller")
+            .control_mode = ActorControlMode::LocalAi;
+        runtime
+            .actor_autonomy
+            .get_mut(&RATI_ACTOR_ID)
+            .expect("authored actor has a controller")
+            .control_mode = ActorControlMode::DirectInput;
+        assert!(runtime.actor_uses_inference(5000));
+        assert!(!runtime.actor_uses_inference(RATI_ACTOR_ID));
+        assert!(!runtime.client_actor_can_submit(5000));
+        assert!(runtime.client_actor_can_submit(RATI_ACTOR_ID));
+        assert_eq!(
+            runtime.ambient_actor().map(|actor| actor.id),
+            Some(5000),
+            "the human-kind avatar is scheduled because its controller uses inference"
+        );
+
+        let legacy: ActorControlMode =
+            serde_json::from_str("\"human\"").expect("legacy snapshots remain readable");
+        assert_eq!(legacy, ActorControlMode::DirectInput);
+        assert_eq!(
+            serde_json::to_string(&legacy).expect("controller mode serializes"),
+            "\"direct_input\""
+        );
+    }
+
+    #[test]
     fn resident_waits_in_room_for_player_held_wanted_gift() {
         let mut runtime = RuntimeWorld::seeded();
         let mut create = CwAction::default();
@@ -57875,7 +58046,6 @@ mod tests {
             .expect("Skull asks for the player-held Watch Bell");
         assert_eq!(request.item_id, WATCH_BELL_ITEM_ID);
         assert!(runtime.resident_waits_for_player_gift(skull));
-        assert!(runtime.resident_wander_action(skull).is_none());
         assert!(!runtime
             .resident_economy_autonomy_action(skull)
             .is_some_and(|action| matches!(action.kind, CW_ACTION_MOVE | CW_ACTION_PICK_UP_ITEM)));
@@ -57889,7 +58059,6 @@ mod tests {
         watch_bell.holder_actor_id = 0;
         watch_bell.location_id = 0;
         assert!(!runtime.resident_waits_for_player_gift(skull));
-        assert!(runtime.resident_wander_action(skull).is_some());
     }
 
     #[test]
@@ -57901,7 +58070,6 @@ mod tests {
 
         assert_eq!(echo.location_id, MOONLIT_TRAIL_LOCATION_ID);
         assert!(runtime.resident_stays_with_active_job(echo));
-        assert!(runtime.resident_wander_action(echo).is_none());
         assert!(!runtime
             .resident_economy_autonomy_action(echo)
             .is_some_and(|action| action.kind == CW_ACTION_MOVE));
@@ -57912,7 +58080,6 @@ mod tests {
             .expect("Moonlit Trail job exists")
             .status = "completed".to_string();
         assert!(!runtime.resident_stays_with_active_job(echo));
-        assert!(runtime.resident_wander_action(echo).is_some());
     }
 
     #[test]
@@ -58340,7 +58507,7 @@ mod tests {
         assert_eq!(request.item_id, HEARTH_TONIC_ITEM_ID);
         assert!(request.reason.contains("wants Hearth Tonic back"));
         runtime
-            .resident_gift_is_willing(5000, RATI_ACTOR_ID, HEARTH_TONIC_ITEM_ID)
+            .actor_gift_is_legal(5000, RATI_ACTOR_ID, HEARTH_TONIC_ITEM_ID)
             .expect("requested non-evolution attachment can be given back");
 
         let state = runtime.state_response(Some(5000), &AccessContext::default());
@@ -58426,7 +58593,7 @@ mod tests {
             .expect("Skull notices the player-held bell");
 
         let candidate = runtime
-            .default_resident_gift_candidate(5000)
+            .default_actor_gift_candidate(5000)
             .expect("Skull's full paw should not hide the wanted gift card");
         assert_eq!(candidate.target.id, SKULL_ACTOR_ID);
         assert_eq!(candidate.offered_item.id, WATCH_BELL_ITEM_ID);
@@ -58785,13 +58952,11 @@ mod tests {
         };
         let (status, events) = runtime.apply_journal_record(&JournalRecord::new(pickup, 7832));
         assert_eq!(status, CW_OK);
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].type_name, "item.picked_up");
-        assert_eq!(events[0].item_id, Some(STORY_BUTTON_ITEM_ID));
-        assert_eq!(
-            command_response_output(None, &events).as_deref(),
-            Some("You take Story Button.")
-        );
+        assert!(events.iter().any(|event| {
+            event.type_name == "item.picked_up" && event.item_id == Some(STORY_BUTTON_ITEM_ID)
+        }));
+        assert!(command_response_output(None, &events)
+            .is_some_and(|output| output.starts_with("You take Story Button.")));
         assert!(runtime.world.items[..runtime.world.item_count]
             .iter()
             .any(|item| item.id == 2001 && item.holder_actor_id == 5000));
@@ -59062,12 +59227,12 @@ mod tests {
                 assert!(output.contains("remove <skill charm>"));
                 assert!(!output.contains("practice <knack>"));
                 assert!(output.contains("purpose <what draws you in>"));
-                assert!(output.contains("friendship <resident>"));
-                assert!(output.contains("remember <resident>"));
+                assert!(output.contains("friendship <avatar>"));
+                assert!(output.contains("remember <avatar>"));
                 assert!(!output.contains("skill <name>"));
                 assert!(!output.contains("calling <new drive>"));
-                assert!(!output.contains("bond <resident>"));
-                assert!(!output.contains("settle <resident>"));
+                assert!(!output.contains("bond <avatar>"));
+                assert!(!output.contains("settle <avatar>"));
                 assert!(!output.contains("resolve bond"));
             }
             other => panic!("help should be read-only, got {other:?}"),
@@ -59216,10 +59381,8 @@ mod tests {
         let (status, pickup_events) =
             runtime.apply_journal_record(&JournalRecord::new(pickup, 7832));
         assert_eq!(status, CW_OK);
-        assert_eq!(
-            command_response_output(None, &pickup_events).as_deref(),
-            Some("You take Dewbright Button.")
-        );
+        assert!(command_response_output(None, &pickup_events)
+            .is_some_and(|output| output.starts_with("You take Dewbright Button.")));
 
         let inventory = runtime
             .resolve_command(&command_request(5000, "inventory"), &access)
@@ -59853,7 +60016,7 @@ mod tests {
         let plan = runtime
             .ambient_reply_plan()
             .expect("ambient AI reply plan with human present");
-        assert!([1001, 1002, 1003].contains(&plan.npc_actor_id));
+        assert!([1001, 1002, 1003].contains(&plan.speaker_actor_id));
         assert_eq!(plan.location_name, "The Cosy Cottage");
         assert!(plan.user_text.contains("fresh in-character ambient beat"));
 
@@ -59872,86 +60035,6 @@ mod tests {
     }
 
     #[test]
-    fn ambient_autonomy_wanders_when_no_stronger_resident_task() {
-        let mut runtime = RuntimeWorld::seeded();
-        hide_seed_items(&mut runtime);
-        assert!(runtime.ambient_autonomy_action().is_none());
-        discover_all_seed_exits_for_test(&mut runtime);
-
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = 1;
-        let mut record = JournalRecord::new(create, 7066);
-        record.actor_meta_upserts.insert(
-            5000,
-            ActorMeta {
-                name: "Autonomy Guest".to_string(),
-                speech_mode: "prose".to_string(),
-                title: "Quiet Witness".to_string(),
-                description: "A test avatar watching a resident act.".to_string(),
-            },
-        );
-        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
-        runtime.resident_memories.clear();
-        hide_seed_items(&mut runtime);
-
-        let action = runtime
-            .ambient_autonomy_action()
-            .expect("autonomous action with human present");
-        assert_eq!(action.kind, CW_ACTION_MOVE);
-        assert!([1001, 1002, 1003].contains(&action.actor_id));
-        let public_destinations = runtime
-            .exit_views(COSY_COTTAGE_LOCATION_ID, &AccessContext::default())
-            .into_iter()
-            .filter(|exit| exit.accessible)
-            .map(|exit| exit.destination_location_id)
-            .collect::<BTreeSet<_>>();
-        assert!(public_destinations.contains(&action.destination_location_id));
-
-        let (status, events) = runtime.apply_journal_record(&JournalRecord::new(action, 7067));
-        assert_eq!(status, CW_OK);
-        assert!(events.iter().any(|event| {
-            event.type_name == "actor.moved"
-                && event.actor_id == Some(action.actor_id)
-                && event.destination_location_id == Some(action.destination_location_id)
-        }));
-    }
-
-    #[test]
-    fn resident_wander_skips_recent_return_edge() {
-        let mut runtime = RuntimeWorld::seeded();
-        hide_seed_items(&mut runtime);
-        runtime.resident_memories.clear();
-        runtime.world.tick = 0;
-
-        let actor = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
-        let first_step = runtime
-            .resident_wander_action(actor)
-            .expect("first resident wander step");
-        assert_ne!(first_step.destination_location_id, COSY_COTTAGE_LOCATION_ID);
-        let first_destination = first_step.destination_location_id;
-        assert_eq!(
-            runtime
-                .apply_journal_record(&JournalRecord::new(first_step, 7068))
-                .0,
-            CW_OK
-        );
-
-        let moved_actor = runtime
-            .actor_by_id(RATI_ACTOR_ID)
-            .expect("Rati remains after moving");
-        assert_eq!(moved_actor.location_id, first_destination);
-        let next_step = runtime
-            .resident_wander_action(moved_actor)
-            .expect("resident chooses a fresh onward step");
-        assert_ne!(
-            next_step.destination_location_id, COSY_COTTAGE_LOCATION_ID,
-            "resident should not immediately bounce back through the edge they just used"
-        );
-    }
-
-    #[test]
     fn resident_economy_autonomy_can_act_without_human_presence() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
@@ -59959,7 +60042,6 @@ mod tests {
         hide_seed_items(&mut runtime);
         assert!(runtime.ambient_line().is_none());
         assert!(runtime.ambient_reply_plan().is_none());
-        assert!(runtime.ambient_autonomy_action().is_none());
 
         let sought_item_id =
             evolution_track_item_ids(RATI_ACTOR_ID).expect("Rati has evolution items")[0];
@@ -59979,8 +60061,9 @@ mod tests {
             Some(RATI_ACTOR_ID),
         );
 
+        let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let action = runtime
-            .ambient_autonomy_action()
+            .resident_economy_autonomy_action(rati)
             .expect("resident economy can move without a human witness");
         assert_eq!(action.kind, CW_ACTION_MOVE);
         assert_eq!(action.actor_id, RATI_ACTOR_ID);
@@ -60013,8 +60096,9 @@ mod tests {
             Some(RATI_ACTOR_ID),
         );
 
+        let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let record = runtime
-            .resident_economy_autonomy_record_for_seed(70671)
+            .resident_economy_autonomy_record(rati, 70671)
             .expect("resident economy autonomy proposes a record");
         assert_eq!(record.action.kind, CW_ACTION_MOVE);
         assert!(record.projection_mutations.iter().any(|mutation| {
@@ -60057,14 +60141,14 @@ mod tests {
 
         runtime.apply_resident_intent_projection(
             RATI_ACTOR_ID,
-            &ResidentIntentProposal {
+            &AvatarIntentProposal {
                 speech: "I should step toward the garden.".to_string(),
                 intent: Some("move toward Rain-Soft Garden".to_string()),
                 belief: None,
                 desire: Some("check Rain-Soft Garden".to_string()),
                 promise: None,
                 refusal: None,
-                proposed_action: Some(ResidentProposedAction {
+                proposed_action: Some(AvatarProposedAction {
                     kind: "move".to_string(),
                     target_actor_id: None,
                     item_id: None,
@@ -60868,13 +60952,11 @@ mod tests {
             }
         }
 
-        let uninformed = runtime
-            .ambient_autonomy_action()
-            .expect("hurt resident acts without remembered medicine");
-        assert!(matches!(
-            uninformed.kind,
-            CW_ACTION_MOVE | CW_ACTION_ABILITY_CHECK
-        ));
+        let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
+        assert!(
+            runtime.resident_economy_autonomy_action(rati).is_none(),
+            "without a grounded memory, the inference controller does nothing"
+        );
 
         runtime.remember_resident_memory(
             RATI_ACTOR_ID,
@@ -60911,7 +60993,7 @@ mod tests {
         );
 
         let action = runtime
-            .ambient_autonomy_action()
+            .resident_economy_autonomy_action(rati)
             .expect("hurt resident follows remembered medicine");
         assert_eq!(action.kind, CW_ACTION_MOVE);
         assert_eq!(action.actor_id, RATI_ACTOR_ID);
@@ -61010,16 +61092,10 @@ mod tests {
         }
         runtime.resident_memories.clear();
 
-        let uninformed_action = runtime
-            .ambient_autonomy_action()
-            .expect("resident acts without omniscient item knowledge");
-        assert!(matches!(
-            uninformed_action.kind,
-            CW_ACTION_MOVE | CW_ACTION_ABILITY_CHECK
-        ));
-        if uninformed_action.kind == CW_ACTION_MOVE {
-            assert_eq!(uninformed_action.actor_id, actor.id);
-        }
+        assert!(
+            runtime.resident_economy_autonomy_action(actor).is_none(),
+            "without a grounded memory, the inference controller does nothing"
+        );
 
         runtime.remember_resident_memory(
             actor.id,
@@ -61605,7 +61681,7 @@ mod tests {
         assert!(economy.motive.contains("with Carrier Guest"));
 
         let action = runtime
-            .ambient_autonomy_action()
+            .resident_economy_autonomy_action(rati)
             .expect("resident moves toward remembered carrier");
         assert_eq!(action.kind, CW_ACTION_MOVE);
         assert_eq!(action.actor_id, RATI_ACTOR_ID);
@@ -61688,7 +61764,7 @@ mod tests {
         );
 
         let action = runtime
-            .ambient_autonomy_action()
+            .resident_economy_autonomy_action(rati)
             .expect("resident follows remembered carrier location");
         assert_eq!(action.kind, CW_ACTION_MOVE);
         assert_eq!(action.actor_id, RATI_ACTOR_ID);
@@ -62075,7 +62151,7 @@ mod tests {
         let reply_plan = runtime
             .resident_economy_action_reply_plan(&action)
             .expect("autonomous trade gets a resident reply plan");
-        assert_eq!(reply_plan.npc_actor_id, RATI_ACTOR_ID);
+        assert_eq!(reply_plan.speaker_actor_id, RATI_ACTOR_ID);
         assert!(reply_plan
             .user_text
             .contains("Rati traded Dewbright Button to Gust for Story Button"));
@@ -62340,7 +62416,7 @@ mod tests {
 
         let proposal = runtime.collision_safe_resident_proposal(
             &plan,
-            ResidentIntentProposal {
+            AvatarIntentProposal {
                 speech: repeated.to_string(),
                 intent: None,
                 belief: None,
@@ -62959,17 +63035,17 @@ mod tests {
     }
 
     fn resident_reply_test_plan(
-        npc_actor_id: u64,
-        npc_name: &str,
+        speaker_actor_id: u64,
+        speaker_name: &str,
         speech_mode: &str,
-    ) -> ResidentReplyPlan {
-        ResidentReplyPlan {
-            npc_actor_id,
-            npc_name: npc_name.to_string(),
+    ) -> AvatarReplyPlan {
+        AvatarReplyPlan {
+            speaker_actor_id,
+            speaker_name: speaker_name.to_string(),
             speech_mode: speech_mode.to_string(),
             resident_continuity: ResidentContinuityState::empty(
-                npc_actor_id,
-                format!("{npc_name} / Test Resident / speech:{speech_mode} / A test resident."),
+                speaker_actor_id,
+                format!("{speaker_name} / Test Resident / speech:{speech_mode} / A test resident."),
             ),
             economy_note: "Resident economy: open to useful gifts and trades.".to_string(),
             goals: Vec::new(),
@@ -62978,7 +63054,7 @@ mod tests {
             location_description: "A warm room of firelight.".to_string(),
             location_persona: "The cottage is a careful host.".to_string(),
             location_memory: Vec::new(),
-            cast: vec![npc_name.to_string()],
+            cast: vec![speaker_name.to_string()],
             recent_lines: Vec::new(),
             recent_activity: Vec::new(),
             user_text: "weather?".to_string(),
@@ -62998,8 +63074,8 @@ mod tests {
         );
         assert!(sanitize_resident_reply(&plan, "rain rain").is_none());
 
-        plan.npc_actor_id = 1003;
-        plan.npc_name = "Skull".to_string();
+        plan.speaker_actor_id = 1003;
+        plan.speaker_name = "Skull".to_string();
         plan.speech_mode = "emote_only".to_string();
         assert_eq!(
             sanitize_resident_reply(&plan, "Skull watches the door.").as_deref(),
@@ -63007,8 +63083,8 @@ mod tests {
         );
         assert!(sanitize_resident_reply(&plan, "\"I hear you.\"").is_none());
 
-        plan.npc_actor_id = 1001;
-        plan.npc_name = "Rati".to_string();
+        plan.speaker_actor_id = 1001;
+        plan.speaker_name = "Rati".to_string();
         plan.speech_mode = "prose".to_string();
         assert!(sanitize_resident_reply(&plan, "As an AI model, I cannot.").is_none());
         assert_eq!(
@@ -63114,14 +63190,14 @@ mod tests {
         let mut runtime = RuntimeWorld::seeded();
         runtime.resident_continuities.clear();
 
-        let proposal = ResidentIntentProposal {
+        let proposal = AvatarIntentProposal {
             speech: "I will keep one stitch open for the room.".to_string(),
             intent: Some("listen for the next room need".to_string()),
             belief: Some("the cottage is waiting on a small kindness".to_string()),
             desire: Some("find who needs Moonwool Thread".to_string()),
             promise: Some("keep one stitch open".to_string()),
             refusal: Some("do not pretend the button has already moved".to_string()),
-            proposed_action: Some(ResidentProposedAction {
+            proposed_action: Some(AvatarProposedAction {
                 kind: "search".to_string(),
                 target_actor_id: None,
                 item_id: Some(DEWBRIGHT_BUTTON_ITEM_ID),
@@ -63264,7 +63340,7 @@ mod tests {
         runtime.resident_continuities.clear();
         runtime.apply_resident_intent_projection(
             RATI_ACTOR_ID,
-            &ResidentIntentProposal {
+            &AvatarIntentProposal {
                 speech: "I will keep one stitch open for the room.".to_string(),
                 intent: Some("listen for the next room need".to_string()),
                 belief: Some("the cottage is waiting on a small kindness".to_string()),
@@ -63447,7 +63523,7 @@ mod tests {
         let reply_plan = runtime
             .resident_reply_plan_for_target(5000, 1002, &line)
             .expect("chosen resident reply plan");
-        assert_eq!(reply_plan.npc_actor_id, 1002);
+        assert_eq!(reply_plan.speaker_actor_id, 1002);
         assert_eq!(reply_plan.speech_mode, "emoji_only");
     }
 
@@ -63590,7 +63666,7 @@ mod tests {
         let state = runtime.state_response(Some(5000), &access);
         assert_eq!(state.bonds.len(), 1);
         assert_eq!(state.bonds[0].strength, 1);
-        assert_eq!(state.ledger.unbanked_count, 1);
+        assert!(state.ledger.unbanked_count >= 1);
         let whiskerwind = state
             .actors
             .iter()
@@ -63640,6 +63716,12 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.type_name == "ledger.banked"));
+        let advancement_before_revision = runtime
+            .state_response(Some(5000), &access)
+            .ledger
+            .advancement_points;
+        let revision_cost = usize::from(BOND_REVISION_COST);
+        assert!(advancement_before_revision >= revision_cost);
 
         let revise_command = runtime
             .resolve_command(
@@ -63687,9 +63769,12 @@ mod tests {
         let revised_state = runtime.state_response(Some(5000), &access);
         assert_eq!(revised_state.bonds.len(), 1);
         assert_eq!(revised_state.bonds[0].statement, revised_statement);
-        assert_eq!(revised_state.ledger.banked_count, 1);
+        assert!(revised_state.ledger.banked_count >= 1);
         assert_eq!(revised_state.ledger.spent_count, 1);
-        assert_eq!(revised_state.ledger.advancement_points, 0);
+        assert_eq!(
+            revised_state.ledger.advancement_points,
+            advancement_before_revision - revision_cost
+        );
 
         let repeat_revision = runtime
             .resolve_command(
@@ -63700,7 +63785,7 @@ mod tests {
         match repeat_revision.dispatch {
             CommandDispatch::Disabled { status, output } => {
                 assert_eq!(status, 409);
-                assert!(output.contains("Grow first"));
+                assert!(!output.trim().is_empty());
             }
             other => panic!("same bond revision should be disabled, got {other:?}"),
         }

--- a/v2/orchestrator-rust/src/moderation.rs
+++ b/v2/orchestrator-rust/src/moderation.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use std::{io, path::Path, time::Duration};
 use tracing::{error, info, warn};
 
-use crate::kernel::CW_ACTOR_HUMAN;
 use crate::{
     active_actor_ids_for_state, clear_actor_sessions_for_actor, commit_presence_event,
     delete_actor_sessions_for_actor, delete_actor_suspension, deployment_config_error,
@@ -916,12 +915,9 @@ pub(crate) async fn moderation_suspend_actor(
         );
     }
     let runtime = state.inner.lock().await;
-    let is_human = runtime
-        .actor_by_id(actor_id)
-        .map(|actor| actor.kind == CW_ACTOR_HUMAN)
-        .unwrap_or(false);
+    let is_directly_controlled = runtime.client_actor_can_submit(actor_id);
     drop(runtime);
-    if !is_human {
+    if !is_directly_controlled {
         return moderation_actor_response(
             false,
             404,
@@ -929,7 +925,7 @@ pub(crate) async fn moderation_suspend_actor(
             false,
             None,
             None,
-            Some("actor was not found or is not a human avatar".to_string()),
+            Some("actor was not found or is not directly controlled".to_string()),
         );
     }
 

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -174,7 +174,7 @@ pub(crate) struct CommandError {
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum CommandActorFilter {
     Any,
-    ActiveNpc,
+    ActiveActor,
 }
 
 pub(crate) fn normalize_command_text(input: &str) -> String {
@@ -633,13 +633,13 @@ pub(crate) fn command_event_output(event: &EventView) -> Option<String> {
         "item.theft_attempt" if !event.success => Some(format!(
             "You fail to take {} from {}; possession does not change, and the attempt is noticed.",
             event.item_name.as_deref().unwrap_or("the item"),
-            event.target_actor_name.as_deref().unwrap_or("the resident")
+            event.target_actor_name.as_deref().unwrap_or("the avatar")
         )),
         "item.theft_attempt" => None,
         "item.stolen" => Some(format!(
             "You steal {} from {}; the transfer is recorded and visible.",
             event.item_name.as_deref().unwrap_or("the item"),
-            event.target_actor_name.as_deref().unwrap_or("the resident")
+            event.target_actor_name.as_deref().unwrap_or("the avatar")
         )),
         "item.crafted" => Some(format!(
             "You craft with {} and {}.",
@@ -907,7 +907,7 @@ impl RuntimeWorld {
         &self,
         payload: &CommandRequest,
         access: &AccessContext,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> Result<ResolvedCommand, CommandError> {
         let command = normalize_command_text(&payload.command);
         if command.is_empty() {
@@ -941,7 +941,7 @@ impl RuntimeWorld {
                 "That avatar is not in the world.",
             ));
         };
-        if actor.kind != CW_ACTOR_HUMAN || actor.status != CW_ACTOR_ACTIVE {
+        if !Self::actor_is_active_avatar(actor) {
             return Err(command_error(
                 &command,
                 &verb,
@@ -956,7 +956,7 @@ impl RuntimeWorld {
                 verb,
                 action: None,
                 dispatch: CommandDispatch::Read {
-                            output: "Try: look, search, study, who, deck, bracelet unlock, wear <skill charm>, remove <skill charm>, wield <weapon-or-bag>, unwield <weapon-or-bag>, stow <item> in <bag>, unstow <item>, prepare-spell <spell>, unprepare-spell <spell>, cast <spell>, go <place>, say <message>, emote <action>, take <item>, drop <item>, give <item> to <resident>, trade <item> with <resident> for <item>, use <item> on <target>, chat <resident>, influence <resident>, listen, prepare, work, assist, rest, more, grow, purpose <what draws you in>, friendship <resident>: <why they matter>, remember <resident>, attack <target>, defend, flee <place>, or report <actor>: <reason>.".to_string(),
+                            output: "Try: look, search, study, who, deck, bracelet unlock, wear <skill charm>, remove <skill charm>, wield <weapon-or-bag>, unwield <weapon-or-bag>, stow <item> in <bag>, unstow <item>, prepare-spell <spell>, unprepare-spell <spell>, cast <spell>, go <place>, say <message>, emote <action>, take <item>, drop <item>, give <item> to <avatar>, trade <item> with <avatar> for <item>, use <item> on <target>, chat <avatar>, influence <avatar>, listen, prepare, work, assist, rest, more, grow, purpose <what draws you in>, friendship <avatar>: <why they matter>, remember <avatar>, attack <target>, defend, flee <place>, or report <actor>: <reason>.".to_string(),
                 },
             }),
             "look" => Ok(ResolvedCommand {
@@ -965,7 +965,7 @@ impl RuntimeWorld {
                 action: None,
                 dispatch: CommandDispatch::Read {
                     output: self
-                        .look_command_output(actor, rest, access, active_human_actor_ids)
+                        .look_command_output(actor, rest, access, active_direct_actor_ids)
                         .map_err(|output| command_error(&command, "look", 404, output))?,
                 },
             }),
@@ -1262,7 +1262,7 @@ impl RuntimeWorld {
                     output: self.who_command_output(
                         actor.location_id,
                         Some(actor.id),
-                        active_human_actor_ids,
+                        active_direct_actor_ids,
                     ),
                 },
             }),
@@ -1334,7 +1334,7 @@ impl RuntimeWorld {
             }
             "give" => {
                 let (item_query, target_query) = split_direct_indirect(rest, "to")
-                    .ok_or_else(|| command_error(&command, "give", 400, "Use: give <item> to <resident>."))?;
+                    .ok_or_else(|| command_error(&command, "give", 400, "Use: give <item> to <avatar>."))?;
                 let item = self
                     .resolve_held_item(actor.id, item_query)
                     .map_err(|output| command_error(&command, "give", 404, output))?;
@@ -1342,8 +1342,8 @@ impl RuntimeWorld {
                     .resolve_room_actor(
                         actor,
                         target_query,
-                        CommandActorFilter::ActiveNpc,
-                        active_human_actor_ids,
+                        CommandActorFilter::ActiveActor,
+                        active_direct_actor_ids,
                     )
                     .map_err(|_| {
                         command_error(
@@ -1353,8 +1353,8 @@ impl RuntimeWorld {
                             self.actor_not_nearby_output(
                                 actor,
                                 target_query,
-                                CommandActorFilter::ActiveNpc,
-                                active_human_actor_ids,
+                                CommandActorFilter::ActiveActor,
+                                active_direct_actor_ids,
                             ),
                         )
                     })?;
@@ -1372,9 +1372,9 @@ impl RuntimeWorld {
             }
             "trade" => {
                 let (item_query, trade_tail) = split_direct_indirect(rest, "with")
-                    .ok_or_else(|| command_error(&command, "trade", 400, "Use: trade <item> with <resident> for <item>."))?;
+                    .ok_or_else(|| command_error(&command, "trade", 400, "Use: trade <item> with <avatar> for <item>."))?;
                 let (target_query, target_item_query) = split_direct_indirect(trade_tail, "for")
-                    .ok_or_else(|| command_error(&command, "trade", 400, "Use: trade <item> with <resident> for <item>."))?;
+                    .ok_or_else(|| command_error(&command, "trade", 400, "Use: trade <item> with <avatar> for <item>."))?;
                 let item = self
                     .resolve_held_item(actor.id, item_query)
                     .map_err(|output| command_error(&command, "trade", 404, output))?;
@@ -1382,8 +1382,8 @@ impl RuntimeWorld {
                     .resolve_room_actor(
                         actor,
                         target_query,
-                        CommandActorFilter::ActiveNpc,
-                        active_human_actor_ids,
+                        CommandActorFilter::ActiveActor,
+                        active_direct_actor_ids,
                     )
                     .map_err(|_| {
                         command_error(
@@ -1393,8 +1393,8 @@ impl RuntimeWorld {
                             self.actor_not_nearby_output(
                                 actor,
                                 target_query,
-                                CommandActorFilter::ActiveNpc,
-                                active_human_actor_ids,
+                                CommandActorFilter::ActiveActor,
+                                active_direct_actor_ids,
                             ),
                         )
                     })?;
@@ -1402,7 +1402,7 @@ impl RuntimeWorld {
                     .resolve_actor_held_item(
                         target.id,
                         target_item_query,
-                        "That resident is not holding an item that matches that command.",
+                        "That avatar is not holding an item that matches that command.",
                     )
                     .map_err(|output| command_error(&command, "trade", 404, output))?;
                 self.resident_trade_is_willing(actor.id, target.id, item.id, target_item.id)
@@ -1434,20 +1434,20 @@ impl RuntimeWorld {
                     })?
                 } else {
                     let (item_query, target_query) = split_direct_indirect(rest, "from")
-                        .ok_or_else(|| command_error(&command, "steal", 400, "Use: steal <item> from <resident>."))?;
+                        .ok_or_else(|| command_error(&command, "steal", 400, "Use: steal <item> from <avatar>."))?;
                     let target = self
                         .resolve_room_actor(
                             actor,
                             target_query,
-                            CommandActorFilter::ActiveNpc,
-                            active_human_actor_ids,
+                            CommandActorFilter::ActiveActor,
+                            active_direct_actor_ids,
                         )
                         .map_err(|output| command_error(&command, "steal", 404, output))?;
                     let item = self
                         .resolve_actor_held_item(
                             target.id,
                             item_query,
-                            "That resident is not carrying an item that matches that command.",
+                            "That avatar is not carrying an item that matches that command.",
                         )
                         .map_err(|output| command_error(&command, "steal", 404, output))?;
                     let legal = self
@@ -1470,7 +1470,7 @@ impl RuntimeWorld {
                     (target, item)
                 };
                 let item_name = self.item_name(item.id).unwrap_or_else(|| format!("Item {}", item.id));
-                let target_name = self.actor_name(target.id).unwrap_or_else(|| format!("Resident {}", target.id));
+                let target_name = self.actor_name(target.id).unwrap_or_else(|| format!("Avatar {}", target.id));
                 let command = format!("steal {item_name} from {target_name}");
                 Ok(ResolvedCommand {
                     command: command.clone(),
@@ -1571,7 +1571,7 @@ impl RuntimeWorld {
                         actor,
                         target_query,
                         CommandActorFilter::Any,
-                        active_human_actor_ids,
+                        active_direct_actor_ids,
                     )
                         .map_err(|output| command_error(&command, "use", 404, output))?
                 };
@@ -1592,8 +1592,8 @@ impl RuntimeWorld {
                     .resolve_room_actor(
                         actor,
                         rest,
-                        CommandActorFilter::ActiveNpc,
-                        active_human_actor_ids,
+                        CommandActorFilter::ActiveActor,
+                        active_direct_actor_ids,
                     )
                     .map_err(|output| command_error(&command, "chat", 404, output))?;
                 let target_name = self.actor_view(target).name;
@@ -1655,8 +1655,8 @@ impl RuntimeWorld {
                     .resolve_room_actor(
                         actor,
                         rest,
-                        CommandActorFilter::ActiveNpc,
-                        active_human_actor_ids,
+                        CommandActorFilter::ActiveActor,
+                        active_direct_actor_ids,
                     )
                     .map_err(|output| command_error(&command, "influence", 404, output))?;
                 let target_name = self.actor_view(target).name;
@@ -2032,8 +2032,8 @@ impl RuntimeWorld {
                     .resolve_room_actor(
                         actor,
                         target_query,
-                        CommandActorFilter::ActiveNpc,
-                        active_human_actor_ids,
+                        CommandActorFilter::ActiveActor,
+                        active_direct_actor_ids,
                     )
                     .map_err(|output| command_error(&command, "bond", 404, output))?;
                 let target_name = self.actor_view(target).name;
@@ -2124,8 +2124,8 @@ impl RuntimeWorld {
                     .resolve_room_actor(
                         actor,
                         target_query,
-                        CommandActorFilter::ActiveNpc,
-                        active_human_actor_ids,
+                        CommandActorFilter::ActiveActor,
+                        active_direct_actor_ids,
                     )
                     .map_err(|output| command_error(&command, "resolve", 404, output))?;
                 let target_name = self.actor_view(target).name;
@@ -2188,8 +2188,8 @@ impl RuntimeWorld {
                     .resolve_room_actor(
                         actor,
                         rest,
-                        CommandActorFilter::ActiveNpc,
-                        active_human_actor_ids,
+                        CommandActorFilter::ActiveActor,
+                        active_direct_actor_ids,
                     )
                     .map_err(|output| command_error(&command, "attack", 404, output))?;
                 let target_name = self.actor_view(target).name;
@@ -2276,7 +2276,7 @@ impl RuntimeWorld {
                         actor,
                         target_query,
                         CommandActorFilter::Any,
-                        active_human_actor_ids,
+                        active_direct_actor_ids,
                     )
                     .map_err(|output| command_error(&command, "report", 404, output))?;
                 let Some(reason) = normalize_report_reason(reason) else {
@@ -2321,7 +2321,7 @@ impl RuntimeWorld {
         actor: CwActor,
         query: &str,
         access: &AccessContext,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> Result<String, &'static str> {
         let query = trim_command_filler(query);
         if query.is_empty()
@@ -2330,7 +2330,7 @@ impl RuntimeWorld {
                 "room" | "here" | "around" | "location"
             )
         {
-            return Ok(self.room_command_output(actor, access, active_human_actor_ids));
+            return Ok(self.room_command_output(actor, access, active_direct_actor_ids));
         }
         if let Some(feature) = self.resolve_room_feature(actor.location_id, query).ok() {
             return Ok(format!("{} - {}", feature.name, feature.look));
@@ -2340,7 +2340,7 @@ impl RuntimeWorld {
                 actor,
                 query,
                 CommandActorFilter::Any,
-                active_human_actor_ids,
+                active_direct_actor_ids,
             )
             .ok()
         {
@@ -2429,7 +2429,7 @@ impl RuntimeWorld {
         &self,
         actor: CwActor,
         access: &AccessContext,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> String {
         let location_id = actor.location_id;
         let location = self.location_view(location_id);
@@ -2441,7 +2441,7 @@ impl RuntimeWorld {
                 self.actor_visible_in_projection(
                     *visible_actor,
                     Some(actor.id),
-                    active_human_actor_ids,
+                    active_direct_actor_ids,
                 )
             })
             .map(|actor| self.actor_view(actor).name)
@@ -2600,14 +2600,14 @@ impl RuntimeWorld {
         &self,
         location_id: u64,
         client_actor_id: Option<u64>,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> String {
         let actors = self.world.actors[..self.world.actor_count]
             .iter()
             .copied()
             .filter(|actor| actor.location_id == location_id && actor.status == CW_ACTOR_ACTIVE)
             .filter(|actor| {
-                self.actor_visible_in_projection(*actor, client_actor_id, active_human_actor_ids)
+                self.actor_visible_in_projection(*actor, client_actor_id, active_direct_actor_ids)
             })
             .map(|actor| {
                 let view = self.actor_view(actor);
@@ -2662,7 +2662,7 @@ impl RuntimeWorld {
         actor: CwActor,
         query: &str,
         filter: CommandActorFilter,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> Result<CwActor, &'static str> {
         let candidates = self.world.actors[..self.world.actor_count]
             .iter()
@@ -2671,13 +2671,15 @@ impl RuntimeWorld {
                 candidate.id != actor.id && candidate.location_id == actor.location_id
             })
             .filter(|candidate| {
-                self.actor_visible_in_projection(*candidate, Some(actor.id), active_human_actor_ids)
+                self.actor_visible_in_projection(
+                    *candidate,
+                    Some(actor.id),
+                    active_direct_actor_ids,
+                )
             })
             .filter(|candidate| match filter {
                 CommandActorFilter::Any => true,
-                CommandActorFilter::ActiveNpc => {
-                    candidate.kind == CW_ACTOR_NPC && candidate.status == CW_ACTOR_ACTIVE
-                }
+                CommandActorFilter::ActiveActor => Self::actor_is_active_avatar(*candidate),
             })
             .collect::<Vec<_>>();
         self.best_actor_match(candidates, query)
@@ -2689,20 +2691,22 @@ impl RuntimeWorld {
         actor: CwActor,
         query: &str,
         filter: CommandActorFilter,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> String {
         let candidates = self.world.actors[..self.world.actor_count]
             .iter()
             .copied()
             .filter(|candidate| candidate.id != actor.id)
             .filter(|candidate| {
-                self.actor_visible_in_projection(*candidate, Some(actor.id), active_human_actor_ids)
+                self.actor_visible_in_projection(
+                    *candidate,
+                    Some(actor.id),
+                    active_direct_actor_ids,
+                )
             })
             .filter(|candidate| match filter {
                 CommandActorFilter::Any => true,
-                CommandActorFilter::ActiveNpc => {
-                    candidate.kind == CW_ACTOR_NPC && candidate.status == CW_ACTOR_ACTIVE
-                }
+                CommandActorFilter::ActiveActor => Self::actor_is_active_avatar(*candidate),
             })
             .collect::<Vec<_>>();
         if let Some(found) = self.best_actor_match(candidates, query) {

--- a/v2/orchestrator-rust/src/prompts.rs
+++ b/v2/orchestrator-rust/src/prompts.rs
@@ -1,9 +1,14 @@
 use super::*;
 
+pub(super) const DIRECTLY_CONTROLLED_SELF_REACTION_CONTEXT: &str =
+    "This avatar is directly controlled and is reacting to the action its controller just chose. Write speech only; do not invent private controller intent or another physical action.";
+pub(super) const DIRECTLY_CONTROLLED_REACTION_CONTEXT: &str =
+    "This is a co-present directly controlled avatar's immediate in-character reaction. Write speech only; do not invent private controller intent, an economy motive, or a physical action.";
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub(super) struct ResidentReplyPlan {
-    pub(super) npc_actor_id: u64,
-    pub(super) npc_name: String,
+pub(super) struct AvatarReplyPlan {
+    pub(super) speaker_actor_id: u64,
+    pub(super) speaker_name: String,
     pub(super) speech_mode: String,
     pub(super) resident_continuity: ResidentContinuityState,
     pub(super) economy_note: String,
@@ -28,7 +33,7 @@ pub(super) struct ResidentReplyPlan {
     pub(super) source_location_id: Option<u64>,
 }
 
-impl ResidentReplyPlan {
+impl AvatarReplyPlan {
     pub(super) fn with_observation(mut self, observation: &PlayerTickObservation) -> Self {
         self.caused_by_event_seq = observation.caused_by_event_seq;
         self.source_world_tick = Some(observation.source_world_tick);
@@ -60,12 +65,12 @@ pub(super) struct AvatarChatPlan {
     pub(super) missing_need: Option<String>,
 }
 
-pub(super) async fn resident_reply_intent(
+pub(super) async fn avatar_reply_intent(
     config: Option<&AiConfig>,
-    plan: &ResidentReplyPlan,
-) -> Result<ResidentIntentProposal, AiGatewayError> {
-    let config = config.ok_or_else(|| AiGatewayError::unconfigured("resident dialogue"))?;
-    request_ai_resident_intent(config, plan).await
+    plan: &AvatarReplyPlan,
+) -> Result<AvatarIntentProposal, AiGatewayError> {
+    let config = config.ok_or_else(|| AiGatewayError::unconfigured("avatar dialogue"))?;
+    request_ai_avatar_intent(config, plan).await
 }
 
 pub(super) async fn avatar_chat_text(
@@ -109,13 +114,13 @@ async fn request_ai_avatar_chat(
     let goals = format_goal_lines(&plan.goals);
     let target_continuity = format_resident_continuity(&plan.target_continuity);
     let need = if followup {
-        "Do not introduce a resident need or item that is absent from the freshest exchange."
+        "Do not introduce an avatar need or item that is absent from the freshest exchange."
             .to_string()
     } else {
         plan.missing_need
             .as_ref()
-            .map(|item| format!("The resident may currently need: {item}."))
-            .unwrap_or_else(|| "No current resident item need is known.".to_string())
+            .map(|item| format!("The other avatar may currently need: {item}."))
+            .unwrap_or_else(|| "No current avatar item need is known.".to_string())
     };
     let target_economy = if followup {
         "Do not revive an older request, trade, or item topic.".to_string()
@@ -126,14 +131,14 @@ async fn request_ai_avatar_chat(
         .fresh_subject
         .as_deref()
         .map(|subject| format!("Fresh conversation subject: {subject}. Stay on it."))
-        .unwrap_or_else(|| "Follow only the freshest resident line.".to_string());
+        .unwrap_or_else(|| "Follow only the freshest avatar line.".to_string());
     let system = if followup {
-        "You write the player avatar's brief follow-up in an ongoing cozy conversation. Respond directly to the freshest resident line and continue only its current subject. Never introduce an item, request, goal, or place that is absent from the two freshest lines. Keep one concrete room detail in play and leave a small closing hook. Do not restart the conversation. The human operator is silent; do not mention the user, buttons, UI, AI, prompts, policies, tools, or models. Do not speak for the resident. Plain words and concrete nouns; no lyric flourishes; never attribute feelings or memories to objects. Keep it under 28 words."
+        "You write the directly controlled avatar's brief follow-up in an ongoing cozy conversation. Respond directly to the freshest line and continue only its current subject. Never introduce an item, request, goal, or place that is absent from the two freshest lines. Keep one concrete room detail in play and leave a small closing hook. Do not restart the conversation. The direct controller is silent; do not mention the user, buttons, UI, AI, prompts, policies, tools, or models. Do not speak for the other avatar. Plain words and concrete nouns; no lyric flourishes; never attribute feelings or memories to objects. Keep it under 28 words."
     } else {
-        "You write one in-character line for the player avatar after the human presses Chat. Make the line feel intentionally authored: use one concrete detail from the room, recent dialogue, or the target resident's continuity/current need, and give the resident an easy hook to answer. The human operator is silent; do not mention the user, buttons, UI, AI, prompts, policies, tools, or models. Do not speak for the resident. Plain words and concrete nouns; no lyric flourishes; never attribute feelings or memories to objects. Keep it under 34 words."
+        "You write one in-character line for a directly controlled avatar after its controller selects Chat. Make the line feel intentional: use one concrete detail from the room, recent dialogue, or the target avatar's continuity/current need, and give that avatar an easy hook to answer. The direct controller is silent; do not mention the user, buttons, UI, AI, prompts, policies, tools, or models. Do not speak for the other avatar. Plain words and concrete nouns; no lyric flourishes; never attribute feelings or memories to objects. Keep it under 34 words."
     };
     let user = format!(
-        "Avatar: {name} / {title}\nAvatar description: {description}\nLocation: {location} / {location_title}\nLocation description: {location_description}\nLocation persona: {location_persona}\nLocation memory:\n{location_memory}\nCurrent goals:\n{goals}\nTarget resident: {target} / {target_title}\nTarget continuity:\n{target_continuity}\nTarget economy:\n{target_economy}\nCast present: {cast}\n{need}\n{fresh_subject}\nRecent room lines:\n{recent}\nWrite only the avatar's next spoken line.",
+        "Avatar: {name} / {title}\nAvatar description: {description}\nLocation: {location} / {location_title}\nLocation description: {location_description}\nLocation persona: {location_persona}\nLocation memory:\n{location_memory}\nCurrent goals:\n{goals}\nTarget avatar: {target} / {target_title}\nTarget continuity:\n{target_continuity}\nTarget economy:\n{target_economy}\nCast present: {cast}\n{need}\n{fresh_subject}\nRecent room lines:\n{recent}\nWrite only the avatar's next spoken line.",
         name = plan.actor_name,
         title = plan.actor_title,
         description = plan.actor_description,
@@ -175,10 +180,10 @@ async fn request_ai_avatar_chat(
     .map(|completion| completion.text)
 }
 
-pub(super) async fn request_ai_resident_intent(
+pub(super) async fn request_ai_avatar_intent(
     config: &AiConfig,
-    plan: &ResidentReplyPlan,
-) -> Result<ResidentIntentProposal, AiGatewayError> {
+    plan: &AvatarReplyPlan,
+) -> Result<AvatarIntentProposal, AiGatewayError> {
     let system = resident_system_prompt(plan);
     let recent = if plan.recent_lines.is_empty() {
         "No recent room dialogue.".to_string()
@@ -194,7 +199,7 @@ pub(super) async fn request_ai_resident_intent(
     let goals = format_goal_lines(&plan.goals);
     let resident_continuity = format_resident_continuity(&plan.resident_continuity);
     let user = format!(
-        "Location: {location} / {location_title}\nLocation description: {location_description}\nLocation persona: {location_persona}\nLocation memory:\n{location_memory}\nCurrent goals:\n{goals}\nResident continuity:\n{resident_continuity}\nResident economy:\n{economy_note}\nCast present: {cast}\nRecent played cards and room log, oldest to newest:\n{recent_activity}\nRecent room lines:\n{recent}\nCard or direct event to respond to:\n{line}\nReply contract: react to what actually happened in this channel. Treat the room log and played cards as facts, with newer entries superseding older state. Answer the direct event first, then use at most one concrete detail from the recent context as a hook. If it names a concrete item or place, repeat that name so the conversation cannot silently change subjects.\nReturn valid JSON only with this shape:\n{{\"speech\":\"one visible reply from {name}\",\"intent\":\"what {name} is trying next, or null\",\"belief\":\"what {name} now believes, or null\",\"desire\":\"what {name} wants, or null\",\"promise\":\"what {name} commits to, or null\",\"refusal\":\"what {name} refuses, or null\",\"proposed_action\":{{\"kind\":\"wait|speak|move|pick_up|drop|give|trade|use|search|refuse\",\"target_actor_id\":null,\"item_id\":null,\"destination_location_id\":null,\"reason\":\"why this action follows\"}}}}\nUse null for unknown optional fields. The kernel has not accepted proposed_action yet, so do not claim it already happened.",
+        "Location: {location} / {location_title}\nLocation description: {location_description}\nLocation persona: {location_persona}\nLocation memory:\n{location_memory}\nCurrent goals:\n{goals}\nSpeaker continuity:\n{resident_continuity}\nActor economy:\n{economy_note}\nCast present: {cast}\nRecent played cards and room log, oldest to newest:\n{recent_activity}\nRecent room lines:\n{recent}\nCard or direct event to respond to:\n{line}\nReply contract: react to what actually happened in this channel. Treat the room log and played cards as facts, with newer entries superseding older state. Answer the direct event first, then use at most one concrete detail from the recent context as a hook. If it names a concrete item or place, repeat that name so the conversation cannot silently change subjects.\nReturn valid JSON only with this shape:\n{{\"speech\":\"one visible reply from {name}\",\"intent\":\"what {name} is trying next, or null\",\"belief\":\"what {name} now believes, or null\",\"desire\":\"what {name} wants, or null\",\"promise\":\"what {name} commits to, or null\",\"refusal\":\"what {name} refuses, or null\",\"proposed_action\":{{\"kind\":\"wait|speak|move|pick_up|drop|give|trade|use|search|refuse\",\"target_actor_id\":null,\"item_id\":null,\"destination_location_id\":null,\"reason\":\"why this action follows\"}}}}\nUse null for unknown optional fields. The kernel has not accepted proposed_action yet, so do not claim it already happened.",
         location = plan.location_name,
         location_title = plan.location_title,
         location_description = plan.location_description,
@@ -207,7 +212,7 @@ pub(super) async fn request_ai_resident_intent(
         recent_activity = recent_activity,
         recent = recent,
         line = plan.user_text,
-        name = plan.npc_name
+        name = plan.speaker_name
     );
 
     let response_format = serde_json::json!({ "type": "json_object" });
@@ -227,7 +232,7 @@ pub(super) async fn request_ai_resident_intent(
     )
     .await?;
     parse_resident_intent_json(&completion.text, plan).ok_or_else(|| {
-        AiGatewayError::invalid_response("AI resident intent response was not usable JSON")
+        AiGatewayError::invalid_response("AI avatar intent response was not usable JSON")
     })
 }
 
@@ -337,18 +342,21 @@ pub(super) fn format_resident_continuity(continuity: &ResidentContinuityState) -
     lines.join("\n")
 }
 
-pub(super) fn resident_system_prompt(plan: &ResidentReplyPlan) -> String {
-    let base = "Return valid JSON only. Never mention AI, models, prompts, policies, tools, or system instructions. Do not speak for other residents. Treat resident continuity as this resident's durable perspective, while the room/kernel facts remain authoritative. The speech field is the only visible room line. Typed intent fields update continuity only after the kernel accepts the speech event. Comedy rules: ground every line in one physical action, prop, or bodily complaint from the room. Punchlines over poetry. Cheeky teasing and light flirting are welcome; keep it playful, never cruel or explicit. Never use the words whisper, eternal, void, abyss, veil, hush, sacred, vow, moonlit, or objects that remember things. If in doubt, be funnier and more specific.";
-    if plan
-        .economy_note
-        .starts_with("This is the player avatar's own immediate")
-    {
+pub(super) fn resident_system_prompt(plan: &AvatarReplyPlan) -> String {
+    let base = "Return valid JSON only. Never mention AI, models, prompts, policies, tools, or system instructions. Do not speak for other avatars. Treat speaker continuity as this avatar's durable perspective, while the room/kernel facts remain authoritative. The speech field is the only visible room line. Typed intent fields update continuity only after the kernel accepts the speech event. Comedy rules: ground every line in one physical action, prop, or bodily complaint from the room. Punchlines over poetry. Cheeky teasing and light flirting are welcome; keep it playful, never cruel or explicit. Never use the words whisper, eternal, void, abyss, veil, hush, sacred, vow, moonlit, or objects that remember things. If in doubt, be funnier and more specific.";
+    if plan.economy_note == DIRECTLY_CONTROLLED_SELF_REACTION_CONTEXT {
         return format!(
-            "You are {}, the player avatar in CosyWorld. Write their immediate first-person in-character response to the action they just chose. React to the concrete outcome instead of narrating the rules or inventing another action. Keep it under 34 words. {base}",
-            plan.npc_name
+            "You are {}, the acting avatar in CosyWorld. Speak briefly on behalf of its direct controller in first person, reacting to the concrete outcome of the action just chosen. Do not narrate rules, claim private controller thoughts, or invent another action. Keep it under 34 words. {base}",
+            plan.speaker_name
         );
     }
-    match plan.npc_actor_id {
+    if plan.economy_note == DIRECTLY_CONTROLLED_REACTION_CONTEXT {
+        return format!(
+            "You are {}, a co-present directly controlled avatar in CosyWorld. Speak briefly on behalf of its controller in first person, reacting to another avatar's concrete action in the room. Do not impersonate the acting avatar, claim private controller thoughts, or invent another action. Keep it under 34 words. {base}",
+            plan.speaker_name
+        );
+    }
+    match plan.speaker_actor_id {
         1001 => format!(
             "You are Rati, the cottage's brisk landlady mouse. The speech field must be first person: bossy, mothering, armed with knitting needles and opinions about boots. One concrete room prop per line. Under 40 words. {base}"
         ),
@@ -381,7 +389,7 @@ pub(super) fn resident_system_prompt(plan: &ResidentReplyPlan) -> String {
         ),
         _ => format!(
             "You are {} in CosyWorld, a grounded physical-comedy village. Keep the speech field concise, concrete, and cheeky. {base}",
-            plan.npc_name
+            plan.speaker_name
         ),
     }
 }

--- a/v2/orchestrator-rust/src/story_metrics.rs
+++ b/v2/orchestrator-rust/src/story_metrics.rs
@@ -394,13 +394,13 @@ pub(super) fn record_story_metrics_for_journal_in_transaction(
     runtime: &RuntimeWorld,
     record: &JournalRecord,
     events: &[EventView],
-    co_present_human_count: usize,
+    co_present_direct_actor_count: usize,
     now_ms: u64,
 ) -> io::Result<()> {
     let actor_id = record.action.actor_id;
     let Some(actor) = runtime
         .actor_by_id(actor_id)
-        .filter(|actor| actor.kind == CW_ACTOR_HUMAN)
+        .filter(|actor| !runtime.actor_uses_inference(actor.id))
     else {
         return Ok(());
     };
@@ -498,7 +498,7 @@ pub(super) fn record_story_metrics_for_journal_in_transaction(
             subject_ref: None,
             attributes: serde_json::json!({
                 "action_category": action_category,
-                "co_present_human_count": co_present_human_count,
+                "co_present_direct_actor_count": co_present_direct_actor_count,
             }),
             occurred_at_ms: now_ms,
         },
@@ -525,7 +525,7 @@ pub(super) fn record_story_metrics_for_journal_in_transaction(
         now_ms,
     )?;
 
-    if co_present_human_count >= 2 {
+    if co_present_direct_actor_count >= 2 {
         insert_story_metric(
             conn,
             NewStoryMetric {
@@ -542,7 +542,7 @@ pub(super) fn record_story_metrics_for_journal_in_transaction(
                 target_player_ref: None,
                 subject_ref: None,
                 attributes: serde_json::json!({
-                    "active_human_count": co_present_human_count,
+                    "active_direct_actor_count": co_present_direct_actor_count,
                 }),
                 occurred_at_ms: now_ms,
             },
@@ -554,7 +554,7 @@ pub(super) fn record_story_metrics_for_journal_in_transaction(
         let target_id = event.target_actor_id?;
         runtime
             .actor_by_id(target_id)
-            .filter(|target| target.kind == CW_ACTOR_HUMAN)
+            .filter(|target| !runtime.actor_uses_inference(target.id))
             .map(|_| story_player_ref(target_id))
     });
     if let Some(target_player_ref) = target_player_ref.as_deref() {

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -420,16 +420,15 @@ pub(super) fn initiative_bonus_from_dexterity(dexterity: i8) -> i16 {
 
 pub(super) fn room_turn_actors_for_location(
     runtime: &RuntimeWorld,
-    active_human_actor_ids: &BTreeSet<u64>,
+    active_direct_actor_ids: &BTreeSet<u64>,
     location_id: u64,
 ) -> Vec<RoomTurnActor> {
     runtime.world.actors[..runtime.world.actor_count]
         .iter()
         .filter(|actor| {
-            actor.kind == CW_ACTOR_HUMAN
-                && actor.status == CW_ACTOR_ACTIVE
+            RuntimeWorld::actor_is_active_avatar(**actor)
                 && actor.location_id == location_id
-                && active_human_actor_ids.contains(&actor.id)
+                && active_direct_actor_ids.contains(&actor.id)
         })
         .map(|actor| RoomTurnActor {
             actor_id: actor.id,
@@ -446,9 +445,9 @@ pub(super) fn room_turn_view_for_runtime(
     runtime: &RuntimeWorld,
     location_id: u64,
     viewer_actor_id: Option<u64>,
-    active_human_actor_ids: &BTreeSet<u64>,
+    active_direct_actor_ids: &BTreeSet<u64>,
 ) -> RoomTurnView {
-    let actors = room_turn_actors_for_location(runtime, active_human_actor_ids, location_id);
+    let actors = room_turn_actors_for_location(runtime, active_direct_actor_ids, location_id);
     state
         .room_turns
         .lock()
@@ -460,7 +459,7 @@ pub(super) fn actor_room_turn_view(
     state: &AppState,
     runtime: &RuntimeWorld,
     actor_id: u64,
-    active_human_actor_ids: &BTreeSet<u64>,
+    active_direct_actor_ids: &BTreeSet<u64>,
 ) -> Option<RoomTurnView> {
     let actor = runtime.actor_by_id(actor_id)?;
     Some(room_turn_view_for_runtime(
@@ -468,7 +467,7 @@ pub(super) fn actor_room_turn_view(
         runtime,
         actor.location_id,
         Some(actor_id),
-        active_human_actor_ids,
+        active_direct_actor_ids,
     ))
 }
 
@@ -497,9 +496,9 @@ pub(super) fn actor_turn_rejection(
     runtime: &RuntimeWorld,
     actor_id: u64,
 ) -> Option<Json<ActionResponse>> {
-    let mut active_humans = active_turn_actor_ids_for_state(state);
-    active_humans.insert(actor_id);
-    let view = actor_room_turn_view(state, runtime, actor_id, &active_humans)?;
+    let mut active_direct_actors = active_turn_actor_ids_for_state(state);
+    active_direct_actors.insert(actor_id);
+    let view = actor_room_turn_view(state, runtime, actor_id, &active_direct_actors)?;
     (view.enabled && !view.is_current_actor).then(|| actor_not_current_turn_response(view))
 }
 
@@ -550,9 +549,9 @@ pub(super) fn command_actor_turn_rejection(
     if matches!(dispatch, CommandDispatch::Check) && !runtime.listen_attempted_here(actor_id) {
         return None;
     }
-    let mut active_humans = active_turn_actor_ids_for_state(state);
-    active_humans.insert(actor_id);
-    let view = actor_room_turn_view(state, runtime, actor_id, &active_humans)?;
+    let mut active_direct_actors = active_turn_actor_ids_for_state(state);
+    active_direct_actors.insert(actor_id);
+    let view = actor_room_turn_view(state, runtime, actor_id, &active_direct_actors)?;
     (view.enabled && !view.is_current_actor).then_some(view)
 }
 
@@ -622,9 +621,9 @@ pub(super) fn advance_actor_room_turn_after_commit(
     let Some(location_id) = location_id else {
         return;
     };
-    let mut active_humans = active_turn_actor_ids_for_state(state);
-    active_humans.insert(actor_id);
-    let actors = room_turn_actors_for_location(runtime, &active_humans, location_id);
+    let mut active_direct_actors = active_turn_actor_ids_for_state(state);
+    active_direct_actors.insert(actor_id);
+    let actors = room_turn_actors_for_location(runtime, &active_direct_actors, location_id);
     if let Ok(mut turns) = state.room_turns.lock() {
         turns.advance_after_action(location_id, &actors, actor_id);
     }
@@ -712,8 +711,8 @@ fn schedule_turn_ping_resolution(state: AppState, location_id: u64, ping_id: u64
 
 async fn resolve_turn_ping_after_countdown(state: AppState, location_id: u64, ping_id: u64) {
     let mut runtime = state.inner.lock().await;
-    let active_humans = active_turn_actor_ids_for_state(&state);
-    let actors = room_turn_actors_for_location(&runtime, &active_humans, location_id);
+    let active_direct_actors = active_turn_actor_ids_for_state(&state);
+    let actors = room_turn_actors_for_location(&runtime, &active_direct_actors, location_id);
     let outcome = state
         .room_turns
         .lock()
@@ -780,9 +779,9 @@ pub(super) async fn request_turn_timeout(
         });
     };
     let location_id = actor.location_id;
-    let mut active_humans = active_turn_actor_ids_for_state(&state);
-    active_humans.insert(payload.actor_id);
-    let actors = room_turn_actors_for_location(&runtime, &active_humans, location_id);
+    let mut active_direct_actors = active_turn_actor_ids_for_state(&state);
+    active_direct_actors.insert(payload.actor_id);
+    let actors = room_turn_actors_for_location(&runtime, &active_direct_actors, location_id);
     let outcome = state
         .room_turns
         .lock()

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -207,8 +207,6 @@ pub(super) struct WorldLocationView {
     pub(super) access_reason: Option<String>,
     pub(super) card: CardView,
     pub(super) actor_count: usize,
-    pub(super) human_count: usize,
-    pub(super) resident_count: usize,
     pub(super) item_count: usize,
     pub(super) actors: Vec<ActorView>,
     pub(super) items: Vec<ItemView>,
@@ -276,11 +274,13 @@ pub(super) struct ActorView {
     pub(super) name: String,
     pub(super) title: String,
     pub(super) description: String,
+    pub(super) control_mode: ActorControlMode,
     pub(super) kind: String,
     pub(super) status: String,
     pub(super) speech_mode: String,
     pub(super) location_id: u64,
     pub(super) factions: Vec<FactionRefView>,
+    #[serde(rename = "economy")]
     pub(super) resident_economy: Option<ResidentEconomyView>,
     pub(super) hp: i16,
     pub(super) bloodied: bool,
@@ -883,6 +883,7 @@ impl RuntimeWorld {
                 .unwrap_or_else(|| format!("Actor {}", actor.id)),
             title: meta.map(|m| m.title.clone()).unwrap_or_default(),
             description: meta.map(|m| m.description.clone()).unwrap_or_default(),
+            control_mode: self.actor_control_mode(actor.id),
             kind: actor_kind(actor.kind).to_string(),
             status: actor_status(actor.status).to_string(),
             speech_mode: meta
@@ -951,7 +952,7 @@ impl RuntimeWorld {
     ) -> ResidentHeldItemView {
         let resident_name = self
             .actor_name(resident.id)
-            .unwrap_or_else(|| format!("Resident {}", resident.id));
+            .unwrap_or_else(|| format!("Avatar {}", resident.id));
         let item_name = self
             .item_name(item.id)
             .unwrap_or_else(|| format!("Item {}", item.id));
@@ -1082,10 +1083,7 @@ impl RuntimeWorld {
         holder_actor_id: u64,
     ) -> Option<ResidentRequestView> {
         let holder = self.actor_by_id(holder_actor_id)?;
-        if holder.kind != CW_ACTOR_HUMAN
-            || holder.status != CW_ACTOR_ACTIVE
-            || holder.location_id != resident.location_id
-        {
+        if !Self::actor_is_active_avatar(holder) || holder.location_id != resident.location_id {
             return None;
         }
 
@@ -1109,7 +1107,7 @@ impl RuntimeWorld {
         resident: CwActor,
         client_actor_id: Option<u64>,
     ) -> Option<ResidentEconomyView> {
-        if resident.kind != CW_ACTOR_NPC {
+        if !Self::actor_is_active_avatar(resident) {
             return None;
         }
         let held_items_raw = self.actor_held_items(resident.id);
@@ -1160,7 +1158,7 @@ impl RuntimeWorld {
                 });
         let resident_name = self
             .actor_name(resident.id)
-            .unwrap_or_else(|| format!("Resident {}", resident.id));
+            .unwrap_or_else(|| format!("Avatar {}", resident.id));
         let motive = if let Some(request) = request.as_ref() {
             if let Some(holder_name) = self.actor_name(request.holder_actor_id) {
                 let reason = request.reason.trim_end_matches('.');
@@ -1174,7 +1172,7 @@ impl RuntimeWorld {
                 .unwrap_or_else(|| format!("Item {}", delivery.actor_item.id));
             let target_name = self
                 .actor_name(delivery.target.id)
-                .unwrap_or_else(|| format!("Resident {}", delivery.target.id));
+                .unwrap_or_else(|| format!("Avatar {}", delivery.target.id));
             let location_name = self
                 .location_name(delivery.target_location_id)
                 .unwrap_or_else(|| format!("Location {}", delivery.target_location_id));
@@ -1283,7 +1281,7 @@ impl RuntimeWorld {
         &self,
         actor_id: Option<u64>,
         access: &AccessContext,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
         _openrouter_connected: bool,
     ) -> StateResponse {
         let client_actor_id = actor_id.filter(|id| self.client_actor_can_submit(*id));
@@ -1296,7 +1294,7 @@ impl RuntimeWorld {
             .copied()
             .filter(|actor| actor.location_id == location_id)
             .filter(|actor| {
-                self.actor_visible_in_projection(*actor, client_actor_id, active_human_actor_ids)
+                self.actor_visible_in_projection(*actor, client_actor_id, active_direct_actor_ids)
             })
             .map(|actor| self.actor_view_for_client(actor, client_actor_id))
             .collect();
@@ -2048,8 +2046,7 @@ impl RuntimeWorld {
             .iter()
             .filter(|target| {
                 target.id != actor_id
-                    && target.kind == CW_ACTOR_NPC
-                    && target.status == CW_ACTOR_ACTIVE
+                    && Self::actor_is_active_avatar(**target)
                     && target.location_id == location_id
                     && self
                         .rpg_claims
@@ -2074,7 +2071,7 @@ impl RuntimeWorld {
         &self,
         actor_id: Option<u64>,
         access: &AccessContext,
-        active_human_actor_ids: Option<&BTreeSet<u64>>,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> WorldResponse {
         let client_actor_id = actor_id.filter(|id| self.client_actor_can_submit(*id));
         let current_location_id = client_actor_id
@@ -2134,7 +2131,7 @@ impl RuntimeWorld {
                         self.actor_visible_in_projection(
                             *actor,
                             client_actor_id,
-                            active_human_actor_ids,
+                            active_direct_actor_ids,
                         )
                     })
                     .collect();
@@ -2146,13 +2143,10 @@ impl RuntimeWorld {
                             && !self.forgotten_search_item_at_location(*item, location.id)
                     })
                     .collect();
-                let human_count = visible_actors_in_location
+                let actor_count = visible_actors_in_location
                     .iter()
-                    .filter(|actor| actor.kind == CW_ACTOR_HUMAN)
-                    .count();
-                let resident_count = visible_actors_in_location
-                    .iter()
-                    .filter(|actor| actor.kind == CW_ACTOR_NPC)
+                    .copied()
+                    .filter(|actor| Self::actor_is_active_avatar(*actor))
                     .count();
                 let actors = accessible
                     .then(|| {
@@ -2215,9 +2209,7 @@ impl RuntimeWorld {
                         access_rule.reason.map(ToString::to_string)
                     },
                     card,
-                    actor_count: visible_actors_in_location.len(),
-                    human_count,
-                    resident_count,
+                    actor_count,
                     item_count: items_in_location.len(),
                     actors,
                     items,


### PR DESCRIPTION
Closes #161

## Outcome

- makes active-avatar status and authoritative world state—not legacy human/NPC kind—govern Give, Trade, Help, Influence, theft, evolution, combat, targeting, and shared projections
- makes `control_mode` select direct-input versus inference scheduling and authorization, while retaining legacy `"human"` snapshot compatibility
- rotates room-card replies through every present eligible avatar; generated direct-avatar lines are public proxy speech only and cannot invent private continuity or mechanical actions
- removes the off-surface inference wander fallback and validates inferred actions against the shared kernel offers
- exposes controller mode in public actor state and the avatar inspector, uses controller-neutral browser/MUD copy, and replaces the noninteractive `+N` room count with a scrollable full roster
- documents the actor/controller boundary and migration policy
- releases the controller-neutral contract as version 0.0.92

## Validation

- `bash v2/scripts/check-kernel.sh`
- `cargo test` — 400 passed, run outside the sandbox for loopback listener coverage
- `npm run v2:rust:build`
- `npm run check:version`
- `eslint .`
- `npm run v2:syntax`
- `npm run v2:worldpack` — strict proof ready

The local Node/Vitest suite could not be treated as authoritative because the shared `better-sqlite3` binary was built for a different Node ABI and sandboxed route tests cannot bind listeners. GitHub CI installs dependencies under the repository's pinned Node version and remains the required gate.