### PR TITLE
feat(packs): evacuate occupants on unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.166",
+  "version": "0.0.167",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/content-pack-contract.test.mjs
+++ b/test/v2/content-pack-contract.test.mjs
@@ -631,6 +631,7 @@ describe("Content Pack Manifest v1", () => {
       "sha256:ef70c61617e4c6f6cf905f049dddbb053e84b520f545ed2d01b3180cf39d75d1",
       "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
       "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc",
+      "sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628",
     ]);
   });
 

--- a/test/v2/core-pack-composition.test.mjs
+++ b/test/v2/core-pack-composition.test.mjs
@@ -1,4 +1,6 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,8 +16,10 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../
 const read = (relativePath) => JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), "utf8"));
 const official = read("v2/content/official/registry.json");
 const coreOnly = read("v2/content/core-only/registry.json");
+const coreRuby = read("v2/content/core-ruby/registry.json");
 const servicesOnly = read("v2/content/services-only/registry.json");
 const coreManifest = read("v2/content/core/pack.json");
+const packMigrationPath = path.join(repoRoot, "v2/scripts/migrate-pack-unmount.mjs");
 
 describe("independently mountable CosyWorld Core", () => {
   it("boots with the shared SRD profile, explicit world rules, and typed effects", () => {
@@ -169,7 +173,7 @@ describe("independently mountable CosyWorld Core", () => {
     occupied.world_actors.push({ id: 5000, kind: 1, location_id: 1 });
     const occupiedBefore = structuredClone(occupied);
     expect(() => migratePackUnmount(occupied, coreOnly, "cosyworld.core", servicesOnly))
-      .toThrow(/human actors 5000 still occupy/);
+      .toThrow(/actors 5000 still occupy/);
     expect(occupied).toEqual(occupiedBefore);
 
     const remounted = migratePackRemount(
@@ -221,6 +225,208 @@ describe("independently mountable CosyWorld Core", () => {
       migratePackRemount(conflicting, servicesOnly, "cosyworld.core", coreOnly))
       .toThrow(/world_items identity 2001 is already active/);
     expect(conflicting).toEqual(conflictingBefore);
+
+    const wrongBundle = structuredClone(vacant);
+    wrongBundle.worldpack_bundle_hash = "sha256:not-the-source";
+    const wrongBundleBefore = structuredClone(wrongBundle);
+    expect(() =>
+      migratePackUnmount(wrongBundle, coreOnly, "cosyworld.core", servicesOnly))
+      .toThrow(/snapshot bundle does not match the source registry/);
+    expect(wrongBundle).toEqual(wrongBundleBefore);
+
+    const wrongRemountBundle = structuredClone(result.snapshot);
+    wrongRemountBundle.worldpack_bundle_hash = "sha256:not-the-target";
+    const wrongRemountBundleBefore = structuredClone(wrongRemountBundle);
+    expect(() =>
+      migratePackRemount(wrongRemountBundle, servicesOnly, "cosyworld.core", coreOnly))
+      .toThrow(/snapshot bundle does not match the source registry/);
+    expect(wrongRemountBundle).toEqual(wrongRemountBundleBefore);
+  });
+
+  it("atomically evacuates occupied expansion rooms through composition policy", () => {
+    const occupied = {
+      worldpack_bundle_hash: coreRuby.manifest.bundle_hash,
+      world_actors: [
+        { id: 5000, kind: 1, location_id: 11 },
+        { id: 5001, kind: 1, location_id: 12 },
+        { id: 5002, kind: 2, location_id: 11 },
+      ],
+      world_items: [
+        {
+          id: 2001,
+          location_id: 11,
+          holder_actor_id: 5000,
+          zone: 3,
+          container_item_id: 0,
+        },
+        {
+          id: 2002,
+          location_id: 11,
+          holder_actor_id: 0,
+          zone: 3,
+          container_item_id: 2001,
+        },
+        {
+          id: 9001,
+          location_id: 12,
+          holder_actor_id: 0,
+          zone: 1,
+          container_item_id: 0,
+        },
+        {
+          id: 9002,
+          location_id: 12,
+          holder_actor_id: 0,
+          zone: 1,
+          container_item_id: 9001,
+        },
+      ],
+      world_locations: [{ id: 1 }, { id: 11 }, { id: 12 }],
+      world_exits: [
+        { from_location_id: 1, to_location_id: 11 },
+        { from_location_id: 11, to_location_id: 12 },
+      ],
+      content_context: {
+        mapping_version: coreRuby.content_references.mapping_version,
+        references: coreRuby.content_references.entries,
+      },
+    };
+    const source = structuredClone(occupied);
+    const result = migratePackUnmount(
+      source,
+      coreRuby,
+      "ruby-high.first-bell",
+      coreOnly,
+    );
+    expect(source).toEqual(occupied);
+    expect(result.evacuated).toEqual([
+      { actor_id: 5000, from_location_id: 11, to_location_id: 1 },
+      { actor_id: 5001, from_location_id: 12, to_location_id: 1 },
+      { actor_id: 5002, from_location_id: 11, to_location_id: 1 },
+    ]);
+    expect(result.removed).toEqual({ actors: 0, items: 2, locations: 2, exits: 2 });
+    expect(result.snapshot.world_actors.map((actor) => actor.location_id)).toEqual([1, 1, 1]);
+    expect(result.snapshot.world_items.map((item) => item.location_id)).toEqual([1, 1]);
+    expect(result.snapshot.world_locations).toEqual([{ id: 1 }]);
+    expect(result.transaction.evacuation).toEqual({
+      mode: "move_occupants",
+      destination_location: "cosyworld.core:location/1",
+      destination_pack_id: "cosyworld.core",
+      destination_location_id: 1,
+      actors: result.evacuated,
+      moved_item_ids: [2001, 2002],
+    });
+    const frozen = result.snapshot.pack_mount_state.frozen["ruby-high.first-bell"];
+    expect(frozen.evacuation).toEqual(result.transaction.evacuation);
+    expect(frozen.arrays.world_items.map(({ value }) => value.id)).toEqual([9001, 9002]);
+
+    const remounted = migratePackRemount(
+      result.snapshot,
+      coreOnly,
+      "ruby-high.first-bell",
+      coreRuby,
+    );
+    expect(remounted.snapshot.world_actors.map((actor) => actor.location_id)).toEqual([1, 1, 1]);
+    expect(remounted.snapshot.world_items.map((item) => item.location_id)).toEqual([
+      1,
+      1,
+      12,
+      12,
+    ]);
+    expect(remounted.snapshot.world_locations).toEqual([
+      { id: 1 },
+      { id: 11 },
+      { id: 12 },
+    ]);
+
+    const missingDestination = structuredClone(occupied);
+    missingDestination.world_locations = [{ id: 11 }, { id: 12 }];
+    const missingDestinationBefore = structuredClone(missingDestination);
+    expect(() => migratePackUnmount(
+      missingDestination,
+      coreRuby,
+      "ruby-high.first-bell",
+      coreOnly,
+    )).toThrow(/destination location 1 is not active/);
+    expect(missingDestination).toEqual(missingDestinationBefore);
+
+    const activeEncounter = structuredClone(occupied);
+    activeEncounter.world_combat_encounters = [{
+      id: 77,
+      location_id: 11,
+      participants: [{ actor_id: 5000 }],
+    }];
+    const activeEncounterBefore = structuredClone(activeEncounter);
+    expect(() => migratePackUnmount(
+      activeEncounter,
+      coreRuby,
+      "ruby-high.first-bell",
+      coreOnly,
+    )).toThrow(/cannot interrupt active encounter 77/);
+    expect(activeEncounter).toEqual(activeEncounterBefore);
+  });
+
+  it("writes an observable evacuation transaction atomically through the admin CLI", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cosyworld-pack-evacuation-"));
+    try {
+      const inputPath = path.join(tempRoot, "snapshot.json");
+      const outputPath = path.join(tempRoot, "unmounted.json");
+      const snapshot = {
+        worldpack_bundle_hash: coreRuby.manifest.bundle_hash,
+        world_actors: [{ id: 5000, kind: 1, location_id: 11 }],
+        world_items: [],
+        world_locations: [{ id: 1 }, { id: 11 }],
+        world_exits: [{ from_location_id: 1, to_location_id: 11 }],
+      };
+      fs.writeFileSync(inputPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+      const migrated = spawnSync(process.execPath, [
+        packMigrationPath,
+        "--operation",
+        "unmount",
+        "--input",
+        inputPath,
+        "--output",
+        outputPath,
+        "--registry",
+        path.join(repoRoot, "v2/content/core-ruby/registry.json"),
+        "--target-registry",
+        path.join(repoRoot, "v2/content/core-only/registry.json"),
+        "--pack",
+        "ruby-high.first-bell",
+      ], { cwd: repoRoot, encoding: "utf8" });
+      expect(migrated.status, migrated.stderr).toBe(0);
+      expect(migrated.stdout).toContain('"sequence":1');
+      expect(migrated.stdout).toContain('"evacuated_actor_ids":[5000]');
+      expect(JSON.parse(fs.readFileSync(outputPath, "utf8")).world_actors[0].location_id).toBe(1);
+      expect(JSON.parse(fs.readFileSync(inputPath, "utf8"))).toEqual(snapshot);
+
+      const failedInputPath = path.join(tempRoot, "missing-destination.json");
+      const failedOutputPath = path.join(tempRoot, "should-not-exist.json");
+      fs.writeFileSync(failedInputPath, `${JSON.stringify({
+        ...snapshot,
+        world_locations: [{ id: 11 }],
+      }, null, 2)}\n`);
+      const failed = spawnSync(process.execPath, [
+        packMigrationPath,
+        "--operation",
+        "unmount",
+        "--input",
+        failedInputPath,
+        "--output",
+        failedOutputPath,
+        "--registry",
+        path.join(repoRoot, "v2/content/core-ruby/registry.json"),
+        "--target-registry",
+        path.join(repoRoot, "v2/content/core-only/registry.json"),
+        "--pack",
+        "ruby-high.first-bell",
+      ], { cwd: repoRoot, encoding: "utf8" });
+      expect(failed.status).not.toBe(0);
+      expect(failed.stderr).toContain("destination location 1 is not active");
+      expect(fs.existsSync(failedOutputPath)).toBe(false);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("provides a non-world services composition without silently mounting Core", () => {

--- a/test/v2/core-ruby-composition.test.mjs
+++ b/test/v2/core-ruby-composition.test.mjs
@@ -26,6 +26,18 @@ describe("Core + Ruby High composition", () => {
       "ruby-high.first-bell",
       "cosyworld.composition.core-ruby",
     ]);
+    expect(registry.manifest.pack_lifecycle).toEqual({
+      schema_version: 1,
+      unmount: [{
+        pack_id: "ruby-high.first-bell",
+        evacuation: {
+          mode: "move_occupants",
+          destination_location: "cosyworld.core:location/1",
+          destination_pack_id: "cosyworld.core",
+          destination_location_id: 1,
+        },
+      }],
+    });
     expect(registry.resources.exits.filter((exit) =>
       [1, 11].includes(exit.from_location_id)
       && [1, 11].includes(exit.to_location_id))).toEqual([
@@ -107,6 +119,36 @@ describe("Core + Ruby High composition", () => {
       });
       expect(checked.status).not.toBe(0);
       expect(checked.stderr).toContain("outside a composition bridge pack");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an evacuation destination that would disappear with its pack", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cosyworld-evacuation-policy-"));
+    const compiledRoot = path.join(tempRoot, "core-ruby");
+    try {
+      fs.cpSync(path.join(repoRoot, "v2/content/core-ruby"), compiledRoot, {
+        recursive: true,
+      });
+      const manifestPath = path.join(compiledRoot, "worldpack.json");
+      const registryPath = path.join(compiledRoot, "registry.json");
+      const manifestCopy = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      const registryCopy = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+      const evacuation = manifestCopy.pack_lifecycle.unmount[0].evacuation;
+      evacuation.destination_location = "ruby-high.first-bell:location/11";
+      evacuation.destination_pack_id = "ruby-high.first-bell";
+      evacuation.destination_location_id = 11;
+      registryCopy.manifest = manifestCopy;
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifestCopy, null, 2)}\n`);
+      fs.writeFileSync(registryPath, `${JSON.stringify(registryCopy, null, 2)}\n`);
+
+      const checked = spawnSync(process.execPath, [checkerPath, compiledRoot], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
+      expect(checked.status).not.toBe(0);
+      expect(checked.stderr).toContain("evacuation destination would unmount");
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/v2/content/core-ruby/registry.json
+++ b/v2/content/core-ruby/registry.json
@@ -9,6 +9,20 @@
     "version": 1,
     "description": "The Core world and Ruby High mounted together as peer world packs.",
     "entry_location": "cosyworld.core:location/1",
+    "pack_lifecycle": {
+      "schema_version": 1,
+      "unmount": [
+        {
+          "pack_id": "ruby-high.first-bell",
+          "evacuation": {
+            "mode": "move_occupants",
+            "destination_location": "cosyworld.core:location/1",
+            "destination_pack_id": "cosyworld.core",
+            "destination_location_id": 1
+          }
+        }
+      ]
+    },
     "rules_profile": "cosyworld.srd5/1",
     "active_rules_variants": [],
     "active_rules_extensions": [],
@@ -592,7 +606,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:abd0a109c955d8534e8f71b3e897a7535a3c6016e5045c6fc398b3bf6669cf18",
+    "bundle_hash": "sha256:710d9bc1c3c8af1828ca0e54beb66ad7053a3c2105623eb80915342e77d14cca",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",

--- a/v2/content/core-ruby/worldpack.json
+++ b/v2/content/core-ruby/worldpack.json
@@ -7,6 +7,20 @@
   "version": 1,
   "description": "The Core world and Ruby High mounted together as peer world packs.",
   "entry_location": "cosyworld.core:location/1",
+  "pack_lifecycle": {
+    "schema_version": 1,
+    "unmount": [
+      {
+        "pack_id": "ruby-high.first-bell",
+        "evacuation": {
+          "mode": "move_occupants",
+          "destination_location": "cosyworld.core:location/1",
+          "destination_pack_id": "cosyworld.core",
+          "destination_location_id": 1
+        }
+      }
+    ]
+  },
   "rules_profile": "cosyworld.srd5/1",
   "active_rules_variants": [],
   "active_rules_extensions": [],
@@ -590,7 +604,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:abd0a109c955d8534e8f71b3e897a7535a3c6016e5045c6fc398b3bf6669cf18",
+  "bundle_hash": "sha256:710d9bc1c3c8af1828ca0e54beb66ad7053a3c2105623eb80915342e77d14cca",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -35,7 +35,40 @@
         "sha256:02147a6629b038e2e9a28039f829bc6ad67881fe3391a0edabf744fd362427df",
         "sha256:ef70c61617e4c6f6cf905f049dddbb053e84b520f545ed2d01b3180cf39d75d1",
         "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
-        "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc"
+        "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc",
+        "sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628"
+      ]
+    },
+    "pack_lifecycle": {
+      "schema_version": 1,
+      "unmount": [
+        {
+          "pack_id": "cosyworld.campaign.the-lantern-keeper",
+          "evacuation": {
+            "mode": "move_occupants",
+            "destination_location": "cosyworld.core:location/1",
+            "destination_pack_id": "cosyworld.core",
+            "destination_location_id": 1
+          }
+        },
+        {
+          "pack_id": "cosyworld.the-holy-land",
+          "evacuation": {
+            "mode": "move_occupants",
+            "destination_location": "cosyworld.core:location/1",
+            "destination_pack_id": "cosyworld.core",
+            "destination_location_id": 1
+          }
+        },
+        {
+          "pack_id": "ruby-high.first-bell",
+          "evacuation": {
+            "mode": "move_occupants",
+            "destination_location": "cosyworld.core:location/1",
+            "destination_pack_id": "cosyworld.core",
+            "destination_location_id": 1
+          }
+        }
       ]
     },
     "rules_profile": "cosyworld.srd5/1",
@@ -621,7 +654,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628",
+    "bundle_hash": "sha256:9e91a900766633f5f52b8fe58e8f409f020233553e3fe5bf24ff519553e972ac",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -33,7 +33,40 @@
       "sha256:02147a6629b038e2e9a28039f829bc6ad67881fe3391a0edabf744fd362427df",
       "sha256:ef70c61617e4c6f6cf905f049dddbb053e84b520f545ed2d01b3180cf39d75d1",
       "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
-      "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc"
+      "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc",
+      "sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628"
+    ]
+  },
+  "pack_lifecycle": {
+    "schema_version": 1,
+    "unmount": [
+      {
+        "pack_id": "cosyworld.campaign.the-lantern-keeper",
+        "evacuation": {
+          "mode": "move_occupants",
+          "destination_location": "cosyworld.core:location/1",
+          "destination_pack_id": "cosyworld.core",
+          "destination_location_id": 1
+        }
+      },
+      {
+        "pack_id": "cosyworld.the-holy-land",
+        "evacuation": {
+          "mode": "move_occupants",
+          "destination_location": "cosyworld.core:location/1",
+          "destination_pack_id": "cosyworld.core",
+          "destination_location_id": 1
+        }
+      },
+      {
+        "pack_id": "ruby-high.first-bell",
+        "evacuation": {
+          "mode": "move_occupants",
+          "destination_location": "cosyworld.core:location/1",
+          "destination_pack_id": "cosyworld.core",
+          "destination_location_id": 1
+        }
+      }
     ]
   },
   "rules_profile": "cosyworld.srd5/1",
@@ -619,7 +652,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628",
+  "bundle_hash": "sha256:9e91a900766633f5f52b8fe58e8f409f020233553e3fe5bf24ff519553e972ac",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -288,22 +288,31 @@ rebuilds contexts that are already present. The tool never changes the numeric
 ids themselves and preserves self-contained contexts for unavailable packs.
 
 Unmounting a world pack is an explicit offline migration, never an implicit
-runtime fallback. `v2:pack:unmount` refuses to proceed while a human actor still
-occupies a location owned by the pack. Once vacant, it removes the pack-owned
-live projection and freezes the exact entities, item/card zones, projection
-maps, and canonical context in the snapshot's versioned `pack_mount_state`.
+runtime fallback. A composition may declare a schema-version-1
+`pack_lifecycle.unmount` policy that moves every non-pack-owned occupant and
+their carried or nested items to one public location owned by a pack that
+remains mounted. Controller type does not change the policy. The
+compiler resolves and validates that destination; the migration verifies it is
+present in both the target registry and active snapshot before moving anything.
+Without one unique policy, or while an occupant is in an active encounter,
+`v2:pack:unmount` refuses to proceed. Once vacant or successfully evacuated, it
+removes the pack-owned live projection and freezes the exact entities,
+item/card zones, projection maps, and canonical context in the snapshot's
+versioned `pack_mount_state`.
 Pending transfer offers that reference the pack become durable `invalidated`
 tombstones, and matching one-use gift policies become consumed; remount never
 revives either transient authorization. Every action composition certificate
 includes the latest mount transaction sequence, so an action card issued before
 unmount remains stale even after the exact pack and entity identities return.
 Each committed operation records source/target bundle hashes, counts, a stable
-state hash, and a monotonic sequence. Remount requires the exact frozen source
-registry and restores the same identities; collisions fail without changing
-the input. The CLI writes through a same-directory temporary file and atomic
-rename. Archive the source snapshot and stop writers before running it; then
-start the single authoritative writer with the exact target registry supplied
-to the tool.
+state hash, a monotonic sequence, and any completed actor/item evacuation.
+Remount requires the exact frozen source registry and restores the same pack
+identities without undoing the actors' completed evacuation; collisions fail
+without changing the input. Both directions require the snapshot's active
+bundle hash to match the supplied source registry. The CLI writes through a
+same-directory temporary file and atomic rename. Archive the source snapshot
+and stop writers before running it; then start the single authoritative writer
+with the exact target registry supplied to the tool.
 
 ## Runtime discovery and access
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.166"
+version = "0.0.167"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.166"
+version = "0.0.167"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -1286,6 +1286,69 @@ for (const gate of accessGates) {
   }
 }
 
+if (manifest.pack_lifecycle !== undefined) {
+  const lifecycle = manifest.pack_lifecycle;
+  if (!isObject(lifecycle) || lifecycle.schema_version !== 1) {
+    fail("worldpack pack_lifecycle must be a schema-version-1 object");
+  } else if (
+    Object.keys(lifecycle).some((field) => !["schema_version", "unmount"].includes(field))
+  ) {
+    fail("worldpack pack_lifecycle has unknown fields");
+  } else {
+    const policies = asArray("worldpack pack_lifecycle unmount", lifecycle.unmount);
+    if (policies.length === 0) {
+      fail("worldpack pack_lifecycle unmount policies cannot be empty");
+    }
+    const policyPackIds = new Set();
+    for (const policy of policies) {
+      if (!isObject(policy) || !isNonEmptyString(policy.pack_id) || !isObject(policy.evacuation)) {
+        fail("worldpack pack_lifecycle contains a malformed unmount policy");
+        continue;
+      }
+      if (Object.keys(policy).some((field) => !["pack_id", "evacuation"].includes(field))) {
+        fail(`worldpack pack_lifecycle ${policy.pack_id} policy has unknown fields`);
+      }
+      if (!has(packIds, policy.pack_id)) {
+        fail(`worldpack pack_lifecycle references missing pack ${policy.pack_id}`);
+      }
+      if (policyPackIds.has(policy.pack_id)) {
+        fail(`worldpack pack_lifecycle duplicates unmount policy for ${policy.pack_id}`);
+      }
+      policyPackIds.add(policy.pack_id);
+      const evacuation = policy.evacuation;
+      if (
+        Object.keys(evacuation).some((field) =>
+          ![
+            "mode",
+            "destination_location",
+            "destination_pack_id",
+            "destination_location_id",
+          ].includes(field))
+      ) {
+        fail(`worldpack pack_lifecycle ${policy.pack_id} evacuation has unknown fields`);
+      }
+      if (evacuation.mode !== "move_occupants") {
+        fail(`worldpack pack_lifecycle ${policy.pack_id} has invalid evacuation mode`);
+      }
+      const destinationId = Number(evacuation.destination_location_id);
+      const destinationPackId = locationPackById.get(destinationId);
+      const expectedReference = `${destinationPackId}:location/${destinationId}`;
+      if (!Number.isInteger(destinationId) || !has(locationIds, destinationId)) {
+        fail(`worldpack pack_lifecycle ${policy.pack_id} references missing evacuation destination`);
+      } else if (
+        evacuation.destination_pack_id !== destinationPackId
+          || evacuation.destination_location !== expectedReference
+      ) {
+        fail(`worldpack pack_lifecycle ${policy.pack_id} evacuation destination identity does not match`);
+      } else if (destinationPackId === policy.pack_id) {
+        fail(`worldpack pack_lifecycle ${policy.pack_id} evacuation destination would unmount`);
+      } else if (gateByLocationId.has(destinationId)) {
+        fail(`worldpack pack_lifecycle ${policy.pack_id} evacuation destination must be public`);
+      }
+    }
+  }
+}
+
 for (const profile of characterCreationProfiles) {
   validateRequiredStrings("character creation profile", profile, [
     "name",

--- a/v2/scripts/compile-worldpack.mjs
+++ b/v2/scripts/compile-worldpack.mjs
@@ -126,6 +126,109 @@ function loadAvatarNaming(world, worldDir) {
   return config;
 }
 
+function loadPackLifecycle(world) {
+  const lifecycle = world.pack_lifecycle;
+  if (lifecycle === undefined) return null;
+  assert(
+    lifecycle && typeof lifecycle === "object" && !Array.isArray(lifecycle),
+    "world pack_lifecycle must be an object",
+  );
+  assert(
+    Object.keys(lifecycle).every((field) => ["schema_version", "unmount"].includes(field)),
+    "world pack_lifecycle has unknown fields",
+  );
+  assert(lifecycle.schema_version === 1, "world pack_lifecycle schema_version must be 1");
+  assert(Array.isArray(lifecycle.unmount), "world pack_lifecycle must declare unmount policies");
+  assert(lifecycle.unmount.length > 0, "world pack_lifecycle unmount policies cannot be empty");
+  const packIds = new Set(world.packs ?? []);
+  const seenPackIds = new Set();
+  for (const policy of lifecycle.unmount) {
+    assert(
+      policy && typeof policy === "object" && !Array.isArray(policy),
+      "world pack_lifecycle unmount policy must be an object",
+    );
+    assert(
+      Object.keys(policy).every((field) => ["pack_id", "evacuation"].includes(field)),
+      "world pack_lifecycle unmount policy has unknown fields",
+    );
+    assert(
+      typeof policy.pack_id === "string" && packIds.has(policy.pack_id),
+      `world pack_lifecycle references unmounted pack ${policy.pack_id}`,
+    );
+    assert(
+      !seenPackIds.has(policy.pack_id),
+      `world pack_lifecycle duplicates unmount policy for ${policy.pack_id}`,
+    );
+    seenPackIds.add(policy.pack_id);
+    const evacuation = policy.evacuation;
+    assert(
+      evacuation && typeof evacuation === "object" && !Array.isArray(evacuation),
+      `world pack_lifecycle ${policy.pack_id} evacuation must be an object`,
+    );
+    assert(
+      Object.keys(evacuation).every((field) =>
+        ["mode", "destination_location"].includes(field)),
+      `world pack_lifecycle ${policy.pack_id} evacuation has unknown fields`,
+    );
+    assert(
+      evacuation.mode === "move_occupants",
+      `world pack_lifecycle ${policy.pack_id} evacuation mode must be move_occupants`,
+    );
+    const destination = String(evacuation.destination_location ?? "");
+    const match = destination.match(/^([a-z0-9][a-z0-9.-]*):location\/([1-9]\d*)$/);
+    assert(
+      match && packIds.has(match[1]),
+      `world pack_lifecycle ${policy.pack_id} has invalid evacuation destination ${destination}`,
+    );
+    assert(
+      match[1] !== policy.pack_id,
+      `world pack_lifecycle ${policy.pack_id} evacuation destination must survive unmount`,
+    );
+  }
+  return lifecycle;
+}
+
+function compilePackLifecycle(lifecycle, resources) {
+  if (!lifecycle) return null;
+  const locationsByReference = new Map(
+    resources.locations.map((location) => [
+      `${location.pack_id}:location/${location.id}`,
+      location,
+    ]),
+  );
+  const packsWithLocations = new Set(resources.locations.map((location) => location.pack_id));
+  const gatedLocationIds = new Set(
+    resources.access_gates.map((gate) => Number(gate.location_id)),
+  );
+  return {
+    schema_version: 1,
+    unmount: lifecycle.unmount.map((policy) => {
+      assert(
+        packsWithLocations.has(policy.pack_id),
+        `world pack_lifecycle ${policy.pack_id} does not own any locations`,
+      );
+      const destination = locationsByReference.get(policy.evacuation.destination_location);
+      assert(
+        destination,
+        `world pack_lifecycle ${policy.pack_id} evacuation destination ${policy.evacuation.destination_location} does not exist`,
+      );
+      assert(
+        !gatedLocationIds.has(Number(destination.id)),
+        `world pack_lifecycle ${policy.pack_id} evacuation destination ${policy.evacuation.destination_location} must be public`,
+      );
+      return {
+        pack_id: policy.pack_id,
+        evacuation: {
+          mode: policy.evacuation.mode,
+          destination_location: policy.evacuation.destination_location,
+          destination_pack_id: destination.pack_id,
+          destination_location_id: Number(destination.id),
+        },
+      };
+    }),
+  };
+}
+
 function sha256(parts) {
   const hash = crypto.createHash("sha256");
   for (const part of parts) {
@@ -466,6 +569,7 @@ runContributionSchemaMutationTests();
 const engineVersion = readJson(path.resolve(v2Root, "../package.json")).version;
 const world = readJson(path.join(worldDir, "world.json"));
 const avatarNaming = loadAvatarNaming(world, worldDir);
+const packLifecycleSource = loadPackLifecycle(world);
 const lockPath = path.join(worldDir, "pack.lock.json");
 const legacyLockPath = path.join(worldDir, "world.lock.json");
 const lock = readJson(
@@ -922,14 +1026,17 @@ const contentReferences = buildContentReferenceMapping(
   }),
   CANONICAL_ID_MAPPING_VERSION,
 );
+const packLifecycle = compilePackLifecycle(packLifecycleSource, resources);
 const {
   persistence_compatibility: _persistenceCompatibility,
   avatar_naming: _avatarNamingSource,
+  pack_lifecycle: _packLifecycleSource,
   ...worldIdentity
 } = world;
 const bundleHash = sha256([
   json(worldIdentity),
   ...(avatarNaming ? [json(avatarNaming)] : []),
+  ...(packLifecycle ? [json(packLifecycle)] : []),
   json(packSummary),
   ...Object.values(resources).map(json),
   json(externalCards),
@@ -959,6 +1066,7 @@ const manifest = {
   entry_location: world.entry_location,
   ...(world.entry_grant_id ? { entry_grant_id: world.entry_grant_id } : {}),
   ...(persistenceCompatibility ? { persistence_compatibility: persistenceCompatibility } : {}),
+  ...(packLifecycle ? { pack_lifecycle: packLifecycle } : {}),
   rules_profile: world.rules_profile,
   active_rules_variants: activeRulesVariants,
   active_rules_extensions: activeRulesExtensions,

--- a/v2/scripts/migrate-pack-unmount.mjs
+++ b/v2/scripts/migrate-pack-unmount.mjs
@@ -179,6 +179,125 @@ function appendTransaction(state, transaction) {
   return committed;
 }
 
+function evacuateOccupiedActors(
+  snapshot,
+  sourceRegistry,
+  targetRegistry,
+  packId,
+  locationIds,
+  occupied,
+) {
+  if (occupied.length === 0) return null;
+  const policies = sourceRegistry.manifest?.pack_lifecycle?.unmount ?? [];
+  const matches = policies.filter((policy) => policy.pack_id === packId);
+  if (matches.length !== 1) {
+    throw new Error(
+      `cannot unmount ${packId}: actors ${occupied.map((actor) => actor.id).join(", ")} still occupy pack locations and no unique evacuation policy is available`,
+    );
+  }
+  const policy = matches[0];
+  const evacuation = policy.evacuation;
+  if (
+    sourceRegistry.manifest.pack_lifecycle.schema_version !== 1
+      || evacuation?.mode !== "move_occupants"
+      || !Number.isInteger(evacuation.destination_location_id)
+  ) {
+    throw new Error(`cannot unmount ${packId}: evacuation policy is malformed`);
+  }
+  const destinationId = evacuation.destination_location_id;
+  const targetLocation = (targetRegistry.resources?.locations ?? [])
+    .find((location) =>
+      Number(location.id) === destinationId
+        && location.pack_id === evacuation.destination_pack_id);
+  if (
+    !targetLocation
+      || hasId(locationIds, destinationId)
+      || evacuation.destination_location
+        !== `${evacuation.destination_pack_id}:location/${destinationId}`
+  ) {
+    throw new Error(
+      `cannot unmount ${packId}: evacuation destination ${evacuation.destination_location ?? destinationId} is not mounted in the target composition`,
+    );
+  }
+  if (!(snapshot.world_locations ?? []).some((location) => Number(location.id) === destinationId)) {
+    throw new Error(
+      `cannot unmount ${packId}: evacuation destination location ${destinationId} is not active in the snapshot`,
+    );
+  }
+  const occupiedActorIds = new Set(occupied.map((actor) => Number(actor.id)));
+  const blockingEncounter = (snapshot.world_combat_encounters ?? []).find((encounter) =>
+    hasId(locationIds, encounter.location_id)
+      && (encounter.participants ?? [])
+        .some((participant) => occupiedActorIds.has(Number(participant.actor_id))));
+  if (blockingEncounter) {
+    throw new Error(
+      `cannot unmount ${packId}: evacuation cannot interrupt active encounter ${blockingEncounter.id ?? "unknown"}`,
+    );
+  }
+
+  const movedItemIds = new Set();
+  for (const item of snapshot.world_items ?? []) {
+    if (occupiedActorIds.has(Number(item.holder_actor_id))) {
+      movedItemIds.add(Number(item.id));
+    }
+  }
+  let foundNestedItem = true;
+  while (foundNestedItem) {
+    foundNestedItem = false;
+    for (const item of snapshot.world_items ?? []) {
+      if (
+        !movedItemIds.has(Number(item.id))
+          && movedItemIds.has(Number(item.container_item_id))
+      ) {
+        movedItemIds.add(Number(item.id));
+        foundNestedItem = true;
+      }
+    }
+  }
+
+  const actors = [...occupied]
+    .sort((left, right) => Number(left.id) - Number(right.id))
+    .map((actor) => ({
+      actor_id: Number(actor.id),
+      from_location_id: Number(actor.location_id),
+      to_location_id: destinationId,
+    }));
+  for (const actor of occupied) actor.location_id = destinationId;
+  for (const item of snapshot.world_items ?? []) {
+    if (movedItemIds.has(Number(item.id))) item.location_id = destinationId;
+  }
+  return {
+    mode: evacuation.mode,
+    destination_location: evacuation.destination_location,
+    destination_pack_id: evacuation.destination_pack_id,
+    destination_location_id: destinationId,
+    actors,
+    moved_item_ids: [...movedItemIds].sort((left, right) => left - right),
+  };
+}
+
+function frozenItemIds(snapshot, authoredItemIds, actorIds, locationIds) {
+  const itemIds = new Set(authoredItemIds);
+  let foundDependency = true;
+  while (foundDependency) {
+    foundDependency = false;
+    for (const item of snapshot.world_items ?? []) {
+      const itemId = Number(item.id);
+      if (
+        itemIds.has(itemId)
+          || (!hasId(actorIds, item.holder_actor_id)
+            && !hasId(locationIds, item.location_id)
+            && !itemIds.has(Number(item.container_item_id)))
+      ) {
+        continue;
+      }
+      itemIds.add(itemId);
+      foundDependency = true;
+    }
+  }
+  return itemIds;
+}
+
 export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegistry) {
   if (!registryHasPack(sourceRegistry, packId)) {
     throw new Error(`pack ${packId} is not mounted in the source registry`);
@@ -189,6 +308,11 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
   if (registryHasPack(targetRegistry, packId)) {
     throw new Error(`target registry still mounts pack ${packId}`);
   }
+  if (snapshot.worldpack_bundle_hash !== sourceRegistry.manifest.bundle_hash) {
+    throw new Error(
+      `cannot unmount ${packId}: snapshot bundle does not match the source registry`,
+    );
+  }
 
   const migrated = structuredClone(snapshot);
   const mountState = packMountState(migrated, true);
@@ -197,13 +321,25 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
   }
 
   const actorIds = packHandles(sourceRegistry, packId, "actor");
-  const itemIds = packHandles(sourceRegistry, packId, "item");
+  const authoredItemIds = packHandles(sourceRegistry, packId, "item");
   const locationIds = packHandles(sourceRegistry, packId, "location");
   const occupied = (migrated.world_actors ?? [])
-    .filter((actor) => actor.kind === 1 && hasId(locationIds, actor.location_id));
-  if (occupied.length > 0) {
-    throw new Error(`cannot unmount ${packId}: human actors ${occupied.map((actor) => actor.id).join(", ")} still occupy pack locations`);
-  }
+    .filter((actor) =>
+      !hasId(actorIds, actor.id) && hasId(locationIds, actor.location_id));
+  const evacuation = evacuateOccupiedActors(
+    migrated,
+    sourceRegistry,
+    targetRegistry,
+    packId,
+    locationIds,
+    occupied,
+  );
+  const itemIds = frozenItemIds(
+    migrated,
+    authoredItemIds,
+    actorIds,
+    locationIds,
+  );
 
   const before = {
     actors: migrated.world_actors?.length ?? 0,
@@ -404,6 +540,7 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
       transfer_offer_ids: invalidatedOfferIds,
       gift_auto_accept_ids: consumedGiftAutoAcceptIds,
     },
+    ...(evacuation ? { evacuation } : {}),
   };
   const stateHash = frozenStateHash(frozen);
   mountState.frozen[packId] = frozen;
@@ -425,9 +562,15 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
       transfer_offers: invalidatedOfferIds.length,
       gift_auto_accepts: consumedGiftAutoAcceptIds.length,
     },
+    ...(evacuation ? { evacuation } : {}),
   });
 
-  return { snapshot: migrated, removed, transaction };
+  return {
+    snapshot: migrated,
+    removed,
+    evacuated: evacuation?.actors ?? [],
+    transaction,
+  };
 }
 
 export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegistry) {
@@ -436,6 +579,11 @@ export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegis
   }
   if (!targetRegistry || !registryHasPack(targetRegistry, packId)) {
     throw new Error(`target registry does not mount pack ${packId}`);
+  }
+  if (snapshot.worldpack_bundle_hash !== sourceRegistry.manifest.bundle_hash) {
+    throw new Error(
+      `cannot remount ${packId}: snapshot bundle does not match the source registry`,
+    );
   }
   const migrated = structuredClone(snapshot);
   const mountState = packMountState(migrated);
@@ -529,7 +677,17 @@ if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
       ? migratePackUnmount(snapshot, registry, packId, target)
       : migratePackRemount(snapshot, registry, packId, target);
     writeJsonAtomically(output, result.snapshot);
-    console.log(`${operation}ed ${packId}: ${JSON.stringify(result.removed ?? result.restored)}`);
+    console.log(`${operation}ed ${packId}: ${JSON.stringify({
+      counts: result.removed ?? result.restored,
+      transaction: {
+        sequence: result.transaction.sequence,
+        status: result.transaction.status,
+        state_hash: result.transaction.state_hash,
+      },
+      ...(result.evacuated?.length
+        ? { evacuated_actor_ids: result.evacuated.map((entry) => entry.actor_id) }
+        : {}),
+    })}`);
   } catch (error) {
     console.error(`pack mount migration failed: ${error.message}`);
     process.exit(1);

--- a/v2/worlds/core-ruby/world.json
+++ b/v2/worlds/core-ruby/world.json
@@ -7,6 +7,18 @@
   "entry_location": "cosyworld.core:location/1",
   "avatar_naming": "../shared/cozy-fantasy-avatar-naming.json",
   "rules_profile": "cosyworld.srd5/1",
+  "pack_lifecycle": {
+    "schema_version": 1,
+    "unmount": [
+      {
+        "pack_id": "ruby-high.first-bell",
+        "evacuation": {
+          "mode": "move_occupants",
+          "destination_location": "cosyworld.core:location/1"
+        }
+      }
+    ]
+  },
   "packs": [
     "cosyworld.core",
     "ruby-high.first-bell",

--- a/v2/worlds/official/world.json
+++ b/v2/worlds/official/world.json
@@ -7,6 +7,32 @@
   "entry_location": "cosyworld.core:location/1",
   "avatar_naming": "../shared/cozy-fantasy-avatar-naming.json",
   "rules_profile": "cosyworld.srd5/1",
+  "pack_lifecycle": {
+    "schema_version": 1,
+    "unmount": [
+      {
+        "pack_id": "cosyworld.campaign.the-lantern-keeper",
+        "evacuation": {
+          "mode": "move_occupants",
+          "destination_location": "cosyworld.core:location/1"
+        }
+      },
+      {
+        "pack_id": "cosyworld.the-holy-land",
+        "evacuation": {
+          "mode": "move_occupants",
+          "destination_location": "cosyworld.core:location/1"
+        }
+      },
+      {
+        "pack_id": "ruby-high.first-bell",
+        "evacuation": {
+          "mode": "move_occupants",
+          "destination_location": "cosyworld.core:location/1"
+        }
+      }
+    ]
+  },
   "persistence_compatibility": {
     "schema_version": 1,
     "replay_compatible_bundle_hashes": [
@@ -33,7 +59,8 @@
       "sha256:02147a6629b038e2e9a28039f829bc6ad67881fe3391a0edabf744fd362427df",
       "sha256:ef70c61617e4c6f6cf905f049dddbb053e84b520f545ed2d01b3180cf39d75d1",
       "sha256:f5cd5ce7a1bb8447811afd5af6a6d31d4709a4f6ee1988a77fc254111d572f17",
-      "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc"
+      "sha256:5b66ce6369fbf04814b2812f30c5e5940bf6b08100f2aa4bf87be5ddd8d58ecc",
+      "sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628"
     ]
   },
   "packs": [


### PR DESCRIPTION
## Summary

- Add compiled, validated pack-unmount evacuation policies.
- Move every non-pack actor and their carried/nested items to a public mounted fallback before unmount, regardless of controller kind.
- Freeze pack-owned and stranded state, invalidate offers, record the evacuation in the deterministic transaction, and preserve it across remount.
- Fail atomically for missing destinations, active encounters, malformed policy, or a source-bundle mismatch.

Part of #28.

## Compatibility

- Release: `0.0.167`
- Official bundle: `sha256:9e91a900766633f5f52b8fe58e8f409f020233553e3fe5bf24ff519553e972ac`
- Declares the prior production bundle `sha256:aa077d2657f65b1258f26101d0fd65c6bb672efdf688bc21b28334cd4352d628` replay-compatible.
- Regenerates the official and core-ruby manifests.

## Validation

- `npm run check`
- `npm run v2:check`
- Pre-push `npm run check`
- 439 JS tests and 500 Rust tests pass.

## Review checklist

- [x] Evacuation is controller-neutral.
- [x] Carried and nested items follow occupants.
- [x] Failed migrations leave the input and output untouched.
- [x] Transaction evidence is deterministic and replay-safe.
- [x] Remount restores frozen pack state without teleporting evacuated actors back.