### PR TITLE
Define the focused encounter contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.176",
+  "version": "0.0.177",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.176",
+      "version": "0.0.177",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.176",
+  "version": "0.0.177",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.176"
+version = "0.0.177"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.176"
+version = "0.0.177"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1922,6 +1922,8 @@ struct JournalRecord {
     source_location_id: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     resident_decision: Option<ResidentDecisionTrace>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    focused_encounter: Option<FocusedEncounterJournalContext>,
     action: CwAction,
     seed: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1972,8 +1974,9 @@ impl JournalRecord {
                 )
             })
             .unwrap_or_default();
+        let focused_encounter = focused_encounter_context_for_action(&action);
         Self {
-            version: 7,
+            version: FOCUSED_ENCOUNTER_JOURNAL_VERSION,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry()
                 .content_reference_context(action_content_handles(&action)),
@@ -1990,6 +1993,7 @@ impl JournalRecord {
             observed_through_seq: None,
             source_location_id: None,
             resident_decision: None,
+            focused_encounter,
             action,
             seed,
             ripple_source: None,
@@ -9999,6 +10003,9 @@ impl RuntimeWorld {
     }
 
     fn apply_journal_record(&mut self, record: &JournalRecord) -> (u32, Vec<EventView>) {
+        if !focused_encounter_journal_context_is_supported(record) {
+            return (CW_ERR_RULE, Vec::new());
+        }
         self.expire_transfer_offers();
         for (actor_id, meta) in &record.actor_meta_upserts {
             self.actors.insert(*actor_id, meta.clone());
@@ -30567,22 +30574,6 @@ fn commit_resident_reply_record(
     (status == CW_OK).then_some(events)
 }
 
-fn advance_turn_and_capture_player_tick_observation(
-    state: &AppState,
-    runtime: &mut RuntimeWorld,
-    location_id: Option<u64>,
-    actor_id: u64,
-    status: u32,
-    events: &mut Vec<EventView>,
-) -> Option<PlayerTickObservation> {
-    advance_actor_room_turn_after_commit(state, runtime, location_id, actor_id, status, events);
-    let observation = player_tick_observation(runtime, location_id, actor_id, status, events);
-    if status == CW_OK {
-        append_action_receipt(state, runtime, actor_id, events);
-    }
-    observation
-}
-
 fn append_action_receipt(
     state: &AppState,
     runtime: &RuntimeWorld,
@@ -50249,7 +50240,7 @@ mod tests {
         assert!(action_journal_has_records(&path).expect("has records"));
         let records = read_action_journal(&path).expect("read records");
         assert_eq!(records.len(), 2);
-        assert_eq!(records[0].version, 7);
+        assert_eq!(records[0].version, 8);
         assert_eq!(records[0].content_context.mapping_version, 1);
         let location_reference = records[0]
             .content_context

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::{ConnectInfo, State},
     Json,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::net::SocketAddr;
 
@@ -10,6 +10,234 @@ use super::*;
 
 pub(super) const ORDERED_SCENE_BASE_GRACE_MS: u64 = 45_000;
 pub(super) const ORDERED_SCENE_NEED_TIME_MS: u64 = 60_000;
+pub(super) const FOCUSED_ENCOUNTER_PROTOCOL: &str = "cosyworld.focused-encounter/1";
+pub(super) const FOCUSED_COMBAT_PROFILE_ID: &str = "cosyworld.focused.combat";
+pub(super) const FOCUSED_COMBAT_PROFILE_VERSION: u16 = 1;
+pub(super) const FOCUSED_ENCOUNTER_JOURNAL_VERSION: u32 = 8;
+const FOCUSED_ENCOUNTER_SCHEMA_VERSION: u8 = 1;
+const FOCUSED_ENCOUNTER_MIN_PARTICIPANTS: usize = 2;
+const FOCUSED_ENCOUNTER_MAX_PARTICIPANTS: usize = 6;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum FocusedActivationStep {
+    Control,
+    Setup,
+    Commit,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct FocusedEncounterJournalContext {
+    pub(super) protocol: String,
+    pub(super) encounter_id: u64,
+    pub(super) profile_id: String,
+    pub(super) profile_version: u16,
+    pub(super) activation_step: FocusedActivationStep,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct FocusedActivationBudget {
+    pub(super) setup_limit: u8,
+    pub(super) setup_remaining: u8,
+    pub(super) commit_remaining: u8,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub(super) struct FocusedActivationEffect {
+    pub(super) advances_world: bool,
+    pub(super) activation_complete: bool,
+}
+
+impl FocusedActivationBudget {
+    fn new(setup_available: bool) -> Self {
+        Self {
+            setup_limit: u8::from(setup_available),
+            setup_remaining: u8::from(setup_available),
+            commit_remaining: 1,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn consume(
+        &mut self,
+        step: FocusedActivationStep,
+    ) -> Result<FocusedActivationEffect, &'static str> {
+        match step {
+            FocusedActivationStep::Control => Ok(FocusedActivationEffect {
+                advances_world: false,
+                activation_complete: false,
+            }),
+            FocusedActivationStep::Setup if self.setup_remaining > 0 => {
+                self.setup_remaining = 0;
+                Ok(FocusedActivationEffect {
+                    advances_world: false,
+                    activation_complete: false,
+                })
+            }
+            FocusedActivationStep::Commit if self.commit_remaining > 0 => {
+                self.commit_remaining = 0;
+                self.setup_remaining = 0;
+                Ok(FocusedActivationEffect {
+                    advances_world: true,
+                    activation_complete: true,
+                })
+            }
+            FocusedActivationStep::Setup => Err("focused encounter setup already used"),
+            FocusedActivationStep::Commit => Err("focused encounter commit already used"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct FocusedEncounterNode {
+    pub(super) id: String,
+    pub(super) kind: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct FocusedEncounterRelation {
+    pub(super) from: String,
+    pub(super) kind: String,
+    pub(super) to: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct FocusedEncounterCondition {
+    pub(super) id: String,
+    pub(super) source: String,
+    pub(super) trigger: String,
+    pub(super) expiry: String,
+    pub(super) consumed: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct FocusedEncounterView {
+    pub(super) schema_version: u8,
+    pub(super) protocol: &'static str,
+    pub(super) encounter_id: u64,
+    pub(super) profile_id: String,
+    pub(super) profile_version: u16,
+    pub(super) location_id: u64,
+    pub(super) phase: String,
+    pub(super) concurrency_policy: &'static str,
+    pub(super) participant_order: Vec<u64>,
+    pub(super) current_actor_id: u64,
+    pub(super) round: u64,
+    pub(super) activation_budget: FocusedActivationBudget,
+    pub(super) objective_clock_id: String,
+    pub(super) danger_clock_id: Option<String>,
+    pub(super) pressure_trigger: String,
+    pub(super) local_nodes: Vec<FocusedEncounterNode>,
+    pub(super) relations: Vec<FocusedEncounterRelation>,
+    pub(super) conditions: Vec<FocusedEncounterCondition>,
+    pub(super) completion_predicate: String,
+    pub(super) stop_predicate: String,
+    pub(super) retreat_predicate: String,
+    pub(super) worldpack_bundle_hash: String,
+    pub(super) rules_profile: String,
+}
+
+impl FocusedEncounterView {
+    fn validate(&self) -> Result<(), &'static str> {
+        if self.schema_version != FOCUSED_ENCOUNTER_SCHEMA_VERSION
+            || self.protocol != FOCUSED_ENCOUNTER_PROTOCOL
+            || self.encounter_id == 0
+            || self.profile_id.trim().is_empty()
+            || self.profile_version == 0
+            || self.location_id == 0
+            || self.phase.trim().is_empty()
+            || self.concurrency_policy != ConcurrencyPolicy::SceneTurn.as_str()
+            || self.objective_clock_id.trim().is_empty()
+            || self.worldpack_bundle_hash.trim().is_empty()
+            || self.rules_profile.trim().is_empty()
+        {
+            return Err("focused encounter contract is incomplete");
+        }
+        let max_participants = if self.profile_id == FOCUSED_COMBAT_PROFILE_ID {
+            CW_MAX_COMBAT_PARTICIPANTS
+        } else {
+            FOCUSED_ENCOUNTER_MAX_PARTICIPANTS
+        };
+        if !(FOCUSED_ENCOUNTER_MIN_PARTICIPANTS..=max_participants)
+            .contains(&self.participant_order.len())
+            || self.participant_order.contains(&0)
+            || self
+                .participant_order
+                .iter()
+                .copied()
+                .collect::<BTreeSet<_>>()
+                .len()
+                != self.participant_order.len()
+            || !self.participant_order.contains(&self.current_actor_id)
+        {
+            return Err("focused encounter participant order is invalid");
+        }
+        Ok(())
+    }
+
+    fn waiting_actor_ids(&self) -> Vec<u64> {
+        self.participant_order
+            .iter()
+            .copied()
+            .filter(|actor_id| *actor_id != self.current_actor_id)
+            .collect()
+    }
+
+    #[allow(dead_code)]
+    fn pass(&mut self, actor_id: u64) -> Result<(), &'static str> {
+        if actor_id != self.current_actor_id {
+            return Err("only the current participant can pass");
+        }
+        let current_index = self
+            .participant_order
+            .iter()
+            .position(|participant_id| *participant_id == actor_id)
+            .ok_or("focused encounter current participant is missing")?;
+        let next_index = (current_index + 1) % self.participant_order.len();
+        if next_index == 0 {
+            self.round = self.round.saturating_add(1);
+        }
+        self.current_actor_id = self.participant_order[next_index];
+        self.activation_budget =
+            FocusedActivationBudget::new(self.activation_budget.setup_limit > 0);
+        Ok(())
+    }
+}
+
+pub(super) fn focused_encounter_context_for_action(
+    action: &CwAction,
+) -> Option<FocusedEncounterJournalContext> {
+    let activation_step = match action.kind {
+        CW_ACTION_COMBAT_NEED_TIME => FocusedActivationStep::Control,
+        CW_ACTION_COMBAT_START
+        | CW_ACTION_COMBAT_JOIN
+        | CW_ACTION_COMBAT_ATTACK
+        | CW_ACTION_COMBAT_FINESSE_ATTACK
+        | CW_ACTION_COMBAT_DODGE
+        | CW_ACTION_COMBAT_ESCAPE
+        | CW_ACTION_COMBAT_PASS => FocusedActivationStep::Commit,
+        _ => return None,
+    };
+    (action.content_id != 0).then(|| FocusedEncounterJournalContext {
+        protocol: FOCUSED_ENCOUNTER_PROTOCOL.to_string(),
+        encounter_id: action.content_id,
+        profile_id: FOCUSED_COMBAT_PROFILE_ID.to_string(),
+        profile_version: FOCUSED_COMBAT_PROFILE_VERSION,
+        activation_step,
+    })
+}
+
+pub(super) fn focused_encounter_journal_context_is_supported(record: &JournalRecord) -> bool {
+    let Some(expected) = focused_encounter_context_for_action(&record.action) else {
+        return record.focused_encounter.is_none();
+    };
+    let Some(context) = record.focused_encounter.as_ref() else {
+        // Historical combat rows predate this envelope and retain combat/1 semantics.
+        return record.version < FOCUSED_ENCOUNTER_JOURNAL_VERSION;
+    };
+    context == &expected
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ConcurrencyPolicy {
@@ -36,6 +264,8 @@ pub(super) struct RoomTurnView {
     pub enabled: bool,
     pub policy: &'static str,
     pub scene_kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub focused: Option<FocusedEncounterView>,
     pub explanation: Option<String>,
     pub room_id: u64,
     pub current_actor_id: Option<u64>,
@@ -65,6 +295,7 @@ impl RoomTurnView {
             enabled: false,
             policy: ConcurrencyPolicy::Concurrent.as_str(),
             scene_kind: None,
+            focused: None,
             explanation: None,
             room_id,
             current_actor_id: None,
@@ -164,22 +395,64 @@ pub(super) fn combat_need_time_used(
     })
 }
 
+fn focused_combat_encounter(runtime: &RuntimeWorld, actor_id: u64) -> Option<FocusedEncounterView> {
+    let encounter = runtime.active_combat_encounter_for_actor(actor_id)?;
+    let job_id = runtime.combat_job_id_for_encounter(encounter.id)?;
+    let job = runtime.jobs.get(&job_id)?;
+    let current_actor_id = runtime.combat_current_actor_id(encounter.id)?;
+    let participant_order = encounter.participants[..encounter.participant_count]
+        .iter()
+        .filter(|participant| participant.flags & CW_COMBAT_PARTICIPANT_ESCAPED == 0)
+        .map(|participant| participant.actor_id)
+        .collect::<Vec<_>>();
+    let rules_profile = runtime
+        .scene_rules_context(
+            encounter.location_id,
+            runtime.world.next_event_seq.saturating_sub(1),
+        )
+        .map(|context| context.rules_profile)
+        .unwrap_or_else(|| active_content().manifest.rules_profile.clone());
+    let focused = FocusedEncounterView {
+        schema_version: FOCUSED_ENCOUNTER_SCHEMA_VERSION,
+        protocol: FOCUSED_ENCOUNTER_PROTOCOL,
+        encounter_id: encounter.id,
+        profile_id: FOCUSED_COMBAT_PROFILE_ID.to_string(),
+        profile_version: FOCUSED_COMBAT_PROFILE_VERSION,
+        location_id: encounter.location_id,
+        phase: "conflict".to_string(),
+        concurrency_policy: ConcurrencyPolicy::SceneTurn.as_str(),
+        participant_order,
+        current_actor_id,
+        round: u64::from(encounter.round),
+        activation_budget: FocusedActivationBudget::new(false),
+        objective_clock_id: job.progress_clock_id.clone(),
+        danger_clock_id: (!job.danger_clock_id.trim().is_empty())
+            .then(|| job.danger_clock_id.clone()),
+        pressure_trigger: "activation_end".to_string(),
+        local_nodes: Vec::new(),
+        relations: Vec::new(),
+        conditions: Vec::new(),
+        completion_predicate: "objective_clock_completed".to_string(),
+        stop_predicate: "hostility_resolved".to_string(),
+        retreat_predicate: "participant_escaped".to_string(),
+        worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
+        rules_profile,
+    };
+    focused.validate().ok()?;
+    Some(focused)
+}
+
 pub(super) fn combat_turn_view(
     runtime: &RuntimeWorld,
     actor_id: u64,
     room_id: u64,
 ) -> Option<RoomTurnView> {
-    let encounter = runtime.active_combat_encounter_for_actor(actor_id)?;
-    let current_actor_id = runtime.combat_current_actor_id(encounter.id)?;
+    let focused = focused_combat_encounter(runtime, actor_id)?;
+    let current_actor_id = focused.current_actor_id;
     let current_actor_name = runtime.actor_name(current_actor_id);
     let is_current_actor = current_actor_id == actor_id;
-    let need_time_used = combat_need_time_used(runtime, encounter.id, current_actor_id);
-    let waiting_actor_ids = encounter.participants[..encounter.participant_count]
-        .iter()
-        .filter(|participant| participant.flags & CW_COMBAT_PARTICIPANT_ESCAPED == 0)
-        .map(|participant| participant.actor_id)
-        .filter(|participant_id| *participant_id != current_actor_id)
-        .collect::<Vec<_>>();
+    let need_time_used = combat_need_time_used(runtime, focused.encounter_id, current_actor_id);
+    let waiting_actor_ids = focused.waiting_actor_ids();
     let explanation = Some(format!(
         "Combat is an ordered scene. {} acts now; chat and inspection stay available.",
         current_actor_name
@@ -190,6 +463,7 @@ pub(super) fn combat_turn_view(
         enabled: true,
         policy: ConcurrencyPolicy::SceneTurn.as_str(),
         scene_kind: Some("combat"),
+        focused: Some(focused.clone()),
         explanation,
         room_id,
         current_actor_id: Some(current_actor_id),
@@ -205,7 +479,7 @@ pub(super) fn combat_turn_view(
         need_time_extension_ms: ORDERED_SCENE_NEED_TIME_MS,
         handoff_key: Some(format!(
             "combat:{}:{}:{}",
-            encounter.id, encounter.round, current_actor_id
+            focused.encounter_id, focused.round, current_actor_id
         )),
         can_request_timeout: false,
         timeout_requests: Vec::new(),
@@ -215,7 +489,7 @@ pub(super) fn combat_turn_view(
         ping_expires_at_ms: None,
         ping_responder_ids: Vec::new(),
         ping_target_actor_id: None,
-        round: u64::from(encounter.round),
+        round: focused.round,
     })
 }
 
@@ -391,6 +665,22 @@ pub(super) fn advance_actor_room_turn_after_commit(
     }
 }
 
+pub(super) fn advance_turn_and_capture_player_tick_observation(
+    state: &AppState,
+    runtime: &mut RuntimeWorld,
+    location_id: Option<u64>,
+    actor_id: u64,
+    status: u32,
+    events: &mut Vec<EventView>,
+) -> Option<PlayerTickObservation> {
+    advance_actor_room_turn_after_commit(state, runtime, location_id, actor_id, status, events);
+    let observation = player_tick_observation(runtime, location_id, actor_id, status, events);
+    if status == CW_OK {
+        append_action_receipt(state, runtime, actor_id, events);
+    }
+    observation
+}
+
 pub(super) async fn request_turn_timeout(
     ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
@@ -486,6 +776,14 @@ mod tests {
         let view = RoomTurnView::idle(1);
         assert!(!view.enabled);
         assert_eq!(view.policy, "concurrent");
+        assert!(view.focused.is_none());
+        assert!(
+            serde_json::to_value(&view)
+                .expect("idle turn serializes")
+                .get("focused")
+                .is_none(),
+            "ordinary rooms omit the focused encounter envelope"
+        );
         assert!(!view.ping_active);
         assert_eq!(view.grace_period_ms, 0);
     }
@@ -499,5 +797,178 @@ mod tests {
                 enabled: true,
             }
         ));
+    }
+
+    #[test]
+    fn combat_projects_the_versioned_focused_encounter_contract() {
+        let mut runtime = RuntimeWorld::seeded();
+        let create = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_CREATE_ACTOR,
+                actor_id: 5000,
+                location_id: MOONLIT_TRAIL_LOCATION_ID,
+                ..CwAction::default()
+            },
+            81_000,
+        );
+        assert_eq!(runtime.apply_journal_record(&create).0, CW_OK);
+
+        let encounter_id = combat_encounter_id(MOONLIT_JOB_ID);
+        let start = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_COMBAT_START,
+                actor_id: 5000,
+                target_actor_id: MOONLIT_ECHO_ACTOR_ID,
+                content_id: encounter_id,
+                ..CwAction::default()
+            },
+            81_001,
+        )
+        .into_system();
+        assert_eq!(runtime.apply_journal_record(&start).0, CW_OK);
+
+        let focused =
+            focused_combat_encounter(&runtime, 5000).expect("combat projects focused state");
+        assert_eq!(focused.protocol, FOCUSED_ENCOUNTER_PROTOCOL);
+        assert_eq!(focused.profile_id, FOCUSED_COMBAT_PROFILE_ID);
+        assert_eq!(focused.profile_version, FOCUSED_COMBAT_PROFILE_VERSION);
+        assert_eq!(focused.objective_clock_id, MOONLIT_PROGRESS_CLOCK_ID);
+        assert_eq!(
+            focused.danger_clock_id.as_deref(),
+            Some(MOONLIT_DANGER_CLOCK_ID)
+        );
+        assert_eq!(focused.activation_budget.setup_limit, 0);
+        assert_eq!(focused.activation_budget.setup_remaining, 0);
+        assert_eq!(focused.activation_budget.commit_remaining, 1);
+        assert_eq!(focused.pressure_trigger, "activation_end");
+        assert!(focused.validate().is_ok());
+
+        let turn = combat_turn_view(&runtime, 5000, MOONLIT_TRAIL_LOCATION_ID)
+            .expect("combat turn uses focused projection");
+        assert_eq!(turn.focused, Some(focused));
+        assert_eq!(
+            serde_json::to_value(&turn).expect("focused turn serializes")["focused"]["protocol"],
+            FOCUSED_ENCOUNTER_PROTOCOL
+        );
+    }
+
+    #[test]
+    fn combat_and_work_share_one_scheduler_and_activation_budget() {
+        let mut combat = FocusedEncounterView {
+            schema_version: FOCUSED_ENCOUNTER_SCHEMA_VERSION,
+            protocol: FOCUSED_ENCOUNTER_PROTOCOL,
+            encounter_id: 90_001,
+            profile_id: FOCUSED_COMBAT_PROFILE_ID.to_string(),
+            profile_version: FOCUSED_COMBAT_PROFILE_VERSION,
+            location_id: 3,
+            phase: "conflict".to_string(),
+            concurrency_policy: ConcurrencyPolicy::SceneTurn.as_str(),
+            participant_order: vec![5000, 5001],
+            current_actor_id: 5000,
+            round: 1,
+            activation_budget: FocusedActivationBudget::new(false),
+            objective_clock_id: "coach-practice.objective".to_string(),
+            danger_clock_id: Some("coach-practice.danger".to_string()),
+            pressure_trigger: "activation_end".to_string(),
+            local_nodes: Vec::new(),
+            relations: Vec::new(),
+            conditions: Vec::new(),
+            completion_predicate: "objective_clock_completed".to_string(),
+            stop_predicate: "yield".to_string(),
+            retreat_predicate: "leave_practice".to_string(),
+            worldpack_bundle_hash: "sha256:test".to_string(),
+            rules_profile: "cosyworld.srd5/1".to_string(),
+        };
+        let mut work = FocusedEncounterView {
+            encounter_id: 90_002,
+            profile_id: "cosyworld.focused.work".to_string(),
+            phase: "repair".to_string(),
+            activation_budget: FocusedActivationBudget::new(true),
+            objective_clock_id: "bridge-repair.progress".to_string(),
+            danger_clock_id: Some("bridge-repair.delay".to_string()),
+            stop_predicate: "work_withdrawn".to_string(),
+            retreat_predicate: "materials_recovered".to_string(),
+            ..combat.clone()
+        };
+        assert!(combat.validate().is_ok());
+        assert!(work.validate().is_ok());
+
+        let setup = work
+            .activation_budget
+            .consume(FocusedActivationStep::Setup)
+            .expect("work setup");
+        assert!(!setup.advances_world);
+        assert!(!setup.activation_complete);
+        let commit = work
+            .activation_budget
+            .consume(FocusedActivationStep::Commit)
+            .expect("work commit");
+        assert!(commit.advances_world);
+        assert!(commit.activation_complete);
+        assert!(work
+            .activation_budget
+            .consume(FocusedActivationStep::Commit)
+            .is_err());
+
+        combat.pass(5000).expect("combat pass");
+        work.pass(5000).expect("work pass");
+        assert_eq!(combat.current_actor_id, 5001);
+        assert_eq!(work.current_actor_id, 5001);
+        assert_eq!(combat.round, work.round);
+        assert_eq!(combat.activation_budget.setup_remaining, 0);
+        assert_eq!(work.activation_budget.setup_remaining, 1);
+        assert_eq!(combat.activation_budget.commit_remaining, 1);
+        assert_eq!(work.activation_budget.commit_remaining, 1);
+    }
+
+    #[test]
+    fn focused_journal_context_defaults_historical_combat_and_fails_closed() {
+        let action = CwAction {
+            kind: CW_ACTION_COMBAT_ATTACK,
+            actor_id: 5000,
+            target_actor_id: 1004,
+            content_id: 90_003,
+            ..CwAction::default()
+        };
+        let record = JournalRecord::new(action, 81_002);
+        let context = record
+            .focused_encounter
+            .as_ref()
+            .expect("new combat row carries focused context");
+        assert_eq!(context.protocol, FOCUSED_ENCOUNTER_PROTOCOL);
+        assert_eq!(context.profile_id, FOCUSED_COMBAT_PROFILE_ID);
+        assert_eq!(context.profile_version, FOCUSED_COMBAT_PROFILE_VERSION);
+        assert_eq!(context.activation_step, FocusedActivationStep::Commit);
+        assert!(focused_encounter_journal_context_is_supported(&record));
+
+        let mut historical_json = serde_json::to_value(&record).expect("journal row serializes");
+        historical_json["version"] = serde_json::json!(7);
+        historical_json
+            .as_object_mut()
+            .expect("journal row object")
+            .remove("focused_encounter");
+        let historical: JournalRecord =
+            serde_json::from_value(historical_json).expect("historical combat row defaults");
+        assert!(focused_encounter_journal_context_is_supported(&historical));
+
+        let mut missing_context = historical;
+        missing_context.version = FOCUSED_ENCOUNTER_JOURNAL_VERSION;
+        assert!(!focused_encounter_journal_context_is_supported(
+            &missing_context
+        ));
+
+        let mut incompatible = record;
+        incompatible
+            .focused_encounter
+            .as_mut()
+            .expect("focused context")
+            .profile_version += 1;
+        let mut runtime = RuntimeWorld::seeded();
+        let before = RuntimeSnapshot::from_runtime(&runtime);
+        assert_eq!(runtime.apply_journal_record(&incompatible).0, CW_ERR_RULE);
+        assert_eq!(
+            serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime)).unwrap(),
+            serde_json::to_value(before).unwrap()
+        );
     }
 }

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74995
+74986


### PR DESCRIPTION
## Summary
- project existing ordered combat through a versioned, domain-neutral Focused Encounter envelope
- journal exact profile, version, and activation context while preserving pre-v8 combat replay and failing closed on new mismatches
- prove combat and cooperative work share one scheduler and Setup → Commit budget while ordinary chat rooms omit the envelope

## Validation
- `npm test` — 448 passed
- `cargo test --manifest-path v2/orchestrator-rust/Cargo.toml` — 510 passed
- `npm run check`
- `npm run v2:check`
- `npm run check:version`

Advances #274

## Checklist
- [x] version bumped to 0.0.177
- [x] ordinary room/chat UI unchanged
- [x] browser and living-world smoke green