### PR TITLE
Fix pack migration recovery from journal checkpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.167",
+  "version": "0.0.168",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/core-pack-composition.test.mjs
+++ b/test/v2/core-pack-composition.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 
 import { migrateContentReferenceDocument } from "../../v2/scripts/migrate-content-references.mjs";
@@ -424,6 +425,162 @@ describe("independently mountable CosyWorld Core", () => {
       expect(failed.status).not.toBe(0);
       expect(failed.stderr).toContain("destination location 1 is not active");
       expect(fs.existsSync(failedOutputPath)).toBe(false);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("moves the complete rules binding with each composition transaction", () => {
+    const sourceRegistry = structuredClone(coreOnly);
+    const targetRegistry = structuredClone(servicesOnly);
+    sourceRegistry.manifest.rules_profile = "rules/source";
+    sourceRegistry.manifest.active_rules_variants = ["variant/source"];
+    sourceRegistry.manifest.active_rules_extensions = ["extension/source"];
+    targetRegistry.manifest.rules_profile = "rules/target";
+    targetRegistry.manifest.active_rules_variants = ["variant/target"];
+    targetRegistry.manifest.active_rules_extensions = ["extension/target"];
+    const snapshot = {
+      worldpack_bundle_hash: sourceRegistry.manifest.bundle_hash,
+      rules_profile: "rules/source",
+      active_rules_variants: ["variant/source"],
+      active_rules_extensions: ["extension/source"],
+      world_actors: [],
+      world_items: [],
+      world_locations: [],
+      world_exits: [],
+      content_context: {
+        mapping_version: sourceRegistry.content_references.mapping_version,
+        references: [],
+        active_rulesets: [],
+      },
+    };
+
+    const unmounted = migratePackUnmount(
+      snapshot,
+      sourceRegistry,
+      "cosyworld.core",
+      targetRegistry,
+    );
+    expect(unmounted.snapshot).toMatchObject({
+      rules_profile: "rules/target",
+      active_rules_variants: ["variant/target"],
+      active_rules_extensions: ["extension/target"],
+    });
+    expect(unmounted.transaction).toMatchObject({
+      source_rules: {
+        rules_profile: "rules/source",
+        active_rules_variants: ["variant/source"],
+        active_rules_extensions: ["extension/source"],
+      },
+      target_rules: {
+        rules_profile: "rules/target",
+        active_rules_variants: ["variant/target"],
+        active_rules_extensions: ["extension/target"],
+      },
+    });
+
+    const remounted = migratePackRemount(
+      unmounted.snapshot,
+      targetRegistry,
+      "cosyworld.core",
+      sourceRegistry,
+    );
+    expect(remounted.snapshot).toMatchObject({
+      rules_profile: "rules/source",
+      active_rules_variants: ["variant/source"],
+      active_rules_extensions: ["extension/source"],
+    });
+  });
+
+  it("requires an exact quiescent journal checkpoint for durable CLI migration", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cosyworld-pack-checkpoint-"));
+    const eventDbPath = path.join(tempRoot, "events.sqlite");
+    const inputPath = path.join(tempRoot, "snapshot.json");
+    const outputPath = path.join(tempRoot, "unmounted.json");
+    const snapshot = {
+      action_journal_seq: 1,
+      worldpack_bundle_hash: coreRuby.manifest.bundle_hash,
+      world_actors: [],
+      world_items: [],
+      world_locations: [{ id: 1 }, { id: 11 }],
+      world_exits: [{ from_location_id: 1, to_location_id: 11 }],
+    };
+    const cliArgs = (input, output) => [
+      packMigrationPath,
+      "--operation",
+      "unmount",
+      "--input",
+      input,
+      "--output",
+      output,
+      "--registry",
+      path.join(repoRoot, "v2/content/core-ruby/registry.json"),
+      "--target-registry",
+      path.join(repoRoot, "v2/content/core-only/registry.json"),
+      "--pack",
+      "ruby-high.first-bell",
+    ];
+
+    try {
+      fs.writeFileSync(inputPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+      const database = new Database(eventDbPath);
+      database.exec(`
+        CREATE TABLE action_journal (
+          journal_seq INTEGER PRIMARY KEY AUTOINCREMENT
+        );
+        CREATE TABLE actor_jobs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          status TEXT NOT NULL
+        );
+        INSERT INTO action_journal DEFAULT VALUES;
+      `);
+      database.close();
+
+      const missingDatabase = spawnSync(
+        process.execPath,
+        cliArgs(inputPath, outputPath),
+        { cwd: repoRoot, encoding: "utf8" },
+      );
+      expect(missingDatabase.status).not.toBe(0);
+      expect(missingDatabase.stderr).toContain("--event-db is required");
+      expect(fs.existsSync(outputPath)).toBe(false);
+
+      const migrated = spawnSync(process.execPath, [
+        ...cliArgs(inputPath, outputPath),
+        "--event-db",
+        eventDbPath,
+      ], { cwd: repoRoot, encoding: "utf8" });
+      expect(migrated.status, migrated.stderr).toBe(0);
+      expect(migrated.stdout).toContain('"action_journal_seq":1');
+      expect(JSON.parse(fs.readFileSync(outputPath, "utf8")).action_journal_seq).toBe(1);
+
+      const staleInputPath = path.join(tempRoot, "stale.json");
+      const staleOutputPath = path.join(tempRoot, "stale-output.json");
+      fs.writeFileSync(staleInputPath, `${JSON.stringify({
+        ...snapshot,
+        action_journal_seq: 2,
+      }, null, 2)}\n`);
+      const stale = spawnSync(process.execPath, [
+        ...cliArgs(staleInputPath, staleOutputPath),
+        "--event-db",
+        eventDbPath,
+      ], { cwd: repoRoot, encoding: "utf8" });
+      expect(stale.status).not.toBe(0);
+      expect(stale.stderr).toContain("checkpoint 2 does not match journal head 1");
+      expect(fs.existsSync(staleOutputPath)).toBe(false);
+
+      const busyDatabase = new Database(eventDbPath);
+      busyDatabase.prepare("INSERT INTO actor_jobs (status) VALUES ('pending')").run();
+      busyDatabase.close();
+      const busyOutputPath = path.join(tempRoot, "busy-output.json");
+      const busy = spawnSync(process.execPath, [
+        ...cliArgs(inputPath, busyOutputPath),
+        "--event-db",
+        eventDbPath,
+      ], { cwd: repoRoot, encoding: "utf8" });
+      expect(busy.status).not.toBe(0);
+      expect(busy.stderr).toContain("1 actor job(s) are pending or running");
+      expect(fs.existsSync(busyOutputPath)).toBe(false);
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -202,8 +202,8 @@ npm run v2:worldpack:compile
 npm run v2:worldpack
 npm run v2:worldpack:inspect
 npm run v2:content-refs:migrate -- --input legacy.json --output migrated.json
-npm run v2:pack:unmount -- --operation unmount --input snapshot.json --output unmounted.json --registry v2/content/core-only/registry.json --target-registry v2/content/services-only/registry.json --pack cosyworld.core
-npm run v2:pack:unmount -- --operation remount --input unmounted.json --output remounted.json --registry v2/content/services-only/registry.json --target-registry v2/content/core-only/registry.json --pack cosyworld.core
+npm run v2:pack:unmount -- --operation unmount --input snapshot.json --output unmounted.json --event-db events.sqlite --registry v2/content/core-only/registry.json --target-registry v2/content/services-only/registry.json --pack cosyworld.core
+npm run v2:pack:unmount -- --operation remount --input unmounted.json --output remounted.json --event-db events.sqlite --registry v2/content/services-only/registry.json --target-registry v2/content/core-only/registry.json --pack cosyworld.core
 ```
 
 `sync` skips workspace packs and materializes Git-backed packs below `v2/content/imports`. Git sources must use an HTTPS GitHub URL and a full 40-character commit. It never follows a branch or tag at build time.
@@ -309,10 +309,20 @@ state hash, a monotonic sequence, and any completed actor/item evacuation.
 Remount requires the exact frozen source registry and restores the same pack
 identities without undoing the actors' completed evacuation; collisions fail
 without changing the input. Both directions require the snapshot's active
-bundle hash to match the supplied source registry. The CLI writes through a
-same-directory temporary file and atomic rename. Archive the source snapshot
-and stop writers before running it; then start the single authoritative writer
-with the exact target registry supplied to the tool.
+bundle hash to match the supplied source registry, and move the top-level rules
+profile, variants, and extensions to the target composition in the same
+transaction.
+
+With an event store, every committed action writes a snapshot checkpoint tagged
+with its exact `action_journal_seq`. Startup restores that checkpoint and
+replays only the newer journal suffix, so an offline pack migration remains
+authoritative without rewriting historical journal rows. The migration CLI
+requires `--event-db` for a checkpointed snapshot, takes an immediate SQLite
+write lock, verifies the snapshot cursor equals the journal head, and refuses
+to run while actor jobs are pending or running. It writes through a
+same-directory temporary file and atomic rename. Stop the writer and archive
+the source snapshot before running it; then start one authoritative writer with
+the exact target registry supplied to the tool.
 
 ## Runtime discovery and access
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.167"
+version = "0.0.168"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.167"
+version = "0.0.168"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/journal_checkpoint.rs
+++ b/v2/orchestrator-rust/src/journal_checkpoint.rs
@@ -1,0 +1,266 @@
+use super::*;
+
+macro_rules! replay_journal_continuity {
+    ($journal_path:expr, $snapshot_path:expr $(,)?) => {{
+        let journal_path = $journal_path;
+        match $snapshot_path {
+            Some(snapshot_path) => {
+                match RuntimeWorld::from_snapshot_and_action_journal(snapshot_path, journal_path) {
+                    Ok(runtime) => {
+                        info!(
+                            "loaded journal checkpoint {} and replayed suffix from {}",
+                            snapshot_path.display(),
+                            journal_path.display()
+                        );
+                        Ok(runtime)
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                        RuntimeWorld::from_action_journal(journal_path)
+                    }
+                    Err(error) => {
+                        warn!(
+                            "journal checkpoint {} is unavailable; attempting full replay from {}: {}",
+                            snapshot_path.display(),
+                            journal_path.display(),
+                            error
+                        );
+                        RuntimeWorld::from_action_journal(journal_path)
+                    }
+                }
+            }
+            None => RuntimeWorld::from_action_journal(journal_path),
+        }
+    }};
+}
+pub(super) use replay_journal_continuity;
+
+macro_rules! replay_action_journal_after {
+    ($runtime:ident, $path:expr, $after_seq:expr) => {
+        let records = read_action_journal_after_seq($path, $after_seq)?;
+        let mut canonical_natural_features =
+            read_canonical_natural_feature_reveals_after_journal_seq($path, $after_seq)?;
+        let mut canonical_quest_loot =
+            read_canonical_quest_loot_allocations_after_journal_seq($path, $after_seq)?;
+        let mut pending_natural_features = Vec::new();
+        let mut migrated_bundle_hashes = BTreeSet::new();
+        let mut replayed_through_seq = $after_seq;
+        for (journal_seq, record) in records {
+            let compatibility = persisted_worldpack_replay_compatibility(
+                &record.worldpack_bundle_hash,
+                "action journal",
+            )?;
+            if compatibility == WorldpackReplayCompatibility::DeclaredMigration {
+                migrated_bundle_hashes.insert(record.worldpack_bundle_hash.clone());
+            }
+            validate_persisted_content_context_for_replay(
+                &record.content_context,
+                "action journal",
+                compatibility == WorldpackReplayCompatibility::DeclaredMigration,
+            )?;
+            if !record.rules_profile.is_empty()
+                && record.rules_profile != active_content().manifest.rules_profile
+            {
+                return Err(snapshot_error(format!(
+                    "action journal rules profile {} does not match active rules profile {}",
+                    record.rules_profile,
+                    active_content().manifest.rules_profile
+                )));
+            }
+            if record.active_rules_variants != active_content().manifest.active_rules_variants {
+                return Err(snapshot_error(format!(
+                    "action journal rules variants {:?} do not match active variants {:?}",
+                    record.active_rules_variants,
+                    active_content().manifest.active_rules_variants
+                )));
+            }
+            if record.active_rules_extensions != active_content().manifest.active_rules_extensions {
+                return Err(snapshot_error(format!(
+                    "action journal rules extensions {:?} do not match active extensions {:?}",
+                    record.active_rules_extensions,
+                    active_content().manifest.active_rules_extensions
+                )));
+            }
+            validate_journal_rule_binding(&record)?;
+
+            let _ = $runtime.apply_journal_record(&record);
+            replayed_through_seq = journal_seq;
+            if let Some(events) = canonical_natural_features.remove(&journal_seq) {
+                pending_natural_features.extend(events);
+            }
+            $runtime.restore_ready_natural_feature_evidence(&mut pending_natural_features)?;
+            if let Some(events) = canonical_quest_loot.remove(&journal_seq) {
+                for event in events {
+                    $runtime.restore_canonical_quest_loot_evidence(&record, &event)?;
+                }
+            }
+        }
+        pending_natural_features.extend(canonical_natural_features.into_values().flatten());
+        if !canonical_quest_loot.is_empty() {
+            return Err(snapshot_error(
+                "canonical quest loot evidence has no matching action journal record",
+            ));
+        }
+        if !migrated_bundle_hashes.is_empty() {
+            warn!(
+                "replayed action journal through declared worldpack migration(s) from [{}] to {}",
+                migrated_bundle_hashes
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                active_content().manifest.bundle_hash
+            );
+        }
+        $runtime.action_journal_seq = replayed_through_seq;
+        $runtime.recompute_counters();
+        $runtime.ensure_seed_topology();
+        $runtime.ensure_active_actor_rules_facets();
+        $runtime.ensure_seed_rpg_projection();
+        $runtime.backfill_generated_avatar_flavor();
+        $runtime.ensure_actor_autonomy();
+        $runtime.restore_ready_natural_feature_evidence(&mut pending_natural_features)?;
+        for event in pending_natural_features {
+            $runtime.restore_natural_feature_reveal_evidence(&event)?;
+        }
+        $runtime.backfill_generated_place_governance();
+        $runtime.backfill_settlement_buildings();
+        let mint_seed = $runtime.next_seed;
+        $runtime.ensure_canonical_identities(mint_seed);
+        $runtime.refresh_all_canonical_events();
+    };
+}
+
+impl RuntimeWorld {
+    pub(super) fn from_action_journal(path: &Path) -> io::Result<Self> {
+        let mut runtime = Self::seeded();
+        replay_action_journal_after!(runtime, path, 0);
+        Ok(runtime)
+    }
+
+    pub(super) fn from_snapshot_and_action_journal(
+        snapshot_path: &Path,
+        journal_path: &Path,
+    ) -> io::Result<Self> {
+        let mut runtime = Self::load_snapshot(snapshot_path)?;
+        let checkpoint_seq = runtime.action_journal_seq;
+        if checkpoint_seq == 0 {
+            return Err(snapshot_error(
+                "snapshot has no action-journal checkpoint cursor",
+            ));
+        }
+        let journal_head = latest_action_journal_seq(journal_path)?;
+        if checkpoint_seq > journal_head {
+            return Err(snapshot_error(format!(
+                "snapshot action-journal checkpoint {checkpoint_seq} is ahead of journal head {journal_head}"
+            )));
+        }
+        replay_action_journal_after!(runtime, journal_path, checkpoint_seq);
+        Ok(runtime)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(label: &str, extension: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "cosyworld-{label}-{}-{}.{}",
+            std::process::id(),
+            now_seed(),
+            extension
+        ))
+    }
+
+    #[test]
+    fn snapshot_checkpoint_preserves_migration_state_and_replays_only_the_suffix() {
+        std::thread::Builder::new()
+            .name("journal-checkpoint-replay".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(run_snapshot_checkpoint_replay)
+            .expect("spawn journal checkpoint replay thread")
+            .join()
+            .expect("journal checkpoint replay thread");
+    }
+
+    fn run_snapshot_checkpoint_replay() {
+        let journal_path = temp_path("journal-checkpoint", "sqlite");
+        let snapshot_path = temp_path("journal-checkpoint", "json");
+        let _ = fs::remove_file(&journal_path);
+        let _ = fs::remove_file(&snapshot_path);
+
+        let mut create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: 1,
+            ..CwAction::default()
+        };
+        let mut create_record = JournalRecord::new(create, 73_001);
+        create_record.actor_meta_upserts.insert(
+            5000,
+            ActorMeta {
+                name: "Checkpoint Walker".to_string(),
+                speech_mode: "prose".to_string(),
+                title: "Journal Cartographer".to_string(),
+                description: "A checkpoint replay fixture.".to_string(),
+            },
+        );
+        append_action_journal(&journal_path, &create_record).expect("append checkpoint prefix");
+
+        let mut checkpoint =
+            RuntimeWorld::from_action_journal(&journal_path).expect("replay checkpoint prefix");
+        assert_eq!(checkpoint.action_journal_seq, 1);
+        checkpoint
+            .content
+            .insert(990_001, "checkpoint-only".to_string());
+        checkpoint.pack_mount_state = PackMountState(serde_json::json!({
+            "schema_version": 1,
+            "next_transaction_seq": 2,
+            "frozen": {},
+            "history": [{
+                "sequence": 1,
+                "status": "committed",
+                "operation": "soft_unmount",
+                "pack_id": "fixture.pack"
+            }]
+        }));
+        checkpoint
+            .save_snapshot(&snapshot_path)
+            .expect("save journal checkpoint");
+
+        create.kind = CW_ACTION_SAY;
+        create.content_id = 990_002;
+        let mut suffix_record = JournalRecord::new(create, 73_002);
+        suffix_record
+            .content_upserts
+            .insert(990_002, "suffix line".to_string());
+        append_action_journal(&journal_path, &suffix_record).expect("append checkpoint suffix");
+
+        let restored =
+            RuntimeWorld::from_snapshot_and_action_journal(&snapshot_path, &journal_path)
+                .expect("restore checkpoint plus suffix");
+        assert_eq!(restored.action_journal_seq, 2);
+        assert_eq!(
+            restored.content.get(&990_001).map(String::as_str),
+            Some("checkpoint-only")
+        );
+        assert_eq!(
+            restored.content.get(&990_002).map(String::as_str),
+            Some("suffix line")
+        );
+        assert_eq!(restored.pack_mount_state.composition_revision(), 1);
+
+        let mut ahead = RuntimeSnapshot::from_runtime(&restored);
+        ahead.action_journal_seq = 3;
+        fs::write(
+            &snapshot_path,
+            serde_json::to_vec_pretty(&ahead).expect("serialize ahead checkpoint"),
+        )
+        .expect("write ahead checkpoint");
+        let error = RuntimeWorld::from_snapshot_and_action_journal(&snapshot_path, &journal_path)
+            .expect_err("checkpoint ahead of the journal must fail");
+        assert!(error.to_string().contains("ahead of journal head 2"));
+
+        let _ = fs::remove_file(journal_path);
+        let _ = fs::remove_file(snapshot_path);
+    }
+}

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -17,6 +17,7 @@ mod content_registry;
 mod crafting;
 mod generated_places;
 mod hosted_access;
+mod journal_checkpoint;
 mod kernel;
 mod legacy_import;
 mod moderation;
@@ -1703,6 +1704,7 @@ struct RuntimeWorld {
     orb_reward_claims: BTreeSet<String>,
     listen_attempt_claims: BTreeSet<String>,
     pack_mount_state: PackMountState,
+    action_journal_seq: u64,
     presence_states: BTreeMap<u64, bool>,
     event_log: Vec<EventView>,
     recent_room_lines: BTreeMap<u64, Vec<EventView>>,
@@ -1726,6 +1728,8 @@ struct RuntimeSnapshot {
     active_rules_extensions: Vec<String>,
     #[serde(default, skip_serializing_if = "PackMountState::is_empty")]
     pack_mount_state: PackMountState,
+    #[serde(default)]
+    action_journal_seq: u64,
 
     world_version: u32,
     tick: u64,
@@ -5326,10 +5330,13 @@ impl AppState {
         let mut runtime = match event_store_path.as_deref() {
             Some(path) => {
                 match init_event_store(path).and_then(|_| action_journal_has_records(path)) {
-                    Ok(true) => match RuntimeWorld::from_action_journal(path) {
+                    Ok(true) => match journal_checkpoint::replay_journal_continuity!(
+                        path,
+                        snapshot_path.as_deref().map(PathBuf::as_path),
+                    ) {
                         Ok(runtime) => {
                             info!(
-                                "replayed CosyWorld v2 action journal from {}",
+                                "restored CosyWorld v2 journal continuity from {}",
                                 path.display()
                             );
                             runtime
@@ -6179,13 +6186,14 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 9,
+            version: 10,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
             active_rules_variants: active_content().manifest.active_rules_variants.clone(),
             active_rules_extensions: active_content().manifest.active_rules_extensions.clone(),
             pack_mount_state: runtime.pack_mount_state.clone(),
+            action_journal_seq: runtime.action_journal_seq,
 
             world_version: runtime.world.version,
             tick: runtime.world.tick,
@@ -6459,6 +6467,7 @@ impl RuntimeSnapshot {
             orb_reward_claims: self.orb_reward_claims,
             listen_attempt_claims: self.listen_attempt_claims,
             pack_mount_state: self.pack_mount_state,
+            action_journal_seq: self.action_journal_seq,
             presence_states: BTreeMap::new(),
             event_log: self.event_log,
             recent_room_lines: self.recent_room_lines,
@@ -6787,97 +6796,6 @@ impl RuntimeWorld {
         }
     }
 
-    fn from_action_journal(path: &Path) -> io::Result<Self> {
-        let mut runtime = Self::seeded();
-        let records = read_action_journal_with_seq(path)?;
-        let mut canonical_natural_features =
-            read_canonical_natural_feature_reveals_by_journal_seq(path)?;
-        let mut canonical_quest_loot = read_canonical_quest_loot_allocations_by_journal_seq(path)?;
-        let mut pending_natural_features = Vec::new();
-        let mut migrated_bundle_hashes = BTreeSet::new();
-        for (journal_seq, record) in records {
-            let compatibility = persisted_worldpack_replay_compatibility(
-                &record.worldpack_bundle_hash,
-                "action journal",
-            )?;
-            if compatibility == WorldpackReplayCompatibility::DeclaredMigration {
-                migrated_bundle_hashes.insert(record.worldpack_bundle_hash.clone());
-            }
-            validate_persisted_content_context_for_replay(
-                &record.content_context,
-                "action journal",
-                compatibility == WorldpackReplayCompatibility::DeclaredMigration,
-            )?;
-            if !record.rules_profile.is_empty()
-                && record.rules_profile != active_content().manifest.rules_profile
-            {
-                return Err(snapshot_error(format!(
-                    "action journal rules profile {} does not match active rules profile {}",
-                    record.rules_profile,
-                    active_content().manifest.rules_profile
-                )));
-            }
-            if record.active_rules_variants != active_content().manifest.active_rules_variants {
-                return Err(snapshot_error(format!(
-                    "action journal rules variants {:?} do not match active variants {:?}",
-                    record.active_rules_variants,
-                    active_content().manifest.active_rules_variants
-                )));
-            }
-            if record.active_rules_extensions != active_content().manifest.active_rules_extensions {
-                return Err(snapshot_error(format!(
-                    "action journal rules extensions {:?} do not match active extensions {:?}",
-                    record.active_rules_extensions,
-                    active_content().manifest.active_rules_extensions
-                )));
-            }
-            validate_journal_rule_binding(&record)?;
-
-            let _ = runtime.apply_journal_record(&record);
-            if let Some(events) = canonical_natural_features.remove(&journal_seq) {
-                pending_natural_features.extend(events);
-            }
-            runtime.restore_ready_natural_feature_evidence(&mut pending_natural_features)?;
-            if let Some(events) = canonical_quest_loot.remove(&journal_seq) {
-                for event in events {
-                    runtime.restore_canonical_quest_loot_evidence(&record, &event)?;
-                }
-            }
-        }
-        pending_natural_features.extend(canonical_natural_features.into_values().flatten());
-        if !canonical_quest_loot.is_empty() {
-            return Err(snapshot_error(
-                "canonical quest loot evidence has no matching action journal record",
-            ));
-        }
-        if !migrated_bundle_hashes.is_empty() {
-            warn!(
-                "replayed action journal through declared worldpack migration(s) from [{}] to {}",
-                migrated_bundle_hashes
-                    .into_iter()
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                active_content().manifest.bundle_hash
-            );
-        }
-        runtime.recompute_counters();
-        runtime.ensure_seed_topology();
-        runtime.ensure_active_actor_rules_facets();
-        runtime.ensure_seed_rpg_projection();
-        runtime.backfill_generated_avatar_flavor();
-        runtime.ensure_actor_autonomy();
-        runtime.restore_ready_natural_feature_evidence(&mut pending_natural_features)?;
-        for event in pending_natural_features {
-            runtime.restore_natural_feature_reveal_evidence(&event)?;
-        }
-        runtime.backfill_generated_place_governance();
-        runtime.backfill_settlement_buildings();
-        let mint_seed = runtime.next_seed;
-        runtime.ensure_canonical_identities(mint_seed);
-        runtime.refresh_all_canonical_events();
-        Ok(runtime)
-    }
-
     fn seeded() -> Self {
         let mut world = CwWorld::default();
 
@@ -6938,6 +6856,7 @@ impl RuntimeWorld {
             orb_reward_claims: BTreeSet::new(),
             listen_attempt_claims: BTreeSet::new(),
             pack_mount_state: PackMountState::default(),
+            action_journal_seq: 0,
             presence_states: BTreeMap::new(),
             event_log: Vec::new(),
             recent_room_lines: BTreeMap::new(),
@@ -39916,7 +39835,7 @@ fn commit_journal_record(
             }
         },
     };
-    let (status, events, _actor_job_inserted, _committed_journal_seq) = if let Some(path) =
+    let (status, events, _actor_job_inserted, committed_journal_seq) = if let Some(path) =
         state.event_store_path.as_deref()
     {
         let mut conn = match open_event_store(path) {
@@ -40256,6 +40175,9 @@ fn commit_journal_record(
     if !events.is_empty() {
         state.mark_activity();
     }
+    if committed_journal_seq > 0 {
+        runtime.action_journal_seq = committed_journal_seq;
+    }
     persist_runtime(state, runtime);
     Ok((status, events))
 }
@@ -40265,7 +40187,10 @@ fn restore_runtime_from_durable_state(
     runtime: &mut RuntimeWorld,
     event_store_path: &Path,
 ) -> io::Result<()> {
-    let mut restored = RuntimeWorld::from_action_journal(event_store_path)?;
+    let mut restored = journal_checkpoint::replay_journal_continuity!(
+        event_store_path,
+        state.snapshot_path.as_deref().map(PathBuf::as_path),
+    )?;
     advance_runtime_next_event_seq_from_store(&mut restored, event_store_path)?;
     hydrate_runtime_canonical_state(&mut restored, event_store_path)?;
     if let Some(path) = state.resident_continuity_path.as_deref() {
@@ -40299,15 +40224,13 @@ fn journal_commit_recovery_error(
 }
 
 fn persist_runtime(state: &AppState, runtime: &RuntimeWorld) {
-    if state.event_store_path.is_none() {
-        if let Some(path) = state.snapshot_path.as_deref() {
-            if let Err(error) = runtime.save_snapshot(path) {
-                warn!(
-                    "failed to persist CosyWorld v2 snapshot {}: {}",
-                    path.display(),
-                    error
-                );
-            }
+    if let Some(path) = state.snapshot_path.as_deref() {
+        if let Err(error) = runtime.save_snapshot(path) {
+            warn!(
+                "failed to persist CosyWorld v2 snapshot {}: {}",
+                path.display(),
+                error
+            );
         }
     }
     if let Some(path) = state.resident_continuity_path.as_deref() {
@@ -41082,20 +41005,28 @@ fn fail_or_retry_actor_job(path: &Path, job: &ActorJob, error: &str) -> io::Resu
 
 #[cfg(test)]
 fn read_action_journal(path: &Path) -> io::Result<Vec<JournalRecord>> {
-    Ok(read_action_journal_with_seq(path)?
+    Ok(read_action_journal_after_seq(path, 0)?
         .into_iter()
         .map(|(_, record)| record)
         .collect())
 }
 
-fn read_action_journal_with_seq(path: &Path) -> io::Result<Vec<(u64, JournalRecord)>> {
+fn read_action_journal_after_seq(
+    path: &Path,
+    after_seq: u64,
+) -> io::Result<Vec<(u64, JournalRecord)>> {
     init_event_store(path)?;
     let conn = open_event_store(path)?;
     let mut stmt = conn
-        .prepare("SELECT journal_seq, record_json FROM action_journal ORDER BY journal_seq ASC")
+        .prepare(
+            "SELECT journal_seq, record_json
+             FROM action_journal
+             WHERE journal_seq > ?1
+             ORDER BY journal_seq ASC",
+        )
         .map_err(sqlite_error)?;
     let rows = stmt
-        .query_map([], |row| {
+        .query_map(params![after_seq as i64], |row| {
             Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
         })
         .map_err(sqlite_error)?;
@@ -41114,22 +41045,35 @@ fn read_action_journal_with_seq(path: &Path) -> io::Result<Vec<(u64, JournalReco
     Ok(records)
 }
 
-fn read_canonical_natural_feature_reveals_by_journal_seq(
+fn read_canonical_natural_feature_reveals_after_journal_seq(
     path: &Path,
+    after_seq: u64,
 ) -> io::Result<BTreeMap<u64, Vec<EventView>>> {
-    read_canonical_events_by_journal_seq(path, "natural_feature.revealed", CW_MAX_LOCATIONS as i64)
+    read_canonical_events_after_journal_seq(
+        path,
+        "natural_feature.revealed",
+        CW_MAX_LOCATIONS as i64,
+        after_seq,
+    )
 }
 
-fn read_canonical_quest_loot_allocations_by_journal_seq(
+fn read_canonical_quest_loot_allocations_after_journal_seq(
     path: &Path,
+    after_seq: u64,
 ) -> io::Result<BTreeMap<u64, Vec<EventView>>> {
-    read_canonical_events_by_journal_seq(path, "quest.loot_allocated", CW_MAX_ITEMS as i64)
+    read_canonical_events_after_journal_seq(
+        path,
+        "quest.loot_allocated",
+        CW_MAX_ITEMS as i64,
+        after_seq,
+    )
 }
 
-fn read_canonical_events_by_journal_seq(
+fn read_canonical_events_after_journal_seq(
     path: &Path,
     event_type: &str,
     limit: i64,
+    after_seq: u64,
 ) -> io::Result<BTreeMap<u64, Vec<EventView>>> {
     init_event_store(path)?;
     let conn = open_event_store(path)?;
@@ -41149,8 +41093,18 @@ fn read_canonical_events_by_journal_seq(
              WHERE events.world_id = ?1
                AND events.world_epoch = ?2
                AND events.event_type = ?3
+               AND COALESCE((
+                   SELECT commits.action_journal_seq
+                   FROM canonical_commits AS commits
+                   WHERE commits.world_id = events.world_id
+                     AND commits.world_epoch = events.world_epoch
+                     AND events.seq BETWEEN commits.first_world_seq AND commits.last_world_seq
+                   ORDER BY (commits.last_world_seq - commits.first_world_seq) ASC,
+                            commits.action_journal_seq ASC
+                   LIMIT 1
+               ), 9223372036854775807) > ?4
              ORDER BY events.seq ASC
-             LIMIT ?4",
+             LIMIT ?5",
         )
         .map_err(sqlite_error)?;
     let rows = stmt
@@ -41159,6 +41113,7 @@ fn read_canonical_events_by_journal_seq(
                 OFFICIAL_WORLD_ID,
                 OFFICIAL_WORLD_EPOCH as i64,
                 event_type,
+                after_seq as i64,
                 limit
             ],
             |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, String>(1)?)),
@@ -44757,8 +44712,26 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn divergent_capacity_processes_converge_without_affinity() {
+    #[test]
+    fn divergent_capacity_processes_converge_without_affinity() {
+        std::thread::Builder::new()
+            .name("capacity-convergence".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(4)
+                    .thread_stack_size(16 * 1024 * 1024)
+                    .enable_all()
+                    .build()
+                    .expect("build capacity convergence runtime")
+                    .block_on(run_divergent_capacity_processes());
+            })
+            .expect("spawn capacity convergence thread")
+            .join()
+            .expect("capacity convergence thread");
+    }
+
+    async fn run_divergent_capacity_processes() {
         let path = std::env::temp_dir().join(format!(
             "cosyworld-capacity-convergence-{}-{}.sqlite",
             std::process::id(),
@@ -45241,6 +45214,7 @@ mod tests {
             .spawn(|| {
                 tokio::runtime::Builder::new_multi_thread()
                     .worker_threads(2)
+                    .thread_stack_size(16 * 1024 * 1024)
                     .enable_all()
                     .build()
                     .expect("build hot-room regional chaos runtime")
@@ -52478,6 +52452,16 @@ mod tests {
 
     #[test]
     fn durable_entity_versions_rehydrate_replayed_runtime_before_next_write() {
+        std::thread::Builder::new()
+            .name("durable-version-rehydrate".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(run_durable_entity_version_rehydration)
+            .expect("spawn durable version rehydration thread")
+            .join()
+            .expect("durable version rehydration thread");
+    }
+
+    fn run_durable_entity_version_rehydration() {
         let path = std::env::temp_dir().join(format!(
             "cosyworld-canonical-version-rehydrate-{}-{}.sqlite",
             std::process::id(),
@@ -60309,6 +60293,7 @@ mod tests {
             .into_runtime()
             .expect("pre-combat-choice snapshot restores");
         assert_eq!(replayed.apply_journal_record(persisted_record).0, CW_OK);
+        replayed.action_journal_seq = runtime.action_journal_seq;
         assert_eq!(
             serde_json::to_value(RuntimeSnapshot::from_runtime(&replayed))
                 .expect("replayed state serializes"),
@@ -71745,7 +71730,7 @@ mod tests {
     }
 
     #[test]
-    fn journal_backed_runtime_skips_redundant_full_snapshot_writes() {
+    fn journal_backed_runtime_writes_checkpoint_snapshots() {
         let runtime = RuntimeWorld::seeded();
         let event_store_path = std::env::temp_dir().join(format!(
             "cosyworld-v2-persist-journal-{}-{}.sqlite",
@@ -71764,8 +71749,11 @@ mod tests {
         state.snapshot_path = Some(Arc::new(snapshot_path.clone()));
         persist_runtime(&state, &runtime);
 
-        assert!(!snapshot_path.exists());
+        let snapshot =
+            RuntimeWorld::load_snapshot(&snapshot_path).expect("journal checkpoint snapshot loads");
+        assert_eq!(snapshot.action_journal_seq, runtime.action_journal_seq);
         let _ = fs::remove_file(event_store_path);
+        let _ = fs::remove_file(snapshot_path);
     }
 
     #[test]

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-75188
+75176

--- a/v2/scripts/migrate-pack-unmount.mjs
+++ b/v2/scripts/migrate-pack-unmount.mjs
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
 
 const PACK_MOUNT_STATE_SCHEMA_VERSION = 1;
 
@@ -145,6 +146,27 @@ function targetContentContext(current, targetRegistry, unmountedPackId) {
       .map((reference) => structuredClone(targetReferences.get(reference.canonical_ref))),
     active_rulesets: targetRulesets(targetRegistry),
   };
+}
+
+function registryRuleBinding(registry) {
+  return {
+    rules_profile: registry.manifest?.rules_profile ?? "",
+    active_rules_variants: structuredClone(
+      registry.manifest?.active_rules_variants ?? [],
+    ),
+    active_rules_extensions: structuredClone(
+      registry.manifest?.active_rules_extensions ?? [],
+    ),
+  };
+}
+
+function applyRegistryBinding(snapshot, registry) {
+  const binding = registryRuleBinding(registry);
+  snapshot.worldpack_bundle_hash = registry.manifest.bundle_hash;
+  snapshot.rules_profile = binding.rules_profile;
+  snapshot.active_rules_variants = binding.active_rules_variants;
+  snapshot.active_rules_extensions = binding.active_rules_extensions;
+  return binding;
 }
 
 function packMountState(snapshot, create = false) {
@@ -315,6 +337,7 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
   }
 
   const migrated = structuredClone(snapshot);
+  const sourceRules = registryRuleBinding(sourceRegistry);
   const mountState = packMountState(migrated, true);
   if (mountState.frozen[packId]) {
     throw new Error(`pack ${packId} is already soft-unmounted`);
@@ -549,13 +572,15 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
     targetRegistry,
     packId,
   );
-  migrated.worldpack_bundle_hash = targetRegistry.manifest.bundle_hash;
+  const targetRules = applyRegistryBinding(migrated, targetRegistry);
   const transaction = appendTransaction(mountState, {
     operation: "soft_unmount",
     pack_id: packId,
     pack_version: frozen.pack_version,
     source_bundle_hash: frozen.source_bundle_hash,
     target_bundle_hash: frozen.target_bundle_hash,
+    source_rules: sourceRules,
+    target_rules: targetRules,
     state_hash: stateHash,
     counts: removed,
     invalidated: {
@@ -586,6 +611,7 @@ export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegis
     );
   }
   const migrated = structuredClone(snapshot);
+  const sourceRules = registryRuleBinding(sourceRegistry);
   const mountState = packMountState(migrated);
   const frozen = mountState?.frozen?.[packId];
   if (!frozen) {
@@ -619,7 +645,7 @@ export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegis
     restoreNestedMapEntries(migrated.world_simulation, field, entries);
   }
   migrated.content_context = structuredClone(frozen.content_context);
-  migrated.worldpack_bundle_hash = targetRegistry.manifest.bundle_hash;
+  const targetRules = applyRegistryBinding(migrated, targetRegistry);
   delete mountState.frozen[packId];
   const restored = {
     actors: frozen.arrays?.world_actors?.length ?? 0,
@@ -633,6 +659,8 @@ export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegis
     pack_version: frozen.pack_version,
     source_bundle_hash: sourceRegistry.manifest.bundle_hash,
     target_bundle_hash: targetRegistry.manifest.bundle_hash,
+    source_rules: sourceRules,
+    target_rules: targetRules,
     state_hash: frozenStateHash(frozen),
     counts: restored,
   });
@@ -656,6 +684,55 @@ function writeJsonAtomically(output, value) {
   }
 }
 
+function writeWithJournalCheckpoint(eventDbPath, snapshot, output, value) {
+  const checkpoint = snapshot.action_journal_seq ?? 0;
+  if (!eventDbPath) {
+    if (checkpoint !== 0) {
+      throw new Error(
+        "--event-db is required when the snapshot has an action-journal checkpoint",
+      );
+    }
+    writeJsonAtomically(output, value);
+    return null;
+  }
+  if (!Number.isSafeInteger(checkpoint) || checkpoint <= 0) {
+    throw new Error(
+      "snapshot action_journal_seq must be a positive safe integer when --event-db is supplied",
+    );
+  }
+
+  const database = new Database(path.resolve(eventDbPath), {
+    fileMustExist: true,
+  });
+  try {
+    database.pragma("busy_timeout = 5000");
+    return database.transaction(() => {
+      const journalHead = Number(database
+        .prepare("SELECT COALESCE(MAX(journal_seq), 0) FROM action_journal")
+        .pluck()
+        .get());
+      if (checkpoint !== journalHead) {
+        throw new Error(
+          `snapshot action-journal checkpoint ${checkpoint} does not match journal head ${journalHead}`,
+        );
+      }
+      const activeJobs = Number(database
+        .prepare("SELECT COUNT(*) FROM actor_jobs WHERE status IN ('pending', 'running')")
+        .pluck()
+        .get());
+      if (activeJobs !== 0) {
+        throw new Error(
+          `cannot migrate while ${activeJobs} actor job(s) are pending or running`,
+        );
+      }
+      writeJsonAtomically(output, value);
+      return checkpoint;
+    }).immediate();
+  } finally {
+    database.close();
+  }
+}
+
 const scriptPath = fileURLToPath(import.meta.url);
 if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
   try {
@@ -665,10 +742,11 @@ if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
     const output = option(args, "--output");
     const registryPath = option(args, "--registry");
     const targetPath = option(args, "--target-registry");
+    const eventDbPath = option(args, "--event-db");
     const packId = option(args, "--pack");
     if (!input || !output || !registryPath || !targetPath || !packId
         || !["unmount", "remount"].includes(operation)) {
-      throw new Error("usage: migrate-pack-unmount.mjs --operation unmount|remount --input snapshot.json --output migrated.json --registry source-registry.json --target-registry target-registry.json --pack PACK_ID");
+      throw new Error("usage: migrate-pack-unmount.mjs --operation unmount|remount --input snapshot.json --output migrated.json --registry source-registry.json --target-registry target-registry.json --pack PACK_ID [--event-db events.sqlite]");
     }
     const snapshot = JSON.parse(fs.readFileSync(path.resolve(input), "utf8"));
     const registry = JSON.parse(fs.readFileSync(path.resolve(registryPath), "utf8"));
@@ -676,7 +754,12 @@ if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
     const result = operation === "unmount"
       ? migratePackUnmount(snapshot, registry, packId, target)
       : migratePackRemount(snapshot, registry, packId, target);
-    writeJsonAtomically(output, result.snapshot);
+    const checkpoint = writeWithJournalCheckpoint(
+      eventDbPath,
+      snapshot,
+      output,
+      result.snapshot,
+    );
     console.log(`${operation}ed ${packId}: ${JSON.stringify({
       counts: result.removed ?? result.restored,
       transaction: {
@@ -687,6 +770,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
       ...(result.evacuated?.length
         ? { evacuated_actor_ids: result.evacuated.map((entry) => entry.actor_id) }
         : {}),
+      ...(checkpoint === null ? {} : { action_journal_seq: checkpoint }),
     })}`);
   } catch (error) {
     console.error(`pack mount migration failed: ${error.message}`);

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -106,12 +106,13 @@ async function startServer(tempDir) {
     COSYWORLD_CONTENT_REGISTRY_PATH: registryPath,
     COSYWORLD_CONTENT_ROOT: contentRoot,
     COSYWORLD_DEPLOY_PROFILE: "local",
+    RUST_LOG: "cosyworld_orchestrator=info",
     COSYWORLD_V2_ADDR: `127.0.0.1:${port}`,
     COSYWORLD_DISABLE_CTRL_C_SHUTDOWN: "1",
     COSYWORLD_DEV_ALLOW_UNSIGNED_WALLET: "1",
     COSYWORLD_DEV_AVATAR_CHAT_DELAY_MS: "0",
     COSYWORLD_CANONICAL_LEASE_TTL_MS: "1000",
-    COSYWORLD_V2_SNAPSHOT_PATH: "off",
+    COSYWORLD_V2_SNAPSHOT_PATH: resolve(tempDir, "snapshot.json"),
     COSYWORLD_V2_EVENT_DB_PATH: resolve(tempDir, "events.sqlite"),
     COSYWORLD_V2_GENERATED_ASSET_DIR: resolve(tempDir, "generated"),
     COSYWORLD_RUBY_HIGH_WALLET_CARDS: JSON.stringify({
@@ -363,6 +364,10 @@ async function main() {
     await stopServer(first.proc);
     first = null;
     second = await startServer(tempDir);
+    assert(
+      second.output.some((line) => line.includes("loaded journal checkpoint")),
+      `restart did not use the journal checkpoint: ${second.output.slice(-40).join("")}`,
+    );
     const replayed = await fetchJson(stateUrl(second.baseUrl, actorId, actorSession));
     assertContext(replayed, {
       location: "Homeroom",
@@ -415,7 +420,7 @@ async function main() {
       loop: [
         "The Cosy Cottage",
         "Homeroom",
-        "journal replay",
+        "journal checkpoint replay",
         "The Cosy Cottage",
       ],
     }, null, 2));


### PR DESCRIPTION
Part of #28.

- Persist the action-journal cursor in runtime snapshots and replay only the suffix after restart.
- Move rules-profile bindings atomically with pack composition migrations.
- Require an exact, quiescent event-store checkpoint for offline migration.
- Add checkpoint/suffix replay, CLI refusal, composition, and restart smoke coverage.

Root cause: startup rebuilt state from the full raw journal, silently discarding offline snapshot migrations.

Checks: `npm run check`, `npm run v2:composition:smoke`, `npm run v2:smoke`, Rust 501/501, Vitest 441/441.