### PR TITLE
Share legal action candidates with residents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.134",
+  "version": "0.0.135",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.134",
+      "version": "0.0.135",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.134",
+  "version": "0.0.135",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.134"
+version = "0.0.135"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.134"
+version = "0.0.135"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -21404,6 +21404,16 @@ impl RuntimeWorld {
         ))
     }
 
+    fn legal_action_candidates(
+        &self,
+        actor_id: Option<u64>,
+        access: &AccessContext,
+    ) -> (PrimaryAction, Vec<RankedActionOffer>) {
+        let primary_action = self.primary_action(actor_id, access);
+        let action_offers = self.ranked_action_offers(actor_id, access, &primary_action);
+        (primary_action, action_offers)
+    }
+
     fn ranked_action_offers(
         &self,
         actor_id: Option<u64>,
@@ -24773,9 +24783,29 @@ impl RuntimeWorld {
     }
 
     fn preferred_job_contribution_intent(&self, actor_id: u64) -> Option<JobContributionIntent> {
-        ["prepare", "work", "help", "check", "study"]
+        let (_, offers) = self.legal_action_candidates(Some(actor_id), &AccessContext::default());
+        offers
             .into_iter()
-            .find_map(|kind| self.job_contribution_intent(actor_id, kind, None, None, None))
+            .filter(action_offer_is_reachable)
+            .filter(|offer| matches!(offer.kind.as_str(), "prepare" | "work" | "help" | "study"))
+            .find_map(|offer| {
+                let project = offer.project?;
+                let intent = self.job_contribution_intent(
+                    actor_id,
+                    &offer.kind,
+                    Some(&project.id),
+                    project.strategy_id.as_deref(),
+                    None,
+                )?;
+                let target_matches = offer.target.as_ref().is_some_and(|target| {
+                    target.kind == intent.target.kind
+                        && target.id == intent.target.id.parse::<u64>().ok()
+                });
+                (target_matches
+                    && project.progress_clock_id == intent.strategy.clock_id
+                    && project.strategy_id.as_deref() == Some(intent.strategy.id.as_str()))
+                .then_some(intent)
+            })
     }
 
     fn resident_job_autonomy_record(&self, actor: CwActor, seed: u64) -> Option<JournalRecord> {
@@ -29416,8 +29446,7 @@ async fn submit_action_offer(
     );
     let validation = {
         let runtime = state.inner.lock().await;
-        let primary = runtime.primary_action(Some(actor_id), &access);
-        let offers = runtime.ranked_action_offers(Some(actor_id), &access, &primary);
+        let (_, offers) = runtime.legal_action_candidates(Some(actor_id), &access);
         let Some(offer) = offers
             .iter()
             .find(|offer| offer.offer_id == submission.offer_id)
@@ -70000,6 +70029,9 @@ mod tests {
                     .expect("Rati exists")
                     .location_id = MOONLIT_TRAIL_LOCATION_ID;
 
+                let inference_candidates = runtime
+                    .legal_action_candidates(Some(resident_id), &AccessContext::default())
+                    .1;
                 let inference_intent = runtime
                     .preferred_job_contribution_intent(resident_id)
                     .expect("the resident sees an authored local contribution");
@@ -70008,6 +70040,15 @@ mod tests {
                     .entry(resident_id)
                     .or_default()
                     .control_mode = ActorControlMode::DirectInput;
+                let direct_candidates = runtime
+                    .legal_action_candidates(Some(resident_id), &AccessContext::default())
+                    .1;
+                assert_eq!(
+                    serde_json::to_value(&direct_candidates).expect("direct candidates serialize"),
+                    serde_json::to_value(&inference_candidates)
+                        .expect("inference candidates serialize"),
+                    "controller mode cannot change legal candidate enumeration"
+                );
                 let direct_intent = runtime
                     .preferred_job_contribution_intent(resident_id)
                     .expect("the same avatar keeps the contribution under direct input");
@@ -70055,6 +70096,24 @@ mod tests {
                     .expect("pre-contribution snapshot restores");
                 assert_eq!(replayed.apply_journal_record(&record).0, CW_OK);
                 assert_eq!(quest_projection_signature(&replayed), expected);
+
+                let local_clock_ids = runtime
+                    .jobs
+                    .values()
+                    .filter(|job| job.location_ids.contains(&MOONLIT_TRAIL_LOCATION_ID))
+                    .map(|job| job.progress_clock_id.clone())
+                    .collect::<Vec<_>>();
+                for clock_id in local_clock_ids {
+                    if let Some(clock) = runtime.clocks.get_mut(&clock_id) {
+                        clock.filled = clock.segments;
+                    }
+                }
+                assert!(runtime
+                    .preferred_job_contribution_intent(resident_id)
+                    .is_none());
+                assert!(runtime
+                    .resident_job_autonomy_record(resident, 97_002)
+                    .is_none());
             })
             .expect("spawn resident job autonomy test")
             .join()

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -1686,8 +1686,7 @@ impl RuntimeWorld {
         let chat_bond_claimed_target_ids = client_actor_id
             .map(|id| self.chat_bond_claimed_target_ids(id, location_id))
             .unwrap_or_default();
-        let primary_action = self.primary_action(client_actor_id, access);
-        let action_offers = self.ranked_action_offers(client_actor_id, access, &primary_action);
+        let (primary_action, action_offers) = self.legal_action_candidates(client_actor_id, access);
         let action_hand = compose_action_hand(&action_offers);
         let inspector = self.inspector_view(
             location_id,


### PR DESCRIPTION
Progresses #155.

Player state, offer submission, and resident job choice now share the exact server-owned legal candidate enumerator. Resident autonomy resolves only reachable authored project offers and fails closed when the offer, target, clock, or strategy no longer matches.

Validated by the full pre-push gate: 427 JS tests, worldpack/proof/kernel checks, 474 Rust tests, and syntax checks.