### PR TITLE
Advertise ordered combat controls in runtime metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.94",
+      "version": "0.0.95",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.94"
+version = "0.0.95"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.94"
+version = "0.0.95"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1962,7 +1962,7 @@ struct MetaCombat {
     kernel_version: u32,
     action_economy: &'static str,
     resolution: &'static str,
-    actions: [&'static str; 3],
+    actions: [&'static str; 5],
 }
 
 #[derive(Debug, Serialize)]
@@ -23984,7 +23984,7 @@ async fn meta(State(state): State<AppState>) -> Json<MetaResponse> {
             kernel_version: CW_KERNEL_VERSION,
             action_economy: "one_action_per_turn",
             resolution: "nonlethal_subdual_at_1_hp",
-            actions: ["attack", "dodge", "escape"],
+            actions: ["attack", "dodge", "escape", "pass", "need_time"],
         },
         worldpack: MetaWorldpack {
             id: active_content().manifest.id.clone(),
@@ -47538,6 +47538,17 @@ mod tests {
         assert!(healthy.last_read_success_at_unix.is_some());
         assert!(healthy.last_error_code.is_none());
         let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn metadata_advertises_every_ordered_combat_action() {
+        let state = test_app_state(RuntimeWorld::seeded(), None);
+        let combat = meta(State(state)).await.0.combat;
+
+        assert_eq!(
+            combat.actions,
+            ["attack", "dodge", "escape", "pass", "need_time"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #168 and #174.

Production verification of 0.0.94 found that the browser, MUD, journal, and C kernel supported `pass` / `need_time`, while `/meta` still advertised only `attack` / `dodge` / `escape`. This adds both controls to the public combat action list and locks the five-action contract with a regression.

## Validation
- `npm run check` (419 JavaScript tests, worldpack/proof checks, C kernel, 411 Rust tests, syntax)
- `npm run lint`
- `npm run build:js`
- `npm run check:version`
- `cargo fmt --all --check`
- `git diff --check`