### PR TITLE
Certify focused encounter turns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.177",
+  "version": "0.0.178",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.177",
+      "version": "0.0.178",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.177",
+  "version": "0.0.178",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.177"
+version = "0.0.178"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.177"
+version = "0.0.178"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -497,6 +497,124 @@ fn drive_combat_inference_turns(
     Ok(CW_OK)
 }
 
+fn drive_available_combat_turns(
+    state: &AppState,
+    runtime: &mut RuntimeWorld,
+    encounter_id: u64,
+    requesting_actor_id: u64,
+    events: &mut Vec<EventView>,
+) -> io::Result<u32> {
+    for _ in 0..CW_MAX_COMBAT_PARTICIPANTS {
+        let status = drive_combat_inference_turns(state, runtime, encounter_id, events)?;
+        if status != CW_OK {
+            return Ok(status);
+        }
+        let Some(current_actor_id) = runtime.combat_current_actor_id(encounter_id) else {
+            return Ok(CW_OK);
+        };
+        let grace_period_ms = ORDERED_SCENE_BASE_GRACE_MS.saturating_add(
+            if combat_need_time_used(runtime, encounter_id, current_actor_id) {
+                ORDERED_SCENE_NEED_TIME_MS
+            } else {
+                0
+            },
+        );
+        let active_direct_actors = active_actor_ids_for_focused_grace(state, grace_period_ms);
+        if current_actor_id == requesting_actor_id
+            || runtime.actor_uses_inference(current_actor_id)
+            || active_direct_actors.contains(&current_actor_id)
+        {
+            return Ok(CW_OK);
+        }
+        let record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_COMBAT_PASS,
+                actor_id: current_actor_id,
+                content_id: encounter_id,
+                ..CwAction::default()
+            },
+            runtime.next_seed_value(),
+        )
+        .into_system();
+        let (status, pass_events) = commit_journal_record(state, runtime, record)?;
+        events.extend(pass_events);
+        if status != CW_OK {
+            return Ok(status);
+        }
+    }
+    Ok(CW_ERR_RULE)
+}
+
+fn focused_combat_turn_needs_recovery(
+    state: &AppState,
+    runtime: &RuntimeWorld,
+    encounter_id: u64,
+) -> bool {
+    let Some(encounter) = runtime.active_combat_encounter(encounter_id) else {
+        return false;
+    };
+    let Some(current_actor_id) = runtime.combat_current_actor_id(encounter_id) else {
+        return false;
+    };
+    if runtime.actor_uses_inference(current_actor_id) {
+        return true;
+    }
+    let grace_period_ms = ORDERED_SCENE_BASE_GRACE_MS.saturating_add(
+        if combat_need_time_used(runtime, encounter_id, current_actor_id) {
+            ORDERED_SCENE_NEED_TIME_MS
+        } else {
+            0
+        },
+    );
+    let active_direct_actors = active_actor_ids_for_focused_grace(state, grace_period_ms);
+    if active_direct_actors.contains(&current_actor_id) {
+        return false;
+    }
+    encounter.participants[..encounter.participant_count]
+        .iter()
+        .filter(|participant| participant.flags & CW_COMBAT_PARTICIPANT_ESCAPED == 0)
+        .map(|participant| participant.actor_id)
+        .any(|actor_id| {
+            runtime.actor_uses_inference(actor_id) || active_direct_actors.contains(&actor_id)
+        })
+}
+
+async fn recover_available_combat_turns(state: &AppState) -> io::Result<Vec<EventView>> {
+    let mut runtime = state.inner.lock().await;
+    let encounter_ids = runtime.world.combat_encounters[..runtime.world.combat_encounter_count]
+        .iter()
+        .map(|encounter| encounter.id)
+        .filter(|encounter_id| runtime.active_combat_encounter(*encounter_id).is_some())
+        .collect::<Vec<_>>();
+    let mut events = Vec::new();
+    for encounter_id in encounter_ids {
+        if !focused_combat_turn_needs_recovery(state, &runtime, encounter_id) {
+            continue;
+        }
+        let status =
+            drive_available_combat_turns(state, &mut runtime, encounter_id, 0, &mut events)?;
+        if status != CW_OK {
+            return Err(io::Error::other(format!(
+                "focused encounter {encounter_id} recovery failed with status {status}"
+            )));
+        }
+    }
+    Ok(events)
+}
+
+pub(super) fn start_focused_encounter_scheduler(state: AppState) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            match recover_available_combat_turns(&state).await {
+                Ok(events) if !events.is_empty() => broadcast_events(&state, &events),
+                Ok(_) => {}
+                Err(error) => warn!("focused encounter recovery failed: {error}"),
+            }
+        }
+    });
+}
+
 pub(super) async fn apply_combat_choice(
     state: AppState,
     actor_id: u64,
@@ -642,11 +760,16 @@ pub(super) async fn apply_combat_choice(
         }
     }
 
-    let inference_status =
-        match drive_combat_inference_turns(&state, &mut runtime, encounter_id, &mut events) {
-            Ok(status) => status,
-            Err(_) => 500,
-        };
+    let inference_status = match drive_available_combat_turns(
+        &state,
+        &mut runtime,
+        encounter_id,
+        actor_id,
+        &mut events,
+    ) {
+        Ok(status) => status,
+        Err(_) => 500,
+    };
     if inference_status != CW_OK {
         drop(runtime);
         broadcast_events(&state, &released_events);
@@ -768,8 +891,13 @@ pub(super) async fn apply_combat_choice(
     };
     events.extend(player_events);
     if status == CW_OK {
-        status = match drive_combat_inference_turns(&state, &mut runtime, encounter_id, &mut events)
-        {
+        status = match drive_available_combat_turns(
+            &state,
+            &mut runtime,
+            encounter_id,
+            actor_id,
+            &mut events,
+        ) {
             Ok(inference_status) => inference_status,
             Err(_) => 500,
         };
@@ -807,7 +935,7 @@ pub(super) async fn apply_combat_choice(
     })
 }
 
-fn combat_join_action(actor_id: u64, encounter_id: u64) -> CwAction {
+pub(super) fn combat_join_action(actor_id: u64, encounter_id: u64) -> CwAction {
     CwAction {
         kind: CW_ACTION_COMBAT_JOIN,
         actor_id,
@@ -908,6 +1036,120 @@ mod tests {
         assert_eq!(action.actor_id, 5001);
         assert_eq!(action.content_id, 9001);
         assert_eq!(action.modifier, 1);
+    }
+
+    #[tokio::test]
+    async fn focused_scheduler_replayably_passes_unavailable_direct_participants() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Present Companion",
+        );
+        create_test_human(
+            &mut runtime,
+            5001,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Unavailable Companion",
+        );
+        for (actor_id, dexterity) in [(5000, 100), (5001, 50), (1004, 1)] {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == actor_id)
+                .expect("focused scheduler participant");
+            actor.stats.dexterity = dexterity;
+            actor.stats.hp_base = 100;
+            runtime
+                .actor_autonomy
+                .entry(actor_id)
+                .or_default()
+                .control_mode = ActorControlMode::DirectInput;
+        }
+        let encounter_id = combat_encounter_id(MOONLIT_JOB_ID);
+        let start = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_COMBAT_START,
+                actor_id: 5000,
+                target_actor_id: 1004,
+                content_id: encounter_id,
+                ..CwAction::default()
+            },
+            71_910,
+        )
+        .into_system();
+        assert_eq!(runtime.apply_journal_record(&start).0, CW_OK);
+        assert_eq!(
+            runtime
+                .apply_journal_record(
+                    &JournalRecord::new(combat_join_action(5001, encounter_id), 71_911)
+                        .into_system()
+                )
+                .0,
+            CW_OK
+        );
+        let pass = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_COMBAT_PASS,
+                actor_id: 5000,
+                content_id: encounter_id,
+                ..CwAction::default()
+            },
+            71_912,
+        )
+        .into_player_card();
+        assert_eq!(runtime.apply_journal_record(&pass).0, CW_OK);
+        assert_eq!(runtime.combat_current_actor_id(encounter_id), Some(5001));
+
+        let replay_base = RuntimeSnapshot::from_runtime(&runtime);
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-focused-recovery-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        let state = test_app_state(runtime, Some(path.clone()));
+        assert!(
+            recover_available_combat_turns(&state)
+                .await
+                .expect("idle recovery succeeds")
+                .is_empty(),
+            "a scene with nobody available must not churn Pass records"
+        );
+
+        let (session, _) = issue_actor_session(&state, 5000);
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &session),
+            Some(5000)
+        );
+        let events = recover_available_combat_turns(&state)
+            .await
+            .expect("focused scheduler recovery succeeds");
+        assert!(events
+            .iter()
+            .any(|event| { event.type_name == "combat.pass" && event.actor_id == Some(5001) }));
+        let runtime = state.inner.lock().await;
+        assert_eq!(runtime.combat_current_actor_id(encounter_id), Some(5000));
+        drop(runtime);
+
+        let journal = read_action_journal(&path).expect("focused recovery journal");
+        assert!(journal.iter().any(|record| {
+            record.action.kind == CW_ACTION_COMBAT_PASS
+                && record.action.actor_id == 5001
+                && record.origin == JournalOrigin::System
+                && record.focused_encounter.is_some()
+        }));
+        let mut replayed = replay_base
+            .into_runtime()
+            .expect("focused recovery checkpoint restores");
+        for record in &journal {
+            assert_eq!(replayed.apply_journal_record(record).0, CW_OK);
+        }
+        assert_eq!(replayed.combat_current_actor_id(encounter_id), Some(5000));
+        let _ = fs::remove_file(path);
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -147,6 +147,8 @@ impl RuntimeWorld {
         let primary_action = self.primary_action(actor_id, access);
         let mut action_offers = self.ranked_action_offers(actor_id, access, &primary_action);
         for offer in &mut action_offers {
+            offer.composition_trace.focused_encounter = actor_id
+                .and_then(|actor_id| focused_encounter_offer_context(self, actor_id, &offer.kind));
             offer.composition_id = offer.composition_trace.certificate();
         }
         (primary_action, action_offers)

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -34,6 +34,8 @@ mod rpg;
 mod rules_context;
 mod settlement_buildings;
 mod story_metrics;
+#[cfg(test)]
+mod test_support;
 mod transfers;
 mod turns;
 mod uses;
@@ -103,6 +105,8 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use story_metrics::*;
+#[cfg(test)]
+use test_support::*;
 use tokio::{
     net::TcpListener,
     signal,
@@ -1841,6 +1845,10 @@ enum JournalOrigin {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct ResidentDecisionCandidateTrace {
     offer_id: String,
+    #[serde(default)]
+    composition_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    focused_encounter: Option<FocusedEncounterOfferContext>,
     kind: String,
     provider_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1855,6 +1863,10 @@ struct ResidentDecisionCandidateTrace {
 struct ResidentDecisionChoiceTrace {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     offer_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    composition_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    focused_encounter: Option<FocusedEncounterOfferContext>,
     offer_kind: String,
     policy_rank: u8,
     policy_score: i16,
@@ -1958,6 +1970,8 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
+const JOURNAL_RECORD_VERSION: u32 = 9;
+
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
         let origin = match action.kind {
@@ -1976,7 +1990,7 @@ impl JournalRecord {
             .unwrap_or_default();
         let focused_encounter = focused_encounter_context_for_action(&action);
         Self {
-            version: FOCUSED_ENCOUNTER_JOURNAL_VERSION,
+            version: JOURNAL_RECORD_VERSION,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry()
                 .content_reference_context(action_content_handles(&action)),
@@ -5246,6 +5260,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     configured_content_registry().map_err(io::Error::other)?;
     let state = AppState::bootstrap().await?;
     let _canonical_capacity_scheduler = start_canonical_capacity_scheduler(state.clone());
+    start_focused_encounter_scheduler(state.clone());
     start_actor_job_worker(state.clone());
     start_event_store_retry_scheduler(state.clone());
     start_ownership_refresh_scheduler(state.clone());
@@ -5253,7 +5268,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     start_moderation_retention_scheduler(state.clone());
     start_story_metrics_retention_scheduler(state.clone());
     let app = routes::app_router(state);
-
     let addr: SocketAddr = std::env::var("COSYWORLD_V2_ADDR")
         .unwrap_or_else(|_| "127.0.0.1:3102".to_string())
         .parse()?;
@@ -23161,18 +23175,26 @@ impl RuntimeWorld {
             .into_iter()
             .filter(action_offer_is_reachable)
             .collect::<Vec<_>>();
-        let chosen_offer_id = offers
+        let chosen_offer = offers
             .iter()
             .find(|offer| self.resident_offer_matches_record(offer, &candidate.record))
-            .map(|offer| offer.offer_id.clone());
+            .map(|offer| {
+                (
+                    offer.offer_id.clone(),
+                    offer.composition_id.clone(),
+                    offer.composition_trace.focused_encounter.clone(),
+                )
+            });
         let candidates = offers
             .into_iter()
             .map(|offer| {
-                let selected = chosen_offer_id
-                    .as_deref()
-                    .is_some_and(|offer_id| offer.offer_id == offer_id);
+                let selected = chosen_offer
+                    .as_ref()
+                    .is_some_and(|(offer_id, _, _)| offer.offer_id == *offer_id);
                 ResidentDecisionCandidateTrace {
                     offer_id: offer.offer_id,
+                    composition_id: offer.composition_id,
+                    focused_encounter: offer.composition_trace.focused_encounter,
                     kind: offer.kind,
                     provider_id: offer.provider.id,
                     target: offer.target,
@@ -23195,7 +23217,14 @@ impl RuntimeWorld {
             observed_through_seq: self.world.next_event_seq.saturating_sub(1),
             candidates,
             choice: ResidentDecisionChoiceTrace {
-                offer_id: chosen_offer_id,
+                offer_id: chosen_offer
+                    .as_ref()
+                    .map(|(offer_id, _, _)| offer_id.clone()),
+                composition_id: chosen_offer
+                    .as_ref()
+                    .map(|(_, composition_id, _)| composition_id.clone()),
+                focused_encounter: chosen_offer
+                    .and_then(|(_, _, focused_encounter)| focused_encounter),
                 offer_kind,
                 policy_rank: candidate.rank,
                 policy_score: candidate.score,
@@ -42265,88 +42294,6 @@ mod tests {
         assert!(resolve_process_id(Some("api-a"), Some("api-b"), "local").is_err());
     }
 
-    fn test_app_state(runtime: RuntimeWorld, event_store_path: Option<PathBuf>) -> AppState {
-        let (tx, _) = broadcast::channel(32);
-        let canonical_fanout_seq = runtime.world.next_event_seq.saturating_sub(1);
-        let canonical_region_id = DEFAULT_CANONICAL_REGION_ID.to_string();
-        let canonical_store_id = if let Some(path) = event_store_path.as_deref() {
-            init_event_store(path).expect("initialize canonical test store");
-            let store_id = ensure_canonical_store_identity(
-                path,
-                OFFICIAL_WORLD_ID,
-                OFFICIAL_WORLD_EPOCH,
-                &format!("test-store:{}", random_hex(8)),
-                now_millis(),
-            )
-            .expect("canonical test store identity");
-            ensure_region_authority(
-                path,
-                OFFICIAL_WORLD_ID,
-                OFFICIAL_WORLD_EPOCH,
-                &canonical_region_id,
-                now_millis(),
-            )
-            .expect("canonical test region authority");
-            store_id
-        } else {
-            format!("test-memory:{}", random_hex(8))
-        };
-        AppState {
-            inner: Arc::new(Mutex::new(runtime)),
-            tx,
-            deployment: DeploymentConfig::local(),
-            snapshot_path: None,
-            resident_continuity_path: None,
-            event_store_path: event_store_path.clone().map(Arc::new),
-            event_store_health: Arc::new(StdMutex::new(EventStoreHealth::default())),
-            account_auth: AccountAuth::for_test(event_store_path.clone().map(Arc::new)),
-            ownership_index: Arc::new(RwLock::new(OwnershipIndex::default())),
-            trust_client_card_ids: false,
-            dev_reset_enabled: false,
-            ai_config: Arc::new(None),
-            generation_controls: Arc::new(GenerationControls::default()),
-            avatar_art_config: Arc::new(None),
-            generated_asset_dir: Arc::new(std::env::temp_dir().join("cosyworld-test-generated")),
-            ambient: AmbientConfig {
-                quiet_after: Duration::from_secs(1),
-            },
-            box_burn_verifier: Arc::new(None),
-            ownership_feed: Arc::new(OwnershipFeedConfig::default()),
-            ownership_feed_health: Arc::new(StdMutex::new(OwnershipFeedHealth::default())),
-            hosted_access_config: Arc::new(HostedAccessConfig::default()),
-            last_world_event_at: Arc::new(StdMutex::new(Instant::now())),
-            wallet_sessions: Arc::new(StdMutex::new(WalletSessions::default())),
-            qr_wallet_logins: Arc::new(StdMutex::new(QrWalletLogins::default())),
-            wallet_actor_links: Arc::new(StdMutex::new(BTreeMap::new())),
-            actor_sessions: Arc::new(StdMutex::new(ActorSessions::default())),
-            actor_suspensions: Arc::new(StdMutex::new(BTreeMap::new())),
-            rate_limiter: Arc::new(StdMutex::new(RateLimiter::default())),
-            inactive_inventory_release_conflicts: Arc::new(StdMutex::new(BTreeSet::new())),
-            canonical_command_lock: Arc::new(Mutex::new(())),
-            canonical_owner_id: Arc::new(format!("test:{}", random_hex(8))),
-            canonical_store_id: Arc::new(canonical_store_id),
-            canonical_region_id: Arc::new(canonical_region_id),
-            canonical_lease_ttl: DEFAULT_CANONICAL_LEASE_TTL,
-            canonical_applied_journal_seq: Arc::new(AtomicU64::new(0)),
-            canonical_fanout_seq: Arc::new(AtomicU64::new(canonical_fanout_seq)),
-            canonical_fanout_lock: Arc::new(StdMutex::new(())),
-            canonical_routing: Arc::new(CanonicalRoutingConfig::default()),
-            canonical_recovery: Arc::new(None),
-            regional_presence: Arc::new(StdMutex::new(BTreeMap::new())),
-            room_memory_cache: Arc::new(StdMutex::new(BTreeMap::new())),
-            room_memory_jobs: Arc::new(StdMutex::new(BTreeSet::new())),
-            room_chat_heartbeats: Arc::new(StdMutex::new(BTreeSet::new())),
-            actor_job_notify: Arc::new(Notify::new()),
-            avatar_chat_delay: Duration::ZERO,
-            moderation_token: None,
-            moderation_report_retention: ModerationReportRetention {
-                days: Some(DEFAULT_MODERATION_REPORT_RETENTION_DAYS),
-            },
-            story_metrics_retention: StoryMetricsRetention::default(),
-            allow_unsigned_wallet_claims: false,
-        }
-    }
-
     fn configure_capacity_test_state(
         mut state: AppState,
         process_id: &str,
@@ -42431,25 +42378,6 @@ mod tests {
             cards: None,
             envelope: None,
         }
-    }
-
-    fn create_test_human(runtime: &mut RuntimeWorld, actor_id: u64, location_id: u64, name: &str) {
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = actor_id;
-        create.location_id = location_id;
-        let mut record = JournalRecord::new(create, 70_000 + actor_id);
-        record.actor_meta_upserts.insert(
-            actor_id,
-            ActorMeta {
-                name: name.to_string(),
-                speech_mode: "prose".to_string(),
-                title: "Relay Test Avatar".to_string(),
-                description: "A test avatar controlled through the narrative move relay."
-                    .to_string(),
-            },
-        );
-        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
     }
 
     fn quest_projection_signature(runtime: &RuntimeWorld) -> serde_json::Value {
@@ -50240,7 +50168,7 @@ mod tests {
         assert!(action_journal_has_records(&path).expect("has records"));
         let records = read_action_journal(&path).expect("read records");
         assert_eq!(records.len(), 2);
-        assert_eq!(records[0].version, 8);
+        assert_eq!(records[0].version, JOURNAL_RECORD_VERSION);
         assert_eq!(records[0].content_context.mapping_version, 1);
         let location_reference = records[0]
             .content_context
@@ -59708,6 +59636,24 @@ mod tests {
             .find(|offer| offer.kind == "attack")
             .expect("Attack is offered")
             .clone();
+        let focused_offer = attack_offer
+            .composition_trace
+            .focused_encounter
+            .as_ref()
+            .expect("focused combat offers carry encounter identity");
+        assert_eq!(focused_offer.protocol, FOCUSED_ENCOUNTER_PROTOCOL);
+        assert_eq!(focused_offer.encounter_id, encounter_id);
+        assert_eq!(focused_offer.profile_id, FOCUSED_COMBAT_PROFILE_ID);
+        assert_eq!(
+            focused_offer.profile_version,
+            FOCUSED_COMBAT_PROFILE_VERSION
+        );
+        assert_eq!(focused_offer.activation_step, FocusedActivationStep::Commit);
+        assert_eq!(focused_offer.current_actor_id, 5000);
+        assert_eq!(
+            attack_offer.composition_id,
+            attack_offer.composition_trace.certificate()
+        );
         let defend_offer = direct_offers
             .iter()
             .find(|offer| offer.kind == "defend")
@@ -59752,7 +59698,7 @@ mod tests {
         assert_eq!(
             serde_json::to_value(&inference_offers).expect("inference offers serialize"),
             serde_json::to_value(&direct_offers).expect("direct offers serialize"),
-            "controller mode cannot change combat enumeration or targets"
+            "controller mode cannot change combat enumeration, targets, or certificates"
         );
 
         let mut forged_offer = attack_offer.clone();
@@ -59899,6 +59845,22 @@ mod tests {
                 .iter()
                 .find(|candidate| candidate.kind == "flee")
                 .map(|candidate| candidate.offer_id.as_str())
+        );
+        assert_eq!(
+            trace.choice.composition_id.as_deref(),
+            trace
+                .candidates
+                .iter()
+                .find(|candidate| candidate.kind == "flee")
+                .map(|candidate| candidate.composition_id.as_str())
+        );
+        assert_eq!(
+            trace.choice.focused_encounter.as_ref(),
+            trace
+                .candidates
+                .iter()
+                .find(|candidate| candidate.kind == "flee")
+                .and_then(|candidate| candidate.focused_encounter.as_ref())
         );
         assert!(trace
             .candidates
@@ -61644,6 +61606,12 @@ mod tests {
             MOONLIT_TRAIL_LOCATION_ID,
             "Careful Combatant",
         );
+        create_test_human(
+            &mut runtime,
+            5001,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Absent Companion",
+        );
         let actor = runtime
             .world
             .actors
@@ -61653,6 +61621,15 @@ mod tests {
             .expect("combatant");
         actor.stats.dexterity = 100;
         actor.stats.hp_base = 100;
+        let companion = runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|actor| actor.id == 5001)
+            .expect("companion");
+        companion.stats.dexterity = 50;
+        companion.stats.hp_base = 100;
         let echo = runtime
             .world
             .actors
@@ -61676,6 +61653,8 @@ mod tests {
         )
         .into_system();
         assert_eq!(runtime.apply_journal_record(&start).0, CW_OK);
+        let join = JournalRecord::new(combat_join_action(5001, encounter_id), 71_902).into_system();
+        assert_eq!(runtime.apply_journal_record(&join).0, CW_OK);
         assert_eq!(runtime.combat_current_actor_id(encounter_id), Some(5000));
         let replay_base = RuntimeSnapshot::from_runtime(&runtime);
         let path = std::env::temp_dir().join(format!(
@@ -61768,6 +61747,10 @@ mod tests {
         assert!(passed
             .events
             .iter()
+            .any(|event| { event.type_name == "combat.pass" && event.actor_id == Some(5001) }));
+        assert!(passed
+            .events
+            .iter()
             .any(|event| event.type_name == "combat.turn.ended"));
 
         let runtime = state.inner.lock().await;
@@ -61776,6 +61759,12 @@ mod tests {
         let expected_current = runtime.combat_current_actor_id(encounter_id);
         drop(runtime);
         let journal = read_action_journal(&path).expect("ordered scene journal");
+        assert!(journal.iter().any(|record| {
+            record.action.kind == CW_ACTION_COMBAT_PASS
+                && record.action.actor_id == 5001
+                && record.origin == JournalOrigin::System
+                && record.focused_encounter.is_some()
+        }));
 
         let mut replayed = replay_base
             .into_runtime()

--- a/v2/orchestrator-rust/src/rules_context.rs
+++ b/v2/orchestrator-rust/src/rules_context.rs
@@ -13,6 +13,8 @@ pub(super) struct ActionCompositionTraceView {
     pub(super) rules_pack_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) rules_context: Option<SceneRulesContextView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) focused_encounter: Option<FocusedEncounterOfferContext>,
     pub(super) source_card_instances: Vec<ActionSourceCollectibleView>,
     pub(super) target: Option<ActionTargetView>,
     pub(super) applied_variants: Vec<String>,
@@ -118,6 +120,7 @@ impl RuntimeWorld {
             rules_pack_id: binding.pack_id.clone(),
             rules_pack_version: binding.pack_version.clone(),
             rules_context,
+            focused_encounter: None,
             source_card_instances: contributions.source_card_instances,
             target: contributions.target,
             applied_variants: content.manifest.active_rules_variants.clone(),

--- a/v2/orchestrator-rust/src/test_support.rs
+++ b/v2/orchestrator-rust/src/test_support.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+pub(super) fn test_app_state(runtime: RuntimeWorld, event_store_path: Option<PathBuf>) -> AppState {
+    let (tx, _) = broadcast::channel(32);
+    let canonical_fanout_seq = runtime.world.next_event_seq.saturating_sub(1);
+    let canonical_region_id = DEFAULT_CANONICAL_REGION_ID.to_string();
+    let canonical_store_id = if let Some(path) = event_store_path.as_deref() {
+        init_event_store(path).expect("initialize canonical test store");
+        let store_id = ensure_canonical_store_identity(
+            path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &format!("test-store:{}", random_hex(8)),
+            now_millis(),
+        )
+        .expect("canonical test store identity");
+        ensure_region_authority(
+            path,
+            OFFICIAL_WORLD_ID,
+            OFFICIAL_WORLD_EPOCH,
+            &canonical_region_id,
+            now_millis(),
+        )
+        .expect("canonical test region authority");
+        store_id
+    } else {
+        format!("test-memory:{}", random_hex(8))
+    };
+    AppState {
+        inner: Arc::new(Mutex::new(runtime)),
+        tx,
+        deployment: DeploymentConfig::local(),
+        snapshot_path: None,
+        resident_continuity_path: None,
+        event_store_path: event_store_path.clone().map(Arc::new),
+        event_store_health: Arc::new(StdMutex::new(EventStoreHealth::default())),
+        account_auth: AccountAuth::for_test(event_store_path.clone().map(Arc::new)),
+        ownership_index: Arc::new(RwLock::new(OwnershipIndex::default())),
+        trust_client_card_ids: false,
+        dev_reset_enabled: false,
+        ai_config: Arc::new(None),
+        generation_controls: Arc::new(GenerationControls::default()),
+        avatar_art_config: Arc::new(None),
+        generated_asset_dir: Arc::new(std::env::temp_dir().join("cosyworld-test-generated")),
+        ambient: AmbientConfig {
+            quiet_after: Duration::from_secs(1),
+        },
+        box_burn_verifier: Arc::new(None),
+        ownership_feed: Arc::new(OwnershipFeedConfig::default()),
+        ownership_feed_health: Arc::new(StdMutex::new(OwnershipFeedHealth::default())),
+        hosted_access_config: Arc::new(HostedAccessConfig::default()),
+        last_world_event_at: Arc::new(StdMutex::new(Instant::now())),
+        wallet_sessions: Arc::new(StdMutex::new(WalletSessions::default())),
+        qr_wallet_logins: Arc::new(StdMutex::new(QrWalletLogins::default())),
+        wallet_actor_links: Arc::new(StdMutex::new(BTreeMap::new())),
+        actor_sessions: Arc::new(StdMutex::new(ActorSessions::default())),
+        actor_suspensions: Arc::new(StdMutex::new(BTreeMap::new())),
+        rate_limiter: Arc::new(StdMutex::new(RateLimiter::default())),
+        inactive_inventory_release_conflicts: Arc::new(StdMutex::new(BTreeSet::new())),
+        canonical_command_lock: Arc::new(Mutex::new(())),
+        canonical_owner_id: Arc::new(format!("test:{}", random_hex(8))),
+        canonical_store_id: Arc::new(canonical_store_id),
+        canonical_region_id: Arc::new(canonical_region_id),
+        canonical_lease_ttl: DEFAULT_CANONICAL_LEASE_TTL,
+        canonical_applied_journal_seq: Arc::new(AtomicU64::new(0)),
+        canonical_fanout_seq: Arc::new(AtomicU64::new(canonical_fanout_seq)),
+        canonical_fanout_lock: Arc::new(StdMutex::new(())),
+        canonical_routing: Arc::new(CanonicalRoutingConfig::default()),
+        canonical_recovery: Arc::new(None),
+        regional_presence: Arc::new(StdMutex::new(BTreeMap::new())),
+        room_memory_cache: Arc::new(StdMutex::new(BTreeMap::new())),
+        room_memory_jobs: Arc::new(StdMutex::new(BTreeSet::new())),
+        room_chat_heartbeats: Arc::new(StdMutex::new(BTreeSet::new())),
+        actor_job_notify: Arc::new(Notify::new()),
+        avatar_chat_delay: Duration::ZERO,
+        moderation_token: None,
+        moderation_report_retention: ModerationReportRetention {
+            days: Some(DEFAULT_MODERATION_REPORT_RETENTION_DAYS),
+        },
+        story_metrics_retention: StoryMetricsRetention::default(),
+        allow_unsigned_wallet_claims: false,
+    }
+}
+
+pub(super) fn create_test_human(
+    runtime: &mut RuntimeWorld,
+    actor_id: u64,
+    location_id: u64,
+    name: &str,
+) {
+    let create = CwAction {
+        kind: CW_ACTION_CREATE_ACTOR,
+        actor_id,
+        location_id,
+        ..CwAction::default()
+    };
+    let mut record = JournalRecord::new(create, 70_000 + actor_id);
+    record.actor_meta_upserts.insert(
+        actor_id,
+        ActorMeta {
+            name: name.to_string(),
+            speech_mode: "prose".to_string(),
+            title: "Relay Test Avatar".to_string(),
+            description: "A test avatar controlled through the narrative move relay.".to_string(),
+        },
+    );
+    assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+}

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -5,6 +5,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::net::SocketAddr;
+use std::time::{Duration, Instant};
 
 use super::*;
 
@@ -33,6 +34,18 @@ pub(super) struct FocusedEncounterJournalContext {
     pub(super) profile_id: String,
     pub(super) profile_version: u16,
     pub(super) activation_step: FocusedActivationStep,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct FocusedEncounterOfferContext {
+    pub(super) protocol: String,
+    pub(super) encounter_id: u64,
+    pub(super) profile_id: String,
+    pub(super) profile_version: u16,
+    pub(super) activation_step: FocusedActivationStep,
+    pub(super) current_actor_id: u64,
+    pub(super) round: u64,
+    pub(super) handoff_key: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -139,6 +152,33 @@ pub(super) struct FocusedEncounterView {
 }
 
 impl FocusedEncounterView {
+    fn handoff_key(&self) -> String {
+        format!(
+            "{}:{}:{}:{}:{}",
+            self.profile_id,
+            self.profile_version,
+            self.encounter_id,
+            self.round,
+            self.current_actor_id
+        )
+    }
+
+    fn offer_context(
+        &self,
+        activation_step: FocusedActivationStep,
+    ) -> FocusedEncounterOfferContext {
+        FocusedEncounterOfferContext {
+            protocol: self.protocol.to_string(),
+            encounter_id: self.encounter_id,
+            profile_id: self.profile_id.clone(),
+            profile_version: self.profile_version,
+            activation_step,
+            current_actor_id: self.current_actor_id,
+            round: self.round,
+            handoff_key: self.handoff_key(),
+        }
+    }
+
     fn validate(&self) -> Result<(), &'static str> {
         if self.schema_version != FOCUSED_ENCOUNTER_SCHEMA_VERSION
             || self.protocol != FOCUSED_ENCOUNTER_PROTOCOL
@@ -395,6 +435,28 @@ pub(super) fn combat_need_time_used(
     })
 }
 
+pub(super) fn active_actor_ids_for_focused_grace(
+    state: &AppState,
+    grace_period_ms: u64,
+) -> BTreeSet<u64> {
+    let active_window = Duration::from_millis(grace_period_ms);
+    let mut ids = active_actor_ids_with_window(&state.actor_sessions, active_window);
+    if let Ok(mut presence) = state.regional_presence.lock() {
+        let now = Instant::now();
+        presence.retain(|_, state| {
+            now.saturating_duration_since(state.last_seen_at) <= ACTIVE_ACTOR_WINDOW
+        });
+        ids.extend(presence.iter().filter_map(|(actor_id, state)| {
+            (state.active && now.saturating_duration_since(state.last_seen_at) <= active_window)
+                .then_some(*actor_id)
+        }));
+    }
+    if let Ok(suspensions) = state.actor_suspensions.lock() {
+        ids.retain(|id| !suspensions.contains_key(id));
+    }
+    ids
+}
+
 fn focused_combat_encounter(runtime: &RuntimeWorld, actor_id: u64) -> Option<FocusedEncounterView> {
     let encounter = runtime.active_combat_encounter_for_actor(actor_id)?;
     let job_id = runtime.combat_job_id_for_encounter(encounter.id)?;
@@ -442,6 +504,19 @@ fn focused_combat_encounter(runtime: &RuntimeWorld, actor_id: u64) -> Option<Foc
     Some(focused)
 }
 
+pub(super) fn focused_encounter_offer_context(
+    runtime: &RuntimeWorld,
+    actor_id: u64,
+    offer_kind: &str,
+) -> Option<FocusedEncounterOfferContext> {
+    let activation_step = match offer_kind {
+        "attack" | "defend" | "flee" => FocusedActivationStep::Commit,
+        _ => return None,
+    };
+    let focused = focused_combat_encounter(runtime, actor_id)?;
+    (focused.current_actor_id == actor_id).then(|| focused.offer_context(activation_step))
+}
+
 pub(super) fn combat_turn_view(
     runtime: &RuntimeWorld,
     actor_id: u64,
@@ -477,10 +552,7 @@ pub(super) fn combat_turn_view(
                 .unwrap_or_default(),
         ),
         need_time_extension_ms: ORDERED_SCENE_NEED_TIME_MS,
-        handoff_key: Some(format!(
-            "combat:{}:{}:{}",
-            focused.encounter_id, focused.round, current_actor_id
-        )),
+        handoff_key: Some(focused.handoff_key()),
         can_request_timeout: false,
         timeout_requests: Vec::new(),
         waiting_actor_ids,
@@ -849,6 +921,44 @@ mod tests {
         assert_eq!(
             serde_json::to_value(&turn).expect("focused turn serializes")["focused"]["protocol"],
             FOCUSED_ENCOUNTER_PROTOCOL
+        );
+
+        let offered = runtime
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| offer.kind == "attack")
+            .expect("current actor receives a certified attack");
+        let reconnected = RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .expect("focused encounter reconnects from its snapshot");
+        let reconnected_offer = reconnected
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| offer.kind == "attack")
+            .expect("reconnect projects the current attack");
+        assert_eq!(reconnected_offer.offer_id, offered.offer_id);
+        assert_eq!(reconnected_offer.composition_id, offered.composition_id);
+        assert_eq!(
+            reconnected_offer.composition_trace.focused_encounter,
+            offered.composition_trace.focused_encounter
+        );
+
+        let pass = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_COMBAT_PASS,
+                actor_id: 5000,
+                content_id: encounter_id,
+                ..CwAction::default()
+            },
+            81_002,
+        )
+        .into_player_card();
+        assert_eq!(runtime.apply_journal_record(&pass).0, CW_OK);
+        assert!(
+            runtime.plan_combat_offer_action(5000, &offered).is_err(),
+            "the prior turn certificate expires after Pass"
         );
     }
 

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74986
+74975

--- a/v2/scripts/rust-lint-warning-ceiling.txt
+++ b/v2/scripts/rust-lint-warning-ceiling.txt
@@ -1,3 +1,3 @@
 # Lines beginning with "warning:" from cargo clippy --all-targets on the
 # deployed main baseline. Existing debt is allowed; new warnings are not.
-249
+248


### PR DESCRIPTION
## Summary
- bind focused-scene offers to encounter/profile/version/current actor/round/handoff identity and hash that into composition certificates
- record the same certificate for direct and inference controllers, restore it on reconnect, and reject prior-turn offers
- replayably Pass unavailable participants after base or Need Time grace without changing ordinary-room UI

## Validation
- `npm test` — 448
- `cargo test` — 511
- `npm run v2:check`
- `npm run check:version`

Advances #274

## Checklist
- [x] version 0.0.178
- [x] ordinary chat UI unchanged
- [x] `main.rs` ceiling lowered to 74975
- [x] Clippy ceiling lowered to 248