### PR TITLE
Make advertised offer commands executable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.185",
+  "version": "0.0.186",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.185",
+      "version": "0.0.186",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.185",
+  "version": "0.0.186",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.185"
+version = "0.0.186"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.185"
+version = "0.0.186"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -179,8 +179,18 @@ impl RuntimeWorld {
         actor_id: Option<u64>,
         access: &AccessContext,
     ) -> (PrimaryAction, Vec<RankedActionOffer>) {
-        let primary_action = self.primary_action(actor_id, access);
+        let mut primary_action = self.primary_action(actor_id, access);
         let mut action_offers = self.ranked_action_offers(actor_id, access, &primary_action);
+        let primary_offer_kind = match primary_action.kind.as_str() {
+            "travel" => "move",
+            kind => kind,
+        };
+        if let Some(offer) = action_offers
+            .iter()
+            .find(|offer| offer.kind == primary_offer_kind)
+        {
+            primary_action.command = offer.command.clone();
+        }
         for offer in &mut action_offers {
             offer.composition_trace.focused_encounter = actor_id
                 .and_then(|actor_id| focused_encounter_offer_context(self, actor_id, &offer.kind));
@@ -375,6 +385,10 @@ impl RuntimeWorld {
             let label = self.action_offer_label(kind, &verb, "Scout", Some(&target), None);
             let accessible_label =
                 self.action_offer_accessible_label(kind, &verb, &label, Some(&target), None);
+            let command = format!(
+                "scout {}",
+                target.label.as_deref().unwrap_or("the journey destination")
+            );
             let provider = self.action_offer_provider(kind, actor_id, Some(&target), None);
             let state_revision = self.world.next_event_seq.saturating_sub(1);
             let source_collectible = self.location_source_collectible(actor_id);
@@ -420,7 +434,7 @@ impl RuntimeWorld {
                 verb,
                 label,
                 accessible_label,
-                command: "explore path".to_string(),
+                command,
                 rank: action_offer_rank(kind),
                 disabled: false,
                 disabled_reason: None,
@@ -1690,5 +1704,94 @@ impl RuntimeWorld {
                 .map(|bond| format!("bond_resolved:{}", bond.id)),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command_request(actor_id: u64, command: &str) -> CommandRequest {
+        CommandRequest {
+            actor_id,
+            actor_session: None,
+            command: command.to_string(),
+            wallet_address: None,
+            wallet: None,
+            wallet_session: None,
+            owned_card_ids: None,
+            cards: None,
+            envelope: None,
+        }
+    }
+
+    #[test]
+    fn composed_offers_advertise_commands_the_typed_client_can_resolve() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Offer Tester");
+        let access = AccessContext::default();
+        let (primary, offers) = runtime.legal_action_candidates(Some(5000), &access);
+
+        for offer in &offers {
+            runtime
+                .resolve_command(&command_request(5000, &offer.command), &access)
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "{} advertised unroutable command {:?}: {}",
+                        offer.offer_id, offer.command, error.output
+                    )
+                });
+        }
+        runtime
+            .resolve_command(&command_request(5000, &primary.command), &access)
+            .expect("the primary action advertises a routable command");
+        assert!(offers.iter().any(|offer| offer.command == primary.command));
+
+        let offer = offers
+            .iter()
+            .find(|offer| {
+                offer
+                    .composition_trace
+                    .contextual_offers
+                    .iter()
+                    .any(|id| id == "cosyworld.core:cottage-ask-local-lead")
+            })
+            .expect("the core pack contributes its Cottage offer");
+        assert_eq!(offer.label, "Ask for a local lead");
+        assert_eq!(offer.command, "influence Rati");
+        let resolved = runtime
+            .resolve_command(&command_request(5000, &offer.command), &access)
+            .expect("the advertised contextual command resolves");
+        assert_eq!(resolved.command, offer.command);
+        assert!(matches!(
+            resolved.dispatch,
+            CommandDispatch::Influence {
+                target_actor_id: RATI_ACTOR_ID
+            }
+        ));
+
+        let scout = offers
+            .iter()
+            .find(|offer| offer.kind == "explore_path")
+            .expect("the seeded long journey exposes Scout");
+        let destination_location_id = scout
+            .target
+            .as_ref()
+            .and_then(|target| target.id)
+            .expect("Scout advertises its destination");
+        let destination_label = scout
+            .target
+            .as_ref()
+            .and_then(|target| target.label.as_deref())
+            .expect("Scout advertises its destination label");
+        assert_eq!(scout.command, format!("scout {destination_label}"));
+        assert!(matches!(
+            runtime
+                .resolve_command(&command_request(5000, &scout.command), &access)
+                .expect("the advertised Scout command resolves")
+                .dispatch,
+            CommandDispatch::Scout
+        ));
+        assert!(destination_location_id > 0);
     }
 }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -20112,10 +20112,14 @@ impl RuntimeWorld {
         if can_influence {
             let (authored_label, _, _) =
                 self.contextual_action_contributions(actor_id, "srd5.2.1:influence");
+            let command = self
+                .default_chat_target(actor_id)
+                .map(|target| format!("influence {}", self.actor_view(target).name))
+                .unwrap_or_else(|| "influence".to_string());
             options.push(ActionOption {
                 kind: "influence".to_string(),
                 label: authored_label.unwrap_or_else(|| "Influence".to_string()),
-                command: "ask for a local lead".to_string(),
+                command,
             });
         }
         if offers.option_flags & CW_OFFER_CHECK != 0 {
@@ -20288,11 +20292,12 @@ impl RuntimeWorld {
             });
         }
 
-        let selected_kind = options
+        let (selected_kind, selected_command) = options
             .iter()
             .min_by_key(|option| self.action_offer_rank_for_actor(&option.kind, actor_id))
-            .map(|option| option.kind.as_str())
-            .unwrap_or("act");
+            .map(|option| (option.kind.clone(), option.command.clone()))
+            .unwrap_or_else(|| ("act".to_string(), "look".to_string()));
+        let selected_kind = selected_kind.as_str();
 
         PrimaryAction {
             kind: match selected_kind {
@@ -20328,38 +20333,7 @@ impl RuntimeWorld {
                 _ => "Act",
             }
             .to_string(),
-            command: match selected_kind {
-                "chat" => "chat".to_string(),
-                "influence" => "ask for a local lead".to_string(),
-                "move" => "go".to_string(),
-                "flee" => "flee".to_string(),
-                "give_item" => "give".to_string(),
-                "trade_item" => "trade".to_string(),
-                "theft" => "steal".to_string(),
-                "use_item" => "use".to_string(),
-                "use_feature" => default_feature_use
-                    .as_ref()
-                    .map(|candidate| {
-                        format!("use {} on {}", candidate.item_name, candidate.feature_name)
-                    })
-                    .unwrap_or_else(|| "use".to_string()),
-                "rest" => "rest".to_string(),
-                "attack" => "attack".to_string(),
-                "defend" => "defend".to_string(),
-                "pick_up" => "take".to_string(),
-                "drop_item" => "drop".to_string(),
-                "check" => "listen".to_string(),
-                "study" => "study the moonlit signs".to_string(),
-                "cast_spell" => "cast steady light".to_string(),
-                "prepare" => "prepare".to_string(),
-                "work" => "work".to_string(),
-                "help" => "assist".to_string(),
-                "create_bond" => self
-                    .default_bond_command(actor_id)
-                    .unwrap_or_else(|| "bond".to_string()),
-                "resolve_bond" => "remember".to_string(),
-                _ => "look".to_string(),
-            },
+            command: selected_command,
             disabled: false,
             options,
         }
@@ -29439,6 +29413,18 @@ async fn command_inner(
             )
             .await;
             command_action_response_with_events(resolved, response.into_action(), presence_events)
+        }
+        CommandDispatch::Scout => {
+            let Json(response) = explore_pathway(
+                ConnectInfo(client_addr),
+                State(state),
+                Json(ActorRequest {
+                    actor_id: payload.actor_id,
+                    actor_session: payload.actor_session,
+                }),
+            )
+            .await;
+            command_action_response_with_events(resolved, response, presence_events)
         }
         CommandDispatch::Flee {
             destination_location_id,
@@ -66861,7 +66847,7 @@ mod tests {
         let state = runtime.state_response(Some(5000), &access);
         assert_eq!(state.primary_action.kind, "pick_up");
         assert_eq!(state.primary_action.label, "Take");
-        assert_eq!(state.primary_action.command, "take");
+        assert_eq!(state.primary_action.command, "take Hearth Tonic");
         assert!(!state
             .primary_action
             .options

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -58,6 +58,7 @@ pub(crate) enum CommandDispatch {
     Move {
         destination_location_id: u64,
     },
+    Scout,
     Flee {
         destination_location_id: u64,
     },
@@ -230,6 +231,7 @@ pub(crate) fn canonical_command_verb(verb: &str) -> String {
         "i" | "inv" | "inventory" | "deck" => "inventory",
         "who" | "where" => "who",
         "go" | "move" | "travel" => "go",
+        "scout" | "explore" => "scout",
         "get" | "take" | "pick" => "take",
         "give" | "gift" => "give",
         "trade" | "swap" | "barter" => "trade",
@@ -490,6 +492,7 @@ pub(crate) fn command_action_failure_output(resolved: &ResolvedCommand, status: 
     }
     match &resolved.dispatch {
         CommandDispatch::Move { .. } => "That path is not open from here right now.",
+        CommandDispatch::Scout => "That route can no longer be scouted from here.",
         CommandDispatch::Flee { .. } => "The room has calmed; flee is not needed.",
         CommandDispatch::Check => "The room did not catch that Listen. Try once more.",
         CommandDispatch::Study => "There is no authored subject to Study here now.",
@@ -1276,7 +1279,7 @@ impl RuntimeWorld {
                 verb,
                 action: None,
                 dispatch: CommandDispatch::Read {
-                            output: "Try: look, search, study, who, choice, support <project>, choose <project>, delegate choice to <avatar>, deck, wear <skill charm>, remove <skill charm>, wield <weapon-or-bag>, unwield <weapon-or-bag>, stow <item> in <bag>, unstow <item>, prepare-spell <spell>, unprepare-spell <spell>, cast <spell>, go <place>, say <message>, emote <action>, take <item>, drop <item>, give <item> to <avatar>, request <item> from <avatar>, trade <item> with <avatar> for <item>, offers, accept <offer>, decline <offer>, withdraw <offer>, mute <avatar>, unmute <avatar>, block <avatar>, unblock <avatar>, use <item> on <target>, chat <avatar>, influence <avatar>, listen, prepare, work, assist, rest, more, purpose <what draws you in>, friendship <avatar>: <why they matter>, remember <avatar>, attack <target>, defend, flee <place>, pass, need time, or report <actor>: <reason>.".to_string(),
+                            output: "Try: look, search, study, who, choice, support <project>, choose <project>, delegate choice to <avatar>, deck, wear <skill charm>, remove <skill charm>, wield <weapon-or-bag>, unwield <weapon-or-bag>, stow <item> in <bag>, unstow <item>, prepare-spell <spell>, unprepare-spell <spell>, cast <spell>, go <place>, scout <place>, say <message>, emote <action>, take <item>, drop <item>, give <item> to <avatar>, request <item> from <avatar>, trade <item> with <avatar> for <item>, offers, accept <offer>, decline <offer>, withdraw <offer>, mute <avatar>, unmute <avatar>, block <avatar>, unblock <avatar>, use <item> on <target>, chat <avatar>, influence <avatar>, listen, prepare, work, assist, rest, more, purpose <what draws you in>, friendship <avatar>: <why they matter>, remember <avatar>, attack <target>, defend, flee <place>, pass, need time, or report <actor>: <reason>.".to_string(),
                 },
             }),
             "look" => Ok(ResolvedCommand {
@@ -1688,9 +1691,9 @@ impl RuntimeWorld {
                 })
             }
             "go" => {
-                let destination = self.resolve_exit_destination(actor, rest, access).map_err(|output| {
-                    command_error(&command, "go", 404, output)
-                })?;
+                let destination = self
+                    .resolve_exit_destination(actor, rest, access)
+                    .map_err(|output| command_error(&command, "go", 404, output))?;
                 Ok(ResolvedCommand {
                     command: format!("go {}", self.location_name(destination).unwrap_or_else(|| destination.to_string())),
                     verb,
@@ -1698,6 +1701,47 @@ impl RuntimeWorld {
                     dispatch: CommandDispatch::Move {
                         destination_location_id: destination,
                     },
+                })
+            }
+            "scout" => {
+                let target = self
+                    .scout_action_offer_target(actor.id, access)
+                    .ok_or_else(|| {
+                        command_error(
+                            &command,
+                            "scout",
+                            404,
+                            "There is no route to Scout here.",
+                        )
+                    })?;
+                let destination = target.id.ok_or_else(|| {
+                    command_error(
+                        &command,
+                        "scout",
+                        409,
+                        "The current journey has no destination.",
+                    )
+                })?;
+                let target_label = target
+                    .label
+                    .unwrap_or_else(|| self.location_name(destination).unwrap_or_default());
+                let query = trim_command_filler(rest);
+                if !query.is_empty()
+                    && command_match_score(&target_label, &command_key(query)).is_none()
+                {
+                    return Err(command_error(
+                        &command,
+                        "scout",
+                        404,
+                        "No current journey destination matches that command.",
+                    ));
+                }
+                let canonical = format!("scout {target_label}");
+                Ok(ResolvedCommand {
+                    command: canonical.clone(),
+                    verb,
+                    action: Some(command_action("explore_path", "Scout", &canonical)),
+                    dispatch: CommandDispatch::Scout,
                 })
             }
             "flee" => {

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74912
+74898


### PR DESCRIPTION
Closes #306

- preserve pack-authored labels while advertising canonical typed commands
- route exact primary, item, Influence, and Scout invocations through `/commands`
- fail composition tests when any live offer advertises an unroutable command
- release 0.0.186

Checks: `npm run check`