### PR TITLE
Advance First Tale after Garden arrival

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.184",
+  "version": "0.0.185",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.184",
+      "version": "0.0.185",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.184",
+  "version": "0.0.185",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.184"
+version = "0.0.185"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.184"
+version = "0.0.185"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -6415,6 +6415,7 @@ impl RuntimeSnapshot {
             runtime.ensure_seed_rpg_projection();
             runtime.backfill_generated_avatar_flavor();
             runtime.backfill_listen_attempt_claims_from_events();
+            runtime.backfill_first_tale_destination_arrivals();
             runtime.refresh_all_resident_continuities();
             runtime.ensure_actor_autonomy();
             runtime.backfill_generated_place_governance();
@@ -6428,7 +6429,6 @@ impl RuntimeSnapshot {
         })
     }
 }
-
 impl ResidentContinuitySnapshot {
     fn from_runtime(runtime: &RuntimeWorld) -> Self {
         Self {
@@ -6440,7 +6440,6 @@ impl ResidentContinuitySnapshot {
         }
     }
 }
-
 fn default_zone() -> String {
     ZONE_SANCTUARY.to_string()
 }
@@ -10079,6 +10078,7 @@ impl RuntimeWorld {
             let committed_events = events.clone();
             events.extend(self.apply_influence_projection(&action, &committed_events));
             self.reinforce_search_memories_from_events(&events);
+            self.record_first_tale_destination_arrivals(&events);
             let committed_events = events.clone();
             events.extend(self.apply_event_lifecycle_hooks(
                 &action,

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -11,6 +11,56 @@ pub(super) enum MovementPlan {
 }
 
 impl RuntimeWorld {
+    pub(super) fn first_tale_destination_reached(&self, actor_id: u64) -> bool {
+        self.rpg_claims
+            .contains(&first_tale_destination_claim_key(actor_id))
+            || self
+                .actor_by_id(actor_id)
+                .is_some_and(|actor| actor.location_id == RAIN_SOFT_GARDEN_LOCATION_ID)
+    }
+
+    pub(super) fn record_first_tale_destination_arrivals(&mut self, events: &[EventView]) {
+        let actor_ids = events
+            .iter()
+            .filter(|event| {
+                event.success
+                    && event.type_name == "actor.moved"
+                    && (event.location_id == Some(RAIN_SOFT_GARDEN_LOCATION_ID)
+                        || event.destination_location_id == Some(RAIN_SOFT_GARDEN_LOCATION_ID))
+            })
+            .filter_map(|event| event.actor_id)
+            .collect::<BTreeSet<_>>();
+        for actor_id in actor_ids {
+            self.rpg_claims
+                .insert(first_tale_destination_claim_key(actor_id));
+        }
+    }
+
+    pub(super) fn backfill_first_tale_destination_arrivals(&mut self) {
+        let mut actor_ids = self
+            .event_log
+            .iter()
+            .filter(|event| {
+                event.success
+                    && event.type_name == "actor.moved"
+                    && (event.location_id == Some(RAIN_SOFT_GARDEN_LOCATION_ID)
+                        || event.destination_location_id == Some(RAIN_SOFT_GARDEN_LOCATION_ID))
+            })
+            .filter_map(|event| event.actor_id)
+            .collect::<BTreeSet<_>>();
+        actor_ids.extend(self.journeys.iter().filter_map(|(actor_id, journey)| {
+            journey
+                .path
+                .get(..=journey.current_step)
+                .is_some_and(|path| path.contains(&RAIN_SOFT_GARDEN_LOCATION_ID))
+                .then_some(*actor_id)
+        }));
+        for actor_id in actor_ids {
+            self.rpg_claims
+                .insert(first_tale_destination_claim_key(actor_id));
+        }
+    }
+
     pub(super) fn current_reachable_offer(
         &self,
         actor_id: u64,
@@ -201,6 +251,12 @@ impl RuntimeWorld {
             .into_iter()
             .any(|exit| exit.accessible && !exit.locked)
     }
+}
+
+fn first_tale_destination_claim_key(actor_id: u64) -> String {
+    format!(
+        "first_tale:v{FIRST_TALE_TRACE_SCHEMA_VERSION}:actor:{actor_id}:destination:{RAIN_SOFT_GARDEN_LOCATION_ID}"
+    )
 }
 
 #[cfg(test)]
@@ -459,6 +515,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn first_tale_destination_progress_survives_snapshot_and_legacy_backfill() {
+        let actor_id = 5000;
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            actor_id,
+            COSY_COTTAGE_LOCATION_ID,
+            "Returning Pathfinder",
+        );
+        runtime
+            .listen_attempt_claims
+            .insert(listen_attempt_claim_key(actor_id, COSY_COTTAGE_LOCATION_ID));
+        let arrival = runtime.append_actor_moved_event(
+            actor_id,
+            COSY_COTTAGE_LOCATION_ID,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+        );
+        runtime.record_first_tale_destination_arrivals(&[arrival]);
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .find(|actor| actor.id == actor_id)
+            .expect("First Tale actor exists")
+            .location_id = MOONLIT_TRAIL_LOCATION_ID;
+        assert!(runtime.first_tale_view(actor_id).is_none());
+
+        let restored = RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .expect("First Tale progress survives snapshot restore");
+        assert!(restored.first_tale_view(actor_id).is_none());
+
+        let mut legacy_snapshot = RuntimeSnapshot::from_runtime(&runtime);
+        legacy_snapshot
+            .rpg_claims
+            .remove(&first_tale_destination_claim_key(actor_id));
+        let backfilled = legacy_snapshot
+            .into_runtime()
+            .expect("legacy arrival progress backfills from movement");
+        assert!(backfilled.first_tale_view(actor_id).is_none());
+        assert!(backfilled.first_tale_destination_reached(actor_id));
+    }
+
     async fn submit_offer_for_test(
         state: &AppState,
         actor_session: &str,
@@ -503,9 +603,12 @@ mod tests {
         create_test_human(
             &mut runtime,
             actor_id,
-            RAIN_SOFT_GARDEN_LOCATION_ID,
+            COSY_COTTAGE_LOCATION_ID,
             "Offer Pathfinder",
         );
+        runtime
+            .listen_attempt_claims
+            .insert(listen_attempt_claim_key(actor_id, COSY_COTTAGE_LOCATION_ID));
         runtime.callings.insert(
             actor_id,
             CallingState {
@@ -513,6 +616,12 @@ mod tests {
                 statement: EXPLORER_CALLING_STATEMENT.to_string(),
                 source_event_seq: None,
             },
+        );
+        discover_seed_exit_for_actor_for_test(
+            &mut runtime,
+            actor_id,
+            COSY_COTTAGE_LOCATION_ID,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
         );
         discover_seed_exit_for_actor_for_test(
             &mut runtime,
@@ -546,6 +655,43 @@ mod tests {
             offer
         };
 
+        {
+            let runtime = state.inner.lock().await;
+            assert_eq!(
+                runtime
+                    .first_tale_view(actor_id)
+                    .expect("the discovered lead is visible")
+                    .phase,
+                "follow_lead"
+            );
+        }
+        let garden_offer = {
+            let runtime = state.inner.lock().await;
+            current_offer(&runtime, "move", RAIN_SOFT_GARDEN_LOCATION_ID)
+        };
+        let garden_response = submit_offer_for_test(
+            &state,
+            &actor_session,
+            "/actions/move",
+            garden_offer,
+            serde_json::json!({
+                "actor_id": actor_id,
+                "destination_location_id": RAIN_SOFT_GARDEN_LOCATION_ID,
+            }),
+        )
+        .await;
+        assert!(garden_response.ok, "{garden_response:?}");
+        {
+            let runtime = state.inner.lock().await;
+            assert_eq!(
+                runtime
+                    .first_tale_view(actor_id)
+                    .expect("arrival advances the First Tale")
+                    .phase,
+                "contribute"
+            );
+        }
+
         let mut final_travel_offer = None;
         let first_scout = {
             let runtime = state.inner.lock().await;
@@ -560,6 +706,10 @@ mod tests {
         )
         .await;
         assert!(first_scout_response.ok, "{first_scout_response:?}");
+        let pathway = {
+            let runtime = state.inner.lock().await;
+            runtime.journeys[&actor_id].path.clone()
+        };
 
         for step in 1..=3 {
             let next_location_id = {
@@ -598,6 +748,13 @@ mod tests {
             )
             .await;
             assert!(travel_response.ok, "step {step}: {travel_response:?}");
+            {
+                let runtime = state.inner.lock().await;
+                assert!(
+                    runtime.first_tale_view(actor_id).is_none(),
+                    "the Garden contribution is hidden when it is not locally actionable"
+                );
+            }
             if step < 3 {
                 let scout = {
                     let runtime = state.inner.lock().await;
@@ -625,6 +782,35 @@ mod tests {
             event.type_name == "journey.completed" && event.actor_id == Some(actor_id)
         }));
         drop(runtime);
+
+        for destination_location_id in pathway[..pathway.len() - 1].iter().rev().copied() {
+            let reverse_offer = {
+                let runtime = state.inner.lock().await;
+                current_offer(&runtime, "move", destination_location_id)
+            };
+            let reverse_response = submit_offer_for_test(
+                &state,
+                &actor_session,
+                "/actions/move",
+                reverse_offer,
+                serde_json::json!({
+                    "actor_id": actor_id,
+                    "destination_location_id": destination_location_id,
+                }),
+            )
+            .await;
+            assert!(reverse_response.ok, "{reverse_response:?}");
+        }
+        {
+            let runtime = state.inner.lock().await;
+            assert_eq!(
+                runtime
+                    .first_tale_view(actor_id)
+                    .expect("the Garden contribution returns on backtracking")
+                    .phase,
+                "contribute"
+            );
+        }
 
         let stale_retry = submit_offer_for_test(
             &state,

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -920,11 +920,19 @@ impl RuntimeWorld {
         }
         let trace_event_seq = self.first_tale_trace_event_seq(actor_id);
         let has_lead = self.listen_attempt_claimed_at(actor_id, COSY_COTTAGE_LOCATION_ID);
+        let destination_reached = self.first_tale_destination_reached(actor_id);
+        if trace_event_seq.is_none()
+            && has_lead
+            && destination_reached
+            && actor.location_id != RAIN_SOFT_GARDEN_LOCATION_ID
+        {
+            return None;
+        }
         let phase = if trace_event_seq.is_some() {
             "complete"
         } else if !has_lead {
             "notice"
-        } else if actor.location_id != RAIN_SOFT_GARDEN_LOCATION_ID {
+        } else if !destination_reached {
             "follow_lead"
         } else {
             "contribute"


### PR DESCRIPTION
Closes #305

- persist arrival at Rain-Soft Garden
- hide the Garden-only prompt while it is not locally actionable
- reuse the generated-path journey fixture through backtracking and snapshot migration
- release 0.0.185

Checks: `npm run check`