### PR TITLE
Restore replay-safe combat join sides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.96",
+      "version": "0.0.97",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -1603,9 +1603,12 @@ static cw_status apply_combat_join(cw_world *world, const cw_action *action, uin
   cw_combat_participant *participant = &encounter->participants[encounter->participant_count++];
   memset(participant, 0, sizeof(*participant));
   participant->actor_id = actor->id;
-  /* Controller provenance is not a combat faction. Callers may choose side 2
-     explicitly; otherwise a joining actor joins the initiating side. */
-  participant->side = action->modifier == 2 ? 2 : 1;
+  /* A zero modifier is the historical journal shape and must retain the
+     original kind-based replay rule. New callers write side 1 or 2
+     explicitly so controller provenance is not used as a faction. */
+  participant->side = action->modifier == 1 || action->modifier == 2
+      ? (uint8_t)action->modifier
+      : (actor->kind == CW_ACTOR_HUMAN ? 1 : 2);
   participant->initiative = (int16_t)(raw + ability_modifier(actor->stats.dexterity));
   sort_combat_participants(encounter);
   for (size_t i = 0; i < encounter->participant_count; ++i) {

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -11,6 +11,13 @@ static cw_item *test_find_item(cw_world *world, cw_id item_id) {
   return 0;
 }
 
+static cw_actor *test_find_actor(cw_world *world, cw_id actor_id) {
+  for (size_t i = 0; i < world->actor_count; ++i) {
+    if (world->actors[i].id == actor_id) return &world->actors[i];
+  }
+  return 0;
+}
+
 static void test_kernel_capacities_are_runtime_sized(void) {
   assert(CW_MAX_ACTORS >= 512u);
   assert(CW_MAX_ITEMS >= 1024u);
@@ -1223,6 +1230,62 @@ static void test_search_and_craft_create_without_consuming_inputs(void) {
   assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
 }
 
+static uint8_t test_combat_side(const cw_combat_encounter *encounter, cw_id actor_id) {
+  for (size_t i = 0; i < encounter->participant_count; ++i) {
+    if (encounter->participants[i].actor_id == actor_id) {
+      return encounter->participants[i].side;
+    }
+  }
+  return 0;
+}
+
+static void test_combat_join_preserves_legacy_sides_and_accepts_explicit_sides(void) {
+  cw_world world;
+  cw_event_buffer events;
+  cw_world_init(&world);
+  assert(cw_seed_cosy_cottage(&world, &events) == CW_OK);
+
+  cw_action create = {0};
+  create.kind = CW_ACTION_CREATE_ACTOR;
+  create.location_id = 3;
+  create.actor_id = 5001;
+  assert(cw_world_apply(&world, &create, 901, &events) == CW_OK);
+  create.actor_id = 5002;
+  assert(cw_world_apply(&world, &create, 902, &events) == CW_OK);
+
+  cw_actor *initiator = test_find_actor(&world, 5001);
+  cw_actor *legacy_human = test_find_actor(&world, 5002);
+  cw_actor *legacy_npc = test_find_actor(&world, 1001);
+  cw_actor *explicit_npc = test_find_actor(&world, 1002);
+  cw_actor *target = test_find_actor(&world, 1004);
+  assert(initiator && legacy_human && legacy_npc && explicit_npc && target);
+  legacy_npc->location_id = 3;
+  explicit_npc->location_id = 3;
+
+  cw_action start = {0};
+  start.kind = CW_ACTION_COMBAT_START;
+  start.actor_id = initiator->id;
+  start.target_actor_id = target->id;
+  start.content_id = 9901;
+  assert(cw_world_apply(&world, &start, 903, &events) == CW_OK);
+
+  cw_action join = {0};
+  join.kind = CW_ACTION_COMBAT_JOIN;
+  join.content_id = start.content_id;
+  join.actor_id = legacy_human->id;
+  assert(cw_world_apply(&world, &join, 904, &events) == CW_OK);
+  join.actor_id = legacy_npc->id;
+  assert(cw_world_apply(&world, &join, 905, &events) == CW_OK);
+  join.actor_id = explicit_npc->id;
+  join.modifier = 1;
+  assert(cw_world_apply(&world, &join, 906, &events) == CW_OK);
+
+  const cw_combat_encounter *encounter = &world.combat_encounters[0];
+  assert(test_combat_side(encounter, legacy_human->id) == 1);
+  assert(test_combat_side(encounter, legacy_npc->id) == 2);
+  assert(test_combat_side(encounter, explicit_npc->id) == 1);
+}
+
 static void apply_replay_sequence(cw_world *world, cw_event *events, size_t *event_count) {
   cw_event_buffer buffer;
   *event_count = 0;
@@ -1297,6 +1360,7 @@ int main(void) {
   test_npc_pickup_can_evolve_self();
   test_inventory_uses_weight_and_container_capacity();
   test_search_and_craft_create_without_consuming_inputs();
+  test_combat_join_preserves_legacy_sides_and_accepts_explicit_sides();
   test_deterministic_replay();
   puts("cosy kernel tests passed");
   return 0;

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.96"
+version = "0.0.97"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.96"
+version = "0.0.97"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -407,12 +407,7 @@ pub(super) async fn apply_combat_choice(
         }
     } else if !runtime.combat_actor_is_participant(encounter_id, actor_id) {
         let record = JournalRecord::new(
-            CwAction {
-                kind: CW_ACTION_COMBAT_JOIN,
-                actor_id,
-                content_id: encounter_id,
-                ..CwAction::default()
-            },
+            combat_join_action(actor_id, encounter_id),
             runtime.next_seed_value(),
         )
         .into_system();
@@ -603,6 +598,18 @@ pub(super) async fn apply_combat_choice(
     })
 }
 
+fn combat_join_action(actor_id: u64, encounter_id: u64) -> CwAction {
+    CwAction {
+        kind: CW_ACTION_COMBAT_JOIN,
+        actor_id,
+        content_id: encounter_id,
+        // New journal records declare encounter allegiance explicitly. A zero
+        // modifier remains reserved for historical replay.
+        modifier: 1,
+        ..CwAction::default()
+    }
+}
+
 pub(super) fn combat_encounter_id(job_id: &str) -> u64 {
     let mut hash = 0xcbf2_9ce4_8422_2325u64;
     // Encounter identity predates the finesse rules and remains stable across
@@ -616,4 +623,18 @@ pub(super) fn combat_encounter_id(job_id: &str) -> u64 {
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
     hash.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_combat_join_records_declare_the_initiating_side() {
+        let action = combat_join_action(5001, 9001);
+        assert_eq!(action.kind, CW_ACTION_COMBAT_JOIN);
+        assert_eq!(action.actor_id, 5001);
+        assert_eq!(action.content_id, 9001);
+        assert_eq!(action.modifier, 1);
+    }
 }


### PR DESCRIPTION
Fixes #178

- preserve the historical zero-modifier join rule during journal replay
- write side 1 explicitly for newly committed orchestrator join records
- cover legacy human/NPC joins and explicit controller-neutral sides in the C kernel
- add a Rust contract test for new join record shape
- bump release to 0.0.97

Validation:
- `npm run v2:kernel`
- 413 Rust tests
- `npm run check:version`
- `git diff --check`