### PR TITLE
Add transactional cold mount support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.168",
+  "version": "0.0.169",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,
@@ -31,6 +31,7 @@
     "v2:worldpack:compile": "node v2/scripts/compile-worldpack.mjs",
     "v2:worldpack:lock": "node v2/scripts/compile-worldpack.mjs --write-lock",
     "v2:content-refs:migrate": "node v2/scripts/migrate-content-references.mjs",
+    "v2:pack:mount": "node v2/scripts/migrate-pack-unmount.mjs --operation mount",
     "v2:pack:unmount": "node v2/scripts/migrate-pack-unmount.mjs",
     "v2:srd:import": "node v2/scripts/import-srd-5.1.mjs && node v2/scripts/import-srd-5.2.1.mjs",
     "v2:srd:check": "node v2/scripts/import-srd-5.1.mjs --check && node v2/scripts/import-srd-5.2.1.mjs --check",

--- a/test/v2/core-pack-composition.test.mjs
+++ b/test/v2/core-pack-composition.test.mjs
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import { migrateContentReferenceDocument } from "../../v2/scripts/migrate-content-references.mjs";
 import {
+  migratePackMount,
   migratePackRemount,
   migratePackUnmount,
 } from "../../v2/scripts/migrate-pack-unmount.mjs";
@@ -242,6 +243,96 @@ describe("independently mountable CosyWorld Core", () => {
       migratePackRemount(wrongRemountBundle, servicesOnly, "cosyworld.core", coreOnly))
       .toThrow(/snapshot bundle does not match the source registry/);
     expect(wrongRemountBundle).toEqual(wrongRemountBundleBefore);
+  });
+
+  it("cold-mounts one experience and its composition bridge without rewriting live state", () => {
+    const snapshot = {
+      worldpack_bundle_hash: coreOnly.manifest.bundle_hash,
+      rules_profile: coreOnly.manifest.rules_profile,
+      active_rules_variants: coreOnly.manifest.active_rules_variants,
+      active_rules_extensions: coreOnly.manifest.active_rules_extensions,
+      world_actors: [{ id: 5000, kind: 1, location_id: 1 }],
+      world_items: [{ id: 7000, holder_actor_id: 5000, location_id: 1, zone: 3 }],
+      world_locations: [{ id: 1 }],
+      world_exits: [],
+      content_context: {
+        mapping_version: coreOnly.content_references.mapping_version,
+        references: coreOnly.content_references.entries
+          .filter((entry) =>
+            entry.canonical_ref === "pack://cosyworld.core/location/1"),
+        active_rulesets: [],
+      },
+    };
+    const source = structuredClone(snapshot);
+    const result = migratePackMount(
+      source,
+      coreOnly,
+      "ruby-high.first-bell",
+      coreRuby,
+    );
+    expect(source).toEqual(snapshot);
+    expect(result.snapshot.worldpack_bundle_hash).toBe(coreRuby.manifest.bundle_hash);
+    expect(result.snapshot.world_actors).toEqual(snapshot.world_actors);
+    expect(result.snapshot.world_items).toEqual(snapshot.world_items);
+    expect(result.snapshot.world_locations).toEqual(snapshot.world_locations);
+    expect(result.snapshot.content_context.references).toEqual(
+      snapshot.content_context.references,
+    );
+    expect(result.snapshot.content_context.active_rulesets.length).toBeGreaterThan(0);
+    expect(result.transaction).toMatchObject({
+      sequence: 1,
+      status: "committed",
+      operation: "cold_mount",
+      pack_id: "ruby-high.first-bell",
+      pack_version: "1.3.5",
+      source_bundle_hash: coreOnly.manifest.bundle_hash,
+      target_bundle_hash: coreRuby.manifest.bundle_hash,
+      mounted_pack_ids: [
+        "ruby-high.first-bell",
+        "cosyworld.composition.core-ruby",
+      ],
+    });
+    expect(result.transaction.state_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.mounted).toEqual(Object.fromEntries(
+      ["actors", "items", "locations", "exits"].map((resource) => [
+        resource,
+        coreRuby.resources[resource].filter((row) =>
+          result.transaction.mounted_pack_ids.includes(row.pack_id))
+          .length,
+      ]),
+    ));
+
+    const frozen = structuredClone(snapshot);
+    frozen.pack_mount_state = {
+      schema_version: 1,
+      next_transaction_seq: 2,
+      frozen: { "another.pack": {} },
+      history: [{ sequence: 1, status: "committed", operation: "soft_unmount" }],
+    };
+    const frozenBefore = structuredClone(frozen);
+    expect(() => migratePackMount(
+      frozen,
+      coreOnly,
+      "ruby-high.first-bell",
+      coreRuby,
+    )).toThrow(/soft-unmounted packs await remount/);
+    expect(frozen).toEqual(frozenBefore);
+
+    const changedIdentity = structuredClone(coreRuby);
+    changedIdentity.manifest.packs.find((pack) =>
+      pack.id === "cosyworld.core").version = "9.9.9";
+    expect(() => migratePackMount(
+      snapshot,
+      coreOnly,
+      "ruby-high.first-bell",
+      changedIdentity,
+    )).toThrow(/cannot change source pack identity cosyworld.core/);
+    expect(() => migratePackMount(
+      snapshot,
+      coreOnly,
+      "ruby-high.first-bell",
+      official,
+    )).toThrow(/cold mount target adds unrelated pack/);
   });
 
   it("atomically evacuates occupied expansion rooms through composition policy", () => {

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -202,6 +202,7 @@ npm run v2:worldpack:compile
 npm run v2:worldpack
 npm run v2:worldpack:inspect
 npm run v2:content-refs:migrate -- --input legacy.json --output migrated.json
+npm run v2:pack:mount -- --input core.json --output core-ruby.json --event-db events.sqlite --registry v2/content/core-only/registry.json --target-registry v2/content/core-ruby/registry.json --pack ruby-high.first-bell
 npm run v2:pack:unmount -- --operation unmount --input snapshot.json --output unmounted.json --event-db events.sqlite --registry v2/content/core-only/registry.json --target-registry v2/content/services-only/registry.json --pack cosyworld.core
 npm run v2:pack:unmount -- --operation remount --input unmounted.json --output remounted.json --event-db events.sqlite --registry v2/content/services-only/registry.json --target-registry v2/content/core-only/registry.json --pack cosyworld.core
 ```
@@ -287,8 +288,17 @@ The runtime enriches legacy database rows in memory, while the explicit
 rebuilds contexts that are already present. The tool never changes the numeric
 ids themselves and preserves self-contained contexts for unavailable packs.
 
-Unmounting a world pack is an explicit offline migration, never an implicit
-runtime fallback. A composition may declare a schema-version-1
+Mounting or unmounting a world pack is an explicit offline migration, never an
+implicit runtime fallback. A cold mount requires a strictly additive target:
+every existing pack keeps the same version and integrity, and the only new
+packs may be the requested pack, its required dependencies, and composition
+bridges that connect it. It refuses while any soft-unmounted pack is still
+frozen. The transaction changes the bundle, rules binding, canonical context,
+and mount revision atomically; on restart the runtime deterministically seeds
+the newly mounted entities and composition-owned paths without rewriting
+existing live state or identities.
+
+A composition may declare a schema-version-1
 `pack_lifecycle.unmount` policy that moves every non-pack-owned occupant and
 their carried or nested items to one public location owned by a pack that
 remains mounted. Controller type does not change the policy. The

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.168"
+version = "0.0.169"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.168"
+version = "0.0.169"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/migrate-pack-unmount.mjs
+++ b/v2/scripts/migrate-pack-unmount.mjs
@@ -118,6 +118,80 @@ function registryHasPack(registry, packId) {
   return packVersion(registry, packId) !== undefined;
 }
 
+function registryPacks(registry) {
+  return new Map((registry.manifest?.packs ?? []).map((pack) => [pack.id, pack]));
+}
+
+function samePackIdentity(left, right) {
+  return left?.version === right?.version
+    && left?.integrity === right?.integrity;
+}
+
+function requiredMountClosure(targetPacks, packId) {
+  const required = new Set();
+  const pending = [packId];
+  while (pending.length > 0) {
+    const currentId = pending.pop();
+    if (required.has(currentId)) continue;
+    const current = targetPacks.get(currentId);
+    if (!current) {
+      throw new Error(`target registry is missing required pack ${currentId}`);
+    }
+    required.add(currentId);
+    for (const dependency of current.dependency_requirements ?? []) {
+      if (!dependency.optional) pending.push(dependency.id);
+    }
+  }
+  return required;
+}
+
+function additiveMountPlan(sourceRegistry, targetRegistry, packId) {
+  const sourcePacks = registryPacks(sourceRegistry);
+  const targetPacks = registryPacks(targetRegistry);
+  if (sourcePacks.has(packId)) {
+    throw new Error(`source registry already mounts pack ${packId}`);
+  }
+  if (!targetPacks.has(packId)) {
+    throw new Error(`target registry does not mount pack ${packId}`);
+  }
+  for (const [sourcePackId, sourcePack] of sourcePacks) {
+    const targetPack = targetPacks.get(sourcePackId);
+    if (!targetPack) {
+      throw new Error(`cold mount cannot remove source pack ${sourcePackId}`);
+    }
+    if (!samePackIdentity(sourcePack, targetPack)) {
+      throw new Error(
+        `cold mount cannot change source pack identity ${sourcePackId}`,
+      );
+    }
+  }
+
+  const addedPacks = (targetRegistry.manifest?.packs ?? [])
+    .filter((pack) => !sourcePacks.has(pack.id));
+  const required = requiredMountClosure(targetPacks, packId);
+  for (const pack of addedPacks) {
+    const composition = pack.extensions?.["x-cosyworld-composition"];
+    const isRequestedCompositionBridge = composition?.role === "bridge"
+      && (pack.dependency_closure ?? []).includes(packId);
+    if (!required.has(pack.id) && !isRequestedCompositionBridge) {
+      throw new Error(`cold mount target adds unrelated pack ${pack.id}`);
+    }
+  }
+  return addedPacks;
+}
+
+function mountedResourceCounts(targetRegistry, addedPackIds) {
+  const mounted = new Set(addedPackIds);
+  return Object.fromEntries(
+    ["actors", "items", "locations", "exits"].map((resource) => [
+      resource,
+      (targetRegistry.resources?.[resource] ?? [])
+        .filter((row) => mounted.has(row.pack_id))
+        .length,
+    ]),
+  );
+}
+
 function targetRulesets(registry) {
   if (!registry) return [];
   const providers = new Map();
@@ -135,13 +209,13 @@ function targetRulesets(registry) {
   });
 }
 
-function targetContentContext(current, targetRegistry, unmountedPackId) {
+function targetContentContext(current, targetRegistry, removedPackId = null) {
   const targetReferences = new Map((targetRegistry.content_references?.entries ?? [])
     .map((entry) => [entry.canonical_ref, entry]));
   return {
     mapping_version: targetRegistry.content_references?.mapping_version ?? 0,
     references: (current?.references ?? [])
-      .filter((reference) => reference.pack_id !== unmountedPackId)
+      .filter((reference) => reference.pack_id !== removedPackId)
       .filter((reference) => targetReferences.has(reference.canonical_ref))
       .map((reference) => structuredClone(targetReferences.get(reference.canonical_ref))),
     active_rulesets: targetRulesets(targetRegistry),
@@ -667,6 +741,54 @@ export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegis
   return { snapshot: migrated, restored, transaction };
 }
 
+export function migratePackMount(snapshot, sourceRegistry, packId, targetRegistry) {
+  if (!targetRegistry) {
+    throw new Error("cold mount requires a target registry");
+  }
+  if (snapshot.worldpack_bundle_hash !== sourceRegistry.manifest.bundle_hash) {
+    throw new Error(
+      `cannot mount ${packId}: snapshot bundle does not match the source registry`,
+    );
+  }
+  const addedPacks = additiveMountPlan(sourceRegistry, targetRegistry, packId);
+  const migrated = structuredClone(snapshot);
+  const sourceRules = registryRuleBinding(sourceRegistry);
+  const mountState = packMountState(migrated, true);
+  if (mountState.frozen[packId]) {
+    throw new Error(`pack ${packId} has frozen soft-unmount state; use remount`);
+  }
+  const frozenPackIds = Object.keys(mountState.frozen);
+  if (frozenPackIds.length > 0) {
+    throw new Error(
+      `cannot cold-mount while soft-unmounted packs await remount: ${frozenPackIds.join(", ")}`,
+    );
+  }
+
+  migrated.content_context = targetContentContext(
+    migrated.content_context,
+    targetRegistry,
+  );
+  const targetRules = applyRegistryBinding(migrated, targetRegistry);
+  const mountedPackIds = addedPacks.map((pack) => pack.id);
+  const mounted = mountedResourceCounts(targetRegistry, mountedPackIds);
+  const plan = {
+    operation: "cold_mount",
+    pack_id: packId,
+    pack_version: packVersion(targetRegistry, packId),
+    source_bundle_hash: sourceRegistry.manifest.bundle_hash,
+    target_bundle_hash: targetRegistry.manifest.bundle_hash,
+    source_rules: sourceRules,
+    target_rules: targetRules,
+    mounted_pack_ids: mountedPackIds,
+    counts: mounted,
+  };
+  const transaction = appendTransaction(mountState, {
+    ...plan,
+    state_hash: frozenStateHash(plan),
+  });
+  return { snapshot: migrated, mounted, transaction };
+}
+
 function option(args, name) {
   const index = args.indexOf(name);
   return index < 0 ? undefined : args[index + 1];
@@ -745,15 +867,17 @@ if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
     const eventDbPath = option(args, "--event-db");
     const packId = option(args, "--pack");
     if (!input || !output || !registryPath || !targetPath || !packId
-        || !["unmount", "remount"].includes(operation)) {
-      throw new Error("usage: migrate-pack-unmount.mjs --operation unmount|remount --input snapshot.json --output migrated.json --registry source-registry.json --target-registry target-registry.json --pack PACK_ID [--event-db events.sqlite]");
+        || !["mount", "unmount", "remount"].includes(operation)) {
+      throw new Error("usage: migrate-pack-unmount.mjs --operation mount|unmount|remount --input snapshot.json --output migrated.json --registry source-registry.json --target-registry target-registry.json --pack PACK_ID [--event-db events.sqlite]");
     }
     const snapshot = JSON.parse(fs.readFileSync(path.resolve(input), "utf8"));
     const registry = JSON.parse(fs.readFileSync(path.resolve(registryPath), "utf8"));
     const target = JSON.parse(fs.readFileSync(path.resolve(targetPath), "utf8"));
-    const result = operation === "unmount"
-      ? migratePackUnmount(snapshot, registry, packId, target)
-      : migratePackRemount(snapshot, registry, packId, target);
+    const result = operation === "mount"
+      ? migratePackMount(snapshot, registry, packId, target)
+      : operation === "unmount"
+        ? migratePackUnmount(snapshot, registry, packId, target)
+        : migratePackRemount(snapshot, registry, packId, target);
     const checkpoint = writeWithJournalCheckpoint(
       eventDbPath,
       snapshot,
@@ -761,7 +885,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
       result.snapshot,
     );
     console.log(`${operation}ed ${packId}: ${JSON.stringify({
-      counts: result.removed ?? result.restored,
+      counts: result.removed ?? result.restored ?? result.mounted,
       transaction: {
         sequence: result.transaction.sequence,
         status: result.transaction.status,
@@ -769,6 +893,9 @@ if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
       },
       ...(result.evacuated?.length
         ? { evacuated_actor_ids: result.evacuated.map((entry) => entry.actor_id) }
+        : {}),
+      ...(result.transaction.mounted_pack_ids
+        ? { mounted_pack_ids: result.transaction.mounted_pack_ids }
         : {}),
       ...(checkpoint === null ? {} : { action_journal_seq: checkpoint }),
     })}`);

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -5,7 +5,9 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+
+import Database from "better-sqlite3";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const v2Root = resolve(scriptDir, "..");
@@ -13,8 +15,10 @@ const orchestratorDir = resolve(v2Root, "orchestrator-rust");
 const binaryPath = process.env.COSYWORLD_COMPOSITION_SMOKE_BINARY
   ? resolve(process.env.COSYWORLD_COMPOSITION_SMOKE_BINARY)
   : resolve(orchestratorDir, "target/debug/cosyworld-orchestrator");
-const registryPath = resolve(v2Root, "content/core-ruby/registry.json");
+const coreOnlyRegistryPath = resolve(v2Root, "content/core-only/registry.json");
+const coreRubyRegistryPath = resolve(v2Root, "content/core-ruby/registry.json");
 const contentRoot = resolve(v2Root, "content");
+const packMigrationPath = resolve(v2Root, "scripts/migrate-pack-unmount.mjs");
 const walletAddress = "core-ruby-composition-smoke";
 
 function assert(condition, message) {
@@ -89,7 +93,7 @@ function stopServer(proc) {
   });
 }
 
-async function startServer(tempDir) {
+async function startServer(tempDir, registryPath, snapshotPath) {
   const port = await freePort();
   const output = [];
   const env = { ...process.env };
@@ -112,7 +116,7 @@ async function startServer(tempDir) {
     COSYWORLD_DEV_ALLOW_UNSIGNED_WALLET: "1",
     COSYWORLD_DEV_AVATAR_CHAT_DELAY_MS: "0",
     COSYWORLD_CANONICAL_LEASE_TTL_MS: "1000",
-    COSYWORLD_V2_SNAPSHOT_PATH: resolve(tempDir, "snapshot.json"),
+    COSYWORLD_V2_SNAPSHOT_PATH: snapshotPath,
     COSYWORLD_V2_EVENT_DB_PATH: resolve(tempDir, "events.sqlite"),
     COSYWORLD_V2_GENERATED_ASSET_DIR: resolve(tempDir, "generated"),
     COSYWORLD_RUBY_HIGH_WALLET_CARDS: JSON.stringify({
@@ -132,6 +136,21 @@ async function startServer(tempDir) {
   const baseUrl = `http://127.0.0.1:${port}`;
   const meta = await waitForMeta(baseUrl, proc, output);
   return { proc, output, baseUrl, meta };
+}
+
+async function waitForActorJobs(eventDbPath) {
+  const deadline = Date.now() + 12_000;
+  while (Date.now() < deadline) {
+    const database = new Database(eventDbPath, { readonly: true });
+    const active = Number(database
+      .prepare("SELECT COUNT(*) FROM actor_jobs WHERE status IN ('pending', 'running')")
+      .pluck()
+      .get());
+    database.close();
+    if (active === 0) return;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+  }
+  throw new Error("source actor jobs did not become quiescent before cold mount");
 }
 
 function stateUrl(baseUrl, actorId, actorSession) {
@@ -244,13 +263,78 @@ async function main() {
   await access(binaryPath, constants.X_OK).catch(() => {
     throw new Error(`Missing orchestrator binary at ${binaryPath}. Build it before this smoke.`);
   });
-  await access(registryPath, constants.R_OK);
+  await access(coreOnlyRegistryPath, constants.R_OK);
+  await access(coreRubyRegistryPath, constants.R_OK);
   const tempDir = await mkdtemp(resolve(tmpdir(), "cosyworld-core-ruby-"));
+  const snapshotPath = resolve(tempDir, "snapshot.json");
+  const eventDbPath = resolve(tempDir, "events.sqlite");
+  let source = null;
   let first = null;
   let second = null;
 
   try {
-    first = await startServer(tempDir);
+    source = await startServer(tempDir, coreOnlyRegistryPath, snapshotPath);
+    assert(
+      source.meta.worldpack?.id === "cosyworld.core-only",
+      JSON.stringify(source.meta.worldpack),
+    );
+    const created = await postJson(`${source.baseUrl}/avatar`, {
+      name: "Boundary Walker",
+      wallet_address: walletAddress,
+    });
+    assert(created.ok && created.actor?.id && created.actor_session, JSON.stringify(created));
+    const actorId = created.actor.id;
+    const actorSession = created.actor_session;
+    const sourceCottage = await fetchJson(stateUrl(source.baseUrl, actorId, actorSession));
+    assertContext(sourceCottage, {
+      location: "The Cosy Cottage",
+      locationPack: "cosyworld.core",
+      selectedBy: "cosyworld.core",
+      capability: "cosyworld.core/rules",
+      offerVerb: "Notice",
+      sourceCard: "cosy-cottage",
+    });
+    assert(
+      sourceCottage.action_offers?.every((offer) =>
+        offer.composition_trace?.worldpack_bundle_hash
+          === source.meta.worldpack.bundle_hash
+          && offer.composition_trace?.pack_mount_revision === 0),
+      "source offers did not bind the pre-mount composition",
+    );
+    await waitForActorJobs(eventDbPath);
+    await stopServer(source.proc);
+    source = null;
+
+    const mounted = spawnSync(process.execPath, [
+      packMigrationPath,
+      "--operation",
+      "mount",
+      "--input",
+      snapshotPath,
+      "--output",
+      snapshotPath,
+      "--event-db",
+      eventDbPath,
+      "--registry",
+      coreOnlyRegistryPath,
+      "--target-registry",
+      coreRubyRegistryPath,
+      "--pack",
+      "ruby-high.first-bell",
+    ], { cwd: resolve(v2Root, ".."), encoding: "utf8" });
+    assert(mounted.status === 0, mounted.stderr || mounted.stdout);
+    assert(
+      mounted.stdout.includes(
+        '"mounted_pack_ids":["ruby-high.first-bell","cosyworld.composition.core-ruby"]',
+      ),
+      `cold mount transaction was not observable: ${mounted.stdout}`,
+    );
+
+    first = await startServer(tempDir, coreRubyRegistryPath, snapshotPath);
+    assert(
+      first.output.some((line) => line.includes("loaded journal checkpoint")),
+      `cold mount restart did not use the journal checkpoint: ${first.output.slice(-40).join("")}`,
+    );
     assert(first.meta.worldpack?.id === "cosyworld.core-ruby", JSON.stringify(first.meta.worldpack));
     assert(
       first.meta.worldpack?.packs?.map((pack) => pack.id).join(",")
@@ -264,14 +348,6 @@ async function main() {
       `wrong mounted packs: ${JSON.stringify(first.meta.worldpack?.packs)}`,
     );
 
-    const created = await postJson(`${first.baseUrl}/avatar`, {
-      name: "Boundary Walker",
-      wallet_address: walletAddress,
-    });
-    assert(created.ok && created.actor?.id && created.actor_session, JSON.stringify(created));
-    const actorId = created.actor.id;
-    const actorSession = created.actor_session;
-
     const cottage = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
     assertContext(cottage, {
       location: "The Cosy Cottage",
@@ -281,6 +357,13 @@ async function main() {
       offerVerb: "Notice",
       sourceCard: "cosy-cottage",
     });
+    assert(
+      cottage.action_offers?.every((offer) =>
+        offer.composition_trace?.worldpack_bundle_hash
+          === first.meta.worldpack.bundle_hash
+          && offer.composition_trace?.pack_mount_revision === 1),
+      "cold-mounted offers did not bind the committed composition revision",
+    );
     await command(first.baseUrl, actorId, actorSession, "say core side");
     const discovered = await discoverExit(first.baseUrl, actorId, actorSession, 11);
     const travelOffer = discovered.action_offers?.find((offer) =>
@@ -363,7 +446,7 @@ async function main() {
 
     await stopServer(first.proc);
     first = null;
-    second = await startServer(tempDir);
+    second = await startServer(tempDir, coreRubyRegistryPath, snapshotPath);
     assert(
       second.output.some((line) => line.includes("loaded journal checkpoint")),
       `restart did not use the journal checkpoint: ${second.output.slice(-40).join("")}`,
@@ -425,6 +508,7 @@ async function main() {
       ],
     }, null, 2));
   } finally {
+    if (source) await stopServer(source.proc);
     if (first) await stopServer(first.proc);
     if (second) await stopServer(second.proc);
     await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Part of #28.

- Adds a strictly additive offline cold-mount transaction with exact pack identity and composition-bridge validation.
- Switches bundle, rules context, content context, and mount revision atomically while preserving existing live state.
- Refuses frozen, unrelated, destructive, or identity-changing targets.
- Proves Core-only → Core+Ruby migration, journal checkpoint restart, avatar continuity, target seeding, and bridge traversal.

Checks: `npm run check`; `npm run v2:smoke`; cold-mount composition smoke passed inside `npm run v2:check` (the first full run later hit the known Coach-combat timing check, which passed unchanged on isolated rerun).