### PR TITLE
Project location rules context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.146",
+  "version": "0.0.147",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.146",
+      "version": "0.0.147",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.146",
+  "version": "0.0.147",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.146"
+version = "0.0.147"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.146"
+version = "0.0.147"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -241,6 +241,25 @@ impl ContentRegistry {
             .map(String::as_str)
     }
 
+    pub(super) fn active_ruleset_for_pack(&self, pack_id: &str) -> Option<&ActiveRulesetContext> {
+        if let Some(selected) = self
+            .active_rulesets
+            .iter()
+            .find(|context| context.selected_by_pack_id == pack_id)
+        {
+            return Some(selected);
+        }
+
+        let pack = self.pack(pack_id)?;
+        let mut inherited = self.active_rulesets.iter().filter(|context| {
+            pack.dependency_closure
+                .iter()
+                .any(|dependency| dependency == &context.selected_by_pack_id)
+        });
+        let selected = inherited.next()?;
+        inherited.next().is_none().then_some(selected)
+    }
+
     pub(super) fn asset_mounts(&self) -> &[SeedAssetMount] {
         &self.content.asset_mounts
     }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -26,6 +26,7 @@ mod quest_loot;
 mod rate_limit;
 mod resident_offer_scoring;
 mod routes;
+mod rules_context;
 mod settlement_buildings;
 mod story_metrics;
 mod transfers;
@@ -75,6 +76,7 @@ use qrcode::{render::svg, QrCode};
 use quest_loot::*;
 use rand::{rngs::OsRng, RngCore};
 use rate_limit::*;
+use rules_context::*;
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use settlement_buildings::*;
@@ -3007,21 +3009,6 @@ struct ActionPackProvenanceView {
     pack_id: String,
     pack_version: String,
     rules_namespace: String,
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct ActionCompositionTraceView {
-    rules_profile: String,
-    rules_pack_id: String,
-    rules_pack_version: String,
-    source_card_instances: Vec<ActionSourceCollectibleView>,
-    target: Option<ActionTargetView>,
-    applied_variants: Vec<String>,
-    active_extensions: Vec<String>,
-    applied_reskins: Vec<String>,
-    contextual_offers: Vec<String>,
-    resolver: String,
-    state_revision: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -10522,6 +10509,8 @@ impl RuntimeWorld {
                 record.initial_origin_id.as_deref(),
                 record.initial_physical_description.as_deref(),
             ));
+            let committed_events = events.clone();
+            events.extend(self.apply_rules_context_transition_projection(&committed_events));
             self.apply_economy_disclosure_projection(&action, &mut events);
             if action.kind == CW_ACTION_RULES_STUDY {
                 if let Some(check) = events.iter().find(|event| {
@@ -21782,15 +21771,13 @@ impl RuntimeWorld {
                 "no_active_avatar",
             )];
         };
-        let zone = self
-            .actor_by_id(actor_id)
-            .map(|actor| {
+        let actor_location_id = self.actor_by_id(actor_id).map(|actor| actor.location_id);
+        let zone = actor_location_id
+            .map(|location_id| {
                 self.room_sheets
-                    .get(&actor.location_id)
+                    .get(&location_id)
                     .map(|sheet| room_sheet_zone(sheet).to_string())
-                    .unwrap_or_else(|| {
-                        default_zone_for_scope("room", actor.location_id).to_string()
-                    })
+                    .unwrap_or_else(|| default_zone_for_scope("room", location_id).to_string())
             })
             .unwrap_or_else(default_zone);
         let options: Vec<ActionOption> = if primary_action.options.is_empty() {
@@ -21888,6 +21875,9 @@ impl RuntimeWorld {
                     rules_profile: active_content().manifest.rules_profile.clone(),
                     rules_pack_id: binding.pack_id.clone(),
                     rules_pack_version: binding.pack_version.clone(),
+                    rules_context: actor_location_id.and_then(|location_id| {
+                        self.scene_rules_context(location_id, state_revision)
+                    }),
                     source_card_instances,
                     target: target.clone(),
                     applied_variants: active_content().manifest.active_rules_variants.clone(),
@@ -21969,6 +21959,8 @@ impl RuntimeWorld {
                 rules_profile: active_content().manifest.rules_profile.clone(),
                 rules_pack_id: binding.pack_id.clone(),
                 rules_pack_version: binding.pack_version.clone(),
+                rules_context: actor_location_id
+                    .and_then(|location_id| self.scene_rules_context(location_id, state_revision)),
                 source_card_instances,
                 target: Some(target.clone()),
                 applied_variants: active_content().manifest.active_rules_variants.clone(),
@@ -22105,6 +22097,7 @@ impl RuntimeWorld {
                 rules_profile: active_content().manifest.rules_profile.clone(),
                 rules_pack_id: binding.pack_id,
                 rules_pack_version: binding.pack_version,
+                rules_context: None,
                 source_card_instances: Vec::new(),
                 target: target.clone(),
                 applied_variants: active_content().manifest.active_rules_variants.clone(),

--- a/v2/orchestrator-rust/src/rules_context.rs
+++ b/v2/orchestrator-rust/src/rules_context.rs
@@ -1,0 +1,330 @@
+use super::*;
+
+const SCENE_RULES_CONTEXT_SCHEMA_VERSION: u8 = 1;
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct ActionCompositionTraceView {
+    pub(super) rules_profile: String,
+    pub(super) rules_pack_id: String,
+    pub(super) rules_pack_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) rules_context: Option<SceneRulesContextView>,
+    pub(super) source_card_instances: Vec<ActionSourceCollectibleView>,
+    pub(super) target: Option<ActionTargetView>,
+    pub(super) applied_variants: Vec<String>,
+    pub(super) active_extensions: Vec<String>,
+    pub(super) applied_reskins: Vec<String>,
+    pub(super) contextual_offers: Vec<String>,
+    pub(super) resolver: String,
+    pub(super) state_revision: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct SceneRulesContextView {
+    pub(super) schema_version: u8,
+    pub(super) location_id: u64,
+    pub(super) location_pack_id: String,
+    pub(super) rules_profile: String,
+    pub(super) selected_by_pack_id: String,
+    pub(super) capability_id: String,
+    pub(super) provider_pack_id: String,
+    pub(super) provider_pack_version: String,
+    pub(super) state_revision: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct SceneRulesContextTransition {
+    schema_version: u8,
+    from: SceneRulesContextView,
+    to: SceneRulesContextView,
+}
+
+impl SceneRulesContextView {
+    fn same_ruleset(&self, other: &Self) -> bool {
+        self.rules_profile == other.rules_profile
+            && self.selected_by_pack_id == other.selected_by_pack_id
+            && self.capability_id == other.capability_id
+            && self.provider_pack_id == other.provider_pack_id
+            && self.provider_pack_version == other.provider_pack_version
+    }
+}
+
+impl RuntimeWorld {
+    fn scene_location_pack_id(&self, location_id: u64) -> Option<String> {
+        self.generated_places
+            .get(&location_id)
+            .map(|place| place.pack_id.clone())
+            .or_else(|| {
+                active_content()
+                    .locations
+                    .iter()
+                    .find(|location| location.id == location_id)
+                    .map(|location| location.pack_id.clone())
+            })
+            .filter(|pack_id| !pack_id.trim().is_empty())
+    }
+
+    pub(super) fn scene_rules_context(
+        &self,
+        location_id: u64,
+        state_revision: u64,
+    ) -> Option<SceneRulesContextView> {
+        let location_pack_id = self.scene_location_pack_id(location_id)?;
+        let selected = content_registry().active_ruleset_for_pack(&location_pack_id)?;
+        Some(SceneRulesContextView {
+            schema_version: SCENE_RULES_CONTEXT_SCHEMA_VERSION,
+            location_id,
+            location_pack_id,
+            rules_profile: active_content().manifest.rules_profile.clone(),
+            selected_by_pack_id: selected.selected_by_pack_id.clone(),
+            capability_id: selected.capability_id.clone(),
+            provider_pack_id: selected.provider_pack_id.clone(),
+            provider_pack_version: selected.provider_pack_version.clone(),
+            state_revision,
+        })
+    }
+
+    pub(super) fn apply_rules_context_transition_projection(
+        &mut self,
+        events: &[EventView],
+    ) -> Vec<EventView> {
+        let movements = events
+            .iter()
+            .filter(|event| event.type_name == "actor.moved" && event.success)
+            .filter_map(|event| {
+                Some((
+                    event,
+                    event.actor_id?,
+                    event.location_id?,
+                    event.destination_location_id?,
+                ))
+            })
+            .collect::<Vec<_>>();
+        let mut projected = Vec::new();
+        for (movement, actor_id, from_location_id, to_location_id) in movements {
+            let Some(from) = self.scene_rules_context(from_location_id, movement.seq) else {
+                continue;
+            };
+            let Some(to) = self.scene_rules_context(to_location_id, movement.seq) else {
+                continue;
+            };
+            if from.same_ruleset(&to) {
+                continue;
+            }
+
+            let transition = SceneRulesContextTransition {
+                schema_version: SCENE_RULES_CONTEXT_SCHEMA_VERSION,
+                from,
+                to: to.clone(),
+            };
+            let mut content_context = content_registry().content_reference_context([
+                ("actor", actor_id),
+                ("location", from_location_id),
+                ("location", to_location_id),
+            ]);
+            content_context.active_rulesets = vec![ActiveRulesetContext {
+                selected_by_pack_id: to.selected_by_pack_id.clone(),
+                capability_id: to.capability_id.clone(),
+                provider_pack_id: to.provider_pack_id.clone(),
+                provider_pack_version: to.provider_pack_version.clone(),
+            }];
+            let event = EventView {
+                seq: self.world.next_event_seq,
+                type_name: "rules_context.changed".to_string(),
+                success: true,
+                actor_id: Some(actor_id),
+                actor_name: self.actor_name(actor_id),
+                location_id: Some(from_location_id),
+                location_name: self.location_name(from_location_id),
+                destination_location_id: Some(to_location_id),
+                destination_location_name: self.location_name(to_location_id),
+                content: serde_json::to_string(&transition).ok(),
+                caused_by_event_seq: Some(movement.seq),
+                content_context,
+                ..EventView::default()
+            };
+            self.world.next_event_seq = self.world.next_event_seq.saturating_add(1);
+            self.push_projected_event(event.clone());
+            projected.push(event);
+        }
+        projected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_human(runtime: &mut RuntimeWorld, actor_id: u64, location_id: u64, name: &str) {
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_CREATE_ACTOR,
+                actor_id,
+                location_id,
+                ..CwAction::default()
+            },
+            147_000 + actor_id,
+        );
+        record.actor_meta_upserts.insert(
+            actor_id,
+            ActorMeta {
+                name: name.to_string(),
+                speech_mode: "prose".to_string(),
+                title: "Boundary Test Avatar".to_string(),
+                description: "A test avatar crossing one pack boundary.".to_string(),
+            },
+        );
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+    }
+
+    fn human_held_items(runtime: &RuntimeWorld, actor_id: u64) -> Vec<(u64, u8)> {
+        runtime.world.items[..runtime.world.item_count]
+            .iter()
+            .filter(|item| item.holder_actor_id == actor_id)
+            .map(|item| (item.id, item.zone))
+            .collect()
+    }
+
+    #[test]
+    fn state_and_offers_project_the_location_selected_rules_context() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Rules Context Tester",
+        );
+
+        let cottage = runtime.state_response(Some(5000), &AccessContext::default());
+        let cottage_context = cottage.rules_context.expect("cottage rules context");
+        assert!(!cottage.action_offers.is_empty());
+        assert_eq!(cottage_context.location_pack_id, "cosyworld.core");
+        assert_eq!(cottage_context.selected_by_pack_id, "cosyworld.core");
+        assert_eq!(cottage_context.capability_id, "cosyworld.core/rules");
+        assert!(cottage.action_offers.iter().all(|offer| {
+            offer
+                .composition_trace
+                .rules_context
+                .as_ref()
+                .is_some_and(|context| context == &cottage_context)
+        }));
+
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|actor| actor.id == 5000)
+            .expect("test actor")
+            .location_id = 11;
+        let homeroom = runtime.state_response(Some(5000), &AccessContext::default());
+        let homeroom_context = homeroom.rules_context.expect("homeroom rules context");
+        assert!(!homeroom.action_offers.is_empty());
+        assert_eq!(homeroom_context.location_pack_id, "ruby-high.first-bell");
+        assert_eq!(homeroom_context.selected_by_pack_id, "ruby-high.first-bell");
+        assert_eq!(homeroom_context.capability_id, "ruby-high.first-bell/rules");
+        assert!(homeroom.action_offers.iter().all(|offer| {
+            offer
+                .composition_trace
+                .rules_context
+                .as_ref()
+                .is_some_and(|context| context == &homeroom_context)
+        }));
+
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|actor| actor.id == 5000)
+            .expect("test actor")
+            .location_id = 700;
+        let inherited = runtime
+            .state_response(Some(5000), &AccessContext::default())
+            .rules_context
+            .expect("inherited rules context");
+        assert_eq!(inherited.location_pack_id, "cosyworld.the-holy-land");
+        assert_eq!(inherited.selected_by_pack_id, "cosyworld.core");
+        assert_eq!(inherited.capability_id, "cosyworld.core/rules");
+    }
+
+    #[test]
+    fn cross_pack_move_changes_context_atomically_without_moving_cards() {
+        let mut base = RuntimeWorld::seeded();
+        create_test_human(&mut base, 5000, COSY_COTTAGE_LOCATION_ID, "Boundary Tester");
+        let held_before = human_held_items(&base, 5000);
+        let item_count_before = base.world.item_count;
+        let actor_meta_before =
+            serde_json::to_value(base.actors.get(&5000)).expect("serialize actor identity");
+        let record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_MOVE,
+                actor_id: 5000,
+                destination_location_id: 11,
+                ..CwAction::default()
+            },
+            147_026,
+        );
+
+        let mut first = base.clone();
+        let mut replay = base;
+        let (status, events) = first.apply_journal_record(&record);
+        let (replay_status, replay_events) = replay.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert_eq!(replay_status, CW_OK);
+        assert_eq!(
+            serde_json::to_value(&events).expect("serialize first events"),
+            serde_json::to_value(&replay_events).expect("serialize replay events")
+        );
+
+        let movement = events
+            .iter()
+            .find(|event| event.type_name == "actor.moved")
+            .expect("kernel movement commits");
+        let changed = events
+            .iter()
+            .find(|event| event.type_name == "rules_context.changed")
+            .expect("cross-pack move changes rules context");
+        assert_eq!(changed.caused_by_event_seq, Some(movement.seq));
+        let transition: SceneRulesContextTransition = serde_json::from_str(
+            changed
+                .content
+                .as_deref()
+                .expect("rules transition is inspectable"),
+        )
+        .expect("rules transition schema");
+        assert_eq!(transition.from.capability_id, "cosyworld.core/rules");
+        assert_eq!(transition.to.capability_id, "ruby-high.first-bell/rules");
+        assert_eq!(changed.content_context.active_rulesets.len(), 1);
+        let persisted_context = &changed.content_context.active_rulesets[0];
+        assert_eq!(
+            persisted_context.selected_by_pack_id,
+            transition.to.selected_by_pack_id
+        );
+        assert_eq!(persisted_context.capability_id, transition.to.capability_id);
+        assert_eq!(
+            persisted_context.provider_pack_id,
+            transition.to.provider_pack_id
+        );
+        assert_eq!(
+            persisted_context.provider_pack_version,
+            transition.to.provider_pack_version
+        );
+
+        let state = first.state_response(Some(5000), &AccessContext::default());
+        assert_eq!(state.location.id, 11);
+        assert_eq!(
+            state
+                .rules_context
+                .as_ref()
+                .map(|context| context.capability_id.as_str()),
+            Some("ruby-high.first-bell/rules")
+        );
+        assert_eq!(first.world.item_count, item_count_before);
+        assert_eq!(human_held_items(&first, 5000), held_before);
+        assert_eq!(
+            serde_json::to_value(first.actors.get(&5000)).expect("serialize actor identity"),
+            actor_meta_before
+        );
+    }
+}

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -31,6 +31,7 @@ pub(super) struct StateResponse {
     pub(super) world_id: String,
     pub(super) world_epoch: u64,
     pub(super) world_seq: u64,
+    pub(super) rules_context: Option<SceneRulesContextView>,
     pub(super) location: LocationView,
     pub(super) exits: Vec<ExitView>,
     pub(super) actors: Vec<ActorView>,
@@ -1714,6 +1715,8 @@ impl RuntimeWorld {
             world_id: OFFICIAL_WORLD_ID.to_string(),
             world_epoch: OFFICIAL_WORLD_EPOCH,
             world_seq: self.world.next_event_seq.saturating_sub(1),
+            rules_context: self
+                .scene_rules_context(location_id, self.world.next_event_seq.saturating_sub(1)),
             location,
             exits,
             actors,


### PR DESCRIPTION
- expose the location-selected rules capability in state and action traces
- emit one causal, replay-stable context change on cross-ruleset movement
- preserve identity and card zones while inherited selectors fail closed on ambiguity

Checks: `npm run check` (427 Node, 494 Rust, worldpacks, kernel, proof, syntax)

Refs #26