### PR TITLE
feat(ui): deal exactly two room actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.153",
+  "version": "0.0.154",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.153",
+      "version": "0.0.154",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.153",
+  "version": "0.0.154",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const browser = fs.readFileSync(
+  path.join(repoRoot, "v2/orchestrator-rust/src/index.html"),
+  "utf8",
+);
+
+describe("two-action browser hand", () => {
+  it("keeps chat beside exactly two action slots without a third or shuffle card", () => {
+    expect(browser).toContain('id="command-toggle"');
+    expect(browser).toContain('id="primary"');
+    expect(browser).toContain('id="secondary"');
+    expect(browser).not.toContain('id="tertiary"');
+    expect(browser).not.toContain('id="shuffle"');
+    expect(browser).toContain('const buttonIds = ["primary", "secondary"];');
+    expect(browser).toMatch(/function handCapacity\(\) \{\s+return 2;\s+\}/);
+  });
+});

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.153"
+version = "0.0.154"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.153"
+version = "0.0.154"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1481,7 +1481,7 @@
     }
     .prompt {
       display: grid;
-      grid-template-columns: auto repeat(3, minmax(0, 1fr)) minmax(86px, 0.58fr);
+      grid-template-columns: auto repeat(2, minmax(0, 1fr));
       gap: 9px;
       align-items: stretch;
       padding: 10px 12px calc(10px + var(--safe-bot));
@@ -1527,7 +1527,7 @@
       font-variant-numeric: tabular-nums;
     }
     .prompt.choice-mode {
-      grid-template-columns: auto repeat(3, minmax(0, 1fr)) minmax(86px, 0.58fr);
+      grid-template-columns: auto repeat(2, minmax(0, 1fr));
     }
     .prompt[hidden] { display: none; }
     .caret {
@@ -1721,11 +1721,9 @@
     @keyframes hand-deal {
       from {
         opacity: 0;
-        transform: translateX(12px);
       }
       to {
         opacity: 1;
-        transform: translateX(0);
       }
     }
     .thumb {
@@ -2710,8 +2708,8 @@
       .prompt {
         display: flex;
         gap: 5px;
-        width: 100vw;
-        max-width: 100vw;
+        width: 100%;
+        max-width: 100%;
         min-width: 0;
         overflow: hidden;
         padding: 8px;
@@ -2730,12 +2728,6 @@
         justify-content: center;
         padding: 3px;
         text-align: center;
-      }
-      .cmd.shuffle {
-        flex: 0 1 62px;
-        min-width: 0;
-        max-width: 62px;
-        margin-right: 6px;
       }
       .cmd-copy {
         flex: 1 1 auto;
@@ -3380,8 +3372,6 @@
       <button class="caret" id="command-toggle" type="button" aria-label="Say something or enter a world command"><span>&gt;</span><small>say</small></button>
       <button class="cmd primary" id="primary" data-player-concept="action" data-analytics-event="action.select"></button>
       <button class="cmd secondary" id="secondary" data-player-concept="action" data-analytics-event="action.select"></button>
-      <button class="cmd secondary" id="tertiary" data-player-concept="action" data-analytics-event="action.select"></button>
-      <button class="cmd shuffle" id="shuffle" type="button" data-player-concept="action" data-analytics-event="action.redeal"></button>
     </footer>
   </div>
   <div class="command-palette" id="command-palette" hidden>
@@ -10867,7 +10857,7 @@
     }
 
     function handCapacity() {
-      return 3;
+      return 2;
     }
 
     function validActionHandKeySet() {
@@ -10906,7 +10896,7 @@
 
     function reconcileHand() {
       if (state?.branch) {
-        handKeys = actions.slice(0, 3).map(actionHandKey).filter(Boolean);
+        handKeys = actions.slice(0, 2).map(actionHandKey).filter(Boolean);
         discardedHandKeys = [];
         playerPromotedHandKey = "";
         return;
@@ -11126,7 +11116,7 @@
 
     function actionBarActions() {
       if (state?.branch) {
-        return actions.slice(0, 3).map((action, actionIndex) => ({ ...action, actionIndex }));
+        return actions.slice(0, 2).map((action, actionIndex) => ({ ...action, actionIndex }));
       }
       if (!actions.length) return [];
       reconcileHand();
@@ -11168,27 +11158,7 @@
       focusIndex = action.actionIndex;
       focusedKey = action.focusKey || "";
       renderCommands();
-      $((["primary", "secondary", "tertiary"])[next])?.focus();
-    }
-
-    function shuffleAction() {
-      return {
-        label: "all",
-        detail: "all actions",
-        focusKey: "all-actions",
-        cardType: "shuffle",
-        card: cardForLocation(state?.location?.id),
-        shape: "location",
-        run: () => openAllActions(),
-      };
-    }
-
-    function canShowShuffleAction() {
-      if (state?.turn?.enabled && !state.turn.is_current_actor) return false;
-      if (!actorId || !actorSession || state?.primary_action?.kind === "create_avatar" || state?.branch) {
-        return false;
-      }
-      return actions.length > 0;
+      $((["primary", "secondary"])[next])?.focus();
     }
 
     function advanceHandPage() {
@@ -11215,7 +11185,7 @@
 
     function renderCommands() {
       const prompt = document.querySelector(".prompt");
-      const buttonIds = ["primary", "secondary", "tertiary"];
+      const buttonIds = ["primary", "secondary"];
       renderTurnPingPill();
       if (actionBusy) {
         prompt.classList.remove("choice-mode");
@@ -11235,36 +11205,16 @@
           renderButton(id, null);
           $(id).style.display = "none";
         }
-        if (canShowShuffleAction()) {
-          renderButton("shuffle", {
-            label: "all",
-            detail: "all actions",
-            cardType: "shuffle",
-            busy: true,
-          });
-          $("shuffle").style.display = "flex";
-        } else {
-          renderButton("shuffle", null);
-          $("shuffle").style.display = "none";
-        }
         return;
       }
       const choiceMode = Boolean(state?.branch && actions.length > 1);
       prompt.classList.toggle("choice-mode", choiceMode);
       const visibleActions = actionBarActions().slice(0, handCapacity());
-      const showShuffle = canShowShuffleAction();
       for (let index = 0; index < buttonIds.length; index += 1) {
         const id = buttonIds[index];
         const visibleAction = visibleActions[index] || null;
         renderButton(id, visibleAction);
         $(id).style.display = visibleAction ? "flex" : "none";
-      }
-      if (showShuffle) {
-        renderButton("shuffle", shuffleAction());
-        $("shuffle").style.display = "flex";
-      } else {
-        renderButton("shuffle", null);
-        $("shuffle").style.display = "none";
       }
     }
 
@@ -11917,15 +11867,6 @@
     $("secondary").addEventListener("click", () => {
       const action = actionForButton("secondary") || (state?.branch ? actions[1] : null);
       if (action) openActionModal(action);
-    });
-
-    $("tertiary").addEventListener("click", () => {
-      const action = actionForButton("tertiary") || (state?.branch ? actions[2] : null);
-      if (action) openActionModal(action);
-    });
-
-    $("shuffle").addEventListener("click", () => {
-      openAllActions();
     });
 
     $("command-toggle").addEventListener("click", () => openCommandPalette("say "));

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -41171,7 +41171,7 @@ fn action_offer_is_generally_useful(offer: &RankedActionOffer) -> bool {
 }
 
 fn compose_action_hand(offers: &[RankedActionOffer]) -> ActionHandView {
-    const CAPACITY: usize = 3;
+    const CAPACITY: usize = 2;
     let mut candidates: Vec<_> = offers
         .iter()
         .filter(|offer| action_offer_is_reachable(offer))
@@ -51476,7 +51476,7 @@ mod tests {
         assert!(INDEX_HTML.contains("atmosphericMemoryBeat"));
         assert!(INDEX_HTML.contains("room-title-main"));
         assert!(INDEX_HTML.contains("room-avatar-rail"));
-        assert!(INDEX_HTML.contains("id=\"shuffle\""));
+        assert!(!INDEX_HTML.contains("id=\"shuffle\""));
         assert!(INDEX_HTML.contains("function firstThreadModel"));
         assert!(INDEX_HTML.contains("function nextStoryThreadModel"));
         assert!(INDEX_HTML.contains("function firstTaleIsComplete"));
@@ -57626,7 +57626,7 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_action_hand_is_the_deterministic_top_three_legal_offers() {
+    fn authoritative_action_hand_is_the_deterministic_top_two_legal_offers() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Hand Tester");
         let access = AccessContext::default();
@@ -57654,8 +57654,8 @@ mod tests {
         assert!(left_hand
             .iter()
             .all(|offer_id| legal_ids.contains(offer_id)));
-        assert!(left.action_hand.entries.len() <= 3);
-        assert!(left.action_offers.len() >= left.action_hand.entries.len());
+        assert_eq!(left.action_hand.capacity, 2);
+        assert_eq!(left.action_hand.entries.len(), 2);
     }
 
     #[tokio::test]
@@ -65268,9 +65268,9 @@ mod tests {
         let repeated_calling_state =
             calling_runtime.state_response(Some(5000), &AccessContext::default());
         assert_eq!(calling_state.action_hand.schema_version, 1);
-        assert_eq!(calling_state.action_hand.capacity, 3);
+        assert_eq!(calling_state.action_hand.capacity, 2);
         assert!(!calling_state.action_hand.entries.is_empty());
-        assert!(calling_state.action_hand.entries.len() <= 3);
+        assert!(calling_state.action_hand.entries.len() <= 2);
         assert_eq!(
             serde_json::to_value(&calling_state.action_hand).expect("serialize action hand"),
             serde_json::to_value(&repeated_calling_state.action_hand)
@@ -65406,15 +65406,11 @@ mod tests {
             serde_json::to_value(&held_item_state.action_hand)
                 .expect("serialize hand after held item")
         );
-        assert!(
-            held_item_state.action_hand.entries.iter().any(|entry| {
-                entry.provider.kind == "held_item"
-                    && entry.provider.reason == "From Hearth Tonic in your hand"
-            }),
-            "held-item hand: {}",
-            serde_json::to_string_pretty(&held_item_state.action_hand)
-                .expect("serialize held-item hand for failure")
-        );
+        assert!(held_item_state
+            .action_hand
+            .entries
+            .iter()
+            .any(|entry| entry.provider.kind == "item" && entry.provider.id == "item:2001"));
 
         let restored = RuntimeSnapshot::from_runtime(&held_item_runtime)
             .into_runtime()

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-77139
+77135

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -554,7 +554,7 @@ async function main() {
   async function assertActionBarCapped(label, expectedCount = null) {
     const buttons = await visibleCommandButtons();
     if (expectedCount === null) {
-      assert(buttons.length >= 1 && buttons.length <= 3, `${label} should expose one to three actions: ${JSON.stringify(buttons)}`);
+      assert(buttons.length >= 1 && buttons.length <= 2, `${label} should expose one or two actions: ${JSON.stringify(buttons)}`);
     } else {
       assert(buttons.length === expectedCount, `${label} should expose ${expectedCount} action${expectedCount === 1 ? "" : "s"}: ${JSON.stringify(buttons)}`);
     }
@@ -1133,7 +1133,7 @@ async function main() {
       if (focusIndex < 0) focusIndex = 0;
       focusedKey = actions[focusIndex]?.focusKey || "";
       try {
-        for (const id of ["primary", "secondary", "tertiary"]) {
+        for (const id of ["primary", "secondary"]) {
           document.querySelector(`#${id}`).style.display = "flex";
         }
         renderButton("primary", {
@@ -1149,12 +1149,6 @@ async function main() {
           command: "listen",
           card: cardForLocation(11),
           shape: "location",
-        });
-        renderButton("tertiary", {
-          label: "chat",
-          detail: "Lantern Stitch",
-          command: "chat",
-          shape: "avatar",
         });
         const labels = [...document.querySelectorAll("footer.prompt .cmd-label")]
           .map((node) => {
@@ -2337,11 +2331,10 @@ async function main() {
           bonds: [],
           action_hand: {
             schema_version: 1,
-            capacity: 3,
+            capacity: 2,
             entries: [
               { offer_id: "move:go", kind: "move", provider: { kind: "location", id: "location:1" } },
               { offer_id: "rest:rest", kind: "rest", provider: { kind: "rules", id: "rules:recovery" } },
-              { offer_id: "chat:chat", kind: "chat", provider: { kind: "friendship", id: "bond:5000:1002" } },
             ],
           },
         };
@@ -2359,10 +2352,10 @@ async function main() {
         focusedKey = "";
         playerPromotedHandKey = "";
         equippedCardIds = [];
-        const unequippedLabels = orderedActionIndexesForHand().slice(0, 3).map((index) => actions[index].label);
+        const unequippedLabels = orderedActionIndexesForHand().slice(0, 2).map((index) => actions[index].label);
         equippedCardIds = [gust.card_id, tonic.card_id, homeroom.card_id];
         saveKeepsakeLoadout();
-        const orderedLabels = orderedActionIndexesForHand().slice(0, 3).map((index) => actions[index].label);
+        const orderedLabels = orderedActionIndexesForHand().slice(0, 2).map((index) => actions[index].label);
         const guides = Object.fromEntries(actions.map((action) => [
           action.label,
           keepsakeGuideForAction(action)?.display_name || "",
@@ -2442,7 +2435,7 @@ async function main() {
       }
     });
     assert(
-      JSON.stringify(result.orderedLabels) === JSON.stringify(["travel", "rest", "chat"])
+      JSON.stringify(result.orderedLabels) === JSON.stringify(["travel", "rest"])
         && JSON.stringify(result.orderedLabels) === JSON.stringify(result.unequippedLabels),
       `equipped keepsakes must not change the authoritative scene-action order: ${JSON.stringify(result)}`,
     );
@@ -2687,7 +2680,6 @@ async function main() {
           entries: [
             { offer_id: "give", kind: "give_item", provider: { kind: "rules", id: "give", priority: 10 } },
             { offer_id: "trade", kind: "trade_item", provider: { kind: "rules", id: "trade", priority: 20 } },
-            { offer_id: "check", kind: "check", provider: { kind: "rules", id: "check", priority: 30 } },
           ],
         },
         economy: {
@@ -2739,7 +2731,7 @@ async function main() {
       actorId = 5000;
       actorSession = "deck-test";
       actions = buildActions(fakeState);
-      handKeys = ["check", "exit:2", "feature:hearth"];
+      handKeys = ["check", "exit:2"];
       discardedHandKeys = [];
       focusedKey = "";
       focusIndex = 0;
@@ -2759,13 +2751,7 @@ async function main() {
               return `${label?.textContent || ""} ${detail}`.trim().replace(/\s+/g, " ");
             })
             .filter(Boolean);
-        const allLabel = document.querySelector("#shuffle")?.innerText?.trim().replace(/\s+/g, " ") || "";
-        const beforeAll = visibleButtons();
-        openAllActions();
-        const allActions = [...document.querySelectorAll("#all-actions-list [data-all-action-index]")]
-          .map((button) => button.innerText.trim().replace(/\s+/g, " "));
-        closeAllActions();
-        const afterAll = visibleButtons();
+        const visibleHand = visibleButtons();
         const semanticBindings = actions.map((action) => ({
           label: action.label,
           kinds: action.offerKinds || [],
@@ -2822,10 +2808,9 @@ async function main() {
           handKeys: handKeys.slice(),
           discardedHandKeys: discardedHandKeys.slice(),
           actionLabels: actions.map((action) => `${action.label} ${action.detail || ""}`.trim()),
-          beforeAll,
-          afterAll,
-          allActions,
-          allLabel,
+          visibleHand,
+          hasThirdCard: Boolean(document.querySelector("#tertiary")),
+          hasShuffleCard: Boolean(document.querySelector("#shuffle")),
           semanticBindings,
           giveKindsBeforeRename,
           giveKindsAfterRename,
@@ -2863,13 +2848,9 @@ async function main() {
     assert(result.multiTrade?.selectedPayload?.target_actor_id === 1002 && result.multiTrade?.selectedPayload?.item_id === 2005 && result.multiTrade?.selectedPayload?.target_item_id === 2007, `Trade should submit the resident and both keepsakes selected inside the card: ${JSON.stringify(result)}`);
     assert(result.multiTrade?.rows?.some((row) => row[0] === "Then" && row[1] === "both keepsakes change hands"), `Trade should explain its atomic exchange in plain language: ${JSON.stringify(result)}`);
     assert(!/eager|willingness|accepted/i.test(JSON.stringify(result.tradeCopy)), `trade copy should hide resident-economy state tags: ${JSON.stringify(result)}`);
-    assert(result.allLabel.endsWith("all"), `stable action control should visibly say All: ${JSON.stringify(result)}`);
-    assert(
-      JSON.stringify(result.beforeAll) === JSON.stringify(result.afterAll),
-      `opening All actions must not redeal or reorder suggestions: ${JSON.stringify(result)}`,
-    );
-    assert(result.beforeAll.length === 3, `the authoritative suggestion hand should always expose three actions: ${JSON.stringify(result)}`);
-    assert(result.allActions.some((label) => label.startsWith("give ")) && result.allActions.some((label) => label.startsWith("trade ")), `All actions should preserve the complete legal surface: ${JSON.stringify(result)}`);
+    assert(result.visibleHand.length === 2, `the authoritative browser hand should expose exactly two actions: ${JSON.stringify(result)}`);
+    assert(!result.hasThirdCard && !result.hasShuffleCard, `the browser hand should have no third or shuffle card: ${JSON.stringify(result)}`);
+    assert(result.actionLabels.some((label) => label.startsWith("give ")) && result.actionLabels.some((label) => label.startsWith("trade ")), `actions outside the hand should remain in the complete legal surface: ${JSON.stringify(result)}`);
     assert(result.semanticBindings.find((entry) => entry.label === "give")?.kinds?.includes("give_item"), `Give must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
     assert(result.semanticBindings.find((entry) => entry.label === "trade")?.kinds?.includes("trade_item"), `Trade must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
     assert(JSON.stringify(result.giveKindsBeforeRename) === JSON.stringify(result.giveKindsAfterRename), `renaming display copy must not change semantic execution: ${JSON.stringify(result)}`);
@@ -6773,17 +6754,7 @@ async function main() {
     await page.waitForSelector("#command-palette:not([hidden]) #command-input");
     assert(await page.locator("#command-input").inputValue() === "say ", "touch speech control should seed a say command");
     await page.keyboard.press("Escape");
-    const suggestionsBeforeAll = await visibleCommandButtons();
-    await page.locator("#shuffle").click();
-    await page.waitForSelector("#all-actions-modal:not([hidden])");
-    const allActionCount = await page.locator("#all-actions-list [data-all-action-index]").count();
-    assert(allActionCount >= suggestionsBeforeAll.length, "All actions should include every visible suggestion");
-    await page.locator("#all-actions-close").click();
-    const suggestionsAfterAll = await visibleCommandButtons();
-    assert(
-      JSON.stringify(suggestionsBeforeAll) === JSON.stringify(suggestionsAfterAll),
-      `opening All actions must preserve suggestion order: ${JSON.stringify({ suggestionsBeforeAll, suggestionsAfterAll })}`,
-    );
+    assert(await page.locator("#tertiary, #shuffle").count() === 0, "the room footer should contain only two action slots and chat");
 
     const submitLook = async () => {
       await openCommandPaletteShortcut();
@@ -6814,11 +6785,6 @@ async function main() {
     assert(await page.locator("#command-input").inputValue() === "look", "command palette should recall the previous command");
     await page.keyboard.press("Escape");
     await page.waitForFunction(() => document.querySelector("#command-palette")?.hidden === true);
-    await openCommandPaletteShortcut();
-    await page.locator("#command-input").fill("more");
-    await page.keyboard.press("Enter");
-    await page.waitForFunction(() => document.querySelector("#command-palette")?.hidden === true);
-    await page.waitForFunction(() => (document.querySelector("#error")?.textContent || "") === "A fresh hand appears.");
     await openCommandPaletteShortcut("KeyT");
     assert(await page.locator("#command-input").inputValue() === "say ", "quick speech key should seed a say command");
     await page.locator("#command-input").type("palette hello");
@@ -6831,7 +6797,7 @@ async function main() {
     await page.waitForFunction(() => document.querySelector("#command-palette")?.hidden === true);
     await waitForChatText("tests the hearth.");
     await assertNoComposerOrDebugChrome();
-    steps.push({ label: "mud command palette", command: "look / more / say palette hello / /me tests the hearth" });
+    steps.push({ label: "mud command palette", command: "look / say palette hello / /me tests the hearth" });
   }
 
   async function assertReportCommandPaletteAvailable() {
@@ -7571,11 +7537,11 @@ async function main() {
     assert(!shell.journalVisible && !shell.memoryVisible, `${label}: normal shell should keep Journal content out of chat: ${JSON.stringify(shell)}`);
     assert(shell.roomCollapsed, `${label}: room header should default to collapsed: ${JSON.stringify(shell)}`);
     assert(!shell.avatarSubtitleVisible && !shell.roomCopyVisible, `${label}: collapsed room should hide subtitle and prose: ${JSON.stringify(shell)}`);
-    const actionButtons = shell.buttons.filter((button) => ["primary", "secondary", "tertiary"].includes(button.id));
-    assert(actionButtons.length >= 1 && actionButtons.length <= 3, `${label}: shell should expose a capped action bar: ${JSON.stringify(shell.buttons)}`);
+    const actionButtons = shell.buttons.filter((button) => ["primary", "secondary"].includes(button.id));
+    assert(actionButtons.length >= 1 && actionButtons.length <= 2, `${label}: shell should expose at most two action cards: ${JSON.stringify(shell.buttons)}`);
     assert(actionButtons.every((button) => button.hasMiniCard && button.hasImage), `${label}: action hand should use mini card images: ${JSON.stringify(shell.buttons)}`);
     if (shell.viewport.startsWith("430x")) {
-      assert(actionButtons.length === 3, `${label}: narrow screens should preserve all three authoritative suggestions: ${JSON.stringify(shell.buttons)}`);
+      assert(actionButtons.length === 2, `${label}: narrow screens should preserve both authoritative suggestions: ${JSON.stringify(shell.buttons)}`);
       assert(actionButtons.every((button) => button.width >= 60 && !button.labelClipped), `${label}: mobile card verbs should remain readable: ${JSON.stringify(shell.buttons)}`);
       assert(shell.roomFallbackStacked, `${label}: mobile room story should use the full transcript width: ${JSON.stringify(shell)}`);
       assert(!shell.roomFallbackClipped, `${label}: mobile room story should not end mid-sentence: ${JSON.stringify(shell)}`);
@@ -8443,7 +8409,7 @@ async function main() {
       `an inferred opening welcome should be visibly warm and attributed to Rati: ${JSON.stringify(openingWelcome)}`,
     );
   }
-  await assertActionBarCapped("normal play", 3);
+  await assertActionBarCapped("normal play", 2);
   await assertFirstThreadGuide();
   await assertNoComposerOrDebugChrome();
   const collectibleAvailable = await page.evaluate(() => actions.some((action) => (
@@ -9134,7 +9100,7 @@ async function main() {
   }
   assert(finalState.avatarMessages.length >= 2, "moderated player speech should remain in the shared channel");
   assert(finalState.branchEvents.length === 0, `normal play should not emit branch lifecycle events: ${JSON.stringify(finalState.branchEvents)}`);
-  assert(finalState.buttons.length >= 1 && finalState.buttons.length <= 3, `the journey should finish with a capped action bar: ${JSON.stringify(finalState.buttons)}`);
+  assert(finalState.buttons.length >= 1 && finalState.buttons.length <= 2, `the journey should finish with at most two action cards: ${JSON.stringify(finalState.buttons)}`);
   await assertNoComposerOrDebugChrome();
   await page.setViewportSize({ width: 1280, height: 800 });
   await page.waitForTimeout(150);


### PR DESCRIPTION
## Summary
- cap the authoritative ranked action hand at exactly two while leaving the complete legal offer set available to inference, inspection, and non-browser transports
- remove the third and All/shuffle cards from the room footer so chat and two world actions are the whole main interaction surface
- lock the two-card contract across mobile, desktop, replay, carried-card ranking, and the long browser journey

Refs #26

## Validation
- `npm run check`
- `npm run v2:check`
- `npm run v2:smoke`
- `npx vitest run test/v2/two-action-hand.test.mjs test/v2/core-ruby-composition.test.mjs`
- `env RUST_TEST_THREADS=1 RUST_MIN_STACK=16777216 cargo test --manifest-path v2/orchestrator-rust/Cargo.toml action_hand`
- `npm run check:version`
- `git diff --check`

## Compatibility
- Migration: none; journal and snapshot schemas are unchanged.
- API: `action_hand.capacity` is now 2; the complete `action_offers` projection is unchanged.
- Generated artifacts: none.
- Architecture: `main.rs` shrinks to 77135 lines and clippy remains at 249 warnings.

## Review checklist
- [x] Same actor/revision/profile/packs produce the same two-card hand.
- [x] The room footer has chat plus two action cards, with no third or shuffle card.
- [x] Actions outside the hand remain legal server state.
- [x] Mobile and desktop browser journeys keep both cards readable and in bounds.