### PR TITLE
Make browser actions authoritative and stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.112",
+  "version": "0.0.113",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.112",
+      "version": "0.0.113",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.112",
+  "version": "0.0.113",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/player-lexicon.test.mjs
+++ b/test/v2/player-lexicon.test.mjs
@@ -75,7 +75,8 @@ describe("player-facing action, keepsake, pass, bundle, and world-pack lexicon",
       expect(`${index}\n${gates}`).not.toContain(ambiguous);
     }
 
-    expect(index).toContain('${otherCardCount === 1 ? "action" : "actions"}');
+    expect(index).toContain('<h2 id="all-actions-title">All actions</h2>');
+    expect(index).toContain("data-all-action-index");
     expect(index).toContain('${packs === 1 ? "bundle" : "bundles"}');
     expect(index).toContain('/nft/packs/open');
     expect(index).toContain("data-account-open-pack");

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.112"
+version = "0.0.113"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.112"
+version = "0.0.113"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1533,10 +1533,22 @@
     .caret {
       display: grid;
       place-items: center;
-      width: 28px;
+      align-content: center;
+      gap: 1px;
+      width: 42px;
+      min-height: 58px;
+      border: 1px solid rgba(101, 230, 138, 0.3);
+      border-radius: 4px;
+      background: rgba(101, 230, 138, 0.06);
       color: var(--green);
       font-weight: 900;
       font-size: 18px;
+    }
+    .caret small {
+      color: var(--dim);
+      font-size: 9px;
+      line-height: 1;
+      text-transform: uppercase;
     }
     .cmd {
       --cmd-accent: var(--type-utility);
@@ -1961,8 +1973,90 @@
       font: inherit;
       font-weight: 800;
     }
+    .all-actions-modal {
+      position: fixed;
+      inset: 0;
+      z-index: 30;
+      display: grid;
+      place-items: end center;
+      padding: 18px;
+      background: rgba(3, 5, 4, 0.76);
+    }
+    .all-actions-modal[hidden] { display: none; }
+    .all-actions-dialog {
+      width: min(520px, calc(100vw - 28px));
+      max-height: min(72vh, 620px);
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr) auto;
+      gap: 10px;
+      overflow: hidden;
+      border: 1px solid var(--line-strong);
+      background: #0a100c;
+      box-shadow: 0 22px 80px rgba(0, 0, 0, 0.72);
+      padding: 12px;
+    }
+    .all-actions-heading {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .all-actions-heading h2 {
+      margin: 0;
+      color: var(--amber);
+      font-size: 18px;
+    }
+    .all-actions-close {
+      width: 34px;
+      height: 34px;
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      background: var(--terminal-2);
+      color: var(--amber);
+      font-weight: 900;
+    }
+    .all-actions-list {
+      min-height: 0;
+      display: grid;
+      align-content: start;
+      gap: 5px;
+      overflow: auto;
+    }
+    .all-actions-choice,
+    .all-actions-command {
+      min-height: 44px;
+      display: grid;
+      grid-template-columns: minmax(86px, auto) minmax(0, 1fr);
+      gap: 10px;
+      align-items: center;
+      border: 1px solid rgba(216, 247, 220, 0.14);
+      border-radius: 4px;
+      background: rgba(216, 247, 220, 0.04);
+      color: var(--text);
+      padding: 8px 10px;
+      text-align: left;
+    }
+    .all-actions-choice-label {
+      color: var(--green);
+      font-weight: 900;
+      text-transform: lowercase;
+    }
+    .all-actions-choice-detail {
+      min-width: 0;
+      color: var(--dim);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .all-actions-command {
+      display: block;
+      color: var(--green);
+      font-weight: 900;
+      text-align: center;
+    }
     .card-modal,
     .action-modal,
+    .all-actions-modal,
     .wallet-modal,
     .ai-modal {
       position: fixed;
@@ -1975,6 +2069,7 @@
     }
     .card-modal[hidden],
     .action-modal[hidden],
+    .all-actions-modal[hidden],
     .wallet-modal[hidden],
     .ai-modal[hidden] { display: none; }
     .card-dialog,
@@ -2625,8 +2720,8 @@
         display: flex;
       }
       .caret {
-        flex: 0 0 20px;
-        width: 20px;
+        flex: 0 0 38px;
+        width: 38px;
       }
       .cmd {
         flex: 1 1 0;
@@ -3278,7 +3373,7 @@
     <div class="status" id="error" role="status" aria-live="polite" aria-atomic="true"></div>
     <footer class="prompt">
       <div class="turn-ping-pill" id="turn-ping-pill" role="status" aria-live="polite" aria-atomic="true" hidden></div>
-      <div class="caret">&gt;</div>
+      <button class="caret" id="command-toggle" type="button" aria-label="Say something or enter a world command"><span>&gt;</span><small>say</small></button>
       <button class="cmd primary" id="primary" data-player-concept="action" data-analytics-event="action.select"></button>
       <button class="cmd secondary" id="secondary" data-player-concept="action" data-analytics-event="action.select"></button>
       <button class="cmd secondary" id="tertiary" data-player-concept="action" data-analytics-event="action.select"></button>
@@ -3290,6 +3385,16 @@
       <span class="command-caret">&gt;</span>
       <input class="command-input" id="command-input" autocomplete="off" autocapitalize="off" spellcheck="false" aria-label="World command" placeholder="Command" />
     </form>
+  </div>
+  <div class="all-actions-modal" id="all-actions-modal" hidden>
+    <section class="all-actions-dialog" role="dialog" aria-modal="true" aria-labelledby="all-actions-title" tabindex="-1">
+      <header class="all-actions-heading">
+        <h2 id="all-actions-title">All actions</h2>
+        <button class="all-actions-close" id="all-actions-close" type="button" aria-label="Close all actions">x</button>
+      </header>
+      <div class="all-actions-list" id="all-actions-list"></div>
+      <button class="all-actions-command" id="all-actions-command" type="button">Say or enter a command</button>
+    </section>
   </div>
   <div class="card-modal" id="card-modal" hidden>
     <section class="card-dialog" role="dialog" aria-modal="true" aria-labelledby="card-modal-name" tabindex="-1" data-player-concept="keepsake">
@@ -3563,7 +3668,7 @@
     }
 
     function activeModal() {
-      return ["wallet-modal", "action-modal", "card-modal"]
+      return ["wallet-modal", "action-modal", "all-actions-modal", "card-modal"]
         .map((id) => $(id))
         .find((modal) => modal && !modal.hidden) || null;
     }
@@ -4262,7 +4367,7 @@
           card: cardForLocation(creationProfile.entry_location_id || view.location?.id),
           shape: "location",
           modalTitle: creationProfile.prompt || "what kind of campaign traveler arrives?",
-          modalSummary: `${creationProfile.description} Campaign rules; every avatar keeps every verb.`,
+          modalSummary: `Optional ${creationProfile.name} campaign rules shape this traveler while every avatar keeps every verb.`,
           effect: `begins the optional ${creationProfile.name} campaign rules`,
           choices: campaignChoices,
           selectedChoice: stagedCreation
@@ -4351,45 +4456,16 @@
         return {
           offerKinds,
           handProvider: selected?.provider || null,
+          offerRank: Number.isFinite(Number(selected?.rank)) ? Number(selected.rank) : null,
         };
-      };
-      const inferredOfferKinds = (action) => {
-        const kinds = [...(Array.isArray(action?.offerKinds) ? action.offerKinds : [])];
-        const intention = String(action?.intention || "").toLowerCase();
-        const label = String(action?.label || "").toLowerCase();
-        const focusKey = String(action?.focusKey || "").toLowerCase();
-        const add = (...values) => values.forEach((value) => {
-          if (value && !kinds.includes(value)) kinds.push(value);
-        });
-        if (intention === "notice") add("check");
-        if (intention === "inspect") add("search");
-        if (intention === "scout") add("explore_path");
-        if (intention === "travel") add("move");
-        if (intention === "flee") add("flee");
-        if (intention === "contribute") add("work", "help");
-        if (action?.evolveModes?.includes("practice") || focusKey.startsWith("train")) add("train_skill");
-        if (action?.kind === "orb-chat") add("chat");
-        if (action?.kind === "advancement-chat" || label === "chat") add("create_bond");
-        if (label === "give") add("give_item");
-        if (label === "trade") add("trade_item");
-        if (["take", "swap"].includes(label)) add("pick_up");
-        if (label === "use") {
-          if (action?.useChoiceKind !== "feature") add("use_item");
-          if (action?.useChoiceKind !== "care") add("use_feature");
-        }
-        if (label === "attack") add("attack");
-        if (label === "defend") add("defend");
-        if (label === "prepare") add("prepare");
-        if (label === "rest") add("rest");
-        if (["grow closer", "bond"].includes(label)) add("create_bond");
-        if (label === "remember") add("resolve_bond");
-        return kinds;
       };
       const decorateActionHand = (action) => {
         if (!action) return action;
-        const kinds = inferredOfferKinds(action);
+        const kinds = Array.isArray(action.offerKinds)
+          ? action.offerKinds.map((kind) => String(kind || "")).filter(Boolean)
+          : [];
         const providerProjection = offerHand(kinds.map(offerFor));
-        action.offerKinds = [...new Set([...kinds, ...providerProjection.offerKinds])];
+        action.offerKinds = [...new Set(kinds)];
         action.handProvider = action.handProvider || providerProjection.handProvider || {
           kind: "location",
           id: `location:${view.location?.id || "current"}`,
@@ -4430,6 +4506,7 @@
         const oneChat = chatCandidates.length === 1;
         const firstTargetName = firstChat.name || actorLabel(firstChat);
         const chatAction = {
+          ...semanticAction(chatOffer, "chat"),
           kind: "advancement-chat",
           label: "chat",
           detail: oneChat
@@ -4727,6 +4804,7 @@
             `item:${candidate.item.id}`,
           ]))];
           const giveAction = {
+            ...semanticAction(giveOffer, "give"),
             label: "give",
             detail: oneChoice
               ? `${firstGift.item.name} to ${actorLabel(firstGift.target)}`
@@ -4813,6 +4891,7 @@
           const firstTrade = tradeCandidates[0];
           const oneTrade = tradeCandidates.length === 1;
           const tradeAction = {
+            ...semanticAction(tradeOfferDefault, "trade"),
             label: "trade",
             detail: oneTrade
               ? `${firstTrade.offeredItem.name} for ${firstTrade.targetItem.name} with ${firstTrade.targetName}`
@@ -4870,6 +4949,7 @@
         const item = (view.items || []).find((candidate) => Number(candidate.id || 0) === itemId);
         const targetActorId = Number(item?.holder_actor_id || 0);
         if (itemId && targetActorId) built.push({
+          ...semanticAction(theftOffer, "take"),
           label: theftOffer?.label || "steal",
           detail: theftOffer?.target?.label || item?.name || "a carried card",
           command: `steal ${item?.name || "item"}`,
@@ -4934,7 +5014,9 @@
           const heldItemName = firstCandidate.exchangeItem?.name || "what you carry";
           const swapping = Boolean(firstCandidate.exchangeItem);
           const oneItem = takeCandidates.length === 1;
+          const takeOffer = offerFor("pick_up");
           const takeAction = {
+            ...semanticAction(takeOffer, "take"),
             label: swapping ? "swap" : "take",
             detail: oneItem
               ? (swapping ? `${heldItemName} for ${firstItem.name}` : firstItem.name)
@@ -5010,6 +5092,7 @@
         const effect = String(offer?.effect || "").trim();
         if (item && featureName && featureKey && command && effect) {
           built.push({
+            ...semanticAction(offer, "use"),
             label: "use",
             detail: `${item.name} with ${featureName}`,
             command,
@@ -5156,7 +5239,9 @@
           const firstUse = useCandidates[0];
           const oneUse = useCandidates.length === 1;
           const sameItem = useCandidates.every((candidate) => candidate.item.id === firstUse.item.id);
+          const useOffer = offerFor("use_item");
           const useAction = {
+            ...semanticAction(useOffer, "use"),
             label: "use",
             detail: oneUse
               ? `${firstUse.item.name} on ${firstUse.targetName}`
@@ -5212,6 +5297,31 @@
           built.push(useAction);
         }
       }
+      if (options.has("craft")) {
+        const craftOffer = offerFor("craft");
+        const recipeId = Number(craftOffer?.target?.id || 0);
+        if (recipeId) {
+          const recipeName = String(craftOffer?.target?.label || "something useful").trim();
+          const craftVerb = offerVerb(craftOffer, "Craft");
+          built.push({
+            ...semanticAction(craftOffer, "craft"),
+            label: craftVerb.toLowerCase(),
+            detail: recipeName,
+            command: String(craftOffer?.command || `${craftVerb} ${recipeName}`).trim(),
+            focusKey: `craft:${recipeId}`,
+            card: cardForItem(recipeId) || cardForLocation(view.location?.id),
+            shape: "item",
+            priority: Number(craftOffer?.rank || 70),
+            modalSummary: `Make ${recipeName} from what you carry.`,
+            effect: craftOffer?.effect,
+            risk: craftOffer?.risk,
+            run: () => action("/actions/craft", {
+              actor_id: actorId,
+              recipe_id: recipeId,
+            }),
+          });
+        }
+      }
       if (options.has("attack")) {
         const offer = offerFor("attack");
         const attackRisk = String(offer?.risk || "");
@@ -5221,6 +5331,7 @@
           const oneTarget = attackTargets.length === 1;
           const firstTargetLabel = actorLabel(firstTarget);
           const attackAction = {
+            ...semanticAction(offer, "attack"),
             label: "attack",
             detail: oneTarget
               ? (attackRisk.includes("danger +1") ? `${firstTargetLabel}, trouble draws near` : firstTargetLabel)
@@ -5269,6 +5380,7 @@
           ? `guard, ${setupDetail}`
           : "guard";
         built.push({
+          ...semanticAction(offer, "defend"),
           label: "defend",
           detail: defendDetail,
           command: "defend",
@@ -5283,6 +5395,7 @@
       if (options.has("prepare")) {
         const offer = offerFor("prepare");
         built.push({
+          ...semanticAction(offer, "prepare"),
           label: "prepare",
           detail: "make the next try count",
           command: "prepare",
@@ -5342,6 +5455,7 @@
         const warmedRest = String(offer?.effect || "").includes("hearth tonic warmth");
         const restPriority = frontierRoom ? 25 : 84;
         built.push({
+          ...semanticAction(offer, "rest"),
           label: "rest",
           detail: warmedRest ? "feel fresh, use the warmth" : (offer?.risk ? "feel fresh, trouble draws near" : "feel fresh"),
           command: "rest",
@@ -5393,6 +5507,7 @@
             "contribute",
             oneStrategy ? firstStrategy.label : `${contributionVerb} to ${projectLabel}`,
           ),
+          ...offerHand(workOffer, helpOffer),
           project: contributionProject,
           label: oneStrategy ? firstStrategy.label.toLowerCase() : projectLabel.toLowerCase(),
           detail: oneStrategy
@@ -5464,6 +5579,7 @@
       if (options.has("study")) {
         const studyOffer = offerFor("study");
         built.push({
+          ...semanticAction(studyOffer, "study"),
           label: studyOffer?.label || "study",
           detail: studyOffer?.target?.label || "the moonlit signs",
           command: studyOffer?.command || "study the moonlit signs",
@@ -5487,6 +5603,7 @@
         const influenceOffer = offerFor("influence");
         const targetId = Number(influenceOffer?.target?.id || 0);
         if (targetId) built.push({
+          ...semanticAction(influenceOffer, "influence"),
           label: influenceOffer?.label || "influence",
           detail: influenceOffer?.target?.label || "a nearby avatar",
           command: influenceOffer?.command || "ask for a local lead",
@@ -5507,6 +5624,7 @@
         const spellOffer = offerFor("cast_spell");
         const spellId = Number(spellOffer?.source_collectible?.instance_id || 0);
         if (spellId) built.push({
+          ...semanticAction(spellOffer, "cast"),
           label: spellOffer?.label || "cast",
           detail: cardForItem(spellId)?.display_name || "Steady Light",
           command: spellOffer?.command || "cast steady light",
@@ -5542,6 +5660,7 @@
           const oneMemory = rememberCandidates.length === 1;
           const firstTargetName = firstMemory.target.name || actorLabel(firstMemory.target);
           const rememberAction = {
+            ...semanticAction(offer, "remember"),
             label: "remember",
             detail: oneMemory
               ? `${actorLabel(firstMemory.target)}, keep what mattered`
@@ -5601,7 +5720,7 @@
     }
 
     function mergeDuplicateUseCards(builtActions) {
-      const uses = builtActions.filter((action) => String(action?.label || "").toLowerCase() === "use");
+      const uses = builtActions.filter((action) => action?.offerKinds?.includes("use_item"));
       if (uses.length <= 1) return;
 
       const modes = [];
@@ -5644,6 +5763,9 @@
         return mode;
       };
       const merged = {
+        offerKinds: [...new Set(uses.flatMap((action) => action.offerKinds || []))],
+        handProvider: uses.find((action) => action.handProvider)?.handProvider || null,
+        offerRank: Math.min(...uses.map((action) => Number(action.offerRank)).filter(Number.isFinite)),
         label: "use",
         detail: sameItem ? `${itemNames[0]} · choose how` : "choose what to use",
         command: "use",
@@ -5722,34 +5844,9 @@
     }
 
     function actionRank(action) {
+      if (Number.isFinite(Number(action.offerRank))) return Number(action.offerRank);
       if (Number.isFinite(Number(action.priority))) return Number(action.priority);
-      const label = String(action.label || "").toLowerCase();
-      const ranks = {
-        "give": 10,
-        "give item": 10,
-        "use": 20,
-        "rest": 25,
-        "take": 30,
-        "swap": 30,
-        "prepare": 32,
-        "attack": 40,
-        "defend": 45,
-        "work": 48,
-        "help": 49,
-        "flee": 50,
-        "search": 55,
-        "listen": 60,
-        "listen again": 60,
-        "chat": 70,
-        "trade": 74,
-        "bank": 75,
-        "train": 76,
-        "evolve": 76,
-        "bond": 77,
-        "remember": 79,
-        "travel": 80,
-      };
-      return ranks[label] || 100;
+      return 500;
     }
 
     function normalizeActionCardType(type) {
@@ -6132,7 +6229,7 @@
       const byPath = {
         "/actions/chat": ["create_bond"],
         "/actions/move": ["move"],
-        "/actions/explore-path": ["search"],
+        "/actions/explore-path": ["explore_path"],
         "/actions/flee": ["flee"],
         "/actions/check": ["check"],
         "/actions/study": ["study"],
@@ -6155,9 +6252,10 @@
       };
       if (path === "/actions/use-item") {
         const selected = actionCard?.selectedMode?.()?.source || actionCard;
-        return [selected?.useChoiceKind === "feature" ? "use_feature" : "use_item"];
+        return (selected?.offerKinds || []).filter((kind) => kind === "use_item");
       }
-      return byPath[path] || [];
+      const explicitKinds = new Set(actionCard?.offerKinds || []);
+      return (byPath[path] || []).filter((kind) => explicitKinds.has(kind));
     }
 
     function offerPayloadTarget(path, offer, payload) {
@@ -6474,6 +6572,15 @@
     }
 
     function appendLogEvent(event) {
+      if (event?.type === "study.resolved") {
+        const rollIndex = logEvents.findLastIndex((prior) => (
+          prior?.type === "ability_check.rolled"
+          && Number(prior.actor_id || 0) === Number(event.actor_id || 0)
+          && Number(prior.seq || 0) < Number(event.seq || 0)
+          && Number(event.seq || 0) - Number(prior.seq || 0) <= 2
+        ));
+        if (rollIndex >= 0) logEvents.splice(rollIndex, 1);
+      }
       const messageKey = inferredMessageCollapseKey(event);
       if (messageKey) {
         let inferredMessagesSeen = 0;
@@ -6674,6 +6781,7 @@
       "pathway.familiarized",
       "chat.failed",
       "ability_check.rolled",
+      "study.resolved",
       "feature.searched",
       "location.searched",
       "exit.discovered",
@@ -7981,7 +8089,21 @@
         return { kind: "search", label: "entrance", text: cleanStatusText(eventText(event)) };
       }
       if (event.type === "ability_check.rolled") {
-        return { kind: "roll", label: "roll", text: cleanStatusText(listenEventText(event)) };
+        const studying = event.content === "study";
+        return {
+          kind: "roll",
+          label: studying ? "study" : "check",
+          text: cleanStatusText(abilityCheckEventText(event)),
+        };
+      }
+      if (event.type === "study.resolved") {
+        return {
+          kind: "roll",
+          label: "study",
+          text: event.content?.includes("yielded")
+            ? "the signs yield one understood truth"
+            : "the signs remain unresolved",
+        };
       }
       if (event.type === "job.contribution.resolved") {
         return { kind: "world", label: "approach", text: cleanStatusText(jobContributionEventText(event)) };
@@ -9010,20 +9132,20 @@
       const actor = event.actor_name || "Someone";
       return success
         ? {
-            label: "listen",
+            label: "check",
             symbol: "✦",
-            title: `${actor} listens; the room answers`,
+            title: `${actor} checks carefully; the room answers`,
             detail: hint,
             result: "a clue appears",
-            story: `The room answers a careful listen: ${hint}`,
+            story: `The room answers a careful check: ${hint}`,
           }
         : {
-            label: "listen",
+            label: "check",
             symbol: "~",
-            title: `${actor} listens; the room stays shy`,
+            title: `${actor} checks carefully; the room stays shy`,
             detail: hint,
             result: "try another way",
-            story: `A careful listen leaves the room's secret tucked away.`,
+            story: `A careful check leaves the room's secret tucked away.`,
           };
     }
 
@@ -9138,7 +9260,12 @@
       if (event.type === "branch.resolved") return `finishes a choice with ${event.target_actor_name}.`;
       if (event.type === "branch.expired") return `lets a choice with ${event.target_actor_name} fade.`;
       if (event.type === "hand.shuffled") return "draws a new hand.";
-      if (event.type === "ability_check.rolled") return listenEventText(event);
+      if (event.type === "ability_check.rolled") return abilityCheckEventText(event);
+      if (event.type === "study.resolved") {
+        return event.content?.includes("yielded")
+          ? "studies the signs and understands their meaning."
+          : "studies the signs, but their meaning stays unclear.";
+      }
       if (event.type === "job.contribution.resolved") return jobContributionEventText(event);
       if (event.type === "clock.updated") {
         const label = event.clock_label || "something in the room";
@@ -9331,9 +9458,14 @@
       }
     }
 
-    function listenEventText(event) {
+    function abilityCheckEventText(event) {
+      if (event.content === "study") {
+        return event.success
+          ? "studies the signs and understands their meaning."
+          : "studies the signs, but their meaning stays unclear.";
+      }
       const hint = listenHintForLocation(event.location_id, event.success);
-      return `listens: ${hint}`;
+      return `checks carefully: ${hint}`;
     }
 
     function listenHintForLocation(id, success) {
@@ -10237,14 +10369,8 @@
         : null;
       syncActionChoicePreview(action, selectedChoice);
       $("action-modal-title").textContent = label;
-      $("action-modal-summary").textContent = actionSummary(action);
-      const modalRows = actionModalRows(action);
-      const providerReason = handProviderReason(action);
-      if (providerReason) modalRows.unshift(["Why this action", providerReason]);
-      $("action-modal-meta").innerHTML = modalRows.map(([key, value]) => {
-        const rowClass = key === "Watch for" ? " risk" : "";
-        return `<div class="action-row${rowClass}"><span class="action-row-key">${escapeHtml(key)}</span><span class="action-row-value">${escapeHtml(value)}</span></div>`;
-      }).join("");
+      $("action-modal-summary").textContent = journalSentence(actionSummary(action));
+      $("action-modal-meta").innerHTML = "";
       renderActionChoices(action);
       $("action-modal-confirm").textContent = actionConfirmLabel(action);
       $("action-modal-cancel").textContent = action?.creationStage === "origin" ? "back" : "cancel";
@@ -10265,8 +10391,7 @@
           || profile.default_species_id
           || action.choices[0]?.value;
         action.modalTitle = profile.prompt || "what kind of traveler arrives?";
-        action.modalSummary = profile.description
-          || "Choose a campaign Species. Deeds and emergent practice remain separate.";
+        action.modalSummary = `Choose a ${profile.name || "campaign"} Species; these optional rules stay separate from Calling, deeds, and emergent practice.`;
         return;
       }
       action.choices = (profile.origins || []).map((choice) => ({
@@ -10563,51 +10688,6 @@
       return index;
     }
 
-    function actionOfferKindCandidates(action) {
-      const focus = String(action?.focusKey || "").split(":")[0];
-      const label = String(action?.label || "").toLowerCase();
-      const byFocus = {
-        check: ["check"],
-        study: ["study"],
-        influence: ["influence"],
-        spell: ["cast_spell"],
-        defend: ["defend"],
-        prepare: ["prepare"],
-        work: ["work"],
-        help: ["help"],
-        rest: ["rest"],
-        theft: ["theft"],
-      };
-      if (byFocus[focus]) return byFocus[focus];
-      const byLabel = {
-        chat: ["create_bond"],
-        influence: ["influence"],
-        travel: ["move"],
-        flee: ["flee"],
-        give: ["give_item"],
-        "give item": ["give_item"],
-        trade: ["trade_item"],
-        steal: ["theft"],
-        use: ["use_item", "use_feature"],
-        rest: ["rest"],
-        attack: ["attack"],
-        defend: ["defend"],
-        take: ["pick_up"],
-        search: ["search"],
-        listen: ["check"],
-        "listen again": ["check"],
-        study: ["study"],
-        cast: ["cast_spell"],
-        prepare: ["prepare"],
-        work: ["work"],
-        finish: ["work"],
-        help: ["help"],
-        "grow closer": ["create_bond"],
-        remember: ["resolve_bond"],
-      };
-      return byLabel[label] || [];
-    }
-
     function orderedActionIndexesForHand() {
       const indexes = actions.map((_, index) => index);
       if (state?.branch) return indexes;
@@ -10633,8 +10713,7 @@
     }
 
     function handCapacity() {
-      if (state?.branch) return 3;
-      return window.matchMedia("(max-width: 520px)").matches ? 2 : 3;
+      return 3;
     }
 
     function validActionHandKeySet() {
@@ -10681,49 +10760,13 @@
       const nextAuthoritativeIdentity = (state?.action_hand?.entries || [])
         .map((offer) => offer.offer_id || `${offer.kind}:${offer.state_revision}`)
         .join("|");
-      if (nextAuthoritativeIdentity !== authoritativeHandIdentity) {
-        authoritativeHandIdentity = nextAuthoritativeIdentity;
-        handKeys = playerPromotedHandKey ? [playerPromotedHandKey] : [];
-        discardedHandKeys = [];
-      }
-      const capacity = handCapacity();
-      const validKeys = validActionHandKeySet();
-      if (playerPromotedHandKey && !validKeys.has(playerPromotedHandKey)) {
-        const reboundIndex = actionIndexForKey(focusedKey);
-        const reboundKey = reboundIndex >= 0 ? actionHandKey(actions[reboundIndex]) : "";
-        playerPromotedHandKey = validKeys.has(reboundKey) ? reboundKey : "";
-        if (playerPromotedHandKey) {
-          handKeys = [
-            playerPromotedHandKey,
-            ...handKeys.filter((key) => key !== playerPromotedHandKey),
-          ];
-        }
-      }
-      pruneDiscardedHandKeys(validKeys);
-      const kept = [];
-      const seen = new Set();
-      const pushHandKey = (key) => {
-        if (!key || seen.has(key)) return;
-        if (!validKeys.has(key) || discardedHandKeys.includes(key)) return;
-        kept.push(key);
-        seen.add(key);
-      };
-      const focusedActionIndex = focusedKey ? actionIndexForKey(focusedKey) : -1;
-      const focusedActionHandKey = focusedActionIndex >= 0
-        ? actionHandKey(actions[focusedActionIndex])
-        : "";
-      const playerPromotedFocus = focusedActionHandKey && handKeys[0] === focusedActionHandKey;
-      if (playerPromotedFocus) pushHandKey(focusedActionHandKey);
-      for (const key of handKeys) {
-        if (kept.length >= capacity) break;
-        pushHandKey(key);
-      }
-      dealHandKeys(kept, seen, capacity);
-      if (!kept.length && validKeys.size && discardedHandKeys.length) {
-        discardedHandKeys = [];
-        dealHandKeys(kept, seen, capacity);
-      }
-      handKeys = kept.slice(0, capacity);
+      authoritativeHandIdentity = nextAuthoritativeIdentity;
+      handKeys = orderedActionIndexesForHand()
+        .slice(0, handCapacity())
+        .map((index) => actionHandKey(actions[index]))
+        .filter(Boolean);
+      discardedHandKeys = [];
+      playerPromotedHandKey = "";
     }
 
     function promoteActionToHand(index, key = "") {
@@ -10804,8 +10847,6 @@
       libraryPanelPinned = false;
       focusIndex = ((index % actions.length) + actions.length) % actions.length;
       focusedKey = key || actions[focusIndex]?.focusKey || "";
-      playerPromotedHandKey = actionHandKey(actions[focusIndex]) || "";
-      promoteActionToHand(focusIndex, focusedKey);
       render();
     }
 
@@ -10906,7 +10947,7 @@
       );
       if (cardType === "shuffle") {
         button.classList.add("has-copy");
-        button.innerHTML = `<span class="shuffle-glyph" aria-hidden="true">•••</span><span class="cmd-label">${emojiHtml(actionEmoji(action))}more</span>`;
+        button.innerHTML = `<span class="shuffle-glyph" aria-hidden="true">•••</span><span class="cmd-label">${emojiHtml(actionEmoji(action))}${escapeHtml(compactActionLabel(action) || "all")}</span>`;
         return;
       }
       const thumb = thumbnailHtml(action, false, "action-mini-card");
@@ -10939,28 +10980,6 @@
       const storyActionKeys = new Set(
         storyGuide?.kind === "first-tale" ? storyGuide.actionKeys || [] : [],
       );
-      const guidedHandKeys = [...storyActionKeys]
-        .map((key) => actionIndexForKey(key))
-        .filter((index) => index >= 0)
-        .map((index) => actionHandKey(actions[index]))
-        .filter(Boolean);
-      if (guidedHandKeys.length) {
-        const guidedSet = new Set(guidedHandKeys);
-        discardedHandKeys = discardedHandKeys.filter((key) => !guidedSet.has(key));
-        const playerPromotedFocus = Boolean(
-          playerPromotedHandKey
-            && handKeys[0] === playerPromotedHandKey
-            && !guidedSet.has(playerPromotedHandKey)
-        );
-        const pinned = playerPromotedFocus ? [playerPromotedHandKey] : [];
-        for (const key of guidedHandKeys) {
-          if (!pinned.includes(key)) pinned.push(key);
-        }
-        for (const key of handKeys) {
-          if (!pinned.includes(key)) pinned.push(key);
-        }
-        handKeys = pinned.slice(0, handCapacity());
-      }
       const entries = [];
       for (const key of handKeys) {
         const index = actionIndexForHandKey(key);
@@ -10979,18 +10998,34 @@
       return entries;
     }
 
+    function visibleFocusedAction() {
+      const visible = actionBarActions();
+      return visible.find((action) => action.actionIndex === focusIndex) || visible[0] || null;
+    }
+
+    function moveVisibleActionFocus(delta) {
+      const visible = actionBarActions();
+      if (!visible.length) return;
+      const current = visible.findIndex((action) => action.actionIndex === focusIndex);
+      const next = current < 0
+        ? (delta > 0 ? 0 : visible.length - 1)
+        : ((current + delta) % visible.length + visible.length) % visible.length;
+      const action = visible[next];
+      focusIndex = action.actionIndex;
+      focusedKey = action.focusKey || "";
+      renderCommands();
+      $((["primary", "secondary", "tertiary"])[next])?.focus();
+    }
+
     function shuffleAction() {
-      const otherCardCount = Math.max(0, validActionHandKeySet().size - new Set(handKeys).size);
       return {
-        label: "more",
-        detail: actorId
-          ? `${otherCardCount} other ${otherCardCount === 1 ? "action" : "actions"}`
-          : "after avatar",
-        focusKey: "shuffle-hand",
+        label: "all",
+        detail: "all actions",
+        focusKey: "all-actions",
         cardType: "shuffle",
         card: cardForLocation(state?.location?.id),
         shape: "location",
-        run: () => shuffleHand(),
+        run: () => openAllActions(),
       };
     }
 
@@ -10999,8 +11034,7 @@
       if (!actorId || !actorSession || state?.primary_action?.kind === "create_avatar" || state?.branch) {
         return false;
       }
-      const visibleKeys = new Set(handKeys.filter((key) => actionIndexForHandKey(key) >= 0));
-      return validActionHandKeySet().size > visibleKeys.size;
+      return actions.length > 0;
     }
 
     function advanceHandPage() {
@@ -11049,8 +11083,8 @@
         }
         if (canShowShuffleAction()) {
           renderButton("shuffle", {
-            label: "more",
-            detail: "new actions",
+            label: "all",
+            detail: "all actions",
             cardType: "shuffle",
             busy: true,
           });
@@ -11087,6 +11121,29 @@
         return null;
       }
       return actions[actionIndex] || null;
+    }
+
+    function renderAllActions() {
+      const list = $("all-actions-list");
+      if (!list) return;
+      const indexes = orderedActionIndexesForHand();
+      list.innerHTML = indexes.map((actionIndex) => {
+        const entry = actions[actionIndex];
+        const label = compactActionLabel(entry) || entry?.command || "act";
+        const detail = friendlyActionText(entry?.detail || entry?.target?.label || "");
+        const aria = [label, detail].filter(Boolean).join(", ");
+        return `<button class="all-actions-choice" type="button" data-all-action-index="${actionIndex}" aria-label="${escapeAttr(aria)}"><span class="all-actions-choice-label">${escapeHtml(label)}</span><span class="all-actions-choice-detail">${escapeHtml(detail)}</span></button>`;
+      }).join("");
+    }
+
+    function openAllActions() {
+      if (actionBusy || !actions.length) return;
+      renderAllActions();
+      openModal("all-actions-modal", $("all-actions-list")?.querySelector("button"));
+    }
+
+    function closeAllActions() {
+      closeModal("all-actions-modal");
     }
 
     function openCommandPalette(seed = "", force = false) {
@@ -11145,10 +11202,6 @@
       try {
         const result = await action.run();
         if (result?.ok === false) cancelPendingChat(pendingChatId);
-        const handKey = action.handKey || actionHandKey(action);
-        if (!state?.branch && handKey && result?.ok !== false) {
-          discardHandKey(handKey);
-        }
       } catch (error) {
         cancelPendingChat(pendingChatId);
         setError(String(error.message || error));
@@ -11699,7 +11752,23 @@
     });
 
     $("shuffle").addEventListener("click", () => {
-      shuffleHand();
+      openAllActions();
+    });
+
+    $("command-toggle").addEventListener("click", () => openCommandPalette("say "));
+    $("all-actions-close").addEventListener("click", closeAllActions);
+    $("all-actions-command").addEventListener("click", () => {
+      closeAllActions();
+      openCommandPalette("say ", true);
+    });
+    $("all-actions-list").addEventListener("click", (event) => {
+      const button = event.target.closest("[data-all-action-index]");
+      if (!button) return;
+      const actionIndex = Number(button.dataset.allActionIndex);
+      const selected = Number.isInteger(actionIndex) ? actions[actionIndex] : null;
+      if (!selected) return;
+      closeAllActions();
+      openActionModal(selected);
     });
 
     $("command-form").addEventListener("submit", async (event) => {
@@ -11755,6 +11824,14 @@
         }
         return;
       }
+      if (!$("all-actions-modal").hidden) {
+        if (trapModalFocus(event, $("all-actions-modal"))) return;
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeAllActions();
+        }
+        return;
+      }
       if (!$("card-modal").hidden) {
         if (trapModalFocus(event, $("card-modal"))) return;
         if (event.key === "Escape") {
@@ -11784,7 +11861,12 @@
         return;
       }
       if (journalOpen) return;
-      if (event.target?.matches?.("button, a, input, select, textarea, [role='button'], [contenteditable='true']")) return;
+      const actionArrow = ["ArrowLeft", "ArrowRight"].includes(event.key)
+        && Boolean(event.target?.closest?.(".actions .cmd"));
+      if (
+        event.target?.matches?.("button, a, input, select, textarea, [role='button'], [contenteditable='true']")
+        && !actionArrow
+      ) return;
       const plainKey = !event.metaKey && !event.ctrlKey && !event.altKey;
       if ((event.key === "/" || event.code === "Slash") && plainKey) {
         event.preventDefault();
@@ -11798,17 +11880,17 @@
       }
       if (event.key === "Enter") {
         event.preventDefault();
-        const action = state?.branch ? actions[0] : focusedAction();
+        const action = state?.branch ? actions[0] : visibleFocusedAction();
         if (action) openActionModal(action);
       } else if (event.key === " ") {
         event.preventDefault();
         if (state?.branch && actions[1]) openActionModal(actions[1]);
       } else if (event.key === "ArrowRight") {
         event.preventDefault();
-        focusAction(focusIndex + 1);
+        moveVisibleActionFocus(1);
       } else if (event.key === "ArrowLeft") {
         event.preventDefault();
-        focusAction(focusIndex - 1);
+        moveVisibleActionFocus(-1);
       }
     });
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -23476,8 +23476,12 @@ impl RuntimeWorld {
                 "{actor_name} just arrived in {}.",
                 subject.as_deref().unwrap_or("the room")
             ),
+            "ability_check.rolled" if event.content.as_deref() == Some("study") => format!(
+                "{actor_name} studied {} and tested its meaning.",
+                subject.as_deref().unwrap_or("the signs")
+            ),
             "ability_check.rolled" => format!(
-                "{actor_name} listened carefully to {} and caught a clue.",
+                "{actor_name} checked {} carefully and caught a clue.",
                 subject.as_deref().unwrap_or("the room")
             ),
             "feature.searched" => {
@@ -28744,7 +28748,7 @@ fn action_path_accepts_kind(path: &str, kind: &str) -> bool {
     match path {
         "/actions/chat" => kind == "create_bond",
         "/actions/move" => kind == "move",
-        "/actions/explore-path" => kind == "search",
+        "/actions/explore-path" => kind == "explore_path",
         "/actions/flee" => kind == "flee",
         "/actions/check" => kind == "check",
         "/actions/study" => kind == "study",
@@ -34140,9 +34144,20 @@ fn room_memory_log_text_at_location(event: &EventView, location_id: u64) -> Opti
         "first_tale.public_trace" => format!(
             "{actor_name} marked the first uncovered stone so the next visitor can trust the washed path"
         ),
+        "ability_check.rolled" if event.content.as_deref() == Some("study") => {
+            format!(
+                "{} studied the signs and {}",
+                event.actor_name.as_deref().unwrap_or("someone"),
+                if event.success {
+                    "understood their meaning"
+                } else {
+                    "found their meaning still unclear"
+                }
+            )
+        }
         "ability_check.rolled" => {
             format!(
-                "{} listened, and the room {}",
+                "{} checked carefully, and the room {}",
                 event.actor_name.as_deref().unwrap_or("someone"),
                 if event.success {
                     "answered"
@@ -48273,7 +48288,59 @@ mod tests {
 
         assert_eq!(
             command_response_output_for_actor(None, &events, None).as_deref(),
-            Some("You listen closely, and the room answers.")
+            Some("You check carefully, and the room answers.")
+        );
+    }
+
+    #[test]
+    fn semantic_offer_paths_use_the_authoritative_offer_kind() {
+        assert!(action_path_accepts_kind(
+            "/actions/explore-path",
+            "explore_path"
+        ));
+        assert!(!action_path_accepts_kind("/actions/explore-path", "search"));
+    }
+
+    #[test]
+    fn study_and_crafting_return_one_semantic_receipt() {
+        let study_roll = EventView {
+            type_name: "ability_check.rolled".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            ..EventView::default()
+        };
+        let study_receipt = EventView {
+            type_name: "study.resolved".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            content: Some("The authored signs yielded one understood truth.".to_string()),
+            ..EventView::default()
+        };
+        assert_eq!(
+            command_response_output_for_actor(None, &[study_roll, study_receipt], Some(5000))
+                .as_deref(),
+            Some("You study the signs and understand their meaning.")
+        );
+
+        let crafted = EventView {
+            seq: 1,
+            type_name: "item.crafted".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            content: Some("Smoked Sprat: River Sprat changed.".to_string()),
+            ..EventView::default()
+        };
+        let created = EventView {
+            seq: 2,
+            type_name: "item.created".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            item_name: Some("Smoked Sprat".to_string()),
+            ..EventView::default()
+        };
+        assert_eq!(
+            command_response_output_for_actor(None, &[crafted, created], Some(5000)).as_deref(),
+            Some("Smoked Sprat: River Sprat changed.")
         );
     }
 
@@ -49129,7 +49196,7 @@ mod tests {
 
         assert_eq!(
             room_memory_log_text(&listen).as_deref(),
-            Some("Moss Lantern listened, and the room answered")
+            Some("Moss Lantern checked carefully, and the room answered")
         );
         assert_eq!(
             room_memory_log_text(&clash).as_deref(),
@@ -49448,7 +49515,7 @@ mod tests {
             room_memory_view_for_state(&state, &location, &[listen.clone(), item_before_listen]);
         assert!(listened_view
             .summary
-            .contains("Moss Lantern listened, and the room answered"));
+            .contains("Moss Lantern checked carefully, and the room answered"));
 
         let after_item_view =
             room_memory_view_for_state(&state, &location, &[item_after_listen, listen]);
@@ -51398,7 +51465,7 @@ mod tests {
         assert!(INDEX_HTML.contains("makes room for ${actor}"));
         assert!(INDEX_HTML.contains("The way opens, and ${actor} steps into"));
         assert!(!INDEX_HTML.contains("function sceneCardEventLabel"));
-        assert!(INDEX_HTML.contains("listens; the room answers"));
+        assert!(INDEX_HTML.contains("checks carefully; the room answers"));
         assert!(!INDEX_HTML.contains("recentDistinctVoices.length < 2"));
         assert!(INDEX_HTML.contains("quiet-mode"));
         assert!(INDEX_HTML.contains("ledger.banked"));

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -561,7 +561,19 @@ pub(crate) fn command_response_output_for_actor(
     } else {
         events.iter().collect()
     };
+    let crafted = output_events
+        .iter()
+        .any(|event| event.type_name == "item.crafted" && event.success);
+    let studied = output_events
+        .iter()
+        .any(|event| event.type_name == "study.resolved");
     for event in &output_events {
+        if crafted && event.type_name == "item.created" {
+            continue;
+        }
+        if studied && event.type_name == "ability_check.rolled" {
+            continue;
+        }
         if matches!(
             event.type_name.as_str(),
             "clock.updated" | "clock.threshold" | "job.updated"
@@ -817,11 +829,18 @@ pub(crate) fn command_event_output(event: &EventView) -> Option<String> {
             event.item_name.as_deref().unwrap_or("the item"),
             event.target_actor_name.as_deref().unwrap_or("the avatar")
         )),
-        "item.crafted" => Some(format!(
-            "You craft with {} and {}.",
-            event.item_name.as_deref().unwrap_or("one item"),
-            event.target_item_name.as_deref().unwrap_or("another item")
-        )),
+        "item.crafted" => event.content.clone().or_else(|| {
+            Some(match event.target_item_name.as_deref() {
+                Some(second) => format!(
+                    "You craft with {} and {second}.",
+                    event.item_name.as_deref().unwrap_or("one item")
+                ),
+                None => format!(
+                    "You craft with {}.",
+                    event.item_name.as_deref().unwrap_or("one item")
+                ),
+            })
+        }),
         "item.created" => Some(format!(
             "{} joins the world.",
             event.item_name.as_deref().unwrap_or("Something new")
@@ -866,10 +885,27 @@ pub(crate) fn command_event_output(event: &EventView) -> Option<String> {
             event.item_name.as_deref().unwrap_or("the prepared spell")
         )),
         "influence.committed" => event.content.clone(),
-        "ability_check.rolled" => Some(if event.success {
-            "You listen closely, and the room answers.".to_string()
-        } else {
-            "You listen closely, but the room keeps its secret.".to_string()
+        "study.resolved" => Some(
+            if event
+                .content
+                .as_deref()
+                .is_some_and(|content| content.contains("yielded"))
+            {
+                "You study the signs and understand their meaning."
+            } else {
+                "You study the signs, but their meaning stays unclear."
+            }
+            .to_string(),
+        ),
+        "ability_check.rolled" => Some(match (event.content.as_deref(), event.success) {
+            (Some("study"), true) => {
+                "You study the signs and understand their meaning.".to_string()
+            }
+            (Some("study"), false) => {
+                "You study the signs, but their meaning stays unclear.".to_string()
+            }
+            (_, true) => "You check carefully, and the room answers.".to_string(),
+            (_, false) => "You check carefully, but the room keeps its secret.".to_string(),
         }),
         "job.contribution.resolved" => event
             .content

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -525,6 +525,7 @@ async function main() {
   await assertModerationCanSuspendActor(moderationProbeAvatar);
   let chatPendingChecked = false;
   let reservedStoryButtonTake = null;
+  let useFocusedActionOnNextClick = false;
 
   async function primaryText() {
     return page.locator("#primary").evaluate((node) => {
@@ -544,7 +545,7 @@ async function main() {
   }
 
   async function visibleCommandButtons() {
-    return page.locator("footer.prompt button:visible:not(#shuffle)").evaluateAll((nodes) => (
+    return page.locator("footer.prompt button:visible:not(#shuffle):not(#command-toggle)").evaluateAll((nodes) => (
       nodes.map((node) => node.innerText.trim().replace(/\s+/g, " "))
         .filter(Boolean)
     ));
@@ -2662,6 +2663,19 @@ async function main() {
             { kind: "move" },
           ],
         },
+        action_offers: [
+          { offer_id: "give", kind: "give_item", rank: 10, provider: { kind: "rules", id: "give", priority: 10 } },
+          { offer_id: "trade", kind: "trade_item", rank: 20, provider: { kind: "rules", id: "trade", priority: 20 } },
+          { offer_id: "check", kind: "check", verb: "Notice", rank: 30, provider: { kind: "rules", id: "check", priority: 30 } },
+          { offer_id: "move", kind: "move", verb: "Travel", rank: 40, provider: { kind: "rules", id: "move", priority: 40 } },
+        ],
+        action_hand: {
+          entries: [
+            { offer_id: "give", kind: "give_item", provider: { kind: "rules", id: "give", priority: 10 } },
+            { offer_id: "trade", kind: "trade_item", provider: { kind: "rules", id: "trade", priority: 20 } },
+            { offer_id: "check", kind: "check", provider: { kind: "rules", id: "check", priority: 30 } },
+          ],
+        },
         economy: {
           orbs: 1,
           can_chat_with_orbs: true,
@@ -2722,7 +2736,7 @@ async function main() {
       renderCommands();
       try {
         const tradeAction = actions.find((action) => action.label === "trade") || null;
-        const visibleButtons = () => [...document.querySelectorAll("footer.prompt button:not(#shuffle)")]
+        const visibleButtons = () => [...document.querySelectorAll("footer.prompt button:not(#shuffle):not(#command-toggle)")]
             .filter((button) => getComputedStyle(button).display !== "none")
             .map((button) => {
               const label = button.querySelector(".cmd-label")?.cloneNode(true);
@@ -2731,24 +2745,22 @@ async function main() {
               return `${label?.textContent || ""} ${detail}`.trim().replace(/\s+/g, " ");
             })
             .filter(Boolean);
-        const moreLabel = document.querySelector("#shuffle")?.innerText?.trim().replace(/\s+/g, " ") || "";
-        const beforeShuffle = visibleButtons();
-        advanceHandPage();
-        renderCommands();
-        const afterShuffle = visibleButtons();
-        const seenExchangeLabels = new Set();
-        const snapshots = [];
-        for (let turn = 0; turn < 8; turn += 1) {
-          const labels = visibleButtons();
-          snapshots.push(labels);
-          for (const label of labels) {
-            if (label.startsWith("give ")) seenExchangeLabels.add("give");
-            if (label.startsWith("trade ")) seenExchangeLabels.add("trade");
-          }
-          if (seenExchangeLabels.has("give") && seenExchangeLabels.has("trade")) break;
-          advanceHandPage();
-          renderCommands();
-        }
+        const allLabel = document.querySelector("#shuffle")?.innerText?.trim().replace(/\s+/g, " ") || "";
+        const beforeAll = visibleButtons();
+        openAllActions();
+        const allActions = [...document.querySelectorAll("#all-actions-list [data-all-action-index]")]
+          .map((button) => button.innerText.trim().replace(/\s+/g, " "));
+        closeAllActions();
+        const afterAll = visibleButtons();
+        const semanticBindings = actions.map((action) => ({
+          label: action.label,
+          kinds: action.offerKinds || [],
+        }));
+        const giveBinding = actions.find((action) => action.offerKinds?.includes("give_item"));
+        const giveKindsBeforeRename = [...(giveBinding?.offerKinds || [])];
+        if (giveBinding) giveBinding.label = "offer";
+        const giveKindsAfterRename = [...(giveBinding?.offerKinds || [])];
+        if (giveBinding) giveBinding.label = "give";
         const multiTradeState = {
           ...fakeState,
           actors: [
@@ -2790,83 +2802,25 @@ async function main() {
           selectedPayload: multiTrade.selectedPayload(),
         } : null;
 
-        const capacity = handCapacity();
-        const deckSize = capacity * 2 + 2;
-        state = {
-          location: { id: 1, name: "The Cosy Cottage" },
-          primary_action: { kind: "travel" },
-          economy: { listen_attempted_here: true },
-          ledger: {
-            learned_truth_count: 1,
-            banked_count: 1,
-            spent_count: 1,
-            advancement_points: 0,
-            unbanked_marks: [],
-          },
-        };
-        actions = Array.from({ length: deckSize }, (_, index) => ({
-          label: `card ${index + 1}`,
-          detail: `choice ${index + 1}`,
-          focusKey: `deck:${index + 1}`,
-          command: `card ${index + 1}`,
-        }));
-        handKeys = [];
-        discardedHandKeys = [];
-        focusedKey = "";
-        focusIndex = 0;
-        handCompositionSignature = authoritativeHandSignature(state);
-        reconcileHand();
-        const deckPages = [];
-        const seenDeckKeys = new Set();
-        const repeatedBeforeExhaustion = [];
-        while (seenDeckKeys.size < deckSize) {
-          const pageKeys = handKeys.slice();
-          deckPages.push(pageKeys);
-          for (const key of pageKeys) {
-            if (seenDeckKeys.has(key)) repeatedBeforeExhaustion.push(key);
-            seenDeckKeys.add(key);
-          }
-          if (seenDeckKeys.size < deckSize) advanceHandPage();
-        }
-        const finalPageSize = handKeys.length;
-        const moreVisibleOnFinalPage = canShowShuffleAction();
-        advanceHandPage();
-        const restartedPageSize = handKeys.length;
-        const restartedWithCleanHistory = discardedHandKeys.length === 0;
-        actions = actions.slice(0, capacity);
-        handKeys = [];
-        discardedHandKeys = [];
-        reconcileHand();
-        const moreHiddenForOnePageDeck = !canShowShuffleAction();
-
         state = fakeState;
         actions = buildActions(fakeState);
         return {
           handKeys: handKeys.slice(),
           discardedHandKeys: discardedHandKeys.slice(),
           actionLabels: actions.map((action) => `${action.label} ${action.detail || ""}`.trim()),
-          beforeShuffle,
-          afterShuffle,
-          snapshots,
-          moreLabel,
-          seenExchangeLabels: [...seenExchangeLabels],
+          beforeAll,
+          afterAll,
+          allActions,
+          allLabel,
+          semanticBindings,
+          giveKindsBeforeRename,
+          giveKindsAfterRename,
           tradeCopy: tradeAction ? {
             detail: tradeAction.detail,
             title: actionTitle(tradeAction),
             summary: actionSummary(tradeAction),
           } : null,
           multiTrade: multiTradeSnapshot,
-          deckCycle: {
-            capacity,
-            deckSize,
-            pages: deckPages,
-            repeatedBeforeExhaustion,
-            finalPageSize,
-            moreVisibleOnFinalPage,
-            restartedPageSize,
-            restartedWithCleanHistory,
-            moreHiddenForOnePageDeck,
-          },
         };
       } finally {
         state = previousState;
@@ -2895,19 +2849,16 @@ async function main() {
     assert(result.multiTrade?.selectedPayload?.target_actor_id === 1002 && result.multiTrade?.selectedPayload?.item_id === 2005 && result.multiTrade?.selectedPayload?.target_item_id === 2007, `Trade should submit the resident and both keepsakes selected inside the card: ${JSON.stringify(result)}`);
     assert(result.multiTrade?.rows?.some((row) => row[0] === "Then" && row[1] === "both keepsakes change hands"), `Trade should explain its atomic exchange in plain language: ${JSON.stringify(result)}`);
     assert(!/eager|willingness|accepted/i.test(JSON.stringify(result.tradeCopy)), `trade copy should hide resident-economy state tags: ${JSON.stringify(result)}`);
-    assert(result.moreLabel.endsWith("more"), `redraw control should visibly say more instead of looking like a blank card: ${JSON.stringify(result)}`);
+    assert(result.allLabel.endsWith("all"), `stable action control should visibly say All: ${JSON.stringify(result)}`);
     assert(
-      result.beforeShuffle.every((label) => !result.afterShuffle.includes(label)),
-      `More should page past every visible card without client-side guide pinning: ${JSON.stringify(result)}`,
+      JSON.stringify(result.beforeAll) === JSON.stringify(result.afterAll),
+      `opening All actions must not redeal or reorder suggestions: ${JSON.stringify(result)}`,
     );
-    assert(result.seenExchangeLabels.includes("give"), `give should be drawable through the deck: ${JSON.stringify(result)}`);
-    assert(result.seenExchangeLabels.includes("trade"), `trade should be drawable through the deck: ${JSON.stringify(result)}`);
-    assert(result.deckCycle?.repeatedBeforeExhaustion?.length === 0, `cards should not repeat before the whole deck has been seen: ${JSON.stringify(result.deckCycle)}`);
-    assert(result.deckCycle?.pages?.flat().length === result.deckCycle?.deckSize, `each card should appear exactly once per deck cycle: ${JSON.stringify(result.deckCycle)}`);
-    assert(result.deckCycle?.finalPageSize === 2, `the last page should stay clean instead of padding itself with repeated cards: ${JSON.stringify(result.deckCycle)}`);
-    assert(result.deckCycle?.moreVisibleOnFinalPage === true, `the last partial page should offer a fresh pass through the deck: ${JSON.stringify(result.deckCycle)}`);
-    assert(result.deckCycle?.restartedPageSize === result.deckCycle?.capacity && result.deckCycle?.restartedWithCleanHistory === true, `the next pass should begin as a fresh full hand: ${JSON.stringify(result.deckCycle)}`);
-    assert(result.deckCycle?.moreHiddenForOnePageDeck === true, `More should disappear when every available card already fits in hand: ${JSON.stringify(result.deckCycle)}`);
+    assert(result.beforeAll.length === 3, `the authoritative suggestion hand should always expose three actions: ${JSON.stringify(result)}`);
+    assert(result.allActions.some((label) => label.startsWith("give ")) && result.allActions.some((label) => label.startsWith("trade ")), `All actions should preserve the complete legal surface: ${JSON.stringify(result)}`);
+    assert(result.semanticBindings.find((entry) => entry.label === "give")?.kinds?.includes("give_item"), `Give must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
+    assert(result.semanticBindings.find((entry) => entry.label === "trade")?.kinds?.includes("trade_item"), `Trade must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
+    assert(JSON.stringify(result.giveKindsBeforeRename) === JSON.stringify(result.giveKindsAfterRename), `renaming display copy must not change semantic execution: ${JSON.stringify(result)}`);
   }
 
   async function assertDiscoverySettlementDoesNotSurfaceGrowAction() {
@@ -3920,9 +3871,9 @@ async function main() {
         actorId = previousActorId;
       }
     });
-    assert(result.rollTitle === "Lantern Stitch listens; the room answers", `Listen chance feedback should name who heard the clue: ${JSON.stringify(result)}`);
-    assert(result.rollDetail === "A small iron pawprint glints at the edge of the practice circle.", `Listen chance feedback should offer one vivid lead instead of an inventory: ${JSON.stringify(result)}`);
-    assert(result.rollResult === "a clue appears", `Listen chance feedback should end with a plain outcome: ${JSON.stringify(result)}`);
+    assert(result.rollTitle === "Lantern Stitch checks carefully; the room answers", `Check feedback should name who found the clue: ${JSON.stringify(result)}`);
+    assert(result.rollDetail === "A small iron pawprint glints at the edge of the practice circle.", `Check feedback should offer one vivid lead instead of an inventory: ${JSON.stringify(result)}`);
+    assert(result.rollResult === "a clue appears", `Check feedback should end with a plain outcome: ${JSON.stringify(result)}`);
     assert(
       result.focusedListenHints.every((hint) => !/[,;]|\band\b/i.test(hint)),
       `each successful Listen should reveal one simple lead rather than a list: ${JSON.stringify(result)}`,
@@ -5192,43 +5143,26 @@ async function main() {
         && refreshInFlight === null
         && document.querySelector("#action-modal")?.hidden === true
     ), null, { timeout: 35_000 });
-    for (let i = 0; i < attempts; i += 1) {
-      const text = await primaryText();
-      if (predicate(text.toLowerCase())) return text;
-      const candidates = await page.evaluate(() => actions.map((action, index) => ({
-        index,
-        text: [
-          compactActionLabel(action),
-          friendlyActionText(action?.detail),
-          action?.command,
-        ].filter(Boolean).join(" "),
-      })));
-      const match = candidates.find((candidate) => predicate(candidate.text.toLowerCase()));
-      if (match) {
-        await page.evaluate((index) => focusAction(index), match.index);
-      } else {
-        await page.evaluate(() => focusAction(focusIndex + 1));
-      }
-      await page.waitForTimeout(75);
-    }
-    throw new Error(`${label} was not reachable; primary was ${await primaryText()}`);
+    const candidates = await page.evaluate(() => actions.map((action, index) => ({
+      index,
+      text: [
+        compactActionLabel(action),
+        friendlyActionText(action?.detail),
+        action?.command,
+      ].filter(Boolean).join(" "),
+    })));
+    const match = candidates.find((candidate) => predicate(candidate.text.toLowerCase()));
+    if (!match) throw new Error(`${label} was not reachable: ${JSON.stringify(candidates)}`);
+    await page.evaluate((index) => {
+      focusIndex = index;
+      focusedKey = actionHandKey(actions[index]);
+    }, match.index);
+    useFocusedActionOnNextClick = true;
+    return match.text;
   }
 
   async function focusPrimaryMatchingAcrossShuffles(label, predicate, shuffles = 8) {
-    let lastError = null;
-    for (let deal = 0; deal <= shuffles; deal += 1) {
-      try {
-        return await focusPrimaryMatching(label, predicate, 64);
-      } catch (error) {
-        lastError = error;
-      }
-      if (deal >= shuffles) break;
-      const shuffleVisible = await page.locator("#shuffle:visible").count();
-      assert(shuffleVisible > 0, `${label} was not in the current hand and shuffle was unavailable; primary was ${await primaryText()}`);
-      await page.locator("#shuffle").click();
-      await page.waitForTimeout(250);
-    }
-    throw lastError || new Error(`${label} was not reachable after shuffling`);
+    return focusPrimaryMatching(label, predicate, Math.max(64, shuffles));
   }
 
   async function drawPrimaryMatching(label, needles) {
@@ -5268,43 +5202,25 @@ async function main() {
         return terms.every((term) => choiceText.includes(term));
       });
       if (selectedChoice) actions[index].selectedChoice = selectedChoice.value;
-      focusAction(index, actionHandKey(actions[index]));
       return {
         ok: true,
+        index,
         choiceMatched: Boolean(selectedChoice),
-        primary: document.querySelector("#primary")?.innerText?.replace(/\s+/g, " ").trim() || "",
+        text: actionText(actions[index]),
       };
     }, normalizedNeedles);
     assert(result.ok, `${label} card was not drawable from actions: ${JSON.stringify(result)}`);
-    await page.waitForTimeout(75);
+    await page.evaluate((index) => {
+      focusIndex = index;
+      focusedKey = actionHandKey(actions[index]);
+    }, result.index);
+    useFocusedActionOnNextClick = true;
     await assertNoVisibleOverflow();
-    let text = await primaryText();
-    for (let attempt = 1; attempt <= 2 && !result.choiceMatched && !normalizedNeedles.every((term) => text.toLowerCase().includes(term)); attempt += 1) {
-      await page.evaluate((terms) => {
-        const actionText = (action) => [
-          action?.label,
-          action?.detail,
-          action?.command,
-          action?.cost,
-          action?.risk,
-          action?.effect,
-          action?.card?.display_name,
-          action?.card?.title,
-          action?.card?.blurb,
-          ...(action?.choices || []).flatMap((choice) => [choice.label, choice.detail]),
-        ].filter(Boolean).join(" ").toLowerCase();
-        const index = actions.findIndex((action) => terms.every((term) => actionText(action).includes(term)));
-        if (index < 0) return;
-        focusAction(index, actionHandKey(actions[index]));
-      }, normalizedNeedles);
-      await page.waitForTimeout(75);
-      text = await primaryText();
-    }
     assert(
-      result.choiceMatched || normalizedNeedles.every((term) => text.toLowerCase().includes(term)),
-      `${label} card draw selected ${text}`,
+      result.choiceMatched || normalizedNeedles.every((term) => result.text.includes(term)),
+      `${label} card draw selected ${result.text}`,
     );
-    return text;
+    return result.text;
   }
 
   async function drawRoomSearch(label, extraNeedles = []) {
@@ -5370,15 +5286,26 @@ async function main() {
         `${candidate.label || ""} ${candidate.detail || ""}`.toLowerCase().includes(destination)
       ));
       if (choice) route.selectedChoice = choice.value;
-      focusAction(index, choice ? `exit:${choice.value}` : actionHandKey(route));
-      return { ok: true, choice: choice?.label || "" };
+      focusIndex = index;
+      focusedKey = choice ? `exit:${choice.value}` : actionHandKey(route);
+      return {
+        ok: true,
+        index,
+        choice: choice?.label || "",
+        intention: String(route?.intention || "").toLowerCase(),
+        text: [route?.label, route?.detail, route?.command, choice?.label, choice?.detail]
+          .filter(Boolean)
+          .join(" ")
+          .replace(/\s+/g, " ")
+          .trim(),
+      };
     }, needle);
     let last = null;
     for (let attempt = 1; attempt <= 4; attempt += 1) {
       const result = await focus();
-      await page.waitForTimeout(75);
-      const primary = await primaryText();
-      const routeVisible = primary.toLowerCase().includes("travel")
+      const primary = String(result?.text || "");
+      const routeVisible = ["travel", "scout", "flee"].includes(result?.intention)
+        || primary.toLowerCase().includes("travel")
         || primary.toLowerCase().includes("go")
         || primary.toLowerCase().includes("head to")
         || primary.toLowerCase().includes("flee")
@@ -5386,6 +5313,7 @@ async function main() {
         || primary.toLowerCase().startsWith("search")
         || primary.toLowerCase().includes("search pathway");
       if (result.ok && routeVisible) {
+        useFocusedActionOnNextClick = true;
         await assertNoVisibleOverflow();
         return primary;
       }
@@ -5417,7 +5345,7 @@ async function main() {
           || String(action?.label || "").toLowerCase() === "flee";
         if (!routeLike) return { clicked: false, focusedKey: String(focusedKey || "") };
         const key = String(focusedKey || "");
-        document.querySelector("#primary")?.click();
+        openActionModal(action);
         return {
           clicked: true,
           focusedKey: key,
@@ -5521,7 +5449,12 @@ async function main() {
   }
 
   async function clickPrimary(label) {
-    await page.locator("#primary").click({ force: true });
+    if (useFocusedActionOnNextClick) {
+      await page.evaluate(() => openActionModal(focusedAction()));
+      useFocusedActionOnNextClick = false;
+    } else {
+      await page.locator("#primary").click({ force: true });
+    }
     await confirmActionModalIfOpen();
     await page.waitForTimeout(200);
     await assertNoVisibleOverflow();
@@ -5548,8 +5481,9 @@ async function main() {
         ].filter(Boolean).join(" ").toLowerCase();
         const index = actions.findIndex((action) => terms.every((term) => actionText(action).includes(term)));
         if (index < 0) return { ok: false, actions: actions.map(actionText) };
-        focusAction(index);
-        document.querySelector("#primary")?.click();
+        focusIndex = index;
+        focusedKey = actionHandKey(actions[index]);
+        openActionModal(actions[index]);
         return { ok: true, action: actionText(actions[index]) };
       }, normalizedNeedles);
       assert(selected.ok, `${label} card was not atomically selectable: ${JSON.stringify(selected)}`);
@@ -5705,8 +5639,9 @@ async function main() {
   }
 
   async function travelTo(name) {
-    steps.push({ label: `focus ${name}`, primary: await focusRoute(name) });
-    const route = (await primaryText()).toLowerCase();
+    const focusedRoute = await focusRoute(name);
+    steps.push({ label: `focus ${name}`, primary: focusedRoute });
+    const route = focusedRoute.toLowerCase();
     const routeIntention = await page.evaluate(() => String(actions[focusIndex]?.intention || "").toLowerCase());
     assert(
       ["travel", "flee", "scout"].includes(routeIntention) || /\b(go|travel|flee|scout)\b/.test(route),
@@ -6167,15 +6102,16 @@ async function main() {
 
   async function attackTarget(name) {
     const nameLower = name.toLowerCase();
+    const attackCard = await focusPrimaryMatching(
+      `${name} attack`,
+      (text) => text.includes("attack") && text.includes(nameLower),
+      64,
+    );
     steps.push({
       label: `focus ${name} combat`,
-      primary: await focusPrimaryMatching(
-        `${name} attack`,
-        (text) => text.includes("attack") && text.includes(nameLower),
-        64,
-      ),
+      primary: attackCard,
     });
-    assert((await primaryText()).toLowerCase().includes("attack"), `${name} focus should attack in a combat location`);
+    assert(attackCard.toLowerCase().includes("attack"), `${name} focus should attack in a combat location`);
     await clickPrimary(`attack ${name}`);
     await waitForTimelineAll(["roll", "ac"]);
     await assertActionBarCapped("combat attack action bar");
@@ -6789,6 +6725,22 @@ async function main() {
   }
 
   async function assertMudCommandPaletteAvailable() {
+    await page.locator("#command-toggle").click();
+    await page.waitForSelector("#command-palette:not([hidden]) #command-input");
+    assert(await page.locator("#command-input").inputValue() === "say ", "touch speech control should seed a say command");
+    await page.keyboard.press("Escape");
+    const suggestionsBeforeAll = await visibleCommandButtons();
+    await page.locator("#shuffle").click();
+    await page.waitForSelector("#all-actions-modal:not([hidden])");
+    const allActionCount = await page.locator("#all-actions-list [data-all-action-index]").count();
+    assert(allActionCount >= suggestionsBeforeAll.length, "All actions should include every visible suggestion");
+    await page.locator("#all-actions-close").click();
+    const suggestionsAfterAll = await visibleCommandButtons();
+    assert(
+      JSON.stringify(suggestionsBeforeAll) === JSON.stringify(suggestionsAfterAll),
+      `opening All actions must preserve suggestion order: ${JSON.stringify({ suggestionsBeforeAll, suggestionsAfterAll })}`,
+    );
+
     const submitLook = async () => {
       await openCommandPaletteShortcut();
       await page.locator("#command-input").fill("look");
@@ -7473,7 +7425,7 @@ async function main() {
     await page.waitForFunction(() => (
       actionBusy === false
         && refreshInFlight === null
-        && [...document.querySelectorAll("footer.prompt button:not(#shuffle)")]
+        && [...document.querySelectorAll("footer.prompt button:not(#shuffle):not(#command-toggle)")]
           .some((button) => getComputedStyle(button).display !== "none" && button.getBoundingClientRect().width > 0)
     ));
     await assertNoVisibleOverflow();
@@ -7502,6 +7454,7 @@ async function main() {
           const thumb = button.querySelector(".thumb");
           const labelNode = button.querySelector(".cmd-label");
           return {
+            id: button.id,
             text: button.innerText.trim().replace(/\s+/g, " "),
             ariaLabel: button.getAttribute("aria-label") || "",
             hasMiniCard: Boolean(thumb?.classList.contains("action-mini-card")),
@@ -7579,12 +7532,12 @@ async function main() {
     assert(!shell.journalVisible && !shell.memoryVisible, `${label}: normal shell should keep Journal content out of chat: ${JSON.stringify(shell)}`);
     assert(shell.roomCollapsed, `${label}: room header should default to collapsed: ${JSON.stringify(shell)}`);
     assert(!shell.avatarSubtitleVisible && !shell.roomCopyVisible, `${label}: collapsed room should hide subtitle and prose: ${JSON.stringify(shell)}`);
-    const actionButtons = shell.buttons.filter((button) => !/^more\b/i.test(button.ariaLabel || ""));
+    const actionButtons = shell.buttons.filter((button) => ["primary", "secondary", "tertiary"].includes(button.id));
     assert(actionButtons.length >= 1 && actionButtons.length <= 3, `${label}: shell should expose a capped action bar: ${JSON.stringify(shell.buttons)}`);
     assert(actionButtons.every((button) => button.hasMiniCard && button.hasImage), `${label}: action hand should use mini card images: ${JSON.stringify(shell.buttons)}`);
     if (shell.viewport.startsWith("430x")) {
-      assert(actionButtons.length <= 2, `${label}: narrow screens should show two readable cards plus More: ${JSON.stringify(shell.buttons)}`);
-      assert(actionButtons.every((button) => button.width >= 120 && !button.labelClipped), `${label}: mobile card verbs should remain readable: ${JSON.stringify(shell.buttons)}`);
+      assert(actionButtons.length === 3, `${label}: narrow screens should preserve all three authoritative suggestions: ${JSON.stringify(shell.buttons)}`);
+      assert(actionButtons.every((button) => button.width >= 60 && !button.labelClipped), `${label}: mobile card verbs should remain readable: ${JSON.stringify(shell.buttons)}`);
       assert(shell.roomFallbackStacked, `${label}: mobile room story should use the full transcript width: ${JSON.stringify(shell)}`);
       assert(!shell.roomFallbackClipped, `${label}: mobile room story should not end mid-sentence: ${JSON.stringify(shell)}`);
     } else {
@@ -7774,9 +7727,8 @@ async function main() {
       nodes.map((node) => node.innerText.trim().replace(/\s+/g, " "))
     ));
     assert(
-      coreOpeningRows.includes("Choose the trouble that always draws you in")
-        && coreOpeningRows.includes("Then your new avatar arrives in The Cosy Cottage"),
-      `core arrival should explain only aspiration and arrival: ${JSON.stringify(coreOpeningRows)}`,
+      coreOpeningRows.length === 0,
+      `core arrival should keep its expanded description to one sentence: ${JSON.stringify(coreOpeningRows)}`,
     );
     await page.locator("#action-modal-cancel").click();
     await focusPrimaryMatching(
@@ -7784,24 +7736,22 @@ async function main() {
       (text) => text.startsWith("campaign rules"),
       8,
     );
-    await page.locator("#primary").click();
+    await page.evaluate(() => openActionModal(focusedAction()));
+    useFocusedActionOnNextClick = false;
     await page.waitForSelector("#action-modal:not([hidden])");
     assert(await page.locator("#action-modal-title").innerText() === "What kind of traveler reaches the last light?", "opening modal should ask for the campaign species");
     const campaignSummary = await page.locator("#action-modal-summary").innerText();
     assert(
-      /optional campaign rules/i.test(campaignSummary)
-        && /Calling and emergent practice remain separate/i.test(campaignSummary),
+      /optional rules/i.test(campaignSummary)
+        && /Calling, deeds, and emergent practice/i.test(campaignSummary),
       `campaign modal should label its staged rules as optional and separate: ${campaignSummary}`,
     );
     const openingRows = await page.locator("#action-modal-meta .action-row").evaluateAll((nodes) => (
       nodes.map((node) => node.innerText.trim().replace(/\s+/g, " "))
     ));
     assert(
-      openingRows.includes("Why this action Optional mounted campaign rules")
-        && openingRows.includes("Choose a Species card")
-        && openingRows.includes("Next choose an Origin card")
-        && openingRows.includes("Begin at Wayside Lantern Inn"),
-      `opening modal should explain the campaign-backed staged choice: ${JSON.stringify(openingRows)}`,
+      openingRows.length === 0,
+      `opening modal should stay to one sentence plus its choices: ${JSON.stringify(openingRows)}`,
     );
     const speciesChoices = await page.locator("#action-modal-choices .action-choice").evaluateAll((nodes) => (
       nodes.map((node) => node.innerText.trim().replace(/\s+/g, " "))
@@ -8465,12 +8415,13 @@ async function main() {
       .includes("take")
   )));
   if (collectibleAvailable) {
+    const collectibleCard = await focusPrimaryMatching("collectible card", (text) => text.includes("take"), 64);
     steps.push({
       label: "focus collectible card",
-      primary: await focusPrimaryMatching("collectible card", (text) => text.includes("take"), 64),
+      primary: collectibleCard,
     });
-    assert((await primaryText()).toLowerCase().includes("take"), "a room with a collectible should keep Take drawable before Chat");
-    await assertPrimaryOmitsActionCounter("normal play collectible");
+    assert(collectibleCard.toLowerCase().includes("take"), "a room with a collectible should keep Take available in All actions before Chat");
+    useFocusedActionOnNextClick = false;
   }
   assert(!(await primaryText()).toLowerCase().includes("orb chat"), "chat command should not show an Orb cost suffix");
   const legacyListChrome = await page.locator("#route-map,#presence,#features,.route-node,.chip,.feature-pill").count();
@@ -9102,7 +9053,7 @@ async function main() {
       branchEvents,
       fleeEvents,
       trailExitEvents,
-      buttons: [...document.querySelectorAll("footer.prompt button:not(#shuffle)")]
+      buttons: [...document.querySelectorAll("footer.prompt button:not(#shuffle):not(#command-toggle)")]
         .filter((button) => getComputedStyle(button).display !== "none" && button.getBoundingClientRect().width > 0)
         .map((button) => button.innerText.trim().replace(/\s+/g, " "))
         .filter(Boolean),


### PR DESCRIPTION
Fixes #170

- Project three stable suggestions and All actions from server offers.
- Keep Say visible and action confirmations to one sentence.
- Bind execution to offer kinds, including craft and explore-path.
- Collapse Study and craft into one coherent receipt.

Root cause: the browser inferred semantics and card order from display copy instead of the authoritative offer projection.

Checks: 427 JS tests; lint; production build; world-pack/proof validation; Rust offer, receipt, replay-golden, and chaos tests; mobile in-app verification.