### PR TITLE
Mirror the latest Journal event in the room header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.172",
+  "version": "0.0.173",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.172",
+      "version": "0.0.173",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.172",
+  "version": "0.0.173",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.172"
+version = "0.0.173"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.172"
+version = "0.0.173"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -7525,9 +7525,14 @@
       const toggle = $("room-log-toggle");
       const panel = $("room-memory");
       const memory = roomMemoryModel();
-      const latestText = memory.hasLatestEvent
-        ? atmosphericMemoryBeat(memory.latest) || memory.latest.text
-        : "";
+      const latestJournalEvent = narratedTranscriptEvents(
+        logEvents.filter(eventIsJournalEvent),
+      ).at(-1);
+      const latestText = latestJournalEvent
+        ? journalEventSummary(latestJournalEvent)
+        : memory.hasLatestEvent
+          ? atmosphericMemoryBeat(memory.latest) || memory.latest.text
+          : "";
       toggle.hidden = false;
       renderRoomLogLatest(latestText);
       panel.hidden = false;
@@ -7648,13 +7653,24 @@
       return Boolean(meta?.text || sceneCardEventText(event));
     }
 
+    function journalEventSummary(event) {
+      if (event.type === "message.created") {
+        return journalSummary(`${event.actor_name || "CosyWorld"} — ${eventText(event)}`);
+      }
+      if (isRollEvent(event)) {
+        const roll = rollMeta(event);
+        return journalSummary(`${roll.title} · ${roll.result}`);
+      }
+      const meta = statusUpdateMeta(event);
+      return journalSummary(meta?.text || sceneCardEventText(event));
+    }
+
     function journalEventHtml(event) {
       if (event.type === "message.created") {
-        const speaker = event.actor_name || "CosyWorld";
         const text = eventText(event);
         return journalRowHtml({
           label: "chat",
-          summary: `${speaker} — ${text}`,
+          summary: journalEventSummary(event),
           detail: text,
           kind: event.actor_id === actorId ? "you" : "chat",
         });
@@ -7663,13 +7679,13 @@
         const roll = rollMeta(event);
         return journalRowHtml({
           label: roll.label || "roll",
-          summary: `${roll.title} · ${roll.result}`,
+          summary: journalEventSummary(event),
           detail: roll.story || [roll.detail, roll.result].filter(Boolean).join("; "),
           kind: event.success ? "success" : "failure",
         });
       }
       const meta = statusUpdateMeta(event);
-      const summary = meta?.text || sceneCardEventText(event);
+      const summary = journalEventSummary(event);
       if (!summary) return "";
       const exposureId = worldBeatExposureId(event);
       const attrs = exposureId

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4794,6 +4794,8 @@ async function main() {
           journalHidden: document.querySelector("#journal-view")?.hidden === true,
           journalRows: [...document.querySelectorAll("#journal-log .journal-row")]
             .map((node) => node.textContent.trim().replace(/\s+/g, " ")),
+          latestJournalRow: [...document.querySelectorAll("#journal-log .journal-row-summary")]
+            .at(-1)?.textContent?.trim().replace(/\s+/g, " ") || "",
           journalSummariesOneLine: [...document.querySelectorAll("#journal-log .journal-row > summary")]
             .every((node) => {
               const style = getComputedStyle(node.querySelector(".journal-row-summary"));
@@ -4912,7 +4914,11 @@ async function main() {
         && result.journalRows.some((row) => /Homeroom|search/i.test(row)),
       `system and discovery history should remain available as compact rows in the closed Journal: ${JSON.stringify(result)}`,
     );
-    assert(/A path to Homeroom opened/i.test(result.roomLatest), `the room headline should follow the card's discovery instead of stale bookkeeping: ${JSON.stringify(result)}`);
+    assert(
+      result.roomLatest === result.latestJournalRow
+        && result.roomLatest === "Thimble Guest — Anyone want to follow the newly opened path?",
+      `the room ticker should mirror the newest Journal row: ${JSON.stringify(result)}`,
+    );
     assert(result.preferredPlayerBeat === "Thimble Guest listened; the room answered", `the collapsed log should keep the player's card beat above derived memories and resident ripples: ${JSON.stringify(result)}`);
     assert(result.preferredReportBeat === "Report submitted for Gust.", `direct safety confirmations should still become the collapsed room headline: ${JSON.stringify(result)}`);
     assert(!result.log.includes("Summit Trail") && !result.log.includes("Lorecraft"), `movement and growth events should stay in the room Log: ${JSON.stringify(result)}`);
@@ -7269,6 +7275,8 @@ async function main() {
       };
       return {
         latest: document.querySelector("#room-log-latest")?.textContent?.trim() || "",
+        latestJournalRow: [...document.querySelectorAll("#journal-log .journal-row-summary")]
+          .at(-1)?.textContent?.trim() || "",
         latestVisible: visible(document.querySelector("#room-log-latest")),
         latestHasTrack: Boolean(document.querySelector("#room-log-latest > #room-log-latest-track")),
         latestAriaLive: document.querySelector("#room-log-latest")?.getAttribute("aria-live") || "",
@@ -7293,7 +7301,10 @@ async function main() {
         }),
       };
     });
-    assert(room.latest.length > 8, `${label}: Journal should retain the latest room context: ${JSON.stringify(room)}`);
+    assert(
+      room.latest.length > 8 && room.latest === room.latestJournalRow,
+      `${label}: the ticker should mirror the newest actual Journal row: ${JSON.stringify(room)}`,
+    );
     assert(
       room.latestVisible && room.latestHasTrack && room.latestInsideToggle && !room.latestAriaLive,
       `${label}: the latest event should stay inside the single quiet Journal control without another live region: ${JSON.stringify(room)}`,


### PR DESCRIPTION
## Summary

- Drive the quiet room-header ticker from the newest actual Journal row instead of the room-memory projection.
- Reuse the same one-line summary for chat, rolls, and world events, with room memory only as an empty-journal fallback.
- Bump the runtime to `0.0.173`.

Closes #268.

## Validation

- `npm run lint`
- `npm run check:local`
- `npm run v2:smoke`
- `npm run v2:rust:build`
- pre-push `npm run check`

All passed locally: 445 JavaScript tests, 501 Rust tests, and mobile/desktop browser smokes.

## Review checklist

- [x] Ticker text equals the newest rendered Journal summary.
- [x] Long text scrolls and pauses on hover/focus.
- [x] Reduced motion uses a static ellipsis.
- [x] Empty rooms add no ticker chrome.