### PR TITLE
Keep system events out of room memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.117",
+  "version": "0.0.118",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.117",
+      "version": "0.0.118",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.117",
+  "version": "0.0.118",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.117"
+version = "0.0.118"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.117"
+version = "0.0.118"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -34496,7 +34496,7 @@ fn room_memory_log_text_at_location(event: &EventView, location_id: u64) -> Opti
                 .unwrap_or("a represented item changed form");
             format!("{actor_name} completed the change: {change}")
         }
-        _ => command_event_output(event).unwrap_or_else(|| event.type_name.replace('.', " ")),
+        _ => command_event_output(event)?,
     };
     room_memory_text(Some(&text))
 }
@@ -49339,6 +49339,40 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].kind, "item");
         assert!(entries[0].text.contains("Dewbright Button"));
+    }
+
+    #[test]
+    fn room_memory_log_entries_exclude_unknown_system_events() {
+        for type_name in [
+            "avatar.refined",
+            "pathway.refined",
+            "community_art.funded",
+            "community_art.ready",
+        ] {
+            let event = EventView {
+                type_name: type_name.to_string(),
+                success: true,
+                actor_name: Some("Moss Lantern".to_string()),
+                location_id: Some(COSY_COTTAGE_LOCATION_ID),
+                ..EventView::default()
+            };
+            assert!(
+                room_memory_entry_for_event(&event).is_none(),
+                "{type_name} must not become player-facing room memory"
+            );
+        }
+
+        assert!(
+            room_memory_entry_for_event(&EventView {
+                type_name: "hand.shuffled".to_string(),
+                success: true,
+                actor_name: Some("Moss Lantern".to_string()),
+                location_id: Some(COSY_COTTAGE_LOCATION_ID),
+                ..EventView::default()
+            })
+            .is_some(),
+            "known story-facing events remain available"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Unknown projection and lifecycle events no longer become raw Journal or room-summary copy. Room memory now admits only authored player-facing event language, with regression coverage for avatar, pathway, and community-art system events while preserving known story events.

Impact: the main chat and Journal stay human-readable during the first-tale handoff.

Root cause: the room-memory fallback converted every unknown event type into display text by replacing dots with spaces.

Version: 0.0.118

Refs #165

Validation: 465 Rust tests; 427 JavaScript tests; Rust and browser production builds; lint, C kernel, worldpack/composition checks, strict proof-world, syntax, and version checks.