### PR TITLE
Keep the Journal to one next question

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.120",
+      "version": "0.0.121",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.120"
+version = "0.0.121"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.120"
+version = "0.0.121"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/generated_places.rs
+++ b/v2/orchestrator-rust/src/generated_places.rs
@@ -332,7 +332,7 @@ impl RuntimeWorld {
                 consequence: "The place remains unanchored.".to_string(),
                 memory_summary: "A lasting fixture anchored the place.".to_string(),
                 action_copy: JobActionCopy {
-                    label: "Place a fixture".to_string(),
+                    label: "the anchor fixture".to_string(),
                     summary: "Make one durable, inspectable change.".to_string(),
                 },
                 contribution_schema_version: JOB_CONTRIBUTION_SCHEMA_VERSION,
@@ -398,7 +398,7 @@ impl RuntimeWorld {
                 consequence: "No building choice opens yet.".to_string(),
                 memory_summary: "Distinct travelers made a building choice possible.".to_string(),
                 action_copy: JobActionCopy {
-                    label: "Help the place settle".to_string(),
+                    label: "the place toward settlement".to_string(),
                     summary: "Contribute once in a way another traveler can witness.".to_string(),
                 },
                 contribution_schema_version: JOB_CONTRIBUTION_SCHEMA_VERSION,

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -684,7 +684,7 @@ enum EffectDescriptor {
 
 const JOB_CONTRIBUTION_SCHEMA_VERSION: u8 = 1;
 const CLOCK_PRESENTATION_SCHEMA_VERSION: u8 = 1;
-const MAX_PROMOTED_SHARED_QUESTIONS: usize = 3;
+const MAX_PROMOTED_SHARED_QUESTIONS: usize = 1;
 const MAX_RECENT_CLOCK_CONTRIBUTIONS: usize = 3;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -60323,7 +60323,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_question_promotion_is_bounded_by_story_salience_not_map_order() {
+    fn shared_question_promotion_keeps_one_story_salient_question() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
             &mut runtime,
@@ -60390,24 +60390,20 @@ mod tests {
                 .iter()
                 .map(|question| question.id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["z-high-local", "y-high-immediate", "w-high-communal"]
-        );
-        assert_eq!(
-            promoted
-                .iter()
-                .filter(|question| question.attention == "immediate")
-                .count(),
-            1
-        );
-        assert_eq!(
-            promoted
-                .iter()
-                .filter(|question| question.attention == "communal")
-                .count(),
-            1
+            vec!["z-high-local"]
         );
         assert!(questions.iter().any(|question| {
             question.id == "a-map-first"
+                && !question.promoted
+                && question.presentation_state == "quiet"
+        }));
+        assert!(questions.iter().any(|question| {
+            question.id == "y-high-immediate"
+                && !question.promoted
+                && question.presentation_state == "quiet"
+        }));
+        assert!(questions.iter().any(|question| {
+            question.id == "w-high-communal"
                 && !question.promoted
                 && question.presentation_state == "quiet"
         }));

--- a/v2/orchestrator-rust/src/natural_affordances.rs
+++ b/v2/orchestrator-rust/src/natural_affordances.rs
@@ -754,6 +754,42 @@ mod tests {
         );
         runtime.actors.get_mut(&5000).unwrap().title = "River Reader".to_string();
 
+        let open_questions = runtime.shared_question_views(waypoint_id, Some(5000));
+        assert_eq!(
+            open_questions
+                .iter()
+                .filter(|question| question.promoted)
+                .map(|question| question.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![job_id.as_str()],
+            "the Journal promotes only the most salient concrete question"
+        );
+        let anchor_job_id = generated_place_anchor_job_id(waypoint_id);
+        let connection_job_id = generated_place_connection_job_id(waypoint_id);
+        let settlement_job_id = generated_place_settlement_job_id(waypoint_id);
+        let anchor_question = open_questions
+            .iter()
+            .find(|question| question.id == anchor_job_id)
+            .expect("dangerless anchor work remains visible");
+        assert_eq!(anchor_question.presentation_state, "quiet");
+        assert!(anchor_question.danger_clock_id.is_empty());
+        assert_eq!(anchor_question.danger_segments, 0);
+        assert_eq!(
+            open_questions
+                .iter()
+                .find(|question| question.id == connection_job_id)
+                .map(|question| question.presentation_state.as_str()),
+            Some("quiet")
+        );
+        assert_eq!(
+            open_questions
+                .iter()
+                .find(|question| question.id == settlement_job_id)
+                .map(|question| question.presentation_state.as_str()),
+            Some("unavailable"),
+            "waiting work is not misreported as a completed memory"
+        );
+
         let failed = resolve_investigation_strategy(
             &mut runtime,
             5002,
@@ -867,6 +903,31 @@ mod tests {
                 .completion_memory
                 .clone()
                 .expect("completed investigation has durable one-sentence memory")
+        );
+        add_test_avatar(&mut runtime, 5003, CW_ACTOR_HUMAN, waypoint_id);
+        let revealed_questions = runtime.shared_question_views(waypoint_id, Some(5003));
+        assert_eq!(
+            revealed_questions
+                .iter()
+                .filter(|question| question.promoted)
+                .map(|question| question.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![anchor_job_id.as_str()],
+            "the anchor becomes the one concrete question after discovery"
+        );
+        assert_eq!(
+            revealed_questions
+                .iter()
+                .find(|question| question.id == connection_job_id)
+                .map(|question| question.presentation_state.as_str()),
+            Some("quiet")
+        );
+        assert_eq!(
+            revealed_questions
+                .iter()
+                .find(|question| question.id == settlement_job_id)
+                .map(|question| question.presentation_state.as_str()),
+            Some("unavailable")
         );
         let restored = RuntimeSnapshot::from_runtime(&runtime)
             .into_runtime()

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -2123,13 +2123,16 @@ impl RuntimeWorld {
             .filter(|job| job.location_ids.contains(&location_id))
             .filter_map(|job| {
                 let progress = self.clocks.get(&job.progress_clock_id)?;
-                let danger = self.clocks.get(&job.danger_clock_id)?;
-                let terminal = self.job_status(job) != "active";
-                let settled_clock = if danger.filled >= danger.segments {
-                    danger
+                let danger = if job.danger_clock_id.trim().is_empty() {
+                    None
                 } else {
-                    progress
+                    Some(self.clocks.get(&job.danger_clock_id)?)
                 };
+                let job_status = self.job_status(job);
+                let terminal = matches!(job_status.as_str(), "completed" | "failed");
+                let settled_clock = danger
+                    .filter(|clock| clock.filled >= clock.segments)
+                    .unwrap_or(progress);
                 let natural_completion_memory = self
                     .natural_affordances
                     .values()
@@ -2229,9 +2232,11 @@ impl RuntimeWorld {
                 let mut recent = progress
                     .recent_contributions
                     .iter()
-                    .chain(danger.recent_contributions.iter())
                     .cloned()
                     .collect::<Vec<_>>();
+                if let Some(danger) = danger {
+                    recent.extend(danger.recent_contributions.iter().cloned());
+                }
                 recent.sort_by_key(|entry| std::cmp::Reverse(entry.contribution_event_seq));
                 recent.truncate(MAX_RECENT_CLOCK_CONTRIBUTIONS);
                 let recent_contributions = recent
@@ -2270,7 +2275,7 @@ impl RuntimeWorld {
                     priority: progress.presentation.priority,
                     presentation_state: if terminal {
                         "completed_memory"
-                    } else if available {
+                    } else if job_status == "active" && available {
                         "active"
                     } else {
                         "unavailable"
@@ -2284,14 +2289,16 @@ impl RuntimeWorld {
                     progress_clock_id: progress.id.clone(),
                     filled: progress.filled,
                     segments: progress.segments,
-                    danger_clock_id: danger.id.clone(),
-                    danger_filled: danger.filled,
-                    danger_segments: danger.segments,
+                    danger_clock_id: danger.map(|clock| clock.id.clone()).unwrap_or_default(),
+                    danger_filled: danger.map(|clock| clock.filled).unwrap_or_default(),
+                    danger_segments: danger.map(|clock| clock.segments).unwrap_or_default(),
                     next_revelation,
                     strategies,
                     recent_contributions,
                     completion_memory,
-                    updated_event_seq: progress.updated_event_seq.max(danger.updated_event_seq),
+                    updated_event_seq: danger
+                        .map(|clock| progress.updated_event_seq.max(clock.updated_event_seq))
+                        .unwrap_or(progress.updated_event_seq),
                 })
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
Progresses #165.

- Surface generated-place questions even when they have no danger clock.
- Treat waiting settlement work as unavailable, not completed.
- Promote exactly one concrete Journal question and keep the rest quiet.
- Tighten generated-place action labels.
- Bump the runtime to 0.0.121.

Validated with 427 JS tests, 466 Rust tests, C kernel tests, lint, syntax, version check, browser and Rust builds, all worldpack compositions, and strict proof-world.