### PR TITLE
Build Lonely Forest with its app-scoped token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  FLY_PRIMARY_APP: cosyworld
-
 jobs:
   fly:
     name: Deploy to Fly
@@ -33,18 +30,8 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Resolve deployed image digest
-        id: image
-        run: |
-          image_ref="$(flyctl image show --app "$FLY_PRIMARY_APP" --json | jq -r '.[0] | "\(.Registry)/\(.Repository)@\(.Digest)"')"
-          test -n "$image_ref"
-          test "$image_ref" != "null/null@null"
-          echo "ref=$image_ref" >> "$GITHUB_OUTPUT"
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-      - name: Deploy the same image to Lonely Forest
-        run: flyctl deploy --config fly.lonelyforest.toml --image "${{ steps.image.outputs.ref }}" --ha=false
+      - name: Build and deploy Lonely Forest
+        run: flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
 

--- a/docs/deployment/lonelyforest-fly.md
+++ b/docs/deployment/lonelyforest-fly.md
@@ -1,7 +1,8 @@
 # Lonely Forest on Fly
 
-`lonelyforest.com` runs from the same immutable image digest as the primary
-`cosyworld` Fly app, but it has its own Fly application and persistent volume:
+`lonelyforest.com` runs from the same source revision as the primary
+`cosyworld` Fly app, but it has its own Fly application, image build, and
+persistent volume:
 
 | Domain | Fly app | Volume | WebAuthn RP ID |
 | --- | --- | --- | --- |
@@ -16,9 +17,21 @@ another Fly app, volume, passkey configuration, and explicit deployment target.
 ## Continuous deployment
 
 `.github/workflows/deploy.yml` builds and deploys `fly.toml` first. It then
-resolves the deployed registry digest and passes that exact digest to the
-Lonely Forest deployment. A successful workflow therefore proves both apps are
-running the same artifact; the second app is never rebuilt independently.
+performs a separate remote build from the same checked-out revision using
+`fly.lonelyforest.toml`. A successful workflow therefore proves both apps
+accepted the same source revision. The separate builds let each deployment use
+an app-scoped Fly token; an app-scoped Lonely Forest token cannot pull a private
+image owned by the primary app's registry.
+
+The workflow requires two GitHub Actions secrets:
+
+```text
+FLY_API_TOKEN
+FLY_LONELYFOREST_API_TOKEN
+```
+
+Each secret should be scoped to its corresponding Fly app. An organization-wide
+token is unnecessary.
 
 The Lonely Forest app requires these independently provisioned secrets:
 
@@ -39,8 +52,8 @@ output.
 1. Create `cosyworld-lonelyforest` and a 1 GB encrypted
    `lonelyforest_data` volume in `sjc`.
 2. Provision the production secrets without deploying a machine.
-3. Deploy the current `cosyworld` image by digest with
-   `fly.lonelyforest.toml`.
+3. Build and deploy the current source revision with
+   `fly.lonelyforest.toml` using the Lonely Forest app-scoped token.
 4. Restore the selected Lonely Forest SQLite journal and generated assets to
    the new volume before making the app writable to public traffic.
 5. Add Fly certificates for `lonelyforest.com` and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.90",
+      "version": "0.0.91",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -27,11 +27,20 @@ describe('deploy workflow', () => {
     expect(workflow).not.toContain('group: deploy-${{ github.ref }}');
   });
 
-  it('deploys one immutable Fly image to both apps before publishing a release', () => {
+  it('builds the same revision with app-scoped tokens before publishing a release', () => {
     const fly = job('fly', 'github-release');
-    expect(fly).toContain('flyctl deploy --remote-only --config fly.toml');
-    expect(fly).toContain('flyctl image show --app "$FLY_PRIMARY_APP" --json');
-    expect(fly).toContain('flyctl deploy --config fly.lonelyforest.toml --image "${{ steps.image.outputs.ref }}"');
+    const primaryDeploy = 'flyctl deploy --remote-only --config fly.toml';
+    const lonelyForestDeploy =
+      'flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false';
+    expect(fly).toContain(primaryDeploy);
+    expect(fly).toContain(lonelyForestDeploy);
+    expect(fly.indexOf(primaryDeploy)).toBeLessThan(fly.indexOf(lonelyForestDeploy));
+    expect(fly).toContain('FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}');
+    expect(fly).toContain(
+      'FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}'
+    );
+    expect(fly).not.toContain('flyctl image show');
+    expect(fly).not.toContain('--image');
     expect(workflow).not.toContain('\n  aws:');
     expect(job('github-release')).toContain('needs: [fly]');
   });

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.90"
+version = "0.0.91"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.90"
+version = "0.0.91"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Closes #18

## Outcome

- deploys the primary app with its existing app-scoped token
- independently remote-builds and deploys the same checked-out revision to Lonely Forest with its own app-scoped token
- avoids an organization-wide token and the cross-app private-registry authorization failure
- documents the source-revision parity and least-privilege tradeoff
- bumps the release version to 0.0.91

## Validation

- `npm run check:version`
- parsed `.github/workflows/deploy.yml` as YAML
- `git diff --check`

The definitive validation is the post-merge production workflow because this change specifically repairs the main-branch deploy lane.