### PR TITLE
Make the riverside discovery durable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.119",
+  "version": "0.0.120",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.119",
+      "version": "0.0.120",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.119",
+  "version": "0.0.120",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/cli/cosy_cli.py
+++ b/v2/cli/cosy_cli.py
@@ -600,7 +600,7 @@ class Game:
             marker = " you" if actor.get("id") == self.actor_id else ""
             print(
                 f"  {actor['id']}: {actor['name']} "
-                f"({actor['kind']}, hp {actor['hp']}, lvl {actor['stats']['level']}){marker}"
+                f"(hp {actor['hp']}, lvl {actor['stats']['level']}){marker}"
             )
 
     def print_items(self, items: list[dict[str, object]]) -> None:
@@ -731,6 +731,31 @@ class Game:
                 f"[{seq}] {event.get('clock_label') or 'A room clock'} advances to "
                 f"{event.get('clock_filled') or 0}/{event.get('clock_segments') or 0}."
             )
+        if type_name == "clock.threshold":
+            turning_point = " ".join(str(event.get("content") or "").split())
+            return f"[{seq}] {turning_point or 'The shared work reaches a turning point.'}"
+        if type_name == "natural_feature.revealed":
+            try:
+                evidence = json.loads(str(event.get("content") or "{}"))
+            except json.JSONDecodeError:
+                evidence = {}
+            feature = evidence.get("feature") if isinstance(evidence, dict) else {}
+            feature = feature if isinstance(feature, dict) else {}
+            resource = str(feature.get("resource_kind") or "natural feature").replace("_", " ")
+            if resource == "fish rich water":
+                resource = "fish-rich water"
+            raw_buildings = feature.get("building_archetypes")
+            buildings = (
+                [str(value).replace("_", " ").title() for value in raw_buildings if value]
+                if isinstance(raw_buildings, list)
+                else []
+            )
+            if len(buildings) > 1:
+                support = f"{', '.join(buildings[:-1])}, and {buildings[-1]}"
+            else:
+                support = buildings[0] if buildings else ""
+            consequence = f"; it can support {support}" if support else ""
+            return f"[{seq}] {actor} reveals {resource}{consequence}."
         if type_name == "tag.applied":
             return f"[{seq}] {location} gains {event.get('tag_label') or 'a condition'}."
         if type_name == "tag.cleared":

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.119"
+version = "0.0.120"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.119"
+version = "0.0.120"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/communal_governance.rs
+++ b/v2/orchestrator-rust/src/communal_governance.rs
@@ -225,7 +225,7 @@ pub(super) fn generated_building_governance_decision_id_for_slot(
     }
 }
 
-fn building_choice_label(archetype_id: &str) -> String {
+pub(super) fn building_choice_label(archetype_id: &str) -> String {
     archetype_id
         .split('_')
         .filter(|part| !part.is_empty())

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -9430,7 +9430,9 @@
         candidate.type === "clock.updated"
         && String(candidate.clock_id || "") === String(trace.clock_id || "")
       ));
-      const threshold = descendants.find((candidate) => candidate.type === "clock.threshold");
+      const threshold = descendants
+        .filter((candidate) => candidate.type === "clock.threshold")
+        .sort((left, right) => Number(right.seq || 0) - Number(left.seq || 0))[0];
       const settled = descendants.some((candidate) => candidate.type === "job.updated");
       const question = (state?.shared_questions || []).find((candidate) => (
         String(candidate.progress_clock_id || "") === String(trace.clock_id || "")

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -51549,6 +51549,11 @@ mod tests {
         assert!(INDEX_HTML.contains("help by ${helpers.join(\", \")}"));
         assert!(INDEX_HTML.contains("function causalJobContributionEvent"));
         assert!(INDEX_HTML.contains("function jobContributionDescendants"));
+        assert!(
+            INDEX_HTML.contains(".filter((candidate) => candidate.type === \"clock.threshold\")")
+        );
+        assert!(INDEX_HTML.contains("Number(right.seq || 0) - Number(left.seq || 0)"));
+        assert!(INDEX_HTML.contains("function naturalFeatureEventText"));
         assert!(INDEX_HTML.contains("function physicalDeliveryEventFor"));
 
         assert!(INDEX_HTML.contains("accountPanelPinned && event.key === \"Escape\""));

--- a/v2/orchestrator-rust/src/natural_affordances.rs
+++ b/v2/orchestrator-rust/src/natural_affordances.rs
@@ -850,6 +850,24 @@ mod tests {
         let room_after = serde_json::to_string(&runtime.room_sheet_view(waypoint_id)).unwrap();
         assert!(room_after.contains("fish_rich_water"));
         assert!(room_after.contains("fishery"));
+        let completed_question = runtime
+            .shared_question_views(waypoint_id, Some(5000))
+            .into_iter()
+            .find(|question| question.id == job_id)
+            .expect("revealed feature remains legible as completed shared knowledge");
+        assert_eq!(
+            completed_question.completion_memory.as_deref(),
+            Some(
+                "Travelers found fish-rich water here; it can support Fishery, Smokehouse, and Boathouse."
+            )
+        );
+        assert_eq!(
+            completed_question.situation,
+            completed_question
+                .completion_memory
+                .clone()
+                .expect("completed investigation has durable one-sentence memory")
+        );
         let restored = RuntimeSnapshot::from_runtime(&runtime)
             .into_runtime()
             .expect("natural projection survives snapshot restore");

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -2130,12 +2130,45 @@ impl RuntimeWorld {
                 } else {
                     progress
                 };
+                let natural_completion_memory = self
+                    .natural_affordances
+                    .values()
+                    .find(|state| state.investigation_job_id == job.id)
+                    .and_then(|state| state.revealed_feature.as_ref())
+                    .map(|feature| {
+                        let buildings = feature
+                            .building_archetypes
+                            .iter()
+                            .map(|building| building_choice_label(building.key()))
+                            .collect::<Vec<_>>();
+                        let supported = match buildings.as_slice() {
+                            [] => String::new(),
+                            [only] => only.clone(),
+                            [left, right] => format!("{left} and {right}"),
+                            _ => format!(
+                                "{}, and {}",
+                                buildings[..buildings.len() - 1].join(", "),
+                                buildings.last().cloned().unwrap_or_default()
+                            ),
+                        };
+                        if supported.is_empty() {
+                            format!("Travelers found {} here.", feature.resource_kind.label())
+                        } else {
+                            format!(
+                                "Travelers found {} here; it can support {}.",
+                                feature.resource_kind.label(),
+                                supported
+                            )
+                        }
+                    });
                 let completion_memory = terminal.then(|| {
-                    settled_clock
-                        .completion
-                        .as_ref()
-                        .map(|memory| memory.text.clone())
-                        .unwrap_or_else(|| settled_clock.presentation.completion_memory.clone())
+                    natural_completion_memory.unwrap_or_else(|| {
+                        settled_clock
+                            .completion
+                            .as_ref()
+                            .map(|memory| memory.text.clone())
+                            .unwrap_or_else(|| settled_clock.presentation.completion_memory.clone())
+                    })
                 });
 
                 let reached_situation = job


### PR DESCRIPTION
## What
- keep the latest crossed investigation threshold in the Journal receipt
- preserve the revealed feature and its supported buildings as one completed Journal sentence
- name fish-rich water and Fishery in the CLI without controller-kind badges

## Verification
- 427 JS tests
- 466 Rust tests
- C kernel, worldpacks/proof, lint, syntax, version check
- browser and Rust builds
- production 0.0.119 playthrough reached and completed the generated riverside investigation

Refs #165