### PR TITLE
feat(packs): own cross-pack paths in composition bridges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.165",
+  "version": "0.0.166",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/content-pack-contract.test.mjs
+++ b/test/v2/content-pack-contract.test.mjs
@@ -151,6 +151,41 @@ describe("Content Pack Manifest v1", () => {
     }))).toThrow(/additional properties/);
   });
 
+  it("requires dedicated composition bridges for cross-pack paths", () => {
+    const bridge = manifest("fixture.bridge", {
+      kind: "world",
+      capabilities: [
+        { id: "fixture.bridge/world", kind: "world", version: "1.0.0" },
+      ],
+      dependencies: [
+        {
+          id: "fixture.left",
+          version: ">=1.0.0 <2.0.0",
+          capabilities: ["fixture.left/world"],
+        },
+        {
+          id: "fixture.right",
+          version: ">=1.0.0 <2.0.0",
+          capabilities: ["fixture.right/world"],
+        },
+      ],
+      default_ruleset: null,
+      entry_points: [],
+      resources: { exits: "exits.json" },
+      extensions: {
+        "x-cosyworld-composition": {
+          schema_version: 1,
+          role: "bridge",
+        },
+      },
+    });
+    expect(() => validateContentPackManifest(bridge)).not.toThrow();
+    expect(() => validateContentPackManifest({
+      ...bridge,
+      resources: { exits: "exits.json", actors: "actors.json" },
+    })).toThrow(/may contain only exits or hidden_exits/);
+  });
+
   it("treats rules_profile as a legacy one-profile compatibility alias", () => {
     const legacy = manifest("fixture.legacy", {
       rules_profile: "cosyworld.srd5/1",
@@ -595,6 +630,7 @@ describe("Content Pack Manifest v1", () => {
       "sha256:02147a6629b038e2e9a28039f829bc6ad67881fe3391a0edabf744fd362427df",
       "sha256:ef70c61617e4c6f6cf905f049dddbb053e84b520f545ed2d01b3180cf39d75d1",
       "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
+      "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc",
     ]);
   });
 

--- a/test/v2/core-ruby-composition.test.mjs
+++ b/test/v2/core-ruby-composition.test.mjs
@@ -1,4 +1,6 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -12,6 +14,7 @@ const browser = fs.readFileSync(
   path.join(repoRoot, "v2/orchestrator-rust/src/index.html"),
   "utf8",
 );
+const checkerPath = path.join(repoRoot, "v2/scripts/check-worldpack.mjs");
 
 describe("Core + Ruby High composition", () => {
   it("mounts the peer worlds with only their explicit bridge resources", () => {
@@ -21,6 +24,7 @@ describe("Core + Ruby High composition", () => {
       "cosyworld.rules-profile-srd5",
       "cosyworld.core",
       "ruby-high.first-bell",
+      "cosyworld.composition.core-ruby",
     ]);
     expect(registry.resources.exits.filter((exit) =>
       [1, 11].includes(exit.from_location_id)
@@ -28,14 +32,22 @@ describe("Core + Ruby High composition", () => {
       expect.objectContaining({
         from_location_id: 1,
         to_location_id: 11,
-        pack_id: "ruby-high.first-bell",
+        pack_id: "cosyworld.composition.core-ruby",
       }),
       expect.objectContaining({
         from_location_id: 11,
         to_location_id: 1,
-        pack_id: "ruby-high.first-bell",
+        pack_id: "cosyworld.composition.core-ruby",
       }),
     ]);
+    const locationPacks = new Map(
+      registry.resources.locations.map((location) => [location.id, location.pack_id]),
+    );
+    expect(registry.resources.exits.filter((exit) =>
+      locationPacks.get(exit.from_location_id)
+        !== locationPacks.get(exit.to_location_id)))
+      .toEqual(registry.resources.exits.filter((exit) =>
+        exit.pack_id === "cosyworld.composition.core-ruby"));
     expect(registry.resources.actor_facets).toEqual([
       expect.objectContaining({
         id: "rati-first-bell",
@@ -69,5 +81,34 @@ describe("Core + Ruby High composition", () => {
       }),
     );
     expect(browser).toContain("composition_id: offer.composition_id");
+  });
+
+  it("rejects a reusable pack that claims a cross-pack path", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cosyworld-composition-bridge-"));
+    const compiledRoot = path.join(tempRoot, "core-ruby");
+    try {
+      fs.cpSync(path.join(repoRoot, "v2/content/core-ruby"), compiledRoot, {
+        recursive: true,
+      });
+      const exitsPath = path.join(compiledRoot, "exits.json");
+      const registryPath = path.join(compiledRoot, "registry.json");
+      const exits = JSON.parse(fs.readFileSync(exitsPath, "utf8"));
+      const registryCopy = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+      const crossPackExit = exits.find((exit) =>
+        exit.pack_id === "cosyworld.composition.core-ruby");
+      crossPackExit.pack_id = "ruby-high.first-bell";
+      registryCopy.resources.exits = exits;
+      fs.writeFileSync(exitsPath, `${JSON.stringify(exits, null, 2)}\n`);
+      fs.writeFileSync(registryPath, `${JSON.stringify(registryCopy, null, 2)}\n`);
+
+      const checked = spawnSync(process.execPath, [checkerPath, compiledRoot], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
+      expect(checked.status).not.toBe(0);
+      expect(checked.stderr).toContain("outside a composition bridge pack");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/test/v2/ruby-high-peer-pack.test.mjs
+++ b/test/v2/ruby-high-peer-pack.test.mjs
@@ -40,7 +40,7 @@ describe("Ruby High: First Bell peer pack", () => {
     expect(rubyOnly.resources.card_bindings).toEqual([]);
   });
 
-  it("declares Core as optional and activates only its Core-facing bridges and facets when mounted", () => {
+  it("declares Core as optional while composition owns paths and Ruby owns facets", () => {
     expect(rubyManifest.dependencies).toEqual([
       {
         id: "cosyworld.core",
@@ -54,7 +54,9 @@ describe("Ruby High: First Bell peer pack", () => {
         capabilities: ["cosyworld.rules-profile-srd5/rules"],
       },
     ]);
-    expect(official.resources.exits.filter((exit) => exit.pack_id === "ruby-high.first-bell")).toHaveLength(24);
+    expect(official.resources.exits.filter((exit) => exit.pack_id === "ruby-high.first-bell")).toHaveLength(16);
+    expect(official.resources.exits.filter((exit) =>
+      exit.pack_id === "cosyworld.composition.core-ruby")).toHaveLength(8);
     expect(official.resources.actor_facets).toEqual([expect.objectContaining({
       pack_id: "ruby-high.first-bell",
       actor_id: 1001,
@@ -87,7 +89,10 @@ describe("Ruby High: First Bell peer pack", () => {
     }
     expect(official.resources.exits
       .filter((exit) => gatedLocationIds.has(exit.from_location_id) || gatedLocationIds.has(exit.to_location_id))
-      .every((exit) => exit.pack_id === "ruby-high.first-bell"))
+      .every((exit) => [
+        "ruby-high.first-bell",
+        "cosyworld.composition.core-ruby",
+      ].includes(exit.pack_id)))
       .toBe(true);
     expect(official.resources.factions.find((faction) => faction.id === "ruby_high")?.pack_id)
       .toBe("ruby-high.first-bell");

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -220,6 +220,8 @@ describe("worldpack authored relationships", () => {
       "cosyworld.the-holy-land",
       "cosyworld.lonely-forest.characters",
       "ruby-high.first-bell",
+      "cosyworld.composition.core-ruby",
+      "cosyworld.composition.core-holy-land",
     ]);
     expect(locations).toHaveLength(48);
     expect(rules.map((bundle) => bundle.pack_id)).toEqual([

--- a/v2/content/core-holy-land-bridge/exits.json
+++ b/v2/content/core-holy-land-bridge/exits.json
@@ -1,0 +1,16 @@
+[
+  {
+    "from_location_id": 1,
+    "to_location_id": 700,
+    "flags": 0,
+    "distance": 3,
+    "direction": "north"
+  },
+  {
+    "from_location_id": 700,
+    "to_location_id": 1,
+    "flags": 0,
+    "distance": 3,
+    "direction": "homeward"
+  }
+]

--- a/v2/content/core-holy-land-bridge/pack.json
+++ b/v2/content/core-holy-land-bridge/pack.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "id": "cosyworld.composition.core-holy-land",
+  "name": "CosyWorld Core + Holy Land Bridge",
+  "version": "1.0.0",
+  "kind": "world",
+  "description": "Composition-owned paths connecting CosyWorld Core and The Holy Land.",
+  "license": "MIT",
+  "license_url": "https://opensource.org/license/mit",
+  "engine": ">=0.0.20 <0.1.0",
+  "capabilities": [
+    {
+      "id": "cosyworld.composition.core-holy-land/world",
+      "kind": "world",
+      "version": "1.0.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "cosyworld.core",
+      "version": ">=1.3.0 <2.0.0",
+      "capabilities": [
+        "cosyworld.core/world"
+      ]
+    },
+    {
+      "id": "cosyworld.the-holy-land",
+      "version": ">=1.1.2 <2.0.0",
+      "capabilities": [
+        "cosyworld.the-holy-land/world"
+      ]
+    },
+    {
+      "id": "cosyworld.rules-profile-srd5",
+      "version": ">=1.0.0 <2.0.0",
+      "capabilities": [
+        "cosyworld.rules-profile-srd5/rules"
+      ]
+    }
+  ],
+  "rules_profile": "cosyworld.srd5/1",
+  "default_ruleset": null,
+  "entry_points": [],
+  "provenance": {
+    "author": "Cenetex",
+    "source_name": "CosyWorld official composition",
+    "source_url": "https://github.com/cenetex/cosyworld"
+  },
+  "resources": {
+    "exits": "exits.json"
+  },
+  "extensions": {
+    "x-cosyworld-composition": {
+      "schema_version": 1,
+      "role": "bridge"
+    }
+  }
+}

--- a/v2/content/core-ruby-bridge/exits.json
+++ b/v2/content/core-ruby-bridge/exits.json
@@ -1,0 +1,54 @@
+[
+  {
+    "from_location_id": 1,
+    "to_location_id": 11,
+    "flags": 0,
+    "direction": "south"
+  },
+  {
+    "from_location_id": 11,
+    "to_location_id": 1,
+    "flags": 0,
+    "direction": "out"
+  },
+  {
+    "from_location_id": 12,
+    "to_location_id": 50,
+    "flags": 0,
+    "distance": 3,
+    "direction": "down"
+  },
+  {
+    "from_location_id": 50,
+    "to_location_id": 12,
+    "flags": 0,
+    "distance": 3,
+    "direction": "up"
+  },
+  {
+    "from_location_id": 15,
+    "to_location_id": 32,
+    "flags": 0,
+    "distance": 4,
+    "direction": "up"
+  },
+  {
+    "from_location_id": 32,
+    "to_location_id": 15,
+    "flags": 0,
+    "distance": 4,
+    "direction": "down"
+  },
+  {
+    "from_location_id": 44,
+    "to_location_id": 14,
+    "flags": 0,
+    "direction": "south"
+  },
+  {
+    "from_location_id": 14,
+    "to_location_id": 44,
+    "flags": 0,
+    "direction": "north"
+  }
+]

--- a/v2/content/core-ruby-bridge/pack.json
+++ b/v2/content/core-ruby-bridge/pack.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "id": "cosyworld.composition.core-ruby",
+  "name": "CosyWorld Core + Ruby High Bridge",
+  "version": "1.0.0",
+  "kind": "world",
+  "description": "Composition-owned paths connecting CosyWorld Core and Ruby High.",
+  "license": "MIT",
+  "license_url": "https://opensource.org/license/mit",
+  "engine": ">=0.0.20 <0.1.0",
+  "capabilities": [
+    {
+      "id": "cosyworld.composition.core-ruby/world",
+      "kind": "world",
+      "version": "1.0.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "cosyworld.core",
+      "version": ">=1.3.0 <2.0.0",
+      "capabilities": [
+        "cosyworld.core/world"
+      ]
+    },
+    {
+      "id": "ruby-high.first-bell",
+      "version": ">=1.3.5 <2.0.0",
+      "capabilities": [
+        "ruby-high.first-bell/world"
+      ]
+    },
+    {
+      "id": "cosyworld.rules-profile-srd5",
+      "version": ">=1.0.0 <2.0.0",
+      "capabilities": [
+        "cosyworld.rules-profile-srd5/rules"
+      ]
+    }
+  ],
+  "rules_profile": "cosyworld.srd5/1",
+  "default_ruleset": null,
+  "entry_points": [],
+  "provenance": {
+    "author": "Cenetex",
+    "source_name": "CosyWorld official composition",
+    "source_url": "https://github.com/cenetex/cosyworld"
+  },
+  "resources": {
+    "exits": "exits.json"
+  },
+  "extensions": {
+    "x-cosyworld-composition": {
+      "schema_version": 1,
+      "role": "bridge"
+    }
+  }
+}

--- a/v2/content/core-ruby/assets.json
+++ b/v2/content/core-ruby/assets.json
@@ -27,8 +27,8 @@
   },
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.4",
-    "pack_integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+    "pack_version": "1.3.5",
+    "pack_integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
     "provider": "ruby-high.first-bell/assets",
     "mount": "cards",
     "root": "ruby-high-first-bell",

--- a/v2/content/core-ruby/content_refs.json
+++ b/v2/content/core-ruby/content_refs.json
@@ -2748,7 +2748,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/actor-facet/rati-first-bell",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "actor-facet",
       "local_id": "rati-first-bell",
       "runtime_handle": 1038687835420516
@@ -2756,7 +2756,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card-binding/rati-first-bell-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card-binding",
       "local_id": "rati-first-bell-card",
       "runtime_handle": 3116738573256863
@@ -2764,7 +2764,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-cafeteria",
       "runtime_handle": 3107528363911865
@@ -2772,7 +2772,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-courtyard",
       "runtime_handle": 4782402674832957
@@ -2780,7 +2780,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-greenhouse",
       "runtime_handle": 3662976131116729
@@ -2788,7 +2788,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-homeroom",
       "runtime_handle": 7084902207358373
@@ -2796,7 +2796,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-library",
       "runtime_handle": 6785800264541047
@@ -2804,7 +2804,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-science-lab",
       "runtime_handle": 8201462675675638
@@ -2812,7 +2812,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "captain-null",
       "runtime_handle": 3843573141933674
@@ -2820,7 +2820,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "eliza",
       "runtime_handle": 4124553834845258
@@ -2828,7 +2828,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "indra",
       "runtime_handle": 8687099168741216
@@ -2836,7 +2836,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-flashcards",
       "runtime_handle": 6148366931632609
@@ -2844,7 +2844,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-hall-pass",
       "runtime_handle": 6154026517662833
@@ -2852,7 +2852,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-lab-flask",
       "runtime_handle": 7444186363202775
@@ -2860,7 +2860,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-library-card",
       "runtime_handle": 27821797810153
@@ -2868,7 +2868,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-lunch-tray",
       "runtime_handle": 3064948555071770
@@ -2876,7 +2876,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-notebook",
       "runtime_handle": 5906680647268123
@@ -2884,7 +2884,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-cafeteria",
       "runtime_handle": 232928798345453
@@ -2892,7 +2892,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-courtyard",
       "runtime_handle": 1017422828753302
@@ -2900,7 +2900,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-greenhouse",
       "runtime_handle": 1874830250433117
@@ -2908,7 +2908,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-homeroom",
       "runtime_handle": 6928775784641985
@@ -2916,7 +2916,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-library",
       "runtime_handle": 8204365461548708
@@ -2924,7 +2924,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-science-lab",
       "runtime_handle": 57115334800243
@@ -2932,7 +2932,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "lyra",
       "runtime_handle": 7094866015162716
@@ -2940,7 +2940,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "mika",
       "runtime_handle": 4809241939115652
@@ -2948,7 +2948,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "noor",
       "runtime_handle": 6643976235743711
@@ -2956,7 +2956,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "professor-edward",
       "runtime_handle": 1211962163801060
@@ -2964,7 +2964,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "rati",
       "runtime_handle": 8508280633539606
@@ -2972,7 +2972,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "ravi",
       "runtime_handle": 3914282740523084
@@ -2980,7 +2980,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "ruby",
       "runtime_handle": 442578259385801
@@ -2988,7 +2988,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "sally-science",
       "runtime_handle": 692877066368845
@@ -2996,7 +2996,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "sami",
       "runtime_handle": 5798756249869747
@@ -3004,7 +3004,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "faction",
       "local_id": "ruby_high",
       "runtime_handle": 2919627811514647
@@ -3012,7 +3012,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "10",
       "legacy_runtime_id": 10,
@@ -3021,7 +3021,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "11",
       "legacy_runtime_id": 11,
@@ -3030,7 +3030,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "12",
       "legacy_runtime_id": 12,
@@ -3039,7 +3039,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "13",
       "legacy_runtime_id": 13,
@@ -3048,7 +3048,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "14",
       "legacy_runtime_id": 14,
@@ -3057,7 +3057,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "15",
       "legacy_runtime_id": 15,
@@ -3066,7 +3066,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:10",
       "runtime_handle": 2574024258005683
@@ -3074,7 +3074,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:11",
       "runtime_handle": 944777926762018
@@ -3082,7 +3082,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:12",
       "runtime_handle": 8925253377010016
@@ -3090,7 +3090,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:13",
       "runtime_handle": 1954150505527197
@@ -3098,7 +3098,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:14",
       "runtime_handle": 9002247914113905
@@ -3106,7 +3106,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:15",
       "runtime_handle": 8772787069788936

--- a/v2/content/core-ruby/contributions.json
+++ b/v2/content/core-ruby/contributions.json
@@ -26,7 +26,7 @@
   },
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.4",
+    "pack_version": "1.3.5",
     "rules_profile": "cosyworld.srd5/1",
     "reskins": [
       {

--- a/v2/content/core-ruby/exits.json
+++ b/v2/content/core-ruby/exits.json
@@ -326,20 +326,6 @@
     "pack_id": "cosyworld.core"
   },
   {
-    "from_location_id": 1,
-    "to_location_id": 11,
-    "flags": 0,
-    "direction": "south",
-    "pack_id": "ruby-high.first-bell"
-  },
-  {
-    "from_location_id": 11,
-    "to_location_id": 1,
-    "flags": 0,
-    "direction": "out",
-    "pack_id": "ruby-high.first-bell"
-  },
-  {
     "from_location_id": 10,
     "to_location_id": 11,
     "flags": 0,
@@ -452,12 +438,26 @@
     "pack_id": "ruby-high.first-bell"
   },
   {
+    "from_location_id": 1,
+    "to_location_id": 11,
+    "flags": 0,
+    "direction": "south",
+    "pack_id": "cosyworld.composition.core-ruby"
+  },
+  {
+    "from_location_id": 11,
+    "to_location_id": 1,
+    "flags": 0,
+    "direction": "out",
+    "pack_id": "cosyworld.composition.core-ruby"
+  },
+  {
     "from_location_id": 12,
     "to_location_id": 50,
     "flags": 0,
     "distance": 3,
     "direction": "down",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 50,
@@ -465,7 +465,7 @@
     "flags": 0,
     "distance": 3,
     "direction": "up",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 15,
@@ -473,7 +473,7 @@
     "flags": 0,
     "distance": 4,
     "direction": "up",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 32,
@@ -481,20 +481,20 @@
     "flags": 0,
     "distance": 4,
     "direction": "down",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 44,
     "to_location_id": 14,
     "flags": 0,
     "direction": "south",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 14,
     "to_location_id": 44,
     "flags": 0,
     "direction": "north",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   }
 ]

--- a/v2/content/core-ruby/licenses.json
+++ b/v2/content/core-ruby/licenses.json
@@ -61,13 +61,26 @@
   {
     "pack_id": "ruby-high.first-bell",
     "name": "Ruby High: First Bell",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {
       "author": "Ruby High",
       "source_name": "Ruby High: First Bell",
       "source_url": "https://ruby-high.ai"
+    },
+    "notices": []
+  },
+  {
+    "pack_id": "cosyworld.composition.core-ruby",
+    "name": "CosyWorld Core + Ruby High Bridge",
+    "version": "1.0.0",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld official composition",
+      "source_url": "https://github.com/cenetex/cosyworld"
     },
     "notices": []
   }

--- a/v2/content/core-ruby/registry.json
+++ b/v2/content/core-ruby/registry.json
@@ -592,7 +592,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:a7b45faa4335fa3a4c5501568eb66346463dd46acdaf233a35676fad10e8b945",
+    "bundle_hash": "sha256:abd0a109c955d8534e8f71b3e897a7535a3c6016e5045c6fc398b3bf6669cf18",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1668,7 +1668,7 @@
         "id": "ruby-high.first-bell",
         "name": "Ruby High: First Bell",
         "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-        "version": "1.3.4",
+        "version": "1.3.5",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit",
@@ -1753,7 +1753,7 @@
           "factions": 1,
           "items": 0,
           "locations": 6,
-          "exits": 24,
+          "exits": 16,
           "hidden_exits": 0,
           "room_features": 1,
           "room_sheets": 6,
@@ -1871,7 +1871,107 @@
           "type": "workspace",
           "path": "../../content/ruby-high-first-bell"
         },
-        "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9"
+        "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847"
+      },
+      {
+        "id": "cosyworld.composition.core-ruby",
+        "name": "CosyWorld Core + Ruby High Bridge",
+        "description": "Composition-owned paths connecting CosyWorld Core and Ruby High.",
+        "version": "1.0.0",
+        "kind": "world",
+        "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.composition.core-ruby/world",
+            "kind": "world",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core",
+          "ruby-high.first-bell",
+          "cosyworld.rules-profile-srd5"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.3.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          },
+          {
+            "id": "ruby-high.first-bell",
+            "version": ">=1.3.5 <2.0.0",
+            "capabilities": [
+              "ruby-high.first-bell/world"
+            ]
+          },
+          {
+            "id": "cosyworld.rules-profile-srd5",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.rules-profile-srd5/rules"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.rules-srd-5.2.1",
+          "cosyworld.rules-profile-srd5",
+          "cosyworld.core",
+          "ruby-high.first-bell"
+        ],
+        "default_ruleset": null,
+        "entry_points": [],
+        "provenance": {
+          "author": "Cenetex",
+          "source_name": "CosyWorld official composition",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "actor_facets": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 8,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "action_vocabulary": 0,
+          "fronts": 0,
+          "cards": 0,
+          "card_bindings": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 0,
+          "rules": 0,
+          "character_creation": 0,
+          "reskins": 0,
+          "offers": 0,
+          "variants": 0,
+          "extensions": 0
+        },
+        "extensions": {
+          "x-cosyworld-composition": {
+            "schema_version": 1,
+            "role": "bridge"
+          }
+        },
+        "rules_profile": "cosyworld.srd5/1",
+        "source": {
+          "type": "workspace",
+          "path": "../../content/core-ruby-bridge"
+        },
+        "integrity": "sha256:af0f833ed3be83ff11e9652514bd14bc0112af0d55e4b55f2bcf725420e918ba"
       }
     ],
     "files": {
@@ -4380,20 +4480,6 @@
         "pack_id": "cosyworld.core"
       },
       {
-        "from_location_id": 1,
-        "to_location_id": 11,
-        "flags": 0,
-        "direction": "south",
-        "pack_id": "ruby-high.first-bell"
-      },
-      {
-        "from_location_id": 11,
-        "to_location_id": 1,
-        "flags": 0,
-        "direction": "out",
-        "pack_id": "ruby-high.first-bell"
-      },
-      {
         "from_location_id": 10,
         "to_location_id": 11,
         "flags": 0,
@@ -4506,12 +4592,26 @@
         "pack_id": "ruby-high.first-bell"
       },
       {
+        "from_location_id": 1,
+        "to_location_id": 11,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.composition.core-ruby"
+      },
+      {
+        "from_location_id": 11,
+        "to_location_id": 1,
+        "flags": 0,
+        "direction": "out",
+        "pack_id": "cosyworld.composition.core-ruby"
+      },
+      {
         "from_location_id": 12,
         "to_location_id": 50,
         "flags": 0,
         "distance": 3,
         "direction": "down",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 50,
@@ -4519,7 +4619,7 @@
         "flags": 0,
         "distance": 3,
         "direction": "up",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 15,
@@ -4527,7 +4627,7 @@
         "flags": 0,
         "distance": 4,
         "direction": "up",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 32,
@@ -4535,21 +4635,21 @@
         "flags": 0,
         "distance": 4,
         "direction": "down",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 44,
         "to_location_id": 14,
         "flags": 0,
         "direction": "south",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 14,
         "to_location_id": 44,
         "flags": 0,
         "direction": "north",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       }
     ],
     "hidden_exits": [
@@ -9559,8 +9659,8 @@
     },
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
-      "pack_integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+      "pack_version": "1.3.5",
+      "pack_integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
       "provider": "ruby-high.first-bell/assets",
       "mount": "cards",
       "root": "ruby-high-first-bell",
@@ -10979,7 +11079,7 @@
     },
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "rules_profile": "cosyworld.srd5/1",
       "reskins": [
         {
@@ -11095,13 +11195,26 @@
     {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
         "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.composition.core-ruby",
+      "name": "CosyWorld Core + Ruby High Bridge",
+      "version": "1.0.0",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
       },
       "notices": []
     }
@@ -14492,7 +14605,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/actor-facet/rati-first-bell",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "actor-facet",
         "local_id": "rati-first-bell",
         "runtime_handle": 1038687835420516
@@ -14500,7 +14613,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card-binding/rati-first-bell-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card-binding",
         "local_id": "rati-first-bell-card",
         "runtime_handle": 3116738573256863
@@ -14508,7 +14621,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-cafeteria",
         "runtime_handle": 3107528363911865
@@ -14516,7 +14629,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-courtyard",
         "runtime_handle": 4782402674832957
@@ -14524,7 +14637,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-greenhouse",
         "runtime_handle": 3662976131116729
@@ -14532,7 +14645,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-homeroom",
         "runtime_handle": 7084902207358373
@@ -14540,7 +14653,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-library",
         "runtime_handle": 6785800264541047
@@ -14548,7 +14661,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-science-lab",
         "runtime_handle": 8201462675675638
@@ -14556,7 +14669,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "captain-null",
         "runtime_handle": 3843573141933674
@@ -14564,7 +14677,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "eliza",
         "runtime_handle": 4124553834845258
@@ -14572,7 +14685,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "indra",
         "runtime_handle": 8687099168741216
@@ -14580,7 +14693,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-flashcards",
         "runtime_handle": 6148366931632609
@@ -14588,7 +14701,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-hall-pass",
         "runtime_handle": 6154026517662833
@@ -14596,7 +14709,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-lab-flask",
         "runtime_handle": 7444186363202775
@@ -14604,7 +14717,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-library-card",
         "runtime_handle": 27821797810153
@@ -14612,7 +14725,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-lunch-tray",
         "runtime_handle": 3064948555071770
@@ -14620,7 +14733,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-notebook",
         "runtime_handle": 5906680647268123
@@ -14628,7 +14741,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-cafeteria",
         "runtime_handle": 232928798345453
@@ -14636,7 +14749,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-courtyard",
         "runtime_handle": 1017422828753302
@@ -14644,7 +14757,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-greenhouse",
         "runtime_handle": 1874830250433117
@@ -14652,7 +14765,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-homeroom",
         "runtime_handle": 6928775784641985
@@ -14660,7 +14773,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-library",
         "runtime_handle": 8204365461548708
@@ -14668,7 +14781,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-science-lab",
         "runtime_handle": 57115334800243
@@ -14676,7 +14789,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "lyra",
         "runtime_handle": 7094866015162716
@@ -14684,7 +14797,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "mika",
         "runtime_handle": 4809241939115652
@@ -14692,7 +14805,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "noor",
         "runtime_handle": 6643976235743711
@@ -14700,7 +14813,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "professor-edward",
         "runtime_handle": 1211962163801060
@@ -14708,7 +14821,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "rati",
         "runtime_handle": 8508280633539606
@@ -14716,7 +14829,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "ravi",
         "runtime_handle": 3914282740523084
@@ -14724,7 +14837,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "ruby",
         "runtime_handle": 442578259385801
@@ -14732,7 +14845,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "sally-science",
         "runtime_handle": 692877066368845
@@ -14740,7 +14853,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "sami",
         "runtime_handle": 5798756249869747
@@ -14748,7 +14861,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "faction",
         "local_id": "ruby_high",
         "runtime_handle": 2919627811514647
@@ -14756,7 +14869,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "10",
         "legacy_runtime_id": 10,
@@ -14765,7 +14878,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "11",
         "legacy_runtime_id": 11,
@@ -14774,7 +14887,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "12",
         "legacy_runtime_id": 12,
@@ -14783,7 +14896,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "13",
         "legacy_runtime_id": 13,
@@ -14792,7 +14905,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "14",
         "legacy_runtime_id": 14,
@@ -14801,7 +14914,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "15",
         "legacy_runtime_id": 15,
@@ -14810,7 +14923,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:10",
         "runtime_handle": 2574024258005683
@@ -14818,7 +14931,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:11",
         "runtime_handle": 944777926762018
@@ -14826,7 +14939,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:12",
         "runtime_handle": 8925253377010016
@@ -14834,7 +14947,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:13",
         "runtime_handle": 1954150505527197
@@ -14842,7 +14955,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:14",
         "runtime_handle": 9002247914113905
@@ -14850,7 +14963,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:15",
         "runtime_handle": 8772787069788936

--- a/v2/content/core-ruby/worldpack.json
+++ b/v2/content/core-ruby/worldpack.json
@@ -590,7 +590,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:a7b45faa4335fa3a4c5501568eb66346463dd46acdaf233a35676fad10e8b945",
+  "bundle_hash": "sha256:abd0a109c955d8534e8f71b3e897a7535a3c6016e5045c6fc398b3bf6669cf18",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1666,7 +1666,7 @@
       "id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
       "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit",
@@ -1751,7 +1751,7 @@
         "factions": 1,
         "items": 0,
         "locations": 6,
-        "exits": 24,
+        "exits": 16,
         "hidden_exits": 0,
         "room_features": 1,
         "room_sheets": 6,
@@ -1869,7 +1869,107 @@
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9"
+      "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847"
+    },
+    {
+      "id": "cosyworld.composition.core-ruby",
+      "name": "CosyWorld Core + Ruby High Bridge",
+      "description": "Composition-owned paths connecting CosyWorld Core and Ruby High.",
+      "version": "1.0.0",
+      "kind": "world",
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "engine": ">=0.0.20 <0.1.0",
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-ruby/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        "cosyworld.core",
+        "ruby-high.first-bell",
+        "cosyworld.rules-profile-srd5"
+      ],
+      "dependency_requirements": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "ruby-high.first-bell",
+          "version": ">=1.3.5 <2.0.0",
+          "capabilities": [
+            "ruby-high.first-bell/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "ruby-high.first-bell"
+      ],
+      "default_ruleset": null,
+      "entry_points": [],
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "resource_counts": {
+        "actors": 0,
+        "actor_facets": 0,
+        "access_gates": 0,
+        "factions": 0,
+        "items": 0,
+        "locations": 0,
+        "exits": 8,
+        "hidden_exits": 0,
+        "room_features": 0,
+        "room_sheets": 0,
+        "clocks": 0,
+        "jobs": 0,
+        "action_vocabulary": 0,
+        "fronts": 0,
+        "cards": 0,
+        "card_bindings": 0,
+        "lifecycle_hooks": 0,
+        "evolution_tracks": 0,
+        "recipes": 0,
+        "sentences": 0,
+        "external_cards": 0,
+        "assets": 0,
+        "rules": 0,
+        "character_creation": 0,
+        "reskins": 0,
+        "offers": 0,
+        "variants": 0,
+        "extensions": 0
+      },
+      "extensions": {
+        "x-cosyworld-composition": {
+          "schema_version": 1,
+          "role": "bridge"
+        }
+      },
+      "rules_profile": "cosyworld.srd5/1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-ruby-bridge"
+      },
+      "integrity": "sha256:af0f833ed3be83ff11e9652514bd14bc0112af0d55e4b55f2bcf725420e918ba"
     }
   ],
   "files": {

--- a/v2/content/official/assets.json
+++ b/v2/content/official/assets.json
@@ -26,22 +26,9 @@
     "fallback": null
   },
   {
-    "pack_id": "cosyworld.lonely-forest.characters",
-    "pack_version": "1.1.1",
-    "pack_integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
-    "provider": "cosyworld.lonely-forest.characters/assets",
-    "mount": "characters",
-    "root": "lonely-forest",
-    "directory": "assets/characters/slices",
-    "public_prefix": "/assets/lonely-forest/characters",
-    "content_hash": "sha256:d45eb30a962de236ddba913834e8bdaa7b9c530bc6b66383e272118218797d93",
-    "optional": false,
-    "fallback": null
-  },
-  {
     "pack_id": "cosyworld.the-holy-land",
-    "pack_version": "1.1.1",
-    "pack_integrity": "sha256:bda3362756ed58713d34eb6ded2e54b71c1ecc9463b34d725b9360c01fcbf8ae",
+    "pack_version": "1.1.2",
+    "pack_integrity": "sha256:54099f568bf3ec8eb2b5181bf4ecbe08d0d07d4f863b7ad5e982cec3cb0ca4a2",
     "provider": "cosyworld.the-holy-land/assets",
     "mount": "cards",
     "root": "the-holy-land",
@@ -53,8 +40,8 @@
   },
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.4",
-    "pack_integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+    "pack_version": "1.3.5",
+    "pack_integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
     "provider": "ruby-high.first-bell/assets",
     "mount": "cards",
     "root": "ruby-high-first-bell",
@@ -63,5 +50,18 @@
     "content_hash": "sha256:c6028b77e9871b567178efa708ca03cb6e731fe18b01afe20efd1e0dc05e1c44",
     "optional": true,
     "fallback": "external_uri"
+  },
+  {
+    "pack_id": "cosyworld.lonely-forest.characters",
+    "pack_version": "1.1.1",
+    "pack_integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+    "provider": "cosyworld.lonely-forest.characters/assets",
+    "mount": "characters",
+    "root": "lonely-forest",
+    "directory": "assets/characters/slices",
+    "public_prefix": "/assets/lonely-forest/characters",
+    "content_hash": "sha256:d45eb30a962de236ddba913834e8bdaa7b9c530bc6b66383e272118218797d93",
+    "optional": false,
+    "fallback": null
   }
 ]

--- a/v2/content/official/content_refs.json
+++ b/v2/content/official/content_refs.json
@@ -3193,7 +3193,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7002",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7002",
       "legacy_runtime_id": 7002,
@@ -3202,7 +3202,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7003",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7003",
       "legacy_runtime_id": 7003,
@@ -3211,7 +3211,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7004",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7004",
       "legacy_runtime_id": 7004,
@@ -3220,7 +3220,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7005",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7005",
       "legacy_runtime_id": 7005,
@@ -3229,7 +3229,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7006",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7006",
       "legacy_runtime_id": 7006,
@@ -3238,7 +3238,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7007",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7007",
       "legacy_runtime_id": 7007,
@@ -3247,7 +3247,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7008",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7008",
       "legacy_runtime_id": 7008,
@@ -3256,7 +3256,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7009",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7009",
       "legacy_runtime_id": 7009,
@@ -3265,7 +3265,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7010",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7010",
       "legacy_runtime_id": 7010,
@@ -3274,7 +3274,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7011",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7011",
       "legacy_runtime_id": 7011,
@@ -3283,7 +3283,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7012",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7012",
       "legacy_runtime_id": 7012,
@@ -3292,7 +3292,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7013",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7013",
       "legacy_runtime_id": 7013,
@@ -3301,7 +3301,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7014",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7014",
       "legacy_runtime_id": 7014,
@@ -3310,7 +3310,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7015",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7015",
       "legacy_runtime_id": 7015,
@@ -3319,7 +3319,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7016",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7016",
       "legacy_runtime_id": 7016,
@@ -3328,7 +3328,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/actor/7017",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "actor",
       "local_id": "7017",
       "legacy_runtime_id": 7017,
@@ -3337,7 +3337,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-andrew",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-andrew",
       "runtime_handle": 6063388728752457
@@ -3345,7 +3345,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-bartholomew",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-bartholomew",
       "runtime_handle": 7648376027062685
@@ -3353,7 +3353,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-bethany",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-bethany",
       "runtime_handle": 2176770069418396
@@ -3361,7 +3361,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-bethlehem",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-bethlehem",
       "runtime_handle": 5964004265344755
@@ -3369,7 +3369,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-bethsaida",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-bethsaida",
       "runtime_handle": 29790776979747
@@ -3377,7 +3377,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-caesarea-philippi",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-caesarea-philippi",
       "runtime_handle": 7420082354530316
@@ -3385,7 +3385,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-cana",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-cana",
       "runtime_handle": 2186253045555771
@@ -3393,7 +3393,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-capernaum",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-capernaum",
       "runtime_handle": 5013152061240789
@@ -3401,7 +3401,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-emmaus-road",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-emmaus-road",
       "runtime_handle": 1568974415455853
@@ -3409,7 +3409,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-gethsemane",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-gethsemane",
       "runtime_handle": 6837635026717251
@@ -3417,7 +3417,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-hillside",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-hillside",
       "runtime_handle": 1193107754509678
@@ -3425,7 +3425,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-james-alphaeus",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-james-alphaeus",
       "runtime_handle": 1905366564737411
@@ -3433,7 +3433,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-james-zebedee",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-james-zebedee",
       "runtime_handle": 2907890190753132
@@ -3441,7 +3441,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-jericho",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-jericho",
       "runtime_handle": 1055350545325908
@@ -3449,7 +3449,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-jerusalem",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-jerusalem",
       "runtime_handle": 5847702027772177
@@ -3457,7 +3457,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-john-zebedee",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-john-zebedee",
       "runtime_handle": 7247410113966080
@@ -3465,7 +3465,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-jordan-river",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-jordan-river",
       "runtime_handle": 3907096302986452
@@ -3473,7 +3473,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-judas-iscariot",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-judas-iscariot",
       "runtime_handle": 8599464094757645
@@ -3481,7 +3481,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-matthew",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-matthew",
       "runtime_handle": 216768732182754
@@ -3489,7 +3489,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-nazareth",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-nazareth",
       "runtime_handle": 1703437341058016
@@ -3497,7 +3497,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-philip",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-philip",
       "runtime_handle": 1025391333820435
@@ -3505,7 +3505,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-sea-of-galilee",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-sea-of-galilee",
       "runtime_handle": 3176257800157183
@@ -3513,7 +3513,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-simon-peter",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-simon-peter",
       "runtime_handle": 8988635300116232
@@ -3521,7 +3521,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-simon-zealot",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-simon-zealot",
       "runtime_handle": 1120775867313045
@@ -3529,7 +3529,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-supplicant-emmaus",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-supplicant-emmaus",
       "runtime_handle": 8807463321091281
@@ -3537,7 +3537,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-supplicant-jericho",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-supplicant-jericho",
       "runtime_handle": 2503838062989616
@@ -3545,7 +3545,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-supplicant-lake",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-supplicant-lake",
       "runtime_handle": 435093098690522
@@ -3553,7 +3553,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-supplicant-well",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-supplicant-well",
       "runtime_handle": 8379734215276720
@@ -3561,7 +3561,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-sychar-well",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-sychar-well",
       "runtime_handle": 5199758672964838
@@ -3569,7 +3569,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-thaddaeus",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-thaddaeus",
       "runtime_handle": 2964664635736234
@@ -3577,7 +3577,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-thomas",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "card",
       "local_id": "holy-land-thomas",
       "runtime_handle": 8641029134420332
@@ -3585,7 +3585,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/700",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "700",
       "legacy_runtime_id": 700,
@@ -3594,7 +3594,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/701",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "701",
       "legacy_runtime_id": 701,
@@ -3603,7 +3603,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/702",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "702",
       "legacy_runtime_id": 702,
@@ -3612,7 +3612,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/703",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "703",
       "legacy_runtime_id": 703,
@@ -3621,7 +3621,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/704",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "704",
       "legacy_runtime_id": 704,
@@ -3630,7 +3630,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/705",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "705",
       "legacy_runtime_id": 705,
@@ -3639,7 +3639,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/706",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "706",
       "legacy_runtime_id": 706,
@@ -3648,7 +3648,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/707",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "707",
       "legacy_runtime_id": 707,
@@ -3657,7 +3657,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/708",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "708",
       "legacy_runtime_id": 708,
@@ -3666,7 +3666,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/709",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "709",
       "legacy_runtime_id": 709,
@@ -3675,7 +3675,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/710",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "710",
       "legacy_runtime_id": 710,
@@ -3684,7 +3684,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/711",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "711",
       "legacy_runtime_id": 711,
@@ -3693,7 +3693,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/712",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "712",
       "legacy_runtime_id": 712,
@@ -3702,7 +3702,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/713",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "713",
       "legacy_runtime_id": 713,
@@ -3711,7 +3711,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/location/714",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "location",
       "local_id": "714",
       "legacy_runtime_id": 714,
@@ -3720,7 +3720,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A700",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:700",
       "runtime_handle": 7425976209670718
@@ -3728,7 +3728,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A701",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:701",
       "runtime_handle": 6204684693382178
@@ -3736,7 +3736,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A702",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:702",
       "runtime_handle": 5142712702127214
@@ -3744,7 +3744,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A703",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:703",
       "runtime_handle": 2952708076765554
@@ -3752,7 +3752,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A704",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:704",
       "runtime_handle": 3014214197745708
@@ -3760,7 +3760,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A705",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:705",
       "runtime_handle": 3400739153275700
@@ -3768,7 +3768,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A706",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:706",
       "runtime_handle": 2594495794026741
@@ -3776,7 +3776,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A707",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:707",
       "runtime_handle": 5427182539397525
@@ -3784,7 +3784,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A708",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:708",
       "runtime_handle": 6003305734945460
@@ -3792,7 +3792,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A709",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:709",
       "runtime_handle": 5856902222036411
@@ -3800,7 +3800,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A710",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:710",
       "runtime_handle": 6909097621799092
@@ -3808,7 +3808,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A711",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:711",
       "runtime_handle": 5891935710839028
@@ -3816,7 +3816,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A712",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:712",
       "runtime_handle": 2608647237945698
@@ -3824,7 +3824,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A713",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:713",
       "runtime_handle": 5848703543063276
@@ -3832,7 +3832,7 @@
     {
       "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A714",
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
+      "pack_version": "1.1.2",
       "kind": "room-sheet",
       "local_id": "holy-land:room:714",
       "runtime_handle": 8480266781972399
@@ -3840,7 +3840,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/actor-facet/rati-first-bell",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "actor-facet",
       "local_id": "rati-first-bell",
       "runtime_handle": 1038687835420516
@@ -3848,7 +3848,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card-binding/rati-first-bell-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card-binding",
       "local_id": "rati-first-bell-card",
       "runtime_handle": 3116738573256863
@@ -3856,7 +3856,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-cafeteria",
       "runtime_handle": 3107528363911865
@@ -3864,7 +3864,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-courtyard",
       "runtime_handle": 4782402674832957
@@ -3872,7 +3872,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-greenhouse",
       "runtime_handle": 3662976131116729
@@ -3880,7 +3880,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-homeroom",
       "runtime_handle": 7084902207358373
@@ -3888,7 +3888,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-library",
       "runtime_handle": 6785800264541047
@@ -3896,7 +3896,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-science-lab",
       "runtime_handle": 8201462675675638
@@ -3904,7 +3904,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "captain-null",
       "runtime_handle": 3843573141933674
@@ -3912,7 +3912,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "eliza",
       "runtime_handle": 4124553834845258
@@ -3920,7 +3920,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "indra",
       "runtime_handle": 8687099168741216
@@ -3928,7 +3928,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-flashcards",
       "runtime_handle": 6148366931632609
@@ -3936,7 +3936,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-hall-pass",
       "runtime_handle": 6154026517662833
@@ -3944,7 +3944,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-lab-flask",
       "runtime_handle": 7444186363202775
@@ -3952,7 +3952,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-library-card",
       "runtime_handle": 27821797810153
@@ -3960,7 +3960,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-lunch-tray",
       "runtime_handle": 3064948555071770
@@ -3968,7 +3968,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-notebook",
       "runtime_handle": 5906680647268123
@@ -3976,7 +3976,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-cafeteria",
       "runtime_handle": 232928798345453
@@ -3984,7 +3984,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-courtyard",
       "runtime_handle": 1017422828753302
@@ -3992,7 +3992,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-greenhouse",
       "runtime_handle": 1874830250433117
@@ -4000,7 +4000,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-homeroom",
       "runtime_handle": 6928775784641985
@@ -4008,7 +4008,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-library",
       "runtime_handle": 8204365461548708
@@ -4016,7 +4016,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-science-lab",
       "runtime_handle": 57115334800243
@@ -4024,7 +4024,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "lyra",
       "runtime_handle": 7094866015162716
@@ -4032,7 +4032,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "mika",
       "runtime_handle": 4809241939115652
@@ -4040,7 +4040,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "noor",
       "runtime_handle": 6643976235743711
@@ -4048,7 +4048,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "professor-edward",
       "runtime_handle": 1211962163801060
@@ -4056,7 +4056,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "rati",
       "runtime_handle": 8508280633539606
@@ -4064,7 +4064,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "ravi",
       "runtime_handle": 3914282740523084
@@ -4072,7 +4072,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "ruby",
       "runtime_handle": 442578259385801
@@ -4080,7 +4080,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "sally-science",
       "runtime_handle": 692877066368845
@@ -4088,7 +4088,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "sami",
       "runtime_handle": 5798756249869747
@@ -4096,7 +4096,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "faction",
       "local_id": "ruby_high",
       "runtime_handle": 2919627811514647
@@ -4104,7 +4104,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "10",
       "legacy_runtime_id": 10,
@@ -4113,7 +4113,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "11",
       "legacy_runtime_id": 11,
@@ -4122,7 +4122,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "12",
       "legacy_runtime_id": 12,
@@ -4131,7 +4131,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "13",
       "legacy_runtime_id": 13,
@@ -4140,7 +4140,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "14",
       "legacy_runtime_id": 14,
@@ -4149,7 +4149,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "15",
       "legacy_runtime_id": 15,
@@ -4158,7 +4158,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:10",
       "runtime_handle": 2574024258005683
@@ -4166,7 +4166,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:11",
       "runtime_handle": 944777926762018
@@ -4174,7 +4174,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:12",
       "runtime_handle": 8925253377010016
@@ -4182,7 +4182,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:13",
       "runtime_handle": 1954150505527197
@@ -4190,7 +4190,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:14",
       "runtime_handle": 9002247914113905
@@ -4198,7 +4198,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:15",
       "runtime_handle": 8772787069788936

--- a/v2/content/official/contributions.json
+++ b/v2/content/official/contributions.json
@@ -26,7 +26,7 @@
   },
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.4",
+    "pack_version": "1.3.5",
     "rules_profile": "cosyworld.srd5/1",
     "reskins": [
       {

--- a/v2/content/official/exits.json
+++ b/v2/content/official/exits.json
@@ -382,22 +382,6 @@
     "pack_id": "cosyworld.campaign.the-lantern-keeper"
   },
   {
-    "from_location_id": 1,
-    "to_location_id": 700,
-    "flags": 0,
-    "distance": 3,
-    "direction": "north",
-    "pack_id": "cosyworld.the-holy-land"
-  },
-  {
-    "from_location_id": 700,
-    "to_location_id": 1,
-    "flags": 0,
-    "distance": 3,
-    "direction": "homeward",
-    "pack_id": "cosyworld.the-holy-land"
-  },
-  {
     "from_location_id": 700,
     "to_location_id": 712,
     "flags": 0,
@@ -635,17 +619,19 @@
   },
   {
     "from_location_id": 1,
-    "to_location_id": 11,
+    "to_location_id": 700,
     "flags": 0,
-    "direction": "south",
-    "pack_id": "ruby-high.first-bell"
+    "distance": 3,
+    "direction": "north",
+    "pack_id": "cosyworld.composition.core-holy-land"
   },
   {
-    "from_location_id": 11,
+    "from_location_id": 700,
     "to_location_id": 1,
     "flags": 0,
-    "direction": "out",
-    "pack_id": "ruby-high.first-bell"
+    "distance": 3,
+    "direction": "homeward",
+    "pack_id": "cosyworld.composition.core-holy-land"
   },
   {
     "from_location_id": 10,
@@ -760,12 +746,26 @@
     "pack_id": "ruby-high.first-bell"
   },
   {
+    "from_location_id": 1,
+    "to_location_id": 11,
+    "flags": 0,
+    "direction": "south",
+    "pack_id": "cosyworld.composition.core-ruby"
+  },
+  {
+    "from_location_id": 11,
+    "to_location_id": 1,
+    "flags": 0,
+    "direction": "out",
+    "pack_id": "cosyworld.composition.core-ruby"
+  },
+  {
     "from_location_id": 12,
     "to_location_id": 50,
     "flags": 0,
     "distance": 3,
     "direction": "down",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 50,
@@ -773,7 +773,7 @@
     "flags": 0,
     "distance": 3,
     "direction": "up",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 15,
@@ -781,7 +781,7 @@
     "flags": 0,
     "distance": 4,
     "direction": "up",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 32,
@@ -789,20 +789,20 @@
     "flags": 0,
     "distance": 4,
     "direction": "down",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 44,
     "to_location_id": 14,
     "flags": 0,
     "direction": "south",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   },
   {
     "from_location_id": 14,
     "to_location_id": 44,
     "flags": 0,
     "direction": "north",
-    "pack_id": "ruby-high.first-bell"
+    "pack_id": "cosyworld.composition.core-ruby"
   }
 ]

--- a/v2/content/official/licenses.json
+++ b/v2/content/official/licenses.json
@@ -105,22 +105,9 @@
     ]
   },
   {
-    "pack_id": "cosyworld.lonely-forest.characters",
-    "name": "Lonely Forest Character Art",
-    "version": "1.1.1",
-    "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
-    "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
-    "provenance": {
-      "author": "Cenetex",
-      "source_name": "Cenetex Lonely Forest character art",
-      "source_url": "https://github.com/cenetex/cosyworld"
-    },
-    "notices": []
-  },
-  {
     "pack_id": "cosyworld.the-holy-land",
     "name": "The Holy Land",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {
@@ -131,15 +118,54 @@
     "notices": []
   },
   {
+    "pack_id": "cosyworld.composition.core-holy-land",
+    "name": "CosyWorld Core + Holy Land Bridge",
+    "version": "1.0.0",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld official composition",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
+  },
+  {
     "pack_id": "ruby-high.first-bell",
     "name": "Ruby High: First Bell",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {
       "author": "Ruby High",
       "source_name": "Ruby High: First Bell",
       "source_url": "https://ruby-high.ai"
+    },
+    "notices": []
+  },
+  {
+    "pack_id": "cosyworld.composition.core-ruby",
+    "name": "CosyWorld Core + Ruby High Bridge",
+    "version": "1.0.0",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld official composition",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
+  },
+  {
+    "pack_id": "cosyworld.lonely-forest.characters",
+    "name": "Lonely Forest Character Art",
+    "version": "1.1.1",
+    "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+    "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "Cenetex Lonely Forest character art",
+      "source_url": "https://github.com/cenetex/cosyworld"
     },
     "notices": []
   }

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -34,7 +34,8 @@
         "sha256:fd5012d745f00283c16bea59c0d014393dd064e9751c7728b0e2e6ba6a39690c",
         "sha256:02147a6629b038e2e9a28039f829bc6ad67881fe3391a0edabf744fd362427df",
         "sha256:ef70c61617e4c6f6cf905f049dddbb053e84b520f545ed2d01b3180cf39d75d1",
-        "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17"
+        "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
+        "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc"
       ]
     },
     "rules_profile": "cosyworld.srd5/1",
@@ -620,7 +621,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc",
+    "bundle_hash": "sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1872,100 +1873,10 @@
         "integrity": "sha256:16523d55b283bb0e89a147a1d88bb4b1977a09ae9a75fe76d7a866f9cac7dd65"
       },
       {
-        "id": "cosyworld.lonely-forest.characters",
-        "name": "Lonely Forest Character Art",
-        "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
-        "version": "1.1.1",
-        "kind": "assets",
-        "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
-        "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
-        "engine": ">=0.0.20 <0.1.0",
-        "capabilities": [
-          {
-            "id": "cosyworld.lonely-forest.characters/assets",
-            "kind": "assets",
-            "version": "1.0.0"
-          }
-        ],
-        "dependencies": [
-          "cosyworld.core",
-          "cosyworld.rules-profile-srd5"
-        ],
-        "dependency_requirements": [
-          {
-            "id": "cosyworld.core",
-            "version": ">=1.0.0 <2.0.0",
-            "capabilities": [
-              "cosyworld.core/world"
-            ]
-          },
-          {
-            "id": "cosyworld.rules-profile-srd5",
-            "version": ">=1.0.0 <2.0.0",
-            "capabilities": [
-              "cosyworld.rules-profile-srd5/rules"
-            ]
-          }
-        ],
-        "dependency_closure": [
-          "cosyworld.rules-srd-5.2.1",
-          "cosyworld.rules-profile-srd5",
-          "cosyworld.core"
-        ],
-        "default_ruleset": null,
-        "entry_points": [
-          {
-            "kind": "asset_mount",
-            "id": "characters"
-          }
-        ],
-        "provenance": {
-          "author": "Cenetex",
-          "source_name": "Cenetex Lonely Forest character art",
-          "source_url": "https://github.com/cenetex/cosyworld"
-        },
-        "resource_counts": {
-          "actors": 0,
-          "actor_facets": 0,
-          "access_gates": 0,
-          "factions": 0,
-          "items": 0,
-          "locations": 0,
-          "exits": 0,
-          "hidden_exits": 0,
-          "room_features": 0,
-          "room_sheets": 0,
-          "clocks": 0,
-          "jobs": 0,
-          "action_vocabulary": 0,
-          "fronts": 0,
-          "cards": 0,
-          "card_bindings": 0,
-          "lifecycle_hooks": 0,
-          "evolution_tracks": 0,
-          "recipes": 0,
-          "sentences": 0,
-          "external_cards": 0,
-          "assets": 1,
-          "rules": 0,
-          "character_creation": 0,
-          "reskins": 0,
-          "offers": 0,
-          "variants": 0,
-          "extensions": 0
-        },
-        "rules_profile": "cosyworld.srd5/1",
-        "source": {
-          "type": "workspace",
-          "path": "../../content/lonely-forest"
-        },
-        "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff"
-      },
-      {
         "id": "cosyworld.the-holy-land",
         "name": "The Holy Land",
         "description": "A watercolor pilgrimage through Gospel-associated places with the Twelve and generative wayside supplicants; Jesus is not depicted as an actor or collectible card.",
-        "version": "1.1.1",
+        "version": "1.1.2",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit",
@@ -2030,7 +1941,7 @@
           "factions": 0,
           "items": 0,
           "locations": 15,
-          "exits": 32,
+          "exits": 30,
           "hidden_exits": 0,
           "room_features": 15,
           "room_sheets": 15,
@@ -2058,13 +1969,113 @@
           "type": "workspace",
           "path": "../../content/the-holy-land"
         },
-        "integrity": "sha256:bda3362756ed58713d34eb6ded2e54b71c1ecc9463b34d725b9360c01fcbf8ae"
+        "integrity": "sha256:54099f568bf3ec8eb2b5181bf4ecbe08d0d07d4f863b7ad5e982cec3cb0ca4a2"
+      },
+      {
+        "id": "cosyworld.composition.core-holy-land",
+        "name": "CosyWorld Core + Holy Land Bridge",
+        "description": "Composition-owned paths connecting CosyWorld Core and The Holy Land.",
+        "version": "1.0.0",
+        "kind": "world",
+        "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.composition.core-holy-land/world",
+            "kind": "world",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core",
+          "cosyworld.the-holy-land",
+          "cosyworld.rules-profile-srd5"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.3.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          },
+          {
+            "id": "cosyworld.the-holy-land",
+            "version": ">=1.1.2 <2.0.0",
+            "capabilities": [
+              "cosyworld.the-holy-land/world"
+            ]
+          },
+          {
+            "id": "cosyworld.rules-profile-srd5",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.rules-profile-srd5/rules"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.rules-srd-5.2.1",
+          "cosyworld.rules-profile-srd5",
+          "cosyworld.core",
+          "cosyworld.the-holy-land"
+        ],
+        "default_ruleset": null,
+        "entry_points": [],
+        "provenance": {
+          "author": "Cenetex",
+          "source_name": "CosyWorld official composition",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "actor_facets": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 2,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "action_vocabulary": 0,
+          "fronts": 0,
+          "cards": 0,
+          "card_bindings": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 0,
+          "rules": 0,
+          "character_creation": 0,
+          "reskins": 0,
+          "offers": 0,
+          "variants": 0,
+          "extensions": 0
+        },
+        "extensions": {
+          "x-cosyworld-composition": {
+            "schema_version": 1,
+            "role": "bridge"
+          }
+        },
+        "rules_profile": "cosyworld.srd5/1",
+        "source": {
+          "type": "workspace",
+          "path": "../../content/core-holy-land-bridge"
+        },
+        "integrity": "sha256:0ed36b254e7eb3fb588db28f3e9401b31fc9ee1d66efd0f8e80292176c43a913"
       },
       {
         "id": "ruby-high.first-bell",
         "name": "Ruby High: First Bell",
         "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-        "version": "1.3.4",
+        "version": "1.3.5",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit",
@@ -2149,7 +2160,7 @@
           "factions": 1,
           "items": 0,
           "locations": 6,
-          "exits": 24,
+          "exits": 16,
           "hidden_exits": 0,
           "room_features": 1,
           "room_sheets": 6,
@@ -2267,7 +2278,197 @@
           "type": "workspace",
           "path": "../../content/ruby-high-first-bell"
         },
-        "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9"
+        "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847"
+      },
+      {
+        "id": "cosyworld.composition.core-ruby",
+        "name": "CosyWorld Core + Ruby High Bridge",
+        "description": "Composition-owned paths connecting CosyWorld Core and Ruby High.",
+        "version": "1.0.0",
+        "kind": "world",
+        "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.composition.core-ruby/world",
+            "kind": "world",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core",
+          "ruby-high.first-bell",
+          "cosyworld.rules-profile-srd5"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.3.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          },
+          {
+            "id": "ruby-high.first-bell",
+            "version": ">=1.3.5 <2.0.0",
+            "capabilities": [
+              "ruby-high.first-bell/world"
+            ]
+          },
+          {
+            "id": "cosyworld.rules-profile-srd5",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.rules-profile-srd5/rules"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.rules-srd-5.2.1",
+          "cosyworld.rules-profile-srd5",
+          "cosyworld.core",
+          "ruby-high.first-bell"
+        ],
+        "default_ruleset": null,
+        "entry_points": [],
+        "provenance": {
+          "author": "Cenetex",
+          "source_name": "CosyWorld official composition",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "actor_facets": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 8,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "action_vocabulary": 0,
+          "fronts": 0,
+          "cards": 0,
+          "card_bindings": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 0,
+          "rules": 0,
+          "character_creation": 0,
+          "reskins": 0,
+          "offers": 0,
+          "variants": 0,
+          "extensions": 0
+        },
+        "extensions": {
+          "x-cosyworld-composition": {
+            "schema_version": 1,
+            "role": "bridge"
+          }
+        },
+        "rules_profile": "cosyworld.srd5/1",
+        "source": {
+          "type": "workspace",
+          "path": "../../content/core-ruby-bridge"
+        },
+        "integrity": "sha256:af0f833ed3be83ff11e9652514bd14bc0112af0d55e4b55f2bcf725420e918ba"
+      },
+      {
+        "id": "cosyworld.lonely-forest.characters",
+        "name": "Lonely Forest Character Art",
+        "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
+        "version": "1.1.1",
+        "kind": "assets",
+        "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+        "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.lonely-forest.characters/assets",
+            "kind": "assets",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core",
+          "cosyworld.rules-profile-srd5"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          },
+          {
+            "id": "cosyworld.rules-profile-srd5",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.rules-profile-srd5/rules"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.rules-srd-5.2.1",
+          "cosyworld.rules-profile-srd5",
+          "cosyworld.core"
+        ],
+        "default_ruleset": null,
+        "entry_points": [
+          {
+            "kind": "asset_mount",
+            "id": "characters"
+          }
+        ],
+        "provenance": {
+          "author": "Cenetex",
+          "source_name": "Cenetex Lonely Forest character art",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "actor_facets": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 0,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "action_vocabulary": 0,
+          "fronts": 0,
+          "cards": 0,
+          "card_bindings": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 1,
+          "rules": 0,
+          "character_creation": 0,
+          "reskins": 0,
+          "offers": 0,
+          "variants": 0,
+          "extensions": 0
+        },
+        "rules_profile": "cosyworld.srd5/1",
+        "source": {
+          "type": "workspace",
+          "path": "../../content/lonely-forest"
+        },
+        "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff"
       }
     ],
     "files": {
@@ -5676,22 +5877,6 @@
         "pack_id": "cosyworld.campaign.the-lantern-keeper"
       },
       {
-        "from_location_id": 1,
-        "to_location_id": 700,
-        "flags": 0,
-        "distance": 3,
-        "direction": "north",
-        "pack_id": "cosyworld.the-holy-land"
-      },
-      {
-        "from_location_id": 700,
-        "to_location_id": 1,
-        "flags": 0,
-        "distance": 3,
-        "direction": "homeward",
-        "pack_id": "cosyworld.the-holy-land"
-      },
-      {
         "from_location_id": 700,
         "to_location_id": 712,
         "flags": 0,
@@ -5929,17 +6114,19 @@
       },
       {
         "from_location_id": 1,
-        "to_location_id": 11,
+        "to_location_id": 700,
         "flags": 0,
-        "direction": "south",
-        "pack_id": "ruby-high.first-bell"
+        "distance": 3,
+        "direction": "north",
+        "pack_id": "cosyworld.composition.core-holy-land"
       },
       {
-        "from_location_id": 11,
+        "from_location_id": 700,
         "to_location_id": 1,
         "flags": 0,
-        "direction": "out",
-        "pack_id": "ruby-high.first-bell"
+        "distance": 3,
+        "direction": "homeward",
+        "pack_id": "cosyworld.composition.core-holy-land"
       },
       {
         "from_location_id": 10,
@@ -6054,12 +6241,26 @@
         "pack_id": "ruby-high.first-bell"
       },
       {
+        "from_location_id": 1,
+        "to_location_id": 11,
+        "flags": 0,
+        "direction": "south",
+        "pack_id": "cosyworld.composition.core-ruby"
+      },
+      {
+        "from_location_id": 11,
+        "to_location_id": 1,
+        "flags": 0,
+        "direction": "out",
+        "pack_id": "cosyworld.composition.core-ruby"
+      },
+      {
         "from_location_id": 12,
         "to_location_id": 50,
         "flags": 0,
         "distance": 3,
         "direction": "down",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 50,
@@ -6067,7 +6268,7 @@
         "flags": 0,
         "distance": 3,
         "direction": "up",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 15,
@@ -6075,7 +6276,7 @@
         "flags": 0,
         "distance": 4,
         "direction": "up",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 32,
@@ -6083,21 +6284,21 @@
         "flags": 0,
         "distance": 4,
         "direction": "down",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 44,
         "to_location_id": 14,
         "flags": 0,
         "direction": "south",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       },
       {
         "from_location_id": 14,
         "to_location_id": 44,
         "flags": 0,
         "direction": "north",
-        "pack_id": "ruby-high.first-bell"
+        "pack_id": "cosyworld.composition.core-ruby"
       }
     ],
     "hidden_exits": [
@@ -12997,22 +13198,9 @@
       "fallback": null
     },
     {
-      "pack_id": "cosyworld.lonely-forest.characters",
-      "pack_version": "1.1.1",
-      "pack_integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
-      "provider": "cosyworld.lonely-forest.characters/assets",
-      "mount": "characters",
-      "root": "lonely-forest",
-      "directory": "assets/characters/slices",
-      "public_prefix": "/assets/lonely-forest/characters",
-      "content_hash": "sha256:d45eb30a962de236ddba913834e8bdaa7b9c530bc6b66383e272118218797d93",
-      "optional": false,
-      "fallback": null
-    },
-    {
       "pack_id": "cosyworld.the-holy-land",
-      "pack_version": "1.1.1",
-      "pack_integrity": "sha256:bda3362756ed58713d34eb6ded2e54b71c1ecc9463b34d725b9360c01fcbf8ae",
+      "pack_version": "1.1.2",
+      "pack_integrity": "sha256:54099f568bf3ec8eb2b5181bf4ecbe08d0d07d4f863b7ad5e982cec3cb0ca4a2",
       "provider": "cosyworld.the-holy-land/assets",
       "mount": "cards",
       "root": "the-holy-land",
@@ -13024,8 +13212,8 @@
     },
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
-      "pack_integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+      "pack_version": "1.3.5",
+      "pack_integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
       "provider": "ruby-high.first-bell/assets",
       "mount": "cards",
       "root": "ruby-high-first-bell",
@@ -13034,6 +13222,19 @@
       "content_hash": "sha256:c6028b77e9871b567178efa708ca03cb6e731fe18b01afe20efd1e0dc05e1c44",
       "optional": true,
       "fallback": "external_uri"
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "pack_version": "1.1.1",
+      "pack_integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+      "provider": "cosyworld.lonely-forest.characters/assets",
+      "mount": "characters",
+      "root": "lonely-forest",
+      "directory": "assets/characters/slices",
+      "public_prefix": "/assets/lonely-forest/characters",
+      "content_hash": "sha256:d45eb30a962de236ddba913834e8bdaa7b9c530bc6b66383e272118218797d93",
+      "optional": false,
+      "fallback": null
     }
   ],
   "rules": [
@@ -14761,7 +14962,7 @@
     },
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "rules_profile": "cosyworld.srd5/1",
       "reskins": [
         {
@@ -14935,22 +15136,9 @@
       ]
     },
     {
-      "pack_id": "cosyworld.lonely-forest.characters",
-      "name": "Lonely Forest Character Art",
-      "version": "1.1.1",
-      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
-      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
-      "provenance": {
-        "author": "Cenetex",
-        "source_name": "Cenetex Lonely Forest character art",
-        "source_url": "https://github.com/cenetex/cosyworld"
-      },
-      "notices": []
-    },
-    {
       "pack_id": "cosyworld.the-holy-land",
       "name": "The Holy Land",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
@@ -14961,15 +15149,54 @@
       "notices": []
     },
     {
+      "pack_id": "cosyworld.composition.core-holy-land",
+      "name": "CosyWorld Core + Holy Land Bridge",
+      "version": "1.0.0",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
         "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.composition.core-ruby",
+      "name": "CosyWorld Core + Ruby High Bridge",
+      "version": "1.0.0",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "version": "1.1.1",
+      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
       },
       "notices": []
     }
@@ -18905,7 +19132,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7002",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7002",
         "legacy_runtime_id": 7002,
@@ -18914,7 +19141,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7003",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7003",
         "legacy_runtime_id": 7003,
@@ -18923,7 +19150,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7004",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7004",
         "legacy_runtime_id": 7004,
@@ -18932,7 +19159,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7005",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7005",
         "legacy_runtime_id": 7005,
@@ -18941,7 +19168,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7006",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7006",
         "legacy_runtime_id": 7006,
@@ -18950,7 +19177,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7007",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7007",
         "legacy_runtime_id": 7007,
@@ -18959,7 +19186,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7008",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7008",
         "legacy_runtime_id": 7008,
@@ -18968,7 +19195,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7009",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7009",
         "legacy_runtime_id": 7009,
@@ -18977,7 +19204,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7010",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7010",
         "legacy_runtime_id": 7010,
@@ -18986,7 +19213,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7011",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7011",
         "legacy_runtime_id": 7011,
@@ -18995,7 +19222,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7012",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7012",
         "legacy_runtime_id": 7012,
@@ -19004,7 +19231,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7013",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7013",
         "legacy_runtime_id": 7013,
@@ -19013,7 +19240,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7014",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7014",
         "legacy_runtime_id": 7014,
@@ -19022,7 +19249,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7015",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7015",
         "legacy_runtime_id": 7015,
@@ -19031,7 +19258,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7016",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7016",
         "legacy_runtime_id": 7016,
@@ -19040,7 +19267,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/actor/7017",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "actor",
         "local_id": "7017",
         "legacy_runtime_id": 7017,
@@ -19049,7 +19276,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-andrew",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-andrew",
         "runtime_handle": 6063388728752457
@@ -19057,7 +19284,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-bartholomew",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-bartholomew",
         "runtime_handle": 7648376027062685
@@ -19065,7 +19292,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-bethany",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-bethany",
         "runtime_handle": 2176770069418396
@@ -19073,7 +19300,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-bethlehem",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-bethlehem",
         "runtime_handle": 5964004265344755
@@ -19081,7 +19308,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-bethsaida",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-bethsaida",
         "runtime_handle": 29790776979747
@@ -19089,7 +19316,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-caesarea-philippi",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-caesarea-philippi",
         "runtime_handle": 7420082354530316
@@ -19097,7 +19324,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-cana",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-cana",
         "runtime_handle": 2186253045555771
@@ -19105,7 +19332,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-capernaum",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-capernaum",
         "runtime_handle": 5013152061240789
@@ -19113,7 +19340,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-emmaus-road",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-emmaus-road",
         "runtime_handle": 1568974415455853
@@ -19121,7 +19348,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-gethsemane",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-gethsemane",
         "runtime_handle": 6837635026717251
@@ -19129,7 +19356,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-hillside",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-hillside",
         "runtime_handle": 1193107754509678
@@ -19137,7 +19364,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-james-alphaeus",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-james-alphaeus",
         "runtime_handle": 1905366564737411
@@ -19145,7 +19372,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-james-zebedee",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-james-zebedee",
         "runtime_handle": 2907890190753132
@@ -19153,7 +19380,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-jericho",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-jericho",
         "runtime_handle": 1055350545325908
@@ -19161,7 +19388,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-jerusalem",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-jerusalem",
         "runtime_handle": 5847702027772177
@@ -19169,7 +19396,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-john-zebedee",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-john-zebedee",
         "runtime_handle": 7247410113966080
@@ -19177,7 +19404,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-jordan-river",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-jordan-river",
         "runtime_handle": 3907096302986452
@@ -19185,7 +19412,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-judas-iscariot",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-judas-iscariot",
         "runtime_handle": 8599464094757645
@@ -19193,7 +19420,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-matthew",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-matthew",
         "runtime_handle": 216768732182754
@@ -19201,7 +19428,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-nazareth",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-nazareth",
         "runtime_handle": 1703437341058016
@@ -19209,7 +19436,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-philip",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-philip",
         "runtime_handle": 1025391333820435
@@ -19217,7 +19444,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-sea-of-galilee",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-sea-of-galilee",
         "runtime_handle": 3176257800157183
@@ -19225,7 +19452,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-simon-peter",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-simon-peter",
         "runtime_handle": 8988635300116232
@@ -19233,7 +19460,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-simon-zealot",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-simon-zealot",
         "runtime_handle": 1120775867313045
@@ -19241,7 +19468,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-supplicant-emmaus",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-supplicant-emmaus",
         "runtime_handle": 8807463321091281
@@ -19249,7 +19476,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-supplicant-jericho",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-supplicant-jericho",
         "runtime_handle": 2503838062989616
@@ -19257,7 +19484,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-supplicant-lake",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-supplicant-lake",
         "runtime_handle": 435093098690522
@@ -19265,7 +19492,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-supplicant-well",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-supplicant-well",
         "runtime_handle": 8379734215276720
@@ -19273,7 +19500,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-sychar-well",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-sychar-well",
         "runtime_handle": 5199758672964838
@@ -19281,7 +19508,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-thaddaeus",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-thaddaeus",
         "runtime_handle": 2964664635736234
@@ -19289,7 +19516,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/card/holy-land-thomas",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "card",
         "local_id": "holy-land-thomas",
         "runtime_handle": 8641029134420332
@@ -19297,7 +19524,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/700",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "700",
         "legacy_runtime_id": 700,
@@ -19306,7 +19533,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/701",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "701",
         "legacy_runtime_id": 701,
@@ -19315,7 +19542,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/702",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "702",
         "legacy_runtime_id": 702,
@@ -19324,7 +19551,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/703",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "703",
         "legacy_runtime_id": 703,
@@ -19333,7 +19560,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/704",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "704",
         "legacy_runtime_id": 704,
@@ -19342,7 +19569,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/705",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "705",
         "legacy_runtime_id": 705,
@@ -19351,7 +19578,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/706",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "706",
         "legacy_runtime_id": 706,
@@ -19360,7 +19587,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/707",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "707",
         "legacy_runtime_id": 707,
@@ -19369,7 +19596,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/708",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "708",
         "legacy_runtime_id": 708,
@@ -19378,7 +19605,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/709",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "709",
         "legacy_runtime_id": 709,
@@ -19387,7 +19614,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/710",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "710",
         "legacy_runtime_id": 710,
@@ -19396,7 +19623,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/711",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "711",
         "legacy_runtime_id": 711,
@@ -19405,7 +19632,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/712",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "712",
         "legacy_runtime_id": 712,
@@ -19414,7 +19641,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/713",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "713",
         "legacy_runtime_id": 713,
@@ -19423,7 +19650,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/location/714",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "location",
         "local_id": "714",
         "legacy_runtime_id": 714,
@@ -19432,7 +19659,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A700",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:700",
         "runtime_handle": 7425976209670718
@@ -19440,7 +19667,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A701",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:701",
         "runtime_handle": 6204684693382178
@@ -19448,7 +19675,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A702",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:702",
         "runtime_handle": 5142712702127214
@@ -19456,7 +19683,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A703",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:703",
         "runtime_handle": 2952708076765554
@@ -19464,7 +19691,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A704",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:704",
         "runtime_handle": 3014214197745708
@@ -19472,7 +19699,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A705",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:705",
         "runtime_handle": 3400739153275700
@@ -19480,7 +19707,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A706",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:706",
         "runtime_handle": 2594495794026741
@@ -19488,7 +19715,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A707",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:707",
         "runtime_handle": 5427182539397525
@@ -19496,7 +19723,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A708",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:708",
         "runtime_handle": 6003305734945460
@@ -19504,7 +19731,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A709",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:709",
         "runtime_handle": 5856902222036411
@@ -19512,7 +19739,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A710",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:710",
         "runtime_handle": 6909097621799092
@@ -19520,7 +19747,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A711",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:711",
         "runtime_handle": 5891935710839028
@@ -19528,7 +19755,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A712",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:712",
         "runtime_handle": 2608647237945698
@@ -19536,7 +19763,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A713",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:713",
         "runtime_handle": 5848703543063276
@@ -19544,7 +19771,7 @@
       {
         "canonical_ref": "pack://cosyworld.the-holy-land/room-sheet/holy-land%3Aroom%3A714",
         "pack_id": "cosyworld.the-holy-land",
-        "pack_version": "1.1.1",
+        "pack_version": "1.1.2",
         "kind": "room-sheet",
         "local_id": "holy-land:room:714",
         "runtime_handle": 8480266781972399
@@ -19552,7 +19779,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/actor-facet/rati-first-bell",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "actor-facet",
         "local_id": "rati-first-bell",
         "runtime_handle": 1038687835420516
@@ -19560,7 +19787,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card-binding/rati-first-bell-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card-binding",
         "local_id": "rati-first-bell-card",
         "runtime_handle": 3116738573256863
@@ -19568,7 +19795,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-cafeteria",
         "runtime_handle": 3107528363911865
@@ -19576,7 +19803,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-courtyard",
         "runtime_handle": 4782402674832957
@@ -19584,7 +19811,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-greenhouse",
         "runtime_handle": 3662976131116729
@@ -19592,7 +19819,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-homeroom",
         "runtime_handle": 7084902207358373
@@ -19600,7 +19827,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-library",
         "runtime_handle": 6785800264541047
@@ -19608,7 +19835,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-science-lab",
         "runtime_handle": 8201462675675638
@@ -19616,7 +19843,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "captain-null",
         "runtime_handle": 3843573141933674
@@ -19624,7 +19851,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "eliza",
         "runtime_handle": 4124553834845258
@@ -19632,7 +19859,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "indra",
         "runtime_handle": 8687099168741216
@@ -19640,7 +19867,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-flashcards",
         "runtime_handle": 6148366931632609
@@ -19648,7 +19875,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-hall-pass",
         "runtime_handle": 6154026517662833
@@ -19656,7 +19883,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-lab-flask",
         "runtime_handle": 7444186363202775
@@ -19664,7 +19891,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-library-card",
         "runtime_handle": 27821797810153
@@ -19672,7 +19899,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-lunch-tray",
         "runtime_handle": 3064948555071770
@@ -19680,7 +19907,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-notebook",
         "runtime_handle": 5906680647268123
@@ -19688,7 +19915,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-cafeteria",
         "runtime_handle": 232928798345453
@@ -19696,7 +19923,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-courtyard",
         "runtime_handle": 1017422828753302
@@ -19704,7 +19931,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-greenhouse",
         "runtime_handle": 1874830250433117
@@ -19712,7 +19939,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-homeroom",
         "runtime_handle": 6928775784641985
@@ -19720,7 +19947,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-library",
         "runtime_handle": 8204365461548708
@@ -19728,7 +19955,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-science-lab",
         "runtime_handle": 57115334800243
@@ -19736,7 +19963,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "lyra",
         "runtime_handle": 7094866015162716
@@ -19744,7 +19971,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "mika",
         "runtime_handle": 4809241939115652
@@ -19752,7 +19979,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "noor",
         "runtime_handle": 6643976235743711
@@ -19760,7 +19987,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "professor-edward",
         "runtime_handle": 1211962163801060
@@ -19768,7 +19995,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "rati",
         "runtime_handle": 8508280633539606
@@ -19776,7 +20003,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "ravi",
         "runtime_handle": 3914282740523084
@@ -19784,7 +20011,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "ruby",
         "runtime_handle": 442578259385801
@@ -19792,7 +20019,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "sally-science",
         "runtime_handle": 692877066368845
@@ -19800,7 +20027,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "sami",
         "runtime_handle": 5798756249869747
@@ -19808,7 +20035,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "faction",
         "local_id": "ruby_high",
         "runtime_handle": 2919627811514647
@@ -19816,7 +20043,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "10",
         "legacy_runtime_id": 10,
@@ -19825,7 +20052,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "11",
         "legacy_runtime_id": 11,
@@ -19834,7 +20061,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "12",
         "legacy_runtime_id": 12,
@@ -19843,7 +20070,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "13",
         "legacy_runtime_id": 13,
@@ -19852,7 +20079,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "14",
         "legacy_runtime_id": 14,
@@ -19861,7 +20088,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "15",
         "legacy_runtime_id": 15,
@@ -19870,7 +20097,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:10",
         "runtime_handle": 2574024258005683
@@ -19878,7 +20105,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:11",
         "runtime_handle": 944777926762018
@@ -19886,7 +20113,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:12",
         "runtime_handle": 8925253377010016
@@ -19894,7 +20121,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:13",
         "runtime_handle": 1954150505527197
@@ -19902,7 +20129,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:14",
         "runtime_handle": 9002247914113905
@@ -19910,7 +20137,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:15",
         "runtime_handle": 8772787069788936

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -32,7 +32,8 @@
       "sha256:fd5012d745f00283c16bea59c0d014393dd064e9751c7728b0e2e6ba6a39690c",
       "sha256:02147a6629b038e2e9a28039f829bc6ad67881fe3391a0edabf744fd362427df",
       "sha256:ef70c61617e4c6f6cf905f049dddbb053e84b520f545ed2d01b3180cf39d75d1",
-      "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17"
+      "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
+      "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc"
     ]
   },
   "rules_profile": "cosyworld.srd5/1",
@@ -618,7 +619,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc",
+  "bundle_hash": "sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1870,100 +1871,10 @@
       "integrity": "sha256:16523d55b283bb0e89a147a1d88bb4b1977a09ae9a75fe76d7a866f9cac7dd65"
     },
     {
-      "id": "cosyworld.lonely-forest.characters",
-      "name": "Lonely Forest Character Art",
-      "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
-      "version": "1.1.1",
-      "kind": "assets",
-      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
-      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
-      "engine": ">=0.0.20 <0.1.0",
-      "capabilities": [
-        {
-          "id": "cosyworld.lonely-forest.characters/assets",
-          "kind": "assets",
-          "version": "1.0.0"
-        }
-      ],
-      "dependencies": [
-        "cosyworld.core",
-        "cosyworld.rules-profile-srd5"
-      ],
-      "dependency_requirements": [
-        {
-          "id": "cosyworld.core",
-          "version": ">=1.0.0 <2.0.0",
-          "capabilities": [
-            "cosyworld.core/world"
-          ]
-        },
-        {
-          "id": "cosyworld.rules-profile-srd5",
-          "version": ">=1.0.0 <2.0.0",
-          "capabilities": [
-            "cosyworld.rules-profile-srd5/rules"
-          ]
-        }
-      ],
-      "dependency_closure": [
-        "cosyworld.rules-srd-5.2.1",
-        "cosyworld.rules-profile-srd5",
-        "cosyworld.core"
-      ],
-      "default_ruleset": null,
-      "entry_points": [
-        {
-          "kind": "asset_mount",
-          "id": "characters"
-        }
-      ],
-      "provenance": {
-        "author": "Cenetex",
-        "source_name": "Cenetex Lonely Forest character art",
-        "source_url": "https://github.com/cenetex/cosyworld"
-      },
-      "resource_counts": {
-        "actors": 0,
-        "actor_facets": 0,
-        "access_gates": 0,
-        "factions": 0,
-        "items": 0,
-        "locations": 0,
-        "exits": 0,
-        "hidden_exits": 0,
-        "room_features": 0,
-        "room_sheets": 0,
-        "clocks": 0,
-        "jobs": 0,
-        "action_vocabulary": 0,
-        "fronts": 0,
-        "cards": 0,
-        "card_bindings": 0,
-        "lifecycle_hooks": 0,
-        "evolution_tracks": 0,
-        "recipes": 0,
-        "sentences": 0,
-        "external_cards": 0,
-        "assets": 1,
-        "rules": 0,
-        "character_creation": 0,
-        "reskins": 0,
-        "offers": 0,
-        "variants": 0,
-        "extensions": 0
-      },
-      "rules_profile": "cosyworld.srd5/1",
-      "source": {
-        "type": "workspace",
-        "path": "../../content/lonely-forest"
-      },
-      "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff"
-    },
-    {
       "id": "cosyworld.the-holy-land",
       "name": "The Holy Land",
       "description": "A watercolor pilgrimage through Gospel-associated places with the Twelve and generative wayside supplicants; Jesus is not depicted as an actor or collectible card.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit",
@@ -2028,7 +1939,7 @@
         "factions": 0,
         "items": 0,
         "locations": 15,
-        "exits": 32,
+        "exits": 30,
         "hidden_exits": 0,
         "room_features": 15,
         "room_sheets": 15,
@@ -2056,13 +1967,113 @@
         "type": "workspace",
         "path": "../../content/the-holy-land"
       },
-      "integrity": "sha256:bda3362756ed58713d34eb6ded2e54b71c1ecc9463b34d725b9360c01fcbf8ae"
+      "integrity": "sha256:54099f568bf3ec8eb2b5181bf4ecbe08d0d07d4f863b7ad5e982cec3cb0ca4a2"
+    },
+    {
+      "id": "cosyworld.composition.core-holy-land",
+      "name": "CosyWorld Core + Holy Land Bridge",
+      "description": "Composition-owned paths connecting CosyWorld Core and The Holy Land.",
+      "version": "1.0.0",
+      "kind": "world",
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "engine": ">=0.0.20 <0.1.0",
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-holy-land/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        "cosyworld.core",
+        "cosyworld.the-holy-land",
+        "cosyworld.rules-profile-srd5"
+      ],
+      "dependency_requirements": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.the-holy-land",
+          "version": ">=1.1.2 <2.0.0",
+          "capabilities": [
+            "cosyworld.the-holy-land/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "cosyworld.the-holy-land"
+      ],
+      "default_ruleset": null,
+      "entry_points": [],
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "resource_counts": {
+        "actors": 0,
+        "actor_facets": 0,
+        "access_gates": 0,
+        "factions": 0,
+        "items": 0,
+        "locations": 0,
+        "exits": 2,
+        "hidden_exits": 0,
+        "room_features": 0,
+        "room_sheets": 0,
+        "clocks": 0,
+        "jobs": 0,
+        "action_vocabulary": 0,
+        "fronts": 0,
+        "cards": 0,
+        "card_bindings": 0,
+        "lifecycle_hooks": 0,
+        "evolution_tracks": 0,
+        "recipes": 0,
+        "sentences": 0,
+        "external_cards": 0,
+        "assets": 0,
+        "rules": 0,
+        "character_creation": 0,
+        "reskins": 0,
+        "offers": 0,
+        "variants": 0,
+        "extensions": 0
+      },
+      "extensions": {
+        "x-cosyworld-composition": {
+          "schema_version": 1,
+          "role": "bridge"
+        }
+      },
+      "rules_profile": "cosyworld.srd5/1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-holy-land-bridge"
+      },
+      "integrity": "sha256:0ed36b254e7eb3fb588db28f3e9401b31fc9ee1d66efd0f8e80292176c43a913"
     },
     {
       "id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
       "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit",
@@ -2147,7 +2158,7 @@
         "factions": 1,
         "items": 0,
         "locations": 6,
-        "exits": 24,
+        "exits": 16,
         "hidden_exits": 0,
         "room_features": 1,
         "room_sheets": 6,
@@ -2265,7 +2276,197 @@
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9"
+      "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847"
+    },
+    {
+      "id": "cosyworld.composition.core-ruby",
+      "name": "CosyWorld Core + Ruby High Bridge",
+      "description": "Composition-owned paths connecting CosyWorld Core and Ruby High.",
+      "version": "1.0.0",
+      "kind": "world",
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "engine": ">=0.0.20 <0.1.0",
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-ruby/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        "cosyworld.core",
+        "ruby-high.first-bell",
+        "cosyworld.rules-profile-srd5"
+      ],
+      "dependency_requirements": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "ruby-high.first-bell",
+          "version": ">=1.3.5 <2.0.0",
+          "capabilities": [
+            "ruby-high.first-bell/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "ruby-high.first-bell"
+      ],
+      "default_ruleset": null,
+      "entry_points": [],
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "resource_counts": {
+        "actors": 0,
+        "actor_facets": 0,
+        "access_gates": 0,
+        "factions": 0,
+        "items": 0,
+        "locations": 0,
+        "exits": 8,
+        "hidden_exits": 0,
+        "room_features": 0,
+        "room_sheets": 0,
+        "clocks": 0,
+        "jobs": 0,
+        "action_vocabulary": 0,
+        "fronts": 0,
+        "cards": 0,
+        "card_bindings": 0,
+        "lifecycle_hooks": 0,
+        "evolution_tracks": 0,
+        "recipes": 0,
+        "sentences": 0,
+        "external_cards": 0,
+        "assets": 0,
+        "rules": 0,
+        "character_creation": 0,
+        "reskins": 0,
+        "offers": 0,
+        "variants": 0,
+        "extensions": 0
+      },
+      "extensions": {
+        "x-cosyworld-composition": {
+          "schema_version": 1,
+          "role": "bridge"
+        }
+      },
+      "rules_profile": "cosyworld.srd5/1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-ruby-bridge"
+      },
+      "integrity": "sha256:af0f833ed3be83ff11e9652514bd14bc0112af0d55e4b55f2bcf725420e918ba"
+    },
+    {
+      "id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
+      "version": "1.1.1",
+      "kind": "assets",
+      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "engine": ">=0.0.20 <0.1.0",
+      "capabilities": [
+        {
+          "id": "cosyworld.lonely-forest.characters/assets",
+          "kind": "assets",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        "cosyworld.core",
+        "cosyworld.rules-profile-srd5"
+      ],
+      "dependency_requirements": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core"
+      ],
+      "default_ruleset": null,
+      "entry_points": [
+        {
+          "kind": "asset_mount",
+          "id": "characters"
+        }
+      ],
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "resource_counts": {
+        "actors": 0,
+        "actor_facets": 0,
+        "access_gates": 0,
+        "factions": 0,
+        "items": 0,
+        "locations": 0,
+        "exits": 0,
+        "hidden_exits": 0,
+        "room_features": 0,
+        "room_sheets": 0,
+        "clocks": 0,
+        "jobs": 0,
+        "action_vocabulary": 0,
+        "fronts": 0,
+        "cards": 0,
+        "card_bindings": 0,
+        "lifecycle_hooks": 0,
+        "evolution_tracks": 0,
+        "recipes": 0,
+        "sentences": 0,
+        "external_cards": 0,
+        "assets": 1,
+        "rules": 0,
+        "character_creation": 0,
+        "reskins": 0,
+        "offers": 0,
+        "variants": 0,
+        "extensions": 0
+      },
+      "rules_profile": "cosyworld.srd5/1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/lonely-forest"
+      },
+      "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff"
     }
   ],
   "files": {

--- a/v2/content/ruby-high-first-bell/exits.json
+++ b/v2/content/ruby-high-first-bell/exits.json
@@ -1,23 +1,5 @@
 [
   {
-    "from_location_id": 1,
-    "to_location_id": 11,
-    "flags": 0,
-    "direction": "south",
-    "requires_packs": [
-      "cosyworld.core"
-    ]
-  },
-  {
-    "from_location_id": 11,
-    "to_location_id": 1,
-    "flags": 0,
-    "direction": "out",
-    "requires_packs": [
-      "cosyworld.core"
-    ]
-  },
-  {
     "from_location_id": 10,
     "to_location_id": 11,
     "flags": 0,
@@ -112,63 +94,5 @@
     "to_location_id": 14,
     "flags": 0,
     "direction": "north"
-  },
-  {
-    "from_location_id": 12,
-    "to_location_id": 50,
-    "flags": 0,
-    "distance": 3,
-    "direction": "down",
-    "requires_packs": [
-      "cosyworld.core"
-    ]
-  },
-  {
-    "from_location_id": 50,
-    "to_location_id": 12,
-    "flags": 0,
-    "distance": 3,
-    "direction": "up",
-    "requires_packs": [
-      "cosyworld.core"
-    ]
-  },
-  {
-    "from_location_id": 15,
-    "to_location_id": 32,
-    "flags": 0,
-    "distance": 4,
-    "direction": "up",
-    "requires_packs": [
-      "cosyworld.core"
-    ]
-  },
-  {
-    "from_location_id": 32,
-    "to_location_id": 15,
-    "flags": 0,
-    "distance": 4,
-    "direction": "down",
-    "requires_packs": [
-      "cosyworld.core"
-    ]
-  },
-  {
-    "from_location_id": 44,
-    "to_location_id": 14,
-    "flags": 0,
-    "direction": "south",
-    "requires_packs": [
-      "cosyworld.core"
-    ]
-  },
-  {
-    "from_location_id": 14,
-    "to_location_id": 44,
-    "flags": 0,
-    "direction": "north",
-    "requires_packs": [
-      "cosyworld.core"
-    ]
   }
 ]

--- a/v2/content/ruby-high-first-bell/pack.json
+++ b/v2/content/ruby-high-first-bell/pack.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "ruby-high.first-bell",
   "name": "Ruby High: First Bell",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "kind": "world",
   "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
   "license": "MIT",

--- a/v2/content/ruby-high-only/assets.json
+++ b/v2/content/ruby-high-only/assets.json
@@ -1,8 +1,8 @@
 [
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.4",
-    "pack_integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+    "pack_version": "1.3.5",
+    "pack_integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
     "provider": "ruby-high.first-bell/assets",
     "mount": "cards",
     "root": "ruby-high-first-bell",

--- a/v2/content/ruby-high-only/content_refs.json
+++ b/v2/content/ruby-high-only/content_refs.json
@@ -1045,7 +1045,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-cafeteria",
       "runtime_handle": 3107528363911865
@@ -1053,7 +1053,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-courtyard",
       "runtime_handle": 4782402674832957
@@ -1061,7 +1061,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-greenhouse",
       "runtime_handle": 3662976131116729
@@ -1069,7 +1069,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-homeroom",
       "runtime_handle": 7084902207358373
@@ -1077,7 +1077,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-library",
       "runtime_handle": 6785800264541047
@@ -1085,7 +1085,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "card",
       "local_id": "location-science-lab",
       "runtime_handle": 8201462675675638
@@ -1093,7 +1093,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "captain-null",
       "runtime_handle": 3843573141933674
@@ -1101,7 +1101,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "eliza",
       "runtime_handle": 4124553834845258
@@ -1109,7 +1109,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "indra",
       "runtime_handle": 8687099168741216
@@ -1117,7 +1117,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-flashcards",
       "runtime_handle": 6148366931632609
@@ -1125,7 +1125,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-hall-pass",
       "runtime_handle": 6154026517662833
@@ -1133,7 +1133,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-lab-flask",
       "runtime_handle": 7444186363202775
@@ -1141,7 +1141,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-library-card",
       "runtime_handle": 27821797810153
@@ -1149,7 +1149,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-lunch-tray",
       "runtime_handle": 3064948555071770
@@ -1157,7 +1157,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "item-notebook",
       "runtime_handle": 5906680647268123
@@ -1165,7 +1165,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-cafeteria",
       "runtime_handle": 232928798345453
@@ -1173,7 +1173,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-courtyard",
       "runtime_handle": 1017422828753302
@@ -1181,7 +1181,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-greenhouse",
       "runtime_handle": 1874830250433117
@@ -1189,7 +1189,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-homeroom",
       "runtime_handle": 6928775784641985
@@ -1197,7 +1197,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-library",
       "runtime_handle": 8204365461548708
@@ -1205,7 +1205,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "location-science-lab",
       "runtime_handle": 57115334800243
@@ -1213,7 +1213,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "lyra",
       "runtime_handle": 7094866015162716
@@ -1221,7 +1221,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "mika",
       "runtime_handle": 4809241939115652
@@ -1229,7 +1229,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "noor",
       "runtime_handle": 6643976235743711
@@ -1237,7 +1237,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "professor-edward",
       "runtime_handle": 1211962163801060
@@ -1245,7 +1245,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "rati",
       "runtime_handle": 8508280633539606
@@ -1253,7 +1253,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "ravi",
       "runtime_handle": 3914282740523084
@@ -1261,7 +1261,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "ruby",
       "runtime_handle": 442578259385801
@@ -1269,7 +1269,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "sally-science",
       "runtime_handle": 692877066368845
@@ -1277,7 +1277,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "external-card",
       "local_id": "sami",
       "runtime_handle": 5798756249869747
@@ -1285,7 +1285,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "faction",
       "local_id": "ruby_high",
       "runtime_handle": 2919627811514647
@@ -1293,7 +1293,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "10",
       "legacy_runtime_id": 10,
@@ -1302,7 +1302,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "11",
       "legacy_runtime_id": 11,
@@ -1311,7 +1311,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "12",
       "legacy_runtime_id": 12,
@@ -1320,7 +1320,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "13",
       "legacy_runtime_id": 13,
@@ -1329,7 +1329,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "14",
       "legacy_runtime_id": 14,
@@ -1338,7 +1338,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/location/15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "location",
       "local_id": "15",
       "legacy_runtime_id": 15,
@@ -1347,7 +1347,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:10",
       "runtime_handle": 2574024258005683
@@ -1355,7 +1355,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:11",
       "runtime_handle": 944777926762018
@@ -1363,7 +1363,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:12",
       "runtime_handle": 8925253377010016
@@ -1371,7 +1371,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:13",
       "runtime_handle": 1954150505527197
@@ -1379,7 +1379,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:14",
       "runtime_handle": 9002247914113905
@@ -1387,7 +1387,7 @@
     {
       "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "kind": "room-sheet",
       "local_id": "room:15",
       "runtime_handle": 8772787069788936

--- a/v2/content/ruby-high-only/contributions.json
+++ b/v2/content/ruby-high-only/contributions.json
@@ -1,7 +1,7 @@
 [
   {
     "pack_id": "ruby-high.first-bell",
-    "pack_version": "1.3.4",
+    "pack_version": "1.3.5",
     "rules_profile": "cosyworld.srd5/1",
     "reskins": [
       {

--- a/v2/content/ruby-high-only/licenses.json
+++ b/v2/content/ruby-high-only/licenses.json
@@ -48,7 +48,7 @@
   {
     "pack_id": "ruby-high.first-bell",
     "name": "Ruby High: First Bell",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {

--- a/v2/content/ruby-high-only/registry.json
+++ b/v2/content/ruby-high-only/registry.json
@@ -593,7 +593,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:a3ca02b2d1c688109a4bc3c8228d6f617e193f4f364cf994eea6f7d9d7efb55a",
+    "bundle_hash": "sha256:83e2512b416589cde02590e3429bb928b12a522a547247427ae22bad52d36d14",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -757,7 +757,7 @@
         "id": "ruby-high.first-bell",
         "name": "Ruby High: First Bell",
         "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-        "version": "1.3.4",
+        "version": "1.3.5",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit",
@@ -959,7 +959,7 @@
           "type": "workspace",
           "path": "../../content/ruby-high-first-bell"
         },
-        "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9"
+        "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847"
       }
     ],
     "files": {
@@ -1979,8 +1979,8 @@
   "assets": [
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
-      "pack_integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+      "pack_version": "1.3.5",
+      "pack_integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
       "provider": "ruby-high.first-bell/assets",
       "mount": "cards",
       "root": "ruby-high-first-bell",
@@ -3374,7 +3374,7 @@
   "contributions": [
     {
       "pack_id": "ruby-high.first-bell",
-      "pack_version": "1.3.4",
+      "pack_version": "1.3.5",
       "rules_profile": "cosyworld.srd5/1",
       "reskins": [
         {
@@ -3477,7 +3477,7 @@
     {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
@@ -5171,7 +5171,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-cafeteria",
         "runtime_handle": 3107528363911865
@@ -5179,7 +5179,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-courtyard",
         "runtime_handle": 4782402674832957
@@ -5187,7 +5187,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-greenhouse",
         "runtime_handle": 3662976131116729
@@ -5195,7 +5195,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-homeroom",
         "runtime_handle": 7084902207358373
@@ -5203,7 +5203,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-library",
         "runtime_handle": 6785800264541047
@@ -5211,7 +5211,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "card",
         "local_id": "location-science-lab",
         "runtime_handle": 8201462675675638
@@ -5219,7 +5219,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/captain-null",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "captain-null",
         "runtime_handle": 3843573141933674
@@ -5227,7 +5227,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/eliza",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "eliza",
         "runtime_handle": 4124553834845258
@@ -5235,7 +5235,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/indra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "indra",
         "runtime_handle": 8687099168741216
@@ -5243,7 +5243,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-flashcards",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-flashcards",
         "runtime_handle": 6148366931632609
@@ -5251,7 +5251,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-hall-pass",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-hall-pass",
         "runtime_handle": 6154026517662833
@@ -5259,7 +5259,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lab-flask",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-lab-flask",
         "runtime_handle": 7444186363202775
@@ -5267,7 +5267,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-library-card",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-library-card",
         "runtime_handle": 27821797810153
@@ -5275,7 +5275,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-lunch-tray",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-lunch-tray",
         "runtime_handle": 3064948555071770
@@ -5283,7 +5283,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/item-notebook",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "item-notebook",
         "runtime_handle": 5906680647268123
@@ -5291,7 +5291,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-cafeteria",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-cafeteria",
         "runtime_handle": 232928798345453
@@ -5299,7 +5299,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-courtyard",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-courtyard",
         "runtime_handle": 1017422828753302
@@ -5307,7 +5307,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-greenhouse",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-greenhouse",
         "runtime_handle": 1874830250433117
@@ -5315,7 +5315,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-homeroom",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-homeroom",
         "runtime_handle": 6928775784641985
@@ -5323,7 +5323,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-library",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-library",
         "runtime_handle": 8204365461548708
@@ -5331,7 +5331,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/location-science-lab",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "location-science-lab",
         "runtime_handle": 57115334800243
@@ -5339,7 +5339,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/lyra",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "lyra",
         "runtime_handle": 7094866015162716
@@ -5347,7 +5347,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/mika",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "mika",
         "runtime_handle": 4809241939115652
@@ -5355,7 +5355,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/noor",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "noor",
         "runtime_handle": 6643976235743711
@@ -5363,7 +5363,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/professor-edward",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "professor-edward",
         "runtime_handle": 1211962163801060
@@ -5371,7 +5371,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/rati",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "rati",
         "runtime_handle": 8508280633539606
@@ -5379,7 +5379,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ravi",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "ravi",
         "runtime_handle": 3914282740523084
@@ -5387,7 +5387,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/ruby",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "ruby",
         "runtime_handle": 442578259385801
@@ -5395,7 +5395,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sally-science",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "sally-science",
         "runtime_handle": 692877066368845
@@ -5403,7 +5403,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/external-card/sami",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "external-card",
         "local_id": "sami",
         "runtime_handle": 5798756249869747
@@ -5411,7 +5411,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/faction/ruby_high",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "faction",
         "local_id": "ruby_high",
         "runtime_handle": 2919627811514647
@@ -5419,7 +5419,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "10",
         "legacy_runtime_id": 10,
@@ -5428,7 +5428,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "11",
         "legacy_runtime_id": 11,
@@ -5437,7 +5437,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "12",
         "legacy_runtime_id": 12,
@@ -5446,7 +5446,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "13",
         "legacy_runtime_id": 13,
@@ -5455,7 +5455,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "14",
         "legacy_runtime_id": 14,
@@ -5464,7 +5464,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/location/15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "location",
         "local_id": "15",
         "legacy_runtime_id": 15,
@@ -5473,7 +5473,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A10",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:10",
         "runtime_handle": 2574024258005683
@@ -5481,7 +5481,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A11",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:11",
         "runtime_handle": 944777926762018
@@ -5489,7 +5489,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A12",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:12",
         "runtime_handle": 8925253377010016
@@ -5497,7 +5497,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A13",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:13",
         "runtime_handle": 1954150505527197
@@ -5505,7 +5505,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A14",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:14",
         "runtime_handle": 9002247914113905
@@ -5513,7 +5513,7 @@
       {
         "canonical_ref": "pack://ruby-high.first-bell/room-sheet/room%3A15",
         "pack_id": "ruby-high.first-bell",
-        "pack_version": "1.3.4",
+        "pack_version": "1.3.5",
         "kind": "room-sheet",
         "local_id": "room:15",
         "runtime_handle": 8772787069788936

--- a/v2/content/ruby-high-only/worldpack.json
+++ b/v2/content/ruby-high-only/worldpack.json
@@ -591,7 +591,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:a3ca02b2d1c688109a4bc3c8228d6f617e193f4f364cf994eea6f7d9d7efb55a",
+  "bundle_hash": "sha256:83e2512b416589cde02590e3429bb928b12a522a547247427ae22bad52d36d14",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -755,7 +755,7 @@
       "id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
       "description": "An independently bootable school world, card catalog, and entitlement-gated First Bell experience.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit",
@@ -957,7 +957,7 @@
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9"
+      "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847"
     }
   ],
   "files": {

--- a/v2/content/the-holy-land/exits.json
+++ b/v2/content/the-holy-land/exits.json
@@ -1,6 +1,4 @@
 [
-  {"from_location_id": 1, "to_location_id": 700, "flags": 0, "distance": 3, "direction": "north"},
-  {"from_location_id": 700, "to_location_id": 1, "flags": 0, "distance": 3, "direction": "homeward"},
   {"from_location_id": 700, "to_location_id": 712, "flags": 0, "distance": 2, "direction": "north"},
   {"from_location_id": 712, "to_location_id": 700, "flags": 0, "distance": 2, "direction": "south"},
   {"from_location_id": 701, "to_location_id": 703, "flags": 0, "distance": 2, "direction": "northeast"},

--- a/v2/content/the-holy-land/pack.json
+++ b/v2/content/the-holy-land/pack.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "cosyworld.the-holy-land",
   "name": "The Holy Land",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "kind": "world",
   "description": "A watercolor pilgrimage through Gospel-associated places with the Twelve and generative wayside supplicants; Jesus is not depicted as an actor or collectible card.",
   "license": "MIT",

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -97,9 +97,14 @@ topological order. Cycles, missing required packs or capabilities, duplicate
 pack or capability declarations, incompatible pack versions, and incompatible
 engine ranges fail before output is written. Optional dependencies may be
 absent; when present, they must satisfy the same version and capability checks.
-Cross-pack links should live in an explicit bridge pack, an official-world
-composition pack, or dependency-guarded rows owned by the extending pack. They
-must never make the depended-on pack point back into optional content.
+Cross-pack paths live in a dedicated composition bridge pack, never in either
+reusable world pack. A bridge is a world pack marked with
+`x-cosyworld-composition` role `bridge`; it may contain only exits, must depend
+on both endpoint world packs, and has no entry point or default ruleset. The
+compiler rejects any visible or hidden path whose endpoint packs differ unless
+the path is owned by such a bridge. Other one-way extension resources may still
+use dependency-guarded rows owned by the extending pack. They must never make
+the depended-on pack point back into optional content.
 
 Two compiled resources preserve the entity/card boundary for expansion-owned
 metadata. `card_bindings` associates a pack-owned external card with a canonical

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.165"
+version = "0.0.166"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.165"
+version = "0.0.166"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_packs.rs
+++ b/v2/orchestrator-rust/src/content_packs.rs
@@ -338,7 +338,7 @@ mod tests {
     #[test]
     fn catalog_projects_public_locked_partial_and_entitled_access() {
         let public = content_packs_response(&AccessContext::default());
-        assert_eq!(public.packs.len(), 8);
+        assert_eq!(public.packs.len(), 10);
         let core = public
             .packs
             .iter()

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -1288,7 +1288,7 @@ mod tests {
         )
         .expect("official registry loads");
         assert_eq!(registry.content().locations.len(), 48);
-        assert_eq!(registry.content().manifest.packs.len(), 8);
+        assert_eq!(registry.content().manifest.packs.len(), 10);
         assert_eq!(
             registry.content().manifest.rules_profile,
             "cosyworld.srd5/1"

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -62242,7 +62242,7 @@ mod tests {
         assert_eq!(content.manifest.version, 1);
         assert_eq!(content.manifest.schema_version, 2);
         assert_eq!(content.manifest.rules_profile, "cosyworld.srd5/1");
-        assert_eq!(content.manifest.packs.len(), 8);
+        assert_eq!(content.manifest.packs.len(), 10);
 
         assert!(content.manifest.bundle_hash.starts_with("sha256:"));
         assert!(content.manifest.description.contains("seed world"));

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -1231,6 +1231,8 @@ const actorIds = idSet("actors", actors, (actor) => actor.id);
 const actorById = new Map(actors.map((actor) => [actor.id, actor]));
 const itemIds = idSet("items", items, (item) => item.id);
 const locationIds = idSet("locations", locations, (location) => location.id);
+const locationPackById = new Map(locations.map((location) => [location.id, location.pack_id]));
+const packById = new Map(packs.map((pack) => [pack.id, pack]));
 idSet("sentences", sentences, (sentence) => sentence.id);
 const clockIds = idSet("clocks", clocks, (clock) => clock.id);
 const jobIds = idSet("jobs", jobs, (job) => job.id);
@@ -1543,6 +1545,19 @@ for (const exit of exits) {
   if (!has(locationIds, exit.from_location_id) || !has(locationIds, exit.to_location_id)) {
     fail(`exit ${exit.from_location_id}->${exit.to_location_id} references missing location`);
   }
+  const fromPackId = locationPackById.get(exit.from_location_id);
+  const toPackId = locationPackById.get(exit.to_location_id);
+  if (fromPackId && toPackId && fromPackId !== toPackId) {
+    const owner = packById.get(exit.pack_id);
+    if (owner?.extensions?.["x-cosyworld-composition"]?.role !== "bridge") {
+      fail(`exit ${exit.from_location_id}->${exit.to_location_id} crosses ${fromPackId} and ${toPackId} outside a composition bridge pack`);
+    } else {
+      const dependencyIds = new Set(owner.dependencies);
+      if (!dependencyIds.has(fromPackId) || !dependencyIds.has(toPackId)) {
+        fail(`composition bridge ${owner.id} must depend on both ${fromPackId} and ${toPackId}`);
+      }
+    }
+  }
   const pair = `${exit.from_location_id}->${exit.to_location_id}`;
   if (exitPairs.has(pair)) {
     fail(`duplicate exit ${pair}`);
@@ -1584,6 +1599,19 @@ for (const hiddenExit of hiddenExits) {
   hiddenExitIds.add(hiddenExit.id);
   if (!has(locationIds, hiddenExit.from_location_id) || !has(locationIds, hiddenExit.to_location_id)) {
     fail(`hidden exit ${hiddenExit.id} references missing location`);
+  }
+  const fromPackId = locationPackById.get(hiddenExit.from_location_id);
+  const toPackId = locationPackById.get(hiddenExit.to_location_id);
+  if (fromPackId && toPackId && fromPackId !== toPackId) {
+    const owner = packById.get(hiddenExit.pack_id);
+    if (owner?.extensions?.["x-cosyworld-composition"]?.role !== "bridge") {
+      fail(`hidden exit ${hiddenExit.id} crosses ${fromPackId} and ${toPackId} outside a composition bridge pack`);
+    } else {
+      const dependencyIds = new Set(owner.dependencies);
+      if (!dependencyIds.has(fromPackId) || !dependencyIds.has(toPackId)) {
+        fail(`composition bridge ${owner.id} must depend on both ${fromPackId} and ${toPackId}`);
+      }
+    }
   }
   if (hiddenExit.from_location_id === hiddenExit.to_location_id) {
     fail(`hidden exit ${hiddenExit.id} cannot return to the same location`);

--- a/v2/scripts/compile-worldpack.mjs
+++ b/v2/scripts/compile-worldpack.mjs
@@ -820,6 +820,35 @@ for (const bundle of contributionBundles) {
     }
   }
 }
+const packManifestById = new Map(packs.map((pack) => [pack.manifest.id, pack.manifest]));
+const locationOwnerById = new Map();
+for (const location of resources.locations) {
+  assert(
+    !locationOwnerById.has(location.id),
+    `location ${location.id} is declared by more than one pack`,
+  );
+  locationOwnerById.set(location.id, location.pack_id);
+}
+for (const [resourceName, paths] of [
+  ["exit", resources.exits],
+  ["hidden exit", resources.hidden_exits],
+]) {
+  for (const pathRow of paths) {
+    const fromPackId = locationOwnerById.get(pathRow.from_location_id);
+    const toPackId = locationOwnerById.get(pathRow.to_location_id);
+    if (!fromPackId || !toPackId || fromPackId === toPackId) continue;
+    const owner = packManifestById.get(pathRow.pack_id);
+    assert(
+      owner?.extensions?.["x-cosyworld-composition"]?.role === "bridge",
+      `${resourceName} ${pathRow.from_location_id}->${pathRow.to_location_id} crosses ${fromPackId} and ${toPackId}; cross-pack paths must be owned by a composition bridge pack`,
+    );
+    const dependencyIds = new Set(owner.dependencies.map((dependency) => dependency.id));
+    assert(
+      dependencyIds.has(fromPackId) && dependencyIds.has(toPackId),
+      `composition bridge ${owner.id} must depend on both ${fromPackId} and ${toPackId}`,
+    );
+  }
+}
 const activeRulesExtensions = contributionBundles.flatMap((bundle) => bundle.extensions.map((row) => row.id)).sort();
 const activeRulesVariants = contributionBundles.flatMap((bundle) => bundle.variants.map((row) => row.id)).sort();
 const modifiedMaterial = ruleBundles.flatMap((bundle) => {

--- a/v2/scripts/content-pack-contract.mjs
+++ b/v2/scripts/content-pack-contract.mjs
@@ -153,6 +153,48 @@ export function rulesContextValidationErrors(manifest, label = "pack.json") {
   return errors;
 }
 
+export function compositionPackValidationErrors(manifest, label = "pack.json") {
+  const config = manifest.extensions?.["x-cosyworld-composition"];
+  if (config === undefined) return [];
+  const errors = [];
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return [`${label}: x-cosyworld-composition must be an object`];
+  }
+  for (const field of Object.keys(config)) {
+    if (!["schema_version", "role"].includes(field)) {
+      errors.push(`${label}: x-cosyworld-composition has unknown field ${field}`);
+    }
+  }
+  if (config.schema_version !== 1) {
+    errors.push(`${label}: x-cosyworld-composition schema_version must be 1`);
+  }
+  if (config.role !== "bridge") {
+    errors.push(`${label}: x-cosyworld-composition role must be bridge`);
+  }
+  if (manifest.kind !== "world") {
+    errors.push(`${label}: a composition bridge must be a world pack`);
+  }
+  if (manifest.default_ruleset !== null) {
+    errors.push(`${label}: a composition bridge must set default_ruleset to null`);
+  }
+  if ((manifest.entry_points ?? []).length > 0) {
+    errors.push(`${label}: a composition bridge cannot declare entry points`);
+  }
+  const resourceKinds = Object.keys(manifest.resources ?? {});
+  if (
+    resourceKinds.length === 0
+    || resourceKinds.some((resource) => !["exits", "hidden_exits"].includes(resource))
+  ) {
+    errors.push(`${label}: a composition bridge may contain only exits or hidden_exits`);
+  }
+  const worldDependencies = (manifest.dependencies ?? []).filter((dependency) =>
+    (dependency.capabilities ?? []).some((capability) => capability.endsWith("/world")));
+  if (worldDependencies.length < 2) {
+    errors.push(`${label}: a composition bridge must depend on at least two world packs`);
+  }
+  return errors;
+}
+
 export function validateWorldEntityResource(packId, resource, row) {
   const allowedFields = WORLD_ENTITY_FIELDS[resource];
   if (!allowedFields) return row;
@@ -299,6 +341,9 @@ export function validateContentPackManifest(manifest, label = "pack.json") {
     }
   }
   for (const error of rulesContextValidationErrors(manifest, label)) {
+    contractError(error);
+  }
+  for (const error of compositionPackValidationErrors(manifest, label)) {
     contractError(error);
   }
   return manifest;

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -258,6 +258,7 @@ async function main() {
           "cosyworld.rules-profile-srd5",
           "cosyworld.core",
           "ruby-high.first-bell",
+          "cosyworld.composition.core-ruby",
         ].join(","),
       `wrong mounted packs: ${JSON.stringify(first.meta.worldpack?.packs)}`,
     );

--- a/v2/worlds/core-ruby/pack.lock.json
+++ b/v2/worlds/core-ruby/pack.lock.json
@@ -7,7 +7,8 @@
     "cosyworld.rules-srd-5.2.1",
     "cosyworld.rules-profile-srd5",
     "cosyworld.core",
-    "ruby-high.first-bell"
+    "ruby-high.first-bell",
+    "cosyworld.composition.core-ruby"
   ],
   "packs": [
     {
@@ -125,12 +126,12 @@
     },
     {
       "id": "ruby-high.first-bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "source": {
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+      "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -186,6 +187,58 @@
         "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
+      }
+    },
+    {
+      "id": "cosyworld.composition.core-ruby",
+      "version": "1.0.0",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-ruby-bridge"
+      },
+      "integrity": "sha256:af0f833ed3be83ff11e9652514bd14bc0112af0d55e4b55f2bcf725420e918ba",
+      "dependencies": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "ruby-high.first-bell",
+          "version": ">=1.3.5 <2.0.0",
+          "capabilities": [
+            "ruby-high.first-bell/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "ruby-high.first-bell"
+      ],
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-ruby/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
       }
     }
   ],
@@ -252,13 +305,26 @@
     {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
         "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.composition.core-ruby",
+      "name": "CosyWorld Core + Ruby High Bridge",
+      "version": "1.0.0",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
       },
       "notices": []
     }

--- a/v2/worlds/core-ruby/world.json
+++ b/v2/worlds/core-ruby/world.json
@@ -10,6 +10,7 @@
   "packs": [
     "cosyworld.core",
     "ruby-high.first-bell",
+    "cosyworld.composition.core-ruby",
     "cosyworld.rules-srd-5.2.1",
     "cosyworld.rules-profile-srd5"
   ]

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -9,9 +9,11 @@
     "cosyworld.core",
     "cosyworld.rules-srd-5.1",
     "cosyworld.campaign.the-lantern-keeper",
-    "cosyworld.lonely-forest.characters",
     "cosyworld.the-holy-land",
-    "ruby-high.first-bell"
+    "cosyworld.composition.core-holy-land",
+    "ruby-high.first-bell",
+    "cosyworld.composition.core-ruby",
+    "cosyworld.lonely-forest.characters"
   ],
   "packs": [
     {
@@ -212,57 +214,13 @@
       }
     },
     {
-      "id": "cosyworld.lonely-forest.characters",
-      "version": "1.1.1",
-      "source": {
-        "type": "workspace",
-        "path": "../../content/lonely-forest"
-      },
-      "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
-      "dependencies": [
-        {
-          "id": "cosyworld.core",
-          "version": ">=1.0.0 <2.0.0",
-          "capabilities": [
-            "cosyworld.core/world"
-          ]
-        },
-        {
-          "id": "cosyworld.rules-profile-srd5",
-          "version": ">=1.0.0 <2.0.0",
-          "capabilities": [
-            "cosyworld.rules-profile-srd5/rules"
-          ]
-        }
-      ],
-      "dependency_closure": [
-        "cosyworld.rules-srd-5.2.1",
-        "cosyworld.rules-profile-srd5",
-        "cosyworld.core"
-      ],
-      "capabilities": [
-        {
-          "id": "cosyworld.lonely-forest.characters/assets",
-          "kind": "assets",
-          "version": "1.0.0"
-        }
-      ],
-      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
-      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
-      "provenance": {
-        "author": "Cenetex",
-        "source_name": "Cenetex Lonely Forest character art",
-        "source_url": "https://github.com/cenetex/cosyworld"
-      }
-    },
-    {
       "id": "cosyworld.the-holy-land",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "source": {
         "type": "workspace",
         "path": "../../content/the-holy-land"
       },
-      "integrity": "sha256:bda3362756ed58713d34eb6ded2e54b71c1ecc9463b34d725b9360c01fcbf8ae",
+      "integrity": "sha256:54099f568bf3ec8eb2b5181bf4ecbe08d0d07d4f863b7ad5e982cec3cb0ca4a2",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -305,13 +263,65 @@
       }
     },
     {
+      "id": "cosyworld.composition.core-holy-land",
+      "version": "1.0.0",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-holy-land-bridge"
+      },
+      "integrity": "sha256:0ed36b254e7eb3fb588db28f3e9401b31fc9ee1d66efd0f8e80292176c43a913",
+      "dependencies": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.the-holy-land",
+          "version": ">=1.1.2 <2.0.0",
+          "capabilities": [
+            "cosyworld.the-holy-land/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "cosyworld.the-holy-land"
+      ],
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-holy-land/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      }
+    },
+    {
       "id": "ruby-high.first-bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "source": {
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+      "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -367,6 +377,102 @@
         "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
+      }
+    },
+    {
+      "id": "cosyworld.composition.core-ruby",
+      "version": "1.0.0",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-ruby-bridge"
+      },
+      "integrity": "sha256:af0f833ed3be83ff11e9652514bd14bc0112af0d55e4b55f2bcf725420e918ba",
+      "dependencies": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "ruby-high.first-bell",
+          "version": ">=1.3.5 <2.0.0",
+          "capabilities": [
+            "ruby-high.first-bell/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "ruby-high.first-bell"
+      ],
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-ruby/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      }
+    },
+    {
+      "id": "cosyworld.lonely-forest.characters",
+      "version": "1.1.1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/lonely-forest"
+      },
+      "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+      "dependencies": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core"
+      ],
+      "capabilities": [
+        {
+          "id": "cosyworld.lonely-forest.characters/assets",
+          "kind": "assets",
+          "version": "1.0.0"
+        }
+      ],
+      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
       }
     }
   ],
@@ -477,22 +583,9 @@
       ]
     },
     {
-      "pack_id": "cosyworld.lonely-forest.characters",
-      "name": "Lonely Forest Character Art",
-      "version": "1.1.1",
-      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
-      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
-      "provenance": {
-        "author": "Cenetex",
-        "source_name": "Cenetex Lonely Forest character art",
-        "source_url": "https://github.com/cenetex/cosyworld"
-      },
-      "notices": []
-    },
-    {
       "pack_id": "cosyworld.the-holy-land",
       "name": "The Holy Land",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
@@ -503,15 +596,54 @@
       "notices": []
     },
     {
+      "pack_id": "cosyworld.composition.core-holy-land",
+      "name": "CosyWorld Core + Holy Land Bridge",
+      "version": "1.0.0",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
         "author": "Ruby High",
         "source_name": "Ruby High: First Bell",
         "source_url": "https://ruby-high.ai"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.composition.core-ruby",
+      "name": "CosyWorld Core + Ruby High Bridge",
+      "version": "1.0.0",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "version": "1.1.1",
+      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
       },
       "notices": []
     }

--- a/v2/worlds/official/world.json
+++ b/v2/worlds/official/world.json
@@ -32,7 +32,8 @@
       "sha256:fd5012d745f00283c16bea59c0d014393dd064e9751c7728b0e2e6ba6a39690c",
       "sha256:02147a6629b038e2e9a28039f829bc6ad67881fe3391a0edabf744fd362427df",
       "sha256:ef70c61617e4c6f6cf905f049dddbb053e84b520f545ed2d01b3180cf39d75d1",
-      "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17"
+      "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
+      "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc"
     ]
   },
   "packs": [
@@ -43,6 +44,8 @@
     "cosyworld.campaign.the-lantern-keeper",
     "cosyworld.the-holy-land",
     "cosyworld.lonely-forest.characters",
-    "ruby-high.first-bell"
+    "ruby-high.first-bell",
+    "cosyworld.composition.core-ruby",
+    "cosyworld.composition.core-holy-land"
   ]
 }

--- a/v2/worlds/ruby-high-only/pack.lock.json
+++ b/v2/worlds/ruby-high-only/pack.lock.json
@@ -78,12 +78,12 @@
     },
     {
       "id": "ruby-high.first-bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "source": {
         "type": "workspace",
         "path": "../../content/ruby-high-first-bell"
       },
-      "integrity": "sha256:c6f4718f7a73bb1debce6e7737514af3fa8f420d5c9a4d529e2cf4aeba9b14b9",
+      "integrity": "sha256:e8092c36fb9ef2880a19bfb111385137e9c0b635919ab78bd2f98910a0225847",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -191,7 +191,7 @@
     {
       "pack_id": "ruby-high.first-bell",
       "name": "Ruby High: First Bell",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {


### PR DESCRIPTION
## Summary

- Move Core↔Ruby High and Core↔Holy Land paths out of reusable world packs into dedicated composition bridge packs.
- Reject visible or hidden cross-pack paths unless a bridge pack owns them and depends on both endpoint packs.
- Regenerate official and peer composition bundles for release 0.0.166.
- Preserve replay compatibility with the currently deployed official bundle.

This removes an implicit topology dependency from reusable packs and advances the transactional composition acceptance criteria in #28.

## Validation

- `npm run check`
- `npm run v2:check`
- pre-push `npm run check`
- Core↔Ruby composition loop smoke: Cottage → Homeroom → journal replay → Cottage

## Compatibility and migration

- Runtime journal compatibility includes the previously deployed bundle hash.
- Ruby High `1.3.5` and Holy Land `1.1.2` remove only cross-pack path ownership; their internal content is unchanged.

## Generated files

- Refreshed official, Core+Ruby, and Ruby-only registries, locks, worldpack manifests, and derived resources.

## Deployment

- Release version: `0.0.166`.
- Production deployment and `/meta` verification follow merge.

## Review checklist

- [x] Tests cover the changed behavior or the PR explains why no test applies.
- [x] Generated worldpack files and locks are refreshed when source content changes.
- [x] Register review completed for changes under `v2/content/**` against `v2/docs/writing-style.md` (structural path ownership only; prose unchanged except pack metadata).
- [x] Genre review completed: not applicable; no story content or horror changed.

Part of #28.