### PR TITLE
Make campaign avatar creation explicit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.116",
+  "version": "0.0.117",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.116",
+      "version": "0.0.117",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.116",
+  "version": "0.0.117",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.116"
+version = "0.0.117"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.116"
+version = "0.0.117"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -28318,8 +28318,7 @@ async fn create_avatar(
     let selection_requested = payload.character_creation_id.is_some()
         || payload.character_choice_id.is_some()
         || payload.species_id.is_some()
-        || payload.origin_id.is_some()
-        || payload.calling.is_none();
+        || payload.origin_id.is_some();
     let character_selection = if selection_requested {
         let Some(selection) = character_creation_selection(
             payload.character_creation_id.as_deref(),
@@ -55411,6 +55410,42 @@ mod tests {
                 .unwrap_or_else(|| panic!("{type_name} should promise a resident reaction"));
             assert_eq!(reply.speaker_actor_id, RATI_ACTOR_ID, "{type_name}");
         }
+    }
+
+    #[tokio::test]
+    async fn avatar_creation_without_campaign_ids_defaults_to_the_shared_cottage() {
+        let state = test_app_state(RuntimeWorld::seeded(), None);
+        let response = create_avatar(
+            ConnectInfo("127.0.0.1:45109".parse().expect("client address")),
+            State(state.clone()),
+            Json(CreateAvatarRequest {
+                name: Some("Terminal Sprig".to_string()),
+                calling: None,
+                wallet_session: None,
+                character_creation_id: None,
+                character_choice_id: None,
+                species_id: None,
+                origin_id: None,
+            }),
+        )
+        .await
+        .0;
+
+        assert!(response.ok, "{response:?}");
+        let actor = response.actor.expect("shared-world avatar");
+        assert_eq!(actor.location_id, COSY_COTTAGE_LOCATION_ID);
+        let runtime = state.inner.lock().await;
+        assert_eq!(
+            runtime
+                .callings
+                .get(&actor.id)
+                .map(|calling| calling.statement.as_str()),
+            Some(default_calling_statement())
+        );
+        assert!(
+            !runtime.character_identities.contains_key(&actor.id),
+            "optional campaign identity requires explicit campaign ids"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed
- Treat avatar creation as campaign-specific only when campaign selection IDs are present.
- Default name-only and other legacy clients to the shared-world Calling and The Cosy Cottage.
- Add an endpoint regression proving no implicit campaign identity is attached.
- Bump the release to 0.0.117.

## Root cause
The avatar endpoint treated a missing `calling` field as an implicit request for the first mounted campaign profile. The CLI sends only a generated name, so its fresh avatars still spawned at the Wayside Inn after the browser-side fix.

## Player impact
Browser, CLI, and generic API clients now share the same default beginning; optional campaign rules remain available only through an explicit campaign choice.

## Validation
- 464 Rust tests
- 427 JavaScript tests
- C kernel tests
- lint and production JS/Rust builds
- worldpack, strict proof-world, syntax, and version checks

Refs #165