### PR TITLE
Keep durable place work out of encounter resets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.121",
+  "version": "0.0.122",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.121",
+      "version": "0.0.122",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.121",
+  "version": "0.0.122",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.121"
+version = "0.0.122"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/generated_places.rs
+++ b/v2/orchestrator-rust/src/generated_places.rs
@@ -373,6 +373,7 @@ impl RuntimeWorld {
                 loot: None,
             });
 
+        self.reconcile_generated_place_durable_progress(state);
         let settlement_strategies = self
             .generated_place_settlement_ready(state)
             .then(|| self.generated_place_settlement_strategies(state));
@@ -453,6 +454,60 @@ impl RuntimeWorld {
         sheet.projects.extend(projects);
         sheet.projects.sort();
         sheet.projects.dedup();
+    }
+
+    fn reconcile_generated_place_durable_progress(&mut self, state: &GeneratedPlaceState) {
+        let anchor_complete = self
+            .clocks
+            .get(&state.anchor_clock_id)
+            .is_some_and(|clock| clock.completion.is_some())
+            || self
+                .tags
+                .get(&generated_place_anchor_fixture_tag_id(state.location_id))
+                .is_some_and(|tag| {
+                    tag.active
+                        && tag.scope == "room"
+                        && tag.scope_id == state.location_id
+                        && tag.kind == "boon"
+                });
+        let connection_complete =
+            self.clocks
+                .get(&state.connection_clock_id)
+                .is_some_and(|clock| {
+                    clock.completion.is_some()
+                        || clock.recent_contributions.iter().any(|contribution| {
+                            contribution.strategy_id
+                                == format!("{}:physical-delivery", state.connection_job_id)
+                        })
+                });
+        let settlement_complete = state.building_proposal.is_some()
+            || self
+                .clocks
+                .get(&state.settlement_clock_id)
+                .is_some_and(|clock| {
+                    clock.completion.is_some()
+                        || clock.recent_contributions.len() >= usize::from(clock.segments)
+                            && clock
+                                .recent_contributions
+                                .iter()
+                                .map(|contribution| contribution.actor_id)
+                                .collect::<BTreeSet<_>>()
+                                .len()
+                                >= 2
+                });
+        for (clock_id, complete) in [
+            (&state.anchor_clock_id, anchor_complete),
+            (&state.connection_clock_id, connection_complete),
+            (&state.settlement_clock_id, settlement_complete),
+        ] {
+            if !complete {
+                continue;
+            }
+            if let Some(clock) = self.clocks.get_mut(clock_id) {
+                clock.filled = clock.segments;
+                clock.status = "filled".to_string();
+            }
+        }
     }
 
     fn generated_place_settlement_strategies(

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -8087,6 +8087,15 @@ impl RuntimeWorld {
             delivery: None,
             loot: None,
         });
+        if revealed {
+            if let Some(clock) = self.clocks.get_mut(&state.investigation_clock_id) {
+                clock.filled = clock.segments;
+                clock.status = "filled".to_string();
+            }
+            if let Some(job) = self.jobs.get_mut(&state.investigation_job_id) {
+                job.status = "completed".to_string();
+            }
+        }
     }
 
     fn record_natural_investigation_contribution(
@@ -19439,6 +19448,12 @@ impl RuntimeWorld {
             .location_ids
             .iter()
             .any(|id| self.location_is_frontier(*id))
+        {
+            return false;
+        }
+        if job.participant_ids.is_empty()
+            || job.danger_clock_id.trim().is_empty()
+            || !self.clocks.contains_key(&job.danger_clock_id)
         {
             return false;
         }
@@ -62430,6 +62445,134 @@ mod tests {
                     .is_some_and(|content| content.contains("completed"))
         }));
         assert_eq!(runtime.orb_balance(5000), before_second_completion + 2);
+    }
+
+    #[test]
+    fn durable_frontier_projects_never_reset_as_encounters_and_repair_from_evidence() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = runtime.generated_pathway(
+            5000,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            MOONLIT_TRAIL_LOCATION_ID,
+            2,
+        );
+        let waypoint_id = pathway.waypoints[0].id;
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        runtime.ensure_generated_pathway_edge(&pathway, RAIN_SOFT_GARDEN_LOCATION_ID, waypoint_id);
+        create_test_human(&mut runtime, 5000, waypoint_id, "Durable Builder");
+
+        let place = runtime.generated_places[&waypoint_id].clone();
+        let natural = runtime.natural_affordances[&waypoint_id].clone();
+        let mut reveal = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: 5000,
+                ..CwAction::default()
+            },
+            718_900,
+        );
+        reveal
+            .projection_mutations
+            .push(ProjectionMutation::AdvanceClock {
+                clock_id: natural.investigation_clock_id.clone(),
+                amount: runtime.clocks[&natural.investigation_clock_id].segments,
+                reason: "durable_frontier_test_reveal".to_string(),
+            });
+        assert_eq!(runtime.apply_journal_record(&reveal).0, CW_OK);
+        let revealed_natural = runtime.natural_affordances[&waypoint_id].clone();
+
+        let anchor_intent = runtime
+            .job_contribution_intent(5000, "work", Some(&place.anchor_job_id), None, None)
+            .expect("anchor work is available");
+        let mut anchor = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: 5000,
+                ..CwAction::default()
+            },
+            718_901,
+        );
+        anchor
+            .projection_mutations
+            .push(ProjectionMutation::ResolveJobContribution {
+                intent: anchor_intent,
+            });
+        assert_eq!(runtime.apply_journal_record(&anchor).0, CW_OK);
+
+        runtime.world.next_event_seq = runtime
+            .world
+            .next_event_seq
+            .saturating_add(ENCOUNTER_RESET_PLAYER_TICKS);
+        let mut later_tick = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_SAY,
+                actor_id: 5000,
+                content_id: 718_902,
+                ..CwAction::default()
+            },
+            718_902,
+        );
+        later_tick.content_upserts.insert(
+            718_902,
+            "The work should still be here when we return.".to_string(),
+        );
+        let (status, later_events) = runtime.apply_journal_record(&later_tick);
+        assert_eq!(status, CW_OK);
+        assert!(!later_events.iter().any(|event| {
+            event.type_name == "encounter.reset"
+                && event.content.as_deref().is_some_and(|content| {
+                    content.starts_with(&natural.investigation_job_id)
+                        || content.starts_with(&place.anchor_job_id)
+                })
+        }));
+        assert_eq!(
+            runtime.clocks[&natural.investigation_clock_id].filled,
+            runtime.clocks[&natural.investigation_clock_id].segments
+        );
+        assert_eq!(
+            runtime.clocks[&place.anchor_clock_id].filled,
+            runtime.clocks[&place.anchor_clock_id].segments
+        );
+
+        for clock_id in [&natural.investigation_clock_id, &place.anchor_clock_id] {
+            let clock = runtime.clocks.get_mut(clock_id).expect("durable clock");
+            clock.filled = 0;
+            clock.status = "active".to_string();
+        }
+        runtime
+            .jobs
+            .get_mut(&natural.investigation_job_id)
+            .expect("natural investigation job")
+            .status = "active".to_string();
+        runtime
+            .jobs
+            .get_mut(&place.anchor_job_id)
+            .expect("anchor job")
+            .status = "active".to_string();
+
+        runtime.ensure_natural_investigation_project(&revealed_natural);
+        runtime.ensure_generated_place_for_waypoint(
+            &pathway,
+            waypoint_id,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+        );
+        assert_eq!(
+            runtime.clocks[&natural.investigation_clock_id].filled,
+            runtime.clocks[&natural.investigation_clock_id].segments
+        );
+        assert_eq!(
+            runtime.job_status(&runtime.jobs[&natural.investigation_job_id]),
+            "completed"
+        );
+        assert_eq!(
+            runtime.clocks[&place.anchor_clock_id].filled,
+            runtime.clocks[&place.anchor_clock_id].segments
+        );
+        assert!(runtime
+            .generated_place_milestones(waypoint_id)
+            .contains(&"Anchor".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Progresses #165.

Live acceptance exposed generic frontier encounter resets erasing durable discovery and place-building progress. This keeps seasonal resets scoped to participant-bearing threats and reconstructs durable natural/anchor/connection/settlement clocks from their surviving evidence.

Release gates: 427 JS tests, 467 Rust tests, C kernel, lint, syntax, version, webpack, Rust build, all worldpacks/compositions, strict proof world.