### PR TITLE
Fail closed for directly controlled avatar targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.97",
+      "version": "0.0.98",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -144,7 +144,11 @@ The Rust orchestrator currently owns:
   composition traces, and stale/tampered submission rejection.
 - Signed-ownership item materialization with durable receipts, reversible
   Collection returns, and possession provenance.
-- Session-touched and heartbeat-refreshed live human presence, so stale generated avatars do not crowd active rooms.
+- Session-touched and heartbeat-refreshed direct-input presence, so stale
+  directly controlled avatars do not crowd active rooms.
+- Controller-based safety policy: directly controlled avatars cannot be theft
+  or combat targets without durable consent, blocks fail closed, and private
+  economy details are visible only to the controlling avatar.
 - Generated human avatar flavor: name, title, description, and runtime avatar card.
 - Advancement-backed `Chat` for beginning a friendship, plus moderated human-authored `say` lines for shared room speech.
 - OpenAI-compatible contextual resident replies with no deterministic dialogue substitute when inference is unavailable.
@@ -666,6 +670,11 @@ Locations are live channels:
 
 - `/state?actor_id=...` returns the actor's current location, visible presence, available actions, active-human room turn state, and room-scoped recent events.
 - `/world?actor_id=...&actor_session=...&wallet_session=...` returns the shared room map, gated/public status, accessible room contents, and locked-room summaries without exposing locked actor/item details.
+- Each `/world` location reports `actor_count` as all visible avatars, plus
+  `direct_input_actor_count` and `inference_actor_count` from authoritative
+  controller provenance. The transitional `human_count` and `resident_count`
+  fields alias those controller counts for older clients; they no longer inspect
+  kernel actor kind.
 - `/stream?actor_id=...&actor_session=...&wallet_session=...` broadcasts accepted world events over SSE after filtering to public Cottage events plus rooms visible to that actor/wallet. SSE messages include the world event sequence as their event id, and reconnects can replay missed visible events with `after=<seq>` or the native `Last-Event-ID` header. A lagged broadcast receiver is closed so EventSource reconnects from its last delivered id instead of silently skipping room lines. If the bounded replay cannot reach the subscribe-time sequence, the stream emits a named `gap` event and the browser reloads `/state` before continuing live updates.
 - `/events` uses the same visibility query parameters for replay; walletless requests only receive public Cottage-visible events. The response is `{ "world_id": "world://cosyworld/official", "world_epoch": 1, "events": [...], "next_after": 123, "through_seq": 123, "caught_up": true }`, so each event's `seq` completes its canonical public identity tuple. Replay defaults to the latest 80 visible events, accepts `limit=...`, and caps explicit requests at 500. Polling clients pass `next_after` into the next request so the cursor advances across events hidden by room or card visibility; each request scans at most 1,000 raw events.
 - Human presence in `/state` and `/world` is filtered to the current actor plus recently touched actor sessions; durable old avatars are not treated as online occupants.

--- a/v2/docs/combat-system.md
+++ b/v2/docs/combat-system.md
@@ -50,9 +50,13 @@ remain explicit exclusions, not browser approximations.
 ## Product integration
 
 Encounters attach to active worldpack jobs. Rust derives the encounter id from
-the job, limits targets to active declared participants, commits deterministic
-NPC turns, and advances the job only after the player side wins. Sanctuary
-rooms reject encounter creation regardless of pack reskins.
+the job, limits targets to active declared participants, and advances the job
+only after the player side wins. Inference-controlled participants can take
+deterministic turns. A directly controlled avatar is never selected as an
+encounter target without an explicit durable consent policy; until that policy
+exists, the orchestrator fails closed. A block in either direction also removes
+the target. Sanctuary rooms reject encounter creation regardless of pack
+reskins.
 
 The browser and terminal submit current action-offer envelopes through
 `POST /actions/submit`; compatibility endpoints remain `/actions/attack`,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.97"
+version = "0.0.98"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.97"
+version = "0.0.98"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -135,6 +135,8 @@ impl RuntimeWorld {
                         self.actor_by_id(*target_id).is_some_and(|target| {
                             Self::actor_is_active_avatar(target)
                                 && target.location_id == actor.location_id
+                                && !self.actor_control_mode(target.id).is_direct_input()
+                                && !self.actors_blocked(actor.id, target.id)
                         })
                     })
                     .map(|target_id| (job.id.clone(), target_id))

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5969,7 +5969,8 @@
       if (event?.type !== "message.created") return false;
       const numericActorId = Number(event.actor_id || 0);
       const actor = actorForId(numericActorId);
-      return event.source_world_tick != null || actor?.control_mode !== "direct_input";
+      return event.source_world_tick != null
+        || Boolean(actor && actor.control_mode !== "direct_input");
     }
 
     function pacedChatTranscriptEvents(events) {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -19993,6 +19993,10 @@ impl RuntimeWorld {
         let actor = self.actor_by_id(actor_id)?;
         self.active_chat_targets(actor_id)
             .into_iter()
+            .filter(|target| {
+                !self.actor_control_mode(target.id).is_direct_input()
+                    && !self.actors_blocked(actor_id, target.id)
+            })
             .find_map(|target| {
                 self.actor_held_items(target.id)
                     .into_iter()
@@ -42314,6 +42318,7 @@ mod tests {
             "/actions/transfer-offer",
             "/actions/actor-safety",
             "function eventIsMuted",
+            "Boolean(actor && actor.control_mode !== \"direct_input\")",
         ] {
             assert!(
                 INDEX_HTML.contains(contract),
@@ -53982,6 +53987,56 @@ mod tests {
     }
 
     #[test]
+    fn theft_targets_inference_controllers_and_fails_closed_for_players_and_blocks() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Would-be Thief",
+        );
+        create_test_human(
+            &mut runtime,
+            5001,
+            COSY_COTTAGE_LOCATION_ID,
+            "Protected Holder",
+        );
+        let tonic = runtime
+            .world
+            .items
+            .iter_mut()
+            .take(runtime.world.item_count)
+            .find(|item| item.id == 2001)
+            .expect("Hearth Tonic exists");
+        tonic.location_id = 0;
+        tonic.holder_actor_id = 5001;
+        tonic.zone = CW_CARD_ZONE_CARRIED;
+
+        assert!(
+            runtime.default_theft_candidate(5000).is_none(),
+            "a direct-input avatar never becomes an implicit theft target"
+        );
+
+        runtime.actor_autonomy.entry(5001).or_default().control_mode = ActorControlMode::LocalAi;
+        let (target, item) = runtime
+            .default_theft_candidate(5000)
+            .expect("the same avatar is eligible when inference controls it");
+        assert_eq!(target.id, 5001);
+        assert_eq!(item.id, 2001);
+
+        runtime
+            .actor_safety
+            .entry(5001)
+            .or_default()
+            .blocked_actor_ids
+            .insert(5000);
+        assert!(
+            runtime.default_theft_candidate(5000).is_none(),
+            "a block in either direction removes the theft target"
+        );
+    }
+
+    #[test]
     fn banked_advancement_points_train_once_per_rest_and_skill_bonus() {
         let mut runtime = RuntimeWorld::seeded();
         assert_eq!(normalize_skill_id("nimble_hands"), Some("nimble_hands"));
@@ -56335,6 +56390,48 @@ mod tests {
             .options
             .iter()
             .any(|option| matches!(option.kind.as_str(), "prepare" | "work" | "help")));
+    }
+
+    #[test]
+    fn combat_jobs_target_inference_controllers_and_fail_closed_for_players_and_blocks() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Consent Checker",
+        );
+        assert_eq!(
+            runtime.combat_job_for_actor(5000, Some(1004)),
+            Some((MOONLIT_JOB_ID.to_string(), 1004)),
+            "the authored inference-controlled encounter remains playable"
+        );
+
+        runtime
+            .actor_autonomy
+            .get_mut(&1004)
+            .expect("encounter target has controller provenance")
+            .control_mode = ActorControlMode::DirectInput;
+        assert!(
+            runtime.combat_job_for_actor(5000, Some(1004)).is_none(),
+            "a directly controlled avatar is not implicit combat consent"
+        );
+
+        runtime
+            .actor_autonomy
+            .get_mut(&1004)
+            .expect("encounter target retains controller provenance")
+            .control_mode = ActorControlMode::LocalAi;
+        runtime
+            .actor_safety
+            .entry(5000)
+            .or_default()
+            .blocked_actor_ids
+            .insert(1004);
+        assert!(
+            runtime.combat_job_for_actor(5000, Some(1004)).is_none(),
+            "a block in either direction removes the combat target"
+        );
     }
 
     #[test]
@@ -59743,6 +59840,96 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         assert!(!saw_reply, "no fallback reply should follow without AI");
+    }
+
+    #[test]
+    fn direct_player_economy_is_private_and_world_population_uses_controller_provenance() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Economy Viewer",
+        );
+        create_test_human(
+            &mut runtime,
+            5001,
+            COSY_COTTAGE_LOCATION_ID,
+            "Private Holder",
+        );
+        let tonic = runtime
+            .world
+            .items
+            .iter_mut()
+            .take(runtime.world.item_count)
+            .find(|item| item.id == 2001)
+            .expect("Hearth Tonic exists");
+        tonic.location_id = 0;
+        tonic.holder_actor_id = 5001;
+        tonic.zone = CW_CARD_ZONE_CARRIED;
+
+        let state = runtime.state_response(Some(5000), &AccessContext::default());
+        let viewer = state
+            .actors
+            .iter()
+            .find(|actor| actor.id == 5000)
+            .expect("viewing avatar is projected");
+        assert!(
+            viewer.resident_economy.is_some(),
+            "an avatar may inspect its own economy"
+        );
+        let other_player = state
+            .actors
+            .iter()
+            .find(|actor| actor.id == 5001)
+            .expect("co-present avatar is projected");
+        assert!(
+            other_player.resident_economy.is_none(),
+            "another direct player's private economy is not projected"
+        );
+        let inference_actor = state
+            .actors
+            .iter()
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("co-present inference avatar is projected");
+        assert!(
+            inference_actor.resident_economy.is_some(),
+            "inference-controlled economy remains a public world affordance"
+        );
+
+        let world = runtime.world_response(Some(5000), &AccessContext::default());
+        let cottage = world
+            .locations
+            .iter()
+            .find(|location| location.id == COSY_COTTAGE_LOCATION_ID)
+            .expect("Cottage is present in the world projection");
+        assert_eq!(cottage.actor_count, cottage.actors.len());
+        assert_eq!(
+            cottage.direct_input_actor_count + cottage.inference_actor_count,
+            cottage.actor_count
+        );
+        assert_eq!(
+            cottage.legacy_direct_input_actor_count,
+            cottage.direct_input_actor_count
+        );
+        assert_eq!(
+            cottage.legacy_inference_actor_count,
+            cottage.inference_actor_count
+        );
+        assert!(cottage
+            .actors
+            .iter()
+            .filter(|actor| actor.control_mode.is_direct_input())
+            .all(|actor| actor.resident_economy.is_none()));
+        let cottage_json = serde_json::to_value(cottage).expect("serialize location projection");
+        assert_eq!(
+            cottage_json["human_count"],
+            cottage_json["direct_input_actor_count"]
+        );
+        assert_eq!(
+            cottage_json["resident_count"],
+            cottage_json["inference_actor_count"]
+        );
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -223,6 +223,12 @@ pub(super) struct WorldLocationView {
     pub(super) access_reason: Option<String>,
     pub(super) card: CardView,
     pub(super) actor_count: usize,
+    pub(super) direct_input_actor_count: usize,
+    pub(super) inference_actor_count: usize,
+    #[serde(rename = "human_count")]
+    pub(super) legacy_direct_input_actor_count: usize,
+    #[serde(rename = "resident_count")]
+    pub(super) legacy_inference_actor_count: usize,
     pub(super) item_count: usize,
     pub(super) actors: Vec<ActorView>,
     pub(super) items: Vec<ItemView>,
@@ -1254,6 +1260,11 @@ impl RuntimeWorld {
         client_actor_id: Option<u64>,
     ) -> Option<ResidentEconomyView> {
         if !Self::actor_is_active_avatar(resident) {
+            return None;
+        }
+        if self.actor_control_mode(resident.id).is_direct_input()
+            && client_actor_id != Some(resident.id)
+        {
             return None;
         }
         let held_items_raw = self.actor_held_items(resident.id);
@@ -2325,11 +2336,12 @@ impl RuntimeWorld {
                             && !self.forgotten_search_item_at_location(*item, location.id)
                     })
                     .collect();
-                let actor_count = visible_actors_in_location
+                let actor_count = visible_actors_in_location.len();
+                let direct_input_actor_count = visible_actors_in_location
                     .iter()
-                    .copied()
-                    .filter(|actor| Self::actor_is_active_avatar(*actor))
+                    .filter(|actor| self.actor_control_mode(actor.id).is_direct_input())
                     .count();
+                let inference_actor_count = actor_count.saturating_sub(direct_input_actor_count);
                 let actors = accessible
                     .then(|| {
                         visible_actors_in_location
@@ -2392,6 +2404,10 @@ impl RuntimeWorld {
                     },
                     card,
                     actor_count,
+                    direct_input_actor_count,
+                    inference_actor_count,
+                    legacy_direct_input_actor_count: direct_input_actor_count,
+                    legacy_inference_actor_count: inference_actor_count,
                     item_count: items_in_location.len(),
                     actors,
                     items,


### PR DESCRIPTION
## Summary

- fail closed when theft or combat would target a directly controlled avatar; blocks remove targets in either direction
- keep inference-controlled world encounters and theft behavior available without consulting kernel actor kind
- hide another direct player's private inventory/desire projection while preserving their own view and public inference-controlled economy
- default unresolved chat actors to non-inference classification
- restore `actor_count` to all visible avatars, add controller-provenance counts, and expose the old `human_count` / `resident_count` names only as documented compatibility aliases
- document the controller-based safety boundary and bump release to 0.0.98

`moderation_suspend_actor` on current `main` already uses the authoritative controller API (`client_actor_can_submit`) and its existing regression rejects inference-controlled avatars, so this branch does not reintroduce a parallel moderation distinction.

Closes #177

## Validation

- `cargo test --manifest-path v2/orchestrator-rust/Cargo.toml closed_for_players -- --nocapture` — 2 passed
- `cargo test --manifest-path v2/orchestrator-rust/Cargo.toml direct_player_economy_is_private -- --nocapture` — 1 passed
- `npm run check` — 419 JS tests, worldpack/proof checks, C kernel, 416 Rust tests, and syntax checks passed
- `npm run check:version` — passed
- `git diff --check` — passed
- `npm run v2:check` — production-profile and all preceding checks passed; the browser smoke reached an unrelated failure already present on `main`, filed as #182

## Compatibility

`/world.locations[*].actor_count` again means every visible avatar. `direct_input_actor_count` and `inference_actor_count` make controller provenance explicit. Transitional `human_count` and `resident_count` JSON fields alias those counts for older clients and no longer inspect kernel kind.

## Review checklist

- [x] safety decisions use controller provenance, not actor kind
- [x] direct-vs-direct, direct-vs-inference, blocks, privacy, and unresolved-actor fallback have regression coverage
- [x] existing durable transfer consent, stale-offer, and moderation-controller tests remain green
- [x] no generated worldpack artifacts or unrelated dirty-checkout changes are included
- [x] release version is bumped