### PR TITLE
Recognize avatar practices without changing legality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.113",
+  "version": "0.0.114",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.113",
+      "version": "0.0.114",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.113",
+  "version": "0.0.114",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.113"
+version = "0.0.114"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.113"
+version = "0.0.114"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_practice.rs
+++ b/v2/orchestrator-rust/src/actor_practice.rs
@@ -343,4 +343,26 @@ mod tests {
             Some(DeedCategory::Craft)
         );
     }
+
+    #[test]
+    fn practice_projection_is_controller_neutral() {
+        let direct = (1..=5)
+            .map(|seq| deed(seq, DeedCategory::Exploration, &seq.to_string()))
+            .collect::<Vec<_>>();
+        let mut inferred = direct.clone();
+        for deed in &mut inferred {
+            deed.controller_mode = "local_ai".to_string();
+        }
+
+        let direct_state = project_practice(&ActorPracticeState::default(), &refs(&direct));
+        let inferred_state = project_practice(&ActorPracticeState::default(), &refs(&inferred));
+
+        assert_eq!(direct_state, inferred_state);
+        assert_eq!(
+            serde_json::to_value(practice_view(1, &direct_state, &refs(&direct)))
+                .expect("serialize direct-input practice"),
+            serde_json::to_value(practice_view(1, &inferred_state, &refs(&inferred)))
+                .expect("serialize inferred practice")
+        );
+    }
 }

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -8661,13 +8661,18 @@
               || (composedIdentity.class_selection_ready ? "Class ready to choose" : "Class veiled"),
           ].filter(Boolean).join(" · ")
         : "";
+      const practice = avatar?.practice || null;
+      const practiceSummary = practice?.primary
+        ? [practice.epithet, practice.known_for].filter(Boolean).join(" — ")
+        : "still emerging from shared deeds";
       const level = Number(composedIdentity?.level ?? avatar?.stats?.level ?? 1);
       const rows = [
         accountRow("level", composedIdentity && !composedIdentity.class_id
           ? `${level} · classless`
           : String(level)),
-        ...(identityCards ? [accountRow("identity cards", identityCards)] : []),
-        accountRow("purpose", purpose),
+        ...(identityCards ? [accountRow("campaign identity", identityCards)] : []),
+        accountRow("calling", purpose),
+        accountRow("known for", practiceSummary),
         accountRow("journal", growthSummary),
       ];
       const equippedCharms = Array.isArray(state?.deck?.equipped_charms) ? state.deck.equipped_charms : [];
@@ -9827,6 +9832,23 @@
       }[String(actor?.control_mode || "")] || "";
     }
 
+    function actorPracticePanelHtml(actor) {
+      const practice = actor?.practice;
+      if (!practice?.primary) return "";
+      const rows = [
+        economyRowHtml("known for", escapeHtml(
+          [practice.epithet, practice.known_for].filter(Boolean).join(" — ")
+        )),
+      ];
+      for (const [index, evidence] of (practice.evidence || []).slice(0, 2).entries()) {
+        const description = cleanEconomyText(evidence?.description);
+        if (description) {
+          rows.push(economyRowHtml(index === 0 ? "because" : "and", escapeHtml(description)));
+        }
+      }
+      return rows.join("");
+    }
+
     function transferActionForActor(kind, targetActorId) {
       const actorKey = `actor:${Number(targetActorId || 0)}`;
       return (actions || []).find((candidate) => (
@@ -9869,6 +9891,8 @@
     function actorEconomyPanelHtml(actor) {
       if (!actor) return "";
       const rows = [];
+      const practice = actorPracticePanelHtml(actor);
+      if (practice) rows.push(practice);
       const controller = actorControlModeLabel(actor);
       if (controller) rows.push(economyRowHtml("controller", escapeHtml(controller)));
       const economy = actor?.economy || null;

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -20986,6 +20986,22 @@ impl RuntimeWorld {
         )
     }
 
+    fn practice_recognition_for_offer(&self, actor_id: u64, kind: &str) -> Option<String> {
+        let practice = self.actor_practice_view(actor_id)?;
+        let recognized_category = std::iter::once(practice.primary.as_str())
+            .chain(practice.secondary.as_deref())
+            .find(|category| practice_category_matches_offer(category, kind))?;
+        let evidence = practice
+            .evidence
+            .iter()
+            .find(|evidence| evidence.category == recognized_category)?;
+        Some(format!(
+            "Known for {}; recent evidence: {}",
+            practice.known_for,
+            evidence.description.trim_end_matches('.')
+        ))
+    }
+
     fn ranked_action_offers(
         &self,
         actor_id: Option<u64>,
@@ -21233,6 +21249,14 @@ impl RuntimeWorld {
                 claim_key: None,
                 reason: "ranked from an unrevealed journey edge or long route".to_string(),
             });
+        }
+        for offer in &mut offers {
+            let Some(recognition) = self.practice_recognition_for_offer(actor_id, &offer.kind)
+            else {
+                continue;
+            };
+            offer.rank = offer.rank.saturating_sub(5);
+            offer.reason = recognition;
         }
         offers.sort_by_key(|offer| offer.rank);
         offers
@@ -41286,6 +41310,19 @@ fn action_offer_rank(kind: &str) -> u16 {
     }
 }
 
+fn practice_category_matches_offer(category: &str, kind: &str) -> bool {
+    match category {
+        "exploration" => matches!(kind, "explore_path" | "search" | "check" | "move"),
+        "craft" => matches!(kind, "craft" | "use_feature"),
+        "delivery" => matches!(kind, "move" | "give_item" | "trade_item"),
+        "stewardship" => matches!(kind, "prepare" | "work" | "help"),
+        "care" => matches!(kind, "defend" | "use_item" | "rest"),
+        "mediation" => matches!(kind, "influence" | "chat" | "create_bond" | "resolve_bond"),
+        "lore" => matches!(kind, "study" | "search" | "check"),
+        _ => false,
+    }
+}
+
 fn action_offer_intention(kind: &str) -> &str {
     match kind {
         "check" => "notice",
@@ -51407,7 +51444,9 @@ mod tests {
         assert!(!INDEX_HTML.contains("withActor("));
         assert!(INDEX_HTML.contains("setCreationModalStage(campaignAction, \"species\")"));
         assert!(INDEX_HTML.contains("[\"Then\", \"begin classless at level 0\"]"));
-        assert!(INDEX_HTML.contains("accountRow(\"purpose\", purpose)"));
+        assert!(INDEX_HTML.contains("accountRow(\"calling\", purpose)"));
+        assert!(INDEX_HTML.contains("accountRow(\"campaign identity\", identityCards)"));
+        assert!(INDEX_HTML.contains("accountRow(\"known for\", practiceSummary)"));
         assert!(!INDEX_HTML.contains("detail: \"choose calling\""));
         assert!(!INDEX_HTML.contains("modalTitle: \"choose a calling\""));
         assert!(!INDEX_HTML.contains("id=\"ai-key-modal\""));
@@ -51507,6 +51546,9 @@ mod tests {
         assert!(INDEX_HTML.contains("economy.trade_stance"));
         assert!(INDEX_HTML.contains("function actorEconomyPanelHtml"));
         assert!(INDEX_HTML.contains("actor?.economy"));
+        assert!(INDEX_HTML.contains("function actorPracticePanelHtml"));
+        assert!(INDEX_HTML.contains("(practice.evidence || []).slice(0, 2)"));
+        assert!(INDEX_HTML.contains("economyRowHtml(\"known for\""));
         assert!(INDEX_HTML.contains("function actorControlModeLabel"));
         assert!(INDEX_HTML.contains("controller\", escapeHtml(controller)"));
         assert!(INDEX_HTML.contains("return actors.map((actor) =>"));
@@ -60094,6 +60136,78 @@ mod tests {
             serde_json::to_value(&relabeled).expect("serialize relabeled intent"),
             serde_json::to_value(&baseline).expect("serialize baseline intent")
         );
+    }
+
+    #[test]
+    fn practice_recognition_reranks_but_does_not_unlock_opportunities() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Recognized Explorer",
+        );
+        let access = AccessContext::default();
+        let baseline = runtime.state_response(Some(5000), &access);
+        let baseline_kinds = baseline
+            .action_offers
+            .iter()
+            .map(|offer| offer.kind.as_str())
+            .collect::<BTreeSet<_>>();
+        let baseline_notice = baseline
+            .action_offers
+            .iter()
+            .find(|offer| offer.kind == "check")
+            .expect("Notice is already legal before practice recognition");
+
+        for seq in 1..=5 {
+            let claim_key = format!("test:practice:exploration:{seq}");
+            runtime.deeds.insert(
+                claim_key.clone(),
+                DeedRecord {
+                    schema_version: DEED_SCHEMA_VERSION,
+                    id: claim_key.clone(),
+                    actor_id: 5000,
+                    controller_mode: "direct_input".to_string(),
+                    category: DeedCategory::Exploration,
+                    source_action: "srd5.2.1:search".to_string(),
+                    operation: "location.discovered".to_string(),
+                    rules_profile: active_content().manifest.rules_profile.clone(),
+                    contributing_pack_id: active_content().manifest.id.clone(),
+                    source_event_seqs: vec![80_000 + seq],
+                    target_kind: "location".to_string(),
+                    target_id: seq.to_string(),
+                    location_id: Some(seq),
+                    durable_public_trace: true,
+                    claim_key,
+                },
+            );
+        }
+        runtime.rebuild_deed_index();
+
+        let recognized = runtime.state_response(Some(5000), &access);
+        let recognized_kinds = recognized
+            .action_offers
+            .iter()
+            .map(|offer| offer.kind.as_str())
+            .collect::<BTreeSet<_>>();
+        let recognized_notice = recognized
+            .action_offers
+            .iter()
+            .find(|offer| offer.kind == "check")
+            .expect("Notice remains legal after practice recognition");
+
+        assert_eq!(recognized_kinds, baseline_kinds);
+        assert_eq!(
+            recognized_notice.rank,
+            baseline_notice.rank.saturating_sub(5)
+        );
+        assert!(recognized_notice.reason.starts_with("Known for"));
+        let practice = runtime
+            .actor_practice_view(5000)
+            .expect("five public exploration deeds establish practice");
+        assert_eq!(practice.epithet, "Explorer");
+        assert_eq!(practice.evidence.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #153.

- Re-ranks already-legal opportunities from demonstrated practice without unlocking verbs.
- Shows one `known for` line and two supporting deeds in the avatar inspector; keeps Calling, practice, and campaign identity separate in Journal/account detail.
- Keeps the room chat-first and controller-neutral.

Validated with 427 JavaScript tests, 462 Rust tests, lint, production build, version gate, all worldpack compositions, and the strict proof-world check.