### PR TITLE
fix(rules): bind transfer offers to source cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.157",
+  "version": "0.0.158",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.157"
+version = "0.0.158"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.157"
+version = "0.0.158"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/cards.rs
+++ b/v2/orchestrator-rust/src/cards.rs
@@ -931,6 +931,32 @@ pub(super) fn seed_card_for_subject(subject_kind: &str, subject_id: u64) -> Opti
         .map(card_from_seed_content)
 }
 
+impl RuntimeWorld {
+    pub(super) fn item_source_collectible(
+        &self,
+        item_id: u64,
+    ) -> Option<ActionSourceCollectibleView> {
+        let card = seed_card_for_subject("item", item_id).or_else(|| {
+            self.materialization_receipts
+                .values()
+                .find(|receipt| receipt.item_id == item_id)
+                .and_then(|receipt| {
+                    active_content()
+                        .cards
+                        .iter()
+                        .find(|card| card.card_id == receipt.card_id)
+                        .map(card_from_seed_content)
+                })
+        })?;
+        Some(ActionSourceCollectibleView {
+            kind: "item".to_string(),
+            instance_id: item_id,
+            card_id: card.card_id,
+            pack_id: card.pack_id.unwrap_or_else(|| "cosyworld.core".to_string()),
+        })
+    }
+}
+
 pub(super) fn seed_weapon_die_sides(item: &SeedItemContent) -> u8 {
     if item.role != "weapon" {
         return 0;

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -21970,24 +21970,7 @@ impl RuntimeWorld {
             _ => None,
         };
         if let Some(item) = source_item {
-            let card = seed_card_for_subject("item", item.id).or_else(|| {
-                self.materialization_receipts
-                    .values()
-                    .find(|receipt| receipt.item_id == item.id)
-                    .and_then(|receipt| {
-                        active_content()
-                            .cards
-                            .iter()
-                            .find(|card| card.card_id == receipt.card_id)
-                            .map(card_from_seed_content)
-                    })
-            })?;
-            return Some(ActionSourceCollectibleView {
-                kind: "item".to_string(),
-                instance_id: item.id,
-                card_id: card.card_id,
-                pack_id: card.pack_id.unwrap_or_else(|| "cosyworld.core".to_string()),
-            });
+            return self.item_source_collectible(item.id);
         }
         let actor = self.actor_by_id(actor_id)?;
         let card = seed_card_for_subject("location", actor.location_id)?;

--- a/v2/orchestrator-rust/src/transfers.rs
+++ b/v2/orchestrator-rust/src/transfers.rs
@@ -168,6 +168,17 @@ impl RuntimeWorld {
         offer.target = Some(target.clone());
         offer.composition_trace.target = Some(target);
         offer.effect = Some(effect);
+        if let Some(source) = self.item_source_collectible(key.item_id) {
+            offer.source_collectible = Some(source.clone());
+            offer
+                .composition_trace
+                .source_card_instances
+                .retain(|existing| existing.kind != "item");
+            offer
+                .composition_trace
+                .source_card_instances
+                .insert(0, source);
+        }
         offer
     }
 
@@ -454,9 +465,20 @@ mod tests {
             "every exact transfer has a unique offer identity"
         );
         assert!(direct_offers.iter().all(|offer| {
+            let Some(key) = RuntimeWorld::transfer_offer_key(offer) else {
+                return false;
+            };
             offer.provider.kind == "item"
-                && offer.provider.id.starts_with("item:")
-                && RuntimeWorld::transfer_offer_key(offer).is_some()
+                && offer.provider.id == format!("item:{}", key.item_id)
+                && offer
+                    .source_collectible
+                    .as_ref()
+                    .is_some_and(|source| source.instance_id == key.item_id)
+                && offer
+                    .composition_trace
+                    .source_card_instances
+                    .iter()
+                    .any(|source| source.kind == "item" && source.instance_id == key.item_id)
         }));
         let action_hand = compose_action_hand(&direct_offers);
         for kind in ["give_item", "trade_item"] {
@@ -586,6 +608,23 @@ mod tests {
                 .apply_journal_record(&JournalRecord::new(inferred_gift, 98_101))
                 .0,
             CW_OK
+        );
+        let next_offers = runtime.legal_action_candidates(Some(5000), &access).1;
+        assert!(
+            next_offers
+                .iter()
+                .all(|offer| offer.offer_id != inferred_gift_offer.offer_id),
+            "the transferred card's dependent offer expires at the next revision"
+        );
+        assert!(
+            next_offers.iter().all(|offer| {
+                offer
+                    .composition_trace
+                    .source_card_instances
+                    .iter()
+                    .all(|source| source.instance_id != STORY_BUTTON_ITEM_ID)
+            }),
+            "the transferred card no longer contributes to the former holder's offers"
         );
         assert!(runtime
             .plan_transfer_offer_action(5000, &inferred_gift_offer)

--- a/v2/orchestrator-rust/src/uses.rs
+++ b/v2/orchestrator-rust/src/uses.rs
@@ -173,27 +173,6 @@ impl RuntimeWorld {
         !self.healing_use_choices(actor_id).is_empty()
     }
 
-    fn use_source_collectible(&self, item_id: u64) -> Option<ActionSourceCollectibleView> {
-        let card = seed_card_for_subject("item", item_id).or_else(|| {
-            self.materialization_receipts
-                .values()
-                .find(|receipt| receipt.item_id == item_id)
-                .and_then(|receipt| {
-                    active_content()
-                        .cards
-                        .iter()
-                        .find(|card| card.card_id == receipt.card_id)
-                        .map(card_from_seed_content)
-                })
-        })?;
-        Some(ActionSourceCollectibleView {
-            kind: "item".to_string(),
-            instance_id: item_id,
-            card_id: card.card_id,
-            pack_id: card.pack_id.unwrap_or_else(|| "cosyworld.core".to_string()),
-        })
-    }
-
     fn retarget_use_offer(
         &self,
         actor_id: u64,
@@ -274,7 +253,7 @@ impl RuntimeWorld {
         offer.target = Some(target.clone());
         offer.composition_trace.target = Some(target);
         offer.effect = Some(effect);
-        if let Some(source) = self.use_source_collectible(item_id) {
+        if let Some(source) = self.item_source_collectible(item_id) {
             offer.source_collectible = Some(source.clone());
             offer
                 .composition_trace

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-77132
+77115


### PR DESCRIPTION
Closes one #26 acceptance slice.

- bind each exact Give/Trade offer and composition certificate to its carried item instance
- remove dependent offers/traces immediately after possession changes
- share item-card trace construction across attack/use/transfer paths
- lower the `main.rs` ceiling to 77,115

Checks: `npm run check`, `npm run v2:check`, focused transfer/use regressions. Browser unchanged.