### PR TITLE
Make world pulses sparse and actor-causal

### DIFF
--- a/docs/world-simulation.md
+++ b/docs/world-simulation.md
@@ -1,0 +1,48 @@
+# Sparse, Actor-Causal World Simulation
+
+World maintenance is driven by committed played time. Every sixth qualifying
+world tick is a deterministic scheduling opportunity, not a promise to produce
+news. A due interval may update bounded frontier state and publish no event.
+The same journal prefix, content bundle, and seed always produce the same
+maintenance and public-beat decision.
+
+## Public beat budget
+
+A due interval publishes at most one material `world.*` beat. Stakes outrank a
+new opportunity; otherwise a deterministic gate and candidate selection choose
+between a notable weather transition, a concrete delivery need, a new faction
+claim, or a threshold conflict change. Non-notable weather, small pressure
+changes, and repeated active needs remain silent.
+
+Sanctuary state is never changed by automatic maintenance. Background
+opportunity state cannot become stakes. A stakes transition requires a
+journaled, causally relevant action in that same frontier and retains the
+source action sequence when it advances the local danger clock.
+
+## Logistics
+
+`trade_stock`, local use, and supply pressure are aggregate regional state.
+They never represent cargo and never emit a delivery-completed event. When
+scarcity becomes playable, the projection creates or updates a delivery job
+that names an origin, destination, and needed resource. Generic Work/Help
+cannot complete that job: the visible instructions require picking up a
+physical item, traveling with it, and giving, dropping, or using it at the
+destination.
+
+`world.logistics.completed` is derived only when the journal proves:
+
+1. a named active avatar acquired a physical item;
+2. one or more continuous `actor.moved` events carried that avatar from the
+   acquisition room to a different destination; and
+3. the same avatar completed `item.given`, `item.dropped`, or `item.used` there
+   without an intervening transfer that broke possession.
+
+The completion event stores actor id, item id, origin, destination, acquisition
+sequence, every movement sequence, the delivery sequence, source world tick,
+and a combined causal sequence list. Remove any required action from replay
+and the completion cannot be derived. Human-driven and inferred avatars use
+the identical evidence shape.
+
+Older `world.trade.flowed` and `world.trade.disrupted` records remain readable
+for journal compatibility, but new play never emits them and the player UI
+does not repeat their fictional transport prose.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.100",
+      "version": "0.0.101",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.100"
+version = "0.0.101"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.100"
+version = "0.0.101"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -6272,6 +6272,8 @@
       "world.weather.held",
       "world.trade.flowed",
       "world.trade.disrupted",
+      "world.delivery.needed",
+      "world.logistics.completed",
       "world.faction.influence_shifted",
       "world.conflict.pressure_grew",
       "world.conflict.pressure_eased",
@@ -6283,6 +6285,8 @@
       "world.weather.held",
       "world.trade.flowed",
       "world.trade.disrupted",
+      "world.delivery.needed",
+      "world.logistics.completed",
       "world.faction.influence_shifted",
       "world.conflict.pressure_grew",
       "world.conflict.pressure_eased",
@@ -7943,10 +7947,21 @@
         return finishSentence(cleanStatusText(event.content || "The weather settles in and stays"));
       }
       if (type === "world.trade.flowed") {
-        return finishSentence(cleanStatusText(event.content || "Something useful finds its way along the road"));
+        return "Supplies at the far end of the road have changed.";
       }
       if (type === "world.trade.disrupted") {
-        return finishSentence(cleanStatusText(event.content || "Something useful cannot find its way along the road"));
+        return "A distant place is running short, and someone could answer the need.";
+      }
+      if (type === "world.delivery.needed") {
+        return finishSentence(cleanStatusText(event.content || "A distant place needs a physical delivery"));
+      }
+      if (type === "world.logistics.completed") {
+        try {
+          const evidence = JSON.parse(String(event.content || "{}"));
+          return finishSentence(cleanStatusText(evidence.summary || "A traveler completes a physical delivery"));
+        } catch (_error) {
+          return "A traveler completes a physical delivery.";
+        }
       }
       if (type === "world.faction.influence_shifted") {
         return finishSentence(cleanStatusText(event.content || "A familiar presence carries farther today"));

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -748,6 +748,17 @@ struct JobState {
     memory_summary: String,
     #[serde(default)]
     action_copy: JobActionCopy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    delivery: Option<DeliveryJobSpec>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct DeliveryJobSpec {
+    resource: String,
+    origin_location_id: u64,
+    destination_location_id: u64,
+    created_world_tick: u64,
+    updated_world_tick: u64,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -6998,6 +7009,40 @@ impl RuntimeWorld {
                 continue;
             }
 
+            let matching_jobs = self
+                .jobs
+                .values()
+                .filter(|job| self.job_status(job) == "active")
+                .filter(|job| {
+                    job.delivery.as_ref().is_some_and(|delivery| {
+                        delivery.origin_location_id == evidence.origin_location_id
+                            && delivery.destination_location_id == evidence.destination_location_id
+                    })
+                })
+                .map(|job| job.id.clone())
+                .collect::<Vec<_>>();
+            for job_id in matching_jobs {
+                if let Some(progress_clock_id) = self
+                    .jobs
+                    .get(&job_id)
+                    .map(|job| job.progress_clock_id.clone())
+                {
+                    if let Some(clock) = self.clocks.get_mut(&progress_clock_id) {
+                        clock.filled = clock.segments;
+                        clock.status = "filled".to_string();
+                        clock.updated_event_seq = Some(evidence.delivery_event_seq);
+                    }
+                }
+                if let Some(event) = self.set_job_status(
+                    &job_id,
+                    "completed",
+                    evidence.actor_id,
+                    "physical_delivery",
+                ) {
+                    projected.push(event);
+                }
+            }
+
             let actor_name = self
                 .actor_name(evidence.actor_id)
                 .unwrap_or_else(|| format!("Actor {}", evidence.actor_id));
@@ -7728,6 +7773,7 @@ impl RuntimeWorld {
                 summary: "Choose how to help this newly found route settle into a familiar way."
                     .to_string(),
             },
+            delivery: None,
         });
     }
 
@@ -9480,7 +9526,11 @@ impl RuntimeWorld {
             }
             self.reconcile_card_zones();
             let delivery_evidence = self.update_item_provenance(&events);
-            events.extend(self.apply_actor_causal_logistics(delivery_evidence));
+            let logistics_events = self.apply_actor_causal_logistics(delivery_evidence);
+            let public_beat_available = logistics_events
+                .iter()
+                .all(|event| !event.type_name.starts_with("world."));
+            events.extend(logistics_events);
             self.project_qualifying_deeds(&events);
             self.apply_resident_memory_projection(&action, &events);
             if advances_world_tick {
@@ -9491,6 +9541,7 @@ impl RuntimeWorld {
                     &action,
                     record.seed,
                     &committed_events,
+                    public_beat_available,
                 ));
             }
             self.record_autonomous_action(record);
@@ -17254,12 +17305,13 @@ impl RuntimeWorld {
     fn location_has_job(&self, location_id: u64) -> bool {
         self.jobs
             .values()
-            .any(|job| job.location_ids.contains(&location_id))
+            .any(|job| job.delivery.is_none() && job.location_ids.contains(&location_id))
     }
 
     fn active_job_for_location(&self, location_id: u64) -> Option<&JobState> {
         self.jobs
             .values()
+            .filter(|job| job.delivery.is_none())
             .filter(|job| job.location_ids.contains(&location_id))
             .filter(|job| self.job_status(job) == "active")
             .filter_map(|job| {
@@ -17269,6 +17321,153 @@ impl RuntimeWorld {
             })
             .find(|(_, clock)| clock.filled < clock.segments)
             .map(|(job, _)| job)
+    }
+
+    fn ensure_delivery_need_job(
+        &mut self,
+        pulse: &WorldPulse,
+        source_location_id: Option<u64>,
+        caused_by_event_seq: Option<u64>,
+    ) -> Option<EventView> {
+        let trade = &pulse.trade;
+        let existing_id = self.jobs.values().find_map(|job| {
+            let delivery = job.delivery.as_ref()?;
+            (self.job_status(job) == "active"
+                && delivery.origin_location_id == trade.from_location_id
+                && delivery.destination_location_id == trade.to_location_id
+                && delivery.resource == trade.resource)
+                .then(|| job.id.clone())
+        });
+        if let Some(job_id) = existing_id {
+            let destination_name = self
+                .location_name(trade.to_location_id)
+                .unwrap_or_else(|| format!("Location {}", trade.to_location_id));
+            if let Some(job) = self.jobs.get_mut(&job_id) {
+                if let Some(delivery) = job.delivery.as_mut() {
+                    delivery.updated_world_tick = pulse.source_world_tick;
+                }
+                job.stakes = format!(
+                    "{destination_name} needs a represented item, carried there by an actor."
+                );
+            }
+            return None;
+        }
+
+        let origin_name = self
+            .location_name(trade.from_location_id)
+            .unwrap_or_else(|| format!("Location {}", trade.from_location_id));
+        let destination_name = self
+            .location_name(trade.to_location_id)
+            .unwrap_or_else(|| format!("Location {}", trade.to_location_id));
+        let resource_key = trade
+            .resource
+            .chars()
+            .map(|character| {
+                if character.is_ascii_alphanumeric() {
+                    character.to_ascii_lowercase()
+                } else {
+                    '-'
+                }
+            })
+            .collect::<String>();
+        let job_id = format!(
+            "world-delivery:{}:{}:{}:{}",
+            trade.from_location_id, trade.to_location_id, resource_key, pulse.pulse_index
+        );
+        let progress_clock_id = format!("{job_id}:arrived");
+        let danger_clock_id = format!("{job_id}:waiting");
+        let zone = if self.location_is_frontier(trade.to_location_id) {
+            ZONE_FRONTIER
+        } else {
+            ZONE_SANCTUARY
+        };
+        self.clocks.insert(
+            progress_clock_id.clone(),
+            ClockState {
+                id: progress_clock_id.clone(),
+                scope: "room".to_string(),
+                scope_id: trade.to_location_id,
+                kind: "progress".to_string(),
+                zone: zone.to_string(),
+                label: format!("Bring {} from {origin_name}", trade.resource),
+                segments: 1,
+                filled: 0,
+                visible_to_players: true,
+                status: "active".to_string(),
+                on_fill: Vec::new(),
+                created_event_seq: None,
+                updated_event_seq: None,
+            },
+        );
+        self.clocks.insert(
+            danger_clock_id.clone(),
+            ClockState {
+                id: danger_clock_id.clone(),
+                scope: "room".to_string(),
+                scope_id: trade.to_location_id,
+                kind: "danger".to_string(),
+                zone: zone.to_string(),
+                label: format!("{destination_name} goes without"),
+                segments: 4,
+                filled: 0,
+                visible_to_players: true,
+                status: "active".to_string(),
+                on_fill: Vec::new(),
+                created_event_seq: None,
+                updated_event_seq: None,
+            },
+        );
+        self.jobs.insert(
+            job_id.clone(),
+            JobState {
+                pack_id: String::new(),
+                id: job_id,
+                premise: format!(
+                    "Bring a physical {} from {origin_name} to {destination_name}.",
+                    trade.resource
+                ),
+                stakes: format!(
+                    "{destination_name} needs an actor to carry a represented item there."
+                ),
+                location_ids: vec![trade.from_location_id, trade.to_location_id],
+                participant_ids: Vec::new(),
+                progress_clock_id,
+                danger_clock_id,
+                status: "active".to_string(),
+                reward: JobReward::Label(format!(
+                    "{destination_name} remembers who answered the need."
+                )),
+                consequence: format!("{destination_name} continues to go without."),
+                memory_summary: format!(
+                    "A physical delivery connected {origin_name} and {destination_name}."
+                ),
+                action_copy: JobActionCopy {
+                    label: format!("Carry {} to {destination_name}", trade.resource),
+                    summary: format!(
+                        "Pick up a physical item at {origin_name}, travel with it, then give, drop, or use it at {destination_name}."
+                    ),
+                },
+                delivery: Some(DeliveryJobSpec {
+                    resource: trade.resource.clone(),
+                    origin_location_id: trade.from_location_id,
+                    destination_location_id: trade.to_location_id,
+                    created_world_tick: pulse.source_world_tick,
+                    updated_world_tick: pulse.source_world_tick,
+                }),
+            },
+        );
+        Some(self.append_world_history_event(
+            "world.delivery.needed",
+            trade.from_location_id,
+            Some(trade.to_location_id),
+            format!(
+                "{destination_name} is running short of {}. A physical item picked up at {origin_name} can be carried there.",
+                trade.resource
+            ),
+            pulse.source_world_tick,
+            source_location_id,
+            caused_by_event_seq,
+        ))
     }
 
     fn world_stakes_consent(
@@ -17339,6 +17538,7 @@ impl RuntimeWorld {
         action: &CwAction,
         entropy: u64,
         source_events: &[EventView],
+        allow_public_beat: bool,
     ) -> Vec<EventView> {
         let Some(actor) = self.actor_by_id(action.actor_id) else {
             return Vec::new();
@@ -17370,113 +17570,97 @@ impl RuntimeWorld {
         };
 
         let mut events = Vec::new();
-        let weather_location = self
-            .location_name(pulse.weather.location_id)
-            .unwrap_or_else(|| format!("Location {}", pulse.weather.location_id));
-        events.push(self.append_world_history_event(
-            "world.weather.shifted",
-            pulse.weather.location_id,
-            None,
-            format!(
-                "At {weather_location}, {} gives way to {}. The changed air asks nothing of anyone.",
-                pulse.weather.before,
-                pulse.weather.after
-            ),
-            pulse.source_world_tick,
-            source_location_id,
-            caused_by_event_seq,
-        ));
-
-        let trade_origin = self
-            .location_name(pulse.trade.from_location_id)
-            .unwrap_or_else(|| format!("Location {}", pulse.trade.from_location_id));
-        let trade_destination = self
-            .location_name(pulse.trade.to_location_id)
-            .unwrap_or_else(|| format!("Location {}", pulse.trade.to_location_id));
-        let (trade_type, trade_content) = if pulse.trade.moved {
-            (
-                "world.trade.flowed",
-                format!(
-                    "A caravan carries {} {} from {trade_origin} to {trade_destination}; {}. The road is open enough to follow.",
-                    pulse.trade.amount,
-                    pulse.trade.resource,
-                    pulse.trade.reason
-                ),
-            )
-        } else {
-            (
-                "world.trade.disrupted",
-                format!(
-                    "The {} between {trade_origin} and {trade_destination} cannot find its way; {}. Either end of the road may need a visitor.",
-                    pulse.trade.resource,
-                    pulse.trade.reason
-                ),
-            )
-        };
-        events.push(self.append_world_history_event(
-            trade_type,
-            pulse.trade.from_location_id,
-            Some(pulse.trade.to_location_id),
-            trade_content,
-            pulse.source_world_tick,
-            source_location_id,
-            caused_by_event_seq,
-        ));
-
-        if let Some(faction) = pulse.faction.as_ref() {
-            let from_name = self
-                .location_name(faction.from_location_id)
-                .unwrap_or_else(|| format!("Location {}", faction.from_location_id));
-            let to_name = self
-                .location_name(faction.to_location_id)
-                .unwrap_or_else(|| format!("Location {}", faction.to_location_id));
-            events.push(self.append_world_history_event(
-                "world.faction.influence_shifted",
-                faction.from_location_id,
-                Some(faction.to_location_id),
-                format!(
-                    "{} carries its promises from {from_name} toward {to_name}. By evening, {to_name} has heard the claim.",
-                    faction.faction_name
-                ),
-                pulse.source_world_tick,
-                source_location_id,
-                caused_by_event_seq,
-            ));
-        }
-
-        if pulse.conflict.after != pulse.conflict.before || pulse.conflict.escalated {
-            let conflict_location = self
-                .location_name(pulse.conflict.location_id)
-                .unwrap_or_else(|| format!("Location {}", pulse.conflict.location_id));
-            let event_type = if pulse.conflict.escalated {
-                "world.conflict.escalated"
-            } else if pulse.conflict.after > pulse.conflict.before {
-                "world.conflict.pressure_grew"
-            } else {
-                "world.conflict.pressure_eased"
-            };
-            let conflict_cause = if pulse.conflict.class == PulseEffectClass::Stakes {
-                stakes_consent.as_ref().map(|(_, event_seq, _)| *event_seq)
-            } else {
-                caused_by_event_seq
-            };
-            events.push(self.append_world_history_event(
-                event_type,
-                pulse.conflict.location_id,
-                None,
-                if pulse.conflict.escalated {
-                    format!("In {conflict_location}, old strains meet and the air hardens.")
-                } else if pulse.conflict.after > pulse.conflict.before {
-                    format!(
-                        "The air in {conflict_location} draws taut around an unanswered strain."
-                    )
-                } else {
-                    format!("Whatever pressed on {conflict_location} loosens, for now.")
-                },
-                pulse.source_world_tick,
-                source_location_id,
-                conflict_cause,
-            ));
+        if allow_public_beat {
+            match pulse.public_beat {
+                Some(PulseBeatKind::Weather) if pulse.weather.notable => {
+                    let weather_location = self
+                        .location_name(pulse.weather.location_id)
+                        .unwrap_or_else(|| format!("Location {}", pulse.weather.location_id));
+                    events.push(self.append_world_history_event(
+                        "world.weather.shifted",
+                        pulse.weather.location_id,
+                        None,
+                        format!(
+                            "At {weather_location}, {} gives way to {}. Travelers there may need to change their plans.",
+                            pulse.weather.before, pulse.weather.after
+                        ),
+                        pulse.source_world_tick,
+                        source_location_id,
+                        caused_by_event_seq,
+                    ));
+                }
+                Some(PulseBeatKind::DeliveryNeed) if pulse.trade.needs_delivery => {
+                    if let Some(event) = self.ensure_delivery_need_job(
+                        &pulse,
+                        source_location_id,
+                        caused_by_event_seq,
+                    ) {
+                        events.push(event);
+                    }
+                }
+                Some(PulseBeatKind::Faction) => {
+                    if let Some(faction) = pulse.faction.as_ref() {
+                        let from_name = self
+                            .location_name(faction.from_location_id)
+                            .unwrap_or_else(|| format!("Location {}", faction.from_location_id));
+                        let to_name = self
+                            .location_name(faction.to_location_id)
+                            .unwrap_or_else(|| format!("Location {}", faction.to_location_id));
+                        events.push(self.append_world_history_event(
+                            "world.faction.influence_shifted",
+                            faction.from_location_id,
+                            Some(faction.to_location_id),
+                            format!(
+                                "{} carries its promises from {from_name} toward {to_name}. People at {to_name} now have a new claim to answer.",
+                                faction.faction_name
+                            ),
+                            pulse.source_world_tick,
+                            source_location_id,
+                            caused_by_event_seq,
+                        ));
+                    }
+                }
+                Some(PulseBeatKind::Conflict)
+                    if pulse.conflict.after != pulse.conflict.before
+                        || pulse.conflict.escalated =>
+                {
+                    let conflict_location = self
+                        .location_name(pulse.conflict.location_id)
+                        .unwrap_or_else(|| format!("Location {}", pulse.conflict.location_id));
+                    let event_type = if pulse.conflict.escalated {
+                        "world.conflict.escalated"
+                    } else if pulse.conflict.after > pulse.conflict.before {
+                        "world.conflict.pressure_grew"
+                    } else {
+                        "world.conflict.pressure_eased"
+                    };
+                    let conflict_cause = if pulse.conflict.class == PulseEffectClass::Stakes {
+                        stakes_consent.as_ref().map(|(_, event_seq, _)| *event_seq)
+                    } else {
+                        caused_by_event_seq
+                    };
+                    events.push(self.append_world_history_event(
+                        event_type,
+                        pulse.conflict.location_id,
+                        None,
+                        if pulse.conflict.escalated {
+                            format!(
+                                "In {conflict_location}, old strains meet and the air hardens."
+                            )
+                        } else if pulse.conflict.after > pulse.conflict.before {
+                            format!(
+                                "The air in {conflict_location} draws taut around an unanswered strain."
+                            )
+                        } else {
+                            format!("Whatever pressed on {conflict_location} loosens, for now.")
+                        },
+                        pulse.source_world_tick,
+                        source_location_id,
+                        conflict_cause,
+                    ));
+                }
+                _ => {}
+            }
         }
 
         if pulse.conflict.escalated && pulse.conflict.class == PulseEffectClass::Stakes {
@@ -48261,6 +48445,8 @@ mod tests {
         assert!(INDEX_HTML.contains("const worldTranscriptEventTypes = new Set(["));
         assert!(INDEX_HTML.contains("world.weather.shifted"));
         assert!(INDEX_HTML.contains("world.trade.flowed"));
+        assert!(INDEX_HTML.contains("world.delivery.needed"));
+        assert!(INDEX_HTML.contains("world.logistics.completed"));
         assert!(INDEX_HTML.contains("world.faction.influence_shifted"));
         assert!(INDEX_HTML.contains("world.conflict.escalated"));
         assert!(INDEX_HTML.contains(
@@ -50593,12 +50779,12 @@ mod tests {
     #[test]
     fn srd_action_replay_golden_is_byte_stable_and_offline() {
         let fixture: serde_json::Value = serde_json::from_str(include_str!(
-            "../tests/fixtures/srd-action-replay-golden-v1.json"
+            "../tests/fixtures/srd-action-replay-golden-v2.json"
         ))
         .expect("golden replay fixture is valid JSON");
         assert_eq!(
             fixture.get("schema").and_then(serde_json::Value::as_str),
-            Some("cosyworld.replay-golden/1")
+            Some("cosyworld.replay-golden/2")
         );
         let records: Vec<JournalRecord> = serde_json::from_value(
             fixture
@@ -69821,7 +70007,7 @@ mod tests {
     }
 
     #[test]
-    fn played_time_pulse_mutates_and_records_distant_world_history() {
+    fn played_time_pulse_can_maintain_distant_state_without_public_fiction() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
             &mut runtime,
@@ -69844,10 +70030,7 @@ mod tests {
             let (status, events) =
                 runtime.apply_journal_record(&JournalRecord::new(action, 80_001 + offset));
             assert_eq!(status, CW_OK);
-            if events
-                .iter()
-                .any(|event| event.type_name == "world.weather.shifted")
-            {
+            if runtime.world.tick % WORLD_PULSE_INTERVAL_TICKS == 0 {
                 pulse_events = events;
             }
         }
@@ -69858,13 +70041,23 @@ mod tests {
             runtime.world_simulation.last_advanced_tick,
             runtime.world.tick
         );
-        assert!(pulse_events
-            .iter()
-            .any(|event| event.type_name == "world.weather.shifted"));
-        assert!(pulse_events.iter().any(|event| matches!(
+        assert!(
+            pulse_events
+                .iter()
+                .filter(|event| event.type_name.starts_with("world."))
+                .count()
+                <= 1
+        );
+        assert!(!pulse_events.iter().any(|event| matches!(
             event.type_name.as_str(),
-            "world.trade.flowed" | "world.trade.disrupted"
+            "world.trade.flowed" | "world.trade.disrupted" | "world.logistics.completed"
         )));
+        assert!(pulse_events.iter().all(|event| {
+            let content = event.content.as_deref().unwrap_or_default().to_lowercase();
+            !["caravan", "courier", "shipment"]
+                .iter()
+                .any(|claim| content.contains(claim))
+        }));
         assert!(!pulse_events
             .iter()
             .any(|event| event.type_name == "world.conflict.escalated"));
@@ -69884,7 +70077,6 @@ mod tests {
 
         let world = runtime.world_response(Some(5000), &AccessContext::default());
         assert_eq!(world.simulation.pulse_index, 1);
-        assert!(!world.simulation.recent_history.is_empty());
         assert!(world.simulation.recent_history.windows(2).all(|pair| {
             pair[0].source_world_tick > pair[1].source_world_tick
                 || (pair[0].source_world_tick == pair[1].source_world_tick
@@ -69961,6 +70153,188 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_scarcity_creates_a_physical_delivery_job_without_claiming_completion() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pulse = WorldPulse {
+            pulse_index: 4,
+            source_world_tick: 24,
+            weather: WeatherShift {
+                class: PulseEffectClass::Ambient,
+                location_id: MOONLIT_TRAIL_LOCATION_ID,
+                before: "settled".to_string(),
+                after: "settled".to_string(),
+                intensity: 0,
+                changed: false,
+                notable: false,
+            },
+            trade: TradeOutcome {
+                class: PulseEffectClass::Opportunity,
+                from_location_id: MOONLIT_TRAIL_LOCATION_ID,
+                to_location_id: 2,
+                resource: "herbs".to_string(),
+                moved: false,
+                amount: 0,
+                reason: "useful stores are running thin".to_string(),
+                needs_delivery: true,
+            },
+            faction: None,
+            conflict: ConflictOutcome {
+                class: PulseEffectClass::Opportunity,
+                location_id: MOONLIT_TRAIL_LOCATION_ID,
+                before: 0,
+                after: 0,
+                escalated: false,
+                front_ids: Vec::new(),
+                faction_ids: Vec::new(),
+                reason: "quiet".to_string(),
+            },
+            public_beat: Some(PulseBeatKind::DeliveryNeed),
+        };
+        let event = runtime
+            .ensure_delivery_need_job(&pulse, Some(1), Some(77))
+            .expect("a new need creates one public opportunity");
+        assert_eq!(event.type_name, "world.delivery.needed");
+        assert_eq!(event.location_id, Some(MOONLIT_TRAIL_LOCATION_ID));
+        assert_eq!(event.destination_location_id, Some(2));
+        assert_eq!(event.caused_by_event_seq, Some(77));
+        assert!(!runtime
+            .event_log
+            .iter()
+            .any(|event| event.type_name == "world.logistics.completed"));
+        let job = runtime
+            .jobs
+            .values()
+            .find(|job| job.delivery.is_some())
+            .expect("the opportunity has a concrete job");
+        assert_eq!(runtime.job_status(job), "active");
+        assert!(job.premise.contains("physical"));
+        assert!(job.action_copy.summary.contains("Pick up a physical item"));
+        assert!(
+            runtime.active_progress_clock_id_for_location(2).is_none(),
+            "generic Work cannot abstractly complete a physical delivery"
+        );
+        assert!(
+            runtime
+                .ensure_delivery_need_job(&pulse, Some(1), Some(78))
+                .is_none(),
+            "the same active need updates silently instead of duplicating public news"
+        );
+    }
+
+    #[test]
+    fn causal_delivery_evidence_completes_the_matching_delivery_job() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pulse = WorldPulse {
+            pulse_index: 5,
+            source_world_tick: 30,
+            weather: WeatherShift {
+                class: PulseEffectClass::Ambient,
+                location_id: MOONLIT_TRAIL_LOCATION_ID,
+                before: "settled".to_string(),
+                after: "settled".to_string(),
+                intensity: 0,
+                changed: false,
+                notable: false,
+            },
+            trade: TradeOutcome {
+                class: PulseEffectClass::Opportunity,
+                from_location_id: MOONLIT_TRAIL_LOCATION_ID,
+                to_location_id: RAIN_SOFT_GARDEN_LOCATION_ID,
+                resource: "herbs".to_string(),
+                moved: false,
+                amount: 0,
+                reason: "useful stores are running thin".to_string(),
+                needs_delivery: true,
+            },
+            faction: None,
+            conflict: ConflictOutcome {
+                class: PulseEffectClass::Opportunity,
+                location_id: MOONLIT_TRAIL_LOCATION_ID,
+                before: 0,
+                after: 0,
+                escalated: false,
+                front_ids: Vec::new(),
+                faction_ids: Vec::new(),
+                reason: "quiet".to_string(),
+            },
+            public_beat: Some(PulseBeatKind::DeliveryNeed),
+        };
+        runtime
+            .ensure_delivery_need_job(&pulse, Some(COSY_COTTAGE_LOCATION_ID), Some(77))
+            .expect("delivery need");
+        let job_id = runtime
+            .jobs
+            .values()
+            .find(|job| job.delivery.is_some())
+            .map(|job| job.id.clone())
+            .expect("delivery job");
+
+        let projected = runtime.apply_actor_causal_logistics(vec![DeliveryEvidence {
+            actor_id: RATI_ACTOR_ID,
+            item_id: DEWBRIGHT_BUTTON_ITEM_ID,
+            origin_location_id: MOONLIT_TRAIL_LOCATION_ID,
+            destination_location_id: RAIN_SOFT_GARDEN_LOCATION_ID,
+            acquisition_event_seq: 80,
+            movement_event_seqs: vec![81],
+            delivery_event_seq: 82,
+        }]);
+
+        assert_eq!(runtime.job_status(&runtime.jobs[&job_id]), "completed");
+        assert!(projected
+            .iter()
+            .any(|event| event.type_name == "job.updated"));
+        assert_eq!(
+            projected
+                .iter()
+                .filter(|event| event.type_name == "world.logistics.completed")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn sixty_world_ticks_without_a_delivery_chain_never_invent_logistics() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Quiet Witness",
+        );
+        for seed in 97_000..97_060 {
+            assert_eq!(
+                runtime
+                    .apply_journal_record(&JournalRecord::new(
+                        CwAction {
+                            kind: CW_ACTION_ABILITY_CHECK,
+                            actor_id: 5000,
+                            ability: LISTEN_ABILITY,
+                            dc: LISTEN_DC,
+                            ..CwAction::default()
+                        },
+                        seed,
+                    ))
+                    .0,
+                CW_OK
+            );
+        }
+        assert_eq!(
+            runtime
+                .event_log
+                .iter()
+                .filter(|event| event.type_name == "world.logistics.completed")
+                .count(),
+            0
+        );
+        assert!(runtime.event_log.iter().all(|event| {
+            let content = event.content.as_deref().unwrap_or_default().to_lowercase();
+            !["caravan", "courier", "shipment", "carried item"]
+                .iter()
+                .any(|claim| content.contains(claim))
+        }));
+    }
+
+    #[test]
     fn consented_frontier_pulse_classifies_beats_and_advances_only_the_local_clock() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
@@ -70006,24 +70380,16 @@ mod tests {
             },
             91_337,
             std::slice::from_ref(&source_event),
+            true,
         );
-        let weather = events
-            .iter()
-            .find(|event| event.type_name == "world.weather.shifted")
-            .expect("ambient beat is public history");
-        assert!(weather
-            .content
-            .as_deref()
-            .is_some_and(|content| content.starts_with("At ")
-                && content.ends_with("The changed air asks nothing of anyone.")));
-        let trade = events
-            .iter()
-            .find(|event| event.type_name.starts_with("world.trade."))
-            .expect("opportunity beat is public history");
-        assert!(trade
-            .content
-            .as_deref()
-            .is_some_and(|content| content.contains("road") || content.contains("visitor")));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.type_name.starts_with("world."))
+                .count(),
+            1,
+            "a due pulse publishes at most its highest-priority material beat"
+        );
         let escalation = events
             .iter()
             .find(|event| event.type_name == "world.conflict.escalated")

--- a/v2/orchestrator-rust/src/story_metrics.rs
+++ b/v2/orchestrator-rust/src/story_metrics.rs
@@ -874,6 +874,8 @@ pub(super) fn world_beat_is_renderable(event: &EventView) -> bool {
                 | "world.weather.held"
                 | "world.trade.flowed"
                 | "world.trade.disrupted"
+                | "world.delivery.needed"
+                | "world.logistics.completed"
                 | "world.faction.influence_shifted"
                 | "world.conflict.pressure_grew"
                 | "world.conflict.pressure_eased"
@@ -1017,7 +1019,10 @@ fn story_action_category(event: &EventView) -> &'static str {
 }
 
 fn story_world_beat_kind(type_name: &str) -> &'static str {
-    if type_name.starts_with("world.trade.") {
+    if type_name.starts_with("world.trade.")
+        || type_name.starts_with("world.delivery.")
+        || type_name.starts_with("world.logistics.")
+    {
         "trade"
     } else if type_name.starts_with("world.faction.") {
         "faction"

--- a/v2/orchestrator-rust/src/world_simulation.rs
+++ b/v2/orchestrator-rust/src/world_simulation.rs
@@ -49,6 +49,14 @@ pub(crate) enum PulseEffectClass {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PulseBeatKind {
+    Weather,
+    DeliveryNeed,
+    Faction,
+    Conflict,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct WorldStakesConsent {
     pub location_id: u64,
 }
@@ -101,6 +109,7 @@ pub(crate) struct WorldPulse {
     pub trade: TradeOutcome,
     pub faction: Option<FactionAction>,
     pub conflict: ConflictOutcome,
+    pub public_beat: Option<PulseBeatKind>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -110,6 +119,8 @@ pub(crate) struct WeatherShift {
     pub before: String,
     pub after: String,
     pub intensity: u8,
+    pub changed: bool,
+    pub notable: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -121,6 +132,7 @@ pub(crate) struct TradeOutcome {
     pub moved: bool,
     pub amount: u8,
     pub reason: String,
+    pub needs_delivery: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -228,8 +240,13 @@ impl WorldSimulationState {
 
         let weather = self.advance_weather(seed, route.from_location_id, entropy, world_tick);
         let trade = self.advance_trade(seed, route, &weather, entropy, world_tick);
-        let faction =
-            self.advance_faction(seed, entropy, source_location_id, trade.moved, world_tick);
+        let faction = self.advance_faction(
+            seed,
+            entropy,
+            source_location_id,
+            !trade.needs_delivery,
+            world_tick,
+        );
         let conflict = self.advance_conflict(
             seed,
             &trade,
@@ -237,6 +254,14 @@ impl WorldSimulationState {
             &weather,
             stakes_consent,
             world_tick,
+        );
+        let public_beat = select_public_beat(
+            entropy,
+            self.pulse_index,
+            &weather,
+            &trade,
+            faction.as_ref(),
+            &conflict,
         );
 
         Some(WorldPulse {
@@ -246,6 +271,7 @@ impl WorldSimulationState {
             trade,
             faction,
             conflict,
+            public_beat,
         })
     }
 
@@ -308,20 +334,32 @@ impl WorldSimulationState {
         let palette = weather_palette(biome);
         let location = self.locations.entry(location_id).or_default();
         let before = location.weather.clone();
-        let mut index = deterministic_index(entropy, self.pulse_index ^ location_id, palette.len());
-        if palette[index].0 == before && palette.len() > 1 {
-            index = (index + 1) % palette.len();
-        }
-        let (after, intensity) = palette[index];
-        location.weather = after.to_string();
+        let before_intensity = location.weather_intensity;
+        let change_weather =
+            deterministic_index(entropy, self.pulse_index ^ location_id ^ 0x57ea_7e12, 3) == 0;
+        let index = deterministic_index(entropy, self.pulse_index ^ location_id, palette.len());
+        let (candidate, candidate_intensity) = palette[index];
+        let (after, intensity) = if change_weather {
+            (candidate.to_string(), candidate_intensity)
+        } else {
+            (before.clone(), before_intensity)
+        };
+        let changed = after != before || intensity != before_intensity;
+        let notable = changed
+            && (intensity >= 3
+                || before_intensity >= 3
+                || before_intensity.abs_diff(intensity) >= 2);
+        location.weather = after.clone();
         location.weather_intensity = intensity;
         location.last_pulse_tick = world_tick;
         WeatherShift {
             class: PulseEffectClass::Ambient,
             location_id,
             before,
-            after: after.to_string(),
+            after,
             intensity,
+            changed,
+            notable,
         }
     }
 
@@ -352,42 +390,16 @@ impl WorldSimulationState {
             .get(&route.from_location_id)
             .map(|location| location.trade_stock)
             .unwrap_or_default();
-        let blocked_reason = if weather.intensity >= 3 {
-            Some(format!("{} makes the route unsafe", weather.after))
-        } else if origin_stock <= 0 {
-            Some("the source market has nothing left to send".to_string())
-        } else {
-            None
-        };
-
-        if let Some(reason) = blocked_reason {
-            if let Some(origin) = self.locations.get_mut(&route.from_location_id) {
-                origin.trade_pressure = origin
-                    .trade_pressure
-                    .saturating_add(1)
-                    .min(MAX_TRADE_PRESSURE);
-                origin.last_pulse_tick = world_tick;
-            }
-            if let Some(destination) = self.locations.get_mut(&route.to_location_id) {
-                destination.trade_pressure = destination
-                    .trade_pressure
-                    .saturating_add(1)
-                    .min(MAX_TRADE_PRESSURE);
-                destination.last_pulse_tick = world_tick;
-            }
-            return TradeOutcome {
-                class: PulseEffectClass::Opportunity,
-                from_location_id: route.from_location_id,
-                to_location_id: route.to_location_id,
-                resource,
-                moved: false,
-                amount: 0,
-                reason,
-            };
-        }
-
+        let destination_stock = self
+            .locations
+            .get(&route.to_location_id)
+            .map(|location| location.trade_stock)
+            .unwrap_or_default();
+        // Regional stock is pressure, not represented cargo. Sources
+        // replenish and destinations consume locally; only actor/item events
+        // may claim that anything travelled.
         if let Some(origin) = self.locations.get_mut(&route.from_location_id) {
-            origin.trade_stock = origin.trade_stock.saturating_sub(1).max(0);
+            origin.trade_stock = origin.trade_stock.saturating_add(1).min(MAX_TRADE_STOCK);
             origin.trade_pressure = origin
                 .trade_pressure
                 .saturating_sub(1)
@@ -395,26 +407,32 @@ impl WorldSimulationState {
             origin.last_pulse_tick = world_tick;
         }
         if let Some(destination) = self.locations.get_mut(&route.to_location_id) {
-            destination.trade_stock = destination
-                .trade_stock
-                .saturating_add(1)
-                .min(MAX_TRADE_STOCK);
+            destination.trade_stock = destination.trade_stock.saturating_sub(1).max(0);
             destination.trade_pressure = destination
                 .trade_pressure
-                .saturating_sub(1)
-                .max(MIN_TRADE_PRESSURE);
-            let imports = destination.imports.entry(resource.clone()).or_default();
-            *imports = imports.saturating_add(1);
+                .saturating_add(1)
+                .min(MAX_TRADE_PRESSURE);
             destination.last_pulse_tick = world_tick;
         }
+        let needs_delivery = weather.intensity >= 3 || origin_stock <= 0 || destination_stock <= 2;
+        let reason = if weather.intensity >= 3 {
+            format!("{} leaves the route difficult to supply", weather.after)
+        } else if origin_stock <= 0 {
+            "the source has too little to answer the need".to_string()
+        } else if destination_stock <= 2 {
+            "useful stores at the destination are running thin".to_string()
+        } else {
+            "local stores changed without a represented delivery".to_string()
+        };
         TradeOutcome {
             class: PulseEffectClass::Opportunity,
             from_location_id: route.from_location_id,
             to_location_id: route.to_location_id,
             resource,
-            moved: true,
-            amount: 1,
-            reason: "the route held through the weather".to_string(),
+            moved: false,
+            amount: 0,
+            reason,
+            needs_delivery,
         }
     }
 
@@ -423,7 +441,7 @@ impl WorldSimulationState {
         seed: &WorldSimulationSeed,
         entropy: u64,
         source_location_id: Option<u64>,
-        trade_moved: bool,
+        local_supply_steady: bool,
         world_tick: u64,
     ) -> Option<FactionAction> {
         let zone_by_location = seed
@@ -495,7 +513,7 @@ impl WorldSimulationState {
             .collect::<Vec<_>>();
 
         let faction = self.factions.entry(faction_id.clone()).or_default();
-        faction.momentum = if trade_moved {
+        faction.momentum = if local_supply_steady {
             faction.momentum.saturating_add(1)
         } else {
             faction.momentum.saturating_sub(1)
@@ -631,6 +649,43 @@ impl WorldSimulationState {
             reason: reason.to_string(),
         }
     }
+}
+
+fn select_public_beat(
+    entropy: u64,
+    pulse_index: u64,
+    weather: &WeatherShift,
+    trade: &TradeOutcome,
+    faction: Option<&FactionAction>,
+    conflict: &ConflictOutcome,
+) -> Option<PulseBeatKind> {
+    if conflict.escalated {
+        return Some(PulseBeatKind::Conflict);
+    }
+    // A due pulse is a scheduling opportunity. Most due pulses quietly
+    // maintain bounded state and publish nothing.
+    if deterministic_index(entropy, pulse_index ^ 0xbea7_0001, 4) != 0 {
+        return None;
+    }
+    let mut candidates = Vec::new();
+    if trade.needs_delivery {
+        candidates.push(PulseBeatKind::DeliveryNeed);
+    }
+    if weather.notable {
+        candidates.push(PulseBeatKind::Weather);
+    }
+    if faction.is_some_and(|action| action.influence_after != action.influence_before) {
+        candidates.push(PulseBeatKind::Faction);
+    }
+    if conflict.after != conflict.before && (conflict.after == 0 || conflict.after >= 3) {
+        candidates.push(PulseBeatKind::Conflict);
+    }
+    choose(
+        &candidates,
+        entropy.rotate_left(13),
+        pulse_index ^ 0xbea7_0002,
+    )
+    .copied()
 }
 
 fn default_weather() -> String {
@@ -814,6 +869,44 @@ mod tests {
     }
 
     #[test]
+    fn a_due_pulse_can_be_a_deterministic_public_no_op() {
+        let seed = test_seed();
+        let entropy = (1_u64..=256)
+            .find(|entropy| {
+                let mut candidate = WorldSimulationState::default();
+                candidate
+                    .advance_if_due(&seed, WORLD_PULSE_INTERVAL_TICKS, *entropy, Some(1), None)
+                    .is_some_and(|pulse| pulse.public_beat.is_none())
+            })
+            .expect("the scheduler admits silent due pulses");
+        let mut left = WorldSimulationState::default();
+        let mut right = WorldSimulationState::default();
+        let left_pulse = left
+            .advance_if_due(&seed, WORLD_PULSE_INTERVAL_TICKS, entropy, Some(1), None)
+            .expect("left pulse");
+        let right_pulse = right
+            .advance_if_due(&seed, WORLD_PULSE_INTERVAL_TICKS, entropy, Some(1), None)
+            .expect("right pulse");
+        assert_eq!(left_pulse, right_pulse);
+        assert_eq!(left_pulse.public_beat, None);
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn due_pulses_do_not_force_weather_to_change() {
+        let seed = test_seed();
+        let held = (1_u64..=256).find_map(|entropy| {
+            let mut state = WorldSimulationState::default();
+            state
+                .advance_if_due(&seed, WORLD_PULSE_INTERVAL_TICKS, entropy, Some(1), None)
+                .filter(|pulse| !pulse.weather.changed)
+        });
+        let pulse = held.expect("some due weather maintenance is intentionally quiet");
+        assert_eq!(pulse.weather.before, pulse.weather.after);
+        assert!(!pulse.weather.notable);
+    }
+
+    #[test]
     fn different_committed_seeds_can_create_different_history() {
         let seed = test_seed();
         let mut baseline_state = WorldSimulationState::default();
@@ -849,6 +942,7 @@ mod tests {
             moved: false,
             amount: 0,
             reason: "blocked".to_string(),
+            needs_delivery: true,
         };
         let faction = FactionAction {
             class: PulseEffectClass::Opportunity,
@@ -866,6 +960,8 @@ mod tests {
             before: "settled".to_string(),
             after: "a ridge storm".to_string(),
             intensity: 3,
+            changed: true,
+            notable: true,
         };
         let conflict = state.advance_conflict(&seed, &trade, Some(&faction), &weather, None, 6);
         assert!(!conflict.escalated);
@@ -901,8 +997,7 @@ mod tests {
         let mut state = WorldSimulationState::default();
         let mut weather_locations = BTreeSet::new();
         let mut faction_ids = BTreeSet::new();
-        let mut saw_trade = false;
-        let mut saw_disruption = false;
+        let mut saw_delivery_need = false;
         let mut saw_conflict_change = false;
         let mut saw_stakes = false;
 
@@ -913,8 +1008,11 @@ mod tests {
                 .advance_if_due(&seed, tick, entropy, None, None)
                 .expect("each interval produces a pulse");
             weather_locations.insert(pulse.weather.location_id);
-            saw_trade |= pulse.trade.moved;
-            saw_disruption |= !pulse.trade.moved;
+            assert!(
+                !pulse.trade.moved,
+                "aggregate maintenance never claims physical movement"
+            );
+            saw_delivery_need |= pulse.trade.needs_delivery;
             if let Some(faction) = pulse.faction {
                 faction_ids.insert(faction.faction_id);
             }
@@ -926,8 +1024,10 @@ mod tests {
             weather_locations.len() >= 2,
             "weather should roam between rooms"
         );
-        assert!(saw_trade, "clear routes should move real stock");
-        assert!(saw_disruption, "storms or scarcity should interrupt trade");
+        assert!(
+            saw_delivery_need,
+            "local use and difficult weather should eventually expose a delivery need"
+        );
         assert!(faction_ids.len() >= 2, "multiple factions should propagate");
         assert!(
             saw_conflict_change,
@@ -937,7 +1037,7 @@ mod tests {
         assert!(state
             .locations
             .values()
-            .any(|location| !location.imports.is_empty()));
+            .all(|location| location.imports.is_empty()));
     }
 
     #[test]

--- a/v2/orchestrator-rust/tests/fixtures/srd-action-replay-golden-v2.json
+++ b/v2/orchestrator-rust/tests/fixtures/srd-action-replay-golden-v2.json
@@ -1,0 +1,78 @@
+{
+  "schema": "cosyworld.replay-golden/2",
+  "description": "Offline append-only replay covering legacy combat/2-style attack, combat/3 encounter start, generic checks, project projection, the active SRD Search/Study profile, and sparse due pulses that reserve no public event sequence when nothing material happens.",
+  "records": [
+    {
+      "version": 1,
+      "action": {"kind":1,"ability":0,"dc":0,"actor_id":5000,"target_actor_id":0,"location_id":3,"destination_location_id":0,"content_id":0,"item_id":0,"target_item_id":0,"output_item_id":0,"output_target_id":0,"modifier":0,"output_target_kind":0,"output_item_kind":0,"output_item_charges":0,"roll_mode":0},
+      "seed": 4200
+    },
+    {
+      "version": 1,
+      "action": {"kind":7,"ability":0,"dc":0,"actor_id":5000,"target_actor_id":1004,"location_id":0,"destination_location_id":0,"content_id":0,"item_id":0,"target_item_id":0,"output_item_id":0,"output_target_id":0,"modifier":0,"output_target_kind":0,"output_item_kind":0,"output_item_charges":0,"roll_mode":0},
+      "seed": 4201
+    },
+    {
+      "version": 1,
+      "action": {"kind":4,"ability":4,"dc":10,"actor_id":5000,"target_actor_id":0,"location_id":0,"destination_location_id":0,"content_id":0,"item_id":0,"target_item_id":0,"output_item_id":0,"output_target_id":0,"modifier":0,"output_target_kind":0,"output_item_kind":0,"output_item_charges":0,"roll_mode":0},
+      "seed": 4202
+    },
+    {
+      "version": 1,
+      "action": {"kind":0,"ability":0,"dc":0,"actor_id":5000,"target_actor_id":0,"location_id":0,"destination_location_id":0,"content_id":0,"item_id":0,"target_item_id":0,"output_item_id":0,"output_target_id":0,"modifier":0,"output_target_kind":0,"output_item_kind":0,"output_item_charges":0,"roll_mode":0},
+      "seed": 4203,
+      "projection_mutations": [
+        {"kind":"advance_clock","clock_id":"moonlit-trail.progress","amount":1,"reason":"golden_project"}
+      ]
+    },
+    {
+      "version": 6,
+      "rules_profile": "cosyworld.srd5/1",
+      "rules_action": "srd5.2.1:search",
+      "resolver": "discovery_search_v1",
+      "origin": "player_card",
+      "action": {"kind":21,"ability":4,"dc":10,"actor_id":5000,"target_actor_id":0,"location_id":0,"destination_location_id":0,"content_id":0,"item_id":0,"target_item_id":0,"output_item_id":0,"output_target_id":0,"modifier":0,"output_target_kind":0,"output_item_kind":0,"output_item_charges":0,"roll_mode":0},
+      "seed": 4204
+    },
+    {
+      "version": 6,
+      "rules_profile": "cosyworld.srd5/1",
+      "rules_action": "srd5.2.1:study",
+      "resolver": "discovery_study_v1",
+      "origin": "player_card",
+      "action": {"kind":22,"ability":3,"dc":10,"actor_id":5000,"target_actor_id":0,"location_id":0,"destination_location_id":0,"content_id":0,"item_id":0,"target_item_id":0,"output_item_id":0,"output_target_id":0,"modifier":0,"output_target_kind":0,"output_item_kind":0,"output_item_charges":0,"roll_mode":0},
+      "seed": 4205
+    },
+    {
+      "version": 1,
+      "action": {"kind":15,"ability":0,"dc":0,"actor_id":5000,"target_actor_id":1004,"location_id":0,"destination_location_id":0,"content_id":9003,"item_id":0,"target_item_id":0,"output_item_id":0,"output_target_id":0,"modifier":0,"output_target_kind":0,"output_item_kind":0,"output_item_charges":0,"roll_mode":0},
+      "seed": 4206
+    }
+  ],
+  "expected": {
+    "rules_profile": "cosyworld.srd5/1",
+    "kernel_version": 5,
+    "world_tick": 8,
+    "next_event_seq": 17,
+    "actor": {"id":5000,"location_id":3,"status":1,"damage":0},
+    "echo": {"id":1004,"status":1,"damage":4,"current_hp":2},
+    "project_clock": 1,
+    "encounter": {"id":9003,"status":1,"round":1,"participant_count":2},
+    "events": [
+      [2,"actor.created",true,5000,null,null,null,null,null,null,12,null,null,null,null],
+      [3,"actor.entered_location",true,5000,null,null,null,null,null,null,null,null,null,null,null],
+      [5,"combat.attack.attempt",true,5000,1004,17,1,18,11,null,null,null,null,null,null],
+      [6,"combat.attack.hit",true,5000,1004,17,1,18,11,4,2,null,null,null,null],
+      [7,"clock.updated",true,5000,null,null,null,null,null,null,null,"moonlit-trail.danger",1,1,"attack"],
+      [8,"ability_check.rolled",true,5000,null,12,2,14,10,null,null,null,null,null,null],
+      [9,"clock.updated",true,5000,null,null,null,null,null,null,null,"moonlit-trail.progress",1,1,"golden_project"],
+      [10,"ability_check.rolled",false,5000,null,2,2,4,10,null,null,null,null,null,null],
+      [11,"ability_check.rolled",false,5000,null,2,1,3,10,null,null,null,null,null,null],
+      [12,"study.resolved",true,5000,null,null,null,null,null,null,null,null,null,null,"The authored signs remain unresolved."],
+      [13,"combat.encounter.started",true,5000,1004,null,null,null,null,null,null,null,null,null,null],
+      [14,"combat.initiative.rolled",true,5000,null,4,null,4,null,null,null,null,null,null,null],
+      [15,"combat.initiative.rolled",true,1004,null,13,1,14,null,null,null,null,null,null,null],
+      [16,"combat.turn.started",true,1004,null,null,null,1,null,null,null,null,null,null,null]
+    ]
+  }
+}


### PR DESCRIPTION
Closes #152.

## What changed

- makes each due world pulse a deterministic scheduling opportunity that can publish nothing and caps it at one material `world.*` beat
- stops aggregate regional stock maintenance from claiming that cargo, caravans, couriers, or shipments physically moved
- creates a concrete delivery job when scarcity becomes playable; generic Work/Help cannot complete it
- completes delivery jobs only from the existing incremental actor/item possession evidence and keeps human-driven and inferred avatars on the same evidence path
- limits weather narration to notable transitions, preserves consent-gated stakes, and suppresses a scheduled beat when the same action already produced a causal logistics completion
- teaches the browser and story metrics about `world.delivery.needed` and `world.logistics.completed`, while keeping old aggregate trade records readable without repeating fictional carrier prose
- versions the replay golden for the intentional removal of phantom event-sequence reservations
- bumps the release to 0.0.101 and documents the actor-causal simulation contract

## Why

The scheduled pulse treated aggregate trade pressure as proof of a physical delivery and emitted multiple public beats every interval. That fabricated off-screen entities and made quiet maintenance noisy. The runtime already had an incremental item-provenance projection capable of proving real cross-room deliveries, so this change makes that projection the only source of completion claims.

## Impact

Players receive less filler and no invented logistics. Scarcity now becomes an explicit physical-delivery opportunity, and a completion is credited only after the journal proves the same avatar acquired an item, moved with it, and delivered it at another location.

## Validation

- 425 Node tests
- strict official/composed worldpack checks and proof-world validation
- C kernel checks
- 433 Rust tests
- syntax checks
- ESLint
- Rust build
- production webpack build
- focused silent-pulse, 60-tick no-phantom-logistics, delivery-job, replay, and browser-contract regressions