### PR TITLE
feat(packs): preserve state across soft unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.162",
+  "version": "0.0.163",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/core-pack-composition.test.mjs
+++ b/test/v2/core-pack-composition.test.mjs
@@ -5,7 +5,10 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { migrateContentReferenceDocument } from "../../v2/scripts/migrate-content-references.mjs";
-import { migratePackUnmount } from "../../v2/scripts/migrate-pack-unmount.mjs";
+import {
+  migratePackRemount,
+  migratePackUnmount,
+} from "../../v2/scripts/migrate-pack-unmount.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const read = (relativePath) => JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"));
@@ -67,29 +70,51 @@ describe("independently mountable CosyWorld Core", () => {
     expect(handles["pack://cosyworld.core/location/1"]).toBe(1);
   });
 
-  it("allows a safe Core unmount only after every human leaves its locations", () => {
+  it("soft-unmounts and remounts Core without losing identities or card zones", () => {
     const vacant = {
       worldpack_bundle_hash: coreOnly.manifest.bundle_hash,
       world_actors: [{ id: 1001, kind: 2, location_id: 1 }],
-      world_items: [{ id: 2001, location_id: 3 }],
+      world_items: [{
+        id: 2001,
+        location_id: 3,
+        holder_actor_id: 1001,
+        zone: 3,
+        container_item_id: 0,
+      }],
       world_locations: [{ id: 1 }, { id: 3 }],
       world_exits: [{ from_location_id: 1, to_location_id: 3 }],
       world_evolution_tracks: [{ actor_id: 1001 }],
       world_combat_encounters: [{ location_id: 3, participants: [{ actor_id: 1001 }] }],
       actor_meta: { 1001: { name: "Rati" } },
+      equipped_charms: { 1001: [2001] },
+      item_provenance: { 2001: { item_id: 2001, origin: "seed_pack" } },
       natural_affordances: { 3: { location_id: 3 } },
       clocks: { "natural-investigation:3:survey": { scope_id: 3 } },
       jobs: { "natural-investigation:3": { location_ids: [3] } },
       branches: { 1: { actor_id: 5000, target_actor_id: 1001 } },
       bonds: { bond: { actor_id: 5000, target_actor_id: 1001 } },
+      transfer_offers: {
+        gift: {
+          offered_by_actor_id: 5000,
+          offered_to_actor_id: 1001,
+          offered_item_id: 2001,
+        },
+      },
       resident_continuities: { 1001: { resident_id: 1001 } },
       resident_memories: { memory: { carrier_actor_id: 1001, kind: "item", subject_id: 2001, location_id: 3 } },
       search_memories: { search: { actor_id: 5000, kind: "location", subject_id: 3, location_id: 3 } },
       tags: { tag: { scope_id: 3 } },
       world_simulation: { locations: { 3: {} }, factions: { hearthbound: {} } },
-      content_context: { mapping_version: 1, references: coreOnly.content_references.entries.slice(0, 3) },
+      content_context: {
+        mapping_version: 1,
+        references: coreOnly.content_references.entries
+          .filter((entry) => entry.pack_id === "cosyworld.core")
+          .slice(0, 3),
+      },
     };
-    const result = migratePackUnmount(structuredClone(vacant), coreOnly, "cosyworld.core", servicesOnly);
+    const source = structuredClone(vacant);
+    const result = migratePackUnmount(source, coreOnly, "cosyworld.core", servicesOnly);
+    expect(source).toEqual(vacant);
     expect(result.removed).toEqual({ actors: 1, items: 1, locations: 2, exits: 1 });
     expect(result.snapshot.worldpack_bundle_hash).toBe(servicesOnly.manifest.bundle_hash);
     for (const field of ["world_evolution_tracks", "world_combat_encounters"]) {
@@ -99,11 +124,82 @@ describe("independently mountable CosyWorld Core", () => {
       expect(result.snapshot[field]).toEqual({});
     }
     expect(result.snapshot.world_simulation).toEqual({ locations: {}, factions: {} });
+    expect(result.snapshot.transfer_offers).toEqual({});
+    expect(result.snapshot.content_context.references).toEqual([]);
+    expect(result.snapshot.pack_mount_state.history).toEqual([
+      expect.objectContaining({
+        sequence: 1,
+        status: "committed",
+        operation: "soft_unmount",
+        pack_id: "cosyworld.core",
+      }),
+    ]);
+    const frozen = result.snapshot.pack_mount_state.frozen["cosyworld.core"];
+    expect(frozen.arrays.world_items[0].value).toMatchObject({
+      id: 2001,
+      holder_actor_id: 1001,
+      zone: 3,
+    });
+    expect(frozen.maps.equipped_charms).toEqual({ 1001: [2001] });
+    expect(frozen.maps.item_provenance).toEqual({
+      2001: { item_id: 2001, origin: "seed_pack" },
+    });
 
     const occupied = structuredClone(vacant);
     occupied.world_actors.push({ id: 5000, kind: 1, location_id: 1 });
+    const occupiedBefore = structuredClone(occupied);
     expect(() => migratePackUnmount(occupied, coreOnly, "cosyworld.core", servicesOnly))
       .toThrow(/human actors 5000 still occupy/);
+    expect(occupied).toEqual(occupiedBefore);
+
+    const remounted = migratePackRemount(
+      result.snapshot,
+      servicesOnly,
+      "cosyworld.core",
+      coreOnly,
+    );
+    expect(remounted.restored).toEqual(result.removed);
+    expect(remounted.snapshot.worldpack_bundle_hash).toBe(coreOnly.manifest.bundle_hash);
+    for (const field of [
+      "world_actors",
+      "world_items",
+      "world_locations",
+      "world_exits",
+      "world_evolution_tracks",
+      "world_combat_encounters",
+      "actor_meta",
+      "equipped_charms",
+      "item_provenance",
+      "natural_affordances",
+      "clocks",
+      "jobs",
+      "branches",
+      "bonds",
+      "transfer_offers",
+      "resident_continuities",
+      "resident_memories",
+      "search_memories",
+      "tags",
+      "world_simulation",
+      "content_context",
+    ]) expect(remounted.snapshot[field], field).toEqual(vacant[field]);
+    expect(remounted.snapshot.pack_mount_state.frozen).toEqual({});
+    expect(remounted.snapshot.pack_mount_state.history).toHaveLength(2);
+    expect(remounted.transaction).toMatchObject({
+      sequence: 2,
+      status: "committed",
+      operation: "remount",
+      pack_id: "cosyworld.core",
+      state_hash: result.transaction.state_hash,
+    });
+
+    const conflicting = structuredClone(result.snapshot);
+    conflicting.world_items.push({ id: 2001, location_id: 0, zone: 1 });
+    const conflictingBefore = structuredClone(conflicting);
+    expect(() =>
+      migratePackRemount(conflicting, servicesOnly, "cosyworld.core", coreOnly))
+      .toThrow(/world_items identity 2001 is already active/);
+    expect(conflicting).toEqual(conflictingBefore);
   });
 
   it("provides a non-world services composition without silently mounting Core", () => {

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -197,7 +197,8 @@ npm run v2:worldpack:compile
 npm run v2:worldpack
 npm run v2:worldpack:inspect
 npm run v2:content-refs:migrate -- --input legacy.json --output migrated.json
-npm run v2:pack:unmount -- --input snapshot.json --output migrated.json --registry v2/content/core-only/registry.json --target-registry v2/content/services-only/registry.json --pack cosyworld.core
+npm run v2:pack:unmount -- --operation unmount --input snapshot.json --output unmounted.json --registry v2/content/core-only/registry.json --target-registry v2/content/services-only/registry.json --pack cosyworld.core
+npm run v2:pack:unmount -- --operation remount --input unmounted.json --output remounted.json --registry v2/content/services-only/registry.json --target-registry v2/content/core-only/registry.json --pack cosyworld.core
 ```
 
 `sync` skips workspace packs and materializes Git-backed packs below `v2/content/imports`. Git sources must use an HTTPS GitHub URL and a full 40-character commit. It never follows a branch or tag at build time.
@@ -284,11 +285,15 @@ ids themselves and preserves self-contained contexts for unavailable packs.
 Unmounting a world pack is an explicit offline migration, never an implicit
 runtime fallback. `v2:pack:unmount` refuses to proceed while a human actor still
 occupies a location owned by the pack. Once vacant, it removes the pack-owned
-runtime projection, retains historical journal/event context, filters the live
-snapshot's canonical references, and records the target registry identity and
-ruleset selection. Archive the source snapshot and stop writers before running
-it; then start the single authoritative writer with the exact target registry
-supplied to the tool.
+live projection and freezes the exact entities, item/card zones, projection
+maps, and canonical context in the snapshot's versioned `pack_mount_state`.
+Each committed operation records source/target bundle hashes, counts, a stable
+state hash, and a monotonic sequence. Remount requires the exact frozen source
+registry and restores the same identities; collisions fail without changing
+the input. The CLI writes through a same-directory temporary file and atomic
+rename. Archive the source snapshot and stop writers before running it; then
+start the single authoritative writer with the exact target registry supplied
+to the tool.
 
 ## Runtime discovery and access
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.162"
+version = "0.0.163"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.162"
+version = "0.0.163"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -65,6 +65,16 @@ pub(super) struct ContentReferenceContext {
     pub(super) active_rulesets: Vec<ActiveRulesetContext>,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(transparent)]
+pub(super) struct PackMountState(pub(super) serde_json::Value);
+
+impl PackMountState {
+    pub(super) fn is_empty(&self) -> bool {
+        self.0.is_null()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ContentReferenceStatus {
     Available,
@@ -1454,5 +1464,31 @@ mod tests {
         assert_eq!(context.active_rulesets.len(), 1);
         assert_eq!(context.active_rulesets[0].capability_id, "rules-pack/core");
         assert_eq!(context.active_rulesets[0].provider_pack_version, "1.0.0");
+    }
+
+    #[test]
+    fn snapshot_round_trip_preserves_pack_mount_state() {
+        let mut runtime = RuntimeWorld::seeded();
+        runtime.pack_mount_state = PackMountState(serde_json::json!({
+            "schema_version": 1,
+            "next_transaction_seq": 2,
+            "frozen": {
+                "example.pack": {
+                    "arrays": {
+                        "world_items": [{
+                            "index": 0,
+                            "value": { "id": 42, "zone": 3 }
+                        }]
+                    }
+                }
+            },
+            "history": [{ "sequence": 1, "operation": "soft_unmount" }]
+        }));
+        let expected = runtime.pack_mount_state.clone();
+
+        let snapshot = RuntimeSnapshot::from_runtime(&runtime);
+        assert_eq!(snapshot.pack_mount_state, expected);
+        let restored = snapshot.into_runtime().expect("snapshot restores");
+        assert_eq!(restored.pack_mount_state, expected);
     }
 }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1702,6 +1702,7 @@ struct RuntimeWorld {
     orb_balances: BTreeMap<u64, i32>,
     orb_reward_claims: BTreeSet<String>,
     listen_attempt_claims: BTreeSet<String>,
+    pack_mount_state: PackMountState,
     presence_states: BTreeMap<u64, bool>,
     event_log: Vec<EventView>,
     recent_room_lines: BTreeMap<u64, Vec<EventView>>,
@@ -1723,6 +1724,8 @@ struct RuntimeSnapshot {
     active_rules_variants: Vec<String>,
     #[serde(default)]
     active_rules_extensions: Vec<String>,
+    #[serde(default, skip_serializing_if = "PackMountState::is_empty")]
+    pack_mount_state: PackMountState,
 
     world_version: u32,
     tick: u64,
@@ -6182,6 +6185,7 @@ impl RuntimeSnapshot {
             rules_profile: active_content().manifest.rules_profile.clone(),
             active_rules_variants: active_content().manifest.active_rules_variants.clone(),
             active_rules_extensions: active_content().manifest.active_rules_extensions.clone(),
+            pack_mount_state: runtime.pack_mount_state.clone(),
 
             world_version: runtime.world.version,
             tick: runtime.world.tick,
@@ -6454,6 +6458,7 @@ impl RuntimeSnapshot {
             orb_balances: self.orb_balances,
             orb_reward_claims: self.orb_reward_claims,
             listen_attempt_claims: self.listen_attempt_claims,
+            pack_mount_state: self.pack_mount_state,
             presence_states: BTreeMap::new(),
             event_log: self.event_log,
             recent_room_lines: self.recent_room_lines,
@@ -6932,6 +6937,7 @@ impl RuntimeWorld {
             orb_balances: BTreeMap::new(),
             orb_reward_claims: BTreeSet::new(),
             listen_attempt_claims: BTreeSet::new(),
+            pack_mount_state: PackMountState::default(),
             presence_states: BTreeMap::new(),
             event_log: Vec::new(),
             recent_room_lines: BTreeMap::new(),

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-75249
+75255

--- a/v2/scripts/migrate-pack-unmount.mjs
+++ b/v2/scripts/migrate-pack-unmount.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+const PACK_MOUNT_STATE_SCHEMA_VERSION = 1;
 
 function packHandles(registry, packId, kind) {
   return new Set((registry.content_references?.entries ?? [])
@@ -15,28 +18,92 @@ function packResourceIds(registry, packId, resource, identity = "id") {
     .map((row) => String(row[identity])));
 }
 
-function deleteMapKeys(map, keys) {
-  if (!map || Array.isArray(map) || typeof map !== "object") return 0;
-  let removed = 0;
-  for (const key of keys) {
-    if (Object.hasOwn(map, String(key))) {
-      delete map[String(key)];
-      removed += 1;
-    }
-  }
-  return removed;
+function hasId(ids, value) {
+  return ids.has(Number(value));
 }
 
-function deleteMapValues(map, predicate) {
-  if (!map || Array.isArray(map) || typeof map !== "object") return 0;
-  let removed = 0;
-  for (const [key, value] of Object.entries(map)) {
-    if (predicate(value, key)) {
-      delete map[key];
-      removed += 1;
+function takeArrayEntries(snapshot, field, predicate) {
+  const frozen = [];
+  const retained = [];
+  for (const [index, value] of (snapshot[field] ?? []).entries()) {
+    if (predicate(value)) {
+      frozen.push({ index, value });
+    } else {
+      retained.push(value);
     }
   }
-  return removed;
+  snapshot[field] = retained;
+  return frozen;
+}
+
+function takeMapKeys(map, keys) {
+  const frozen = {};
+  if (!map || Array.isArray(map) || typeof map !== "object") return frozen;
+  for (const key of keys) {
+    if (Object.hasOwn(map, String(key))) {
+      frozen[String(key)] = map[String(key)];
+      delete map[String(key)];
+    }
+  }
+  return frozen;
+}
+
+function takeMapValues(map, predicate) {
+  const frozen = {};
+  if (!map || Array.isArray(map) || typeof map !== "object") return frozen;
+  for (const [key, value] of Object.entries(map)) {
+    if (predicate(value, key)) {
+      frozen[key] = value;
+      delete map[key];
+    }
+  }
+  return frozen;
+}
+
+function restoreArrayEntries(snapshot, field, frozen, identity) {
+  const restored = [...(snapshot[field] ?? [])];
+  const identities = new Set(restored.map(identity));
+  for (const { value } of frozen) {
+    const key = identity(value);
+    if (identities.has(key)) {
+      throw new Error(`cannot remount: ${field} identity ${key} is already active`);
+    }
+    identities.add(key);
+  }
+  for (const { index, value } of [...frozen].sort((left, right) => left.index - right.index)) {
+    restored.splice(Math.min(index, restored.length), 0, value);
+  }
+  snapshot[field] = restored;
+}
+
+function restoreMapEntries(snapshot, field, frozen) {
+  const restored = { ...(snapshot[field] ?? {}) };
+  for (const [key, value] of Object.entries(frozen ?? {})) {
+    if (Object.hasOwn(restored, key)) {
+      throw new Error(`cannot remount: ${field} identity ${key} is already active`);
+    }
+    restored[key] = value;
+  }
+  snapshot[field] = restored;
+}
+
+function restoreNestedMapEntries(parent, field, frozen) {
+  const restored = { ...(parent[field] ?? {}) };
+  for (const [key, value] of Object.entries(frozen ?? {})) {
+    if (Object.hasOwn(restored, key)) {
+      throw new Error(`cannot remount: world_simulation.${field} identity ${key} is already active`);
+    }
+    restored[key] = value;
+  }
+  parent[field] = restored;
+}
+
+function packVersion(registry, packId) {
+  return (registry.manifest?.packs ?? []).find((pack) => pack.id === packId)?.version;
+}
+
+function registryHasPack(registry, packId) {
+  return packVersion(registry, packId) !== undefined;
 }
 
 function targetRulesets(registry) {
@@ -56,97 +123,344 @@ function targetRulesets(registry) {
   });
 }
 
-export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegistry = null) {
-  if (!(sourceRegistry.manifest?.packs ?? []).some((pack) => pack.id === packId)) {
+function targetContentContext(current, targetRegistry, unmountedPackId) {
+  const targetReferences = new Map((targetRegistry.content_references?.entries ?? [])
+    .map((entry) => [entry.canonical_ref, entry]));
+  return {
+    mapping_version: targetRegistry.content_references?.mapping_version ?? 0,
+    references: (current?.references ?? [])
+      .filter((reference) => reference.pack_id !== unmountedPackId)
+      .filter((reference) => targetReferences.has(reference.canonical_ref))
+      .map((reference) => structuredClone(targetReferences.get(reference.canonical_ref))),
+    active_rulesets: targetRulesets(targetRegistry),
+  };
+}
+
+function packMountState(snapshot, create = false) {
+  if (snapshot.pack_mount_state === undefined && create) {
+    snapshot.pack_mount_state = {
+      schema_version: PACK_MOUNT_STATE_SCHEMA_VERSION,
+      next_transaction_seq: 1,
+      frozen: {},
+      history: [],
+    };
+  }
+  const state = snapshot.pack_mount_state;
+  if (!state) return null;
+  if (state.schema_version !== PACK_MOUNT_STATE_SCHEMA_VERSION
+      || !state.frozen
+      || !Array.isArray(state.history)) {
+    throw new Error("unsupported or malformed pack_mount_state");
+  }
+  return state;
+}
+
+function frozenStateHash(frozen) {
+  const digest = crypto.createHash("sha256").update(JSON.stringify(frozen)).digest("hex");
+  return `sha256:${digest}`;
+}
+
+function appendTransaction(state, transaction) {
+  const sequence = state.next_transaction_seq ?? 1;
+  const committed = { sequence, status: "committed", ...transaction };
+  state.history.push(committed);
+  state.next_transaction_seq = sequence + 1;
+  return committed;
+}
+
+export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegistry) {
+  if (!registryHasPack(sourceRegistry, packId)) {
     throw new Error(`pack ${packId} is not mounted in the source registry`);
   }
-  if ((targetRegistry?.manifest?.packs ?? []).some((pack) => pack.id === packId)) {
+  if (!targetRegistry) {
+    throw new Error("soft unmount requires a target registry");
+  }
+  if (registryHasPack(targetRegistry, packId)) {
     throw new Error(`target registry still mounts pack ${packId}`);
   }
+
+  const migrated = structuredClone(snapshot);
+  const mountState = packMountState(migrated, true);
+  if (mountState.frozen[packId]) {
+    throw new Error(`pack ${packId} is already soft-unmounted`);
+  }
+
   const actorIds = packHandles(sourceRegistry, packId, "actor");
   const itemIds = packHandles(sourceRegistry, packId, "item");
   const locationIds = packHandles(sourceRegistry, packId, "location");
-  const occupied = (snapshot.world_actors ?? []).filter((actor) => actor.kind === 1 && locationIds.has(actor.location_id));
+  const occupied = (migrated.world_actors ?? [])
+    .filter((actor) => actor.kind === 1 && hasId(locationIds, actor.location_id));
   if (occupied.length > 0) {
     throw new Error(`cannot unmount ${packId}: human actors ${occupied.map((actor) => actor.id).join(", ")} still occupy pack locations`);
   }
 
   const before = {
-    actors: snapshot.world_actors?.length ?? 0,
-    items: snapshot.world_items?.length ?? 0,
-    locations: snapshot.world_locations?.length ?? 0,
-    exits: snapshot.world_exits?.length ?? 0,
+    actors: migrated.world_actors?.length ?? 0,
+    items: migrated.world_items?.length ?? 0,
+    locations: migrated.world_locations?.length ?? 0,
+    exits: migrated.world_exits?.length ?? 0,
   };
-  snapshot.world_actors = (snapshot.world_actors ?? []).filter((actor) => !actorIds.has(actor.id));
-  snapshot.world_items = (snapshot.world_items ?? []).filter((item) => !itemIds.has(item.id));
-  snapshot.world_locations = (snapshot.world_locations ?? []).filter((location) => !locationIds.has(location.id));
-  snapshot.world_exits = (snapshot.world_exits ?? []).filter((exit) => !locationIds.has(exit.from_location_id) && !locationIds.has(exit.to_location_id));
-  snapshot.world_evolution_tracks = (snapshot.world_evolution_tracks ?? []).filter((track) => !actorIds.has(track.actor_id));
-  snapshot.world_combat_encounters = (snapshot.world_combat_encounters ?? []).filter((encounter) =>
-    !locationIds.has(encounter.location_id)
-      && !(encounter.participants ?? []).some((participant) => actorIds.has(participant.actor_id)));
+  const arrays = {
+    world_actors: takeArrayEntries(
+      migrated,
+      "world_actors",
+      (actor) => hasId(actorIds, actor.id),
+    ),
+    world_items: takeArrayEntries(
+      migrated,
+      "world_items",
+      (item) => hasId(itemIds, item.id),
+    ),
+    world_locations: takeArrayEntries(
+      migrated,
+      "world_locations",
+      (location) => hasId(locationIds, location.id),
+    ),
+    world_exits: takeArrayEntries(
+      migrated,
+      "world_exits",
+      (exit) =>
+        hasId(locationIds, exit.from_location_id)
+          || hasId(locationIds, exit.to_location_id),
+    ),
+    world_evolution_tracks: takeArrayEntries(
+      migrated,
+      "world_evolution_tracks",
+      (track) => hasId(actorIds, track.actor_id),
+    ),
+    world_combat_encounters: takeArrayEntries(
+      migrated,
+      "world_combat_encounters",
+      (encounter) =>
+        hasId(locationIds, encounter.location_id)
+          || (encounter.participants ?? [])
+            .some((participant) => hasId(actorIds, participant.actor_id)),
+    ),
+  };
 
-  for (const field of ["actor_meta", "actor_autonomy", "callings", "orb_balances"]) deleteMapKeys(snapshot[field], actorIds);
-  for (const field of ["item_meta"]) deleteMapKeys(snapshot[field], itemIds);
-  for (const field of ["location_names", "location_meta", "room_sheets", "natural_affordances"]) {
-    deleteMapKeys(snapshot[field], locationIds);
+  const maps = {};
+  for (const field of [
+    "actor_meta",
+    "actor_autonomy",
+    "actor_rules_facets",
+    "callings",
+    "character_identities",
+    "charm_slots",
+    "deed_ids_by_actor",
+    "equipped_charms",
+    "orb_balances",
+    "prepared_spells",
+  ]) maps[field] = takeMapKeys(migrated[field], actorIds);
+  for (const field of ["item_meta", "item_provenance"]) {
+    maps[field] = takeMapKeys(migrated[field], itemIds);
   }
-  deleteMapKeys(snapshot.clocks, packResourceIds(sourceRegistry, packId, "clocks"));
-  deleteMapKeys(snapshot.jobs, packResourceIds(sourceRegistry, packId, "jobs"));
-  deleteMapValues(snapshot.clocks, (clock) => locationIds.has(clock.scope_id));
-  deleteMapValues(snapshot.jobs, (job) =>
-    (job.location_ids ?? []).some((locationId) => locationIds.has(locationId)));
-  deleteMapKeys(snapshot.world_simulation?.locations, locationIds);
-  deleteMapKeys(snapshot.world_simulation?.factions, packResourceIds(sourceRegistry, packId, "factions"));
+  for (const field of [
+    "generated_places",
+    "location_names",
+    "location_meta",
+    "natural_affordances",
+    "recent_room_lines",
+    "room_sheets",
+  ]) maps[field] = takeMapKeys(migrated[field], locationIds);
 
-  deleteMapValues(snapshot.branches, (branch) => actorIds.has(branch.actor_id) || actorIds.has(branch.target_actor_id));
-  deleteMapValues(snapshot.generated_pathways, (pathway) =>
-    locationIds.has(pathway.origin_location_id) || locationIds.has(pathway.destination_location_id));
-  deleteMapValues(snapshot.journeys, (journey) =>
-    actorIds.has(journey.actor_id)
-      || locationIds.has(journey.origin_location_id)
-      || locationIds.has(journey.destination_location_id)
-      || (journey.path ?? []).some((locationId) => locationIds.has(locationId)));
+  maps.clocks = takeMapKeys(
+    migrated.clocks,
+    packResourceIds(sourceRegistry, packId, "clocks"),
+  );
+  Object.assign(
+    maps.clocks,
+    takeMapValues(migrated.clocks, (clock) => hasId(locationIds, clock.scope_id)),
+  );
+  maps.jobs = takeMapKeys(
+    migrated.jobs,
+    packResourceIds(sourceRegistry, packId, "jobs"),
+  );
+  Object.assign(
+    maps.jobs,
+    takeMapValues(
+      migrated.jobs,
+      (job) => (job.location_ids ?? []).some((locationId) => hasId(locationIds, locationId)),
+    ),
+  );
+  maps.branches = takeMapValues(
+    migrated.branches,
+    (branch) =>
+      hasId(actorIds, branch.actor_id) || hasId(actorIds, branch.target_actor_id),
+  );
+  maps.generated_pathways = takeMapValues(
+    migrated.generated_pathways,
+    (pathway) =>
+      hasId(locationIds, pathway.origin_location_id)
+        || hasId(locationIds, pathway.destination_location_id),
+  );
+  maps.journeys = takeMapValues(
+    migrated.journeys,
+    (journey) =>
+      hasId(actorIds, journey.actor_id)
+        || hasId(locationIds, journey.origin_location_id)
+        || hasId(locationIds, journey.destination_location_id)
+        || (journey.path ?? []).some((locationId) => hasId(locationIds, locationId)),
+  );
   for (const field of ["skills", "ledger_marks", "advancement_spends"]) {
-    deleteMapValues(snapshot[field], (entry) => actorIds.has(entry.actor_id));
+    maps[field] = takeMapValues(
+      migrated[field],
+      (entry) => hasId(actorIds, entry.actor_id),
+    );
   }
-  deleteMapValues(snapshot.bonds, (bond) => actorIds.has(bond.actor_id) || actorIds.has(bond.target_actor_id));
-  deleteMapValues(snapshot.resident_continuities, (continuity) => actorIds.has(continuity.resident_id));
-  deleteMapValues(snapshot.resident_memories, (memory) =>
-    actorIds.has(memory.carrier_actor_id)
-      || actorIds.has(memory.source_actor_id)
-      || actorIds.has(memory.holder_actor_id)
-      || locationIds.has(memory.location_id)
-      || (memory.kind === "actor" && actorIds.has(memory.subject_id))
-      || (memory.kind === "item" && itemIds.has(memory.subject_id)));
-  deleteMapValues(snapshot.search_memories, (memory) =>
-    actorIds.has(memory.actor_id)
-      || locationIds.has(memory.location_id)
-      || (memory.kind === "actor" && actorIds.has(memory.subject_id))
-      || (memory.kind === "item" && itemIds.has(memory.subject_id))
-      || (memory.kind === "location" && locationIds.has(memory.subject_id)));
-  deleteMapValues(snapshot.tags, (tag) =>
-    actorIds.has(tag.scope_id) || itemIds.has(tag.scope_id) || locationIds.has(tag.scope_id));
+  maps.bonds = takeMapValues(
+    migrated.bonds,
+    (bond) => hasId(actorIds, bond.actor_id) || hasId(actorIds, bond.target_actor_id),
+  );
+  maps.resident_continuities = takeMapValues(
+    migrated.resident_continuities,
+    (continuity) => hasId(actorIds, continuity.resident_id),
+  );
+  maps.resident_memories = takeMapValues(
+    migrated.resident_memories,
+    (memory) =>
+      hasId(actorIds, memory.carrier_actor_id)
+        || hasId(actorIds, memory.source_actor_id)
+        || hasId(actorIds, memory.holder_actor_id)
+        || hasId(locationIds, memory.location_id)
+        || (memory.kind === "actor" && hasId(actorIds, memory.subject_id))
+        || (memory.kind === "item" && hasId(itemIds, memory.subject_id)),
+  );
+  maps.search_memories = takeMapValues(
+    migrated.search_memories,
+    (memory) =>
+      hasId(actorIds, memory.actor_id)
+        || hasId(locationIds, memory.location_id)
+        || (memory.kind === "actor" && hasId(actorIds, memory.subject_id))
+        || (memory.kind === "item" && hasId(itemIds, memory.subject_id))
+        || (memory.kind === "location" && hasId(locationIds, memory.subject_id)),
+  );
+  maps.tags = takeMapValues(
+    migrated.tags,
+    (tag) =>
+      hasId(actorIds, tag.scope_id)
+        || hasId(itemIds, tag.scope_id)
+        || hasId(locationIds, tag.scope_id),
+  );
+  maps.transfer_offers = takeMapValues(
+    migrated.transfer_offers,
+    (offer) =>
+      hasId(actorIds, offer.offered_by_actor_id)
+        || hasId(actorIds, offer.offered_to_actor_id)
+        || hasId(itemIds, offer.offered_item_id)
+        || hasId(itemIds, offer.requested_item_id),
+  );
+  maps.gift_auto_accepts = takeMapValues(
+    migrated.gift_auto_accepts,
+    (policy) =>
+      hasId(actorIds, policy.recipient_actor_id)
+        || hasId(actorIds, policy.offered_by_actor_id)
+        || hasId(itemIds, policy.item_id),
+  );
 
-  if (snapshot.content_context) {
-    snapshot.content_context.references = (snapshot.content_context.references ?? [])
-      .filter((reference) => reference.pack_id !== packId);
-    if (targetRegistry) {
-      snapshot.content_context.mapping_version = targetRegistry.content_references.mapping_version;
-      snapshot.content_context.active_rulesets = targetRulesets(targetRegistry);
-    }
-  }
-  if (targetRegistry) snapshot.worldpack_bundle_hash = targetRegistry.manifest.bundle_hash;
-
-  return {
-    snapshot,
-    removed: {
-      actors: before.actors - snapshot.world_actors.length,
-      items: before.items - snapshot.world_items.length,
-      locations: before.locations - snapshot.world_locations.length,
-      exits: before.exits - snapshot.world_exits.length,
-    },
+  migrated.world_simulation ??= {};
+  const worldSimulation = {
+    locations: takeMapKeys(migrated.world_simulation.locations, locationIds),
+    factions: takeMapKeys(
+      migrated.world_simulation.factions,
+      packResourceIds(sourceRegistry, packId, "factions"),
+    ),
   };
+  const removed = {
+    actors: before.actors - migrated.world_actors.length,
+    items: before.items - migrated.world_items.length,
+    locations: before.locations - migrated.world_locations.length,
+    exits: before.exits - migrated.world_exits.length,
+  };
+  const frozen = {
+    pack_id: packId,
+    pack_version: packVersion(sourceRegistry, packId),
+    source_bundle_hash: sourceRegistry.manifest.bundle_hash,
+    target_bundle_hash: targetRegistry.manifest.bundle_hash,
+    content_context: structuredClone(migrated.content_context ?? {}),
+    arrays,
+    maps,
+    world_simulation: worldSimulation,
+  };
+  const stateHash = frozenStateHash(frozen);
+  mountState.frozen[packId] = frozen;
+  migrated.content_context = targetContentContext(
+    migrated.content_context,
+    targetRegistry,
+    packId,
+  );
+  migrated.worldpack_bundle_hash = targetRegistry.manifest.bundle_hash;
+  const transaction = appendTransaction(mountState, {
+    operation: "soft_unmount",
+    pack_id: packId,
+    pack_version: frozen.pack_version,
+    source_bundle_hash: frozen.source_bundle_hash,
+    target_bundle_hash: frozen.target_bundle_hash,
+    state_hash: stateHash,
+    counts: removed,
+  });
+
+  return { snapshot: migrated, removed, transaction };
+}
+
+export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegistry) {
+  if (registryHasPack(sourceRegistry, packId)) {
+    throw new Error(`source registry already mounts pack ${packId}`);
+  }
+  if (!targetRegistry || !registryHasPack(targetRegistry, packId)) {
+    throw new Error(`target registry does not mount pack ${packId}`);
+  }
+  const migrated = structuredClone(snapshot);
+  const mountState = packMountState(migrated);
+  const frozen = mountState?.frozen?.[packId];
+  if (!frozen) {
+    throw new Error(`pack ${packId} has no frozen soft-unmount state`);
+  }
+  if (frozen.target_bundle_hash !== sourceRegistry.manifest.bundle_hash) {
+    throw new Error(`cannot remount ${packId}: current registry does not match the unmount target`);
+  }
+  if (frozen.source_bundle_hash !== targetRegistry.manifest.bundle_hash
+      || frozen.pack_version !== packVersion(targetRegistry, packId)) {
+    throw new Error(`cannot remount ${packId}: target registry does not match the frozen source`);
+  }
+
+  const arrayIdentities = {
+    world_actors: (actor) => actor.id,
+    world_items: (item) => item.id,
+    world_locations: (location) => location.id,
+    world_exits: (exit) =>
+      `${exit.from_location_id}:${exit.to_location_id}:${exit.flags ?? 0}`,
+    world_evolution_tracks: (track) => track.actor_id,
+    world_combat_encounters: (encounter) => encounter.id,
+  };
+  for (const [field, entries] of Object.entries(frozen.arrays ?? {})) {
+    restoreArrayEntries(migrated, field, entries, arrayIdentities[field]);
+  }
+  for (const [field, entries] of Object.entries(frozen.maps ?? {})) {
+    restoreMapEntries(migrated, field, entries);
+  }
+  migrated.world_simulation ??= {};
+  for (const [field, entries] of Object.entries(frozen.world_simulation ?? {})) {
+    restoreNestedMapEntries(migrated.world_simulation, field, entries);
+  }
+  migrated.content_context = structuredClone(frozen.content_context);
+  migrated.worldpack_bundle_hash = targetRegistry.manifest.bundle_hash;
+  delete mountState.frozen[packId];
+  const restored = {
+    actors: frozen.arrays?.world_actors?.length ?? 0,
+    items: frozen.arrays?.world_items?.length ?? 0,
+    locations: frozen.arrays?.world_locations?.length ?? 0,
+    exits: frozen.arrays?.world_exits?.length ?? 0,
+  };
+  const transaction = appendTransaction(mountState, {
+    operation: "remount",
+    pack_id: packId,
+    pack_version: frozen.pack_version,
+    source_bundle_hash: sourceRegistry.manifest.bundle_hash,
+    target_bundle_hash: targetRegistry.manifest.bundle_hash,
+    state_hash: frozenStateHash(frozen),
+    counts: restored,
+  });
+  return { snapshot: migrated, restored, transaction };
 }
 
 function option(args, name) {
@@ -154,26 +468,42 @@ function option(args, name) {
   return index < 0 ? undefined : args[index + 1];
 }
 
+function writeJsonAtomically(output, value) {
+  const destination = path.resolve(output);
+  const temporary = `${destination}.tmp-${process.pid}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+  try {
+    fs.renameSync(temporary, destination);
+  } catch (error) {
+    fs.rmSync(temporary, { force: true });
+    throw error;
+  }
+}
+
 const scriptPath = fileURLToPath(import.meta.url);
 if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
   try {
     const args = process.argv.slice(2);
+    const operation = option(args, "--operation") ?? "unmount";
     const input = option(args, "--input");
     const output = option(args, "--output");
     const registryPath = option(args, "--registry");
     const targetPath = option(args, "--target-registry");
     const packId = option(args, "--pack");
-    if (!input || !output || !registryPath || !packId) {
-      throw new Error("usage: migrate-pack-unmount.mjs --input snapshot.json --output migrated.json --registry source-registry.json --pack PACK_ID [--target-registry registry.json]");
+    if (!input || !output || !registryPath || !targetPath || !packId
+        || !["unmount", "remount"].includes(operation)) {
+      throw new Error("usage: migrate-pack-unmount.mjs --operation unmount|remount --input snapshot.json --output migrated.json --registry source-registry.json --target-registry target-registry.json --pack PACK_ID");
     }
     const snapshot = JSON.parse(fs.readFileSync(path.resolve(input), "utf8"));
     const registry = JSON.parse(fs.readFileSync(path.resolve(registryPath), "utf8"));
-    const target = targetPath ? JSON.parse(fs.readFileSync(path.resolve(targetPath), "utf8")) : null;
-    const result = migratePackUnmount(snapshot, registry, packId, target);
-    fs.writeFileSync(path.resolve(output), `${JSON.stringify(result.snapshot, null, 2)}\n`);
-    console.log(`unmounted ${packId}: ${JSON.stringify(result.removed)}`);
+    const target = JSON.parse(fs.readFileSync(path.resolve(targetPath), "utf8"));
+    const result = operation === "unmount"
+      ? migratePackUnmount(snapshot, registry, packId, target)
+      : migratePackRemount(snapshot, registry, packId, target);
+    writeJsonAtomically(output, result.snapshot);
+    console.log(`${operation}ed ${packId}: ${JSON.stringify(result.removed ?? result.restored)}`);
   } catch (error) {
-    console.error(`pack unmount migration failed: ${error.message}`);
+    console.error(`pack mount migration failed: ${error.message}`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
Issue #28

- Freeze pack-owned entities, item/card zones, projection maps, canonical context, and active transfer state in a versioned soft-unmount capsule.
- Remount only into the exact source registry, restoring identities with collision/rollback checks and deterministic transaction history.
- Persist capsules through Rust snapshots; add atomic CLI writes and unmount/remount operation support.
- Release 0.0.163; `npm run check` and `npm run v2:check` pass. `main.rs` grows only six central persistence bridge lines (75,249→75,255); logic/tests remain outside it.