### PR TITLE
feat(rules): select profiles per world

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.159",
+  "version": "0.0.160",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/content-pack-contract.test.mjs
+++ b/test/v2/content-pack-contract.test.mjs
@@ -5,13 +5,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  packAcceptsRulesProfile,
   resolveContentPackGraph,
+  rulesCompatibilityProfiles,
   validateContentPackManifest,
   validateWorldEntityResource,
 } from "../../v2/scripts/content-pack-contract.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const compilerPath = path.join(repoRoot, "v2/scripts/compile-worldpack.mjs");
+const checkerPath = path.join(repoRoot, "v2/scripts/check-worldpack.mjs");
 
 function manifest(id, overrides = {}) {
   return {
@@ -146,6 +149,196 @@ describe("Content Pack Manifest v1", () => {
     expect(() => validateContentPackManifest(manifest("fixture.invalid", {
       surprise: true,
     }))).toThrow(/additional properties/);
+  });
+
+  it("treats rules_profile as a legacy one-profile compatibility alias", () => {
+    const legacy = manifest("fixture.legacy", {
+      rules_profile: "cosyworld.srd5/1",
+    });
+    expect(rulesCompatibilityProfiles(legacy)).toEqual(["cosyworld.srd5/1"]);
+    expect(packAcceptsRulesProfile(legacy, "cosyworld.srd5/1")).toBe(true);
+    expect(packAcceptsRulesProfile(legacy, "fixture.commons/1")).toBe(false);
+
+    const explicit = manifest("fixture.explicit", {
+      rules_compatibility: {
+        profiles: ["cosyworld.srd5/1", "fixture.commons/1"],
+      },
+    });
+    expect(() => validateContentPackManifest(explicit)).not.toThrow();
+    expect(rulesCompatibilityProfiles(explicit)).toEqual([
+      "cosyworld.srd5/1",
+      "fixture.commons/1",
+    ]);
+    expect(packAcceptsRulesProfile(explicit, "fixture.commons/1")).toBe(true);
+
+    expect(() => validateContentPackManifest({
+      ...explicit,
+      rules_profile: "cosyworld.srd5/1",
+    })).toThrow(/legacy one-profile alias/);
+  });
+
+  it("pins the current cosyworld.srd5 profile action declaration as a fixture", () => {
+    const actions = JSON.parse(fs.readFileSync(
+      path.join(repoRoot, "v2/content/rules-profile-srd5/actions.json"),
+      "utf8",
+    ));
+    expect(actions.map((action) => action.id).sort()).toEqual([
+      "srd5.2.1:attack",
+      "srd5.2.1:dash",
+      "srd5.2.1:disengage",
+      "srd5.2.1:dodge",
+      "srd5.2.1:help",
+      "srd5.2.1:hide",
+      "srd5.2.1:influence",
+      "srd5.2.1:magic",
+      "srd5.2.1:ready",
+      "srd5.2.1:search",
+      "srd5.2.1:study",
+      "srd5.2.1:utilize",
+    ]);
+  });
+
+  it("compiles a different selected profile and rejects mismatches consistently", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "cosyworld-rules-profile-"));
+    const contentRoot = path.join(root, "content");
+    const worldDir = path.join(root, "worlds/core-only");
+    const sharedWorldDir = path.join(root, "worlds/shared");
+    const outputDir = path.join(contentRoot, "compiled");
+    const fixtureProfile = "fixture.commons/1";
+    const incompatibleProfile = "fixture.other/1";
+    const fixtureProvider = "fixture.rules-profile-commons";
+    const sourceContentRoot = path.join(repoRoot, "v2/content");
+    const sourceWorldDir = path.join(repoRoot, "v2/worlds/core-only");
+    const writeJson = (filePath, value) => {
+      fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+    };
+    const compile = () => spawnSync(process.execPath, [
+      compilerPath,
+      "--world-dir",
+      worldDir,
+      "--content-root",
+      contentRoot,
+      "--output-dir",
+      outputDir,
+      "--write-lock",
+    ], { cwd: repoRoot, encoding: "utf8" });
+
+    try {
+      fs.mkdirSync(contentRoot, { recursive: true });
+      fs.mkdirSync(worldDir, { recursive: true });
+      fs.mkdirSync(sharedWorldDir, { recursive: true });
+      for (const directory of ["core", "rules-srd-5.2.1"]) {
+        fs.cpSync(
+          path.join(sourceContentRoot, directory),
+          path.join(contentRoot, directory),
+          { recursive: true },
+        );
+      }
+      fs.cpSync(
+        path.join(sourceContentRoot, "rules-profile-srd5"),
+        path.join(contentRoot, "rules-profile-commons"),
+        { recursive: true },
+      );
+      fs.copyFileSync(
+        path.join(sourceWorldDir, "world.json"),
+        path.join(worldDir, "world.json"),
+      );
+      const lock = JSON.parse(fs.readFileSync(
+        path.join(sourceWorldDir, "pack.lock.json"),
+        "utf8",
+      ));
+      const lockedProvider = lock.packs.find(
+        (pack) => pack.id === "cosyworld.rules-profile-srd5",
+      );
+      lockedProvider.id = fixtureProvider;
+      lockedProvider.source.path = "../../content/rules-profile-commons";
+      writeJson(path.join(worldDir, "pack.lock.json"), lock);
+      fs.copyFileSync(
+        path.join(repoRoot, "v2/worlds/shared/cozy-fantasy-avatar-naming.json"),
+        path.join(sharedWorldDir, "cozy-fantasy-avatar-naming.json"),
+      );
+
+      const worldPath = path.join(worldDir, "world.json");
+      const corePackPath = path.join(contentRoot, "core/pack.json");
+      const rulesPackPath = path.join(contentRoot, "rules-profile-commons/pack.json");
+      const profilesPath = path.join(contentRoot, "rules-profile-commons/profiles.json");
+      const actionsPath = path.join(contentRoot, "rules-profile-commons/actions.json");
+      const conformancePath = path.join(contentRoot, "rules-profile-commons/conformance.json");
+      const world = JSON.parse(fs.readFileSync(worldPath, "utf8"));
+      const corePack = JSON.parse(fs.readFileSync(corePackPath, "utf8"));
+      const rulesPack = JSON.parse(fs.readFileSync(rulesPackPath, "utf8"));
+      const profiles = JSON.parse(fs.readFileSync(profilesPath, "utf8"));
+      const actions = JSON.parse(fs.readFileSync(actionsPath, "utf8"))
+        .filter((action) => action.id !== "srd5.2.1:dash");
+      const conformance = JSON.parse(fs.readFileSync(conformancePath, "utf8"))
+        .filter((row) => row.action_id !== "srd5.2.1:dash");
+
+      world.rules_profile = fixtureProfile;
+      world.packs = world.packs.map((packId) => (
+        packId === "cosyworld.rules-profile-srd5" ? fixtureProvider : packId
+      ));
+      delete corePack.rules_profile;
+      corePack.rules_compatibility = {
+        profiles: ["cosyworld.srd5/1", fixtureProfile],
+      };
+      corePack.dependencies[0].id = fixtureProvider;
+      corePack.dependencies[0].capabilities = [`${fixtureProvider}/rules`];
+      rulesPack.id = fixtureProvider;
+      rulesPack.name = "Fixture Commons Rules Profile";
+      rulesPack.capabilities[0].id = `${fixtureProvider}/rules`;
+      rulesPack.rules_profile = fixtureProfile;
+      profiles[0].id = fixtureProfile;
+      writeJson(worldPath, world);
+      writeJson(corePackPath, corePack);
+      writeJson(rulesPackPath, rulesPack);
+      writeJson(profilesPath, profiles);
+      writeJson(actionsPath, actions);
+      writeJson(conformancePath, conformance);
+
+      const selected = compile();
+      expect(selected.status, selected.stderr).toBe(0);
+      const compiled = JSON.parse(fs.readFileSync(
+        path.join(outputDir, "worldpack.json"),
+        "utf8",
+      ));
+      expect(compiled.rules_profile).toBe(fixtureProfile);
+      expect(compiled.packs.find((pack) => pack.id === "cosyworld.core")?.rules_compatibility)
+        .toEqual({ profiles: ["cosyworld.srd5/1", fixtureProfile] });
+      const check = spawnSync(process.execPath, [checkerPath, outputDir], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
+      expect(check.status, check.stderr).toBe(0);
+
+      corePack.rules_compatibility = { profiles: [incompatibleProfile] };
+      writeJson(corePackPath, corePack);
+      const incompatible = compile();
+      expect(incompatible.status).not.toBe(0);
+      expect(incompatible.stderr).toContain(fixtureProfile);
+      expect(incompatible.stderr).toContain(incompatibleProfile);
+
+      corePack.rules_compatibility = { profiles: [fixtureProfile] };
+      writeJson(corePackPath, corePack);
+      writeJson(conformancePath, conformance.slice(1));
+      const incomplete = compile();
+      expect(incomplete.status).not.toBe(0);
+      expect(incomplete.stderr).toMatch(/conformance matrix must cover every action/);
+
+      writeJson(conformancePath, conformance);
+      corePack.rules_compatibility = {
+        profiles: ["cosyworld.srd5/1", fixtureProfile],
+      };
+      writeJson(corePackPath, corePack);
+      world.rules_profile = "cosyworld.srd5/1";
+      writeJson(worldPath, world);
+      const wrongWorld = compile();
+      expect(wrongWorld.status).not.toBe(0);
+      expect(wrongWorld.stderr).toContain(fixtureProvider);
+      expect(wrongWorld.stderr).toContain(fixtureProfile);
+      expect(wrongWorld.stderr).toContain("cosyworld.srd5/1");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("types pack and zone rules selectors and rejects equal-precedence conflicts", () => {

--- a/v2/docs/rules-adapter.md
+++ b/v2/docs/rules-adapter.md
@@ -27,6 +27,19 @@ Resources remain scoped by pack and namespace. Missing source references,
 attribution, resolvers, replay fixtures, or conflicting identities fail the
 worldpack gate and runtime startup.
 
+Each world selects exactly one `rules_profile`. Its `cosyworld.rules/2`
+provider declares that identity and owns the complete action registry plus one
+conformance row per declared action. The twelve actions in
+`cosyworld.srd5/1` are that profile's tested fixture, not a global adapter
+requirement.
+
+Content packs declare the profiles they accept with
+`rules_compatibility.profiles`. During migration, the existing
+`rules_profile` field remains a one-element alias; a pack cannot declare both.
+Compilation fails when a selected profile has no single provider, when a
+content pack excludes it, or when the provider's action and conformance sets
+differ. Compiled worlds still activate only one profile.
+
 ## Authority boundary
 
 In the reference packs, `reference_only` is authoring context and cannot apply

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.159"
+version = "0.0.160"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.159"
+version = "0.0.160"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -136,8 +136,16 @@ pub(super) struct SeedWorldpackPack {
     pub(super) rules_namespace: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) rules_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) rules_compatibility: Option<SeedRulesCompatibility>,
     #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub(super) extensions: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct SeedRulesCompatibility {
+    #[serde(default)]
+    pub(super) profiles: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1060,6 +1068,7 @@ pub(super) fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> R
         || manifest.id.trim().is_empty()
         || manifest.name.trim().is_empty()
         || manifest.version == 0
+        || (!manifest.rules_profile.is_empty() && !valid_rules_profile_id(&manifest.rules_profile))
         || (has_world_pack && manifest.entry_location.trim().is_empty())
         || (!has_world_pack && !manifest.entry_location.trim().is_empty())
         || !valid_sha256_digest(&manifest.bundle_hash)
@@ -1090,6 +1099,30 @@ pub(super) fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> R
         {
             return Err(format!("invalid or duplicate worldpack pack {}", pack.id));
         }
+        if pack.rules_profile.is_some() && pack.rules_compatibility.is_some() {
+            return Err(format!(
+                "pack {} combines legacy rules_profile with rules_compatibility",
+                pack.id
+            ));
+        }
+        if pack
+            .rules_profile
+            .as_deref()
+            .is_some_and(|profile| !valid_rules_profile_id(profile))
+        {
+            return Err(format!("pack {} has an invalid rules profile", pack.id));
+        }
+        if let Some(compatibility) = pack.rules_compatibility.as_ref() {
+            let mut profiles = BTreeSet::new();
+            if compatibility.profiles.is_empty()
+                || compatibility
+                    .profiles
+                    .iter()
+                    .any(|profile| !valid_rules_profile_id(profile) || !profiles.insert(profile))
+            {
+                return Err(format!("pack {} has invalid rules compatibility", pack.id));
+            }
+        }
         if pack.kind == "rules" {
             if !matches!(
                 pack.rules_adapter.as_deref(),
@@ -1106,8 +1139,10 @@ pub(super) fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> R
                     || pack.rules_profile.as_deref() != Some(manifest.rules_profile.as_str())
                 {
                     return Err(format!(
-                        "rules profile pack {} does not provide {}",
-                        pack.id, manifest.rules_profile
+                        "rules profile pack {} provides {} but world selects {}",
+                        pack.id,
+                        pack.rules_profile.as_deref().unwrap_or("no profile"),
+                        manifest.rules_profile
                     ));
                 }
             } else if pack.rules_profile.is_some() {
@@ -1115,13 +1150,24 @@ pub(super) fn validate_worldpack_manifest(manifest: &SeedWorldpackManifest) -> R
                     "reference rules pack {} cannot activate a rules profile",
                     pack.id
                 ));
+            } else if pack.rules_compatibility.is_some() {
+                return Err(format!(
+                    "reference rules pack {} cannot declare rules compatibility",
+                    pack.id
+                ));
             }
         } else if !manifest.rules_profile.is_empty()
-            && pack.rules_profile.as_deref() != Some(manifest.rules_profile.as_str())
+            && !pack_accepts_rules_profile(pack, &manifest.rules_profile)
         {
+            let accepted = pack
+                .rules_compatibility
+                .as_ref()
+                .map(|compatibility| compatibility.profiles.join(", "))
+                .or_else(|| pack.rules_profile.clone())
+                .unwrap_or_else(|| "none".to_string());
             return Err(format!(
-                "pack {} does not target active rules profile {}",
-                pack.id, manifest.rules_profile
+                "pack {} is incompatible with selected rules profile {}; accepted profiles: {}",
+                pack.id, manifest.rules_profile, accepted
             ));
         }
     }
@@ -1164,17 +1210,48 @@ pub(super) fn valid_sha256_digest(value: &str) -> bool {
     })
 }
 
+fn valid_rules_profile_id(value: &str) -> bool {
+    let Some((name, version)) = value.rsplit_once('/') else {
+        return false;
+    };
+    !name.is_empty()
+        && name
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_lowercase() || character.is_ascii_digit())
+        && name.chars().all(|character| {
+            character.is_ascii_lowercase()
+                || character.is_ascii_digit()
+                || matches!(character, '.' | '-')
+        })
+        && !version.is_empty()
+        && !version.starts_with('0')
+        && version.chars().all(|character| character.is_ascii_digit())
+}
+
+fn pack_accepts_rules_profile(pack: &SeedWorldpackPack, profile: &str) -> bool {
+    pack.rules_compatibility
+        .as_ref()
+        .map(|compatibility| {
+            compatibility
+                .profiles
+                .iter()
+                .any(|candidate| candidate == profile)
+        })
+        .unwrap_or_else(|| pack.rules_profile.as_deref() == Some(profile))
+}
+
 fn validate_seed_rules_profile(bundle: &SeedRuleBundle) -> Result<(), String> {
     let resources = &bundle.resources;
     let profile = resources
         .profiles
         .first()
         .ok_or_else(|| format!("rules/2 bundle {} has no profile", bundle.pack_id))?;
-    if profile.id != "cosyworld.srd5/1"
-        || profile.source_document != "System Reference Document 5.2.1"
-        || profile.source_version != "5.2.1"
-        || profile.source_pack != "cosyworld.rules-srd-5.2.1"
-        || profile.license != "CC-BY-4.0"
+    if !valid_rules_profile_id(&profile.id)
+        || profile.source_document.trim().is_empty()
+        || profile.source_version.trim().is_empty()
+        || profile.source_pack.trim().is_empty()
+        || profile.license.trim().is_empty()
         || profile.compatibility_claim != "bounded_profile"
         || profile.excluded_systems.is_empty()
         || profile.cosyworld_deltas.is_empty()
@@ -1185,25 +1262,11 @@ fn validate_seed_rules_profile(bundle: &SeedRuleBundle) -> Result<(), String> {
         return Err(format!("invalid rules profile {}", profile.id));
     }
 
-    let required_actions = BTreeSet::from([
-        "srd5.2.1:attack",
-        "srd5.2.1:dash",
-        "srd5.2.1:disengage",
-        "srd5.2.1:dodge",
-        "srd5.2.1:help",
-        "srd5.2.1:hide",
-        "srd5.2.1:influence",
-        "srd5.2.1:magic",
-        "srd5.2.1:ready",
-        "srd5.2.1:search",
-        "srd5.2.1:study",
-        "srd5.2.1:utilize",
-    ]);
     let mut action_ids = BTreeSet::new();
     for action in &resources.actions {
         let supported = matches!(action.support_status.as_str(), "kernel" | "projection");
-        if !required_actions.contains(action.id.as_str())
-            || action.namespace != "srd5.2.1"
+        if !action.id.starts_with(&format!("{}:", action.namespace))
+            || action.namespace.trim().is_empty()
             || action.domain != "rules_action"
             || action.label.trim().is_empty()
             || action.source_reference.trim().is_empty()
@@ -1222,8 +1285,8 @@ fn validate_seed_rules_profile(bundle: &SeedRuleBundle) -> Result<(), String> {
             return Err(format!("invalid rules action {}", action.id));
         }
     }
-    if action_ids != required_actions {
-        return Err("rules profile does not declare exactly twelve SRD actions".to_string());
+    if action_ids.is_empty() {
+        return Err("rules profile must declare at least one action".to_string());
     }
 
     let mut conformance_ids = BTreeSet::new();
@@ -1255,7 +1318,7 @@ fn validate_seed_rules_profile(bundle: &SeedRuleBundle) -> Result<(), String> {
         let _ = (&row.legal_targets, &row.event_outputs);
     }
     if conformance_ids != action_ids {
-        return Err("rules conformance does not cover exactly twelve SRD actions".to_string());
+        return Err("rules conformance does not cover every declared action".to_string());
     }
 
     let mut operation_ids = BTreeSet::new();
@@ -3257,4 +3320,82 @@ fn validate_seed_effect_descriptor(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod rules_profile_tests {
+    use super::*;
+
+    fn official_manifest() -> SeedWorldpackManifest {
+        serde_json::from_str(include_str!("../../content/official/worldpack.json"))
+            .expect("official worldpack manifest")
+    }
+
+    fn official_rules_profile() -> SeedRuleBundle {
+        serde_json::from_str::<Vec<SeedRuleBundle>>(include_str!(
+            "../../content/official/rules.json"
+        ))
+        .expect("official rules bundles")
+        .into_iter()
+        .find(|bundle| bundle.adapter == "cosyworld.rules/2")
+        .expect("active rules/2 bundle")
+    }
+
+    #[test]
+    fn manifest_accepts_explicit_profile_membership_and_rejects_mismatch() {
+        let mut manifest = official_manifest();
+        let active_profile = manifest.rules_profile.clone();
+        let pack = manifest
+            .packs
+            .iter_mut()
+            .find(|pack| pack.id == "cosyworld.core")
+            .expect("core pack");
+        pack.rules_profile = None;
+        pack.rules_compatibility = Some(SeedRulesCompatibility {
+            profiles: vec![active_profile.clone(), "fixture.commons/1".to_string()],
+        });
+        validate_worldpack_manifest(&manifest).expect("selected profile is accepted");
+
+        let pack = manifest
+            .packs
+            .iter_mut()
+            .find(|pack| pack.id == "cosyworld.core")
+            .expect("core pack");
+        pack.rules_profile = Some(active_profile.clone());
+        let error = validate_worldpack_manifest(&manifest).expect_err("ambiguous compatibility");
+        assert!(error.contains("combines legacy rules_profile"));
+
+        let pack = manifest
+            .packs
+            .iter_mut()
+            .find(|pack| pack.id == "cosyworld.core")
+            .expect("core pack");
+        pack.rules_profile = None;
+        pack.rules_compatibility = Some(SeedRulesCompatibility {
+            profiles: vec!["fixture.commons/1".to_string()],
+        });
+        let error = validate_worldpack_manifest(&manifest).expect_err("profile mismatch");
+        assert!(error.contains(&active_profile));
+        assert!(error.contains("fixture.commons/1"));
+    }
+
+    #[test]
+    fn profile_owns_its_action_set_and_conformance_must_match_it() {
+        let mut bundle = official_rules_profile();
+        bundle
+            .resources
+            .actions
+            .retain(|action| action.id != "srd5.2.1:dash");
+        bundle
+            .resources
+            .conformance
+            .retain(|row| row.action_id != "srd5.2.1:dash");
+        validate_seed_rules_profile(&bundle).expect("eleven-action profile is complete");
+
+        bundle.resources.conformance.pop();
+        assert_eq!(
+            validate_seed_rules_profile(&bundle).expect_err("incomplete conformance"),
+            "rules conformance does not cover every declared action",
+        );
+    }
 }

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -1097,6 +1097,7 @@ mod tests {
             rules_adapter: None,
             rules_namespace: None,
             rules_profile: None,
+            rules_compatibility: None,
             extensions: serde_json::Value::Null,
         }
     }

--- a/v2/schemas/content-pack-manifest-v1.schema.json
+++ b/v2/schemas/content-pack-manifest-v1.schema.json
@@ -65,9 +65,9 @@
     "rules_adapter": { "$ref": "#/definitions/capabilityId" },
     "rules_namespace": { "$ref": "#/definitions/stableId" },
     "rules_profile": {
-      "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9.-]*/[1-9][0-9]*$"
+      "$ref": "#/definitions/rulesProfileId"
     },
+    "rules_compatibility": { "$ref": "#/definitions/rulesCompatibility" },
     "rules": {
       "type": "object",
       "additionalProperties": { "$ref": "#/definitions/relativePath" }
@@ -104,6 +104,23 @@
     "capabilityId": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9.-]*/[a-z0-9][a-z0-9./-]*$"
+    },
+    "rulesProfileId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9.-]*/[1-9][0-9]*$"
+    },
+    "rulesCompatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profiles"],
+      "properties": {
+        "profiles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/definitions/rulesProfileId" }
+        }
+      }
     },
     "semver": {
       "type": "string",

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import {
   CANONICAL_ID_MAPPING_VERSION,
   CONTENT_PACK_CONTRACT,
+  packAcceptsRulesProfile,
   packDeclaresRuleset,
   resolveContentPackGraph,
   rulesContextValidationErrors,
@@ -84,11 +85,6 @@ const supportedRulesAdapters = new Map([
     "magic_effects",
     "conformance",
   ])],
-]);
-const requiredSrdActionIds = new Set([
-  "srd5.2.1:attack", "srd5.2.1:dash", "srd5.2.1:disengage", "srd5.2.1:dodge",
-  "srd5.2.1:help", "srd5.2.1:hide", "srd5.2.1:influence", "srd5.2.1:magic",
-  "srd5.2.1:ready", "srd5.2.1:search", "srd5.2.1:study", "srd5.2.1:utilize",
 ]);
 const allowedItemRoles = new Set(["generic", "consumable", "weapon", "skill_charm", "spell", "container", "tool", "relic"]);
 const allowedItemSizes = new Set(["tiny", "small", "medium", "large"]);
@@ -407,6 +403,9 @@ if (manifest.avatar_naming !== undefined) {
 const entitlementGrants = new Map();
 for (const pack of packs) {
   validateRequiredStrings("worldpack pack", pack, ["name", "description", "version", "kind", "license", "integrity"]);
+  if (pack.rules_profile !== undefined && pack.rules_compatibility !== undefined) {
+    fail(`pack ${pack.id} combines legacy rules_profile with rules_compatibility`);
+  }
   const buildingArchetypes = pack.extensions?.["x-cosyworld-building-archetypes"];
   if (buildingArchetypes !== undefined) {
     for (const error of buildingArchetypeValidationErrors(
@@ -444,13 +443,19 @@ for (const pack of packs) {
       fail(`rules pack ${pack.id} has an invalid rules_namespace`);
     }
     if (pack.rules_adapter === "cosyworld.rules/2" && pack.rules_profile !== manifest.rules_profile) {
-      fail(`rules/2 pack ${pack.id} must provide ${manifest.rules_profile}`);
+      fail(`rules/2 pack ${pack.id} provides ${pack.rules_profile ?? "no profile"} but world selects ${manifest.rules_profile}`);
     }
     if (pack.rules_adapter === "cosyworld.rules/1" && pack.rules_profile !== undefined) {
       fail(`reference rules/1 pack ${pack.id} cannot activate a rules profile`);
     }
-  } else if (pack.rules_profile !== manifest.rules_profile) {
-    fail(`pack ${pack.id} must target ${manifest.rules_profile}`);
+    if (pack.rules_adapter === "cosyworld.rules/1" && pack.rules_compatibility !== undefined) {
+      fail(`reference rules/1 pack ${pack.id} cannot declare rules compatibility`);
+    }
+  } else if (!packAcceptsRulesProfile(pack, manifest.rules_profile)) {
+    fail(
+      `pack ${pack.id} is incompatible with selected profile ${manifest.rules_profile}; `
+      + `accepted profiles: ${JSON.stringify(pack.rules_compatibility?.profiles ?? (pack.rules_profile ? [pack.rules_profile] : []))}`,
+    );
   }
   if (!/^sha256:[0-9a-f]{64}$/.test(pack.integrity ?? "")) {
     fail(`worldpack pack ${pack.id} has an invalid integrity hash`);
@@ -710,6 +715,7 @@ let ruleMonsterSeedCount = 0;
 let ruleActionCount = 0;
 let activeRulesProfile = null;
 let rulesConformance = [];
+const activeActionIds = new Set();
 const playableBindingIds = new Set();
 const equipmentProfileIds = new Set();
 const magicEffectIds = new Set();
@@ -757,7 +763,7 @@ for (const bundle of ruleBundles) {
     }
     for (const profile of profiles) {
       validateRequiredStrings("rules profile", profile, ["source_document", "source_version", "source_pack", "license", "compatibility_claim", "source_reference", "import_transform"]);
-      if (profile.source_version !== "5.2.1" || profile.license !== "CC-BY-4.0" || profile.modified !== true) {
+      if (profile.modified !== true) {
         fail(`rules profile ${profile.id} has invalid source or modification metadata`);
       }
     }
@@ -765,14 +771,12 @@ for (const bundle of ruleBundles) {
     const actions = asArray(`rules bundle ${bundle.pack_id} actions`, bundle.resources.actions ?? []);
     const actionIds = idSet(`rules bundle ${bundle.pack_id} actions`, actions, (action) => action.id);
     ruleActionCount += actions.length;
-    if (actionIds.size !== requiredSrdActionIds.size) fail(`profile ${manifest.rules_profile} must contain twelve SRD actions`);
-    for (const actionId of requiredSrdActionIds) {
-      if (!has(actionIds, actionId)) fail(`profile ${manifest.rules_profile} is missing ${actionId}`);
-    }
+    if (actionIds.size === 0) fail(`profile ${manifest.rules_profile} must contain at least one action`);
+    for (const actionId of actionIds) activeActionIds.add(actionId);
     for (const action of actions) {
       playableBindingIds.add(action.id);
       validateRequiredStrings("rules action", action, ["namespace", "domain", "label", "source_reference", "support_status", "resolver_kind", "cosyworld_delta"]);
-      if (action.namespace !== "srd5.2.1" || action.domain !== "rules_action" || !Array.isArray(action.aliases) || action.aliases.length === 0) {
+      if (!action.id.startsWith(`${action.namespace}:`) || action.domain !== "rules_action" || !Array.isArray(action.aliases) || action.aliases.length === 0) {
         fail(`rules action ${action.id} has invalid identity, domain, or aliases`);
       }
       if (!["kernel", "projection", "unsupported"].includes(action.support_status)) {
@@ -943,7 +947,7 @@ for (const bundle of contributionBundles) {
         fail(`invalid or conflicting contribution ${row.id}`);
       }
       contributionIds.add(row.id);
-      if (!has(requiredSrdActionIds, row.based_on) || !isNonEmptyString(row.source_reference)) {
+      if (!has(activeActionIds, row.based_on) || !isNonEmptyString(row.source_reference)) {
         fail(`contribution ${row.id} has invalid base action or source reference`);
       }
       if (kind === "reskins") {
@@ -1080,7 +1084,7 @@ for (const row of modifiedMaterial) {
     fail(`modified-material entry ${key} has incomplete provenance`);
   }
 }
-for (const actionId of requiredSrdActionIds) {
+for (const actionId of activeActionIds) {
   if (!modifiedMaterialKeys.has(`action:${actionId}`)) {
     fail(`modified-material report is missing action ${actionId}`);
   }

--- a/v2/scripts/compile-worldpack.mjs
+++ b/v2/scripts/compile-worldpack.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import {
   CANONICAL_ID_MAPPING_VERSION,
   CONTENT_PACK_CONTRACT,
+  packAcceptsRulesProfile,
   packDeclaresRuleset,
   resolveContentPackGraph,
   validateContentPackManifest,
@@ -24,7 +25,6 @@ import { assertNaturalAffordanceConfig } from "./natural-affordance-schema.mjs";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const v2Root = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(v2Root, "..");
-const contentRoot = path.join(v2Root, "content");
 const rawArgs = process.argv.slice(2);
 const args = new Set(rawArgs);
 function optionValue(name) {
@@ -33,6 +33,7 @@ function optionValue(name) {
   assert(rawArgs[index + 1] && !rawArgs[index + 1].startsWith("--"), `${name} requires a path`);
   return path.resolve(rawArgs[index + 1]);
 }
+const contentRoot = optionValue("--content-root") ?? path.join(v2Root, "content");
 const worldDir = optionValue("--world-dir") ?? path.join(v2Root, "worlds", "official");
 const outputDir = optionValue("--output-dir") ?? path.join(contentRoot, "official");
 const checkOnly = args.has("--check");
@@ -77,20 +78,6 @@ const supportedRulesAdapters = new Map([
     "magic_effects",
     "conformance",
   ])],
-]);
-const requiredSrdActionIds = new Set([
-  "srd5.2.1:attack",
-  "srd5.2.1:dash",
-  "srd5.2.1:disengage",
-  "srd5.2.1:dodge",
-  "srd5.2.1:help",
-  "srd5.2.1:hide",
-  "srd5.2.1:influence",
-  "srd5.2.1:magic",
-  "srd5.2.1:ready",
-  "srd5.2.1:search",
-  "srd5.2.1:study",
-  "srd5.2.1:utilize",
 ]);
 const contributionKinds = ["reskins", "offers", "variants", "extensions"];
 const reskinFields = new Set([
@@ -327,18 +314,22 @@ function validateRulesV2Resources(packId, profileId, resources) {
   const profiles = resources.profiles ?? [];
   assert(profiles.length === 1, `rules/2 pack ${packId} must declare exactly one profile`);
   assert(profiles[0].id === profileId, `rules/2 pack ${packId} profile does not match ${profileId}`);
-  assert(profiles[0].source_version === "5.2.1", `rules/2 profile ${profileId} must identify SRD 5.2.1`);
-  assert(profiles[0].license === "CC-BY-4.0", `rules/2 profile ${profileId} must preserve its license`);
+  for (const field of ["source_document", "source_version", "source_pack", "license", "compatibility_claim", "source_reference", "import_transform"]) {
+    assert(typeof profiles[0][field] === "string" && profiles[0][field].trim(), `rules/2 profile ${profileId} is missing ${field}`);
+  }
   assert(typeof profiles[0].source_reference === "string" && profiles[0].source_reference.trim(), `rules/2 profile ${profileId} is missing source_reference`);
 
   const actions = resources.actions ?? [];
   const actionIds = uniqueRows(packId, "actions", actions);
-  assert(actionIds.size === requiredSrdActionIds.size, `rules/2 profile ${profileId} must declare all twelve SRD actions`);
-  for (const actionId of requiredSrdActionIds) {
-    assert(actionIds.has(actionId), `rules/2 profile ${profileId} is missing ${actionId}`);
-  }
+  assert(actionIds.size > 0, `rules/2 profile ${profileId} must declare at least one action`);
   for (const action of actions) {
-    assert(action.namespace === "srd5.2.1" && action.domain === "rules_action", `action ${action.id} has invalid namespace or domain`);
+    assert(
+      typeof action.namespace === "string"
+        && action.namespace.trim()
+        && action.id.startsWith(`${action.namespace}:`)
+        && action.domain === "rules_action",
+      `action ${action.id} has invalid namespace or domain`,
+    );
     assert(["kernel", "projection", "unsupported"].includes(action.support_status), `action ${action.id} has invalid support_status`);
     assert(typeof action.label === "string" && action.label.trim(), `action ${action.id} is missing label`);
     assert(typeof action.source_reference === "string" && action.source_reference.trim(), `action ${action.id} is missing source_reference`);
@@ -439,6 +430,7 @@ function validateContributions(pack, rowsByKind, knownActionIds) {
 
 function runContributionSchemaMutationTests() {
   const pack = { id: "fixture.pack" };
+  const fixtureActionIds = new Set(["srd5.2.1:study"]);
   const base = {
     id: "fixture.pack:notes",
     based_on: "srd5.2.1:study",
@@ -449,7 +441,7 @@ function runContributionSchemaMutationTests() {
   try {
     validateContributions(pack, {
       reskins: [{ ...base, scope: { subject_kind: "location", subject_id: 1 }, compatibility: "cosyworld.srd5/1", dc: 9 }],
-    }, requiredSrdActionIds);
+    }, fixtureActionIds);
   } catch {
     rejectedMechanicalReskin = true;
   }
@@ -466,7 +458,7 @@ function runContributionSchemaMutationTests() {
       precedence: { mode: "explicit", priority: 10 },
       fixtures: ["fixture.pack:careful-study-success"],
     }],
-  }, requiredSrdActionIds);
+  }, fixtureActionIds);
 }
 
 runContributionSchemaMutationTests();
@@ -565,13 +557,20 @@ for (const packId of world.packs) {
       `rules pack ${packId} must declare attribution`,
     );
     if (manifest.rules_adapter === "cosyworld.rules/2") {
-      assert(manifest.rules_profile === world.rules_profile, `rules/2 pack ${packId} must provide selected profile ${world.rules_profile}`);
+      assert(
+        manifest.rules_profile === world.rules_profile,
+        `rules/2 pack ${packId} provides ${manifest.rules_profile ?? "no profile"} but world selects ${world.rules_profile}`,
+      );
     } else {
       assert(!manifest.rules_profile, `reference rules/1 pack ${packId} cannot activate a rules profile`);
+      assert(!manifest.rules_compatibility, `reference rules/1 pack ${packId} cannot declare rules compatibility`);
     }
   } else {
     assert(!manifest.rules, `only rules packs may declare rules resources (${packId})`);
-    assert(manifest.rules_profile === world.rules_profile, `pack ${packId} must target selected profile ${world.rules_profile}`);
+    assert(
+      packAcceptsRulesProfile(manifest, world.rules_profile),
+      `pack ${packId} is incompatible with selected profile ${world.rules_profile}; accepted profiles: ${JSON.stringify(manifest.rules_compatibility?.profiles ?? (manifest.rules_profile ? [manifest.rules_profile] : []))}`,
+    );
   }
   const srdDerived = /(?:system reference document|\bsrd\b)/i.test(
     `${manifest.provenance.source_name} ${manifest.attribution?.source_name ?? ""}`,
@@ -730,11 +729,10 @@ for (const pack of packs) {
       rowsByKind[kind] = relativePath ? readJson(path.join(pack.packRoot, relativePath)) : [];
       resourceCounts[kind] = rowsByKind[kind].length;
     }
-    validateContributions(pack.manifest, rowsByKind, requiredSrdActionIds);
     contributionBundles.push({
       pack_id: pack.manifest.id,
       pack_version: pack.manifest.version,
-      rules_profile: pack.manifest.rules_profile,
+      rules_profile: world.rules_profile,
       ...rowsByKind,
     });
   }
@@ -787,6 +785,17 @@ for (const pack of packs) {
     });
     resourceCounts.assets += 1;
   }
+}
+
+const activeRulesBundle = ruleBundles.find(
+  (bundle) => bundle.adapter === "cosyworld.rules/2"
+    && bundle.resources.profiles?.[0]?.id === world.rules_profile,
+);
+const activeActionIds = new Set(
+  (activeRulesBundle?.resources.actions ?? []).map((action) => action.id),
+);
+for (const bundle of contributionBundles) {
+  validateContributions({ id: bundle.pack_id }, bundle, activeActionIds);
 }
 
 const contributionIdentityOwners = new Map();
@@ -870,6 +879,7 @@ const packSummary = packs.map(({ locked, manifest, integrity }) => ({
   ...(manifest.rules_namespace ? { rules_namespace: manifest.rules_namespace } : {}),
   ...(manifest.extensions ? { extensions: manifest.extensions } : {}),
   ...(manifest.rules_profile ? { rules_profile: manifest.rules_profile } : {}),
+  ...(manifest.rules_compatibility ? { rules_compatibility: manifest.rules_compatibility } : {}),
   source: locked.source,
   integrity,
 }));

--- a/v2/scripts/content-pack-contract.mjs
+++ b/v2/scripts/content-pack-contract.mjs
@@ -95,6 +95,19 @@ export function packDeclaresRuleset(manifest, ruleset) {
   );
 }
 
+export function rulesCompatibilityProfiles(manifest) {
+  if (manifest.rules_compatibility !== undefined) {
+    return Array.isArray(manifest.rules_compatibility?.profiles)
+      ? manifest.rules_compatibility.profiles
+      : [];
+  }
+  return manifest.rules_profile === undefined ? [] : [manifest.rules_profile];
+}
+
+export function packAcceptsRulesProfile(manifest, profileId) {
+  return rulesCompatibilityProfiles(manifest).includes(profileId);
+}
+
 export function rulesContextValidationErrors(manifest, label = "pack.json") {
   const config = manifest.extensions?.["x-cosyworld-rules-context"];
   if (config === undefined) return [];
@@ -201,6 +214,11 @@ export function versionSatisfies(version, range, label = "version range") {
 export function validateContentPackManifest(manifest, label = "pack.json") {
   if (!validateSchema(manifest)) {
     contractError(`${label}: ${formatSchemaErrors(validateSchema.errors ?? [])}`);
+  }
+  if (manifest.rules_profile !== undefined && manifest.rules_compatibility !== undefined) {
+    contractError(
+      `${label}: rules_profile is a legacy one-profile alias and cannot be combined with rules_compatibility`,
+    );
   }
 
   const capabilityIds = new Set();


### PR DESCRIPTION
Closes #242

- add explicit per-pack `rules_compatibility.profiles` with the legacy field as a one-profile alias
- make action completeness profile-owned in the compiler, compiled checker, and Rust loader
- prove an independent eleven-action rules/2 provider compiles only in a matching world
- preserve the official bundle hash unchanged

Validated with `npm run check` and `npm run v2:check`.