### PR TITLE
fix(packs): keep stale offers invalidated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.163",
+  "version": "0.0.164",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/core-pack-composition.test.mjs
+++ b/test/v2/core-pack-composition.test.mjs
@@ -98,6 +98,15 @@ describe("independently mountable CosyWorld Core", () => {
           offered_by_actor_id: 5000,
           offered_to_actor_id: 1001,
           offered_item_id: 2001,
+          status: "pending",
+        },
+      },
+      gift_auto_accepts: {
+        policy: {
+          recipient_actor_id: 1001,
+          offered_by_actor_id: 5000,
+          item_id: 2001,
+          consumed: false,
         },
       },
       resident_continuities: { 1001: { resident_id: 1001 } },
@@ -124,7 +133,8 @@ describe("independently mountable CosyWorld Core", () => {
       expect(result.snapshot[field]).toEqual({});
     }
     expect(result.snapshot.world_simulation).toEqual({ locations: {}, factions: {} });
-    expect(result.snapshot.transfer_offers).toEqual({});
+    expect(result.snapshot.transfer_offers.gift.status).toBe("invalidated");
+    expect(result.snapshot.gift_auto_accepts.policy.consumed).toBe(true);
     expect(result.snapshot.content_context.references).toEqual([]);
     expect(result.snapshot.pack_mount_state.history).toEqual([
       expect.objectContaining({
@@ -132,6 +142,10 @@ describe("independently mountable CosyWorld Core", () => {
         status: "committed",
         operation: "soft_unmount",
         pack_id: "cosyworld.core",
+        invalidated: {
+          transfer_offers: 1,
+          gift_auto_accepts: 1,
+        },
       }),
     ]);
     const frozen = result.snapshot.pack_mount_state.frozen["cosyworld.core"];
@@ -144,6 +158,12 @@ describe("independently mountable CosyWorld Core", () => {
     expect(frozen.maps.item_provenance).toEqual({
       2001: { item_id: 2001, origin: "seed_pack" },
     });
+    expect(frozen.invalidated).toEqual({
+      transfer_offer_ids: ["gift"],
+      gift_auto_accept_ids: ["policy"],
+    });
+    expect(frozen.maps.transfer_offers).toBeUndefined();
+    expect(frozen.maps.gift_auto_accepts).toBeUndefined();
 
     const occupied = structuredClone(vacant);
     occupied.world_actors.push({ id: 5000, kind: 1, location_id: 1 });
@@ -175,7 +195,6 @@ describe("independently mountable CosyWorld Core", () => {
       "jobs",
       "branches",
       "bonds",
-      "transfer_offers",
       "resident_continuities",
       "resident_memories",
       "search_memories",
@@ -183,6 +202,8 @@ describe("independently mountable CosyWorld Core", () => {
       "world_simulation",
       "content_context",
     ]) expect(remounted.snapshot[field], field).toEqual(vacant[field]);
+    expect(remounted.snapshot.transfer_offers.gift.status).toBe("invalidated");
+    expect(remounted.snapshot.gift_auto_accepts.policy.consumed).toBe(true);
     expect(remounted.snapshot.pack_mount_state.frozen).toEqual({});
     expect(remounted.snapshot.pack_mount_state.history).toHaveLength(2);
     expect(remounted.transaction).toMatchObject({

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -287,6 +287,11 @@ runtime fallback. `v2:pack:unmount` refuses to proceed while a human actor still
 occupies a location owned by the pack. Once vacant, it removes the pack-owned
 live projection and freezes the exact entities, item/card zones, projection
 maps, and canonical context in the snapshot's versioned `pack_mount_state`.
+Pending transfer offers that reference the pack become durable `invalidated`
+tombstones, and matching one-use gift policies become consumed; remount never
+revives either transient authorization. Every action composition certificate
+includes the latest mount transaction sequence, so an action card issued before
+unmount remains stale even after the exact pack and entity identities return.
 Each committed operation records source/target bundle hashes, counts, a stable
 state hash, and a monotonic sequence. Remount requires the exact frozen source
 registry and restores the same identities; collisions fail without changing

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.163"
+version = "0.0.164"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.163"
+version = "0.0.164"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -1,6 +1,80 @@
 use super::*;
 
+fn submitted_payload_target(
+    path: &str,
+    target: &ActionTargetView,
+    payload: &serde_json::Value,
+) -> Option<u64> {
+    let key = match (path, target.kind.as_str()) {
+        ("/actions/move" | "/actions/flee", "location") => "destination_location_id",
+        ("/actions/craft", "recipe") => "recipe_id",
+        ("/actions/pick-up" | "/actions/drop", "item") => "item_id",
+        ("/actions/trade-item" | "/actions/theft", "item") => "target_item_id",
+        (
+            "/actions/chat"
+            | "/actions/attack"
+            | "/actions/give-item"
+            | "/actions/create-bond"
+            | "/actions/resolve-bond"
+            | "/actions/cast-spell"
+            | "/actions/influence"
+            | "/actions/use-item",
+            "actor",
+        ) => "target_actor_id",
+        _ => return None,
+    };
+    payload.get(key).and_then(serde_json::Value::as_u64)
+}
+
 impl RuntimeWorld {
+    pub(super) fn validate_action_offer_submission(
+        &self,
+        actor_id: u64,
+        access: &AccessContext,
+        submission: &ActionOfferSubmissionRequest,
+    ) -> Result<(), &'static str> {
+        let (_, offers) = self.legal_action_candidates(Some(actor_id), access);
+        let Some(offer) = offers
+            .iter()
+            .find(|offer| offer.offer_id == submission.offer_id)
+        else {
+            return Err("that offer expired; refresh the scene and submit a current offer_id");
+        };
+        if offer.composition_id != submission.composition_id {
+            Err("the scene composition changed; refresh and choose a current action")
+        } else if offer.kind != submission.kind
+            || offer.rules_action != submission.rules_action
+            || offer.operation != submission.operation
+            || offer.rules_profile != submission.rules_profile
+            || offer.state_revision != submission.state_revision
+            || offer.target != submission.target
+            || offer.cost != submission.cost
+            || offer.disabled
+        {
+            Err("offer identity, rules binding, target, cost, or availability was changed")
+        } else if offer.target.as_ref().is_some_and(|target| {
+            submitted_payload_target(&submission.path, target, &submission.payload)
+                .is_some_and(|submitted| target.id != Some(submitted))
+        }) {
+            Err("submitted payload target does not match the authoritative offer")
+        } else if offer.project.as_ref().is_some_and(|project| {
+            submission
+                .payload
+                .get("job_id")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|job_id| job_id != project.id)
+                || submission
+                    .payload
+                    .get("strategy_id")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|strategy_id| project.strategy_id.as_deref() != Some(strategy_id))
+        }) {
+            Err("submitted contribution does not match the authoritative quest strategy")
+        } else {
+            Ok(())
+        }
+    }
+
     pub(super) fn contextual_action_contributions(
         &self,
         actor_id: u64,

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -73,6 +73,16 @@ impl PackMountState {
     pub(super) fn is_empty(&self) -> bool {
         self.0.is_null()
     }
+
+    pub(super) fn composition_revision(&self) -> u64 {
+        self.0
+            .get("history")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|history| history.last())
+            .and_then(|transaction| transaction.get("sequence"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -26933,32 +26933,6 @@ fn action_path_accepts_kind(path: &str, kind: &str) -> bool {
     }
 }
 
-fn submitted_payload_target(
-    path: &str,
-    target: &ActionTargetView,
-    payload: &serde_json::Value,
-) -> Option<u64> {
-    let key = match (path, target.kind.as_str()) {
-        ("/actions/move" | "/actions/flee", "location") => "destination_location_id",
-        ("/actions/craft", "recipe") => "recipe_id",
-        ("/actions/pick-up" | "/actions/drop", "item") => "item_id",
-        ("/actions/trade-item" | "/actions/theft", "item") => "target_item_id",
-        (
-            "/actions/chat"
-            | "/actions/attack"
-            | "/actions/give-item"
-            | "/actions/create-bond"
-            | "/actions/resolve-bond"
-            | "/actions/cast-spell"
-            | "/actions/influence"
-            | "/actions/use-item",
-            "actor",
-        ) => "target_actor_id",
-        _ => return None,
-    };
-    payload.get(key).and_then(serde_json::Value::as_u64)
-}
-
 async fn submit_action_offer(
     ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
@@ -27013,48 +26987,7 @@ async fn submit_action_offer(
     );
     let validation = {
         let runtime = state.inner.lock().await;
-        let (_, offers) = runtime.legal_action_candidates(Some(actor_id), &access);
-        let Some(offer) = offers
-            .iter()
-            .find(|offer| offer.offer_id == submission.offer_id)
-        else {
-            return action_offer_rejected(
-                "that offer expired; refresh the scene and submit a current offer_id",
-            );
-        };
-        if offer.composition_id != submission.composition_id {
-            Err("the scene composition changed; refresh and choose a current action")
-        } else if offer.kind != submission.kind
-            || offer.rules_action != submission.rules_action
-            || offer.operation != submission.operation
-            || offer.rules_profile != submission.rules_profile
-            || offer.state_revision != submission.state_revision
-            || offer.target != submission.target
-            || offer.cost != submission.cost
-            || offer.disabled
-        {
-            Err("offer identity, rules binding, target, cost, or availability was changed")
-        } else if offer.target.as_ref().is_some_and(|target| {
-            submitted_payload_target(&submission.path, target, &submission.payload)
-                .is_some_and(|submitted| target.id != Some(submitted))
-        }) {
-            Err("submitted payload target does not match the authoritative offer")
-        } else if offer.project.as_ref().is_some_and(|project| {
-            submission
-                .payload
-                .get("job_id")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|job_id| job_id != project.id)
-                || submission
-                    .payload
-                    .get("strategy_id")
-                    .and_then(serde_json::Value::as_str)
-                    .is_some_and(|strategy_id| project.strategy_id.as_deref() != Some(strategy_id))
-        }) {
-            Err("submitted contribution does not match the authoritative quest strategy")
-        } else {
-            Ok(())
-        }
+        runtime.validate_action_offer_submission(actor_id, &access, &submission)
     };
     if let Err(reason) = validation {
         return action_offer_rejected(reason);

--- a/v2/orchestrator-rust/src/rules_context.rs
+++ b/v2/orchestrator-rust/src/rules_context.rs
@@ -6,6 +6,7 @@ const SCENE_RULES_CONTEXT_SCHEMA_VERSION: u8 = 1;
 #[derive(Clone, Debug, Serialize)]
 pub(super) struct ActionCompositionTraceView {
     pub(super) worldpack_bundle_hash: String,
+    pub(super) pack_mount_revision: u64,
     pub(super) pack_versions: Vec<ActionPackVersionView>,
     pub(super) rules_profile: String,
     pub(super) rules_pack_id: String,
@@ -101,6 +102,7 @@ impl RuntimeWorld {
         );
         ActionCompositionTraceView {
             worldpack_bundle_hash: content.manifest.bundle_hash.clone(),
+            pack_mount_revision: self.pack_mount_state.composition_revision(),
             pack_versions: content
                 .manifest
                 .packs
@@ -303,6 +305,7 @@ mod tests {
             valid_sha256_digest(&offer.composition_id)
                 && offer.composition_trace.worldpack_bundle_hash
                     == active_content().manifest.bundle_hash
+                && offer.composition_trace.pack_mount_revision == 0
                 && !offer.composition_trace.pack_versions.is_empty()
                 && offer
                     .composition_trace
@@ -389,6 +392,69 @@ mod tests {
         assert_eq!(inherited.location_pack_id, "cosyworld.the-holy-land");
         assert_eq!(inherited.selected_by_pack_id, "cosyworld.core");
         assert_eq!(inherited.capability_id, "cosyworld.core/rules");
+    }
+
+    #[test]
+    fn mount_revision_rejects_pretransaction_offer_without_world_mutation() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Stale Composition Tester",
+        );
+        let offered = runtime
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| offer.kind == "check")
+            .expect("the cottage exposes Notice");
+        runtime.pack_mount_state = PackMountState(serde_json::json!({
+            "schema_version": 1,
+            "next_transaction_seq": 3,
+            "frozen": {},
+            "history": [
+                { "sequence": 1, "status": "committed", "operation": "soft_unmount" },
+                { "sequence": 2, "status": "committed", "operation": "remount" }
+            ]
+        }));
+        let current = runtime
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| offer.offer_id == offered.offer_id)
+            .expect("Notice remains available after remount");
+        assert_eq!(current.offer_id, offered.offer_id);
+        assert_eq!(current.state_revision, offered.state_revision);
+        assert_eq!(current.composition_trace.pack_mount_revision, 2);
+        assert_ne!(current.composition_id, offered.composition_id);
+
+        let before = serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
+            .expect("serialize pre-submission state");
+        let rejected = runtime.validate_action_offer_submission(
+            5000,
+            &AccessContext::default(),
+            &ActionOfferSubmissionRequest {
+                path: "/actions/check".to_string(),
+                offer_id: offered.offer_id,
+                composition_id: offered.composition_id,
+                kind: offered.kind,
+                rules_action: offered.rules_action,
+                operation: offered.operation,
+                rules_profile: offered.rules_profile,
+                state_revision: offered.state_revision,
+                target: offered.target,
+                cost: offered.cost,
+                payload: serde_json::json!({ "actor_id": 5000 }),
+            },
+        );
+        assert_eq!(
+            rejected,
+            Err("the scene composition changed; refresh and choose a current action")
+        );
+        let after = serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
+            .expect("serialize rejected-submission state");
+        assert_eq!(after, before);
     }
 
     #[test]

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-75255
+75188

--- a/v2/scripts/migrate-pack-unmount.mjs
+++ b/v2/scripts/migrate-pack-unmount.mjs
@@ -60,6 +60,17 @@ function takeMapValues(map, predicate) {
   return frozen;
 }
 
+function invalidateMapValues(map, predicate, invalidate) {
+  const invalidated = [];
+  if (!map || Array.isArray(map) || typeof map !== "object") return invalidated;
+  for (const [key, value] of Object.entries(map)) {
+    if (!predicate(value, key)) continue;
+    invalidate(value);
+    invalidated.push(key);
+  }
+  return invalidated;
+}
+
 function restoreArrayEntries(snapshot, field, frozen, identity) {
   const restored = [...(snapshot[field] ?? [])];
   const identities = new Set(restored.map(identity));
@@ -341,20 +352,29 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
         || hasId(itemIds, tag.scope_id)
         || hasId(locationIds, tag.scope_id),
   );
-  maps.transfer_offers = takeMapValues(
+  const invalidatedOfferIds = invalidateMapValues(
     migrated.transfer_offers,
     (offer) =>
-      hasId(actorIds, offer.offered_by_actor_id)
-        || hasId(actorIds, offer.offered_to_actor_id)
-        || hasId(itemIds, offer.offered_item_id)
-        || hasId(itemIds, offer.requested_item_id),
+      (offer.status === undefined || offer.status === "pending")
+        && (hasId(actorIds, offer.offered_by_actor_id)
+          || hasId(actorIds, offer.offered_to_actor_id)
+          || hasId(itemIds, offer.offered_item_id)
+          || hasId(itemIds, offer.requested_item_id)),
+    (offer) => {
+      offer.status = "invalidated";
+      delete offer.resolved_by_actor_id;
+    },
   );
-  maps.gift_auto_accepts = takeMapValues(
+  const consumedGiftAutoAcceptIds = invalidateMapValues(
     migrated.gift_auto_accepts,
     (policy) =>
-      hasId(actorIds, policy.recipient_actor_id)
-        || hasId(actorIds, policy.offered_by_actor_id)
-        || hasId(itemIds, policy.item_id),
+      !policy.consumed
+        && (hasId(actorIds, policy.recipient_actor_id)
+          || hasId(actorIds, policy.offered_by_actor_id)
+          || hasId(itemIds, policy.item_id)),
+    (policy) => {
+      policy.consumed = true;
+    },
   );
 
   migrated.world_simulation ??= {};
@@ -380,6 +400,10 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
     arrays,
     maps,
     world_simulation: worldSimulation,
+    invalidated: {
+      transfer_offer_ids: invalidatedOfferIds,
+      gift_auto_accept_ids: consumedGiftAutoAcceptIds,
+    },
   };
   const stateHash = frozenStateHash(frozen);
   mountState.frozen[packId] = frozen;
@@ -397,6 +421,10 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
     target_bundle_hash: frozen.target_bundle_hash,
     state_hash: stateHash,
     counts: removed,
+    invalidated: {
+      transfer_offers: invalidatedOfferIds.length,
+      gift_auto_accepts: consumedGiftAutoAcceptIds.length,
+    },
   });
 
   return { snapshot: migrated, removed, transaction };


### PR DESCRIPTION
Issue #28

- Tombstone pending pack-bound transfer offers and consume matching one-use gift policies so remount cannot revive transient consent.
- Include the latest mount transaction in action composition certificates so pre-unmount cards reject without mutation after remount.
- Extract authoritative offer validation into composition.rs, shrinking main.rs from 75,255 to 75,188 lines.
- Release 0.0.164; npm run check and npm run v2:check pass with the canonical bundle hash unchanged.