### PR TITLE
Keep open pathway offers valid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.182",
+  "version": "0.0.183",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.182",
+      "version": "0.0.183",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.182",
+  "version": "0.0.183",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.182"
+version = "0.0.183"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.182"
+version = "0.0.183"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -26,6 +26,31 @@ fn submitted_payload_target(
     payload.get(key).and_then(serde_json::Value::as_u64)
 }
 
+fn submitted_offer_legacy_id(submission: &ActionOfferSubmissionRequest) -> Option<&str> {
+    let prefix = format!(
+        "{}:{}:",
+        submission.rules_profile, submission.state_revision
+    );
+    submission.offer_id.strip_prefix(&prefix)
+}
+
+fn offer_composition_matches_at_submitted_revision(
+    offer: &RankedActionOffer,
+    submission: &ActionOfferSubmissionRequest,
+) -> bool {
+    if offer.state_revision <= submission.state_revision {
+        return false;
+    }
+    // Unrelated world events advance every offer envelope. Rebind only that
+    // volatile revision so the certificate still detects real scene changes.
+    let mut trace = offer.composition_trace.clone();
+    trace.state_revision = submission.state_revision;
+    if let Some(rules_context) = trace.rules_context.as_mut() {
+        rules_context.state_revision = submission.state_revision;
+    }
+    trace.certificate() == submission.composition_id
+}
+
 impl RuntimeWorld {
     pub(super) fn validate_action_offer_submission(
         &self,
@@ -34,19 +59,29 @@ impl RuntimeWorld {
         submission: &ActionOfferSubmissionRequest,
     ) -> Result<(), &'static str> {
         let (_, offers) = self.legal_action_candidates(Some(actor_id), access);
-        let Some(offer) = offers
+        let exact_offer = offers
             .iter()
-            .find(|offer| offer.offer_id == submission.offer_id)
-        else {
+            .find(|offer| offer.offer_id == submission.offer_id);
+        let stable_offer = exact_offer.or_else(|| {
+            let legacy_id = submitted_offer_legacy_id(submission)?;
+            offers
+                .iter()
+                .find(|offer| offer.id == legacy_id && offer.kind == submission.kind)
+        });
+        let Some(offer) = stable_offer else {
             return Err("that offer expired; refresh the scene and submit a current offer_id");
         };
-        if offer.composition_id != submission.composition_id {
+        let revision_rebound = exact_offer.is_none()
+            && offer_composition_matches_at_submitted_revision(offer, submission);
+        if !revision_rebound
+            && (exact_offer.is_none() || offer.composition_id != submission.composition_id)
+        {
             Err("the scene composition changed; refresh and choose a current action")
         } else if offer.kind != submission.kind
             || offer.rules_action != submission.rules_action
             || offer.operation != submission.operation
             || offer.rules_profile != submission.rules_profile
-            || offer.state_revision != submission.state_revision
+            || (offer.state_revision != submission.state_revision && !revision_rebound)
             || offer.target != submission.target
             || offer.cost != submission.cost
             || offer.disabled

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -8026,6 +8026,7 @@
 
     function eventIsLowSignalStatus(event) {
       return event?.type === "world.reset"
+        || event?.type === "action.offer_rejected"
         || event?.type === "advancement.spent"
         || String(event?.type || "").startsWith("community_art.");
     }

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -212,6 +212,20 @@ mod tests {
         from_location_id: u64,
         to_location_id: u64,
     ) {
+        discover_seed_exit_for_actor_for_test(
+            runtime,
+            RATI_ACTOR_ID,
+            from_location_id,
+            to_location_id,
+        );
+    }
+
+    fn discover_seed_exit_for_actor_for_test(
+        runtime: &mut RuntimeWorld,
+        actor_id: u64,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) {
         let destination = runtime
             .location_name(to_location_id)
             .unwrap_or_else(|| format!("Location {to_location_id}"));
@@ -230,7 +244,7 @@ mod tests {
             },
         );
         runtime.remember_search_discovery(
-            RATI_ACTOR_ID,
+            actor_id,
             from_location_id,
             SEARCH_MEMORY_KIND_SEED_EXIT,
             to_location_id,
@@ -443,5 +457,187 @@ mod tests {
                 .is_none(),
             "the exact reverse offer cannot bypass immediate-return protection"
         );
+    }
+
+    async fn submit_offer_for_test(
+        state: &AppState,
+        actor_session: &str,
+        path: &str,
+        offer: RankedActionOffer,
+        payload: serde_json::Value,
+    ) -> ActionResponse {
+        let mut payload = payload.as_object().cloned().unwrap_or_default();
+        payload.insert(
+            "actor_session".to_string(),
+            serde_json::Value::String(actor_session.to_string()),
+        );
+        payload.insert(
+            "wallet_address".to_string(),
+            serde_json::Value::String("dev-wallet".to_string()),
+        );
+        submit_action_offer(
+            ConnectInfo("127.0.0.1:44030".parse().expect("client address")),
+            State(state.clone()),
+            Json(ActionOfferSubmissionRequest {
+                path: path.to_string(),
+                offer_id: offer.offer_id,
+                composition_id: offer.composition_id,
+                kind: offer.kind,
+                rules_action: offer.rules_action,
+                operation: offer.operation,
+                rules_profile: offer.rules_profile,
+                state_revision: offer.state_revision,
+                target: offer.target,
+                cost: offer.cost,
+                payload: serde_json::Value::Object(payload),
+            }),
+        )
+        .await
+        .0
+    }
+
+    #[tokio::test]
+    async fn current_offers_traverse_a_generated_pathway_through_completion() {
+        let actor_id = 5000;
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            actor_id,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Offer Pathfinder",
+        );
+        runtime.callings.insert(
+            actor_id,
+            CallingState {
+                actor_id,
+                statement: EXPLORER_CALLING_STATEMENT.to_string(),
+                source_event_seq: None,
+            },
+        );
+        discover_seed_exit_for_actor_for_test(
+            &mut runtime,
+            actor_id,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            MOONLIT_TRAIL_LOCATION_ID,
+        );
+        let state = test_app_state(runtime, None);
+        let (actor_session, _) = issue_actor_session(&state, actor_id);
+
+        let current_offer = |runtime: &RuntimeWorld, kind: &str, target_id: u64| {
+            let view = runtime.state_response(Some(actor_id), &AccessContext::default());
+            let offer = view
+                .action_offers
+                .into_iter()
+                .find(|offer| {
+                    offer.kind == kind
+                        && offer
+                            .target
+                            .as_ref()
+                            .is_some_and(|target| target.id == Some(target_id))
+                })
+                .unwrap_or_else(|| panic!("{kind} offer for {target_id} should be current"));
+            assert!(
+                view.action_hand
+                    .entries
+                    .iter()
+                    .any(|entry| entry.offer_id == offer.offer_id),
+                "{kind} offer for {target_id} should use the browser hand identity"
+            );
+            offer
+        };
+
+        let mut final_travel_offer = None;
+        let first_scout = {
+            let runtime = state.inner.lock().await;
+            current_offer(&runtime, "explore_path", MOONLIT_TRAIL_LOCATION_ID)
+        };
+        let first_scout_response = submit_offer_for_test(
+            &state,
+            &actor_session,
+            "/actions/explore-path",
+            first_scout,
+            serde_json::json!({ "actor_id": actor_id }),
+        )
+        .await;
+        assert!(first_scout_response.ok, "{first_scout_response:?}");
+
+        for step in 1..=3 {
+            let next_location_id = {
+                let runtime = state.inner.lock().await;
+                runtime.journeys[&actor_id].path[step]
+            };
+            let travel = {
+                let runtime = state.inner.lock().await;
+                current_offer(&runtime, "move", next_location_id)
+            };
+            if step == 3 {
+                final_travel_offer = Some(travel.clone());
+                let mut runtime = state.inner.lock().await;
+                runtime.append_async_job_event(
+                    "pathway.refined",
+                    RATI_ACTOR_ID,
+                    None,
+                    Some("unrelated background refinement".to_string()),
+                );
+                runtime.append_async_job_event(
+                    "pathway.refined",
+                    RATI_ACTOR_ID,
+                    None,
+                    Some("another unrelated background refinement".to_string()),
+                );
+            }
+            let travel_response = submit_offer_for_test(
+                &state,
+                &actor_session,
+                "/actions/move",
+                travel,
+                serde_json::json!({
+                    "actor_id": actor_id,
+                    "destination_location_id": next_location_id,
+                }),
+            )
+            .await;
+            assert!(travel_response.ok, "step {step}: {travel_response:?}");
+            if step < 3 {
+                let scout = {
+                    let runtime = state.inner.lock().await;
+                    current_offer(&runtime, "explore_path", MOONLIT_TRAIL_LOCATION_ID)
+                };
+                let scout_response = submit_offer_for_test(
+                    &state,
+                    &actor_session,
+                    "/actions/explore-path",
+                    scout,
+                    serde_json::json!({ "actor_id": actor_id }),
+                )
+                .await;
+                assert!(scout_response.ok, "step {step}: {scout_response:?}");
+            }
+        }
+
+        let runtime = state.inner.lock().await;
+        assert_eq!(
+            runtime.actor_by_id(actor_id).map(|actor| actor.location_id),
+            Some(MOONLIT_TRAIL_LOCATION_ID)
+        );
+        assert!(!runtime.journeys.contains_key(&actor_id));
+        assert!(runtime.event_log.iter().any(|event| {
+            event.type_name == "journey.completed" && event.actor_id == Some(actor_id)
+        }));
+        drop(runtime);
+
+        let stale_retry = submit_offer_for_test(
+            &state,
+            &actor_session,
+            "/actions/move",
+            final_travel_offer.expect("final travel offer was captured"),
+            serde_json::json!({
+                "actor_id": actor_id,
+                "destination_location_id": MOONLIT_TRAIL_LOCATION_ID,
+            }),
+        )
+        .await;
+        assert!(!stale_retry.ok);
+        assert_eq!(stale_retry.status, 409);
     }
 }

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4164,6 +4164,13 @@ async function main() {
           output: "There is no need to fight here now.",
         }),
       },
+      rejectedOffer: {
+        lowSignal: eventIsLowSignalStatus({ type: "action.offer_rejected" }),
+        journaled: eventIsJournalEvent({
+          type: "action.offer_rejected",
+          content: "that offer expired; refresh the scene",
+        }),
+      },
     }));
     assert(result.action.chatCost === "That choice did not land. Here are the choices you have now.", `a stale Chat payment error should not imply that Chat costs Orbs: ${JSON.stringify(result)}`);
     assert(result.action.orbCost === "That choice did not land. Here are the choices you have now.", `non-image payment errors should not advertise another Orb sink: ${JSON.stringify(result)}`);
@@ -4171,6 +4178,10 @@ async function main() {
     assert(result.command.changed === "That choice changed while you were deciding. Nothing else happened; look again.", `stale typed commands should explain the atomic outcome naturally: ${JSON.stringify(result)}`);
     assert(result.action.hurry === "The room needs a breath. Try again in a moment.", `rate limits should sound like the room, not infrastructure: ${JSON.stringify(result)}`);
     assert(result.command.serverGuidance === "There is no need to fight here now.", `typed commands should preserve contextual server guidance: ${JSON.stringify(result)}`);
+    assert(
+      result.rejectedOffer.lowSignal && !result.rejectedOffer.journaled,
+      `offer rejection telemetry should stay out of the player Journal: ${JSON.stringify(result.rejectedOffer)}`,
+    );
     const visibleCopy = [...Object.values(result.action), ...Object.values(result.command)];
     assert(!/session expired|action bar|command could not|action could not|write committed|current state|status 4|status 5/i.test(visibleCopy.join(" ")), `failure feedback should not leak implementation language: ${JSON.stringify(result)}`);
   }


### PR DESCRIPTION
Closes #303

- Keeps a still-legal open path valid across unrelated world-event revision churn while preserving real stale-scene rejection.
- Keeps `action.offer_rejected` telemetry out of the player Journal.
- Covers the browser hand IDs through generated-path completion, stale retry, and forward/reverse browser journeys.

Release: `0.0.183`