### PR TITLE
Route travel through exact shared offers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.142",
+      "version": "0.0.143",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.142"
+version = "0.0.143"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.142"
+version = "0.0.143"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -17,6 +17,7 @@ mod hosted_access;
 mod kernel;
 mod legacy_import;
 mod moderation;
+mod movement;
 mod mud;
 mod natural_affordances;
 mod ownership;
@@ -62,6 +63,7 @@ use hosted_access::*;
 use kernel::*;
 use legacy_import::*;
 use moderation::*;
+use movement::*;
 use mud::*;
 use natural_affordances::*;
 use ownership::*;
@@ -15019,27 +15021,6 @@ impl RuntimeWorld {
         ))
     }
 
-    fn current_reachable_offer(
-        &self,
-        actor_id: u64,
-        offered: &RankedActionOffer,
-    ) -> Option<RankedActionOffer> {
-        self.legal_action_candidates(Some(actor_id), &AccessContext::default())
-            .1
-            .into_iter()
-            .find(|candidate| {
-                candidate.offer_id == offered.offer_id
-                    && candidate.kind == offered.kind
-                    && candidate.rules_action == offered.rules_action
-                    && candidate.operation == offered.operation
-                    && candidate.resolver == offered.resolver
-                    && candidate.state_revision == offered.state_revision
-                    && candidate.provider.id == offered.provider.id
-                    && candidate.target == offered.target
-                    && action_offer_is_reachable(candidate)
-            })
-    }
-
     fn current_item_offer_for_choice(
         &self,
         actor_id: u64,
@@ -22081,6 +22062,7 @@ impl RuntimeWorld {
             })
             .collect();
         offers = self.expand_item_action_offers(actor_id, offers);
+        offers = self.expand_route_action_offers(actor_id, access, offers);
         if let Some(target) = self.scout_action_offer_target(actor_id, access) {
             let kind = "explore_path";
             let binding = resolved_action_binding(kind)
@@ -23413,15 +23395,6 @@ impl RuntimeWorld {
                 .map(|bond| format!("bond_resolved:{}", bond.id)),
             _ => None,
         }
-    }
-
-    fn has_accessible_exit(&self, actor_id: u64, access: &AccessContext) -> bool {
-        let Some(actor) = self.actor_by_id(actor_id) else {
-            return false;
-        };
-        self.exit_views(actor.location_id, access)
-            .into_iter()
-            .any(|exit| exit.accessible && !exit.locked)
     }
 
     fn active_chat_targets(&self, actor_id: u64) -> Vec<CwActor> {
@@ -25206,16 +25179,28 @@ impl RuntimeWorld {
     }
 
     fn fresh_resident_autonomy_action(&self, actor: CwActor, action: CwAction) -> Option<CwAction> {
-        let action = if matches!(action.kind, CW_ACTION_PICK_UP_ITEM | CW_ACTION_DROP_ITEM) {
-            let kind = if action.kind == CW_ACTION_PICK_UP_ITEM {
-                "pick_up"
-            } else {
-                "drop_item"
-            };
-            self.plan_item_choice_action(actor.id, kind, action.item_id, action.target_item_id)
+        let action = match action.kind {
+            CW_ACTION_MOVE => match self
+                .plan_move_choice_action(
+                    actor.id,
+                    action.destination_location_id,
+                    &AccessContext::default(),
+                )
                 .ok()?
-        } else {
-            action
+            {
+                MovementPlan::Adjacent(action) => action,
+                MovementPlan::Journey { .. } => return None,
+            },
+            CW_ACTION_PICK_UP_ITEM | CW_ACTION_DROP_ITEM => {
+                let kind = if action.kind == CW_ACTION_PICK_UP_ITEM {
+                    "pick_up"
+                } else {
+                    "drop_item"
+                };
+                self.plan_item_choice_action(actor.id, kind, action.item_id, action.target_item_id)
+                    .ok()?
+            }
+            _ => action,
         };
         if matches!(action.kind, CW_ACTION_GIVE_ITEM | CW_ACTION_TRADE_ITEM)
             && (self
@@ -37596,7 +37581,7 @@ async fn move_actor(
         &state.wallet_sessions,
         state.allow_unsigned_wallet_claims,
     );
-    let (resolved_access, journey_plan) = {
+    let (resolved_access, movement_plan) = {
         let runtime = state.inner.lock().await;
         if !client_actor_authorized_for_state(
             &runtime,
@@ -37622,7 +37607,11 @@ async fn move_actor(
         let plan = if resolved.view.mode == "denied" {
             None
         } else {
-            Some(runtime.plan_journey_move(payload.actor_id, payload.destination_location_id))
+            Some(runtime.plan_move_choice_action(
+                payload.actor_id,
+                payload.destination_location_id,
+                &access,
+            ))
         };
         (resolved, plan)
     };
@@ -37635,8 +37624,8 @@ async fn move_actor(
             access: resolved_access.view,
         });
     }
-    let journey_plan = journey_plan.expect("allowed movement always creates a journey plan");
-    let journey_plan = match journey_plan {
+    let movement_plan = movement_plan.expect("allowed movement always creates a movement plan");
+    let movement_plan = match movement_plan {
         Ok(plan) => plan,
         Err(_) => {
             record_movement_access_outcome(&state, &resolved_access, "failed");
@@ -37648,7 +37637,12 @@ async fn move_actor(
             });
         }
     };
-    if let Some((action, mut mutation, narration_plan)) = journey_plan {
+    if let MovementPlan::Journey {
+        action,
+        mut mutation,
+        narration: narration_plan,
+    } = movement_plan.clone()
+    {
         // Movement and path discovery commit from deterministic content. Optional
         // AI geography refinement runs after the card response has returned.
         let narration = travel_narration_fallback(&narration_plan);
@@ -37695,14 +37689,12 @@ async fn move_actor(
         ));
     }
 
+    let MovementPlan::Adjacent(action) = movement_plan else {
+        unreachable!("journey movement returned above");
+    };
     let Json(response) = apply_and_broadcast_with_hosted_access(
         state.clone(),
-        CwAction {
-            kind: CW_ACTION_MOVE,
-            actor_id: payload.actor_id,
-            destination_location_id: payload.destination_location_id,
-            ..CwAction::default()
-        },
+        action,
         payload.actor_session.as_deref(),
         resolved_access.hosted_journal_grant(),
     )
@@ -50132,6 +50124,12 @@ mod tests {
         }
     }
 
+    fn seeded_runtime_with_discovered_exits_for_test() -> RuntimeWorld {
+        let mut runtime = RuntimeWorld::seeded();
+        discover_all_seed_exits_for_test(&mut runtime);
+        runtime
+    }
+
     fn move_test_actor(
         runtime: &mut RuntimeWorld,
         actor_id: u64,
@@ -54925,7 +54923,7 @@ mod tests {
 
     #[tokio::test]
     async fn co_present_avatars_move_independently_without_a_room_turn() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "First Walker");
         create_test_human(
             &mut runtime,
@@ -71310,7 +71308,7 @@ mod tests {
 
     #[test]
     fn resident_economy_autonomy_can_act_without_human_presence() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
         runtime.resident_memories.clear();
         hide_seed_items(&mut runtime);
@@ -71346,7 +71344,7 @@ mod tests {
 
     #[test]
     fn resident_economy_autonomy_record_projects_chosen_intent() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
         runtime.resident_memories.clear();
         runtime.resident_continuities.clear();
@@ -72413,7 +72411,7 @@ mod tests {
 
     #[test]
     fn ambient_autonomy_prioritizes_local_keepsake_pickup_over_remote_walking() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
         runtime.resident_memories.clear();
 
@@ -73213,7 +73211,7 @@ mod tests {
 
     #[test]
     fn ambient_autonomy_residents_seek_remembered_healing_items_when_hurt() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         let mut create = CwAction::default();
         create.kind = CW_ACTION_CREATE_ACTOR;
         create.actor_id = 5000;
@@ -73296,7 +73294,7 @@ mod tests {
 
     #[test]
     fn remembered_healing_item_does_not_peek_at_current_charges() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
         runtime.resident_memories.clear();
         runtime
@@ -73347,7 +73345,7 @@ mod tests {
 
     #[test]
     fn ambient_autonomy_residents_move_toward_nearby_sought_items() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         let mut create = CwAction::default();
         create.kind = CW_ACTION_CREATE_ACTOR;
         create.actor_id = 5000;
@@ -73426,7 +73424,7 @@ mod tests {
 
     #[test]
     fn ambient_autonomy_residents_follow_item_memory_across_rooms() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         let mut create = CwAction::default();
         create.kind = CW_ACTION_CREATE_ACTOR;
         create.actor_id = 5000;
@@ -73913,7 +73911,7 @@ mod tests {
 
     #[test]
     fn resident_held_item_seek_follows_carrier_location_memory() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         let mut create = CwAction::default();
         create.kind = CW_ACTION_CREATE_ACTOR;
         create.actor_id = 5000;
@@ -73984,7 +73982,7 @@ mod tests {
 
     #[test]
     fn resident_follows_stale_carrier_memory_instead_of_global_location_truth() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         let mut create = CwAction::default();
         create.kind = CW_ACTION_CREATE_ACTOR;
         create.actor_id = 5000;
@@ -74945,7 +74943,7 @@ mod tests {
 
     #[test]
     fn resident_delivers_requested_non_evolution_attachment_from_memory() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = runtime.world.tick.saturating_add(1);
         runtime.resident_memories.clear();
         runtime
@@ -75017,7 +75015,7 @@ mod tests {
 
     #[test]
     fn resident_delivers_non_track_room_feature_item_to_remembered_want() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
         runtime.resident_memories.clear();
         runtime
@@ -75085,7 +75083,7 @@ mod tests {
 
     #[test]
     fn ambient_autonomy_residents_carry_sought_items_to_remembered_residents() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
         runtime.resident_memories.clear();
         runtime
@@ -75175,7 +75173,7 @@ mod tests {
 
     #[test]
     fn resident_delivery_follows_stale_actor_memory_instead_of_global_truth() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
         runtime.resident_memories.clear();
         runtime
@@ -75243,7 +75241,7 @@ mod tests {
 
     #[test]
     fn resident_delivery_uses_carried_actor_memory_not_live_target_room() {
-        let mut runtime = RuntimeWorld::seeded();
+        let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
         runtime.resident_memories.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -1,0 +1,447 @@
+use super::*;
+
+#[derive(Clone, Debug)]
+pub(super) enum MovementPlan {
+    Adjacent(CwAction),
+    Journey {
+        action: CwAction,
+        mutation: ProjectionMutation,
+        narration: JourneyNarrationPlan,
+    },
+}
+
+impl RuntimeWorld {
+    pub(super) fn current_reachable_offer(
+        &self,
+        actor_id: u64,
+        offered: &RankedActionOffer,
+    ) -> Option<RankedActionOffer> {
+        self.current_reachable_offer_with_access(actor_id, offered, &AccessContext::default())
+    }
+
+    pub(super) fn current_reachable_offer_with_access(
+        &self,
+        actor_id: u64,
+        offered: &RankedActionOffer,
+        access: &AccessContext,
+    ) -> Option<RankedActionOffer> {
+        self.legal_action_candidates(Some(actor_id), access)
+            .1
+            .into_iter()
+            .find(|candidate| {
+                candidate.offer_id == offered.offer_id
+                    && candidate.kind == offered.kind
+                    && candidate.rules_action == offered.rules_action
+                    && candidate.operation == offered.operation
+                    && candidate.resolver == offered.resolver
+                    && candidate.state_revision == offered.state_revision
+                    && candidate.provider.id == offered.provider.id
+                    && candidate.target == offered.target
+                    && action_offer_is_reachable(candidate)
+            })
+    }
+
+    fn current_movement_offer_for_choice(
+        &self,
+        actor_id: u64,
+        destination_location_id: u64,
+        access: &AccessContext,
+    ) -> Result<RankedActionOffer, String> {
+        self.legal_action_candidates(Some(actor_id), access)
+            .1
+            .into_iter()
+            .filter(action_offer_is_reachable)
+            .find(|offer| {
+                offer.kind == "move"
+                    && offer.target.as_ref().is_some_and(|target| {
+                        target.kind == "location" && target.id == Some(destination_location_id)
+                    })
+            })
+            .ok_or_else(|| "That Travel offer is no longer current.".to_string())
+    }
+
+    fn plan_move_offer_action(
+        &self,
+        actor_id: u64,
+        offered: &RankedActionOffer,
+        access: &AccessContext,
+    ) -> Result<MovementPlan, String> {
+        if offered.kind != "move" || !action_offer_is_reachable(offered) {
+            return Err("Travel needs a current reachable route offer.".to_string());
+        }
+        let offer = self
+            .current_reachable_offer_with_access(actor_id, offered, access)
+            .ok_or_else(|| "That Travel offer is no longer current.".to_string())?;
+        let destination_location_id = offer
+            .target
+            .as_ref()
+            .filter(|target| target.kind == "location")
+            .and_then(|target| target.id)
+            .ok_or_else(|| "Travel has no exact destination.".to_string())?;
+        if let Some((action, mutation, narration)) =
+            self.plan_journey_move(actor_id, destination_location_id)?
+        {
+            return Ok(MovementPlan::Journey {
+                action,
+                mutation,
+                narration,
+            });
+        }
+        let action = CwAction {
+            kind: CW_ACTION_MOVE,
+            actor_id,
+            destination_location_id,
+            ..CwAction::default()
+        };
+        if !self.kernel_offer_allows_action(&action) {
+            return Err("The kernel no longer offers that route.".to_string());
+        }
+        Ok(MovementPlan::Adjacent(action))
+    }
+
+    pub(super) fn plan_move_choice_action(
+        &self,
+        actor_id: u64,
+        destination_location_id: u64,
+        access: &AccessContext,
+    ) -> Result<MovementPlan, String> {
+        let offer =
+            self.current_movement_offer_for_choice(actor_id, destination_location_id, access)?;
+        self.plan_move_offer_action(actor_id, &offer, access)
+    }
+
+    fn movement_offer_exits(&self, actor_id: u64, access: &AccessContext) -> Vec<ExitView> {
+        let Some(actor) = self
+            .actor_by_id(actor_id)
+            .filter(|actor| Self::actor_is_active_avatar(*actor))
+        else {
+            return Vec::new();
+        };
+        let journey_next_location_id = self
+            .journey_view(actor_id)
+            .and_then(|journey| journey.next_location_id);
+        let mut exits = self
+            .exit_views(actor.location_id, access)
+            .into_iter()
+            .filter(|exit| exit.accessible && !exit.locked)
+            .collect::<Vec<_>>();
+        exits.sort_by_key(|exit| {
+            (
+                usize::from(journey_next_location_id != Some(exit.destination_location_id)),
+                exit.destination_location_id,
+            )
+        });
+        exits
+    }
+
+    fn retarget_route_action_offer(
+        &self,
+        actor_id: u64,
+        mut offer: RankedActionOffer,
+        exit: ExitView,
+    ) -> RankedActionOffer {
+        let target = ActionTargetView {
+            kind: "location".to_string(),
+            id: Some(exit.destination_location_id),
+            label: Some(exit.destination_location_name.clone()),
+        };
+        let verb = self.action_offer_verb(&offer.kind, actor_id);
+        let fallback = if offer.kind == "flee" { "Flee" } else { "Move" };
+        let label = self.action_offer_label(&offer.kind, &verb, fallback, Some(&target), None);
+        let legacy_id = format!("{}:{}", offer.kind, exit.destination_location_id);
+        offer.id = legacy_id.clone();
+        offer.offer_id = format!(
+            "{}:{}:{}",
+            offer.rules_profile, offer.state_revision, legacy_id
+        );
+        offer.verb = verb.clone();
+        offer.label = label.clone();
+        offer.accessible_label =
+            self.action_offer_accessible_label(&offer.kind, &verb, &label, Some(&target), None);
+        offer.command = normalize_command_text(&format!(
+            "{} {}",
+            if offer.kind == "flee" {
+                "flee to"
+            } else {
+                "go"
+            },
+            exit.destination_location_name
+        ));
+        offer.target = Some(target.clone());
+        offer.composition_trace.target = Some(target);
+        offer
+    }
+
+    pub(super) fn expand_route_action_offers(
+        &self,
+        actor_id: u64,
+        access: &AccessContext,
+        offers: Vec<RankedActionOffer>,
+    ) -> Vec<RankedActionOffer> {
+        let mut expanded = Vec::new();
+        for offer in offers {
+            if !matches!(offer.kind.as_str(), "move" | "flee") {
+                expanded.push(offer);
+                continue;
+            }
+            expanded.extend(
+                self.movement_offer_exits(actor_id, access)
+                    .into_iter()
+                    .map(|exit| self.retarget_route_action_offer(actor_id, offer.clone(), exit)),
+            );
+        }
+        expanded
+    }
+
+    pub(super) fn has_accessible_exit(&self, actor_id: u64, access: &AccessContext) -> bool {
+        let Some(actor) = self.actor_by_id(actor_id) else {
+            return false;
+        };
+        self.exit_views(actor.location_id, access)
+            .into_iter()
+            .any(|exit| exit.accessible && !exit.locked)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn discover_seed_exit_for_test(
+        runtime: &mut RuntimeWorld,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) {
+        let destination = runtime
+            .location_name(to_location_id)
+            .unwrap_or_else(|| format!("Location {to_location_id}"));
+        let id = seed_exit_discovered_tag_id(from_location_id, to_location_id);
+        runtime.tags.insert(
+            id.clone(),
+            RpgTagState {
+                id,
+                scope: "room".to_string(),
+                scope_id: from_location_id,
+                label: format!("path to {destination}"),
+                kind: "discovery".to_string(),
+                active: true,
+                source_event_seq: None,
+                expires: None,
+            },
+        );
+        runtime.remember_search_discovery(
+            RATI_ACTOR_ID,
+            from_location_id,
+            SEARCH_MEMORY_KIND_SEED_EXIT,
+            to_location_id,
+            &seed_exit_search_memory_subject_key(from_location_id, to_location_id),
+        );
+    }
+
+    fn discover_seed_exit_pair_for_test(
+        runtime: &mut RuntimeWorld,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) {
+        discover_seed_exit_for_test(runtime, from_location_id, to_location_id);
+        discover_seed_exit_for_test(runtime, to_location_id, from_location_id);
+    }
+
+    #[test]
+    fn movement_offers_bind_every_accessible_route_for_every_controller() {
+        let mut runtime = RuntimeWorld::seeded();
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("route actor exists")
+            .location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
+        runtime
+            .actor_autonomy
+            .entry(RATI_ACTOR_ID)
+            .or_default()
+            .control_mode = ActorControlMode::DirectInput;
+        discover_seed_exit_pair_for_test(
+            &mut runtime,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            COSY_COTTAGE_LOCATION_ID,
+        );
+        discover_seed_exit_pair_for_test(
+            &mut runtime,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            MOONLIT_TRAIL_LOCATION_ID,
+        );
+        let access = AccessContext::default();
+        let exits = runtime.movement_offer_exits(RATI_ACTOR_ID, &access);
+        assert!(
+            exits.len() >= 2,
+            "the route parity fixture needs at least two accessible exits"
+        );
+        let expected_destination_ids = exits
+            .iter()
+            .map(|exit| exit.destination_location_id)
+            .collect::<Vec<_>>();
+
+        let direct_offers = runtime
+            .legal_action_candidates(Some(RATI_ACTOR_ID), &access)
+            .1
+            .into_iter()
+            .filter(|offer| offer.kind == "move")
+            .collect::<Vec<_>>();
+        assert_eq!(direct_offers.len(), expected_destination_ids.len());
+        assert_eq!(
+            direct_offers
+                .iter()
+                .filter_map(|offer| offer.target.as_ref().and_then(|target| target.id))
+                .collect::<Vec<_>>(),
+            expected_destination_ids
+        );
+        assert_eq!(
+            direct_offers
+                .iter()
+                .map(|offer| offer.offer_id.as_str())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            direct_offers.len(),
+            "every destination has a unique offer identity"
+        );
+        assert!(direct_offers.iter().all(|offer| {
+            offer.target.as_ref().is_some_and(|target| {
+                target.kind == "location"
+                    && target
+                        .label
+                        .as_deref()
+                        .is_some_and(|label| offer.label.contains(label))
+            })
+        }));
+        assert!(
+            direct_offers.iter().all(|offer| {
+                offer.target.as_ref().and_then(|target| target.id) != Some(OLD_OAK_TREE_LOCATION_ID)
+            }),
+            "an undiscovered route cannot enter the shared offer surface"
+        );
+        assert!(runtime
+            .plan_move_choice_action(RATI_ACTOR_ID, OLD_OAK_TREE_LOCATION_ID, &access)
+            .is_err());
+
+        runtime
+            .actor_autonomy
+            .entry(RATI_ACTOR_ID)
+            .or_default()
+            .control_mode = ActorControlMode::LocalAi;
+        let inference_offers = runtime
+            .legal_action_candidates(Some(RATI_ACTOR_ID), &access)
+            .1
+            .into_iter()
+            .filter(|offer| offer.kind == "move")
+            .collect::<Vec<_>>();
+        assert_eq!(
+            serde_json::to_value(&inference_offers).expect("inference route offers serialize"),
+            serde_json::to_value(&direct_offers).expect("direct route offers serialize"),
+            "controller mode cannot change route enumeration or targets"
+        );
+
+        let destination_location_id = exits
+            .iter()
+            .find(|exit| exit.distance <= 1)
+            .map(|exit| exit.destination_location_id)
+            .expect("an adjacent route is available");
+        let offer = direct_offers
+            .iter()
+            .find(|offer| {
+                offer.target.as_ref().and_then(|target| target.id) == Some(destination_location_id)
+            })
+            .expect("the adjacent destination has an exact offer")
+            .clone();
+        let action = match runtime
+            .plan_move_offer_action(RATI_ACTOR_ID, &offer, &access)
+            .expect("the exact route offer plans")
+        {
+            MovementPlan::Adjacent(action) => action,
+            MovementPlan::Journey { .. } => panic!("adjacent route should not create a journey"),
+        };
+        assert_eq!(action.kind, CW_ACTION_MOVE);
+        assert_eq!(action.destination_location_id, destination_location_id);
+        let inference_action = runtime
+            .fresh_resident_autonomy_action(
+                runtime
+                    .actor_by_id(RATI_ACTOR_ID)
+                    .expect("route actor exists"),
+                action,
+            )
+            .expect("inference accepts the same exact route");
+        assert_eq!(inference_action.kind, action.kind);
+        assert_eq!(
+            inference_action.destination_location_id,
+            action.destination_location_id
+        );
+
+        let trace = runtime.resident_decision_trace(&ResidentAutonomyCandidate {
+            actor_id: RATI_ACTOR_ID,
+            rank: 60,
+            score: 0,
+            record: JournalRecord::new(action, 97_200)
+                .into_actor_consequence(runtime.world.tick, None),
+        });
+        assert_eq!(
+            trace.choice.offer_id.as_deref(),
+            Some(offer.offer_id.as_str())
+        );
+        assert!(trace.candidates.iter().any(|candidate| {
+            candidate.selected
+                && candidate.target.as_ref().is_some_and(|target| {
+                    target.kind == "location" && target.id == Some(destination_location_id)
+                })
+        }));
+
+        let mut forged_offer = offer.clone();
+        forged_offer
+            .target
+            .as_mut()
+            .expect("route target exists")
+            .id = Some(999_999);
+        assert!(runtime
+            .plan_move_offer_action(RATI_ACTOR_ID, &forged_offer, &access)
+            .is_err());
+
+        assert_eq!(
+            runtime
+                .apply_journal_record(&JournalRecord::new(action, 97_201))
+                .0,
+            CW_OK
+        );
+        assert!(runtime
+            .plan_move_offer_action(RATI_ACTOR_ID, &offer, &access)
+            .is_err());
+
+        let moved_actor = runtime
+            .actor_by_id(RATI_ACTOR_ID)
+            .expect("route actor moved");
+        let reverse_offer = runtime
+            .legal_action_candidates(Some(RATI_ACTOR_ID), &access)
+            .1
+            .into_iter()
+            .find(|candidate| {
+                candidate.kind == "move"
+                    && candidate
+                        .target
+                        .as_ref()
+                        .is_some_and(|target| target.id == Some(RAIN_SOFT_GARDEN_LOCATION_ID))
+            })
+            .expect("the reverse route is offered");
+        let reverse_action = match runtime
+            .plan_move_offer_action(RATI_ACTOR_ID, &reverse_offer, &access)
+            .expect("the reverse route is mechanically legal")
+        {
+            MovementPlan::Adjacent(action) => action,
+            MovementPlan::Journey { .. } => panic!("reverse route should remain adjacent"),
+        };
+        assert!(
+            runtime
+                .fresh_resident_autonomy_action(moved_actor, reverse_action)
+                .is_none(),
+            "the exact reverse offer cannot bypass immediate-return protection"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- enumerate one exact Travel/Flee offer per accessible discovered route
- route direct and inferred movement through one access-aware planner
- preserve hosted access, journeys, decision traces, stale-offer rejection, and anti-return rules
- extract route logic into `movement.rs`; `main.rs` shrinks by two lines

## Validation
- `npm run check` (427 Node tests, 486 Rust tests)
- exact movement parity regression
- production-profile smoke
- browser smoke reaches the inherited `calling` vs `purpose` vocabulary assertion

Refs #155