### PR TITLE
Restore browser hand drawing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.180",
+  "version": "0.0.181",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.180",
+      "version": "0.0.181",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.180",
+  "version": "0.0.181",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -11,7 +11,7 @@ const browser = fs.readFileSync(
 );
 
 describe("two-action browser hand", () => {
-  it("keeps the chatroom beside exactly two action slots without command entry or overflow cards", () => {
+  it("keeps exactly two action slots and exposes a turn-free draw control", () => {
     expect(browser).not.toContain('id="command-toggle"');
     expect(browser).not.toContain('id="command-palette"');
     expect(browser).not.toContain('id="command-input"');
@@ -19,8 +19,11 @@ describe("two-action browser hand", () => {
     expect(browser).toContain('id="primary"');
     expect(browser).toContain('id="secondary"');
     expect(browser).not.toContain('id="tertiary"');
-    expect(browser).not.toContain('id="shuffle"');
+    expect(browser).toContain('id="shuffle"');
     expect(browser).toContain('const buttonIds = ["primary", "secondary"];');
+    expect(browser).toContain('command: "shuffle"');
+    expect(browser).toContain("advanceHandPage();");
+    expect(browser).toContain('event.type === "hand.shuffled"');
     expect(browser).toMatch(/function handCapacity\(\) \{\s+return 2;\s+\}/);
   });
 });

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.180"
+version = "0.0.181"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.180"
+version = "0.0.181"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1529,6 +1529,12 @@
     .prompt.choice-mode {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
+    .prompt.has-draw {
+      grid-template-columns: repeat(2, minmax(0, 1fr)) minmax(64px, 86px);
+    }
+    .prompt.choice-mode.has-draw {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
     .prompt[hidden] { display: none; }
     .cmd {
       --cmd-accent: var(--type-utility);
@@ -2589,6 +2595,10 @@
         padding: 3px;
         text-align: center;
       }
+      .cmd.shuffle {
+        flex: 0 0 72px;
+        min-width: 72px;
+      }
       .cmd-copy {
         flex: 1 1 auto;
         min-width: 0;
@@ -3273,6 +3283,9 @@
       <div class="turn-ping-pill" id="turn-ping-pill" role="status" aria-live="polite" aria-atomic="true" hidden></div>
       <button class="cmd primary" id="primary" data-player-concept="action" data-analytics-event="action.select"></button>
       <button class="cmd secondary" id="secondary" data-player-concept="action" data-analytics-event="action.select"></button>
+      <button class="cmd shuffle type-shuffle" id="shuffle" data-player-concept="draw" data-analytics-event="action.draw" aria-label="Draw two more actions">
+        <span class="shuffle-glyph" aria-hidden="true">•••</span><span class="cmd-label">more</span>
+      </button>
     </footer>
   </div>
   <div class="card-modal" id="card-modal" hidden>
@@ -3418,6 +3431,7 @@
     let handDealNonce = 1;
     let authoritativeHandIdentity = "";
     let playerPromotedHandKey = "";
+    let handShuffleBusy = false;
     let recoveryPromptPending = false;
     let logEvents = [];
     const seenSeq = new Set();
@@ -6329,10 +6343,12 @@
       const clearFirstTaleAfterAction = firstTaleCelebration
         && !/^(?:need[ -]time)$/i.test(command);
       if (/^(shuffle|deal|more|redraw)$/i.test(command)) {
-        await shuffleHand();
-        setStatus("A fresh hand appears.", "ok");
-        pushCommandOutput(command, "A fresh hand appears. Nothing in the room changes.", true, []);
-        return { ok: true, status: 0, command, events: [] };
+        const result = await shuffleHand();
+        if (result?.ok) {
+          setStatus("A fresh hand appears.", "ok");
+          pushCommandOutput(command, "You draw a new hand.", true, result.events || []);
+        }
+        return result;
       }
       const beforeOrbs = economyOrbCount();
       const result = await post("/commands", withAccess({
@@ -10740,8 +10756,8 @@
 
     function authoritativeHandSignature(view = state) {
       return JSON.stringify((view?.action_hand?.entries || []).map((entry) => [
-        String(entry?.offer_id || ""),
         String(entry?.kind || ""),
+        String(entry?.intention || ""),
         String(entry?.provider?.kind || ""),
         String(entry?.provider?.id || ""),
       ]));
@@ -10829,16 +10845,35 @@
         playerPromotedHandKey = "";
         return;
       }
-      const nextAuthoritativeIdentity = (state?.action_hand?.entries || [])
-        .map((offer) => offer.offer_id || `${offer.kind}:${offer.state_revision}`)
-        .join("|");
+      const nextAuthoritativeIdentity = JSON.stringify(
+        orderedActionIndexesForHand().map((index) => actionHandKey(actions[index])),
+      );
+      const compositionChanged = nextAuthoritativeIdentity !== authoritativeHandIdentity;
       authoritativeHandIdentity = nextAuthoritativeIdentity;
-      handKeys = orderedActionIndexesForHand()
-        .slice(0, handCapacity())
-        .map((index) => actionHandKey(actions[index]))
-        .filter(Boolean);
-      discardedHandKeys = [];
-      playerPromotedHandKey = "";
+      const validKeys = validActionHandKeySet();
+      if (compositionChanged) {
+        handKeys = [];
+        discardedHandKeys = [];
+        playerPromotedHandKey = "";
+      } else {
+        pruneDiscardedHandKeys(validKeys);
+        handKeys = handKeys.filter((key) => (
+          validKeys.has(key) && !discardedHandKeys.includes(key)
+        ));
+        if (playerPromotedHandKey && !validKeys.has(playerPromotedHandKey)) {
+          playerPromotedHandKey = "";
+        }
+      }
+      const kept = [];
+      const seen = new Set();
+      for (const key of handKeys) {
+        if (!key || seen.has(key)) continue;
+        kept.push(key);
+        seen.add(key);
+        if (kept.length >= handCapacity()) break;
+      }
+      dealHandKeys(kept, seen, handCapacity());
+      handKeys = kept;
     }
 
     function promoteActionToHand(index, key = "") {
@@ -11103,20 +11138,45 @@
     }
 
     async function shuffleHand() {
-      if (!actorId || !actorSession || state?.primary_action?.kind === "create_avatar") {
+      if (handShuffleBusy
+        || !actorId
+        || !actorSession
+        || state?.primary_action?.kind === "create_avatar") {
         return null;
       }
-      advanceHandPage();
-      renderCommands();
-      return null;
+      const button = $("shuffle");
+      handShuffleBusy = true;
+      button.disabled = true;
+      try {
+        const result = await post("/commands", withAccess({
+          actor_id: actorId,
+          actor_session: actorSession,
+          command: "shuffle",
+          envelope: canonicalCommandEnvelope(),
+        }));
+        pushEvents(result.events || []);
+        if (!result.ok) {
+          setError(commandFailureMessage(result));
+          return result;
+        }
+        advanceHandPage();
+        renderCommands();
+        return result;
+      } finally {
+        handShuffleBusy = false;
+        button.disabled = false;
+      }
     }
 
     function renderCommands() {
       const prompt = document.querySelector(".prompt");
       const buttonIds = ["primary", "secondary"];
+      const drawButton = $("shuffle");
       renderTurnPingPill();
       if (actionBusy) {
         prompt.classList.remove("choice-mode");
+        prompt.classList.remove("has-draw");
+        drawButton.style.display = "none";
         const busyDetail = typeof pendingAction?.busyDetail === "function"
           ? pendingAction.busyDetail()
           : pendingAction?.busyDetail;
@@ -11136,7 +11196,15 @@
         return;
       }
       const choiceMode = Boolean(state?.branch && actions.length > 1);
+      const canDraw = !state?.branch
+        && actorId
+        && actorSession
+        && state?.primary_action?.kind !== "create_avatar"
+        && validActionHandKeySet().size > handCapacity();
       prompt.classList.toggle("choice-mode", choiceMode);
+      prompt.classList.toggle("has-draw", canDraw);
+      drawButton.style.display = canDraw ? "flex" : "none";
+      drawButton.disabled = handShuffleBusy;
       const visibleActions = actionBarActions().slice(0, handCapacity());
       for (let index = 0; index < buttonIds.length; index += 1) {
         const id = buttonIds[index];
@@ -11733,6 +11801,10 @@
     $("secondary").addEventListener("click", () => {
       const action = actionForButton("secondary") || (state?.branch ? actions[1] : null);
       if (action) openActionModal(action);
+    });
+
+    $("shuffle").addEventListener("click", () => {
+      void shuffleHand();
     });
 
     document.addEventListener("keydown", (event) => {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -29392,6 +29392,14 @@ async fn command_inner(
     }
 
     match resolved.dispatch.clone() {
+        CommandDispatch::Read { .. }
+            if resolved
+                .action
+                .as_ref()
+                .is_some_and(|action| action.kind == "shuffle_hand") =>
+        {
+            commit_shuffle_hand_command(&state, &payload, resolved, presence_events).await
+        }
         CommandDispatch::Read { output } => Json(CommandResponse {
             ok: true,
             status: CW_OK,
@@ -49010,7 +49018,7 @@ mod tests {
         assert!(INDEX_HTML.contains("atmosphericMemoryBeat"));
         assert!(INDEX_HTML.contains("room-title-main"));
         assert!(INDEX_HTML.contains("room-avatar-rail"));
-        assert!(!INDEX_HTML.contains("id=\"shuffle\""));
+        assert!(INDEX_HTML.contains("id=\"shuffle\""));
         assert!(INDEX_HTML.contains("function firstThreadModel"));
         assert!(INDEX_HTML.contains("function nextStoryThreadModel"));
         assert!(INDEX_HTML.contains("function firstTaleIsComplete"));
@@ -52336,10 +52344,11 @@ mod tests {
 
         let state = test_app_state(runtime, None);
         let (actor_session, _) = issue_actor_session(&state, 5000);
-        let (before_tick, before_resident_locations) = {
+        let (before_tick, before_next_event_seq, before_resident_locations) = {
             let runtime = state.inner.lock().await;
             (
                 runtime.world.tick,
+                runtime.world.next_event_seq,
                 [
                     runtime.actor_by_id(RATI_ACTOR_ID).unwrap().location_id,
                     runtime
@@ -52363,20 +52372,22 @@ mod tests {
 
         assert!(response.ok);
         assert_eq!(response.status, CW_OK);
-        assert_eq!(
-            response.output.as_deref(),
-            Some("A fresh hand appears. Nothing in the room changes.")
-        );
-        assert!(!response
+        assert_eq!(response.output.as_deref(), Some("You draw a new hand."));
+        assert!(response
             .events
             .iter()
             .any(|event| event.type_name == "hand.shuffled"));
+        assert!(response
+            .events
+            .iter()
+            .any(|event| event.type_name == "action.receipt"));
         assert!(!response
             .events
             .iter()
             .any(|event| event.type_name == "actor.moved"));
         let runtime = state.inner.lock().await;
         assert_eq!(runtime.world.tick, before_tick);
+        assert_eq!(runtime.world.next_event_seq, before_next_event_seq + 1);
         assert_eq!(
             [
                 runtime.actor_by_id(RATI_ACTOR_ID).unwrap().location_id,
@@ -66289,8 +66300,7 @@ mod tests {
             .expect("shuffle resolves");
         match shuffle.dispatch {
             CommandDispatch::Read { output } => {
-                assert!(output.contains("A fresh hand appears"));
-                assert!(output.contains("Nothing in the room changes"));
+                assert_eq!(output, "You draw a new hand.");
             }
             other => panic!("shuffle should be a free hand redeal hint, got {other:?}"),
         }

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -395,6 +395,62 @@ pub(crate) fn command_action_response_with_events(
     command_action_response_with_prefix_and_events(resolved, response, None, leading_events)
 }
 
+pub(crate) async fn commit_shuffle_hand_command(
+    state: &AppState,
+    payload: &CommandRequest,
+    resolved: ResolvedCommand,
+    leading_events: Vec<EventView>,
+) -> Json<CommandResponse> {
+    let mut runtime = state.inner.lock().await;
+    let location_id = runtime
+        .actor_by_id(payload.actor_id)
+        .map(|actor| actor.location_id)
+        .unwrap_or_default();
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: payload.actor_id,
+            location_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    )
+    .into_player_control();
+    record
+        .projection_mutations
+        .push(ProjectionMutation::ShuffleHand {
+            reason: "player_draw".to_string(),
+        });
+    let Ok((status, mut events)) = commit_journal_record(state, &mut runtime, record) else {
+        return Json(CommandResponse {
+            ok: false,
+            status: 500,
+            command: resolved.command,
+            verb: resolved.verb,
+            output: Some(
+                "That choice got lost before the room could answer. Try once more.".to_string(),
+            ),
+            action: resolved.action,
+            receipt: None,
+            events: leading_events,
+        });
+    };
+    if status == CW_OK && !events.is_empty() {
+        append_action_receipt(state, &runtime, payload.actor_id, &mut events);
+    }
+    drop(runtime);
+    broadcast_events(state, &events);
+    command_action_response_with_events(
+        resolved,
+        ActionResponse {
+            ok: status == CW_OK && !events.is_empty(),
+            status: if events.is_empty() { 409 } else { status },
+            events,
+        },
+        leading_events,
+    )
+}
+
 pub(crate) fn command_action_response_with_prefix_and_events(
     resolved: ResolvedCommand,
     mut response: ActionResponse,
@@ -2430,7 +2486,7 @@ impl RuntimeWorld {
                 verb,
                 action: Some(command_action("shuffle_hand", "Shuffle", "shuffle")),
                 dispatch: CommandDispatch::Read {
-                    output: "A fresh hand appears. Nothing in the room changes.".to_string(),
+                    output: "You draw a new hand.".to_string(),
                 },
             }),
             "bank" => {

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74902
+74912

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -545,7 +545,7 @@ async function main() {
   }
 
   async function visibleCommandButtons() {
-    return page.locator("footer.prompt button:visible").evaluateAll((nodes) => (
+    return page.locator("footer.prompt button:not(#shuffle):visible").evaluateAll((nodes) => (
       nodes.map((node) => node.innerText.trim().replace(/\s+/g, " "))
         .filter(Boolean)
     ));
@@ -559,6 +559,93 @@ async function main() {
       assert(buttons.length === expectedCount, `${label} should expose ${expectedCount} action${expectedCount === 1 ? "" : "s"}: ${JSON.stringify(buttons)}`);
     }
     return buttons;
+  }
+
+  async function assertBrowserDrawReachesEveryLegalAction() {
+    const handSnapshot = () => page.evaluate(() => ({
+      allKeys: [...validActionHandKeySet()],
+      visibleKeys: [...document.querySelectorAll("footer.prompt button[data-hand-key]")]
+        .filter((button) => button.id !== "shuffle" && getComputedStyle(button).display !== "none")
+        .map((button) => button.dataset.handKey)
+        .filter(Boolean),
+      eventSeq: Math.max(0, ...logEvents
+        .filter((event) => event.type === "hand.shuffled")
+        .map((event) => Number(event.seq || 0))),
+      drawVisible: getComputedStyle(document.querySelector("#shuffle")).display !== "none",
+    }));
+    const drawOnce = async (previous) => {
+      const previousSignature = previous.visibleKeys.join("|");
+      const [response] = await Promise.all([
+        page.waitForResponse((candidate) => (
+          candidate.request().method() === "POST"
+          && new URL(candidate.url()).pathname === "/commands"
+          && String(candidate.request().postData() || "").includes("\"command\":\"shuffle\"")
+        )),
+        page.locator("#shuffle").click(),
+      ]);
+      const receipt = await response.json();
+      const drawEvent = (receipt.events || []).find((event) => event.type === "hand.shuffled");
+      assert(receipt.ok && Number(drawEvent?.seq || 0) > previous.eventSeq,
+        `drawing should commit one newer hand.shuffled event: ${JSON.stringify(receipt)}`);
+      await page.waitForFunction(({ signature, eventSeq }) => {
+        const visible = [...document.querySelectorAll("footer.prompt button[data-hand-key]")]
+          .filter((button) => button.id !== "shuffle" && getComputedStyle(button).display !== "none")
+          .map((button) => button.dataset.handKey)
+          .filter(Boolean)
+          .join("|");
+        const latestDraw = Math.max(0, ...logEvents
+          .filter((event) => event.type === "hand.shuffled")
+          .map((event) => Number(event.seq || 0)));
+        return visible !== signature
+          && latestDraw >= eventSeq
+          && document.querySelector("#shuffle")?.disabled === false;
+      }, { signature: previousSignature, eventSeq: Number(drawEvent.seq) });
+      return handSnapshot();
+    };
+
+    const initial = await handSnapshot();
+    assert(initial.allKeys.length > 2, `the opening scene should have actions beyond its first two cards: ${JSON.stringify(initial)}`);
+    assert(initial.drawVisible, "the draw control should appear whenever legal actions remain outside the two-card hand");
+    const initialSignature = initial.visibleKeys.join("|");
+    const seen = new Set();
+    let current = initial;
+    let drawCount = 0;
+    const maxDraws = Math.ceil(initial.allKeys.length / 2) + 1;
+    while (drawCount <= maxDraws) {
+      current.visibleKeys.forEach((key) => seen.add(key));
+      if (initial.allKeys.every((key) => seen.has(key))) break;
+      current = await drawOnce(current);
+      drawCount += 1;
+    }
+    assert(
+      initial.allKeys.every((key) => seen.has(key)),
+      `drawing should surface every legal browser action: ${JSON.stringify({ all: initial.allKeys, seen: [...seen] })}`,
+    );
+
+    while (current.visibleKeys.join("|") !== initialSignature && drawCount <= maxDraws + 1) {
+      current = await drawOnce(current);
+      drawCount += 1;
+    }
+    assert(
+      current.visibleKeys.join("|") === initialSignature,
+      `the hand should cycle deterministically to its first pair: ${JSON.stringify(current.visibleKeys)}`,
+    );
+
+    const layout = await page.evaluate(() => {
+      const prompt = document.querySelector("footer.prompt");
+      const draw = document.querySelector("#shuffle");
+      const rect = draw.getBoundingClientRect();
+      return {
+        promptFits: prompt.scrollWidth <= prompt.clientWidth + 1,
+        drawFits: rect.left >= 0 && rect.right <= window.innerWidth,
+        journaled: logEvents.some((event) => event.type === "hand.shuffled"),
+      };
+    });
+    assert(
+      layout.promptFits && layout.drawFits && layout.journaled,
+      `two cards and their journaled draw control should fit the mobile footer: ${JSON.stringify(layout)}`,
+    );
+    steps.push({ label: "browser draw reaches every legal action", actions: initial.allKeys.length, draws: drawCount });
   }
 
   async function assertFirstThreadGuide() {
@@ -2742,7 +2829,7 @@ async function main() {
       renderCommands();
       try {
         const tradeAction = actions.find((action) => action.label === "trade") || null;
-        const visibleButtons = () => [...document.querySelectorAll("footer.prompt button")]
+        const visibleButtons = () => [...document.querySelectorAll("footer.prompt button:not(#shuffle)")]
             .filter((button) => getComputedStyle(button).display !== "none")
             .map((button) => {
               const label = button.querySelector(".cmd-label")?.cloneNode(true);
@@ -2810,7 +2897,7 @@ async function main() {
           actionLabels: actions.map((action) => `${action.label} ${action.detail || ""}`.trim()),
           visibleHand,
           hasThirdCard: Boolean(document.querySelector("#tertiary")),
-          hasShuffleCard: Boolean(document.querySelector("#shuffle")),
+          hasShuffleCard: getComputedStyle(document.querySelector("#shuffle")).display !== "none",
           semanticBindings,
           giveKindsBeforeRename,
           giveKindsAfterRename,
@@ -2849,7 +2936,7 @@ async function main() {
     assert(result.multiTrade?.rows?.some((row) => row[0] === "Then" && row[1] === "both keepsakes change hands"), `Trade should explain its atomic exchange in plain language: ${JSON.stringify(result)}`);
     assert(!/eager|willingness|accepted/i.test(JSON.stringify(result.tradeCopy)), `trade copy should hide resident-economy state tags: ${JSON.stringify(result)}`);
     assert(result.visibleHand.length === 2, `the authoritative browser hand should expose exactly two actions: ${JSON.stringify(result)}`);
-    assert(!result.hasThirdCard && !result.hasShuffleCard, `the browser hand should have no third or shuffle card: ${JSON.stringify(result)}`);
+    assert(!result.hasThirdCard && result.hasShuffleCard, `the browser hand should keep two action cards beside its draw control: ${JSON.stringify(result)}`);
     assert(result.actionLabels.some((label) => label.startsWith("give ")) && result.actionLabels.some((label) => label.startsWith("trade ")), `actions outside the hand should remain in the complete legal surface: ${JSON.stringify(result)}`);
     assert(result.semanticBindings.find((entry) => entry.label === "give")?.kinds?.includes("give_item"), `Give must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
     assert(result.semanticBindings.find((entry) => entry.label === "trade")?.kinds?.includes("trade_item"), `Trade must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
@@ -6641,10 +6728,10 @@ async function main() {
     assert(result.look.output.includes("east: Rain-Soft Garden") && result.lookEast.ok === true && result.lookEast.output.includes("Rain-Soft Garden"), `directional look should inspect a compass exit: ${JSON.stringify(result)}`);
     assert(
       result.shuffle.ok === true
-        && result.shuffle.output.includes("A fresh hand appears")
-        && result.shuffle.output.includes("Nothing in the room changes")
-        && result.shuffle.events.length === 0,
-      `shuffle command should be a free local hand hint, not a world event: ${JSON.stringify(result.shuffle)}`,
+        && result.shuffle.output === "You draw a new hand."
+        && result.shuffle.events.some((event) => event.type === "hand.shuffled")
+        && result.shuffle.events.some((event) => event.type === "action.receipt"),
+      `shuffle command should journal one free hand draw with its fresh state receipt: ${JSON.stringify(result.shuffle)}`,
     );
     const searchBlockedByFloorItem = result.search.ok === false
       && result.search.status === 409
@@ -6745,8 +6832,9 @@ async function main() {
   async function assertBrowserCommandEntryAbsent() {
     const before = await visibleCommandButtons();
     assert(
-      await page.locator("#command-toggle, #command-palette, #command-input, #all-actions-modal, #tertiary, #shuffle").count() === 0,
-      "the browser room should expose only two world action controls",
+      await page.locator("#command-toggle, #command-palette, #command-input, #all-actions-modal, #tertiary").count() === 0
+        && await page.locator("#shuffle").count() === 1,
+      "the browser room should expose two world action cards and one compact draw control",
     );
     await page.evaluate(() => document.activeElement?.blur?.());
     await page.keyboard.press("Slash");
@@ -8448,6 +8536,7 @@ async function main() {
   }
   await assertActionBarCapped("normal play", 2);
   await assertFirstThreadGuide();
+  await assertBrowserDrawReachesEveryLegalAction();
   await assertNoComposerOrDebugChrome();
   const collectibleAvailable = await page.evaluate(() => actions.some((action) => (
     [compactActionLabel(action), action?.detail, action?.command]
@@ -9134,7 +9223,7 @@ async function main() {
       branchEvents,
       fleeEvents,
       trailExitEvents,
-      buttons: [...document.querySelectorAll("footer.prompt button")]
+      buttons: [...document.querySelectorAll("footer.prompt button:not(#shuffle)")]
         .filter((button) => getComputedStyle(button).display !== "none" && button.getBoundingClientRect().width > 0)
         .map((button) => button.innerText.trim().replace(/\s+/g, " "))
         .filter(Boolean),


### PR DESCRIPTION
Closes #293

- Add a compact “more” control beside the two-card browser hand.
- Rotate through every legal action and preserve the draw across harmless refreshes.
- Journal each draw without consuming a room turn; smoke the full opening hand on mobile.

Validation: `npm test` (448), `cargo test` (514), `npm run v2:architecture`, both browser smoke passes, and the pre-push `npm run check` gate.