### PR TITLE
Transform quest loot at capable places

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.111",
+  "version": "0.0.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.111",
+      "version": "0.0.112",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.111",
+  "version": "0.0.112",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,
@@ -24,7 +24,7 @@
     "v2:check": "./v2/mvp.sh check",
     "v2:stop": "./v2/mvp.sh stop",
     "v2:worldpack": "npm run v2:worldpack:official && npm run v2:worldpack:compositions && npm run v2:proof-world -- --strict",
-    "v2:worldpack:official": "node --test v2/scripts/natural-affordance-schema.test.mjs v2/scripts/building-archetype-schema.test.mjs v2/scripts/loot-table-schema.test.mjs && node v2/scripts/import-srd-5.1.mjs --check && node v2/scripts/import-srd-5.2.1.mjs --check && node v2/scripts/compile-worldpack.mjs --check && node v2/scripts/check-worldpack.mjs",
+    "v2:worldpack:official": "node --test v2/scripts/natural-affordance-schema.test.mjs v2/scripts/building-archetype-schema.test.mjs v2/scripts/loot-table-schema.test.mjs v2/scripts/recipe-schema.test.mjs && node v2/scripts/import-srd-5.1.mjs --check && node v2/scripts/import-srd-5.2.1.mjs --check && node v2/scripts/compile-worldpack.mjs --check && node v2/scripts/check-worldpack.mjs",
     "v2:worldpack:compositions": "node v2/scripts/compile-worldpack.mjs --world-dir v2/worlds/core-only --output-dir v2/content/core-only --check && node v2/scripts/check-worldpack.mjs v2/content/core-only && node v2/scripts/compile-worldpack.mjs --world-dir v2/worlds/ruby-high-only --output-dir v2/content/ruby-high-only --check && node v2/scripts/check-worldpack.mjs v2/content/ruby-high-only && node v2/scripts/compile-worldpack.mjs --world-dir v2/worlds/services-only --output-dir v2/content/services-only --check && node v2/scripts/check-worldpack.mjs v2/content/services-only",
     "v2:worldpack:sync": "node v2/scripts/sync-worldpacks.mjs",
     "v2:worldpack:compile": "node v2/scripts/compile-worldpack.mjs",

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -118,7 +118,7 @@ describe("worldpack Manifest v1 validation", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "requires missing capability cosyworld.core/missing from cosyworld.core@1.3.9",
+      "requires missing capability cosyworld.core/missing from cosyworld.core@1.3.10",
     );
   });
 

--- a/v2/content/core-only/assets.json
+++ b/v2/content/core-only/assets.json
@@ -1,8 +1,8 @@
 [
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.9",
-    "pack_integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+    "pack_version": "1.3.10",
+    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -14,8 +14,8 @@
   },
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.9",
-    "pack_integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+    "pack_version": "1.3.10",
+    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/core-only/content_refs.json
+++ b/v2/content/core-only/content_refs.json
@@ -5,7 +5,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1001",
       "legacy_runtime_id": 1001,
@@ -14,7 +14,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1002",
       "legacy_runtime_id": 1002,
@@ -23,7 +23,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1003",
       "legacy_runtime_id": 1003,
@@ -32,7 +32,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1004",
       "legacy_runtime_id": 1004,
@@ -41,7 +41,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1005",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1005",
       "legacy_runtime_id": 1005,
@@ -50,7 +50,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1040",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1040",
       "legacy_runtime_id": 1040,
@@ -59,7 +59,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1041",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1041",
       "legacy_runtime_id": 1041,
@@ -68,7 +68,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1042",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1042",
       "legacy_runtime_id": 1042,
@@ -77,7 +77,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1043",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1043",
       "legacy_runtime_id": 1043,
@@ -86,7 +86,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1044",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1044",
       "legacy_runtime_id": 1044,
@@ -95,7 +95,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1045",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1045",
       "legacy_runtime_id": 1045,
@@ -104,7 +104,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1046",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1046",
       "legacy_runtime_id": 1046,
@@ -113,7 +113,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1047",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1047",
       "legacy_runtime_id": 1047,
@@ -122,7 +122,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1048",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1048",
       "legacy_runtime_id": 1048,
@@ -131,7 +131,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1049",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1049",
       "legacy_runtime_id": 1049,
@@ -140,7 +140,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1050",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1050",
       "legacy_runtime_id": 1050,
@@ -149,7 +149,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1051",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1051",
       "legacy_runtime_id": 1051,
@@ -158,7 +158,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1052",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1052",
       "legacy_runtime_id": 1052,
@@ -167,7 +167,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1053",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1053",
       "legacy_runtime_id": 1053,
@@ -176,7 +176,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1054",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1054",
       "legacy_runtime_id": 1054,
@@ -185,7 +185,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1055",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1055",
       "legacy_runtime_id": 1055,
@@ -194,7 +194,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1056",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1056",
       "legacy_runtime_id": 1056,
@@ -203,7 +203,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1057",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1057",
       "legacy_runtime_id": 1057,
@@ -212,7 +212,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1058",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1058",
       "legacy_runtime_id": 1058,
@@ -221,7 +221,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1059",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1059",
       "legacy_runtime_id": 1059,
@@ -230,7 +230,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1060",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1060",
       "legacy_runtime_id": 1060,
@@ -239,7 +239,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1061",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1061",
       "legacy_runtime_id": 1061,
@@ -248,7 +248,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1062",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1062",
       "legacy_runtime_id": 1062,
@@ -257,7 +257,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1063",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1063",
       "legacy_runtime_id": 1063,
@@ -266,7 +266,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1064",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1064",
       "legacy_runtime_id": 1064,
@@ -275,7 +275,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1065",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1065",
       "legacy_runtime_id": 1065,
@@ -284,7 +284,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1066",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1066",
       "legacy_runtime_id": 1066,
@@ -293,7 +293,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1067",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1067",
       "legacy_runtime_id": 1067,
@@ -302,7 +302,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1068",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1068",
       "legacy_runtime_id": 1068,
@@ -311,7 +311,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1069",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1069",
       "legacy_runtime_id": 1069,
@@ -320,7 +320,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1070",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1070",
       "legacy_runtime_id": 1070,
@@ -329,7 +329,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-abbey-bookmark",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-abbey-bookmark",
       "runtime_handle": 138956494956560
@@ -337,7 +337,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-azazoth",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-azazoth",
       "runtime_handle": 2742827434789688
@@ -345,7 +345,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-cottage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-cottage",
       "runtime_handle": 3679023710615970
@@ -353,7 +353,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-dewbright-button",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-dewbright-button",
       "runtime_handle": 7543879359126606
@@ -361,7 +361,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-hearth-tonic",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-hearth-tonic",
       "runtime_handle": 6099844187041316
@@ -369,7 +369,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-hearthstone-tag",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-hearthstone-tag",
       "runtime_handle": 445803431082645
@@ -377,7 +377,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-echo",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-moonlit-echo",
       "runtime_handle": 3701779326615881
@@ -385,7 +385,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-trail",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-moonlit-trail",
       "runtime_handle": 3706559719582066
@@ -393,7 +393,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonwool-thread",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-moonwool-thread",
       "runtime_handle": 3248987744606910
@@ -401,7 +401,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-mossglass-bead",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-mossglass-bead",
       "runtime_handle": 406732117808934
@@ -409,7 +409,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-old-oak",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-old-oak",
       "runtime_handle": 6806929065153819
@@ -417,7 +417,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-pearl-deep-resident",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-pearl-deep-resident",
       "runtime_handle": 8634483881055898
@@ -425,7 +425,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-rain-soft-garden",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-rain-soft-garden",
       "runtime_handle": 8636127016066734
@@ -433,7 +433,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-skull",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-skull",
       "runtime_handle": 8174630967825761
@@ -441,7 +441,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-story-button",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-story-button",
       "runtime_handle": 3151408643854036
@@ -449,7 +449,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-threadbare-map-scrap",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-threadbare-map-scrap",
       "runtime_handle": 4482891498418887
@@ -457,7 +457,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-vowbright-angel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-vowbright-angel",
       "runtime_handle": 7966555082684141
@@ -465,7 +465,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-watch-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-watch-bell",
       "runtime_handle": 6205526622615328
@@ -473,7 +473,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-whiskerwind",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-whiskerwind",
       "runtime_handle": 5669444972898140
@@ -481,7 +481,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-wolfprint-charm",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-wolfprint-charm",
       "runtime_handle": 915703357568385
@@ -489,7 +489,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-zadkiel-dark-angel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-zadkiel-dark-angel",
       "runtime_handle": 8315124370132858
@@ -497,7 +497,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/item-ashwood-practice-blade",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "item-ashwood-practice-blade",
       "runtime_handle": 3640187639484502
@@ -505,7 +505,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/item-patchwork-satchel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "item-patchwork-satchel",
       "runtime_handle": 804106637155376
@@ -513,7 +513,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/item-steady-light",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "item-steady-light",
       "runtime_handle": 8614146586928189
@@ -521,7 +521,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-armored-winged-hero",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-armored-winged-hero",
       "runtime_handle": 6600128378329146
@@ -529,7 +529,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-badger-cub",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-badger-cub",
       "runtime_handle": 3524217422483260
@@ -537,7 +537,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-beetle-armor",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-beetle-armor",
       "runtime_handle": 7880939887467250
@@ -545,7 +545,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-blue-shadow-man",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-blue-shadow-man",
       "runtime_handle": 3755993660754793
@@ -553,7 +553,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-blue-squirrel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-blue-squirrel",
       "runtime_handle": 3374679645864704
@@ -561,7 +561,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-cloaked-mouse-reader",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-cloaked-mouse-reader",
       "runtime_handle": 3997082335066109
@@ -569,7 +569,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-forest-dryad",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-forest-dryad",
       "runtime_handle": 8662818472079145
@@ -577,7 +577,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-garden-rabbit",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-garden-rabbit",
       "runtime_handle": 2730391876987516
@@ -585,7 +585,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-golden-squirrel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-golden-squirrel",
       "runtime_handle": 162503682361987
@@ -593,7 +593,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-golden-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-golden-winged-boy",
       "runtime_handle": 4342854739894551
@@ -601,7 +601,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-grey-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-grey-winged-boy",
       "runtime_handle": 1250802238685798
@@ -609,7 +609,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-llama-scholar",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-llama-scholar",
       "runtime_handle": 6908093676132939
@@ -617,7 +617,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-mouse-wanderer",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-mouse-wanderer",
       "runtime_handle": 4601206403124060
@@ -625,7 +625,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-neon-tiger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-neon-tiger",
       "runtime_handle": 6229971572743818
@@ -633,7 +633,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-rabbit-scribe",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-rabbit-scribe",
       "runtime_handle": 8634110685852129
@@ -641,7 +641,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-red-shadow-figure",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-red-shadow-figure",
       "runtime_handle": 3112884101630158
@@ -649,7 +649,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-shadow-wolf",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-shadow-wolf",
       "runtime_handle": 4273988789998875
@@ -657,7 +657,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-steampunk-mouse",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-steampunk-mouse",
       "runtime_handle": 4441668646189737
@@ -665,7 +665,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-sunlit-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-sunlit-winged-boy",
       "runtime_handle": 8615932867192302
@@ -673,7 +673,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-tavern-blond-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-tavern-blond-boy",
       "runtime_handle": 1835702442135722
@@ -681,7 +681,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-veiled-forest-ghost",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-veiled-forest-ghost",
       "runtime_handle": 4799858469869419
@@ -689,7 +689,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-white-ferret-noble",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-white-ferret-noble",
       "runtime_handle": 5084247526999701
@@ -697,7 +697,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-wolf-pup",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-wolf-pup",
       "runtime_handle": 236437027581609
@@ -705,7 +705,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-woodland-bear",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-woodland-bear",
       "runtime_handle": 9000656934868850
@@ -713,7 +713,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-alpine-forest",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-alpine-forest",
       "runtime_handle": 8242458519360113
@@ -721,7 +721,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-circle-of-the-moon",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-circle-of-the-moon",
       "runtime_handle": 1930856172148870
@@ -729,7 +729,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-dark-abyss",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-dark-abyss",
       "runtime_handle": 7382677506125331
@@ -737,7 +737,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-darkest-ocean",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-darkest-ocean",
       "runtime_handle": 5061075064260629
@@ -745,7 +745,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-digital-realm",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-digital-realm",
       "runtime_handle": 5887686546418438
@@ -753,7 +753,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-endless-ocean",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-endless-ocean",
       "runtime_handle": 5401754774320525
@@ -761,7 +761,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-flower-meadow",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-flower-meadow",
       "runtime_handle": 7614022144101722
@@ -769,7 +769,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-goblin-cave",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-goblin-cave",
       "runtime_handle": 3499001612672709
@@ -777,7 +777,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-great-library",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-great-library",
       "runtime_handle": 7328586258800562
@@ -785,7 +785,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-haunted-mansion",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-haunted-mansion",
       "runtime_handle": 7484239537948286
@@ -793,7 +793,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-lofty-peak",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-lofty-peak",
       "runtime_handle": 2456240765655012
@@ -801,7 +801,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-lost-woods",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-lost-woods",
       "runtime_handle": 6580883718503069
@@ -809,7 +809,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-old-oak-tree",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-old-oak-tree",
       "runtime_handle": 2838379433219254
@@ -817,7 +817,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-quiet-abbey",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-quiet-abbey",
       "runtime_handle": 4838231888638100
@@ -825,7 +825,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-solar-temple",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-solar-temple",
       "runtime_handle": 450219611871818
@@ -833,7 +833,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-summit-trail",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-summit-trail",
       "runtime_handle": 8064929121549612
@@ -841,7 +841,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-the-heavens",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-the-heavens",
       "runtime_handle": 6396411156616223
@@ -849,7 +849,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-turgid-swamp",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-turgid-swamp",
       "runtime_handle": 6935773679641332
@@ -857,7 +857,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-wilting-jungle",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-wilting-jungle",
       "runtime_handle": 5897394732936641
@@ -865,7 +865,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/rati",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "rati",
       "runtime_handle": 1392254580257493
@@ -873,7 +873,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.fair-bargain",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "goblin-cave.fair-bargain",
       "runtime_handle": 8054949801377040
@@ -881,7 +881,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.leverage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "goblin-cave.leverage",
       "runtime_handle": 1065707925425919
@@ -889,7 +889,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "haunted-mansion.threshold",
       "runtime_handle": 4535315091897137
@@ -897,7 +897,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.warden-rage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "haunted-mansion.warden-rage",
       "runtime_handle": 6257115991159330
@@ -905,7 +905,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.danger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "moonlit-trail.danger",
       "runtime_handle": 257345026365457
@@ -913,7 +913,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.progress",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "moonlit-trail.progress",
       "runtime_handle": 6085238183587093
@@ -921,7 +921,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/rain-soft-garden.path-washes-out",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "rain-soft-garden.path-washes-out",
       "runtime_handle": 5725575878774039
@@ -929,7 +929,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/rain-soft-garden.trustworthy-path",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "rain-soft-garden.trustworthy-path",
       "runtime_handle": 7366604576604707
@@ -937,7 +937,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.drowned-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "solar-abyss.drowned-bell",
       "runtime_handle": 3555240757788262
@@ -945,7 +945,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.schism",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "solar-abyss.schism",
       "runtime_handle": 4589004266308223
@@ -953,7 +953,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.amends",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "turgid-swamp.amends",
       "runtime_handle": 4432023342275341
@@ -961,7 +961,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.old-grudge",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "turgid-swamp.old-grudge",
       "runtime_handle": 8536373757408084
@@ -969,7 +969,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/abyssal_residents",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "abyssal_residents",
       "runtime_handle": 1688333275188302
@@ -977,7 +977,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/digital_strays",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "digital_strays",
       "runtime_handle": 5048545454289654
@@ -985,7 +985,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/farthest_mists",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "farthest_mists",
       "runtime_handle": 350962558801960
@@ -993,7 +993,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/goblin_market",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "goblin_market",
       "runtime_handle": 3490418888358082
@@ -1001,7 +1001,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/great_library",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "great_library",
       "runtime_handle": 991170045564473
@@ -1009,7 +1009,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/haunted_remnants",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "haunted_remnants",
       "runtime_handle": 4900866309718573
@@ -1017,7 +1017,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/hearthbound",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "hearthbound",
       "runtime_handle": 4046513959484943
@@ -1025,7 +1025,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/lonely_forest_court",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "lonely_forest_court",
       "runtime_handle": 5495209280499345
@@ -1033,7 +1033,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/moon_circle",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "moon_circle",
       "runtime_handle": 3594504273910135
@@ -1041,7 +1041,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/quiet_abbey",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "quiet_abbey",
       "runtime_handle": 7894097855005461
@@ -1049,7 +1049,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/solar_temple",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "solar_temple",
       "runtime_handle": 2642136344425509
@@ -1057,7 +1057,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/goblin-cave%3Amarket-leverage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "goblin-cave:market-leverage",
       "runtime_handle": 5093973293074428
@@ -1065,7 +1065,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/haunted-mansion%3Abarred-threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "haunted-mansion:barred-threshold",
       "runtime_handle": 6295078661322495
@@ -1073,7 +1073,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/moonlit-trail%3Aecho-front",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "moonlit-trail:echo-front",
       "runtime_handle": 3643385637336037
@@ -1081,7 +1081,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/solar-abyss%3Abell-front",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "solar-abyss:bell-front",
       "runtime_handle": 591496292254136
@@ -1089,7 +1089,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/turgid-swamp%3Aold-grudge",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "turgid-swamp:old-grudge",
       "runtime_handle": 5644962986267984
@@ -1097,7 +1097,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/hidden-exit/darkest-ocean%3Adark-abyss",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "hidden-exit",
       "local_id": "darkest-ocean:dark-abyss",
       "runtime_handle": 456562266146446
@@ -1105,7 +1105,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2001",
       "legacy_runtime_id": 2001,
@@ -1114,7 +1114,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2002",
       "legacy_runtime_id": 2002,
@@ -1123,7 +1123,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2003",
       "legacy_runtime_id": 2003,
@@ -1132,7 +1132,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2004",
       "legacy_runtime_id": 2004,
@@ -1141,7 +1141,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2005",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2005",
       "legacy_runtime_id": 2005,
@@ -1150,7 +1150,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2006",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2006",
       "legacy_runtime_id": 2006,
@@ -1159,7 +1159,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2007",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2007",
       "legacy_runtime_id": 2007,
@@ -1168,7 +1168,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2008",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2008",
       "legacy_runtime_id": 2008,
@@ -1177,7 +1177,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2009",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2009",
       "legacy_runtime_id": 2009,
@@ -1186,7 +1186,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2010",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2010",
       "legacy_runtime_id": 2010,
@@ -1195,7 +1195,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2012",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2012",
       "legacy_runtime_id": 2012,
@@ -1204,7 +1204,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2013",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2013",
       "legacy_runtime_id": 2013,
@@ -1213,7 +1213,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2014",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2014",
       "legacy_runtime_id": 2014,
@@ -1222,7 +1222,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/goblin-cave%3Aname-the-price",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "goblin-cave:name-the-price",
       "runtime_handle": 3094113202720990
@@ -1230,7 +1230,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/haunted-mansion%3Aearn-the-threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "haunted-mansion:earn-the-threshold",
       "runtime_handle": 7833342030263292
@@ -1238,7 +1238,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/moonlit-trail%3Aquiet-the-echo",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "moonlit-trail:quiet-the-echo",
       "runtime_handle": 3184352149003600
@@ -1246,7 +1246,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/rain-soft-garden%3Atrustworthy-path",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "rain-soft-garden:trustworthy-path",
       "runtime_handle": 4840596641936491
@@ -1254,7 +1254,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/solar-abyss%3Adrowned-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "solar-abyss:drowned-bell",
       "runtime_handle": 681263158451131
@@ -1262,7 +1262,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/turgid-swamp%3Aamend-the-ledger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "turgid-swamp:amend-the-ledger",
       "runtime_handle": 477973030695414
@@ -1270,7 +1270,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/1",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "1",
       "legacy_runtime_id": 1,
@@ -1279,7 +1279,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/2",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "2",
       "legacy_runtime_id": 2,
@@ -1288,7 +1288,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/3",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "3",
       "legacy_runtime_id": 3,
@@ -1297,7 +1297,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/30",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "30",
       "legacy_runtime_id": 30,
@@ -1306,7 +1306,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/31",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "31",
       "legacy_runtime_id": 31,
@@ -1315,7 +1315,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/32",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "32",
       "legacy_runtime_id": 32,
@@ -1324,7 +1324,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/33",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "33",
       "legacy_runtime_id": 33,
@@ -1333,7 +1333,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/34",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "34",
       "legacy_runtime_id": 34,
@@ -1342,7 +1342,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/35",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "35",
       "legacy_runtime_id": 35,
@@ -1351,7 +1351,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/36",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "36",
       "legacy_runtime_id": 36,
@@ -1360,7 +1360,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/40",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "40",
       "legacy_runtime_id": 40,
@@ -1369,7 +1369,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/41",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "41",
       "legacy_runtime_id": 41,
@@ -1378,7 +1378,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/42",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "42",
       "legacy_runtime_id": 42,
@@ -1387,7 +1387,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/43",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "43",
       "legacy_runtime_id": 43,
@@ -1396,7 +1396,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/44",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "44",
       "legacy_runtime_id": 44,
@@ -1405,7 +1405,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/50",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "50",
       "legacy_runtime_id": 50,
@@ -1414,7 +1414,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/60",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "60",
       "legacy_runtime_id": 60,
@@ -1423,7 +1423,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/61",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "61",
       "legacy_runtime_id": 61,
@@ -1432,7 +1432,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/62",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "62",
       "legacy_runtime_id": 62,
@@ -1441,7 +1441,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/63",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "63",
       "legacy_runtime_id": 63,
@@ -1450,7 +1450,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/64",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "64",
       "legacy_runtime_id": 64,
@@ -1459,7 +1459,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/65",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "65",
       "legacy_runtime_id": 65,
@@ -1468,7 +1468,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "recipe",
       "local_id": "3001",
       "runtime_handle": 828439639934659
@@ -1476,7 +1476,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "recipe",
       "local_id": "3002",
       "runtime_handle": 8276819746843037
@@ -1484,7 +1484,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "recipe",
       "local_id": "3003",
       "runtime_handle": 2153429270847803
@@ -1492,15 +1492,47 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "recipe",
       "local_id": "3004",
       "runtime_handle": 4118340134299628
     },
     {
+      "canonical_ref": "pack://cosyworld.core/recipe/3101",
+      "pack_id": "cosyworld.core",
+      "pack_version": "1.3.10",
+      "kind": "recipe",
+      "local_id": "3101",
+      "runtime_handle": 7229672606288966
+    },
+    {
+      "canonical_ref": "pack://cosyworld.core/recipe/3102",
+      "pack_id": "cosyworld.core",
+      "pack_version": "1.3.10",
+      "kind": "recipe",
+      "local_id": "3102",
+      "runtime_handle": 1504690938736172
+    },
+    {
+      "canonical_ref": "pack://cosyworld.core/recipe/3103",
+      "pack_id": "cosyworld.core",
+      "pack_version": "1.3.10",
+      "kind": "recipe",
+      "local_id": "3103",
+      "runtime_handle": 6273196500967148
+    },
+    {
+      "canonical_ref": "pack://cosyworld.core/recipe/3104",
+      "pack_id": "cosyworld.core",
+      "pack_version": "1.3.10",
+      "kind": "recipe",
+      "local_id": "3104",
+      "runtime_handle": 3035690296456513
+    },
+    {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A1",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:1",
       "runtime_handle": 3639178970696137
@@ -1508,7 +1540,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A2",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:2",
       "runtime_handle": 4328625160851383
@@ -1516,7 +1548,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A3",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:3",
       "runtime_handle": 272728635448160
@@ -1524,7 +1556,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A30",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:30",
       "runtime_handle": 4949881785988127
@@ -1532,7 +1564,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A31",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:31",
       "runtime_handle": 12158853449275
@@ -1540,7 +1572,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A32",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:32",
       "runtime_handle": 3065031734117441
@@ -1548,7 +1580,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A33",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:33",
       "runtime_handle": 8635481635081203
@@ -1556,7 +1588,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A34",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:34",
       "runtime_handle": 3415405010788251
@@ -1564,7 +1596,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A35",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:35",
       "runtime_handle": 8268805670112054
@@ -1572,7 +1604,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A36",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:36",
       "runtime_handle": 1278082739662403
@@ -1580,7 +1612,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A40",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:40",
       "runtime_handle": 2373835638704337
@@ -1588,7 +1620,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A41",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:41",
       "runtime_handle": 302978963504637
@@ -1596,7 +1628,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A42",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:42",
       "runtime_handle": 4669140359619141
@@ -1604,7 +1636,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A43",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:43",
       "runtime_handle": 3577060339822743
@@ -1612,7 +1644,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A44",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:44",
       "runtime_handle": 4396167510730171
@@ -1620,7 +1652,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A50",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:50",
       "runtime_handle": 1673766510642920
@@ -1628,7 +1660,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A60",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:60",
       "runtime_handle": 5586350793250546
@@ -1636,7 +1668,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A61",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:61",
       "runtime_handle": 6162116676111910
@@ -1644,7 +1676,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A62",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:62",
       "runtime_handle": 897159537111265
@@ -1652,7 +1684,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A63",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:63",
       "runtime_handle": 7446099757621175
@@ -1660,7 +1692,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A64",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:64",
       "runtime_handle": 4767551281449957
@@ -1668,7 +1700,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A65",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:65",
       "runtime_handle": 389717939014779

--- a/v2/content/core-only/contributions.json
+++ b/v2/content/core-only/contributions.json
@@ -1,7 +1,7 @@
 [
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.9",
+    "pack_version": "1.3.10",
     "rules_profile": "cosyworld.srd5/1",
     "reskins": [],
     "offers": [

--- a/v2/content/core-only/jobs.json
+++ b/v2/content/core-only/jobs.json
@@ -53,7 +53,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -84,7 +84,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -115,7 +115,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -184,7 +184,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -217,7 +217,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -249,7 +249,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -274,7 +274,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -299,7 +299,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -373,7 +373,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -400,7 +400,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -425,7 +425,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -450,7 +450,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -517,7 +517,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -542,7 +542,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -609,7 +609,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -634,7 +634,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -701,7 +701,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -726,7 +726,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [

--- a/v2/content/core-only/licenses.json
+++ b/v2/content/core-only/licenses.json
@@ -48,7 +48,7 @@
   {
     "pack_id": "cosyworld.core",
     "name": "CosyWorld Core",
-    "version": "1.3.9",
+    "version": "1.3.10",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {

--- a/v2/content/core-only/recipes.json
+++ b/v2/content/core-only/recipes.json
@@ -75,5 +75,148 @@
       "reason": "This repeatable care beat makes frontier practice useful to the next traveler while both persistent ingredients remain in circulation."
     },
     "pack_id": "cosyworld.core"
+  },
+  {
+    "schema_version": 2,
+    "id": 3101,
+    "key": "refine-iron-bloom",
+    "name": "Refine Iron Bloom",
+    "description": "Work a represented iron nodule into a portable bloom at a completed smithy.",
+    "inputs": [
+      {
+        "template_id": "iron_nodule",
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": [
+        "transformation_recipes",
+        "metalworking"
+      ],
+      "recipe_tags": [
+        "smithy",
+        "refinement"
+      ]
+    },
+    "output": {
+      "template_id": "iron_bloom",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    },
+    "pack_id": "cosyworld.core"
+  },
+  {
+    "schema_version": 2,
+    "id": 3102,
+    "key": "forge-waystone-bracket",
+    "name": "Forge Waystone Bracket",
+    "description": "Forge a portable bracket that can be carried to an unfinished place.",
+    "inputs": [
+      {
+        "template_id": "iron_bloom",
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": [
+        "transformation_recipes",
+        "metalworking"
+      ],
+      "recipe_tags": [
+        "smithy",
+        "refinement"
+      ]
+    },
+    "output": {
+      "template_id": "waystone_bracket",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    },
+    "pack_id": "cosyworld.core"
+  },
+  {
+    "schema_version": 2,
+    "id": 3103,
+    "key": "install-waystone-bracket",
+    "name": "Install Waystone Bracket",
+    "description": "Fit a carried bracket into the unfinished ground as a lasting typed anchor.",
+    "inputs": [
+      {
+        "template_id": "waystone_bracket",
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "location_features": [
+        "generated_place_anchor_site"
+      ]
+    },
+    "output": {
+      "template_id": "waystone_bracket",
+      "destination": "installed_at_location",
+      "fallback_destination": "location_floor",
+      "effect": "installed_fixture",
+      "uniqueness": "per_location"
+    },
+    "pack_id": "cosyworld.core"
+  },
+  {
+    "schema_version": 2,
+    "id": 3104,
+    "key": "smoke-river-sprat",
+    "name": "Smoke River Sprat",
+    "description": "Preserve a represented catch at a completed smokehouse.",
+    "inputs": [
+      {
+        "template_id": "river_sprat",
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": [
+        "transformation_recipes",
+        "preservation"
+      ],
+      "recipe_tags": [
+        "smokehouse",
+        "preservation"
+      ]
+    },
+    "output": {
+      "template_id": "smoked_river_sprat",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    },
+    "pack_id": "cosyworld.core"
   }
 ]

--- a/v2/content/core-only/registry.json
+++ b/v2/content/core-only/registry.json
@@ -592,7 +592,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:3202897189e0c14f02b44d668218dfed9866eefbbb3aeff2feb7f1ad234e141e",
+    "bundle_hash": "sha256:e2eb8afc02eacea57562cbe8d662793d3baad6b1d6df8bc04059ec0be6d7a907",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -756,7 +756,7 @@
         "id": "cosyworld.core",
         "name": "CosyWorld Core",
         "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
-        "version": "1.3.9",
+        "version": "1.3.10",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit",
@@ -825,7 +825,7 @@
           "card_bindings": 0,
           "lifecycle_hooks": 19,
           "evolution_tracks": 3,
-          "recipes": 4,
+          "recipes": 8,
           "sentences": 21,
           "external_cards": 0,
           "assets": 2,
@@ -919,6 +919,29 @@
                 "recipe_tags": [
                   "workshop",
                   "repair"
+                ],
+                "cache_policy": "none"
+              },
+              {
+                "id": "smithy",
+                "name": "Smithy",
+                "description": "A shared forge for declared metal transformations and repairs.",
+                "classification": "universal",
+                "capabilities": [
+                  "transformation_recipes",
+                  "metalworking",
+                  "repair_jobs",
+                  "stewardship"
+                ],
+                "upgrade_capabilities": [
+                  "carpentry"
+                ],
+                "quest_templates": [
+                  "service.workshop"
+                ],
+                "recipe_tags": [
+                  "smithy",
+                  "refinement"
                 ],
                 "cache_policy": "none"
               },
@@ -1373,6 +1396,16 @@
                 "size": "small"
               },
               {
+                "id": "smoked_river_sprat",
+                "name": "Smoked River Sprat",
+                "description": "A represented catch preserved at a completed smokehouse for later journeys.",
+                "kind": "keepsake",
+                "charges": 1,
+                "role": "generic",
+                "weight_tenths": 3,
+                "size": "small"
+              },
+              {
                 "id": "glassfin_scale",
                 "name": "Glassfin Scale",
                 "description": "A rare clear scale that keeps a ribbon of river light.",
@@ -1390,6 +1423,26 @@
                 "charges": 1,
                 "role": "generic",
                 "weight_tenths": 20,
+                "size": "small"
+              },
+              {
+                "id": "iron_bloom",
+                "name": "Iron Bloom",
+                "description": "A compact bloom refined from represented ore at a working smithy.",
+                "kind": "keepsake",
+                "charges": 1,
+                "role": "generic",
+                "weight_tenths": 14,
+                "size": "small"
+              },
+              {
+                "id": "waystone_bracket",
+                "name": "Waystone Bracket",
+                "description": "A fitted iron bracket made to hold one lasting marker in place.",
+                "kind": "keepsake",
+                "charges": 1,
+                "role": "generic",
+                "weight_tenths": 12,
                 "size": "small"
               },
               {
@@ -1609,7 +1662,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0"
+        "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
       }
     ],
     "files": {
@@ -5076,7 +5129,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5107,7 +5160,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5138,7 +5191,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -5207,7 +5260,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5240,7 +5293,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5272,7 +5325,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5297,7 +5350,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5322,7 +5375,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -5396,7 +5449,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5423,7 +5476,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5448,7 +5501,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5473,7 +5526,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -5540,7 +5593,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5565,7 +5618,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -5632,7 +5685,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5657,7 +5710,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -5724,7 +5777,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -5749,7 +5802,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -7860,6 +7913,149 @@
           "reason": "This repeatable care beat makes frontier practice useful to the next traveler while both persistent ingredients remain in circulation."
         },
         "pack_id": "cosyworld.core"
+      },
+      {
+        "schema_version": 2,
+        "id": 3101,
+        "key": "refine-iron-bloom",
+        "name": "Refine Iron Bloom",
+        "description": "Work a represented iron nodule into a portable bloom at a completed smithy.",
+        "inputs": [
+          {
+            "template_id": "iron_nodule",
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "transform"
+          }
+        ],
+        "requires": {
+          "building_capabilities": [
+            "transformation_recipes",
+            "metalworking"
+          ],
+          "recipe_tags": [
+            "smithy",
+            "refinement"
+          ]
+        },
+        "output": {
+          "template_id": "iron_bloom",
+          "destination": "actor_hand",
+          "fallback_destination": "location_floor",
+          "effect": "portable",
+          "uniqueness": "per_receipt"
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "schema_version": 2,
+        "id": 3102,
+        "key": "forge-waystone-bracket",
+        "name": "Forge Waystone Bracket",
+        "description": "Forge a portable bracket that can be carried to an unfinished place.",
+        "inputs": [
+          {
+            "template_id": "iron_bloom",
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "transform"
+          }
+        ],
+        "requires": {
+          "building_capabilities": [
+            "transformation_recipes",
+            "metalworking"
+          ],
+          "recipe_tags": [
+            "smithy",
+            "refinement"
+          ]
+        },
+        "output": {
+          "template_id": "waystone_bracket",
+          "destination": "actor_hand",
+          "fallback_destination": "location_floor",
+          "effect": "portable",
+          "uniqueness": "per_receipt"
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "schema_version": 2,
+        "id": 3103,
+        "key": "install-waystone-bracket",
+        "name": "Install Waystone Bracket",
+        "description": "Fit a carried bracket into the unfinished ground as a lasting typed anchor.",
+        "inputs": [
+          {
+            "template_id": "waystone_bracket",
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "transform"
+          }
+        ],
+        "requires": {
+          "location_features": [
+            "generated_place_anchor_site"
+          ]
+        },
+        "output": {
+          "template_id": "waystone_bracket",
+          "destination": "installed_at_location",
+          "fallback_destination": "location_floor",
+          "effect": "installed_fixture",
+          "uniqueness": "per_location"
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "schema_version": 2,
+        "id": 3104,
+        "key": "smoke-river-sprat",
+        "name": "Smoke River Sprat",
+        "description": "Preserve a represented catch at a completed smokehouse.",
+        "inputs": [
+          {
+            "template_id": "river_sprat",
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "transform"
+          }
+        ],
+        "requires": {
+          "building_capabilities": [
+            "transformation_recipes",
+            "preservation"
+          ],
+          "recipe_tags": [
+            "smokehouse",
+            "preservation"
+          ]
+        },
+        "output": {
+          "template_id": "smoked_river_sprat",
+          "destination": "actor_hand",
+          "fallback_destination": "location_floor",
+          "effect": "portable",
+          "uniqueness": "per_receipt"
+        },
+        "pack_id": "cosyworld.core"
       }
     ],
     "sentences": [
@@ -8092,8 +8288,8 @@
   "assets": [
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
-      "pack_integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+      "pack_version": "1.3.10",
+      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -8105,8 +8301,8 @@
     },
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
-      "pack_integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+      "pack_version": "1.3.10",
+      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",
@@ -9500,7 +9696,7 @@
   "contributions": [
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "rules_profile": "cosyworld.srd5/1",
       "reskins": [],
       "offers": [
@@ -9590,7 +9786,7 @@
     {
       "pack_id": "cosyworld.core",
       "name": "CosyWorld Core",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
@@ -10244,7 +10440,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1001",
         "legacy_runtime_id": 1001,
@@ -10253,7 +10449,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1002",
         "legacy_runtime_id": 1002,
@@ -10262,7 +10458,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1003",
         "legacy_runtime_id": 1003,
@@ -10271,7 +10467,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1004",
         "legacy_runtime_id": 1004,
@@ -10280,7 +10476,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1005",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1005",
         "legacy_runtime_id": 1005,
@@ -10289,7 +10485,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1040",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1040",
         "legacy_runtime_id": 1040,
@@ -10298,7 +10494,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1041",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1041",
         "legacy_runtime_id": 1041,
@@ -10307,7 +10503,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1042",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1042",
         "legacy_runtime_id": 1042,
@@ -10316,7 +10512,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1043",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1043",
         "legacy_runtime_id": 1043,
@@ -10325,7 +10521,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1044",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1044",
         "legacy_runtime_id": 1044,
@@ -10334,7 +10530,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1045",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1045",
         "legacy_runtime_id": 1045,
@@ -10343,7 +10539,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1046",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1046",
         "legacy_runtime_id": 1046,
@@ -10352,7 +10548,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1047",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1047",
         "legacy_runtime_id": 1047,
@@ -10361,7 +10557,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1048",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1048",
         "legacy_runtime_id": 1048,
@@ -10370,7 +10566,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1049",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1049",
         "legacy_runtime_id": 1049,
@@ -10379,7 +10575,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1050",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1050",
         "legacy_runtime_id": 1050,
@@ -10388,7 +10584,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1051",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1051",
         "legacy_runtime_id": 1051,
@@ -10397,7 +10593,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1052",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1052",
         "legacy_runtime_id": 1052,
@@ -10406,7 +10602,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1053",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1053",
         "legacy_runtime_id": 1053,
@@ -10415,7 +10611,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1054",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1054",
         "legacy_runtime_id": 1054,
@@ -10424,7 +10620,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1055",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1055",
         "legacy_runtime_id": 1055,
@@ -10433,7 +10629,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1056",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1056",
         "legacy_runtime_id": 1056,
@@ -10442,7 +10638,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1057",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1057",
         "legacy_runtime_id": 1057,
@@ -10451,7 +10647,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1058",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1058",
         "legacy_runtime_id": 1058,
@@ -10460,7 +10656,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1059",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1059",
         "legacy_runtime_id": 1059,
@@ -10469,7 +10665,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1060",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1060",
         "legacy_runtime_id": 1060,
@@ -10478,7 +10674,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1061",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1061",
         "legacy_runtime_id": 1061,
@@ -10487,7 +10683,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1062",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1062",
         "legacy_runtime_id": 1062,
@@ -10496,7 +10692,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1063",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1063",
         "legacy_runtime_id": 1063,
@@ -10505,7 +10701,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1064",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1064",
         "legacy_runtime_id": 1064,
@@ -10514,7 +10710,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1065",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1065",
         "legacy_runtime_id": 1065,
@@ -10523,7 +10719,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1066",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1066",
         "legacy_runtime_id": 1066,
@@ -10532,7 +10728,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1067",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1067",
         "legacy_runtime_id": 1067,
@@ -10541,7 +10737,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1068",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1068",
         "legacy_runtime_id": 1068,
@@ -10550,7 +10746,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1069",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1069",
         "legacy_runtime_id": 1069,
@@ -10559,7 +10755,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1070",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1070",
         "legacy_runtime_id": 1070,
@@ -10568,7 +10764,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-abbey-bookmark",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-abbey-bookmark",
         "runtime_handle": 138956494956560
@@ -10576,7 +10772,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-azazoth",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-azazoth",
         "runtime_handle": 2742827434789688
@@ -10584,7 +10780,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-cottage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-cottage",
         "runtime_handle": 3679023710615970
@@ -10592,7 +10788,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-dewbright-button",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-dewbright-button",
         "runtime_handle": 7543879359126606
@@ -10600,7 +10796,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-hearth-tonic",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-hearth-tonic",
         "runtime_handle": 6099844187041316
@@ -10608,7 +10804,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-hearthstone-tag",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-hearthstone-tag",
         "runtime_handle": 445803431082645
@@ -10616,7 +10812,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-echo",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-moonlit-echo",
         "runtime_handle": 3701779326615881
@@ -10624,7 +10820,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-trail",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-moonlit-trail",
         "runtime_handle": 3706559719582066
@@ -10632,7 +10828,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonwool-thread",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-moonwool-thread",
         "runtime_handle": 3248987744606910
@@ -10640,7 +10836,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-mossglass-bead",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-mossglass-bead",
         "runtime_handle": 406732117808934
@@ -10648,7 +10844,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-old-oak",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-old-oak",
         "runtime_handle": 6806929065153819
@@ -10656,7 +10852,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-pearl-deep-resident",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-pearl-deep-resident",
         "runtime_handle": 8634483881055898
@@ -10664,7 +10860,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-rain-soft-garden",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-rain-soft-garden",
         "runtime_handle": 8636127016066734
@@ -10672,7 +10868,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-skull",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-skull",
         "runtime_handle": 8174630967825761
@@ -10680,7 +10876,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-story-button",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-story-button",
         "runtime_handle": 3151408643854036
@@ -10688,7 +10884,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-threadbare-map-scrap",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-threadbare-map-scrap",
         "runtime_handle": 4482891498418887
@@ -10696,7 +10892,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-vowbright-angel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-vowbright-angel",
         "runtime_handle": 7966555082684141
@@ -10704,7 +10900,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-watch-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-watch-bell",
         "runtime_handle": 6205526622615328
@@ -10712,7 +10908,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-whiskerwind",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-whiskerwind",
         "runtime_handle": 5669444972898140
@@ -10720,7 +10916,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-wolfprint-charm",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-wolfprint-charm",
         "runtime_handle": 915703357568385
@@ -10728,7 +10924,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-zadkiel-dark-angel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-zadkiel-dark-angel",
         "runtime_handle": 8315124370132858
@@ -10736,7 +10932,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/item-ashwood-practice-blade",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "item-ashwood-practice-blade",
         "runtime_handle": 3640187639484502
@@ -10744,7 +10940,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/item-patchwork-satchel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "item-patchwork-satchel",
         "runtime_handle": 804106637155376
@@ -10752,7 +10948,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/item-steady-light",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "item-steady-light",
         "runtime_handle": 8614146586928189
@@ -10760,7 +10956,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-armored-winged-hero",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-armored-winged-hero",
         "runtime_handle": 6600128378329146
@@ -10768,7 +10964,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-badger-cub",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-badger-cub",
         "runtime_handle": 3524217422483260
@@ -10776,7 +10972,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-beetle-armor",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-beetle-armor",
         "runtime_handle": 7880939887467250
@@ -10784,7 +10980,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-blue-shadow-man",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-blue-shadow-man",
         "runtime_handle": 3755993660754793
@@ -10792,7 +10988,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-blue-squirrel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-blue-squirrel",
         "runtime_handle": 3374679645864704
@@ -10800,7 +10996,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-cloaked-mouse-reader",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-cloaked-mouse-reader",
         "runtime_handle": 3997082335066109
@@ -10808,7 +11004,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-forest-dryad",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-forest-dryad",
         "runtime_handle": 8662818472079145
@@ -10816,7 +11012,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-garden-rabbit",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-garden-rabbit",
         "runtime_handle": 2730391876987516
@@ -10824,7 +11020,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-golden-squirrel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-golden-squirrel",
         "runtime_handle": 162503682361987
@@ -10832,7 +11028,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-golden-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-golden-winged-boy",
         "runtime_handle": 4342854739894551
@@ -10840,7 +11036,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-grey-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-grey-winged-boy",
         "runtime_handle": 1250802238685798
@@ -10848,7 +11044,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-llama-scholar",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-llama-scholar",
         "runtime_handle": 6908093676132939
@@ -10856,7 +11052,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-mouse-wanderer",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-mouse-wanderer",
         "runtime_handle": 4601206403124060
@@ -10864,7 +11060,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-neon-tiger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-neon-tiger",
         "runtime_handle": 6229971572743818
@@ -10872,7 +11068,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-rabbit-scribe",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-rabbit-scribe",
         "runtime_handle": 8634110685852129
@@ -10880,7 +11076,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-red-shadow-figure",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-red-shadow-figure",
         "runtime_handle": 3112884101630158
@@ -10888,7 +11084,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-shadow-wolf",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-shadow-wolf",
         "runtime_handle": 4273988789998875
@@ -10896,7 +11092,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-steampunk-mouse",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-steampunk-mouse",
         "runtime_handle": 4441668646189737
@@ -10904,7 +11100,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-sunlit-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-sunlit-winged-boy",
         "runtime_handle": 8615932867192302
@@ -10912,7 +11108,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-tavern-blond-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-tavern-blond-boy",
         "runtime_handle": 1835702442135722
@@ -10920,7 +11116,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-veiled-forest-ghost",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-veiled-forest-ghost",
         "runtime_handle": 4799858469869419
@@ -10928,7 +11124,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-white-ferret-noble",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-white-ferret-noble",
         "runtime_handle": 5084247526999701
@@ -10936,7 +11132,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-wolf-pup",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-wolf-pup",
         "runtime_handle": 236437027581609
@@ -10944,7 +11140,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-woodland-bear",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-woodland-bear",
         "runtime_handle": 9000656934868850
@@ -10952,7 +11148,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-alpine-forest",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-alpine-forest",
         "runtime_handle": 8242458519360113
@@ -10960,7 +11156,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-circle-of-the-moon",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-circle-of-the-moon",
         "runtime_handle": 1930856172148870
@@ -10968,7 +11164,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-dark-abyss",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-dark-abyss",
         "runtime_handle": 7382677506125331
@@ -10976,7 +11172,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-darkest-ocean",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-darkest-ocean",
         "runtime_handle": 5061075064260629
@@ -10984,7 +11180,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-digital-realm",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-digital-realm",
         "runtime_handle": 5887686546418438
@@ -10992,7 +11188,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-endless-ocean",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-endless-ocean",
         "runtime_handle": 5401754774320525
@@ -11000,7 +11196,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-flower-meadow",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-flower-meadow",
         "runtime_handle": 7614022144101722
@@ -11008,7 +11204,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-goblin-cave",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-goblin-cave",
         "runtime_handle": 3499001612672709
@@ -11016,7 +11212,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-great-library",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-great-library",
         "runtime_handle": 7328586258800562
@@ -11024,7 +11220,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-haunted-mansion",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-haunted-mansion",
         "runtime_handle": 7484239537948286
@@ -11032,7 +11228,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-lofty-peak",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-lofty-peak",
         "runtime_handle": 2456240765655012
@@ -11040,7 +11236,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-lost-woods",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-lost-woods",
         "runtime_handle": 6580883718503069
@@ -11048,7 +11244,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-old-oak-tree",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-old-oak-tree",
         "runtime_handle": 2838379433219254
@@ -11056,7 +11252,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-quiet-abbey",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-quiet-abbey",
         "runtime_handle": 4838231888638100
@@ -11064,7 +11260,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-solar-temple",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-solar-temple",
         "runtime_handle": 450219611871818
@@ -11072,7 +11268,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-summit-trail",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-summit-trail",
         "runtime_handle": 8064929121549612
@@ -11080,7 +11276,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-the-heavens",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-the-heavens",
         "runtime_handle": 6396411156616223
@@ -11088,7 +11284,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-turgid-swamp",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-turgid-swamp",
         "runtime_handle": 6935773679641332
@@ -11096,7 +11292,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-wilting-jungle",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-wilting-jungle",
         "runtime_handle": 5897394732936641
@@ -11104,7 +11300,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/rati",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "rati",
         "runtime_handle": 1392254580257493
@@ -11112,7 +11308,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.fair-bargain",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "goblin-cave.fair-bargain",
         "runtime_handle": 8054949801377040
@@ -11120,7 +11316,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.leverage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "goblin-cave.leverage",
         "runtime_handle": 1065707925425919
@@ -11128,7 +11324,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "haunted-mansion.threshold",
         "runtime_handle": 4535315091897137
@@ -11136,7 +11332,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.warden-rage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "haunted-mansion.warden-rage",
         "runtime_handle": 6257115991159330
@@ -11144,7 +11340,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.danger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "moonlit-trail.danger",
         "runtime_handle": 257345026365457
@@ -11152,7 +11348,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.progress",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "moonlit-trail.progress",
         "runtime_handle": 6085238183587093
@@ -11160,7 +11356,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/rain-soft-garden.path-washes-out",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "rain-soft-garden.path-washes-out",
         "runtime_handle": 5725575878774039
@@ -11168,7 +11364,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/rain-soft-garden.trustworthy-path",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "rain-soft-garden.trustworthy-path",
         "runtime_handle": 7366604576604707
@@ -11176,7 +11372,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.drowned-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "solar-abyss.drowned-bell",
         "runtime_handle": 3555240757788262
@@ -11184,7 +11380,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.schism",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "solar-abyss.schism",
         "runtime_handle": 4589004266308223
@@ -11192,7 +11388,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.amends",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "turgid-swamp.amends",
         "runtime_handle": 4432023342275341
@@ -11200,7 +11396,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.old-grudge",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "turgid-swamp.old-grudge",
         "runtime_handle": 8536373757408084
@@ -11208,7 +11404,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/abyssal_residents",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "abyssal_residents",
         "runtime_handle": 1688333275188302
@@ -11216,7 +11412,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/digital_strays",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "digital_strays",
         "runtime_handle": 5048545454289654
@@ -11224,7 +11420,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/farthest_mists",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "farthest_mists",
         "runtime_handle": 350962558801960
@@ -11232,7 +11428,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/goblin_market",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "goblin_market",
         "runtime_handle": 3490418888358082
@@ -11240,7 +11436,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/great_library",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "great_library",
         "runtime_handle": 991170045564473
@@ -11248,7 +11444,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/haunted_remnants",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "haunted_remnants",
         "runtime_handle": 4900866309718573
@@ -11256,7 +11452,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/hearthbound",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "hearthbound",
         "runtime_handle": 4046513959484943
@@ -11264,7 +11460,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/lonely_forest_court",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "lonely_forest_court",
         "runtime_handle": 5495209280499345
@@ -11272,7 +11468,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/moon_circle",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "moon_circle",
         "runtime_handle": 3594504273910135
@@ -11280,7 +11476,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/quiet_abbey",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "quiet_abbey",
         "runtime_handle": 7894097855005461
@@ -11288,7 +11484,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/solar_temple",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "solar_temple",
         "runtime_handle": 2642136344425509
@@ -11296,7 +11492,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/goblin-cave%3Amarket-leverage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "goblin-cave:market-leverage",
         "runtime_handle": 5093973293074428
@@ -11304,7 +11500,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/haunted-mansion%3Abarred-threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "haunted-mansion:barred-threshold",
         "runtime_handle": 6295078661322495
@@ -11312,7 +11508,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/moonlit-trail%3Aecho-front",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "moonlit-trail:echo-front",
         "runtime_handle": 3643385637336037
@@ -11320,7 +11516,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/solar-abyss%3Abell-front",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "solar-abyss:bell-front",
         "runtime_handle": 591496292254136
@@ -11328,7 +11524,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/turgid-swamp%3Aold-grudge",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "turgid-swamp:old-grudge",
         "runtime_handle": 5644962986267984
@@ -11336,7 +11532,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/hidden-exit/darkest-ocean%3Adark-abyss",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "hidden-exit",
         "local_id": "darkest-ocean:dark-abyss",
         "runtime_handle": 456562266146446
@@ -11344,7 +11540,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2001",
         "legacy_runtime_id": 2001,
@@ -11353,7 +11549,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2002",
         "legacy_runtime_id": 2002,
@@ -11362,7 +11558,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2003",
         "legacy_runtime_id": 2003,
@@ -11371,7 +11567,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2004",
         "legacy_runtime_id": 2004,
@@ -11380,7 +11576,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2005",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2005",
         "legacy_runtime_id": 2005,
@@ -11389,7 +11585,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2006",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2006",
         "legacy_runtime_id": 2006,
@@ -11398,7 +11594,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2007",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2007",
         "legacy_runtime_id": 2007,
@@ -11407,7 +11603,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2008",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2008",
         "legacy_runtime_id": 2008,
@@ -11416,7 +11612,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2009",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2009",
         "legacy_runtime_id": 2009,
@@ -11425,7 +11621,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2010",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2010",
         "legacy_runtime_id": 2010,
@@ -11434,7 +11630,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2012",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2012",
         "legacy_runtime_id": 2012,
@@ -11443,7 +11639,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2013",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2013",
         "legacy_runtime_id": 2013,
@@ -11452,7 +11648,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2014",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2014",
         "legacy_runtime_id": 2014,
@@ -11461,7 +11657,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/goblin-cave%3Aname-the-price",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "goblin-cave:name-the-price",
         "runtime_handle": 3094113202720990
@@ -11469,7 +11665,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/haunted-mansion%3Aearn-the-threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "haunted-mansion:earn-the-threshold",
         "runtime_handle": 7833342030263292
@@ -11477,7 +11673,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/moonlit-trail%3Aquiet-the-echo",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "moonlit-trail:quiet-the-echo",
         "runtime_handle": 3184352149003600
@@ -11485,7 +11681,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/rain-soft-garden%3Atrustworthy-path",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "rain-soft-garden:trustworthy-path",
         "runtime_handle": 4840596641936491
@@ -11493,7 +11689,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/solar-abyss%3Adrowned-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "solar-abyss:drowned-bell",
         "runtime_handle": 681263158451131
@@ -11501,7 +11697,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/turgid-swamp%3Aamend-the-ledger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "turgid-swamp:amend-the-ledger",
         "runtime_handle": 477973030695414
@@ -11509,7 +11705,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/1",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "1",
         "legacy_runtime_id": 1,
@@ -11518,7 +11714,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/2",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "2",
         "legacy_runtime_id": 2,
@@ -11527,7 +11723,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/3",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "3",
         "legacy_runtime_id": 3,
@@ -11536,7 +11732,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/30",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "30",
         "legacy_runtime_id": 30,
@@ -11545,7 +11741,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/31",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "31",
         "legacy_runtime_id": 31,
@@ -11554,7 +11750,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/32",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "32",
         "legacy_runtime_id": 32,
@@ -11563,7 +11759,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/33",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "33",
         "legacy_runtime_id": 33,
@@ -11572,7 +11768,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/34",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "34",
         "legacy_runtime_id": 34,
@@ -11581,7 +11777,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/35",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "35",
         "legacy_runtime_id": 35,
@@ -11590,7 +11786,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/36",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "36",
         "legacy_runtime_id": 36,
@@ -11599,7 +11795,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/40",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "40",
         "legacy_runtime_id": 40,
@@ -11608,7 +11804,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/41",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "41",
         "legacy_runtime_id": 41,
@@ -11617,7 +11813,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/42",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "42",
         "legacy_runtime_id": 42,
@@ -11626,7 +11822,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/43",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "43",
         "legacy_runtime_id": 43,
@@ -11635,7 +11831,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/44",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "44",
         "legacy_runtime_id": 44,
@@ -11644,7 +11840,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/50",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "50",
         "legacy_runtime_id": 50,
@@ -11653,7 +11849,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/60",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "60",
         "legacy_runtime_id": 60,
@@ -11662,7 +11858,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/61",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "61",
         "legacy_runtime_id": 61,
@@ -11671,7 +11867,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/62",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "62",
         "legacy_runtime_id": 62,
@@ -11680,7 +11876,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/63",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "63",
         "legacy_runtime_id": 63,
@@ -11689,7 +11885,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/64",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "64",
         "legacy_runtime_id": 64,
@@ -11698,7 +11894,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/65",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "65",
         "legacy_runtime_id": 65,
@@ -11707,7 +11903,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "recipe",
         "local_id": "3001",
         "runtime_handle": 828439639934659
@@ -11715,7 +11911,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "recipe",
         "local_id": "3002",
         "runtime_handle": 8276819746843037
@@ -11723,7 +11919,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "recipe",
         "local_id": "3003",
         "runtime_handle": 2153429270847803
@@ -11731,15 +11927,47 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "recipe",
         "local_id": "3004",
         "runtime_handle": 4118340134299628
       },
       {
+        "canonical_ref": "pack://cosyworld.core/recipe/3101",
+        "pack_id": "cosyworld.core",
+        "pack_version": "1.3.10",
+        "kind": "recipe",
+        "local_id": "3101",
+        "runtime_handle": 7229672606288966
+      },
+      {
+        "canonical_ref": "pack://cosyworld.core/recipe/3102",
+        "pack_id": "cosyworld.core",
+        "pack_version": "1.3.10",
+        "kind": "recipe",
+        "local_id": "3102",
+        "runtime_handle": 1504690938736172
+      },
+      {
+        "canonical_ref": "pack://cosyworld.core/recipe/3103",
+        "pack_id": "cosyworld.core",
+        "pack_version": "1.3.10",
+        "kind": "recipe",
+        "local_id": "3103",
+        "runtime_handle": 6273196500967148
+      },
+      {
+        "canonical_ref": "pack://cosyworld.core/recipe/3104",
+        "pack_id": "cosyworld.core",
+        "pack_version": "1.3.10",
+        "kind": "recipe",
+        "local_id": "3104",
+        "runtime_handle": 3035690296456513
+      },
+      {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A1",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:1",
         "runtime_handle": 3639178970696137
@@ -11747,7 +11975,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A2",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:2",
         "runtime_handle": 4328625160851383
@@ -11755,7 +11983,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A3",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:3",
         "runtime_handle": 272728635448160
@@ -11763,7 +11991,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A30",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:30",
         "runtime_handle": 4949881785988127
@@ -11771,7 +11999,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A31",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:31",
         "runtime_handle": 12158853449275
@@ -11779,7 +12007,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A32",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:32",
         "runtime_handle": 3065031734117441
@@ -11787,7 +12015,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A33",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:33",
         "runtime_handle": 8635481635081203
@@ -11795,7 +12023,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A34",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:34",
         "runtime_handle": 3415405010788251
@@ -11803,7 +12031,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A35",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:35",
         "runtime_handle": 8268805670112054
@@ -11811,7 +12039,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A36",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:36",
         "runtime_handle": 1278082739662403
@@ -11819,7 +12047,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A40",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:40",
         "runtime_handle": 2373835638704337
@@ -11827,7 +12055,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A41",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:41",
         "runtime_handle": 302978963504637
@@ -11835,7 +12063,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A42",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:42",
         "runtime_handle": 4669140359619141
@@ -11843,7 +12071,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A43",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:43",
         "runtime_handle": 3577060339822743
@@ -11851,7 +12079,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A44",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:44",
         "runtime_handle": 4396167510730171
@@ -11859,7 +12087,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A50",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:50",
         "runtime_handle": 1673766510642920
@@ -11867,7 +12095,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A60",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:60",
         "runtime_handle": 5586350793250546
@@ -11875,7 +12103,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A61",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:61",
         "runtime_handle": 6162116676111910
@@ -11883,7 +12111,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A62",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:62",
         "runtime_handle": 897159537111265
@@ -11891,7 +12119,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A63",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:63",
         "runtime_handle": 7446099757621175
@@ -11899,7 +12127,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A64",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:64",
         "runtime_handle": 4767551281449957
@@ -11907,7 +12135,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A65",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:65",
         "runtime_handle": 389717939014779

--- a/v2/content/core-only/worldpack.json
+++ b/v2/content/core-only/worldpack.json
@@ -590,7 +590,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:3202897189e0c14f02b44d668218dfed9866eefbbb3aeff2feb7f1ad234e141e",
+  "bundle_hash": "sha256:e2eb8afc02eacea57562cbe8d662793d3baad6b1d6df8bc04059ec0be6d7a907",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -754,7 +754,7 @@
       "id": "cosyworld.core",
       "name": "CosyWorld Core",
       "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit",
@@ -823,7 +823,7 @@
         "card_bindings": 0,
         "lifecycle_hooks": 19,
         "evolution_tracks": 3,
-        "recipes": 4,
+        "recipes": 8,
         "sentences": 21,
         "external_cards": 0,
         "assets": 2,
@@ -917,6 +917,29 @@
               "recipe_tags": [
                 "workshop",
                 "repair"
+              ],
+              "cache_policy": "none"
+            },
+            {
+              "id": "smithy",
+              "name": "Smithy",
+              "description": "A shared forge for declared metal transformations and repairs.",
+              "classification": "universal",
+              "capabilities": [
+                "transformation_recipes",
+                "metalworking",
+                "repair_jobs",
+                "stewardship"
+              ],
+              "upgrade_capabilities": [
+                "carpentry"
+              ],
+              "quest_templates": [
+                "service.workshop"
+              ],
+              "recipe_tags": [
+                "smithy",
+                "refinement"
               ],
               "cache_policy": "none"
             },
@@ -1371,6 +1394,16 @@
               "size": "small"
             },
             {
+              "id": "smoked_river_sprat",
+              "name": "Smoked River Sprat",
+              "description": "A represented catch preserved at a completed smokehouse for later journeys.",
+              "kind": "keepsake",
+              "charges": 1,
+              "role": "generic",
+              "weight_tenths": 3,
+              "size": "small"
+            },
+            {
               "id": "glassfin_scale",
               "name": "Glassfin Scale",
               "description": "A rare clear scale that keeps a ribbon of river light.",
@@ -1388,6 +1421,26 @@
               "charges": 1,
               "role": "generic",
               "weight_tenths": 20,
+              "size": "small"
+            },
+            {
+              "id": "iron_bloom",
+              "name": "Iron Bloom",
+              "description": "A compact bloom refined from represented ore at a working smithy.",
+              "kind": "keepsake",
+              "charges": 1,
+              "role": "generic",
+              "weight_tenths": 14,
+              "size": "small"
+            },
+            {
+              "id": "waystone_bracket",
+              "name": "Waystone Bracket",
+              "description": "A fitted iron bracket made to hold one lasting marker in place.",
+              "kind": "keepsake",
+              "charges": 1,
+              "role": "generic",
+              "weight_tenths": 12,
               "size": "small"
             },
             {
@@ -1607,7 +1660,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0"
+      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
     }
   ],
   "files": {

--- a/v2/content/core/jobs.json
+++ b/v2/content/core/jobs.json
@@ -53,7 +53,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -84,7 +84,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -115,7 +115,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -183,7 +183,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -216,7 +216,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -248,7 +248,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -273,7 +273,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -298,7 +298,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -371,7 +371,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -398,7 +398,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -423,7 +423,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -448,7 +448,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -514,7 +514,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -539,7 +539,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -605,7 +605,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -630,7 +630,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -696,7 +696,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -721,7 +721,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [

--- a/v2/content/core/pack.json
+++ b/v2/content/core/pack.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "cosyworld.core",
   "name": "CosyWorld Core",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "kind": "world",
   "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
   "license": "MIT",
@@ -113,6 +113,17 @@
           "upgrade_capabilities": ["carpentry"],
           "quest_templates": ["service.workshop"],
           "recipe_tags": ["workshop", "repair"],
+          "cache_policy": "none"
+        },
+        {
+          "id": "smithy",
+          "name": "Smithy",
+          "description": "A shared forge for declared metal transformations and repairs.",
+          "classification": "universal",
+          "capabilities": ["transformation_recipes", "metalworking", "repair_jobs", "stewardship"],
+          "upgrade_capabilities": ["carpentry"],
+          "quest_templates": ["service.workshop"],
+          "recipe_tags": ["smithy", "refinement"],
           "cache_policy": "none"
         },
         {
@@ -378,6 +389,16 @@
           "size": "small"
         },
         {
+          "id": "smoked_river_sprat",
+          "name": "Smoked River Sprat",
+          "description": "A represented catch preserved at a completed smokehouse for later journeys.",
+          "kind": "keepsake",
+          "charges": 1,
+          "role": "generic",
+          "weight_tenths": 3,
+          "size": "small"
+        },
+        {
           "id": "glassfin_scale",
           "name": "Glassfin Scale",
           "description": "A rare clear scale that keeps a ribbon of river light.",
@@ -395,6 +416,26 @@
           "charges": 1,
           "role": "generic",
           "weight_tenths": 20,
+          "size": "small"
+        },
+        {
+          "id": "iron_bloom",
+          "name": "Iron Bloom",
+          "description": "A compact bloom refined from represented ore at a working smithy.",
+          "kind": "keepsake",
+          "charges": 1,
+          "role": "generic",
+          "weight_tenths": 14,
+          "size": "small"
+        },
+        {
+          "id": "waystone_bracket",
+          "name": "Waystone Bracket",
+          "description": "A fitted iron bracket made to hold one lasting marker in place.",
+          "kind": "keepsake",
+          "charges": 1,
+          "role": "generic",
+          "weight_tenths": 12,
           "size": "small"
         },
         {

--- a/v2/content/core/recipes.json
+++ b/v2/content/core/recipes.json
@@ -59,5 +59,112 @@
       "target_id": 3,
       "reason": "This repeatable care beat makes frontier practice useful to the next traveler while both persistent ingredients remain in circulation."
     }
+  },
+  {
+    "schema_version": 2,
+    "id": 3101,
+    "key": "refine-iron-bloom",
+    "name": "Refine Iron Bloom",
+    "description": "Work a represented iron nodule into a portable bloom at a completed smithy.",
+    "inputs": [
+      {
+        "template_id": "iron_nodule",
+        "quantity": 1,
+        "zones": ["carried", "world"],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": ["transformation_recipes", "metalworking"],
+      "recipe_tags": ["smithy", "refinement"]
+    },
+    "output": {
+      "template_id": "iron_bloom",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    }
+  },
+  {
+    "schema_version": 2,
+    "id": 3102,
+    "key": "forge-waystone-bracket",
+    "name": "Forge Waystone Bracket",
+    "description": "Forge a portable bracket that can be carried to an unfinished place.",
+    "inputs": [
+      {
+        "template_id": "iron_bloom",
+        "quantity": 1,
+        "zones": ["carried", "world"],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": ["transformation_recipes", "metalworking"],
+      "recipe_tags": ["smithy", "refinement"]
+    },
+    "output": {
+      "template_id": "waystone_bracket",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    }
+  },
+  {
+    "schema_version": 2,
+    "id": 3103,
+    "key": "install-waystone-bracket",
+    "name": "Install Waystone Bracket",
+    "description": "Fit a carried bracket into the unfinished ground as a lasting typed anchor.",
+    "inputs": [
+      {
+        "template_id": "waystone_bracket",
+        "quantity": 1,
+        "zones": ["carried", "world"],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "location_features": ["generated_place_anchor_site"]
+    },
+    "output": {
+      "template_id": "waystone_bracket",
+      "destination": "installed_at_location",
+      "fallback_destination": "location_floor",
+      "effect": "installed_fixture",
+      "uniqueness": "per_location"
+    }
+  },
+  {
+    "schema_version": 2,
+    "id": 3104,
+    "key": "smoke-river-sprat",
+    "name": "Smoke River Sprat",
+    "description": "Preserve a represented catch at a completed smokehouse.",
+    "inputs": [
+      {
+        "template_id": "river_sprat",
+        "quantity": 1,
+        "zones": ["carried", "world"],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": ["transformation_recipes", "preservation"],
+      "recipe_tags": ["smokehouse", "preservation"]
+    },
+    "output": {
+      "template_id": "smoked_river_sprat",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    }
   }
 ]

--- a/v2/content/official/assets.json
+++ b/v2/content/official/assets.json
@@ -1,8 +1,8 @@
 [
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.9",
-    "pack_integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+    "pack_version": "1.3.10",
+    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -14,8 +14,8 @@
   },
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.9",
-    "pack_integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+    "pack_version": "1.3.10",
+    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/official/content_refs.json
+++ b/v2/content/official/content_refs.json
@@ -306,7 +306,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1001",
       "legacy_runtime_id": 1001,
@@ -315,7 +315,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1002",
       "legacy_runtime_id": 1002,
@@ -324,7 +324,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1003",
       "legacy_runtime_id": 1003,
@@ -333,7 +333,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1004",
       "legacy_runtime_id": 1004,
@@ -342,7 +342,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1005",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1005",
       "legacy_runtime_id": 1005,
@@ -351,7 +351,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1040",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1040",
       "legacy_runtime_id": 1040,
@@ -360,7 +360,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1041",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1041",
       "legacy_runtime_id": 1041,
@@ -369,7 +369,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1042",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1042",
       "legacy_runtime_id": 1042,
@@ -378,7 +378,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1043",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1043",
       "legacy_runtime_id": 1043,
@@ -387,7 +387,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1044",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1044",
       "legacy_runtime_id": 1044,
@@ -396,7 +396,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1045",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1045",
       "legacy_runtime_id": 1045,
@@ -405,7 +405,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1046",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1046",
       "legacy_runtime_id": 1046,
@@ -414,7 +414,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1047",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1047",
       "legacy_runtime_id": 1047,
@@ -423,7 +423,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1048",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1048",
       "legacy_runtime_id": 1048,
@@ -432,7 +432,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1049",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1049",
       "legacy_runtime_id": 1049,
@@ -441,7 +441,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1050",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1050",
       "legacy_runtime_id": 1050,
@@ -450,7 +450,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1051",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1051",
       "legacy_runtime_id": 1051,
@@ -459,7 +459,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1052",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1052",
       "legacy_runtime_id": 1052,
@@ -468,7 +468,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1053",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1053",
       "legacy_runtime_id": 1053,
@@ -477,7 +477,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1054",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1054",
       "legacy_runtime_id": 1054,
@@ -486,7 +486,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1055",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1055",
       "legacy_runtime_id": 1055,
@@ -495,7 +495,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1056",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1056",
       "legacy_runtime_id": 1056,
@@ -504,7 +504,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1057",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1057",
       "legacy_runtime_id": 1057,
@@ -513,7 +513,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1058",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1058",
       "legacy_runtime_id": 1058,
@@ -522,7 +522,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1059",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1059",
       "legacy_runtime_id": 1059,
@@ -531,7 +531,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1060",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1060",
       "legacy_runtime_id": 1060,
@@ -540,7 +540,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1061",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1061",
       "legacy_runtime_id": 1061,
@@ -549,7 +549,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1062",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1062",
       "legacy_runtime_id": 1062,
@@ -558,7 +558,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1063",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1063",
       "legacy_runtime_id": 1063,
@@ -567,7 +567,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1064",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1064",
       "legacy_runtime_id": 1064,
@@ -576,7 +576,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1065",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1065",
       "legacy_runtime_id": 1065,
@@ -585,7 +585,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1066",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1066",
       "legacy_runtime_id": 1066,
@@ -594,7 +594,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1067",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1067",
       "legacy_runtime_id": 1067,
@@ -603,7 +603,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1068",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1068",
       "legacy_runtime_id": 1068,
@@ -612,7 +612,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1069",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1069",
       "legacy_runtime_id": 1069,
@@ -621,7 +621,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/actor/1070",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "actor",
       "local_id": "1070",
       "legacy_runtime_id": 1070,
@@ -630,7 +630,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-abbey-bookmark",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-abbey-bookmark",
       "runtime_handle": 138956494956560
@@ -638,7 +638,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-azazoth",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-azazoth",
       "runtime_handle": 2742827434789688
@@ -646,7 +646,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-cottage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-cottage",
       "runtime_handle": 3679023710615970
@@ -654,7 +654,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-dewbright-button",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-dewbright-button",
       "runtime_handle": 7543879359126606
@@ -662,7 +662,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-hearth-tonic",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-hearth-tonic",
       "runtime_handle": 6099844187041316
@@ -670,7 +670,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-hearthstone-tag",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-hearthstone-tag",
       "runtime_handle": 445803431082645
@@ -678,7 +678,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-echo",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-moonlit-echo",
       "runtime_handle": 3701779326615881
@@ -686,7 +686,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-trail",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-moonlit-trail",
       "runtime_handle": 3706559719582066
@@ -694,7 +694,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-moonwool-thread",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-moonwool-thread",
       "runtime_handle": 3248987744606910
@@ -702,7 +702,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-mossglass-bead",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-mossglass-bead",
       "runtime_handle": 406732117808934
@@ -710,7 +710,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-old-oak",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-old-oak",
       "runtime_handle": 6806929065153819
@@ -718,7 +718,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-pearl-deep-resident",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-pearl-deep-resident",
       "runtime_handle": 8634483881055898
@@ -726,7 +726,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-rain-soft-garden",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-rain-soft-garden",
       "runtime_handle": 8636127016066734
@@ -734,7 +734,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-skull",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-skull",
       "runtime_handle": 8174630967825761
@@ -742,7 +742,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-story-button",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-story-button",
       "runtime_handle": 3151408643854036
@@ -750,7 +750,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-threadbare-map-scrap",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-threadbare-map-scrap",
       "runtime_handle": 4482891498418887
@@ -758,7 +758,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-vowbright-angel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-vowbright-angel",
       "runtime_handle": 7966555082684141
@@ -766,7 +766,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-watch-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-watch-bell",
       "runtime_handle": 6205526622615328
@@ -774,7 +774,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-whiskerwind",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-whiskerwind",
       "runtime_handle": 5669444972898140
@@ -782,7 +782,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-wolfprint-charm",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-wolfprint-charm",
       "runtime_handle": 915703357568385
@@ -790,7 +790,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/cosy-zadkiel-dark-angel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "cosy-zadkiel-dark-angel",
       "runtime_handle": 8315124370132858
@@ -798,7 +798,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/item-ashwood-practice-blade",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "item-ashwood-practice-blade",
       "runtime_handle": 3640187639484502
@@ -806,7 +806,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/item-patchwork-satchel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "item-patchwork-satchel",
       "runtime_handle": 804106637155376
@@ -814,7 +814,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/item-steady-light",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "item-steady-light",
       "runtime_handle": 8614146586928189
@@ -822,7 +822,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-armored-winged-hero",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-armored-winged-hero",
       "runtime_handle": 6600128378329146
@@ -830,7 +830,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-badger-cub",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-badger-cub",
       "runtime_handle": 3524217422483260
@@ -838,7 +838,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-beetle-armor",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-beetle-armor",
       "runtime_handle": 7880939887467250
@@ -846,7 +846,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-blue-shadow-man",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-blue-shadow-man",
       "runtime_handle": 3755993660754793
@@ -854,7 +854,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-blue-squirrel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-blue-squirrel",
       "runtime_handle": 3374679645864704
@@ -862,7 +862,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-cloaked-mouse-reader",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-cloaked-mouse-reader",
       "runtime_handle": 3997082335066109
@@ -870,7 +870,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-forest-dryad",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-forest-dryad",
       "runtime_handle": 8662818472079145
@@ -878,7 +878,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-garden-rabbit",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-garden-rabbit",
       "runtime_handle": 2730391876987516
@@ -886,7 +886,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-golden-squirrel",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-golden-squirrel",
       "runtime_handle": 162503682361987
@@ -894,7 +894,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-golden-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-golden-winged-boy",
       "runtime_handle": 4342854739894551
@@ -902,7 +902,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-grey-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-grey-winged-boy",
       "runtime_handle": 1250802238685798
@@ -910,7 +910,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-llama-scholar",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-llama-scholar",
       "runtime_handle": 6908093676132939
@@ -918,7 +918,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-mouse-wanderer",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-mouse-wanderer",
       "runtime_handle": 4601206403124060
@@ -926,7 +926,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-neon-tiger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-neon-tiger",
       "runtime_handle": 6229971572743818
@@ -934,7 +934,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-rabbit-scribe",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-rabbit-scribe",
       "runtime_handle": 8634110685852129
@@ -942,7 +942,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-red-shadow-figure",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-red-shadow-figure",
       "runtime_handle": 3112884101630158
@@ -950,7 +950,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-shadow-wolf",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-shadow-wolf",
       "runtime_handle": 4273988789998875
@@ -958,7 +958,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-steampunk-mouse",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-steampunk-mouse",
       "runtime_handle": 4441668646189737
@@ -966,7 +966,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-sunlit-winged-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-sunlit-winged-boy",
       "runtime_handle": 8615932867192302
@@ -974,7 +974,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-tavern-blond-boy",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-tavern-blond-boy",
       "runtime_handle": 1835702442135722
@@ -982,7 +982,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-veiled-forest-ghost",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-veiled-forest-ghost",
       "runtime_handle": 4799858469869419
@@ -990,7 +990,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-white-ferret-noble",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-white-ferret-noble",
       "runtime_handle": 5084247526999701
@@ -998,7 +998,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-wolf-pup",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-wolf-pup",
       "runtime_handle": 236437027581609
@@ -1006,7 +1006,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/lf-woodland-bear",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "lf-woodland-bear",
       "runtime_handle": 9000656934868850
@@ -1014,7 +1014,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-alpine-forest",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-alpine-forest",
       "runtime_handle": 8242458519360113
@@ -1022,7 +1022,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-circle-of-the-moon",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-circle-of-the-moon",
       "runtime_handle": 1930856172148870
@@ -1030,7 +1030,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-dark-abyss",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-dark-abyss",
       "runtime_handle": 7382677506125331
@@ -1038,7 +1038,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-darkest-ocean",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-darkest-ocean",
       "runtime_handle": 5061075064260629
@@ -1046,7 +1046,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-digital-realm",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-digital-realm",
       "runtime_handle": 5887686546418438
@@ -1054,7 +1054,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-endless-ocean",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-endless-ocean",
       "runtime_handle": 5401754774320525
@@ -1062,7 +1062,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-flower-meadow",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-flower-meadow",
       "runtime_handle": 7614022144101722
@@ -1070,7 +1070,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-goblin-cave",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-goblin-cave",
       "runtime_handle": 3499001612672709
@@ -1078,7 +1078,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-great-library",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-great-library",
       "runtime_handle": 7328586258800562
@@ -1086,7 +1086,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-haunted-mansion",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-haunted-mansion",
       "runtime_handle": 7484239537948286
@@ -1094,7 +1094,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-lofty-peak",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-lofty-peak",
       "runtime_handle": 2456240765655012
@@ -1102,7 +1102,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-lost-woods",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-lost-woods",
       "runtime_handle": 6580883718503069
@@ -1110,7 +1110,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-old-oak-tree",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-old-oak-tree",
       "runtime_handle": 2838379433219254
@@ -1118,7 +1118,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-quiet-abbey",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-quiet-abbey",
       "runtime_handle": 4838231888638100
@@ -1126,7 +1126,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-solar-temple",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-solar-temple",
       "runtime_handle": 450219611871818
@@ -1134,7 +1134,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-summit-trail",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-summit-trail",
       "runtime_handle": 8064929121549612
@@ -1142,7 +1142,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-the-heavens",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-the-heavens",
       "runtime_handle": 6396411156616223
@@ -1150,7 +1150,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-turgid-swamp",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-turgid-swamp",
       "runtime_handle": 6935773679641332
@@ -1158,7 +1158,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/location-wilting-jungle",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "location-wilting-jungle",
       "runtime_handle": 5897394732936641
@@ -1166,7 +1166,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/card/rati",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "card",
       "local_id": "rati",
       "runtime_handle": 1392254580257493
@@ -1174,7 +1174,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.fair-bargain",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "goblin-cave.fair-bargain",
       "runtime_handle": 8054949801377040
@@ -1182,7 +1182,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.leverage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "goblin-cave.leverage",
       "runtime_handle": 1065707925425919
@@ -1190,7 +1190,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "haunted-mansion.threshold",
       "runtime_handle": 4535315091897137
@@ -1198,7 +1198,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.warden-rage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "haunted-mansion.warden-rage",
       "runtime_handle": 6257115991159330
@@ -1206,7 +1206,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.danger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "moonlit-trail.danger",
       "runtime_handle": 257345026365457
@@ -1214,7 +1214,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.progress",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "moonlit-trail.progress",
       "runtime_handle": 6085238183587093
@@ -1222,7 +1222,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/rain-soft-garden.path-washes-out",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "rain-soft-garden.path-washes-out",
       "runtime_handle": 5725575878774039
@@ -1230,7 +1230,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/rain-soft-garden.trustworthy-path",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "rain-soft-garden.trustworthy-path",
       "runtime_handle": 7366604576604707
@@ -1238,7 +1238,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.drowned-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "solar-abyss.drowned-bell",
       "runtime_handle": 3555240757788262
@@ -1246,7 +1246,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.schism",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "solar-abyss.schism",
       "runtime_handle": 4589004266308223
@@ -1254,7 +1254,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.amends",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "turgid-swamp.amends",
       "runtime_handle": 4432023342275341
@@ -1262,7 +1262,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.old-grudge",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "clock",
       "local_id": "turgid-swamp.old-grudge",
       "runtime_handle": 8536373757408084
@@ -1270,7 +1270,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/abyssal_residents",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "abyssal_residents",
       "runtime_handle": 1688333275188302
@@ -1278,7 +1278,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/digital_strays",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "digital_strays",
       "runtime_handle": 5048545454289654
@@ -1286,7 +1286,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/farthest_mists",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "farthest_mists",
       "runtime_handle": 350962558801960
@@ -1294,7 +1294,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/goblin_market",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "goblin_market",
       "runtime_handle": 3490418888358082
@@ -1302,7 +1302,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/great_library",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "great_library",
       "runtime_handle": 991170045564473
@@ -1310,7 +1310,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/haunted_remnants",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "haunted_remnants",
       "runtime_handle": 4900866309718573
@@ -1318,7 +1318,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/hearthbound",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "hearthbound",
       "runtime_handle": 4046513959484943
@@ -1326,7 +1326,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/lonely_forest_court",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "lonely_forest_court",
       "runtime_handle": 5495209280499345
@@ -1334,7 +1334,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/moon_circle",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "moon_circle",
       "runtime_handle": 3594504273910135
@@ -1342,7 +1342,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/quiet_abbey",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "quiet_abbey",
       "runtime_handle": 7894097855005461
@@ -1350,7 +1350,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/faction/solar_temple",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "faction",
       "local_id": "solar_temple",
       "runtime_handle": 2642136344425509
@@ -1358,7 +1358,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/goblin-cave%3Amarket-leverage",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "goblin-cave:market-leverage",
       "runtime_handle": 5093973293074428
@@ -1366,7 +1366,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/haunted-mansion%3Abarred-threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "haunted-mansion:barred-threshold",
       "runtime_handle": 6295078661322495
@@ -1374,7 +1374,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/moonlit-trail%3Aecho-front",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "moonlit-trail:echo-front",
       "runtime_handle": 3643385637336037
@@ -1382,7 +1382,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/solar-abyss%3Abell-front",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "solar-abyss:bell-front",
       "runtime_handle": 591496292254136
@@ -1390,7 +1390,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/front/turgid-swamp%3Aold-grudge",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "front",
       "local_id": "turgid-swamp:old-grudge",
       "runtime_handle": 5644962986267984
@@ -1398,7 +1398,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/hidden-exit/darkest-ocean%3Adark-abyss",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "hidden-exit",
       "local_id": "darkest-ocean:dark-abyss",
       "runtime_handle": 456562266146446
@@ -1406,7 +1406,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2001",
       "legacy_runtime_id": 2001,
@@ -1415,7 +1415,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2002",
       "legacy_runtime_id": 2002,
@@ -1424,7 +1424,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2003",
       "legacy_runtime_id": 2003,
@@ -1433,7 +1433,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2004",
       "legacy_runtime_id": 2004,
@@ -1442,7 +1442,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2005",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2005",
       "legacy_runtime_id": 2005,
@@ -1451,7 +1451,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2006",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2006",
       "legacy_runtime_id": 2006,
@@ -1460,7 +1460,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2007",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2007",
       "legacy_runtime_id": 2007,
@@ -1469,7 +1469,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2008",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2008",
       "legacy_runtime_id": 2008,
@@ -1478,7 +1478,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2009",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2009",
       "legacy_runtime_id": 2009,
@@ -1487,7 +1487,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2010",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2010",
       "legacy_runtime_id": 2010,
@@ -1496,7 +1496,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2012",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2012",
       "legacy_runtime_id": 2012,
@@ -1505,7 +1505,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2013",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2013",
       "legacy_runtime_id": 2013,
@@ -1514,7 +1514,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/item/2014",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "item",
       "local_id": "2014",
       "legacy_runtime_id": 2014,
@@ -1523,7 +1523,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/goblin-cave%3Aname-the-price",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "goblin-cave:name-the-price",
       "runtime_handle": 3094113202720990
@@ -1531,7 +1531,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/haunted-mansion%3Aearn-the-threshold",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "haunted-mansion:earn-the-threshold",
       "runtime_handle": 7833342030263292
@@ -1539,7 +1539,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/moonlit-trail%3Aquiet-the-echo",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "moonlit-trail:quiet-the-echo",
       "runtime_handle": 3184352149003600
@@ -1547,7 +1547,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/rain-soft-garden%3Atrustworthy-path",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "rain-soft-garden:trustworthy-path",
       "runtime_handle": 4840596641936491
@@ -1555,7 +1555,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/solar-abyss%3Adrowned-bell",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "solar-abyss:drowned-bell",
       "runtime_handle": 681263158451131
@@ -1563,7 +1563,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/job/turgid-swamp%3Aamend-the-ledger",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "job",
       "local_id": "turgid-swamp:amend-the-ledger",
       "runtime_handle": 477973030695414
@@ -1571,7 +1571,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/1",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "1",
       "legacy_runtime_id": 1,
@@ -1580,7 +1580,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/2",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "2",
       "legacy_runtime_id": 2,
@@ -1589,7 +1589,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/3",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "3",
       "legacy_runtime_id": 3,
@@ -1598,7 +1598,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/30",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "30",
       "legacy_runtime_id": 30,
@@ -1607,7 +1607,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/31",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "31",
       "legacy_runtime_id": 31,
@@ -1616,7 +1616,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/32",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "32",
       "legacy_runtime_id": 32,
@@ -1625,7 +1625,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/33",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "33",
       "legacy_runtime_id": 33,
@@ -1634,7 +1634,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/34",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "34",
       "legacy_runtime_id": 34,
@@ -1643,7 +1643,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/35",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "35",
       "legacy_runtime_id": 35,
@@ -1652,7 +1652,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/36",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "36",
       "legacy_runtime_id": 36,
@@ -1661,7 +1661,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/40",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "40",
       "legacy_runtime_id": 40,
@@ -1670,7 +1670,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/41",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "41",
       "legacy_runtime_id": 41,
@@ -1679,7 +1679,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/42",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "42",
       "legacy_runtime_id": 42,
@@ -1688,7 +1688,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/43",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "43",
       "legacy_runtime_id": 43,
@@ -1697,7 +1697,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/44",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "44",
       "legacy_runtime_id": 44,
@@ -1706,7 +1706,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/50",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "50",
       "legacy_runtime_id": 50,
@@ -1715,7 +1715,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/60",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "60",
       "legacy_runtime_id": 60,
@@ -1724,7 +1724,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/61",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "61",
       "legacy_runtime_id": 61,
@@ -1733,7 +1733,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/62",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "62",
       "legacy_runtime_id": 62,
@@ -1742,7 +1742,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/63",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "63",
       "legacy_runtime_id": 63,
@@ -1751,7 +1751,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/64",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "64",
       "legacy_runtime_id": 64,
@@ -1760,7 +1760,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/location/65",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "location",
       "local_id": "65",
       "legacy_runtime_id": 65,
@@ -1769,7 +1769,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3001",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "recipe",
       "local_id": "3001",
       "runtime_handle": 828439639934659
@@ -1777,7 +1777,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3002",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "recipe",
       "local_id": "3002",
       "runtime_handle": 8276819746843037
@@ -1785,7 +1785,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3003",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "recipe",
       "local_id": "3003",
       "runtime_handle": 2153429270847803
@@ -1793,15 +1793,47 @@
     {
       "canonical_ref": "pack://cosyworld.core/recipe/3004",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "recipe",
       "local_id": "3004",
       "runtime_handle": 4118340134299628
     },
     {
+      "canonical_ref": "pack://cosyworld.core/recipe/3101",
+      "pack_id": "cosyworld.core",
+      "pack_version": "1.3.10",
+      "kind": "recipe",
+      "local_id": "3101",
+      "runtime_handle": 7229672606288966
+    },
+    {
+      "canonical_ref": "pack://cosyworld.core/recipe/3102",
+      "pack_id": "cosyworld.core",
+      "pack_version": "1.3.10",
+      "kind": "recipe",
+      "local_id": "3102",
+      "runtime_handle": 1504690938736172
+    },
+    {
+      "canonical_ref": "pack://cosyworld.core/recipe/3103",
+      "pack_id": "cosyworld.core",
+      "pack_version": "1.3.10",
+      "kind": "recipe",
+      "local_id": "3103",
+      "runtime_handle": 6273196500967148
+    },
+    {
+      "canonical_ref": "pack://cosyworld.core/recipe/3104",
+      "pack_id": "cosyworld.core",
+      "pack_version": "1.3.10",
+      "kind": "recipe",
+      "local_id": "3104",
+      "runtime_handle": 3035690296456513
+    },
+    {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A1",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:1",
       "runtime_handle": 3639178970696137
@@ -1809,7 +1841,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A2",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:2",
       "runtime_handle": 4328625160851383
@@ -1817,7 +1849,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A3",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:3",
       "runtime_handle": 272728635448160
@@ -1825,7 +1857,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A30",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:30",
       "runtime_handle": 4949881785988127
@@ -1833,7 +1865,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A31",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:31",
       "runtime_handle": 12158853449275
@@ -1841,7 +1873,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A32",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:32",
       "runtime_handle": 3065031734117441
@@ -1849,7 +1881,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A33",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:33",
       "runtime_handle": 8635481635081203
@@ -1857,7 +1889,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A34",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:34",
       "runtime_handle": 3415405010788251
@@ -1865,7 +1897,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A35",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:35",
       "runtime_handle": 8268805670112054
@@ -1873,7 +1905,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A36",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:36",
       "runtime_handle": 1278082739662403
@@ -1881,7 +1913,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A40",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:40",
       "runtime_handle": 2373835638704337
@@ -1889,7 +1921,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A41",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:41",
       "runtime_handle": 302978963504637
@@ -1897,7 +1929,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A42",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:42",
       "runtime_handle": 4669140359619141
@@ -1905,7 +1937,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A43",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:43",
       "runtime_handle": 3577060339822743
@@ -1913,7 +1945,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A44",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:44",
       "runtime_handle": 4396167510730171
@@ -1921,7 +1953,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A50",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:50",
       "runtime_handle": 1673766510642920
@@ -1929,7 +1961,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A60",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:60",
       "runtime_handle": 5586350793250546
@@ -1937,7 +1969,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A61",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:61",
       "runtime_handle": 6162116676111910
@@ -1945,7 +1977,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A62",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:62",
       "runtime_handle": 897159537111265
@@ -1953,7 +1985,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A63",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:63",
       "runtime_handle": 7446099757621175
@@ -1961,7 +1993,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A64",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:64",
       "runtime_handle": 4767551281449957
@@ -1969,7 +2001,7 @@
     {
       "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A65",
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "kind": "room-sheet",
       "local_id": "room:65",
       "runtime_handle": 389717939014779

--- a/v2/content/official/contributions.json
+++ b/v2/content/official/contributions.json
@@ -1,7 +1,7 @@
 [
   {
     "pack_id": "cosyworld.core",
-    "pack_version": "1.3.9",
+    "pack_version": "1.3.10",
     "rules_profile": "cosyworld.srd5/1",
     "reskins": [],
     "offers": [

--- a/v2/content/official/jobs.json
+++ b/v2/content/official/jobs.json
@@ -53,7 +53,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -84,7 +84,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -115,7 +115,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -184,7 +184,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -217,7 +217,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -249,7 +249,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -274,7 +274,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -299,7 +299,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -373,7 +373,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -400,7 +400,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -425,7 +425,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -450,7 +450,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -517,7 +517,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -542,7 +542,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -609,7 +609,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -634,7 +634,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [
@@ -701,7 +701,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       },
       {
         "version": 1,
@@ -726,7 +726,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9"
+        "pack_version": "1.3.10"
       }
     ],
     "narrated_thresholds": [

--- a/v2/content/official/licenses.json
+++ b/v2/content/official/licenses.json
@@ -48,7 +48,7 @@
   {
     "pack_id": "cosyworld.core",
     "name": "CosyWorld Core",
-    "version": "1.3.9",
+    "version": "1.3.10",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {

--- a/v2/content/official/recipes.json
+++ b/v2/content/official/recipes.json
@@ -75,5 +75,148 @@
       "reason": "This repeatable care beat makes frontier practice useful to the next traveler while both persistent ingredients remain in circulation."
     },
     "pack_id": "cosyworld.core"
+  },
+  {
+    "schema_version": 2,
+    "id": 3101,
+    "key": "refine-iron-bloom",
+    "name": "Refine Iron Bloom",
+    "description": "Work a represented iron nodule into a portable bloom at a completed smithy.",
+    "inputs": [
+      {
+        "template_id": "iron_nodule",
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": [
+        "transformation_recipes",
+        "metalworking"
+      ],
+      "recipe_tags": [
+        "smithy",
+        "refinement"
+      ]
+    },
+    "output": {
+      "template_id": "iron_bloom",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    },
+    "pack_id": "cosyworld.core"
+  },
+  {
+    "schema_version": 2,
+    "id": 3102,
+    "key": "forge-waystone-bracket",
+    "name": "Forge Waystone Bracket",
+    "description": "Forge a portable bracket that can be carried to an unfinished place.",
+    "inputs": [
+      {
+        "template_id": "iron_bloom",
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": [
+        "transformation_recipes",
+        "metalworking"
+      ],
+      "recipe_tags": [
+        "smithy",
+        "refinement"
+      ]
+    },
+    "output": {
+      "template_id": "waystone_bracket",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    },
+    "pack_id": "cosyworld.core"
+  },
+  {
+    "schema_version": 2,
+    "id": 3103,
+    "key": "install-waystone-bracket",
+    "name": "Install Waystone Bracket",
+    "description": "Fit a carried bracket into the unfinished ground as a lasting typed anchor.",
+    "inputs": [
+      {
+        "template_id": "waystone_bracket",
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "location_features": [
+        "generated_place_anchor_site"
+      ]
+    },
+    "output": {
+      "template_id": "waystone_bracket",
+      "destination": "installed_at_location",
+      "fallback_destination": "location_floor",
+      "effect": "installed_fixture",
+      "uniqueness": "per_location"
+    },
+    "pack_id": "cosyworld.core"
+  },
+  {
+    "schema_version": 2,
+    "id": 3104,
+    "key": "smoke-river-sprat",
+    "name": "Smoke River Sprat",
+    "description": "Preserve a represented catch at a completed smokehouse.",
+    "inputs": [
+      {
+        "template_id": "river_sprat",
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "transform"
+      }
+    ],
+    "requires": {
+      "building_capabilities": [
+        "transformation_recipes",
+        "preservation"
+      ],
+      "recipe_tags": [
+        "smokehouse",
+        "preservation"
+      ]
+    },
+    "output": {
+      "template_id": "smoked_river_sprat",
+      "destination": "actor_hand",
+      "fallback_destination": "location_floor",
+      "effect": "portable",
+      "uniqueness": "per_receipt"
+    },
+    "pack_id": "cosyworld.core"
   }
 ]

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -619,7 +619,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:5c79b85a2ef1901382abe6192a0d4f89a587cb8e478c0d3e706776c5873854f4",
+    "bundle_hash": "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -783,7 +783,7 @@
         "id": "cosyworld.core",
         "name": "CosyWorld Core",
         "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
-        "version": "1.3.9",
+        "version": "1.3.10",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit",
@@ -852,7 +852,7 @@
           "card_bindings": 0,
           "lifecycle_hooks": 19,
           "evolution_tracks": 3,
-          "recipes": 4,
+          "recipes": 8,
           "sentences": 21,
           "external_cards": 0,
           "assets": 2,
@@ -946,6 +946,29 @@
                 "recipe_tags": [
                   "workshop",
                   "repair"
+                ],
+                "cache_policy": "none"
+              },
+              {
+                "id": "smithy",
+                "name": "Smithy",
+                "description": "A shared forge for declared metal transformations and repairs.",
+                "classification": "universal",
+                "capabilities": [
+                  "transformation_recipes",
+                  "metalworking",
+                  "repair_jobs",
+                  "stewardship"
+                ],
+                "upgrade_capabilities": [
+                  "carpentry"
+                ],
+                "quest_templates": [
+                  "service.workshop"
+                ],
+                "recipe_tags": [
+                  "smithy",
+                  "refinement"
                 ],
                 "cache_policy": "none"
               },
@@ -1400,6 +1423,16 @@
                 "size": "small"
               },
               {
+                "id": "smoked_river_sprat",
+                "name": "Smoked River Sprat",
+                "description": "A represented catch preserved at a completed smokehouse for later journeys.",
+                "kind": "keepsake",
+                "charges": 1,
+                "role": "generic",
+                "weight_tenths": 3,
+                "size": "small"
+              },
+              {
                 "id": "glassfin_scale",
                 "name": "Glassfin Scale",
                 "description": "A rare clear scale that keeps a ribbon of river light.",
@@ -1417,6 +1450,26 @@
                 "charges": 1,
                 "role": "generic",
                 "weight_tenths": 20,
+                "size": "small"
+              },
+              {
+                "id": "iron_bloom",
+                "name": "Iron Bloom",
+                "description": "A compact bloom refined from represented ore at a working smithy.",
+                "kind": "keepsake",
+                "charges": 1,
+                "role": "generic",
+                "weight_tenths": 14,
+                "size": "small"
+              },
+              {
+                "id": "waystone_bracket",
+                "name": "Waystone Bracket",
+                "description": "A fitted iron bracket made to hold one lasting marker in place.",
+                "kind": "keepsake",
+                "charges": 1,
+                "role": "generic",
+                "weight_tenths": 12,
                 "size": "small"
               },
               {
@@ -1636,7 +1689,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0"
+        "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
       },
       {
         "id": "cosyworld.rules-srd-5.1",
@@ -8122,7 +8175,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8153,7 +8206,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8184,7 +8237,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -8253,7 +8306,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8286,7 +8339,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8318,7 +8371,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8343,7 +8396,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8368,7 +8421,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -8442,7 +8495,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8469,7 +8522,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8494,7 +8547,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8519,7 +8572,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -8586,7 +8639,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8611,7 +8664,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -8678,7 +8731,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8703,7 +8756,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -8770,7 +8823,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           },
           {
             "version": 1,
@@ -8795,7 +8848,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.core",
-            "pack_version": "1.3.9"
+            "pack_version": "1.3.10"
           }
         ],
         "narrated_thresholds": [
@@ -12114,6 +12167,149 @@
           "reason": "This repeatable care beat makes frontier practice useful to the next traveler while both persistent ingredients remain in circulation."
         },
         "pack_id": "cosyworld.core"
+      },
+      {
+        "schema_version": 2,
+        "id": 3101,
+        "key": "refine-iron-bloom",
+        "name": "Refine Iron Bloom",
+        "description": "Work a represented iron nodule into a portable bloom at a completed smithy.",
+        "inputs": [
+          {
+            "template_id": "iron_nodule",
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "transform"
+          }
+        ],
+        "requires": {
+          "building_capabilities": [
+            "transformation_recipes",
+            "metalworking"
+          ],
+          "recipe_tags": [
+            "smithy",
+            "refinement"
+          ]
+        },
+        "output": {
+          "template_id": "iron_bloom",
+          "destination": "actor_hand",
+          "fallback_destination": "location_floor",
+          "effect": "portable",
+          "uniqueness": "per_receipt"
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "schema_version": 2,
+        "id": 3102,
+        "key": "forge-waystone-bracket",
+        "name": "Forge Waystone Bracket",
+        "description": "Forge a portable bracket that can be carried to an unfinished place.",
+        "inputs": [
+          {
+            "template_id": "iron_bloom",
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "transform"
+          }
+        ],
+        "requires": {
+          "building_capabilities": [
+            "transformation_recipes",
+            "metalworking"
+          ],
+          "recipe_tags": [
+            "smithy",
+            "refinement"
+          ]
+        },
+        "output": {
+          "template_id": "waystone_bracket",
+          "destination": "actor_hand",
+          "fallback_destination": "location_floor",
+          "effect": "portable",
+          "uniqueness": "per_receipt"
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "schema_version": 2,
+        "id": 3103,
+        "key": "install-waystone-bracket",
+        "name": "Install Waystone Bracket",
+        "description": "Fit a carried bracket into the unfinished ground as a lasting typed anchor.",
+        "inputs": [
+          {
+            "template_id": "waystone_bracket",
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "transform"
+          }
+        ],
+        "requires": {
+          "location_features": [
+            "generated_place_anchor_site"
+          ]
+        },
+        "output": {
+          "template_id": "waystone_bracket",
+          "destination": "installed_at_location",
+          "fallback_destination": "location_floor",
+          "effect": "installed_fixture",
+          "uniqueness": "per_location"
+        },
+        "pack_id": "cosyworld.core"
+      },
+      {
+        "schema_version": 2,
+        "id": 3104,
+        "key": "smoke-river-sprat",
+        "name": "Smoke River Sprat",
+        "description": "Preserve a represented catch at a completed smokehouse.",
+        "inputs": [
+          {
+            "template_id": "river_sprat",
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "transform"
+          }
+        ],
+        "requires": {
+          "building_capabilities": [
+            "transformation_recipes",
+            "preservation"
+          ],
+          "recipe_tags": [
+            "smokehouse",
+            "preservation"
+          ]
+        },
+        "output": {
+          "template_id": "smoked_river_sprat",
+          "destination": "actor_hand",
+          "fallback_destination": "location_floor",
+          "effect": "portable",
+          "uniqueness": "per_receipt"
+        },
+        "pack_id": "cosyworld.core"
       }
     ],
     "sentences": [
@@ -12767,8 +12963,8 @@
   "assets": [
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
-      "pack_integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+      "pack_version": "1.3.10",
+      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -12780,8 +12976,8 @@
     },
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
-      "pack_integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+      "pack_version": "1.3.10",
+      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",
@@ -14531,7 +14727,7 @@
   "contributions": [
     {
       "pack_id": "cosyworld.core",
-      "pack_version": "1.3.9",
+      "pack_version": "1.3.10",
       "rules_profile": "cosyworld.srd5/1",
       "reskins": [],
       "offers": [
@@ -14673,7 +14869,7 @@
     {
       "pack_id": "cosyworld.core",
       "name": "CosyWorld Core",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
@@ -15813,7 +16009,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1001",
         "legacy_runtime_id": 1001,
@@ -15822,7 +16018,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1002",
         "legacy_runtime_id": 1002,
@@ -15831,7 +16027,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1003",
         "legacy_runtime_id": 1003,
@@ -15840,7 +16036,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1004",
         "legacy_runtime_id": 1004,
@@ -15849,7 +16045,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1005",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1005",
         "legacy_runtime_id": 1005,
@@ -15858,7 +16054,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1040",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1040",
         "legacy_runtime_id": 1040,
@@ -15867,7 +16063,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1041",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1041",
         "legacy_runtime_id": 1041,
@@ -15876,7 +16072,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1042",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1042",
         "legacy_runtime_id": 1042,
@@ -15885,7 +16081,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1043",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1043",
         "legacy_runtime_id": 1043,
@@ -15894,7 +16090,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1044",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1044",
         "legacy_runtime_id": 1044,
@@ -15903,7 +16099,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1045",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1045",
         "legacy_runtime_id": 1045,
@@ -15912,7 +16108,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1046",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1046",
         "legacy_runtime_id": 1046,
@@ -15921,7 +16117,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1047",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1047",
         "legacy_runtime_id": 1047,
@@ -15930,7 +16126,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1048",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1048",
         "legacy_runtime_id": 1048,
@@ -15939,7 +16135,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1049",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1049",
         "legacy_runtime_id": 1049,
@@ -15948,7 +16144,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1050",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1050",
         "legacy_runtime_id": 1050,
@@ -15957,7 +16153,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1051",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1051",
         "legacy_runtime_id": 1051,
@@ -15966,7 +16162,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1052",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1052",
         "legacy_runtime_id": 1052,
@@ -15975,7 +16171,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1053",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1053",
         "legacy_runtime_id": 1053,
@@ -15984,7 +16180,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1054",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1054",
         "legacy_runtime_id": 1054,
@@ -15993,7 +16189,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1055",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1055",
         "legacy_runtime_id": 1055,
@@ -16002,7 +16198,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1056",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1056",
         "legacy_runtime_id": 1056,
@@ -16011,7 +16207,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1057",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1057",
         "legacy_runtime_id": 1057,
@@ -16020,7 +16216,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1058",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1058",
         "legacy_runtime_id": 1058,
@@ -16029,7 +16225,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1059",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1059",
         "legacy_runtime_id": 1059,
@@ -16038,7 +16234,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1060",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1060",
         "legacy_runtime_id": 1060,
@@ -16047,7 +16243,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1061",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1061",
         "legacy_runtime_id": 1061,
@@ -16056,7 +16252,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1062",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1062",
         "legacy_runtime_id": 1062,
@@ -16065,7 +16261,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1063",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1063",
         "legacy_runtime_id": 1063,
@@ -16074,7 +16270,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1064",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1064",
         "legacy_runtime_id": 1064,
@@ -16083,7 +16279,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1065",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1065",
         "legacy_runtime_id": 1065,
@@ -16092,7 +16288,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1066",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1066",
         "legacy_runtime_id": 1066,
@@ -16101,7 +16297,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1067",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1067",
         "legacy_runtime_id": 1067,
@@ -16110,7 +16306,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1068",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1068",
         "legacy_runtime_id": 1068,
@@ -16119,7 +16315,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1069",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1069",
         "legacy_runtime_id": 1069,
@@ -16128,7 +16324,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/actor/1070",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "actor",
         "local_id": "1070",
         "legacy_runtime_id": 1070,
@@ -16137,7 +16333,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-abbey-bookmark",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-abbey-bookmark",
         "runtime_handle": 138956494956560
@@ -16145,7 +16341,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-azazoth",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-azazoth",
         "runtime_handle": 2742827434789688
@@ -16153,7 +16349,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-cottage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-cottage",
         "runtime_handle": 3679023710615970
@@ -16161,7 +16357,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-dewbright-button",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-dewbright-button",
         "runtime_handle": 7543879359126606
@@ -16169,7 +16365,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-hearth-tonic",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-hearth-tonic",
         "runtime_handle": 6099844187041316
@@ -16177,7 +16373,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-hearthstone-tag",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-hearthstone-tag",
         "runtime_handle": 445803431082645
@@ -16185,7 +16381,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-echo",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-moonlit-echo",
         "runtime_handle": 3701779326615881
@@ -16193,7 +16389,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonlit-trail",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-moonlit-trail",
         "runtime_handle": 3706559719582066
@@ -16201,7 +16397,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-moonwool-thread",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-moonwool-thread",
         "runtime_handle": 3248987744606910
@@ -16209,7 +16405,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-mossglass-bead",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-mossglass-bead",
         "runtime_handle": 406732117808934
@@ -16217,7 +16413,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-old-oak",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-old-oak",
         "runtime_handle": 6806929065153819
@@ -16225,7 +16421,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-pearl-deep-resident",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-pearl-deep-resident",
         "runtime_handle": 8634483881055898
@@ -16233,7 +16429,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-rain-soft-garden",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-rain-soft-garden",
         "runtime_handle": 8636127016066734
@@ -16241,7 +16437,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-skull",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-skull",
         "runtime_handle": 8174630967825761
@@ -16249,7 +16445,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-story-button",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-story-button",
         "runtime_handle": 3151408643854036
@@ -16257,7 +16453,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-threadbare-map-scrap",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-threadbare-map-scrap",
         "runtime_handle": 4482891498418887
@@ -16265,7 +16461,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-vowbright-angel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-vowbright-angel",
         "runtime_handle": 7966555082684141
@@ -16273,7 +16469,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-watch-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-watch-bell",
         "runtime_handle": 6205526622615328
@@ -16281,7 +16477,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-whiskerwind",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-whiskerwind",
         "runtime_handle": 5669444972898140
@@ -16289,7 +16485,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-wolfprint-charm",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-wolfprint-charm",
         "runtime_handle": 915703357568385
@@ -16297,7 +16493,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/cosy-zadkiel-dark-angel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "cosy-zadkiel-dark-angel",
         "runtime_handle": 8315124370132858
@@ -16305,7 +16501,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/item-ashwood-practice-blade",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "item-ashwood-practice-blade",
         "runtime_handle": 3640187639484502
@@ -16313,7 +16509,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/item-patchwork-satchel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "item-patchwork-satchel",
         "runtime_handle": 804106637155376
@@ -16321,7 +16517,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/item-steady-light",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "item-steady-light",
         "runtime_handle": 8614146586928189
@@ -16329,7 +16525,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-armored-winged-hero",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-armored-winged-hero",
         "runtime_handle": 6600128378329146
@@ -16337,7 +16533,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-badger-cub",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-badger-cub",
         "runtime_handle": 3524217422483260
@@ -16345,7 +16541,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-beetle-armor",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-beetle-armor",
         "runtime_handle": 7880939887467250
@@ -16353,7 +16549,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-blue-shadow-man",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-blue-shadow-man",
         "runtime_handle": 3755993660754793
@@ -16361,7 +16557,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-blue-squirrel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-blue-squirrel",
         "runtime_handle": 3374679645864704
@@ -16369,7 +16565,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-cloaked-mouse-reader",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-cloaked-mouse-reader",
         "runtime_handle": 3997082335066109
@@ -16377,7 +16573,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-forest-dryad",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-forest-dryad",
         "runtime_handle": 8662818472079145
@@ -16385,7 +16581,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-garden-rabbit",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-garden-rabbit",
         "runtime_handle": 2730391876987516
@@ -16393,7 +16589,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-golden-squirrel",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-golden-squirrel",
         "runtime_handle": 162503682361987
@@ -16401,7 +16597,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-golden-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-golden-winged-boy",
         "runtime_handle": 4342854739894551
@@ -16409,7 +16605,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-grey-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-grey-winged-boy",
         "runtime_handle": 1250802238685798
@@ -16417,7 +16613,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-llama-scholar",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-llama-scholar",
         "runtime_handle": 6908093676132939
@@ -16425,7 +16621,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-mouse-wanderer",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-mouse-wanderer",
         "runtime_handle": 4601206403124060
@@ -16433,7 +16629,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-neon-tiger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-neon-tiger",
         "runtime_handle": 6229971572743818
@@ -16441,7 +16637,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-rabbit-scribe",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-rabbit-scribe",
         "runtime_handle": 8634110685852129
@@ -16449,7 +16645,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-red-shadow-figure",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-red-shadow-figure",
         "runtime_handle": 3112884101630158
@@ -16457,7 +16653,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-shadow-wolf",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-shadow-wolf",
         "runtime_handle": 4273988789998875
@@ -16465,7 +16661,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-steampunk-mouse",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-steampunk-mouse",
         "runtime_handle": 4441668646189737
@@ -16473,7 +16669,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-sunlit-winged-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-sunlit-winged-boy",
         "runtime_handle": 8615932867192302
@@ -16481,7 +16677,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-tavern-blond-boy",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-tavern-blond-boy",
         "runtime_handle": 1835702442135722
@@ -16489,7 +16685,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-veiled-forest-ghost",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-veiled-forest-ghost",
         "runtime_handle": 4799858469869419
@@ -16497,7 +16693,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-white-ferret-noble",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-white-ferret-noble",
         "runtime_handle": 5084247526999701
@@ -16505,7 +16701,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-wolf-pup",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-wolf-pup",
         "runtime_handle": 236437027581609
@@ -16513,7 +16709,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/lf-woodland-bear",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "lf-woodland-bear",
         "runtime_handle": 9000656934868850
@@ -16521,7 +16717,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-alpine-forest",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-alpine-forest",
         "runtime_handle": 8242458519360113
@@ -16529,7 +16725,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-circle-of-the-moon",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-circle-of-the-moon",
         "runtime_handle": 1930856172148870
@@ -16537,7 +16733,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-dark-abyss",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-dark-abyss",
         "runtime_handle": 7382677506125331
@@ -16545,7 +16741,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-darkest-ocean",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-darkest-ocean",
         "runtime_handle": 5061075064260629
@@ -16553,7 +16749,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-digital-realm",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-digital-realm",
         "runtime_handle": 5887686546418438
@@ -16561,7 +16757,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-endless-ocean",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-endless-ocean",
         "runtime_handle": 5401754774320525
@@ -16569,7 +16765,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-flower-meadow",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-flower-meadow",
         "runtime_handle": 7614022144101722
@@ -16577,7 +16773,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-goblin-cave",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-goblin-cave",
         "runtime_handle": 3499001612672709
@@ -16585,7 +16781,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-great-library",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-great-library",
         "runtime_handle": 7328586258800562
@@ -16593,7 +16789,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-haunted-mansion",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-haunted-mansion",
         "runtime_handle": 7484239537948286
@@ -16601,7 +16797,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-lofty-peak",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-lofty-peak",
         "runtime_handle": 2456240765655012
@@ -16609,7 +16805,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-lost-woods",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-lost-woods",
         "runtime_handle": 6580883718503069
@@ -16617,7 +16813,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-old-oak-tree",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-old-oak-tree",
         "runtime_handle": 2838379433219254
@@ -16625,7 +16821,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-quiet-abbey",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-quiet-abbey",
         "runtime_handle": 4838231888638100
@@ -16633,7 +16829,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-solar-temple",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-solar-temple",
         "runtime_handle": 450219611871818
@@ -16641,7 +16837,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-summit-trail",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-summit-trail",
         "runtime_handle": 8064929121549612
@@ -16649,7 +16845,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-the-heavens",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-the-heavens",
         "runtime_handle": 6396411156616223
@@ -16657,7 +16853,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-turgid-swamp",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-turgid-swamp",
         "runtime_handle": 6935773679641332
@@ -16665,7 +16861,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/location-wilting-jungle",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "location-wilting-jungle",
         "runtime_handle": 5897394732936641
@@ -16673,7 +16869,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/card/rati",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "card",
         "local_id": "rati",
         "runtime_handle": 1392254580257493
@@ -16681,7 +16877,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.fair-bargain",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "goblin-cave.fair-bargain",
         "runtime_handle": 8054949801377040
@@ -16689,7 +16885,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/goblin-cave.leverage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "goblin-cave.leverage",
         "runtime_handle": 1065707925425919
@@ -16697,7 +16893,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "haunted-mansion.threshold",
         "runtime_handle": 4535315091897137
@@ -16705,7 +16901,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/haunted-mansion.warden-rage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "haunted-mansion.warden-rage",
         "runtime_handle": 6257115991159330
@@ -16713,7 +16909,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.danger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "moonlit-trail.danger",
         "runtime_handle": 257345026365457
@@ -16721,7 +16917,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/moonlit-trail.progress",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "moonlit-trail.progress",
         "runtime_handle": 6085238183587093
@@ -16729,7 +16925,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/rain-soft-garden.path-washes-out",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "rain-soft-garden.path-washes-out",
         "runtime_handle": 5725575878774039
@@ -16737,7 +16933,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/rain-soft-garden.trustworthy-path",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "rain-soft-garden.trustworthy-path",
         "runtime_handle": 7366604576604707
@@ -16745,7 +16941,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.drowned-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "solar-abyss.drowned-bell",
         "runtime_handle": 3555240757788262
@@ -16753,7 +16949,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/solar-abyss.schism",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "solar-abyss.schism",
         "runtime_handle": 4589004266308223
@@ -16761,7 +16957,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.amends",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "turgid-swamp.amends",
         "runtime_handle": 4432023342275341
@@ -16769,7 +16965,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/clock/turgid-swamp.old-grudge",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "clock",
         "local_id": "turgid-swamp.old-grudge",
         "runtime_handle": 8536373757408084
@@ -16777,7 +16973,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/abyssal_residents",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "abyssal_residents",
         "runtime_handle": 1688333275188302
@@ -16785,7 +16981,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/digital_strays",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "digital_strays",
         "runtime_handle": 5048545454289654
@@ -16793,7 +16989,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/farthest_mists",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "farthest_mists",
         "runtime_handle": 350962558801960
@@ -16801,7 +16997,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/goblin_market",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "goblin_market",
         "runtime_handle": 3490418888358082
@@ -16809,7 +17005,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/great_library",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "great_library",
         "runtime_handle": 991170045564473
@@ -16817,7 +17013,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/haunted_remnants",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "haunted_remnants",
         "runtime_handle": 4900866309718573
@@ -16825,7 +17021,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/hearthbound",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "hearthbound",
         "runtime_handle": 4046513959484943
@@ -16833,7 +17029,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/lonely_forest_court",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "lonely_forest_court",
         "runtime_handle": 5495209280499345
@@ -16841,7 +17037,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/moon_circle",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "moon_circle",
         "runtime_handle": 3594504273910135
@@ -16849,7 +17045,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/quiet_abbey",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "quiet_abbey",
         "runtime_handle": 7894097855005461
@@ -16857,7 +17053,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/faction/solar_temple",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "faction",
         "local_id": "solar_temple",
         "runtime_handle": 2642136344425509
@@ -16865,7 +17061,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/goblin-cave%3Amarket-leverage",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "goblin-cave:market-leverage",
         "runtime_handle": 5093973293074428
@@ -16873,7 +17069,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/haunted-mansion%3Abarred-threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "haunted-mansion:barred-threshold",
         "runtime_handle": 6295078661322495
@@ -16881,7 +17077,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/moonlit-trail%3Aecho-front",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "moonlit-trail:echo-front",
         "runtime_handle": 3643385637336037
@@ -16889,7 +17085,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/solar-abyss%3Abell-front",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "solar-abyss:bell-front",
         "runtime_handle": 591496292254136
@@ -16897,7 +17093,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/front/turgid-swamp%3Aold-grudge",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "front",
         "local_id": "turgid-swamp:old-grudge",
         "runtime_handle": 5644962986267984
@@ -16905,7 +17101,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/hidden-exit/darkest-ocean%3Adark-abyss",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "hidden-exit",
         "local_id": "darkest-ocean:dark-abyss",
         "runtime_handle": 456562266146446
@@ -16913,7 +17109,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2001",
         "legacy_runtime_id": 2001,
@@ -16922,7 +17118,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2002",
         "legacy_runtime_id": 2002,
@@ -16931,7 +17127,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2003",
         "legacy_runtime_id": 2003,
@@ -16940,7 +17136,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2004",
         "legacy_runtime_id": 2004,
@@ -16949,7 +17145,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2005",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2005",
         "legacy_runtime_id": 2005,
@@ -16958,7 +17154,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2006",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2006",
         "legacy_runtime_id": 2006,
@@ -16967,7 +17163,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2007",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2007",
         "legacy_runtime_id": 2007,
@@ -16976,7 +17172,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2008",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2008",
         "legacy_runtime_id": 2008,
@@ -16985,7 +17181,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2009",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2009",
         "legacy_runtime_id": 2009,
@@ -16994,7 +17190,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2010",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2010",
         "legacy_runtime_id": 2010,
@@ -17003,7 +17199,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2012",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2012",
         "legacy_runtime_id": 2012,
@@ -17012,7 +17208,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2013",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2013",
         "legacy_runtime_id": 2013,
@@ -17021,7 +17217,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/item/2014",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "item",
         "local_id": "2014",
         "legacy_runtime_id": 2014,
@@ -17030,7 +17226,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/goblin-cave%3Aname-the-price",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "goblin-cave:name-the-price",
         "runtime_handle": 3094113202720990
@@ -17038,7 +17234,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/haunted-mansion%3Aearn-the-threshold",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "haunted-mansion:earn-the-threshold",
         "runtime_handle": 7833342030263292
@@ -17046,7 +17242,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/moonlit-trail%3Aquiet-the-echo",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "moonlit-trail:quiet-the-echo",
         "runtime_handle": 3184352149003600
@@ -17054,7 +17250,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/rain-soft-garden%3Atrustworthy-path",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "rain-soft-garden:trustworthy-path",
         "runtime_handle": 4840596641936491
@@ -17062,7 +17258,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/solar-abyss%3Adrowned-bell",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "solar-abyss:drowned-bell",
         "runtime_handle": 681263158451131
@@ -17070,7 +17266,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/job/turgid-swamp%3Aamend-the-ledger",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "job",
         "local_id": "turgid-swamp:amend-the-ledger",
         "runtime_handle": 477973030695414
@@ -17078,7 +17274,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/1",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "1",
         "legacy_runtime_id": 1,
@@ -17087,7 +17283,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/2",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "2",
         "legacy_runtime_id": 2,
@@ -17096,7 +17292,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/3",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "3",
         "legacy_runtime_id": 3,
@@ -17105,7 +17301,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/30",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "30",
         "legacy_runtime_id": 30,
@@ -17114,7 +17310,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/31",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "31",
         "legacy_runtime_id": 31,
@@ -17123,7 +17319,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/32",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "32",
         "legacy_runtime_id": 32,
@@ -17132,7 +17328,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/33",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "33",
         "legacy_runtime_id": 33,
@@ -17141,7 +17337,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/34",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "34",
         "legacy_runtime_id": 34,
@@ -17150,7 +17346,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/35",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "35",
         "legacy_runtime_id": 35,
@@ -17159,7 +17355,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/36",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "36",
         "legacy_runtime_id": 36,
@@ -17168,7 +17364,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/40",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "40",
         "legacy_runtime_id": 40,
@@ -17177,7 +17373,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/41",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "41",
         "legacy_runtime_id": 41,
@@ -17186,7 +17382,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/42",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "42",
         "legacy_runtime_id": 42,
@@ -17195,7 +17391,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/43",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "43",
         "legacy_runtime_id": 43,
@@ -17204,7 +17400,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/44",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "44",
         "legacy_runtime_id": 44,
@@ -17213,7 +17409,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/50",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "50",
         "legacy_runtime_id": 50,
@@ -17222,7 +17418,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/60",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "60",
         "legacy_runtime_id": 60,
@@ -17231,7 +17427,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/61",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "61",
         "legacy_runtime_id": 61,
@@ -17240,7 +17436,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/62",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "62",
         "legacy_runtime_id": 62,
@@ -17249,7 +17445,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/63",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "63",
         "legacy_runtime_id": 63,
@@ -17258,7 +17454,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/64",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "64",
         "legacy_runtime_id": 64,
@@ -17267,7 +17463,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/location/65",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "location",
         "local_id": "65",
         "legacy_runtime_id": 65,
@@ -17276,7 +17472,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3001",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "recipe",
         "local_id": "3001",
         "runtime_handle": 828439639934659
@@ -17284,7 +17480,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3002",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "recipe",
         "local_id": "3002",
         "runtime_handle": 8276819746843037
@@ -17292,7 +17488,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3003",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "recipe",
         "local_id": "3003",
         "runtime_handle": 2153429270847803
@@ -17300,15 +17496,47 @@
       {
         "canonical_ref": "pack://cosyworld.core/recipe/3004",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "recipe",
         "local_id": "3004",
         "runtime_handle": 4118340134299628
       },
       {
+        "canonical_ref": "pack://cosyworld.core/recipe/3101",
+        "pack_id": "cosyworld.core",
+        "pack_version": "1.3.10",
+        "kind": "recipe",
+        "local_id": "3101",
+        "runtime_handle": 7229672606288966
+      },
+      {
+        "canonical_ref": "pack://cosyworld.core/recipe/3102",
+        "pack_id": "cosyworld.core",
+        "pack_version": "1.3.10",
+        "kind": "recipe",
+        "local_id": "3102",
+        "runtime_handle": 1504690938736172
+      },
+      {
+        "canonical_ref": "pack://cosyworld.core/recipe/3103",
+        "pack_id": "cosyworld.core",
+        "pack_version": "1.3.10",
+        "kind": "recipe",
+        "local_id": "3103",
+        "runtime_handle": 6273196500967148
+      },
+      {
+        "canonical_ref": "pack://cosyworld.core/recipe/3104",
+        "pack_id": "cosyworld.core",
+        "pack_version": "1.3.10",
+        "kind": "recipe",
+        "local_id": "3104",
+        "runtime_handle": 3035690296456513
+      },
+      {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A1",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:1",
         "runtime_handle": 3639178970696137
@@ -17316,7 +17544,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A2",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:2",
         "runtime_handle": 4328625160851383
@@ -17324,7 +17552,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A3",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:3",
         "runtime_handle": 272728635448160
@@ -17332,7 +17560,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A30",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:30",
         "runtime_handle": 4949881785988127
@@ -17340,7 +17568,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A31",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:31",
         "runtime_handle": 12158853449275
@@ -17348,7 +17576,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A32",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:32",
         "runtime_handle": 3065031734117441
@@ -17356,7 +17584,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A33",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:33",
         "runtime_handle": 8635481635081203
@@ -17364,7 +17592,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A34",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:34",
         "runtime_handle": 3415405010788251
@@ -17372,7 +17600,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A35",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:35",
         "runtime_handle": 8268805670112054
@@ -17380,7 +17608,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A36",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:36",
         "runtime_handle": 1278082739662403
@@ -17388,7 +17616,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A40",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:40",
         "runtime_handle": 2373835638704337
@@ -17396,7 +17624,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A41",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:41",
         "runtime_handle": 302978963504637
@@ -17404,7 +17632,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A42",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:42",
         "runtime_handle": 4669140359619141
@@ -17412,7 +17640,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A43",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:43",
         "runtime_handle": 3577060339822743
@@ -17420,7 +17648,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A44",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:44",
         "runtime_handle": 4396167510730171
@@ -17428,7 +17656,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A50",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:50",
         "runtime_handle": 1673766510642920
@@ -17436,7 +17664,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A60",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:60",
         "runtime_handle": 5586350793250546
@@ -17444,7 +17672,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A61",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:61",
         "runtime_handle": 6162116676111910
@@ -17452,7 +17680,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A62",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:62",
         "runtime_handle": 897159537111265
@@ -17460,7 +17688,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A63",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:63",
         "runtime_handle": 7446099757621175
@@ -17468,7 +17696,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A64",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:64",
         "runtime_handle": 4767551281449957
@@ -17476,7 +17704,7 @@
       {
         "canonical_ref": "pack://cosyworld.core/room-sheet/room%3A65",
         "pack_id": "cosyworld.core",
-        "pack_version": "1.3.9",
+        "pack_version": "1.3.10",
         "kind": "room-sheet",
         "local_id": "room:65",
         "runtime_handle": 389717939014779

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -617,7 +617,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:5c79b85a2ef1901382abe6192a0d4f89a587cb8e478c0d3e706776c5873854f4",
+  "bundle_hash": "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -781,7 +781,7 @@
       "id": "cosyworld.core",
       "name": "CosyWorld Core",
       "description": "The first-party CosyWorld rooms, residents, items, cards, and world systems.",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit",
@@ -850,7 +850,7 @@
         "card_bindings": 0,
         "lifecycle_hooks": 19,
         "evolution_tracks": 3,
-        "recipes": 4,
+        "recipes": 8,
         "sentences": 21,
         "external_cards": 0,
         "assets": 2,
@@ -944,6 +944,29 @@
               "recipe_tags": [
                 "workshop",
                 "repair"
+              ],
+              "cache_policy": "none"
+            },
+            {
+              "id": "smithy",
+              "name": "Smithy",
+              "description": "A shared forge for declared metal transformations and repairs.",
+              "classification": "universal",
+              "capabilities": [
+                "transformation_recipes",
+                "metalworking",
+                "repair_jobs",
+                "stewardship"
+              ],
+              "upgrade_capabilities": [
+                "carpentry"
+              ],
+              "quest_templates": [
+                "service.workshop"
+              ],
+              "recipe_tags": [
+                "smithy",
+                "refinement"
               ],
               "cache_policy": "none"
             },
@@ -1398,6 +1421,16 @@
               "size": "small"
             },
             {
+              "id": "smoked_river_sprat",
+              "name": "Smoked River Sprat",
+              "description": "A represented catch preserved at a completed smokehouse for later journeys.",
+              "kind": "keepsake",
+              "charges": 1,
+              "role": "generic",
+              "weight_tenths": 3,
+              "size": "small"
+            },
+            {
               "id": "glassfin_scale",
               "name": "Glassfin Scale",
               "description": "A rare clear scale that keeps a ribbon of river light.",
@@ -1415,6 +1448,26 @@
               "charges": 1,
               "role": "generic",
               "weight_tenths": 20,
+              "size": "small"
+            },
+            {
+              "id": "iron_bloom",
+              "name": "Iron Bloom",
+              "description": "A compact bloom refined from represented ore at a working smithy.",
+              "kind": "keepsake",
+              "charges": 1,
+              "role": "generic",
+              "weight_tenths": 14,
+              "size": "small"
+            },
+            {
+              "id": "waystone_bracket",
+              "name": "Waystone Bracket",
+              "description": "A fitted iron bracket made to hold one lasting marker in place.",
+              "kind": "keepsake",
+              "charges": 1,
+              "role": "generic",
+              "weight_tenths": 12,
               "size": "small"
             },
             {
@@ -1634,7 +1687,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0"
+      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
     },
     {
       "id": "cosyworld.rules-srd-5.1",

--- a/v2/core-c/include/cosy_kernel.h
+++ b/v2/core-c/include/cosy_kernel.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#define CW_KERNEL_VERSION 5u
+#define CW_KERNEL_VERSION 6u
 
 #define CW_MAX_ACTORS 512u
 #define CW_MAX_ITEMS 1024u
@@ -58,7 +58,8 @@ typedef enum {
 typedef enum {
   CW_PLACEMENT_NONE = 0,
   CW_PLACEMENT_ACTOR_HAND = 1,
-  CW_PLACEMENT_LOCATION_FLOOR = 2
+  CW_PLACEMENT_LOCATION_FLOOR = 2,
+  CW_PLACEMENT_LOCATION_FIXTURE = 3
 } cw_placement_target_kind;
 
 typedef enum {
@@ -95,7 +96,8 @@ typedef enum {
   CW_CARD_ZONE_SPELL_DECK = 4,
   CW_CARD_ZONE_EXHAUSTED = 5,
   CW_CARD_ZONE_CONTAINED = 6,
-  CW_CARD_ZONE_ESCROW = 7
+  CW_CARD_ZONE_ESCROW = 7,
+  CW_CARD_ZONE_INSTALLED = 8
 } cw_card_zone;
 
 typedef enum {
@@ -190,8 +192,18 @@ typedef enum {
   CW_EVENT_ITEM_THEFT_ATTEMPT = 32,
   CW_EVENT_ITEM_STOLEN = 33,
   CW_EVENT_COMBAT_PASS = 34,
-  CW_EVENT_COMBAT_NEED_TIME = 35
+  CW_EVENT_COMBAT_NEED_TIME = 35,
+  CW_EVENT_ITEM_CONSUMED = 36,
+  CW_EVENT_ITEM_EXHAUSTED = 37,
+  CW_EVENT_ITEM_TRANSFORMED = 38
 } cw_event_type;
+
+typedef enum {
+  CW_CRAFT_INPUT_PERSISTS = 0,
+  CW_CRAFT_INPUT_CONSUMED = 1,
+  CW_CRAFT_INPUT_EXHAUSTED = 2,
+  CW_CRAFT_INPUT_TRANSFORMED = 3
+} cw_craft_input_disposition;
 
 typedef enum {
   CW_COMBAT_ENCOUNTER_NONE = 0,
@@ -289,6 +301,14 @@ typedef struct {
   uint8_t output_item_kind;
   uint8_t output_item_charges;
   uint8_t roll_mode;
+  uint8_t item_disposition;
+  uint8_t target_item_disposition;
+  uint16_t reserved;
+  uint16_t output_item_weight_tenths;
+  uint16_t output_container_capacity_tenths;
+  uint8_t output_item_size_class;
+  uint8_t output_item_role;
+  uint16_t reserved2;
 } cw_action;
 
 typedef struct {

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -127,6 +127,21 @@ static cw_item *find_item(cw_world *world, cw_id item_id) {
   return 0;
 }
 
+static void remove_item(cw_world *world, cw_id item_id) {
+  for (size_t i = 0; i < world->item_count; ++i) {
+    if (world->items[i].id != item_id) continue;
+    if (i + 1 < world->item_count) {
+      memmove(
+          &world->items[i],
+          &world->items[i + 1],
+          (world->item_count - i - 1) * sizeof(world->items[0]));
+    }
+    world->item_count--;
+    memset(&world->items[world->item_count], 0, sizeof(world->items[0]));
+    return;
+  }
+}
+
 static const cw_item *find_item_const(const cw_world *world, cw_id item_id) {
   for (size_t i = 0; i < world->item_count; ++i) {
     if (world->items[i].id == item_id) return &world->items[i];
@@ -283,6 +298,12 @@ static cw_status create_item(cw_world *world, cw_id item_id, uint8_t kind, uint8
       item->held_since_tick = 0;
       item->zone = CW_CARD_ZONE_WORLD;
       break;
+    case CW_PLACEMENT_LOCATION_FIXTURE:
+      item->holder_actor_id = 0;
+      item->location_id = target_id;
+      item->held_since_tick = 0;
+      item->zone = CW_CARD_ZONE_INSTALLED;
+      break;
     default:
       world->item_count--;
       return CW_ERR_INVALID;
@@ -394,12 +415,12 @@ cw_status cw_world_set_item_zone(
     cw_id item_id,
     uint8_t zone,
     cw_id container_item_id) {
-  if (!world || !item_id || zone < CW_CARD_ZONE_WORLD || zone > CW_CARD_ZONE_ESCROW) {
+  if (!world || !item_id || zone < CW_CARD_ZONE_WORLD || zone > CW_CARD_ZONE_INSTALLED) {
     return CW_ERR_INVALID;
   }
   cw_item *item = find_item(world, item_id);
   if (!item) return CW_ERR_NOT_FOUND;
-  if (zone == CW_CARD_ZONE_WORLD) {
+  if (zone == CW_CARD_ZONE_WORLD || zone == CW_CARD_ZONE_INSTALLED) {
     if (item->holder_actor_id || !item->location_id || container_item_id) return CW_ERR_RULE;
   } else {
     if (!item->holder_actor_id || item->location_id) return CW_ERR_RULE;
@@ -719,7 +740,9 @@ static cw_status apply_pick_up_item(cw_world *world, const cw_action *action, cw
 
   cw_item *item = find_item(world, action->item_id);
   if (!item) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (item->holder_actor_id || item->location_id != actor->location_id) {
+  if (item->holder_actor_id
+      || item->location_id != actor->location_id
+      || item->zone != CW_CARD_ZONE_WORLD) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
 
@@ -1113,30 +1136,94 @@ static cw_status apply_search(cw_world *world, const cw_action *action, cw_event
   return CW_OK;
 }
 
+static int craft_disposition_removes_item(uint8_t disposition) {
+  return disposition == CW_CRAFT_INPUT_CONSUMED
+      || disposition == CW_CRAFT_INPUT_TRANSFORMED;
+}
+
+static int actor_can_accept_craft_output(
+    const cw_world *world,
+    const cw_actor *actor,
+    const cw_action *action,
+    const cw_item *output) {
+  uint32_t weight = 0;
+  uint32_t capacity = actor_base_capacity_tenths(actor);
+  for (size_t i = 0; i < world->item_count; ++i) {
+    const cw_item *item = &world->items[i];
+    if (item->holder_actor_id != actor->id) continue;
+    if ((item->id == action->item_id
+            && craft_disposition_removes_item(action->item_disposition))
+        || (item->id == action->target_item_id
+            && craft_disposition_removes_item(action->target_item_disposition))) {
+      continue;
+    }
+    weight += item_weight_tenths(item);
+    capacity += item_container_capacity_tenths(item);
+  }
+  weight += item_weight_tenths(output);
+  capacity += item_container_capacity_tenths(output);
+  return weight <= capacity;
+}
+
+static size_t craft_removed_item_count(const cw_world *world, const cw_action *action) {
+  size_t count = 0;
+  if (craft_disposition_removes_item(action->item_disposition)
+      && find_item_const(world, action->item_id)) {
+    count++;
+  }
+  if (action->target_item_id
+      && craft_disposition_removes_item(action->target_item_disposition)
+      && find_item_const(world, action->target_item_id)) {
+    count++;
+  }
+  return count;
+}
+
 static cw_status validate_output_slot(cw_world *world, const cw_action *action, cw_event_buffer *out_events) {
   if (!action->output_item_id) return CW_OK;
   if (!action->output_target_id || !action->output_target_kind || !action->output_item_kind || !action->output_item_charges) {
     return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
   }
+  const uint16_t output_weight = action->output_item_weight_tenths
+      ? action->output_item_weight_tenths : CW_ITEM_DEFAULT_WEIGHT_TENTHS;
+  const uint8_t output_size = action->output_item_size_class
+      ? action->output_item_size_class : CW_ITEM_SIZE_SMALL;
+  const uint8_t output_role = action->output_item_role
+      ? action->output_item_role
+      : (action->output_item_kind == CW_ITEM_POTION ? CW_ITEM_ROLE_CONSUMABLE : CW_ITEM_ROLE_GENERIC);
+  if (!output_weight
+      || output_size < CW_ITEM_SIZE_TINY
+      || output_size > CW_ITEM_SIZE_LARGE
+      || output_role > CW_ITEM_ROLE_RELIC
+      || (action->output_container_capacity_tenths && output_role != CW_ITEM_ROLE_CONTAINER)) {
+    return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
+  }
   if (find_item(world, action->output_item_id)) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
-  if (world->item_count >= CW_MAX_ITEMS) return CW_ERR_FULL;
+  if (world->item_count - craft_removed_item_count(world, action) >= CW_MAX_ITEMS) {
+    return CW_ERR_FULL;
+  }
   switch (action->output_target_kind) {
     case CW_PLACEMENT_ACTOR_HAND: {
       cw_actor *target = find_actor(world, action->output_target_id);
       if (!target || !actor_is_active(target)) return reject(world, out_events, action, CW_REASON_TARGET_NOT_FOUND);
       cw_item output;
       memset(&output, 0, sizeof(output));
-      output.weight_tenths = CW_ITEM_DEFAULT_WEIGHT_TENTHS;
-      output.size_class = CW_ITEM_SIZE_SMALL;
-      output.role = action->output_item_kind == CW_ITEM_POTION ? CW_ITEM_ROLE_CONSUMABLE : CW_ITEM_ROLE_GENERIC;
-      if (!actor_can_exchange(world, target, 0, &output)) {
+      output.weight_tenths = output_weight;
+      output.container_capacity_tenths = action->output_container_capacity_tenths;
+      output.size_class = output_size;
+      output.role = output_role;
+      const int capacity_ok = target->id == action->actor_id
+          ? actor_can_accept_craft_output(world, target, action, &output)
+          : actor_can_exchange(world, target, 0, &output);
+      if (!capacity_ok) {
         return reject(world, out_events, action, CW_REASON_CAPACITY_EXCEEDED);
       }
       return CW_OK;
     }
     case CW_PLACEMENT_LOCATION_FLOOR:
+    case CW_PLACEMENT_LOCATION_FIXTURE:
       if (!find_location(world, action->output_target_id)) return reject(world, out_events, action, CW_REASON_LOCATION_NOT_FOUND);
       return CW_OK;
     default:
@@ -1144,24 +1231,96 @@ static cw_status validate_output_slot(cw_world *world, const cw_action *action, 
   }
 }
 
+static int valid_craft_input_disposition(uint8_t disposition) {
+  return disposition <= CW_CRAFT_INPUT_TRANSFORMED;
+}
+
+static int craft_input_is_local(const cw_item *item, const cw_actor *actor) {
+  return item && actor
+      && ((item->holder_actor_id == actor->id && item->location_id == 0)
+          || (item->holder_actor_id == 0 && item->location_id == actor->location_id));
+}
+
+static void append_craft_input_transition(
+    cw_world *world,
+    cw_event_buffer *out_events,
+    const cw_action *action,
+    const cw_actor *actor,
+    cw_id item_id,
+    uint8_t disposition) {
+  uint8_t event_type = CW_EVENT_NONE;
+  switch (disposition) {
+    case CW_CRAFT_INPUT_CONSUMED: event_type = CW_EVENT_ITEM_CONSUMED; break;
+    case CW_CRAFT_INPUT_EXHAUSTED: event_type = CW_EVENT_ITEM_EXHAUSTED; break;
+    case CW_CRAFT_INPUT_TRANSFORMED: event_type = CW_EVENT_ITEM_TRANSFORMED; break;
+    default: return;
+  }
+  append_event(world, out_events, event_type);
+  if (out_events && out_events->count > 0) {
+    cw_event *event = &out_events->events[out_events->count - 1];
+    event->success = 1;
+    event->actor_id = actor->id;
+    event->location_id = actor->location_id;
+    event->content_id = action->content_id;
+    event->item_id = item_id;
+    event->target_item_id = action->output_item_id;
+  }
+}
+
+static void apply_craft_input_disposition(
+    cw_world *world,
+    cw_event_buffer *out_events,
+    const cw_action *action,
+    const cw_actor *actor,
+    cw_id item_id,
+    uint8_t disposition) {
+  if (disposition == CW_CRAFT_INPUT_PERSISTS) return;
+  append_craft_input_transition(world, out_events, action, actor, item_id, disposition);
+  if (disposition == CW_CRAFT_INPUT_EXHAUSTED) {
+    cw_item *item = find_item(world, item_id);
+    if (!item) return;
+    item->charges = 0;
+    if (item->holder_actor_id == actor->id) item->zone = CW_CARD_ZONE_EXHAUSTED;
+    return;
+  }
+  remove_item(world, item_id);
+}
+
 static cw_status apply_craft(cw_world *world, const cw_action *action, cw_event_buffer *out_events) {
   cw_actor *actor = 0;
   cw_status status = require_active_actor(world, action, out_events, &actor);
   if (status != CW_OK) return status;
-  if (!action->content_id || !action->item_id || !action->target_item_id || action->item_id == action->target_item_id) {
+  if (!action->content_id || !action->item_id
+      || (action->target_item_id && action->item_id == action->target_item_id)
+      || !valid_craft_input_disposition(action->item_disposition)
+      || !valid_craft_input_disposition(action->target_item_disposition)
+      || (!action->target_item_id && action->target_item_disposition != CW_CRAFT_INPUT_PERSISTS)) {
     return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
   }
 
-  cw_item *held = find_item(world, action->item_id);
-  cw_item *floor = find_item(world, action->target_item_id);
-  if (!held || !floor) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (held->holder_actor_id != actor->id || floor->holder_actor_id != 0 || floor->location_id != actor->location_id) {
+  cw_item *first = find_item(world, action->item_id);
+  cw_item *second = action->target_item_id ? find_item(world, action->target_item_id) : 0;
+  if (!first || (action->target_item_id && !second)) {
+    return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
+  }
+  const int legacy_two_input = action->target_item_id
+      && action->item_disposition == CW_CRAFT_INPUT_PERSISTS
+      && action->target_item_disposition == CW_CRAFT_INPUT_PERSISTS;
+  if ((legacy_two_input
+          && (first->holder_actor_id != actor->id
+              || second->holder_actor_id != 0
+              || second->location_id != actor->location_id))
+      || (!legacy_two_input
+          && (!craft_input_is_local(first, actor)
+              || (second && !craft_input_is_local(second, actor))))) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
 
   status = validate_output_slot(world, action, out_events);
   if (status != CW_OK) return status;
 
+  const cw_id first_id = first->id;
+  const cw_id second_id = second ? second->id : 0;
   append_event(world, out_events, CW_EVENT_ITEM_CRAFTED);
   if (out_events && out_events->count > 0) {
     cw_event *event = &out_events->events[out_events->count - 1];
@@ -1169,12 +1328,19 @@ static cw_status apply_craft(cw_world *world, const cw_action *action, cw_event_
     event->actor_id = actor->id;
     event->location_id = actor->location_id;
     event->content_id = action->content_id;
-    event->item_id = held->id;
-    event->target_item_id = floor->id;
+    event->item_id = first_id;
+    event->target_item_id = second_id;
     event->destination_location_id =
-        action->output_target_kind == CW_PLACEMENT_LOCATION_FLOOR ? action->output_target_id : 0;
+        action->output_target_kind == CW_PLACEMENT_ACTOR_HAND ? 0 : action->output_target_id;
     event->target_actor_id =
         action->output_target_kind == CW_PLACEMENT_ACTOR_HAND ? action->output_target_id : 0;
+  }
+
+  apply_craft_input_disposition(
+      world, out_events, action, actor, first_id, action->item_disposition);
+  if (second_id) {
+    apply_craft_input_disposition(
+        world, out_events, action, actor, second_id, action->target_item_disposition);
   }
 
   if (action->output_item_id) {
@@ -1186,6 +1352,17 @@ static cw_status apply_craft(cw_world *world, const cw_action *action, cw_event_
         action->output_target_kind,
         action->output_target_id);
     if (status != CW_OK) return status;
+    cw_item *output = find_item(world, action->output_item_id);
+    if (output) {
+      output->weight_tenths = action->output_item_weight_tenths
+          ? action->output_item_weight_tenths : CW_ITEM_DEFAULT_WEIGHT_TENTHS;
+      output->container_capacity_tenths = action->output_container_capacity_tenths;
+      output->size_class = action->output_item_size_class
+          ? action->output_item_size_class : CW_ITEM_SIZE_SMALL;
+      output->role = action->output_item_role
+          ? action->output_item_role
+          : (action->output_item_kind == CW_ITEM_POTION ? CW_ITEM_ROLE_CONSUMABLE : CW_ITEM_ROLE_GENERIC);
+    }
 
     append_event(world, out_events, CW_EVENT_ITEM_CREATED);
     if (out_events && out_events->count > 0) {
@@ -1193,19 +1370,23 @@ static cw_status apply_craft(cw_world *world, const cw_action *action, cw_event_
       event->success = 1;
       event->actor_id = actor->id;
       event->location_id =
-          action->output_target_kind == CW_PLACEMENT_LOCATION_FLOOR ? action->output_target_id : actor->location_id;
+          action->output_target_kind == CW_PLACEMENT_ACTOR_HAND
+              ? actor->location_id
+              : action->output_target_id;
       event->target_actor_id =
           action->output_target_kind == CW_PLACEMENT_ACTOR_HAND ? action->output_target_id : 0;
       event->destination_location_id =
-          action->output_target_kind == CW_PLACEMENT_LOCATION_FLOOR ? action->output_target_id : 0;
+          action->output_target_kind == CW_PLACEMENT_ACTOR_HAND
+              ? 0
+              : action->output_target_id;
       event->content_id = action->content_id;
       event->item_id = action->output_item_id;
-      event->target_item_id = floor->id;
+      event->target_item_id = second_id;
     }
     maybe_evolve_after_placement(world, actor->id, action->output_item_id, out_events);
   } else {
-    maybe_evolve_after_placement(world, actor->id, held->id, out_events);
-    maybe_evolve_after_placement(world, actor->id, floor->id, out_events);
+    maybe_evolve_after_placement(world, actor->id, first_id, out_events);
+    if (second_id) maybe_evolve_after_placement(world, actor->id, second_id, out_events);
   }
   return CW_OK;
 }
@@ -2031,7 +2212,9 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
   }
   for (size_t i = 0; i < world->item_count; ++i) {
     const cw_item *item = &world->items[i];
-    if (!item->holder_actor_id && item->location_id == actor->location_id) {
+    if (!item->holder_actor_id
+        && item->location_id == actor->location_id
+        && item->zone == CW_CARD_ZONE_WORLD) {
       room_has_loose_item = 1;
       if (actor_can_pick_up(world, actor, item)) {
         out_offers->option_flags |= CW_OFFER_PICK_UP;
@@ -2111,6 +2294,9 @@ const char *cw_event_type_name(uint8_t type) {
     case CW_EVENT_ITEM_STOLEN: return "item.stolen";
     case CW_EVENT_COMBAT_PASS: return "combat.pass";
     case CW_EVENT_COMBAT_NEED_TIME: return "combat.need_time";
+    case CW_EVENT_ITEM_CONSUMED: return "item.consumed";
+    case CW_EVENT_ITEM_EXHAUSTED: return "item.exhausted";
+    case CW_EVENT_ITEM_TRANSFORMED: return "item.transformed";
     default: return "unknown";
   }
 }

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -1228,6 +1228,65 @@ static void test_search_and_craft_create_without_consuming_inputs(void) {
   assert(cw_world_apply(&world, &craft, 77, &events) == CW_ERR_RULE);
   assert(events.count == 1);
   assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
+
+  cw_item *ore = test_find_item(&world, 2002);
+  assert(ore);
+  ore->holder_actor_id = 5001;
+  ore->location_id = 0;
+  ore->zone = CW_CARD_ZONE_CARRIED;
+  cw_action refine = {0};
+  refine.kind = CW_ACTION_CRAFT;
+  refine.actor_id = 5001;
+  refine.content_id = 3101;
+  refine.item_id = 2002;
+  refine.item_disposition = CW_CRAFT_INPUT_TRANSFORMED;
+  refine.output_item_id = 9201;
+  refine.output_target_kind = CW_PLACEMENT_LOCATION_FLOOR;
+  refine.output_target_id = 1;
+  refine.output_item_kind = CW_ITEM_KEEPSAKE;
+  refine.output_item_charges = 1;
+  refine.output_item_weight_tenths = 14;
+  refine.output_item_size_class = CW_ITEM_SIZE_SMALL;
+  refine.output_item_role = CW_ITEM_ROLE_GENERIC;
+  const size_t before_refine_count = world.item_count;
+  assert(cw_world_apply(&world, &refine, 78, &events) == CW_OK);
+  assert(events.count == 3);
+  assert(events.events[0].type == CW_EVENT_ITEM_CRAFTED);
+  assert(events.events[1].type == CW_EVENT_ITEM_TRANSFORMED);
+  assert(events.events[2].type == CW_EVENT_ITEM_CREATED);
+  assert(events.events[1].item_id == 2002);
+  assert(events.events[1].target_item_id == 9201);
+  assert(test_find_item(&world, 2002) == 0);
+  assert(test_find_item(&world, 9201)->location_id == 1);
+  assert(test_find_item(&world, 9201)->weight_tenths == 14);
+  assert(world.item_count == before_refine_count);
+  assert(cw_world_apply(&world, &refine, 79, &events) == CW_ERR_RULE);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
+  assert(world.item_count == before_refine_count);
+
+  cw_action install = refine;
+  install.content_id = 3103;
+  install.item_id = 9201;
+  install.output_item_id = 9202;
+  install.output_target_kind = CW_PLACEMENT_LOCATION_FIXTURE;
+  assert(cw_world_apply(&world, &install, 80, &events) == CW_OK);
+  assert(events.count == 3);
+  assert(events.events[0].type == CW_EVENT_ITEM_CRAFTED);
+  assert(events.events[1].type == CW_EVENT_ITEM_TRANSFORMED);
+  assert(events.events[2].type == CW_EVENT_ITEM_CREATED);
+  assert(test_find_item(&world, 9201) == 0);
+  assert(test_find_item(&world, 9202)->location_id == 1);
+  assert(test_find_item(&world, 9202)->zone == CW_CARD_ZONE_INSTALLED);
+
+  cw_action pickup_fixture = {0};
+  pickup_fixture.kind = CW_ACTION_PICK_UP_ITEM;
+  pickup_fixture.actor_id = 5001;
+  pickup_fixture.item_id = 9202;
+  assert(cw_world_apply(&world, &pickup_fixture, 81, &events) == CW_ERR_RULE);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
+  assert(test_find_item(&world, 9202)->zone == CW_CARD_ZONE_INSTALLED);
 }
 
 static uint8_t test_combat_side(const cw_combat_encounter *encounter, cw_id actor_id) {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.111"
+version = "0.0.112"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.111"
+version = "0.0.112"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -911,29 +911,87 @@ pub(super) struct SeedEvolutionRequirementContent {
     pub(super) target_id: u64,
 }
 
-#[derive(Debug, Deserialize)]
+fn default_recipe_schema_version() -> u8 {
+    1
+}
+
+fn default_recipe_input_quantity() -> u8 {
+    1
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub(super) struct SeedRecipeContent {
+    #[serde(default = "default_recipe_schema_version")]
+    pub(super) schema_version: u8,
     pub(super) id: u64,
     pub(super) key: String,
     pub(super) name: String,
     pub(super) description: String,
+    #[serde(default)]
+    pub(super) pack_id: String,
+    #[serde(default)]
     pub(super) input_item_ids: Vec<u64>,
+    #[serde(default)]
+    pub(super) inputs: Vec<SeedRecipeInputContent>,
+    #[serde(default)]
+    pub(super) requires: SeedRecipeRequirementsContent,
     pub(super) output: Option<SeedRecipeOutputContent>,
-    pub(super) balance: SeedRecipeBalanceContent,
+    #[serde(default)]
+    pub(super) balance: Option<SeedRecipeBalanceContent>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct SeedRecipeInputContent {
+    pub(super) template_id: String,
+    #[serde(default = "default_recipe_input_quantity")]
+    pub(super) quantity: u8,
+    pub(super) zones: Vec<String>,
+    #[serde(default)]
+    pub(super) min_charges: u8,
+    pub(super) disposition: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct SeedRecipeRequirementsContent {
+    #[serde(default)]
+    pub(super) building_capabilities: Vec<String>,
+    #[serde(default)]
+    pub(super) recipe_tags: Vec<String>,
+    #[serde(default)]
+    pub(super) natural_features: Vec<String>,
+    #[serde(default)]
+    pub(super) location_features: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub(super) struct SeedRecipeOutputContent {
+    #[serde(default)]
     pub(super) item_id: u64,
+    #[serde(default)]
+    pub(super) template_id: String,
+    #[serde(default)]
     pub(super) name: String,
+    #[serde(default)]
     pub(super) description: String,
+    #[serde(default)]
     pub(super) kind: String,
+    #[serde(default)]
     pub(super) charges: u8,
+    #[serde(default)]
     pub(super) target_kind: String,
+    #[serde(default)]
     pub(super) target_id: u64,
+    #[serde(default)]
+    pub(super) destination: String,
+    #[serde(default)]
+    pub(super) fallback_destination: String,
+    #[serde(default)]
+    pub(super) effect: String,
+    #[serde(default)]
+    pub(super) uniqueness: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub(super) struct SeedRecipeBalanceContent {
     pub(super) kind: String,
     pub(super) target_kind: String,
@@ -2801,47 +2859,133 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
             || recipe.key.trim().is_empty()
             || recipe.name.trim().is_empty()
             || recipe.description.trim().is_empty()
+        {
+            return Err(format!("invalid seed recipe {}", recipe.id));
+        }
+        if recipe.schema_version == 2 {
+            let mut input_templates = BTreeSet::new();
+            let physical_input_count = recipe
+                .inputs
+                .iter()
+                .map(|input| usize::from(input.quantity))
+                .sum::<usize>();
+            if !recipe.input_item_ids.is_empty()
+                || recipe.inputs.is_empty()
+                || recipe.inputs.len() > 2
+                || physical_input_count == 0
+                || physical_input_count > 2
+                || recipe.inputs.iter().any(|input| {
+                    input.template_id.trim().is_empty()
+                        || !(1..=2).contains(&input.quantity)
+                        || input.min_charges > 20
+                        || input.zones.is_empty()
+                        || input
+                            .zones
+                            .iter()
+                            .any(|zone| !matches!(zone.as_str(), "carried" | "world"))
+                        || !matches!(
+                            input.disposition.as_str(),
+                            "persistent" | "consume" | "exhaust" | "transform"
+                        )
+                        || !input_templates.insert(input.template_id.as_str())
+                })
+                || (recipe.requires.building_capabilities.is_empty()
+                    && recipe.requires.recipe_tags.is_empty()
+                    && recipe.requires.natural_features.is_empty()
+                    && recipe.requires.location_features.is_empty())
+                || (recipe.requires.building_capabilities.is_empty()
+                    != recipe.requires.recipe_tags.is_empty())
+                || (!recipe.requires.building_capabilities.is_empty()
+                    && !recipe
+                        .requires
+                        .building_capabilities
+                        .iter()
+                        .any(|capability| capability == "transformation_recipes"))
+                || recipe.requires.natural_features.len() > 1
+                || recipe.requires.natural_features.iter().any(|feature| {
+                    !matches!(
+                        feature.as_str(),
+                        "fish_rich_water"
+                            | "ore_seam"
+                            | "clay_bank"
+                            | "ancient_woodland"
+                            | "fast_river"
+                            | "reliable_upland_wind"
+                            | "hot_spring"
+                            | "rich_soil"
+                            | "rare_herb_habitat"
+                            | "old_ruins"
+                    )
+                })
+                || recipe
+                    .requires
+                    .location_features
+                    .iter()
+                    .any(|feature| feature != "generated_place_anchor_site")
+                || recipe.output.as_ref().is_none_or(|output| {
+                    output.template_id.trim().is_empty()
+                        || !matches!(
+                            output.destination.as_str(),
+                            "actor_hand" | "location_floor" | "installed_at_location"
+                        )
+                        || output.fallback_destination != "location_floor"
+                        || !matches!(output.effect.as_str(), "portable" | "installed_fixture")
+                        || !matches!(
+                            output.uniqueness.as_str(),
+                            "per_receipt" | "per_location" | "per_world"
+                        )
+                        || (output.destination == "installed_at_location"
+                            && output.effect != "installed_fixture")
+                })
+            {
+                return Err(format!("invalid versioned seed recipe {}", recipe.id));
+            }
+            continue;
+        }
+        let Some(balance) = recipe.balance.as_ref() else {
+            return Err(format!("legacy recipe {} is missing balance", recipe.id));
+        };
+        if recipe.schema_version != 1
             || recipe.input_item_ids.len() != 2
             || recipe.input_item_ids[0] == recipe.input_item_ids[1]
             || recipe
                 .input_item_ids
                 .iter()
                 .any(|item_id| !item_ids.contains(item_id))
-            || recipe.balance.kind.trim().is_empty()
-            || recipe.balance.reason.trim().is_empty()
+            || balance.kind.trim().is_empty()
+            || balance.reason.trim().is_empty()
         {
             return Err(format!("invalid seed recipe {}", recipe.id));
         }
         if !matches!(
-            recipe.balance.kind.as_str(),
+            balance.kind.as_str(),
             "location" | "avatar" | "resident" | "covenant" | "evolution"
         ) {
             return Err(format!(
                 "recipe {} has invalid balance kind {}",
-                recipe.id, recipe.balance.kind
+                recipe.id, balance.kind
             ));
         }
-        let Some(balance_target_kind) = placement_target_kind_from_str(&recipe.balance.target_kind)
-        else {
+        let Some(balance_target_kind) = placement_target_kind_from_str(&balance.target_kind) else {
             return Err(format!(
                 "recipe {} has invalid balance target kind {}",
-                recipe.id, recipe.balance.target_kind
+                recipe.id, balance.target_kind
             ));
         };
         match balance_target_kind {
             CW_PLACEMENT_ACTOR_HAND => {
-                if !actor_ids.contains(&recipe.balance.target_id) {
+                if !actor_ids.contains(&balance.target_id) {
                     return Err(format!(
                         "recipe {} balance references missing actor {}",
-                        recipe.id, recipe.balance.target_id
+                        recipe.id, balance.target_id
                     ));
                 }
             }
             CW_PLACEMENT_LOCATION_FLOOR => {
-                if !location_ids.contains(&recipe.balance.target_id) {
+                if !location_ids.contains(&balance.target_id) {
                     return Err(format!(
                         "recipe {} balance references missing location {}",
-                        recipe.id, recipe.balance.target_id
+                        recipe.id, balance.target_id
                     ));
                 }
             }
@@ -2884,9 +3028,7 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
                 }
                 _ => {}
             }
-            if output.target_kind != recipe.balance.target_kind
-                || output.target_id != recipe.balance.target_id
-            {
+            if output.target_kind != balance.target_kind || output.target_id != balance.target_id {
                 return Err(format!(
                     "recipe {} output slot must match its balance declaration",
                     recipe.id

--- a/v2/orchestrator-rust/src/content_packs.rs
+++ b/v2/orchestrator-rust/src/content_packs.rs
@@ -350,7 +350,7 @@ mod tests {
         assert_eq!(core.asset_providers.len(), 2);
         assert!(core.asset_providers.iter().all(|provider| {
             provider.provider == "cosyworld.core/assets"
-                && provider.cache_namespace.contains("cosyworld.core@1.3.9")
+                && provider.cache_namespace.contains("cosyworld.core@1.3.10")
                 && provider.content_hash.starts_with("sha256:")
         }));
 

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -1112,7 +1112,7 @@ mod tests {
             registry.content().manifest.rules_profile,
             "cosyworld.srd5/1"
         );
-        assert_eq!(registry.pack("cosyworld.core").unwrap().version, "1.3.9");
+        assert_eq!(registry.pack("cosyworld.core").unwrap().version, "1.3.10");
         assert_eq!(
             registry.capability_provider("cosyworld.core/world"),
             Some("cosyworld.core")

--- a/v2/orchestrator-rust/src/crafting.rs
+++ b/v2/orchestrator-rust/src/crafting.rs
@@ -1,0 +1,1141 @@
+use super::*;
+
+pub(super) const CRAFT_RECEIPT_SCHEMA_VERSION: u8 = 1;
+const CRAFT_ITEM_ID_BASE: u64 = 11_000_000_000;
+const CRAFT_ITEM_ID_RANGE: u64 = 1_000_000_000;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct CraftInputState {
+    pub(super) item_id: u64,
+    pub(super) template_id: String,
+    pub(super) zone: String,
+    #[serde(default)]
+    pub(super) charges_before: u8,
+    pub(super) disposition: String,
+    #[serde(default)]
+    pub(super) source_origin: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) transition_event_seq: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct CraftReceiptState {
+    pub(super) schema_version: u8,
+    pub(super) id: String,
+    pub(super) recipe_id: u64,
+    pub(super) recipe_schema_version: u8,
+    pub(super) recipe_key: String,
+    pub(super) pack_id: String,
+    pub(super) pack_version: String,
+    pub(super) rules_profile: String,
+    pub(super) actor_id: u64,
+    pub(super) location_id: u64,
+    pub(super) inputs: Vec<CraftInputState>,
+    pub(super) output_item_id: u64,
+    pub(super) output_template_id: String,
+    pub(super) output_destination: String,
+    #[serde(default)]
+    pub(super) output_fallback_destination: String,
+    pub(super) output_effect: String,
+    #[serde(default)]
+    pub(super) output_uniqueness: String,
+    #[serde(default)]
+    pub(super) capability_source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) craft_event_seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) output_event_seq: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct VersionedCraftPlan {
+    pub(super) action: CwAction,
+    pub(super) receipt: CraftReceiptState,
+}
+
+fn craft_disposition(value: &str) -> Option<u8> {
+    match value {
+        "persistent" => Some(CW_CRAFT_INPUT_PERSISTS),
+        "consume" => Some(CW_CRAFT_INPUT_CONSUMED),
+        "exhaust" => Some(CW_CRAFT_INPUT_EXHAUSTED),
+        "transform" => Some(CW_CRAFT_INPUT_TRANSFORMED),
+        _ => None,
+    }
+}
+
+fn craft_zone(item: CwItem, actor_id: u64, location_id: u64) -> Option<&'static str> {
+    if item.holder_actor_id == actor_id
+        && item.location_id == 0
+        && item.zone == CW_CARD_ZONE_CARRIED
+    {
+        Some("carried")
+    } else if item.holder_actor_id == 0
+        && item.location_id == location_id
+        && item.zone == CW_CARD_ZONE_WORLD
+    {
+        Some("world")
+    } else {
+        None
+    }
+}
+
+fn safe_craft_receipt_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 160
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
+}
+
+fn craft_item_id(receipt_id: &str, nonce: u8) -> u64 {
+    CRAFT_ITEM_ID_BASE
+        + stable_hash_u64(&["craft-item", receipt_id, &nonce.to_string()]) % CRAFT_ITEM_ID_RANGE
+}
+
+fn natural_resource_id(kind: NaturalResourceKind) -> &'static str {
+    match kind {
+        NaturalResourceKind::FishRichWater => "fish_rich_water",
+        NaturalResourceKind::OreSeam => "ore_seam",
+        NaturalResourceKind::ClayBank => "clay_bank",
+        NaturalResourceKind::AncientWoodland => "ancient_woodland",
+        NaturalResourceKind::FastRiver => "fast_river",
+        NaturalResourceKind::ReliableUplandWind => "reliable_upland_wind",
+        NaturalResourceKind::HotSpring => "hot_spring",
+        NaturalResourceKind::RichSoil => "rich_soil",
+        NaturalResourceKind::RareHerbHabitat => "rare_herb_habitat",
+        NaturalResourceKind::OldRuins => "old_ruins",
+    }
+}
+
+impl RuntimeWorld {
+    pub(super) fn physical_item_template_id(&self, item_id: u64) -> Option<String> {
+        self.loot_allocations
+            .values()
+            .find_map(|allocation| {
+                allocation
+                    .item_ids
+                    .iter()
+                    .position(|candidate| *candidate == item_id)
+                    .and_then(|index| allocation.selected_template_ids.get(index))
+                    .cloned()
+            })
+            .or_else(|| {
+                self.craft_receipts
+                    .values()
+                    .find(|receipt| receipt.output_item_id == item_id)
+                    .map(|receipt| receipt.output_template_id.clone())
+            })
+    }
+
+    fn versioned_recipe_capability_source(
+        &self,
+        _actor_id: u64,
+        recipe: &SeedRecipeContent,
+        location_id: u64,
+    ) -> Option<String> {
+        if !recipe.requires.building_capabilities.is_empty() {
+            let building = self.settlement_buildings.values().find(|building| {
+                building.location_id == location_id
+                    && building.status == SettlementBuildingStatus::Completed
+                    && building.access_policy == "public"
+                    && !building.covenant_required
+                    && recipe
+                        .requires
+                        .building_capabilities
+                        .iter()
+                        .all(|required| {
+                            building
+                                .installed_capabilities
+                                .iter()
+                                .any(|installed| installed == required)
+                        })
+                    && recipe.requires.recipe_tags.iter().all(|required| {
+                        building
+                            .recipe_tags
+                            .iter()
+                            .any(|installed| installed == required)
+                    })
+            })?;
+            return Some(format!("building:{}", building.id));
+        }
+        if !recipe.requires.natural_features.iter().all(|required| {
+            self.natural_affordances
+                .get(&location_id)
+                .and_then(|state| state.revealed_feature.as_ref())
+                .is_some_and(|feature| natural_resource_id(feature.resource_kind) == required)
+        }) || !recipe.requires.location_features.iter().all(|required| {
+            required == "generated_place_anchor_site"
+                && self.generated_places.contains_key(&location_id)
+                && !self
+                    .tags
+                    .get(&format!("generated-place:{location_id}:anchor-fixture"))
+                    .is_some_and(|tag| tag.active)
+        }) {
+            return None;
+        }
+        if let Some(feature) = recipe.requires.natural_features.first() {
+            return Some(format!("natural_feature:{feature}"));
+        }
+        if let Some(feature) = recipe.requires.location_features.first() {
+            return Some(format!("location_feature:{feature}"));
+        }
+        None
+    }
+
+    fn versioned_recipe_inputs(
+        &self,
+        actor_id: u64,
+        location_id: u64,
+        recipe: &SeedRecipeContent,
+    ) -> Option<Vec<(CwItem, String, String, String)>> {
+        let mut candidates = self
+            .actor_held_items(actor_id)
+            .into_iter()
+            .chain(self.loose_items_at_location(location_id))
+            .collect::<Vec<_>>();
+        candidates.sort_by_key(|item| item.id);
+        let mut used = BTreeSet::new();
+        let mut resolved = Vec::new();
+        for input in &recipe.inputs {
+            for _ in 0..input.quantity {
+                let item = candidates.iter().copied().find(|item| {
+                    if used.contains(&item.id)
+                        || self.physical_item_template_id(item.id).as_deref()
+                            != Some(input.template_id.as_str())
+                        || item.charges < input.min_charges
+                    {
+                        return false;
+                    }
+                    craft_zone(*item, actor_id, location_id)
+                        .is_some_and(|zone| input.zones.iter().any(|allowed| allowed == zone))
+                })?;
+                let zone = craft_zone(item, actor_id, location_id)?.to_string();
+                used.insert(item.id);
+                resolved.push((
+                    item,
+                    input.disposition.clone(),
+                    zone,
+                    input.template_id.clone(),
+                ));
+            }
+        }
+        Some(resolved)
+    }
+
+    fn actor_can_accept_craft_output(
+        &self,
+        actor_id: u64,
+        inputs: &[(CwItem, String, String, String)],
+        output: CwItem,
+    ) -> bool {
+        let Some(actor) = self.actor_by_id(actor_id) else {
+            return false;
+        };
+        let removed = inputs
+            .iter()
+            .filter(|(_, disposition, _, _)| {
+                matches!(disposition.as_str(), "consume" | "transform")
+            })
+            .map(|(item, _, _, _)| item.id)
+            .collect::<BTreeSet<_>>();
+        let mut weight = 0u32;
+        let mut capacity = actor_base_carrying_capacity_tenths(actor);
+        for item in self.actor_held_items(actor_id) {
+            if removed.contains(&item.id) {
+                continue;
+            }
+            weight += u32::from(effective_item_weight_tenths(item));
+            if item.role == CW_ITEM_ROLE_CONTAINER
+                && item.zone == CW_CARD_ZONE_EQUIPPED
+                && item.container_item_id == 0
+            {
+                capacity += u32::from(item.container_capacity_tenths);
+            }
+        }
+        weight += u32::from(effective_item_weight_tenths(output));
+        weight <= capacity
+    }
+
+    pub(super) fn versioned_craft_plan(
+        &self,
+        actor_id: u64,
+        recipe_id: u64,
+        requested_receipt_id: Option<&str>,
+    ) -> Option<VersionedCraftPlan> {
+        let actor = self.actor_by_id(actor_id)?;
+        if actor.status != CW_ACTOR_ACTIVE {
+            return None;
+        }
+        let recipe = self.recipe_by_id(recipe_id)?;
+        if recipe.schema_version != 2 {
+            return None;
+        }
+        let capability_source =
+            self.versioned_recipe_capability_source(actor_id, recipe, actor.location_id)?;
+        let inputs = self.versioned_recipe_inputs(actor_id, actor.location_id, recipe)?;
+        let output = recipe.output.as_ref()?;
+        if output.uniqueness == "per_world"
+            && self
+                .craft_receipts
+                .values()
+                .any(|receipt| receipt.output_template_id == output.template_id)
+        {
+            return None;
+        }
+        if output.uniqueness == "per_location"
+            && self.craft_receipts.values().any(|receipt| {
+                receipt.output_template_id == output.template_id
+                    && receipt.location_id == actor.location_id
+                    && receipt.output_effect == output.effect
+            })
+        {
+            return None;
+        }
+        let mounted = mounted_loot_item_template(&output.template_id)?;
+        let receipt_id = requested_receipt_id.map(str::to_string).unwrap_or_else(|| {
+            format!(
+                "craft:{}:{}:{}",
+                actor_id, recipe.id, self.world.next_event_seq
+            )
+        });
+        if !safe_craft_receipt_id(&receipt_id) || self.craft_receipts.contains_key(&receipt_id) {
+            return None;
+        }
+        let output_item_id = (0..=u8::MAX)
+            .map(|nonce| craft_item_id(&receipt_id, nonce))
+            .find(|item_id| self.item_by_id(*item_id).is_none())?;
+        let template = &mounted.template;
+        let output_kind = seed_item_kind_from_str(&template.kind)?;
+        let output_role = loot_item_role(&template.role)?;
+        let output_profile = CwItem {
+            id: output_item_id,
+            kind: output_kind,
+            charges: template.charges,
+            weight_tenths: template.weight_tenths,
+            container_capacity_tenths: template.container_capacity_tenths,
+            size_class: item_size_from_str(&template.size)?,
+            role: output_role,
+            zone: CW_CARD_ZONE_CARRIED,
+            holder_actor_id: actor_id,
+            ..CwItem::default()
+        };
+        let requested_destination = output.destination.as_str();
+        let destination = if requested_destination == "actor_hand"
+            && self.actor_can_accept_craft_output(actor_id, &inputs, output_profile)
+        {
+            "actor_hand"
+        } else if matches!(
+            requested_destination,
+            "location_floor" | "installed_at_location"
+        ) || output.fallback_destination == "location_floor"
+        {
+            if requested_destination == "installed_at_location" {
+                "installed_at_location"
+            } else {
+                "location_floor"
+            }
+        } else {
+            return None;
+        };
+        let (output_target_kind, output_target_id) = match destination {
+            "actor_hand" => (CW_PLACEMENT_ACTOR_HAND, actor_id),
+            "installed_at_location" => (CW_PLACEMENT_LOCATION_FIXTURE, actor.location_id),
+            _ => (CW_PLACEMENT_LOCATION_FLOOR, actor.location_id),
+        };
+        let first = inputs.first()?;
+        let second = inputs.get(1);
+        let action = CwAction {
+            kind: CW_ACTION_CRAFT,
+            actor_id,
+            content_id: recipe.id,
+            item_id: first.0.id,
+            target_item_id: second.map(|input| input.0.id).unwrap_or_default(),
+            output_item_id,
+            output_target_id,
+            output_target_kind,
+            output_item_kind: output_kind,
+            output_item_charges: template.charges,
+            output_item_weight_tenths: template.weight_tenths,
+            output_container_capacity_tenths: template.container_capacity_tenths,
+            output_item_size_class: output_profile.size_class,
+            output_item_role: output_role,
+            item_disposition: craft_disposition(&first.1)?,
+            target_item_disposition: second
+                .map(|input| craft_disposition(&input.1))
+                .unwrap_or(Some(CW_CRAFT_INPUT_PERSISTS))?,
+            ..CwAction::default()
+        };
+        let pack_id = if recipe.pack_id.is_empty() {
+            mounted.pack_id.clone()
+        } else {
+            recipe.pack_id.clone()
+        };
+        let pack_version = active_content()
+            .manifest
+            .packs
+            .iter()
+            .find(|pack| pack.id == pack_id)
+            .map(|pack| pack.version.clone())
+            .unwrap_or_else(|| mounted.pack_version.clone());
+        let receipt_inputs = inputs
+            .into_iter()
+            .map(|(item, disposition, zone, template_id)| CraftInputState {
+                item_id: item.id,
+                template_id,
+                zone,
+                charges_before: item.charges,
+                disposition,
+                source_origin: self
+                    .item_provenance
+                    .get(&item.id)
+                    .map(|state| state.origin.clone())
+                    .unwrap_or_else(|| "runtime".to_string()),
+                transition_event_seq: None,
+            })
+            .collect();
+        Some(VersionedCraftPlan {
+            action,
+            receipt: CraftReceiptState {
+                schema_version: CRAFT_RECEIPT_SCHEMA_VERSION,
+                id: receipt_id,
+                recipe_id: recipe.id,
+                recipe_schema_version: recipe.schema_version,
+                recipe_key: recipe.key.clone(),
+                pack_id,
+                pack_version,
+                rules_profile: active_content().manifest.rules_profile.clone(),
+                actor_id,
+                location_id: actor.location_id,
+                inputs: receipt_inputs,
+                output_item_id,
+                output_template_id: output.template_id.clone(),
+                output_destination: destination.to_string(),
+                output_fallback_destination: output.fallback_destination.clone(),
+                output_effect: output.effect.clone(),
+                output_uniqueness: output.uniqueness.clone(),
+                capability_source,
+                craft_event_seq: None,
+                output_event_seq: None,
+            },
+        })
+    }
+
+    pub(super) fn apply_craft_resolution(
+        &mut self,
+        receipt: &CraftReceiptState,
+        committed_events: &[EventView],
+    ) {
+        if self.craft_receipts.contains_key(&receipt.id) {
+            return;
+        }
+        let Some(craft_event) = committed_events.iter().find(|event| {
+            event.success
+                && event.type_name == "item.crafted"
+                && event.content_id == Some(receipt.recipe_id)
+                && event.actor_id == Some(receipt.actor_id)
+        }) else {
+            return;
+        };
+        let Some(output_event) = committed_events.iter().find(|event| {
+            event.success
+                && event.type_name == "item.created"
+                && event.item_id == Some(receipt.output_item_id)
+        }) else {
+            return;
+        };
+        let Some(mounted) = mounted_loot_item_template(&receipt.output_template_id) else {
+            return;
+        };
+        let template = mounted.template;
+        let Some(item) = self.world.items[..self.world.item_count]
+            .iter_mut()
+            .find(|item| item.id == receipt.output_item_id)
+        else {
+            return;
+        };
+        let Some(kind) = seed_item_kind_from_str(&template.kind) else {
+            return;
+        };
+        let Some(role) = loot_item_role(&template.role) else {
+            return;
+        };
+        let Some(size_class) = item_size_from_str(&template.size) else {
+            return;
+        };
+        item.kind = kind;
+        item.charges = template.charges;
+        item.weight_tenths = template.weight_tenths;
+        item.container_capacity_tenths = template.container_capacity_tenths;
+        item.size_class = size_class;
+        item.role = role;
+        self.items.insert(
+            receipt.output_item_id,
+            ItemMeta {
+                name: template.name,
+                description: template.description,
+                skill_id: None,
+                skill_bonus: 0,
+                mechanics: template.mechanics,
+            },
+        );
+        let current_holder_actor_id = opt_id(item.holder_actor_id);
+        let current_location_id = opt_id(item.location_id);
+        self.item_provenance.insert(
+            receipt.output_item_id,
+            ItemProvenanceState {
+                item_id: receipt.output_item_id,
+                origin: format!(
+                    "craft:{}@{}:{}@{}",
+                    receipt.recipe_key,
+                    receipt.recipe_schema_version,
+                    receipt.pack_id,
+                    receipt.pack_version
+                ),
+                acquisition: "item.created".to_string(),
+                previous_holder_actor_id: None,
+                current_holder_actor_id,
+                current_location_id,
+                transfer_count: 0,
+                source_event_seq: Some(output_event.seq),
+                possession_journey: current_holder_actor_id.map(|actor_id| {
+                    PossessionJourneyState::new(actor_id, receipt.location_id, output_event.seq)
+                }),
+            },
+        );
+        let mut committed = receipt.clone();
+        committed.craft_event_seq = Some(craft_event.seq);
+        committed.output_event_seq = Some(output_event.seq);
+        for input in &mut committed.inputs {
+            let event_type = match input.disposition.as_str() {
+                "consume" => "item.consumed",
+                "exhaust" => "item.exhausted",
+                "transform" => "item.transformed",
+                _ => continue,
+            };
+            input.transition_event_seq = committed_events
+                .iter()
+                .find(|event| {
+                    event.success
+                        && event.type_name == event_type
+                        && event.item_id == Some(input.item_id)
+                })
+                .map(|event| event.seq);
+            if let Some(provenance) = self.item_provenance.get_mut(&input.item_id) {
+                provenance.acquisition = event_type.to_string();
+                provenance.source_event_seq = input.transition_event_seq;
+                if matches!(input.disposition.as_str(), "consume" | "transform") {
+                    provenance.previous_holder_actor_id = provenance.current_holder_actor_id;
+                    provenance.current_holder_actor_id = None;
+                    provenance.current_location_id = None;
+                    provenance.possession_journey = None;
+                }
+            }
+        }
+        if receipt.output_effect == "installed_fixture" {
+            let tag_id = format!("generated-place:{}:anchor-fixture", receipt.location_id);
+            self.tags.entry(tag_id.clone()).or_insert(RpgTagState {
+                id: tag_id,
+                scope: "room".to_string(),
+                scope_id: receipt.location_id,
+                label: "crafted anchor fixture".to_string(),
+                kind: "boon".to_string(),
+                active: true,
+                source_event_seq: Some(output_event.seq),
+                expires: None,
+            });
+            if let Some((clock_id, job_id)) = self
+                .generated_places
+                .get(&receipt.location_id)
+                .map(|place| (place.anchor_clock_id.clone(), place.anchor_job_id.clone()))
+            {
+                if let Some(clock) = self.clocks.get_mut(&clock_id) {
+                    clock.filled = clock.segments;
+                    clock.status = "completed".to_string();
+                    clock.updated_event_seq = Some(output_event.seq);
+                }
+                if let Some(job) = self.jobs.get_mut(&job_id) {
+                    job.status = "completed".to_string();
+                }
+            }
+        }
+        self.craft_receipts.insert(committed.id.clone(), committed);
+    }
+
+    pub(super) fn refresh_craft_event_presentation(&self, events: &mut [EventView]) {
+        for event in events {
+            if event.item_name.is_none() {
+                event.item_name = event.item_id.and_then(|item_id| self.item_name(item_id));
+            }
+            if event.target_item_name.is_none() {
+                event.target_item_name = event
+                    .target_item_id
+                    .and_then(|item_id| self.item_name(item_id));
+            }
+            let receipt = self.craft_receipts.values().find(|receipt| {
+                receipt.craft_event_seq == Some(event.seq)
+                    || receipt.output_event_seq == Some(event.seq)
+                    || receipt
+                        .inputs
+                        .iter()
+                        .any(|input| input.transition_event_seq == Some(event.seq))
+            });
+            let Some(receipt) = receipt else {
+                continue;
+            };
+            let recipe_name = self
+                .recipe_name(receipt.recipe_id)
+                .unwrap_or_else(|| "Craft".to_string());
+            let input_name = receipt
+                .inputs
+                .first()
+                .and_then(|input| self.item_name(input.item_id))
+                .unwrap_or_else(|| "the materials".to_string());
+            let output_name = self
+                .item_name(receipt.output_item_id)
+                .unwrap_or_else(|| "the finished piece".to_string());
+            event.content = Some(match event.type_name.as_str() {
+                "item.crafted" => format!("{recipe_name}: {input_name} became {output_name}."),
+                "item.created" if receipt.output_effect == "installed_fixture" => {
+                    format!("{output_name} now anchors this place.")
+                }
+                "item.created" => format!("{output_name} is ready here."),
+                "item.consumed" => format!("{input_name} was used up."),
+                "item.exhausted" => format!("{input_name} needs restoring."),
+                "item.transformed" => format!("{input_name} became {output_name}."),
+                _ => continue,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_ORE_ITEM_ID: u64 = 9_123_456_789;
+
+    fn install_completed_smithy(runtime: &mut RuntimeWorld, location_id: u64) {
+        runtime.settlement_buildings.insert(
+            "test-smithy".to_string(),
+            SettlementBuildingState {
+                schema_version: SETTLEMENT_BUILDING_SCHEMA_VERSION,
+                id: "test-smithy".to_string(),
+                location_id,
+                slot_index: 1,
+                slot_class: "major".to_string(),
+                archetype_id: "smithy".to_string(),
+                name: "Smithy".to_string(),
+                pack_id: "cosyworld.core".to_string(),
+                pack_version: runtime.active_pack_version("cosyworld.core"),
+                governance_decision_id: "test".to_string(),
+                selected_event_seq: 1,
+                construction_clock_id: "test-smithy-clock".to_string(),
+                construction_job_id: "test-smithy-job".to_string(),
+                status: SettlementBuildingStatus::Completed,
+                completed_event_seq: Some(2),
+                declared_capabilities: vec![
+                    "transformation_recipes".to_string(),
+                    "metalworking".to_string(),
+                ],
+                installed_capabilities: vec![
+                    "transformation_recipes".to_string(),
+                    "metalworking".to_string(),
+                ],
+                quest_templates: Vec::new(),
+                recipe_tags: vec!["smithy".to_string(), "refinement".to_string()],
+                access_policy: "public".to_string(),
+                covenant_required: false,
+                loot_table_id: None,
+                public_cache: None,
+                upgrade_clock_id: None,
+                upgrade_job_id: None,
+                upgrade_level: 0,
+                upgraded_event_seq: None,
+                follow_up_job_ids: Vec::new(),
+            },
+        );
+    }
+
+    fn place_quest_ore(runtime: &mut RuntimeWorld, location_id: u64) {
+        let item = CwItem {
+            id: TEST_ORE_ITEM_ID,
+            kind: CW_ITEM_KEEPSAKE,
+            charges: 1,
+            weight_tenths: 20,
+            size_class: CW_ITEM_SIZE_SMALL,
+            role: CW_ITEM_ROLE_GENERIC,
+            zone: CW_CARD_ZONE_WORLD,
+            location_id,
+            ..CwItem::default()
+        };
+        runtime.world.items[runtime.world.item_count] = item;
+        runtime.world.item_count += 1;
+        runtime.items.insert(
+            TEST_ORE_ITEM_ID,
+            ItemMeta {
+                name: "Iron Nodule".to_string(),
+                description: "Quest ore.".to_string(),
+                skill_id: None,
+                skill_bonus: 0,
+                mechanics: None,
+            },
+        );
+        runtime.item_provenance.insert(
+            TEST_ORE_ITEM_ID,
+            ItemProvenanceState {
+                item_id: TEST_ORE_ITEM_ID,
+                origin: "loot:cosyworld.core:loot/shallow-mine-ore@1".to_string(),
+                acquisition: "quest.loot_allocated".to_string(),
+                previous_holder_actor_id: None,
+                current_holder_actor_id: None,
+                current_location_id: Some(location_id),
+                transfer_count: 0,
+                source_event_seq: Some(1),
+                possession_journey: None,
+            },
+        );
+        runtime.loot_allocations.insert(
+            "test-mine-loot".to_string(),
+            LootAllocationState {
+                schema_version: QUEST_LOOT_SCHEMA_VERSION,
+                id: "test-mine-loot".to_string(),
+                job_id: "test-mine-job".to_string(),
+                quest_template_id: "production.shallow_mine".to_string(),
+                table_id: "cosyworld.core:loot/shallow-mine-ore".to_string(),
+                table_version: 1,
+                replay_version: "weighted-fnv1a-v1".to_string(),
+                pack_id: "cosyworld.core".to_string(),
+                pack_version: runtime.active_pack_version("cosyworld.core"),
+                rules_profile: active_content().manifest.rules_profile.clone(),
+                completion_event_seq: 1,
+                allocation_event_seq: 2,
+                roll_seed: 3,
+                roll_input: "test".to_string(),
+                selected_template_ids: vec!["iron_nodule".to_string()],
+                item_ids: vec![TEST_ORE_ITEM_ID],
+                allocation_policy: "building_public_cache".to_string(),
+                destination_kind: "location_stockpile".to_string(),
+                destination_id: format!("location:{location_id}:stockpile"),
+                recipient_actor_id: None,
+                location_id,
+            },
+        );
+    }
+
+    fn commit_plan(runtime: &mut RuntimeWorld, plan: VersionedCraftPlan) -> (u32, Vec<EventView>) {
+        let mut record = JournalRecord::new(plan.action, runtime.next_seed_value());
+        record
+            .projection_mutations
+            .push(ProjectionMutation::ResolveCraft {
+                receipt: plan.receipt,
+            });
+        runtime.apply_journal_record(&record)
+    }
+
+    fn record_for_plan(runtime: &RuntimeWorld, plan: VersionedCraftPlan) -> JournalRecord {
+        let mut record = JournalRecord::new(plan.action, runtime.next_seed_value());
+        record
+            .projection_mutations
+            .push(ProjectionMutation::ResolveCraft {
+                receipt: plan.receipt,
+            });
+        record
+    }
+
+    fn prepared_craft_runtime(location_id: u64) -> RuntimeWorld {
+        let mut runtime = RuntimeWorld::seeded();
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("seed actor")
+            .location_id = location_id;
+        place_quest_ore(&mut runtime, location_id);
+        install_completed_smithy(&mut runtime, location_id);
+        runtime
+    }
+
+    fn test_generated_pathway(runtime: &RuntimeWorld, location_id: u64) -> GeneratedPathwayState {
+        GeneratedPathwayState {
+            id: "replay-pathway".to_string(),
+            origin_location_id: COSY_COTTAGE_LOCATION_ID,
+            destination_location_id: location_id,
+            distance: 1,
+            created_by_actor_id: RATI_ACTOR_ID,
+            waypoints: vec![GeneratedWaypointState {
+                id: location_id,
+                name: runtime.location_name(location_id).expect("location name"),
+                meta: runtime
+                    .location_meta
+                    .get(&location_id)
+                    .cloned()
+                    .expect("location metadata"),
+            }],
+            generation: GenerationProvenance::default(),
+            revealed_edges: BTreeSet::new(),
+            art_eligible: false,
+            familiar: false,
+        }
+    }
+
+    #[test]
+    fn quest_ore_requires_a_smithy_and_transforms_exactly_once() {
+        let mut runtime = RuntimeWorld::seeded();
+        let location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
+        let actor = runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("seed actor");
+        actor.location_id = location_id;
+        place_quest_ore(&mut runtime, location_id);
+        let item_count_before_building = runtime.world.item_count;
+        assert!(runtime
+            .versioned_craft_plan(RATI_ACTOR_ID, 3101, Some("test-refine"))
+            .is_none());
+
+        install_completed_smithy(&mut runtime, location_id);
+        assert_eq!(runtime.world.item_count, item_count_before_building);
+        {
+            let smithy = runtime
+                .settlement_buildings
+                .get_mut("test-smithy")
+                .expect("test smithy");
+            smithy.access_policy = "covenant".to_string();
+            smithy.covenant_required = true;
+        }
+        assert!(runtime
+            .versioned_craft_plan(RATI_ACTOR_ID, 3101, Some("closed-smithy"))
+            .is_none());
+        {
+            let smithy = runtime
+                .settlement_buildings
+                .get_mut("test-smithy")
+                .expect("test smithy");
+            smithy.access_policy = "public".to_string();
+            smithy.covenant_required = false;
+        }
+        for item in runtime.world.items[..runtime.world.item_count]
+            .iter_mut()
+            .filter(|item| item.holder_actor_id == RATI_ACTOR_ID)
+        {
+            item.holder_actor_id = 0;
+            item.location_id = 0;
+            item.zone = CW_CARD_ZONE_WORLD;
+        }
+        let mut kernel_offers = CwActionOffers::default();
+        assert_eq!(
+            unsafe { cw_get_action_offers(&runtime.world, RATI_ACTOR_ID, &mut kernel_offers) },
+            CW_OK
+        );
+        assert_eq!(kernel_offers.option_flags & CW_OFFER_CRAFT, 0);
+        assert!(runtime
+            .primary_action(Some(RATI_ACTOR_ID), &AccessContext::default())
+            .options
+            .iter()
+            .any(|option| option.kind == "craft"));
+        let direct_plan = runtime
+            .versioned_craft_plan(RATI_ACTOR_ID, 3101, Some("test-refine"))
+            .expect("smithy exposes refinement");
+        assert_eq!(
+            direct_plan.receipt.capability_source,
+            "building:test-smithy"
+        );
+        assert_eq!(
+            direct_plan.action.item_disposition,
+            CW_CRAFT_INPUT_TRANSFORMED
+        );
+        runtime
+            .actor_autonomy
+            .entry(RATI_ACTOR_ID)
+            .or_default()
+            .control_mode = ActorControlMode::RoamingAi;
+        runtime.callings.insert(
+            RATI_ACTOR_ID,
+            CallingState {
+                actor_id: RATI_ACTOR_ID,
+                statement: "Courier".to_string(),
+                source_event_seq: Some(1),
+            },
+        );
+        runtime.actor_practices.insert(
+            RATI_ACTOR_ID,
+            ActorPracticeState {
+                primary: Some(DeedCategory::Exploration),
+                ..ActorPracticeState::default()
+            },
+        );
+        assert!(runtime
+            .versioned_craft_plan(RATI_ACTOR_ID, 3101, Some("other-controller"))
+            .is_some());
+
+        let (status, events) = commit_plan(&mut runtime, direct_plan);
+        assert_eq!(status, CW_OK);
+        assert!(runtime.item_by_id(TEST_ORE_ITEM_ID).is_none());
+        let receipt = runtime
+            .craft_receipts
+            .get("test-refine")
+            .expect("durable craft receipt");
+        let bloom_item_id = receipt.output_item_id;
+        assert_eq!(
+            receipt.inputs[0].source_origin,
+            "loot:cosyworld.core:loot/shallow-mine-ore@1"
+        );
+        assert_eq!(
+            runtime.item_provenance[&bloom_item_id].origin,
+            "craft:refine-iron-bloom@2:cosyworld.core@1.3.10"
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.type_name == "item.created")
+                .count(),
+            1
+        );
+        assert!(events.iter().any(|event| {
+            event.type_name == "item.crafted"
+                && event
+                    .content
+                    .as_deref()
+                    .is_some_and(|line| line == "Refine Iron Bloom: Iron Nodule became Iron Bloom.")
+        }));
+        let deed_count = runtime.deeds.len();
+        assert!(runtime
+            .versioned_craft_plan(RATI_ACTOR_ID, 3101, Some("test-refine"))
+            .is_none());
+        assert_eq!(runtime.world.item_count, item_count_before_building);
+        assert_eq!(runtime.deeds.len(), deed_count);
+
+        let drop_record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_DROP_ITEM,
+                actor_id: RATI_ACTOR_ID,
+                item_id: bloom_item_id,
+                ..CwAction::default()
+            },
+            runtime.next_seed_value(),
+        );
+        assert_eq!(runtime.apply_journal_record(&drop_record).0, CW_OK);
+        assert_eq!(
+            runtime
+                .item_by_id(bloom_item_id)
+                .map(|item| item.location_id),
+            Some(location_id)
+        );
+        let pickup_record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_PICK_UP_ITEM,
+                actor_id: RATI_ACTOR_ID,
+                item_id: bloom_item_id,
+                ..CwAction::default()
+            },
+            runtime.next_seed_value(),
+        );
+        assert_eq!(runtime.apply_journal_record(&pickup_record).0, CW_OK);
+        assert_eq!(
+            runtime
+                .item_by_id(bloom_item_id)
+                .map(|item| item.holder_actor_id),
+            Some(RATI_ACTOR_ID)
+        );
+
+        let forge_plan = runtime
+            .versioned_craft_plan(RATI_ACTOR_ID, 3102, Some("test-anchor"))
+            .expect("portable bloom can become a portable bracket");
+        let (forge_status, _) = commit_plan(&mut runtime, forge_plan);
+        assert_eq!(forge_status, CW_OK);
+        assert!(runtime
+            .versioned_craft_plan(RATI_ACTOR_ID, 3103, Some("test-install"))
+            .is_none());
+
+        let pathway = GeneratedPathwayState {
+            id: "test-pathway".to_string(),
+            origin_location_id: COSY_COTTAGE_LOCATION_ID,
+            destination_location_id: location_id,
+            distance: 1,
+            created_by_actor_id: RATI_ACTOR_ID,
+            waypoints: vec![GeneratedWaypointState {
+                id: location_id,
+                name: runtime.location_name(location_id).expect("location name"),
+                meta: runtime
+                    .location_meta
+                    .get(&location_id)
+                    .cloned()
+                    .expect("location metadata"),
+            }],
+            generation: GenerationProvenance::default(),
+            revealed_edges: BTreeSet::new(),
+            art_eligible: false,
+            familiar: false,
+        };
+        runtime.ensure_generated_place_for_waypoint(
+            &pathway,
+            location_id,
+            COSY_COTTAGE_LOCATION_ID,
+        );
+        let bracket_item_id = runtime
+            .craft_receipts
+            .get("test-anchor")
+            .expect("forge receipt")
+            .output_item_id;
+        assert_eq!(
+            runtime
+                .physical_item_template_id(bracket_item_id)
+                .as_deref(),
+            Some("waystone_bracket")
+        );
+        assert!(runtime.item_by_id(bracket_item_id).is_some());
+        assert!(runtime
+            .versioned_recipe_capability_source(
+                RATI_ACTOR_ID,
+                runtime.recipe_by_id(3103).expect("install recipe"),
+                location_id,
+            )
+            .is_some());
+        let anchor_plan = runtime
+            .versioned_craft_plan(RATI_ACTOR_ID, 3103, Some("test-install"))
+            .expect("portable bracket can be installed at an unfinished place");
+        let (anchor_status, _) = commit_plan(&mut runtime, anchor_plan);
+        assert_eq!(anchor_status, CW_OK);
+        let installed_item_id = runtime
+            .craft_receipts
+            .get("test-install")
+            .expect("install receipt")
+            .output_item_id;
+        assert_eq!(
+            runtime.item_by_id(installed_item_id).map(|item| item.zone),
+            Some(CW_CARD_ZONE_INSTALLED)
+        );
+        assert!(!runtime
+            .loose_items_at_location(location_id)
+            .iter()
+            .any(|item| item.id == installed_item_id));
+        let pickup_fixture = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_PICK_UP_ITEM,
+                actor_id: RATI_ACTOR_ID,
+                item_id: installed_item_id,
+                ..CwAction::default()
+            },
+            runtime.next_seed_value(),
+        );
+        assert_ne!(runtime.apply_journal_record(&pickup_fixture).0, CW_OK);
+        assert_eq!(
+            runtime.item_by_id(installed_item_id).map(|item| item.zone),
+            Some(CW_CARD_ZONE_INSTALLED)
+        );
+        assert!(runtime
+            .tags
+            .get(&format!("generated-place:{location_id}:anchor-fixture"))
+            .is_some_and(|tag| tag.active));
+        let generated = runtime
+            .generated_places
+            .get(&location_id)
+            .expect("generated place");
+        assert!(runtime
+            .clocks
+            .get(&generated.anchor_clock_id)
+            .is_some_and(|clock| clock.filled == clock.segments));
+        assert_eq!(
+            runtime
+                .jobs
+                .get(&generated.anchor_job_id)
+                .map(|job| job.status.as_str()),
+            Some("completed")
+        );
+
+        let snapshot = RuntimeSnapshot::from_runtime(&runtime);
+        let restored = snapshot.into_runtime().expect("craft snapshot restores");
+        assert_eq!(restored.craft_receipts, runtime.craft_receipts);
+        assert_eq!(
+            restored
+                .world
+                .items
+                .iter()
+                .take(restored.world.item_count)
+                .map(|item| item.id)
+                .collect::<Vec<_>>(),
+            runtime
+                .world
+                .items
+                .iter()
+                .take(runtime.world.item_count)
+                .map(|item| item.id)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn craft_chain_replays_items_fixtures_provenance_and_deeds_exactly() {
+        let location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
+        let mut committed = prepared_craft_runtime(location_id);
+
+        let refine_record = record_for_plan(
+            &committed,
+            committed
+                .versioned_craft_plan(RATI_ACTOR_ID, 3101, Some("replay-refine"))
+                .expect("refine plan"),
+        );
+        assert_eq!(committed.apply_journal_record(&refine_record).0, CW_OK);
+        let forge_record = record_for_plan(
+            &committed,
+            committed
+                .versioned_craft_plan(RATI_ACTOR_ID, 3102, Some("replay-forge"))
+                .expect("forge plan"),
+        );
+        assert_eq!(committed.apply_journal_record(&forge_record).0, CW_OK);
+
+        let pathway = test_generated_pathway(&committed, location_id);
+        committed.ensure_generated_place_for_waypoint(
+            &pathway,
+            location_id,
+            COSY_COTTAGE_LOCATION_ID,
+        );
+        let install_record = record_for_plan(
+            &committed,
+            committed
+                .versioned_craft_plan(RATI_ACTOR_ID, 3103, Some("replay-install"))
+                .expect("install plan"),
+        );
+        assert_eq!(committed.apply_journal_record(&install_record).0, CW_OK);
+        assert_eq!(
+            committed
+                .actor_deeds(RATI_ACTOR_ID)
+                .into_iter()
+                .filter(|deed| deed.category == DeedCategory::Craft)
+                .count(),
+            3
+        );
+
+        let durable_records = [refine_record, forge_record, install_record]
+            .into_iter()
+            .map(|record| {
+                serde_json::from_str::<JournalRecord>(
+                    &serde_json::to_string(&record).expect("serialize craft journal"),
+                )
+                .expect("deserialize craft journal")
+            })
+            .collect::<Vec<_>>();
+        let mut replayed = prepared_craft_runtime(location_id);
+        assert_eq!(replayed.apply_journal_record(&durable_records[0]).0, CW_OK);
+        assert_eq!(replayed.apply_journal_record(&durable_records[1]).0, CW_OK);
+        let replay_pathway = test_generated_pathway(&replayed, location_id);
+        replayed.ensure_generated_place_for_waypoint(
+            &replay_pathway,
+            location_id,
+            COSY_COTTAGE_LOCATION_ID,
+        );
+        assert_eq!(replayed.apply_journal_record(&durable_records[2]).0, CW_OK);
+
+        assert_eq!(
+            serde_json::to_value(RuntimeSnapshot::from_runtime(&replayed))
+                .expect("serialize replay snapshot"),
+            serde_json::to_value(RuntimeSnapshot::from_runtime(&committed))
+                .expect("serialize committed snapshot")
+        );
+    }
+}

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -17,7 +17,7 @@ pub const CW_MAX_COMBAT_ENCOUNTERS: usize = 32;
 pub const CW_MAX_COMBAT_PARTICIPANTS: usize = 16;
 pub const CW_ITEM_DEFAULT_WEIGHT_TENTHS: u16 = 10;
 
-pub const CW_KERNEL_VERSION: u32 = 5;
+pub const CW_KERNEL_VERSION: u32 = 6;
 
 pub const CW_OK: u32 = 0;
 pub const CW_ERR_RULE: u32 = 4;
@@ -43,6 +43,7 @@ pub const CW_EXIT_LOCKED: u32 = 1 << 0;
 
 pub const CW_PLACEMENT_ACTOR_HAND: u8 = 1;
 pub const CW_PLACEMENT_LOCATION_FLOOR: u8 = 2;
+pub const CW_PLACEMENT_LOCATION_FIXTURE: u8 = 3;
 
 pub const CW_ITEM_POTION: u8 = 1;
 pub const CW_ITEM_EVOLUTION: u8 = 2;
@@ -69,6 +70,7 @@ pub const CW_CARD_ZONE_SPELL_DECK: u8 = 4;
 pub const CW_CARD_ZONE_EXHAUSTED: u8 = 5;
 pub const CW_CARD_ZONE_CONTAINED: u8 = 6;
 pub const CW_CARD_ZONE_ESCROW: u8 = 7;
+pub const CW_CARD_ZONE_INSTALLED: u8 = 8;
 
 pub const CW_ROLL_NORMAL: u8 = 0;
 pub const CW_ROLL_ADVANTAGE: u8 = 1;
@@ -128,6 +130,14 @@ pub const CW_EVENT_ITEM_THEFT_ATTEMPT: u8 = 32;
 pub const CW_EVENT_ITEM_STOLEN: u8 = 33;
 pub const CW_EVENT_COMBAT_PASS: u8 = 34;
 pub const CW_EVENT_COMBAT_NEED_TIME: u8 = 35;
+pub const CW_EVENT_ITEM_CONSUMED: u8 = 36;
+pub const CW_EVENT_ITEM_EXHAUSTED: u8 = 37;
+pub const CW_EVENT_ITEM_TRANSFORMED: u8 = 38;
+
+pub const CW_CRAFT_INPUT_PERSISTS: u8 = 0;
+pub const CW_CRAFT_INPUT_CONSUMED: u8 = 1;
+pub const CW_CRAFT_INPUT_EXHAUSTED: u8 = 2;
+pub const CW_CRAFT_INPUT_TRANSFORMED: u8 = 3;
 
 pub const CW_OFFER_CHAT: u32 = 1 << 0;
 pub const CW_OFFER_CHECK: u32 = 1 << 1;
@@ -247,6 +257,22 @@ pub struct CwAction {
     pub output_item_charges: u8,
     #[serde(default)]
     pub roll_mode: u8,
+    #[serde(default)]
+    pub item_disposition: u8,
+    #[serde(default)]
+    pub target_item_disposition: u8,
+    #[serde(default)]
+    pub reserved: u16,
+    #[serde(default)]
+    pub output_item_weight_tenths: u16,
+    #[serde(default)]
+    pub output_container_capacity_tenths: u16,
+    #[serde(default)]
+    pub output_item_size_class: u8,
+    #[serde(default)]
+    pub output_item_role: u8,
+    #[serde(default)]
+    pub reserved2: u16,
 }
 
 #[repr(C)]

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -11,6 +11,7 @@ mod content_load;
 mod content_packs;
 mod content_policy;
 mod content_registry;
+mod crafting;
 mod generated_places;
 mod hosted_access;
 mod kernel;
@@ -54,6 +55,7 @@ use content_packs::*;
 use content_policy::*;
 use content_registry::*;
 use cosyworld_ai_model::ResidentReplyModelInput;
+use crafting::*;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use generated_places::*;
 use hosted_access::*;
@@ -994,6 +996,9 @@ struct RoomSheetState {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum ProjectionMutation {
+    ResolveCraft {
+        receipt: CraftReceiptState,
+    },
     CreateTransferOffer {
         offer: TransferOfferState,
     },
@@ -1666,6 +1671,7 @@ struct RuntimeWorld {
     npc_cooperation: BTreeMap<String, NpcCooperationState>,
     item_provenance: BTreeMap<u64, ItemProvenanceState>,
     materialization_receipts: BTreeMap<String, MaterializationReceiptState>,
+    craft_receipts: BTreeMap<String, CraftReceiptState>,
     ledger_marks: BTreeMap<String, VisitLedgerMarkState>,
     advancement_spends: BTreeMap<String, AdvancementSpendState>,
     bonds: BTreeMap<String, BondState>,
@@ -1774,6 +1780,8 @@ struct RuntimeSnapshot {
     item_provenance: BTreeMap<u64, ItemProvenanceState>,
     #[serde(default)]
     materialization_receipts: BTreeMap<String, MaterializationReceiptState>,
+    #[serde(default)]
+    craft_receipts: BTreeMap<String, CraftReceiptState>,
     #[serde(default)]
     ledger_marks: BTreeMap<String, VisitLedgerMarkState>,
     #[serde(default)]
@@ -1920,7 +1928,7 @@ impl JournalRecord {
             })
             .unwrap_or_default();
         Self {
-            version: 6,
+            version: 7,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry()
                 .content_reference_context(action_content_handles(&action)),
@@ -3668,6 +3676,8 @@ struct CraftRequest {
     actor_id: u64,
     actor_session: Option<String>,
     recipe_id: u64,
+    #[serde(default)]
+    receipt_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -6335,7 +6345,7 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 8,
+            version: 9,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
@@ -6385,6 +6395,7 @@ impl RuntimeSnapshot {
             npc_cooperation: runtime.npc_cooperation.clone(),
             item_provenance: runtime.item_provenance.clone(),
             materialization_receipts: runtime.materialization_receipts.clone(),
+            craft_receipts: runtime.craft_receipts.clone(),
             ledger_marks: runtime.ledger_marks.clone(),
             advancement_spends: runtime.advancement_spends.clone(),
             bonds: runtime.bonds.clone(),
@@ -6591,6 +6602,7 @@ impl RuntimeSnapshot {
             npc_cooperation: self.npc_cooperation,
             item_provenance: self.item_provenance,
             materialization_receipts: self.materialization_receipts,
+            craft_receipts: self.craft_receipts,
             ledger_marks: self.ledger_marks,
             advancement_spends: self.advancement_spends,
             bonds: self.bonds,
@@ -7042,6 +7054,7 @@ impl RuntimeWorld {
             npc_cooperation: BTreeMap::new(),
             item_provenance: BTreeMap::new(),
             materialization_receipts: BTreeMap::new(),
+            craft_receipts: BTreeMap::new(),
             ledger_marks: BTreeMap::new(),
             advancement_spends: BTreeMap::new(),
             bonds: BTreeMap::new(),
@@ -10231,6 +10244,7 @@ impl RuntimeWorld {
                 &committed_events,
                 &record.projection_mutations,
             ));
+            self.refresh_craft_event_presentation(&mut events);
             events.extend(self.apply_class_readiness_projection(record, &action, &events));
             let committed_events = events.clone();
             events.extend(self.apply_bounded_magic_projection(&action, &committed_events));
@@ -10314,6 +10328,7 @@ impl RuntimeWorld {
                 ));
             }
             self.record_autonomous_action(record);
+            self.refresh_craft_event_presentation(&mut events);
             if record.source_world_tick.is_some() {
                 for event in &mut events {
                     event.apply_async_causality(record);
@@ -10347,6 +10362,9 @@ impl RuntimeWorld {
         let mut events = Vec::new();
         for mutation in mutations {
             match mutation {
+                ProjectionMutation::ResolveCraft { receipt } => {
+                    self.apply_craft_resolution(receipt, committed_events);
+                }
                 ProjectionMutation::CreateTransferOffer { offer } => {
                     self.transfer_offers
                         .entry(offer.id.clone())
@@ -13874,8 +13892,11 @@ impl RuntimeWorld {
             .recipe_name(event.content_id)
             .unwrap_or_else(|| "Craft".to_string());
         let held_name = self.item_name(event.item_id)?;
-        let floor_name = self.item_name(event.target_item_id)?;
-        Some(format!("{recipe_name}: {held_name} met {floor_name}."))
+        if let Some(floor_name) = self.item_name(event.target_item_id) {
+            Some(format!("{recipe_name}: {held_name} met {floor_name}."))
+        } else {
+            Some(format!("{recipe_name}: {held_name} changed."))
+        }
     }
 
     fn item_created_event_context(&self, event: &CwEvent) -> Option<String> {
@@ -15124,6 +15145,7 @@ impl RuntimeWorld {
             .filter(|item| {
                 item.holder_actor_id == 0
                     && item.location_id == location_id
+                    && item.zone == CW_CARD_ZONE_WORLD
                     && !self.forgotten_search_item_at_location(*item, location_id)
             })
             .collect::<Vec<_>>();
@@ -15852,6 +15874,11 @@ impl RuntimeWorld {
     }
 
     fn craft_action_for_recipe(&self, actor_id: u64, recipe_id: u64) -> Option<CwAction> {
+        if self.recipe_by_id(recipe_id)?.schema_version == 2 {
+            return self
+                .versioned_craft_plan(actor_id, recipe_id, None)
+                .map(|plan| plan.action);
+        }
         let actor = self.actor_by_id(actor_id)?;
         if actor.status != CW_ACTOR_ACTIVE {
             return None;
@@ -17188,6 +17215,15 @@ impl RuntimeWorld {
     }
 
     fn kernel_offer_allows_action(&self, action: &CwAction) -> bool {
+        if action.kind == CW_ACTION_CRAFT
+            && self
+                .recipe_by_id(action.content_id)
+                .is_some_and(|recipe| recipe.schema_version == 2)
+        {
+            return self
+                .versioned_craft_plan(action.actor_id, action.content_id, None)
+                .is_some();
+        }
         let required_offer = match action.kind {
             CW_ACTION_NONE | CW_ACTION_SAY | CW_ACTION_CREATE_ACTOR => return true,
             CW_ACTION_MOVE => CW_OFFER_MOVE,
@@ -20731,14 +20767,12 @@ impl RuntimeWorld {
                 command: format!("search {}", target.name),
             });
         }
-        if offers.option_flags & CW_OFFER_CRAFT != 0 {
-            if let Some(recipe) = default_craft_recipe {
-                options.push(ActionOption {
-                    kind: "craft".to_string(),
-                    label: "Craft".to_string(),
-                    command: format!("craft {}", recipe.name),
-                });
-            }
+        if let Some(recipe) = default_craft_recipe {
+            options.push(ActionOption {
+                kind: "craft".to_string(),
+                label: "Craft".to_string(),
+                command: format!("craft {}", recipe.name),
+            });
         }
         if offers.option_flags & CW_OFFER_GIVE_ITEM != 0 && has_actor_gift {
             options.push(ActionOption {
@@ -22166,14 +22200,16 @@ impl RuntimeWorld {
                 }
             }),
             "craft" => self.default_craft_recipe(actor_id).map(|recipe| {
-                let output = recipe
-                    .output
-                    .as_ref()
-                    .map(|output| output.name.as_str())
-                    .unwrap_or("a new keepsake");
-                format!(
-                    "creates {output} from present items without consuming the inputs"
-                )
+                if recipe.schema_version == 2 {
+                    recipe.description.clone()
+                } else {
+                    let output = recipe
+                        .output
+                        .as_ref()
+                        .map(|output| output.name.as_str())
+                        .unwrap_or("a new keepsake");
+                    format!("creates {output} from the two present keepsakes")
+                }
             }),
             "create_bond" => self.default_bondable_resident(actor_id).and_then(|target| {
                 self.actor_name(target.id)
@@ -32319,6 +32355,7 @@ async fn command_inner(
                     actor_id: payload.actor_id,
                     actor_session: payload.actor_session,
                     recipe_id,
+                    receipt_id: None,
                 }),
             )
             .await;
@@ -36941,7 +36978,7 @@ async fn craft(
     ) {
         return action_rate_limited_response();
     }
-    let action = {
+    let (action, mutation) = {
         let runtime = state.inner.lock().await;
         if !client_actor_authorized_for_state(
             &runtime,
@@ -36951,17 +36988,64 @@ async fn craft(
         ) {
             return client_actor_rejected_response();
         }
-        let Some(action) = runtime.craft_action_for_recipe(payload.actor_id, payload.recipe_id)
-        else {
-            return Json(ActionResponse {
-                ok: false,
-                status: 409,
-                events: Vec::new(),
-            });
+        let Some(recipe) = runtime.recipe_by_id(payload.recipe_id) else {
+            return action_offer_rejected("recipe is not available");
         };
-        action
+        if recipe.schema_version == 2 {
+            if let Some(receipt_id) = payload.receipt_id.as_deref() {
+                if let Some(existing) = runtime.craft_receipts.get(receipt_id) {
+                    return Json(ActionResponse {
+                        ok: existing.actor_id == payload.actor_id
+                            && existing.recipe_id == payload.recipe_id,
+                        status: if existing.actor_id == payload.actor_id
+                            && existing.recipe_id == payload.recipe_id
+                        {
+                            CW_OK
+                        } else {
+                            409
+                        },
+                        events: Vec::new(),
+                    });
+                }
+            }
+            let Some(plan) = runtime.versioned_craft_plan(
+                payload.actor_id,
+                payload.recipe_id,
+                payload.receipt_id.as_deref(),
+            ) else {
+                return action_offer_rejected(
+                    "physical inputs, place capability, access, or output space changed",
+                );
+            };
+            (
+                plan.action,
+                Some(ProjectionMutation::ResolveCraft {
+                    receipt: plan.receipt,
+                }),
+            )
+        } else {
+            let Some(action) = runtime.craft_action_for_recipe(payload.actor_id, payload.recipe_id)
+            else {
+                return Json(ActionResponse {
+                    ok: false,
+                    status: 409,
+                    events: Vec::new(),
+                });
+            };
+            (action, None)
+        }
     };
-    apply_and_broadcast(state, action, payload.actor_session.as_deref()).await
+    if let Some(mutation) = mutation {
+        apply_and_broadcast_with_mutations(
+            state,
+            action,
+            payload.actor_session.as_deref(),
+            vec![mutation],
+        )
+        .await
+    } else {
+        apply_and_broadcast(state, action, payload.actor_session.as_deref()).await
+    }
 }
 
 async fn attack(
@@ -44359,6 +44443,7 @@ fn card_zone(zone: u8, holder_actor_id: u64, location_id: u64) -> &'static str {
         CW_CARD_ZONE_EXHAUSTED => "exhausted",
         CW_CARD_ZONE_CONTAINED => "contained",
         CW_CARD_ZONE_ESCROW => "escrow",
+        CW_CARD_ZONE_INSTALLED => "installed",
         _ if holder_actor_id != 0 => "carried",
         _ if location_id != 0 => "world",
         _ => "collection",
@@ -52165,7 +52250,7 @@ mod tests {
         assert!(action_journal_has_records(&path).expect("has records"));
         let records = read_action_journal(&path).expect("read records");
         assert_eq!(records.len(), 2);
-        assert_eq!(records[0].version, 6);
+        assert_eq!(records[0].version, 7);
         assert_eq!(records[0].content_context.mapping_version, 1);
         let location_reference = records[0]
             .content_context
@@ -52173,7 +52258,7 @@ mod tests {
             .iter()
             .find(|reference| reference.canonical_ref == "pack://cosyworld.core/location/1")
             .expect("journal persists its canonical location reference");
-        assert_eq!(location_reference.pack_version, "1.3.9");
+        assert_eq!(location_reference.pack_version, "1.3.10");
         assert_eq!(location_reference.legacy_runtime_id, Some(1));
 
         let replayed = RuntimeWorld::from_action_journal(&path).expect("replay runtime");
@@ -62619,7 +62704,7 @@ mod tests {
         assert_eq!(content.cards.len(), 118);
         assert_eq!(content.lifecycle_hooks.len(), 27);
         assert_eq!(content.evolution_tracks.len(), 3);
-        assert_eq!(content.recipes.len(), 4);
+        assert_eq!(content.recipes.len(), 8);
         assert_eq!(content.rules.len(), 3);
 
         let nib = content

--- a/v2/orchestrator-rust/src/quest_loot.rs
+++ b/v2/orchestrator-rust/src/quest_loot.rs
@@ -106,6 +106,13 @@ struct MountedLootTable {
     templates: BTreeMap<String, LootItemTemplateDefinition>,
 }
 
+#[derive(Clone, Debug)]
+pub(super) struct MountedLootItemTemplate {
+    pub(super) pack_id: String,
+    pub(super) pack_version: String,
+    pub(super) template: LootItemTemplateDefinition,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(super) struct JobLootSpec {
     pub(super) table_id: String,
@@ -406,6 +413,26 @@ fn mounted_loot_table(table_id: &str) -> Option<MountedLootTable> {
     None
 }
 
+pub(super) fn mounted_loot_item_template(template_id: &str) -> Option<MountedLootItemTemplate> {
+    for pack in &active_content().manifest.packs {
+        let Ok(Some(catalog)) = parse_loot_catalog(pack) else {
+            continue;
+        };
+        if let Some(template) = catalog
+            .item_templates
+            .into_iter()
+            .find(|template| template.id == template_id)
+        {
+            return Some(MountedLootItemTemplate {
+                pack_id: pack.id.clone(),
+                pack_version: pack.version.clone(),
+                template,
+            });
+        }
+    }
+    None
+}
+
 pub(super) fn loot_spec_for_table(table_id: &str, quest_template_id: &str) -> Option<JobLootSpec> {
     let mounted = mounted_loot_table(table_id)?;
     Some(JobLootSpec {
@@ -435,7 +462,7 @@ fn loot_item_id(allocation_id: &str, index: usize) -> u64 {
             % LOOT_ITEM_ID_RANGE
 }
 
-fn loot_item_role(value: &str) -> Option<u8> {
+pub(super) fn loot_item_role(value: &str) -> Option<u8> {
     match value {
         "generic" => Some(CW_ITEM_ROLE_GENERIC),
         "consumable" => Some(CW_ITEM_ROLE_CONSUMABLE),

--- a/v2/orchestrator-rust/src/settlement_buildings.rs
+++ b/v2/orchestrator-rust/src/settlement_buildings.rs
@@ -237,6 +237,7 @@ fn allowed_building_capability(value: &str) -> bool {
             | "preservation"
             | "boating"
             | "mining"
+            | "metalworking"
             | "prospecting"
             | "pottery"
             | "carpentry"
@@ -779,6 +780,7 @@ impl RuntimeWorld {
         })
     }
 
+    #[cfg(test)]
     pub(super) fn location_building_recipe_tags(&self, location_id: u64) -> Vec<String> {
         let mut tags = self
             .settlement_buildings
@@ -1976,7 +1978,7 @@ mod tests {
             (
                 "cosyworld.core:loot/fishery-catch",
                 "cosyworld.core",
-                "1.3.9",
+                "1.3.10",
             )
         );
         assert_eq!(

--- a/v2/orchestrator-rust/tests/fixtures/srd-action-replay-golden-v1.json
+++ b/v2/orchestrator-rust/tests/fixtures/srd-action-replay-golden-v1.json
@@ -51,7 +51,7 @@
   ],
   "expected": {
     "rules_profile": "cosyworld.srd5/1",
-    "kernel_version": 5,
+    "kernel_version": 6,
     "world_tick": 8,
     "next_event_seq": 21,
     "actor": {"id":5000,"location_id":3,"status":1,"damage":0},

--- a/v2/orchestrator-rust/tests/fixtures/srd-action-replay-golden-v2.json
+++ b/v2/orchestrator-rust/tests/fixtures/srd-action-replay-golden-v2.json
@@ -51,7 +51,7 @@
   ],
   "expected": {
     "rules_profile": "cosyworld.srd5/1",
-    "kernel_version": 5,
+    "kernel_version": 6,
     "world_tick": 8,
     "next_event_seq": 17,
     "actor": {"id":5000,"location_id":3,"status":1,"damage":0},

--- a/v2/scripts/building-archetype-schema.mjs
+++ b/v2/scripts/building-archetype-schema.mjs
@@ -29,6 +29,7 @@ const capabilities = new Set([
   "preservation",
   "boating",
   "mining",
+  "metalworking",
   "prospecting",
   "pottery",
   "carpentry",

--- a/v2/scripts/check-rust.sh
+++ b/v2/scripts/check-rust.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TIMEOUT_SECS="${COSYWORLD_CARGO_TIMEOUT_SECS:-120}"
+DEFAULT_TIMEOUT_SECS=120
+if [ "${CI:-}" = "true" ]; then
+  DEFAULT_TIMEOUT_SECS=300
+fi
+TIMEOUT_SECS="${COSYWORLD_CARGO_TIMEOUT_SECS:-$DEFAULT_TIMEOUT_SECS}"
 
 run_with_timeout() {
   local label="$1"

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -17,6 +17,7 @@ import { avatarNamingValidationErrors } from "./avatar-naming-schema.mjs";
 import { buildingArchetypeValidationErrors } from "./building-archetype-schema.mjs";
 import { lootTableValidationErrors } from "./loot-table-schema.mjs";
 import { naturalAffordanceValidationErrors } from "./natural-affordance-schema.mjs";
+import { versionedRecipeValidationErrors } from "./recipe-schema.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
@@ -507,7 +508,17 @@ for (const pack of packs) {
 }
 
 const mountedLootTableIds = new Set();
+const mountedLootTemplateIds = new Set();
+const mountedBuildingCapabilities = new Set();
+const mountedBuildingRecipeTags = new Set();
+const mountedBuildingArchetypes = [];
 for (const pack of packs) {
+  for (const template of pack.extensions?.["x-cosyworld-loot-tables"]?.item_templates ?? []) {
+    if (mountedLootTemplateIds.has(template.id)) {
+      fail(`loot item template ${template.id} is mounted more than once`);
+    }
+    mountedLootTemplateIds.add(template.id);
+  }
   for (const table of pack.extensions?.["x-cosyworld-loot-tables"]?.tables ?? []) {
     if (mountedLootTableIds.has(table.id)) {
       fail(`loot table ${table.id} is mounted more than once`);
@@ -520,6 +531,13 @@ for (const pack of packs) {
     const archetype
     of pack.extensions?.["x-cosyworld-building-archetypes"]?.archetypes ?? []
   ) {
+    mountedBuildingArchetypes.push(archetype);
+    for (const capability of archetype.capabilities ?? []) {
+      mountedBuildingCapabilities.add(capability);
+    }
+    for (const tag of archetype.recipe_tags ?? []) {
+      mountedBuildingRecipeTags.add(tag);
+    }
     if (
       archetype.loot_table_id !== undefined
       && !mountedLootTableIds.has(archetype.loot_table_id)
@@ -2038,6 +2056,134 @@ for (const recipe of recipes) {
   }
   recipeIds.add(recipe.id);
   validateRequiredStrings("recipe", recipe, ["key", "name", "description"]);
+  if (recipe.schema_version === 2) {
+    for (const error of versionedRecipeValidationErrors(
+      recipe,
+      {
+        templateIds: mountedLootTemplateIds,
+        buildingArchetypes: mountedBuildingArchetypes,
+      },
+      `recipe ${recipe.id}`,
+    )) {
+      fail(error);
+    }
+    if (!Array.isArray(recipe.inputs) || recipe.inputs.length < 1 || recipe.inputs.length > 2) {
+      fail(`recipe ${recipe.id} must declare one or two physical inputs`);
+    }
+    const inputTemplates = new Set();
+    let physicalInputCount = 0;
+    for (const input of recipe.inputs ?? []) {
+      if (!isObject(input)
+          || !isNonEmptyString(input.template_id)
+          || !mountedLootTemplateIds.has(input.template_id)
+          || inputTemplates.has(input.template_id)) {
+        fail(`recipe ${recipe.id} has an orphan or duplicate input template ${input?.template_id}`);
+      }
+      inputTemplates.add(input?.template_id);
+      if (!Number.isInteger(input?.quantity)
+          || input.quantity < 1
+          || input.quantity > 2) {
+        fail(`recipe ${recipe.id} input ${input?.template_id} must use supported quantity 1 or 2`);
+      } else {
+        physicalInputCount += input.quantity;
+      }
+      if (!Number.isInteger(input?.min_charges ?? 0)
+          || (input?.min_charges ?? 0) < 0
+          || (input?.min_charges ?? 0) > 20) {
+        fail(`recipe ${recipe.id} input ${input?.template_id} has invalid charge requirements`);
+      }
+      if (!Array.isArray(input?.zones)
+          || input.zones.length === 0
+          || new Set(input.zones).size !== input.zones.length
+          || input.zones.some((zone) => !["carried", "world"].includes(zone))) {
+        fail(`recipe ${recipe.id} input ${input?.template_id} has ambiguous zones`);
+      }
+      if (!["persistent", "consume", "exhaust", "transform"].includes(input?.disposition)) {
+        fail(`recipe ${recipe.id} input ${input?.template_id} has undeclared consumption`);
+      }
+    }
+    if (physicalInputCount < 1 || physicalInputCount > 2) {
+      fail(`recipe ${recipe.id} must resolve to one or two physical items`);
+    }
+    const requirements = recipe.requires;
+    const buildingCapabilities = requirements?.building_capabilities ?? [];
+    const buildingRecipeTags = requirements?.recipe_tags ?? [];
+    const naturalFeatures = requirements?.natural_features ?? [];
+    const locationFeatures = requirements?.location_features ?? [];
+    if (!isObject(requirements)
+        || !Array.isArray(buildingCapabilities)
+        || !Array.isArray(buildingRecipeTags)
+        || !Array.isArray(naturalFeatures)
+        || !Array.isArray(locationFeatures)
+        || (buildingCapabilities.length === 0
+          && buildingRecipeTags.length === 0
+          && naturalFeatures.length === 0
+          && locationFeatures.length === 0)) {
+      fail(`recipe ${recipe.id} has no physical place eligibility`);
+    }
+    if ((buildingCapabilities.length === 0) !== (buildingRecipeTags.length === 0)
+        || (buildingCapabilities.length > 0
+          && !buildingCapabilities.includes("transformation_recipes"))
+        || buildingCapabilities.some(
+          (capability) => !mountedBuildingCapabilities.has(capability),
+        )) {
+      fail(`recipe ${recipe.id} has missing or unknown capability tags`);
+    }
+    if (buildingRecipeTags.some((tag) => !mountedBuildingRecipeTags.has(tag))) {
+      fail(`recipe ${recipe.id} has missing or unknown building recipe tags`);
+    }
+    if (buildingCapabilities.length > 0
+        && !mountedBuildingArchetypes.some((archetype) =>
+      buildingCapabilities.every(
+        (capability) => (archetype.capabilities ?? []).includes(capability),
+      )
+      && buildingRecipeTags.every(
+        (tag) => (archetype.recipe_tags ?? []).includes(tag),
+      ))) {
+      fail(`recipe ${recipe.id} has an impossible capability and recipe-tag combination`);
+    }
+    const validNaturalFeatures = new Set([
+      "fish_rich_water",
+      "ore_seam",
+      "clay_bank",
+      "ancient_woodland",
+      "fast_river",
+      "reliable_upland_wind",
+      "hot_spring",
+      "rich_soil",
+      "rare_herb_habitat",
+      "old_ruins",
+    ]);
+    if (!Array.isArray(naturalFeatures)
+        || naturalFeatures.length > 1
+        || naturalFeatures.some((feature) => !validNaturalFeatures.has(feature))) {
+      fail(`recipe ${recipe.id} names ambiguous or unknown natural features`);
+    }
+    if (locationFeatures.length > 1
+        || locationFeatures.some((feature) => feature !== "generated_place_anchor_site")) {
+      fail(`recipe ${recipe.id} names ambiguous or unknown location features`);
+    }
+    const output = recipe.output;
+    if (!isObject(output) || !mountedLootTemplateIds.has(output?.template_id)) {
+      fail(`recipe ${recipe.id} has an orphan output template ${output?.template_id}`);
+    }
+    if (!["actor_hand", "location_floor", "installed_at_location"].includes(output?.destination)) {
+      fail(`recipe ${recipe.id} has impossible destination ${output?.destination}`);
+    }
+    if (output?.fallback_destination !== "location_floor") {
+      fail(`recipe ${recipe.id} is missing a location_floor fallback`);
+    }
+    if (!["portable", "installed_fixture"].includes(output?.effect)
+        || !["per_receipt", "per_location", "per_world"].includes(output?.uniqueness)
+        || (output?.destination === "installed_at_location"
+          && output?.effect !== "installed_fixture")) {
+      fail(`recipe ${recipe.id} has an invalid typed output effect`);
+    }
+    continue;
+  }
+  if (recipe.schema_version !== undefined && recipe.schema_version !== 1) {
+    fail(`recipe ${recipe.id} has unsupported schema_version ${recipe.schema_version}`);
+  }
   if (!Array.isArray(recipe.input_item_ids) || recipe.input_item_ids.length !== 2 || recipe.input_item_ids[0] === recipe.input_item_ids[1]) {
     fail(`recipe ${recipe.id} must declare exactly two distinct input_item_ids`);
   }
@@ -2419,10 +2565,19 @@ function buildWorldpackReport() {
     recipes: recipes.map((recipe) => ({
       id: recipe.id,
       key: recipe.key,
+      schema_version: recipe.schema_version ?? 1,
       input_item_ids: recipe.input_item_ids,
       input_item_names: (recipe.input_item_ids ?? []).map((itemId) => itemById.get(itemId)?.name ?? null),
+      input_templates: (recipe.inputs ?? []).map((input) => ({
+        template_id: input.template_id,
+        zones: input.zones,
+        disposition: input.disposition,
+      })),
       output_item_id: recipe.output?.item_id ?? null,
       output_item_name: recipe.output?.name ?? null,
+      output_template_id: recipe.output?.template_id ?? null,
+      output_destination: recipe.output?.destination ?? recipe.output?.target_kind ?? null,
+      requirements: recipe.requires ?? null,
       balance: recipe.balance ? `${recipe.balance.kind}:${recipe.balance.target_kind}:${recipe.balance.target_id}` : null,
     })),
     evolution_tracks: evolutionTracks.map((track) => ({

--- a/v2/scripts/recipe-schema.mjs
+++ b/v2/scripts/recipe-schema.mjs
@@ -1,0 +1,142 @@
+const inputZones = new Set(["carried", "world"]);
+const inputDispositions = new Set(["persistent", "consume", "exhaust", "transform"]);
+const naturalFeatures = new Set([
+  "fish_rich_water",
+  "ore_seam",
+  "clay_bank",
+  "ancient_woodland",
+  "fast_river",
+  "reliable_upland_wind",
+  "hot_spring",
+  "rich_soil",
+  "rare_herb_habitat",
+  "old_ruins",
+]);
+const locationFeatures = new Set(["generated_place_anchor_site"]);
+const outputDestinations = new Set([
+  "actor_hand",
+  "location_floor",
+  "installed_at_location",
+]);
+const outputEffects = new Set(["portable", "installed_fixture"]);
+const outputUniqueness = new Set(["per_receipt", "per_location", "per_world"]);
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function object(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function uniqueStrings(value, allowed) {
+  return Array.isArray(value)
+    && value.every((entry) => nonEmpty(entry) && (!allowed || allowed.has(entry)))
+    && new Set(value).size === value.length;
+}
+
+export function versionedRecipeValidationErrors(
+  recipe,
+  {
+    templateIds = new Set(),
+    buildingArchetypes = [],
+  } = {},
+  label = `recipe ${String(recipe?.id ?? "unknown")}`,
+) {
+  const errors = [];
+  if (!object(recipe) || recipe.schema_version !== 2) {
+    return [`${label} schema_version must be 2`];
+  }
+  if (!Array.isArray(recipe.inputs) || recipe.inputs.length < 1 || recipe.inputs.length > 2) {
+    errors.push(`${label} must declare one or two physical inputs`);
+  }
+  const seenTemplates = new Set();
+  let physicalInputCount = 0;
+  for (const input of recipe.inputs ?? []) {
+    const inputLabel = `${label} input ${String(input?.template_id ?? "unknown")}`;
+    if (!object(input)
+        || !nonEmpty(input.template_id)
+        || !templateIds.has(input.template_id)
+        || seenTemplates.has(input.template_id)) {
+      errors.push(`${inputLabel} has an orphan or duplicate template`);
+    }
+    seenTemplates.add(input?.template_id);
+    if (!Number.isInteger(input?.quantity)
+        || input.quantity < 1
+        || input.quantity > 2) {
+      errors.push(`${inputLabel} quantity must be 1 or 2`);
+    } else {
+      physicalInputCount += input.quantity;
+    }
+    if (!uniqueStrings(input?.zones, inputZones)) {
+      errors.push(`${inputLabel} has ambiguous zones`);
+    }
+    if (!inputDispositions.has(input?.disposition)) {
+      errors.push(`${inputLabel} has undeclared consumption`);
+    }
+    if (!Number.isInteger(input?.min_charges ?? 0)
+        || (input?.min_charges ?? 0) < 0
+        || (input?.min_charges ?? 0) > 20) {
+      errors.push(`${inputLabel} has invalid charge requirements`);
+    }
+  }
+  if (physicalInputCount < 1 || physicalInputCount > 2) {
+    errors.push(`${label} must resolve to one or two physical items`);
+  }
+
+  const requirements = recipe.requires;
+  const buildingCapabilities = requirements?.building_capabilities ?? [];
+  const recipeTags = requirements?.recipe_tags ?? [];
+  const requiredNaturalFeatures = requirements?.natural_features ?? [];
+  const requiredLocationFeatures = requirements?.location_features ?? [];
+  if (!object(requirements)
+      || !Array.isArray(buildingCapabilities)
+      || !Array.isArray(recipeTags)
+      || !uniqueStrings(requiredNaturalFeatures, naturalFeatures)
+      || requiredNaturalFeatures.length > 1
+      || !uniqueStrings(requiredLocationFeatures, locationFeatures)
+      || requiredLocationFeatures.length > 1
+      || (buildingCapabilities.length === 0
+        && recipeTags.length === 0
+        && requiredNaturalFeatures.length === 0
+        && requiredLocationFeatures.length === 0)) {
+    errors.push(`${label} has no valid physical place eligibility`);
+  }
+  if ((buildingCapabilities.length === 0) !== (recipeTags.length === 0)
+      || (buildingCapabilities.length > 0
+        && !buildingCapabilities.includes("transformation_recipes"))) {
+    errors.push(`${label} has missing capability or recipe tags`);
+  }
+  if (buildingCapabilities.length > 0
+      && !buildingArchetypes.some((archetype) =>
+        buildingCapabilities.every(
+          (capability) => (archetype.capabilities ?? []).includes(capability),
+        )
+        && recipeTags.every((tag) => (archetype.recipe_tags ?? []).includes(tag)))) {
+    errors.push(`${label} has an impossible capability and recipe-tag combination`);
+  }
+
+  const output = recipe.output;
+  if (!object(output) || !templateIds.has(output?.template_id)) {
+    errors.push(`${label} has an orphan output template`);
+  }
+  if (!outputDestinations.has(output?.destination)) {
+    errors.push(`${label} has an impossible destination`);
+  }
+  if (output?.fallback_destination !== "location_floor") {
+    errors.push(`${label} is missing a location_floor fallback`);
+  }
+  if (!outputEffects.has(output?.effect)
+      || !outputUniqueness.has(output?.uniqueness)
+      || (output?.destination === "installed_at_location"
+        && output?.effect !== "installed_fixture")) {
+    errors.push(`${label} has an invalid typed output effect`);
+  }
+  return errors;
+}
+
+export function assertVersionedRecipe(recipe, context, label) {
+  const errors = versionedRecipeValidationErrors(recipe, context, label);
+  if (errors.length > 0) throw new Error(errors.join("; "));
+  return recipe;
+}

--- a/v2/scripts/recipe-schema.test.mjs
+++ b/v2/scripts/recipe-schema.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertVersionedRecipe,
+  versionedRecipeValidationErrors,
+} from "./recipe-schema.mjs";
+
+const context = {
+  templateIds: new Set(["iron_nodule", "iron_bloom"]),
+  buildingArchetypes: [
+    {
+      capabilities: ["transformation_recipes", "metalworking"],
+      recipe_tags: ["smithy", "refinement"],
+    },
+  ],
+};
+
+const valid = {
+  schema_version: 2,
+  id: 3101,
+  inputs: [
+    {
+      template_id: "iron_nodule",
+      quantity: 1,
+      zones: ["carried", "world"],
+      min_charges: 1,
+      disposition: "transform",
+    },
+  ],
+  requires: {
+    building_capabilities: ["transformation_recipes", "metalworking"],
+    recipe_tags: ["smithy", "refinement"],
+  },
+  output: {
+    template_id: "iron_bloom",
+    destination: "actor_hand",
+    fallback_destination: "location_floor",
+    effect: "portable",
+    uniqueness: "per_receipt",
+  },
+};
+
+test("accepts physical capability-bound transformations", () => {
+  assert.equal(assertVersionedRecipe(valid, context), valid);
+  const pair = structuredClone(valid);
+  pair.inputs[0].quantity = 2;
+  assert.equal(assertVersionedRecipe(pair, context), pair);
+});
+
+test("rejects orphan outputs, ambiguous zones, and undeclared consumption", () => {
+  const invalid = structuredClone(valid);
+  invalid.inputs[0].zones = ["carried", "carried"];
+  invalid.inputs[0].disposition = "maybe";
+  invalid.output.template_id = "imaginary";
+  assert.match(
+    versionedRecipeValidationErrors(invalid, context).join("\n"),
+    /ambiguous zones|undeclared consumption|orphan output/,
+  );
+});
+
+test("rejects missing capabilities, impossible destinations, and missing fallbacks", () => {
+  const invalid = structuredClone(valid);
+  invalid.requires.building_capabilities = ["metalworking"];
+  invalid.output.destination = "global_inventory";
+  delete invalid.output.fallback_destination;
+  assert.match(
+    versionedRecipeValidationErrors(invalid, context).join("\n"),
+    /missing capability|impossible destination|missing a location_floor fallback/,
+  );
+});
+
+test("accepts typed generated-place installation without a building", () => {
+  const installation = structuredClone(valid);
+  installation.inputs[0].template_id = "iron_bloom";
+  installation.requires = {
+    location_features: ["generated_place_anchor_site"],
+  };
+  installation.output = {
+    template_id: "iron_bloom",
+    destination: "installed_at_location",
+    fallback_destination: "location_floor",
+    effect: "installed_fixture",
+    uniqueness: "per_location",
+  };
+  assert.equal(assertVersionedRecipe(installation, context), installation);
+});

--- a/v2/worlds/core-only/pack.lock.json
+++ b/v2/worlds/core-only/pack.lock.json
@@ -78,12 +78,12 @@
     },
     {
       "id": "cosyworld.core",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "source": {
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",
@@ -173,7 +173,7 @@
     {
       "pack_id": "cosyworld.core",
       "name": "CosyWorld Core",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -83,12 +83,12 @@
     },
     {
       "id": "cosyworld.core",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "source": {
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:4c3865165cca611003e8827aaa673c1f51cbb155e3fffc6b6b9253dc44dea8f0",
+      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",
@@ -420,7 +420,7 @@
     {
       "pack_id": "cosyworld.core",
       "name": "CosyWorld Core",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {


### PR DESCRIPTION
Closes #104

- Adds versioned, validated physical-input recipes with explicit persist/consume/exhaust/transform transitions.
- Makes output placement, capacity fallback, receipts, provenance, replay, and installed fixtures authoritative.
- Ships Mine ore → Smithy bloom → portable bracket → generated-place anchor, plus Smokehouse preservation.
- Keeps discovery in the existing chat/action flow with one-sentence event text and no new dashboard UI.
- Bumps the app to 0.0.112 and core pack to 1.3.10.

Checks: `npm run check`, `npm run lint`, `npm run v2:rust:build`, `npm run build:js`, production-profile smoke.