### PR TITLE
Keep shared beginnings out of campaign rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.115",
+  "version": "0.0.116",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.115",
+      "version": "0.0.116",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.115",
+  "version": "0.0.116",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.115"
+version = "0.0.116"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.115"
+version = "0.0.116"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -3935,7 +3935,10 @@
     }
 
     async function createAvatar(selection = null) {
-      const profile = (state?.character_creation || [])[0] || null;
+      const profile = selection?.profileId
+        ? (state?.character_creation || [])
+          .find((candidate) => candidate.id === selection.profileId) || null
+        : null;
       const choiceId = selection?.choiceId || profile?.default_choice_id || null;
       const payload = profile
         ? {
@@ -7987,7 +7990,9 @@
     }
 
     function eventIsLowSignalStatus(event) {
-      return event?.type === "world.reset" || event?.type === "advancement.spent";
+      return event?.type === "world.reset"
+        || event?.type === "advancement.spent"
+        || String(event?.type || "").startsWith("community_art.");
     }
 
     function statusUpdateHtml(event) {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -51603,6 +51603,14 @@ mod tests {
         assert!(INDEX_HTML.contains("const storyGuideLabel"));
         assert!(INDEX_HTML.contains("✦ ${escapeHtml(storyGuideLabel)}"));
         assert!(INDEX_HTML.contains("kind: \"avatar-arrival\""));
+        assert!(INDEX_HTML.contains(
+            "const profile = selection?.profileId\n        ? (state?.character_creation || [])"
+        ));
+        assert!(INDEX_HTML
+            .contains(".find((candidate) => candidate.id === selection.profileId) || null"));
+        assert!(INDEX_HTML
+            .contains(": { calling: selection?.calling || authoredCallingChoices[0].statement };"));
+        assert!(INDEX_HTML.contains("String(event?.type || \"\").startsWith(\"community_art.\")"));
         assert!(INDEX_HTML.contains("function pendingAvatarArrivalHtml"));
         assert!(INDEX_HTML.contains("the cottage is making room"));
         assert!(INDEX_HTML.contains("your first little moment is waiting"));


### PR DESCRIPTION
## What changed
- Keep the shared `begin` Calling path independent from optional mounted campaign profiles.
- Preserve explicit campaign creation when the player chooses `campaign rules`.
- Hide `community_art.*` pipeline events from the player Journal.
- Bump the release to 0.0.116.

## Root cause
`createAvatar()` always selected the first mounted character-creation profile, even when the shared `begin` card supplied only a Calling. Players therefore spawned at the campaign entry room, received the campaign identity/class gate, and could not advance the Cottage first-tale handoff.

## Player impact
A normal beginning now arrives at The Cosy Cottage with the chosen Calling and the first tale can progress; optional campaign rules remain opt-in and the chat-first UI no longer exposes art pipeline names.

## Validation
- 463 Rust tests
- 427 JavaScript tests
- C kernel tests
- lint and production JS build
- Rust build
- worldpack, strict proof-world, syntax, and version checks

Refs #165