### PR TITLE
Move latest Journal beat below the room title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.181",
+  "version": "0.0.182",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.181",
+      "version": "0.0.182",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.181",
+  "version": "0.0.182",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.181"
+version = "0.0.182"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.181"
+version = "0.0.182"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2918,25 +2918,22 @@
       grid-template-rows: auto minmax(0, 1fr);
     }
     .room-title-main {
-      flex: 0 1 auto;
-      max-width: 52%;
+      flex: 1 1 auto;
+      max-width: none;
     }
     .room-log-toggle {
-      flex: 1 1 0;
-      min-width: 0;
+      flex: 0 0 auto;
+      min-width: auto;
       min-height: 44px;
       max-width: none;
-      overflow: hidden;
       border: 0;
       border-bottom: 1px solid transparent;
       border-radius: 0;
       background: transparent;
       color: var(--dim);
       padding: 3px 1px 2px;
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
+      display: inline-flex;
       align-items: center;
-      gap: 12px;
       font: inherit;
       font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       font-size: 11px;
@@ -2971,14 +2968,25 @@
     }
     .room-log-latest {
       display: block;
+      width: 100%;
       min-width: 0;
+      margin: 0;
       overflow: hidden;
+      border: 0;
+      border-bottom: 1px solid transparent;
+      border-radius: 0;
+      background: transparent;
+      padding: 4px 1px 5px;
       white-space: nowrap;
       color: var(--faint);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       font-size: 10px;
       font-weight: 500;
       letter-spacing: 0.01em;
       text-align: left;
+      cursor: pointer;
+    }
+    .room-log-latest.is-overflowing {
       -webkit-mask-image: linear-gradient(90deg, transparent, #000 8px, #000 calc(100% - 12px), transparent);
       mask-image: linear-gradient(90deg, transparent, #000 8px, #000 calc(100% - 12px), transparent);
     }
@@ -2995,8 +3003,14 @@
     .room-log-latest.is-overflowing .room-log-latest-track {
       animation: room-log-scroll var(--room-log-duration, 12s) ease-in-out 1.2s infinite alternate;
     }
-    .room-log-toggle:hover .room-log-latest-track,
-    .room-log-toggle:focus-visible .room-log-latest-track {
+    .room-log-latest:hover,
+    .room-log-latest:focus-visible {
+      border-bottom-color: var(--line-strong);
+      color: var(--dim);
+      outline: 0;
+    }
+    .room-log-latest:hover .room-log-latest-track,
+    .room-log-latest:focus-visible .room-log-latest-track {
       animation-play-state: paused;
     }
     @keyframes room-log-scroll {
@@ -3004,7 +3018,7 @@
       to { transform: translateX(calc(-1 * var(--room-log-overflow, 0px))); }
     }
     @media (prefers-reduced-motion: reduce) {
-      .room-log-latest {
+      .room-log-latest.is-overflowing {
         -webkit-mask-image: none;
         mask-image: none;
       }
@@ -3213,11 +3227,11 @@
         gap: 10px;
       }
       .room-title-main {
-        max-width: 56%;
+        max-width: none;
       }
       .room-log-toggle {
-        width: 100%;
-        min-width: 88px;
+        width: auto;
+        min-width: auto;
         min-height: 44px;
       }
       #avatar {
@@ -3259,9 +3273,10 @@
         </div>
         <div class="room-title">
           <span class="room-title-main"><h1 id="location-name">The Cosy Cottage</h1></span>
-          <button class="room-log-toggle" id="room-log-toggle" type="button" aria-expanded="false" aria-controls="journal-view"><span class="room-log-latest" id="room-log-latest" hidden><span class="room-log-latest-track" id="room-log-latest-track"></span></span><span class="room-log-kicker">Journal</span></button>
+          <button class="room-log-toggle" id="room-log-toggle" type="button" aria-expanded="false" aria-controls="journal-view"><span class="room-log-kicker">Journal</span></button>
           <span id="avatar"></span>
         </div>
+        <button class="room-log-latest" id="room-log-latest" type="button" aria-controls="journal-view" hidden><span class="room-log-latest-track" id="room-log-latest-track"></span></button>
         <div class="room-copy" id="location-copy"></div>
       </section>
       <section class="journal-view" id="journal-view" aria-label="Journal" hidden>
@@ -7364,11 +7379,14 @@
       const terminal = document.querySelector(".terminal");
       const journal = $("journal-view");
       const toggle = $("room-log-toggle");
+      const latestControl = $("room-log-latest");
       journal.hidden = !open;
       terminal?.classList.toggle("journal-open", open);
       toggle.setAttribute("aria-expanded", open ? "true" : "false");
       const latest = String(toggle.dataset.latest || "").trim();
-      toggle.setAttribute("aria-label", open ? "Close Journal" : latest ? `Open Journal: ${latest}` : "Open Journal");
+      toggle.setAttribute("aria-label", open ? "Close Journal" : "Open Journal");
+      latestControl.setAttribute("aria-expanded", open ? "true" : "false");
+      latestControl.setAttribute("aria-label", open ? "Close Journal, latest entry" : `Open Journal, latest: ${latest}`);
       toggle.querySelector(".room-log-kicker")?.replaceChildren(document.createTextNode(open ? "Close Journal" : "Journal"));
       document.querySelector(".prompt").hidden = Boolean(panelMode || open);
       if (open) {
@@ -11554,6 +11572,9 @@
     });
 
     $("room-log-toggle").addEventListener("click", () => {
+      setJournalOpen(!journalOpen);
+    });
+    $("room-log-latest").addEventListener("click", () => {
       setJournalOpen(!journalOpen);
     });
 

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -7368,7 +7368,7 @@ async function main() {
         latestVisible: visible(document.querySelector("#room-log-latest")),
         latestHasTrack: Boolean(document.querySelector("#room-log-latest > #room-log-latest-track")),
         latestAriaLive: document.querySelector("#room-log-latest")?.getAttribute("aria-live") || "",
-        latestInsideToggle: document.querySelector("#room-log-latest")?.parentElement?.id === "room-log-toggle",
+        latestBelowTitle: document.querySelector("#room-log-latest")?.previousElementSibling?.classList.contains("room-title") || false,
         expanded: document.querySelector("#room-log-toggle")?.getAttribute("aria-expanded") || "",
         journalVisible: visible(document.querySelector("#journal-view")),
         heroVisible: visible(document.querySelector("#room-hero")),
@@ -7394,8 +7394,8 @@ async function main() {
       `${label}: the ticker should mirror the newest actual Journal row: ${JSON.stringify(room)}`,
     );
     assert(
-      room.latestVisible && room.latestHasTrack && room.latestInsideToggle && !room.latestAriaLive,
-      `${label}: the latest event should stay inside the single quiet Journal control without another live region: ${JSON.stringify(room)}`,
+      room.latestVisible && room.latestHasTrack && room.latestBelowTitle && !room.latestAriaLive,
+      `${label}: the latest event should occupy one quiet line below the title without another live region: ${JSON.stringify(room)}`,
     );
     assert(room.expanded === "false" && !room.journalVisible, `${label}: Journal should start closed: ${JSON.stringify(room)}`);
     assert(!room.memoryVisible && !room.questionsVisible && !room.updatesVisible, `${label}: status and story panels must not occupy the room: ${JSON.stringify(room)}`);
@@ -7445,9 +7445,9 @@ async function main() {
       movingTicker.overflow > 4 && movingTicker.animationName === "room-log-scroll",
       `${label}: a clipped latest event should scroll inside the Journal control: ${JSON.stringify(movingTicker)}`,
     );
-    await page.locator("#room-log-toggle").hover();
+    await page.locator("#room-log-latest").hover();
     const pausedTicker = await page.locator("#room-log-latest-track").evaluate((track) => getComputedStyle(track).animationPlayState);
-    assert(pausedTicker === "paused", `${label}: hovering the Journal control should pause its latest-event ticker`);
+    assert(pausedTicker === "paused", `${label}: hovering the latest-event line should pause its ticker`);
     await page.emulateMedia({ reducedMotion: "reduce" });
     const reducedTicker = await page.locator("#room-log-latest-track").evaluate((track) => {
       const style = getComputedStyle(track);
@@ -7463,7 +7463,7 @@ async function main() {
       renderRoomLogLatest(original);
     }, originalLatest);
 
-    await page.locator("#room-log-toggle").click();
+    await page.locator("#room-log-latest").click();
     await page.waitForFunction(() => (
       document.querySelector("#room-log-toggle")?.getAttribute("aria-expanded") === "true"
       && document.querySelector("#journal-view")?.hidden === false
@@ -7547,6 +7547,52 @@ async function main() {
       };
     });
     assert(restored.hero && restored.chat && restored.prompt, `${label}: closing Journal should restore the chatroom intact: ${JSON.stringify(restored)}`);
+  }
+
+  async function assertJournalTickerLayout() {
+    const originalViewport = page.viewportSize();
+    for (const width of [390, 768, 1280]) {
+      await page.setViewportSize({ width, height: width === 390 ? 844 : 800 });
+      await page.waitForTimeout(50);
+      const layout = await page.evaluate(() => {
+        const rect = (selector) => {
+          const bounds = document.querySelector(selector)?.getBoundingClientRect();
+          return bounds
+            ? { top: bounds.top, bottom: bounds.bottom, left: bounds.left, right: bounds.right, width: bounds.width }
+            : null;
+        };
+        return {
+          title: rect(".room-title"),
+          name: rect(".room-title-main"),
+          toggle: rect("#room-log-toggle"),
+          latest: rect("#room-log-latest"),
+          latestLabel: document.querySelector("#room-log-latest")?.getAttribute("aria-label") || "",
+          toggleLabel: document.querySelector("#room-log-toggle")?.getAttribute("aria-label") || "",
+        };
+      });
+      assert(
+        layout.title && layout.name && layout.toggle && layout.latest,
+        `${width}px: title, Journal control, and latest-event line should all render: ${JSON.stringify(layout)}`,
+      );
+      assert(
+        layout.name.right <= layout.toggle.left + 0.5,
+        `${width}px: location name must not overlap the Journal control: ${JSON.stringify(layout)}`,
+      );
+      assert(
+        layout.latest.top >= layout.title.bottom - 0.5,
+        `${width}px: latest-event line should sit below the title row: ${JSON.stringify(layout)}`,
+      );
+      assert(
+        Math.abs(layout.latest.left - layout.title.left) <= 1
+          && Math.abs(layout.latest.right - layout.title.right) <= 1,
+        `${width}px: latest-event line should use the full room content width: ${JSON.stringify(layout)}`,
+      );
+      assert(
+        /^Open Journal, latest: .+/.test(layout.latestLabel) && layout.toggleLabel === "Open Journal",
+        `${width}px: both Journal entry points need clear accessible names: ${JSON.stringify(layout)}`,
+      );
+    }
+    if (originalViewport) await page.setViewportSize(originalViewport);
   }
 
   async function assertMudShellVisualContract(label) {
@@ -8617,6 +8663,7 @@ async function main() {
   await assertRoomSummaryStaysFlatAndMechanical();
   await assertStatusBarDoesNotOverlayTranscript("mobile status row");
   await assertJournalModeContract("mobile Journal");
+  await assertJournalTickerLayout();
   await assertUiAccessibilityContract("mobile accessibility and navigation");
   await assertMudShellVisualContract(runLivingWorldStress ? "mobile visual shell stress" : "mobile visual shell");
   await assertTimelineAccessibilityBase();


### PR DESCRIPTION
Closes #296

- Keeps the room name and Journal button on one stable row.
- Shows the newest Journal beat on one full-width line beneath it; long beats scroll, pause on hover, and use ellipsis for reduced motion.
- Makes both the Journal button and latest beat accessible entry points without adding another live region.
- Covers 390 px, 768 px, and desktop layouts in the browser journey smoke.

Release: 0.0.182

Checks: `npm run check`; browser journey smoke; local visual pass.