### PR TITLE
Keep the riverside handoff causal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.118",
+  "version": "0.0.119",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.118",
+      "version": "0.0.119",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.118",
+  "version": "0.0.119",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/cli/cosy_cli.py
+++ b/v2/cli/cosy_cli.py
@@ -776,7 +776,12 @@ class Game:
             return f"[{seq}] {actor} flees from {location} to {destination}."
         if type_name == "rule.rejected":
             return f"[{seq}] Rule rejected for {actor} (reason {event.get('reason')})."
-        return f"[{seq}] {type_name}: {event}"
+        label = str(type_name or "event").replace(".", " ")
+        content = " ".join(str(event.get("content") or "").split())
+        if content and not content.startswith(("{", "[")):
+            compact = content if len(content) <= 180 else f"{content[:177].rstrip()}..."
+            return f"[{seq}] {label}: {compact}"
+        return f"[{seq}] {label}."
 
     def with_actor_session(self, payload: dict[str, object]) -> dict[str, object]:
         next_payload = dict(payload)
@@ -1131,7 +1136,11 @@ def location_label(location_id: object) -> str:
 
 
 def event_is_hidden_context(event: dict[str, object]) -> bool:
-    return event.get("type") in {"world.bootstrapped", "actor.presence"}
+    return event.get("type") in {
+        "world.bootstrapped",
+        "actor.presence",
+        "action.receipt",
+    }
 
 
 def world_beat_is_renderable(event: dict[str, object]) -> bool:

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.118"
+version = "0.0.119"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -7466,7 +7466,8 @@
 
     function firstTaleCompletionText(view = state) {
       return String(
-        view?.first_tale?.completion_memory
+        view?.first_tale?.next_invitation
+          || view?.first_tale?.completion_memory
           || "you changed the shared world and left the next visitor a clearer way."
       );
     }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -414,7 +414,6 @@ const ZONE_FRONTIER: &str = "frontier";
 const COSY_COTTAGE_LOCATION_ID: u64 = 1;
 const RAIN_SOFT_GARDEN_LOCATION_ID: u64 = 2;
 const FIRST_TALE_JOB_ID: &str = "rain-soft-garden:trustworthy-path";
-#[cfg(test)]
 const FIRST_TALE_PROGRESS_CLOCK_ID: &str = "rain-soft-garden.trustworthy-path";
 const FIRST_TALE_TRACE_SCHEMA_VERSION: u8 = 1;
 #[cfg(test)]
@@ -12100,9 +12099,14 @@ impl RuntimeWorld {
         action: &CwAction,
         events: &[EventView],
     ) -> Vec<EventView> {
+        let shared_question_complete = self
+            .clocks
+            .get(FIRST_TALE_PROGRESS_CLOCK_ID)
+            .is_some_and(|clock| clock.filled >= clock.segments);
         if !action_is_discovery_check(action)
             || self.first_tale_trace_event_seq(action.actor_id).is_some()
             || !self.listen_attempt_claimed_at(action.actor_id, COSY_COTTAGE_LOCATION_ID)
+            || !shared_question_complete
         {
             return Vec::new();
         }
@@ -21962,15 +21966,25 @@ impl RuntimeWorld {
                     id: Some(recipe.id),
                     label: Some(recipe.name.clone()),
                 }),
-            "move" | "flee" => self
-                .exit_views(actor.location_id, access)
-                .into_iter()
-                .find(|exit| exit.accessible && !exit.locked)
-                .map(|exit| ActionTargetView {
-                    kind: "location".to_string(),
-                    id: Some(exit.destination_location_id),
-                    label: Some(exit.destination_location_name),
-                }),
+            "move" | "flee" => {
+                let journey_next_location_id = (kind == "move")
+                    .then(|| {
+                        self.journey_view(actor_id)
+                            .and_then(|journey| journey.next_location_id)
+                    })
+                    .flatten();
+                self.exit_views(actor.location_id, access)
+                    .into_iter()
+                    .filter(|exit| exit.accessible && !exit.locked)
+                    .min_by_key(|exit| {
+                        usize::from(journey_next_location_id != Some(exit.destination_location_id))
+                    })
+                    .map(|exit| ActionTargetView {
+                        kind: "location".to_string(),
+                        id: Some(exit.destination_location_id),
+                        label: Some(exit.destination_location_name),
+                    })
+            }
             "create_bond" => {
                 self.default_bondable_resident(actor_id)
                     .map(|target| ActionTargetView {
@@ -50417,6 +50431,14 @@ mod tests {
             .find(|offer| offer.kind == "move")
             .expect("the revealed adjacent segment has a Travel offer");
         assert_eq!(first_travel_offer.intention, "travel");
+        assert_eq!(
+            first_travel_offer
+                .target
+                .as_ref()
+                .and_then(|target| target.id),
+            Some(first_waypoint_id),
+            "the route handoff points at the newly revealed waypoint"
+        );
         assert!(first_travel_offer
             .accessible_label
             .starts_with("Travel to "));
@@ -51584,6 +51606,7 @@ mod tests {
         assert!(!INDEX_HTML.contains("chapter ${firstThread.stage} of ${firstThread.total}"));
         assert!(INDEX_HTML.contains("const tale = view.first_tale;"));
         assert!(INDEX_HTML.contains("rain-soft-garden.trustworthy-path"));
+        assert!(INDEX_HTML.contains("view?.first_tale?.next_invitation"));
         assert!(INDEX_HTML.contains("view?.first_tale?.completion_memory"));
         assert!(!INDEX_HTML.contains("notice one little clue."));
         assert!(!INDEX_HTML.contains("keep the clue — let it change you."));
@@ -60084,6 +60107,58 @@ mod tests {
                 .apply_first_tale_public_trace_projection(&action, &events)
                 .is_empty(),
             "the per-avatar public trace is idempotent"
+        );
+    }
+
+    #[test]
+    fn generic_garden_check_cannot_skip_the_first_tale_shared_question() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Early Path Listener",
+        );
+        runtime
+            .listen_attempt_claims
+            .insert(listen_attempt_claim_key(5000, COSY_COTTAGE_LOCATION_ID));
+        assert_eq!(
+            runtime.clocks[FIRST_TALE_PROGRESS_CLOCK_ID].filled, 0,
+            "the shared question starts unanswered"
+        );
+
+        let action = CwAction {
+            kind: CW_ACTION_ABILITY_CHECK,
+            actor_id: 5000,
+            ability: LISTEN_ABILITY,
+            dc: LISTEN_DC,
+            ..CwAction::default()
+        };
+        let check = EventView {
+            seq: 91_000,
+            type_name: "ability_check.rolled".to_string(),
+            success: true,
+            actor_id: Some(5000),
+            actor_name: Some("Early Path Listener".to_string()),
+            location_id: Some(RAIN_SOFT_GARDEN_LOCATION_ID),
+            location_name: Some("Rain-Soft Garden".to_string()),
+            total: Some(LISTEN_DC as i16),
+            dc: Some(LISTEN_DC as i16),
+            ..EventView::default()
+        };
+
+        assert!(
+            runtime
+                .apply_first_tale_public_trace_projection(&action, &[check])
+                .is_empty(),
+            "a generic check cannot stand in for a contribution while the path question is active"
+        );
+        assert_eq!(
+            runtime
+                .first_tale_view(5000)
+                .expect("first tale remains active")
+                .phase,
+            "contribute"
         );
     }
 

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -907,7 +907,7 @@ impl RuntimeWorld {
                 "You noticed the washed path, helped uncover the first stones, and left the next visitor a clearer way."
                     .to_string(),
             next_invitation:
-                "The uncovered line continues toward the riverside. What is making the water worth investigating?"
+                "Follow the uncovered line toward the riverside and investigate what makes its water worth returning to."
                     .to_string(),
             public_trace_created: trace_event_seq.is_some(),
             trace_event_seq,


### PR DESCRIPTION
The first tale now completes only through a real path contribution while its shared question is active; generic Garden checks can only leave a late-arrival trace after that shared work is already complete.

The revealed route waypoint becomes the authoritative Travel target, Journal expands to one actionable riverside sentence, and CLI logs hide embedded action receipts and compact unknown events to one line.

Impact: the Cottage → Garden → generated-riverside handoff stays causal and readable instead of skipping work or pointing back at an arbitrary exit.

Version: 0.0.119

Refs #165

Validation: 466 Rust tests; 427 JavaScript tests; C kernel; lint; official/composed worldpacks; strict proof-world; syntax and version checks; Rust and browser production builds; focused CLI log check.