### PR TITLE
Make route state canonical

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.186",
+  "version": "0.0.187",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.186",
+      "version": "0.0.187",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.186",
+  "version": "0.0.187",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.186"
+version = "0.0.187"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.186"
+version = "0.0.187"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -82,6 +82,7 @@ impl RuntimeWorld {
             || offer.operation != submission.operation
             || offer.rules_profile != submission.rules_profile
             || (offer.state_revision != submission.state_revision && !revision_rebound)
+            || offer.route != submission.route
             || offer.target != submission.target
             || offer.cost != submission.cost
             || offer.disabled
@@ -345,6 +346,7 @@ impl RuntimeWorld {
                     composition_trace,
                     composition_id: String::new(),
                     state_revision,
+                    route: None,
                     category: action_offer_category(&option.kind).to_string(),
                     intention,
                     kind: option.kind,
@@ -416,6 +418,9 @@ impl RuntimeWorld {
                     contextual_offers: Vec::new(),
                 },
             );
+            let route = target.id.and_then(|destination_location_id| {
+                self.scout_route_offer_binding(actor_id, destination_location_id)
+            });
             offers.push(RankedActionOffer {
                 id: legacy_id,
                 offer_id,
@@ -430,6 +435,7 @@ impl RuntimeWorld {
                 composition_trace,
                 composition_id: String::new(),
                 state_revision,
+                route,
                 category: action_offer_category(kind).to_string(),
                 verb,
                 label,
@@ -554,6 +560,7 @@ impl RuntimeWorld {
             composition_trace,
             composition_id: String::new(),
             state_revision,
+            route: None,
             kind: kind.to_string(),
             intention: action_offer_intention(kind).to_string(),
             category: action_offer_category(kind).to_string(),
@@ -1774,6 +1781,7 @@ mod tests {
             .iter()
             .find(|offer| offer.kind == "explore_path")
             .expect("the seeded long journey exposes Scout");
+        assert!(scout.route.is_some(), "Scout is bound to its route version");
         let destination_location_id = scout
             .target
             .as_ref()

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -6283,6 +6283,7 @@
             operation: offer.operation,
             rules_profile: offer.rules_profile,
             state_revision: offer.state_revision,
+            route: offer.route,
             target: offer.target,
             cost: offer.cost,
             payload: authoritativePayload,

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -191,7 +191,7 @@ pub struct CwLocation {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CwExit {
     pub from_location_id: u64,
     pub to_location_id: u64,

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -38,6 +38,7 @@ mod settlement_buildings;
 mod story_metrics;
 #[cfg(test)]
 mod test_support;
+mod topology;
 mod transfers;
 mod turns;
 mod uses;
@@ -119,6 +120,7 @@ use tokio_stream::{
     wrappers::{errors::BroadcastStreamRecvError, BroadcastStream},
     StreamExt,
 };
+use topology::*;
 use tracing::{error, info, warn};
 use turns::*;
 use views::*;
@@ -982,6 +984,7 @@ enum ProjectionMutation {
         location_id: u64,
         invite_id: String,
     },
+    SetRouteLifecycle(RouteLifecycleMutation),
     JourneyTransition {
         pathway: GeneratedPathwayState,
         journey: Option<JourneyState>,
@@ -1568,6 +1571,7 @@ struct RuntimeWorld {
     tags: BTreeMap<String, RpgTagState>,
     jobs: BTreeMap<String, JobState>,
     room_sheets: BTreeMap<u64, RoomSheetState>,
+    routes: BTreeMap<String, RouteRecordState>,
     generated_pathways: BTreeMap<String, GeneratedPathwayState>,
     generated_places: BTreeMap<u64, GeneratedPlaceState>,
     governance_decisions: BTreeMap<String, GovernanceDecisionState>,
@@ -1646,6 +1650,8 @@ struct RuntimeSnapshot {
     world_locations: Vec<CwLocation>,
     #[serde(default)]
     world_exits: Vec<CwExit>,
+    #[serde(default)]
+    routes: BTreeMap<String, RouteRecordState>,
     #[serde(default)]
     world_evolution_tracks: Vec<CwEvolutionTrack>,
     #[serde(default)]
@@ -1872,6 +1878,8 @@ struct JournalRecord {
     #[serde(default)]
     focused_policy_version: u8,
     action: CwAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    route_binding: Option<RouteOfferBinding>,
     seed: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     ripple_source: Option<RippleSource>,
@@ -1905,7 +1913,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 10;
+const JOURNAL_RECORD_VERSION: u32 = 11;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -1946,6 +1954,7 @@ impl JournalRecord {
             offer_kind: None,
             focused_policy_version: 1,
             action,
+            route_binding: None,
             seed,
             ripple_source: None,
             queued_actor_job: None,
@@ -2831,6 +2840,8 @@ struct RankedActionOffer {
     composition_trace: ActionCompositionTraceView,
     composition_id: String,
     state_revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route: Option<RouteOfferBinding>,
 
     category: String,
     verb: String,
@@ -3194,6 +3205,8 @@ struct ActionOfferSubmissionRequest {
     operation: Option<String>,
     rules_profile: String,
     state_revision: u64,
+    #[serde(default)]
+    route: Option<RouteOfferBinding>,
     target: Option<ActionTargetView>,
     cost: Option<ActionCostView>,
     payload: serde_json::Value,
@@ -6119,7 +6132,7 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 10,
+            version: 11,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
@@ -6137,6 +6150,7 @@ impl RuntimeSnapshot {
             world_items: runtime.world.items[..runtime.world.item_count].to_vec(),
             world_locations: runtime.world.locations[..runtime.world.location_count].to_vec(),
             world_exits: runtime.world.exits[..runtime.world.exit_count].to_vec(),
+            routes: runtime.routes.clone(),
             world_evolution_tracks: runtime.world.evolution_tracks
                 [..runtime.world.evolution_track_count]
                 .to_vec(),
@@ -6361,6 +6375,7 @@ impl RuntimeSnapshot {
             tags: self.tags,
             jobs: self.jobs,
             room_sheets: self.room_sheets,
+            routes: self.routes,
             generated_pathways: self.generated_pathways,
             generated_places: self.generated_places,
             governance_decisions: self.governance_decisions,
@@ -6749,6 +6764,7 @@ impl RuntimeWorld {
             tags: BTreeMap::new(),
             jobs: BTreeMap::new(),
             room_sheets: BTreeMap::new(),
+            routes: BTreeMap::new(),
             generated_pathways: BTreeMap::new(),
             generated_places: BTreeMap::new(),
             governance_decisions: BTreeMap::new(),
@@ -6824,15 +6840,11 @@ impl RuntimeWorld {
                 .or_insert_with(|| location.name.clone());
         }
 
-        // Treat the Rust seed topology as authoritative so old snapshots migrate
-        // away from the cottage-as-global-hub layout.
-        self.world.exit_count = 0;
-
-        for exit in &active_content().exits {
-            self.ensure_exit(exit.from_location_id, exit.to_location_id, exit.flags);
-        }
+        self.ensure_authored_route_records();
+        self.ensure_hidden_route_records();
         self.ensure_discovered_hidden_exits();
         self.ensure_generated_pathway_topology();
+        self.rebuild_kernel_exits_from_routes();
         self.ensure_seed_residents();
         self.ensure_seed_items();
         self.normalize_card_zones();
@@ -8228,42 +8240,12 @@ impl RuntimeWorld {
         self.world.item_count += 1;
     }
 
-    fn ensure_exit(&mut self, from_location_id: u64, to_location_id: u64, flags: u32) {
-        if self.world.exits[..self.world.exit_count]
-            .iter()
-            .any(|exit| {
-                exit.from_location_id == from_location_id && exit.to_location_id == to_location_id
-            })
-        {
-            return;
-        }
-        if self.world.exit_count >= CW_MAX_EXITS {
-            return;
-        }
-        let has_from = self.world.locations[..self.world.location_count]
-            .iter()
-            .any(|location| location.id == from_location_id);
-        let has_to = self.world.locations[..self.world.location_count]
-            .iter()
-            .any(|location| location.id == to_location_id);
-        if !has_from || !has_to {
-            return;
-        }
-        self.world.exits[self.world.exit_count] = CwExit {
-            from_location_id,
-            to_location_id,
-            flags,
-        };
-        self.world.exit_count += 1;
-    }
-
     fn ensure_discovered_hidden_exits(&mut self) {
         for hidden_exit in &active_content().hidden_exits {
             if !self.hidden_exit_discovered(hidden_exit) {
                 continue;
             }
-            self.ensure_exit(hidden_exit.from_location_id, hidden_exit.to_location_id, 0);
-            self.ensure_exit(hidden_exit.to_location_id, hidden_exit.from_location_id, 0);
+            self.open_hidden_route(&hidden_exit.id);
         }
     }
 
@@ -8315,6 +8297,7 @@ impl RuntimeWorld {
             .cloned()
             .collect::<Vec<_>>();
         for pathway in pathways {
+            self.ensure_generated_pathway_route_records(&pathway);
             for edge in &pathway.revealed_edges {
                 let Some((from_location_id, to_location_id)) = parse_pathway_edge_key(edge) else {
                     continue;
@@ -8347,8 +8330,8 @@ impl RuntimeWorld {
                 .entry(waypoint.id)
                 .or_insert_with(|| waypoint.meta.clone());
         }
-        self.ensure_exit(from_location_id, to_location_id, 0);
-        self.ensure_exit(to_location_id, from_location_id, 0);
+        self.open_generated_pathway_route(pathway, from_location_id, to_location_id);
+        self.rebuild_kernel_exits_from_routes();
         let pack_id = "cosyworld.core";
         let pack_version = self.active_pack_version(pack_id);
         for location_id in [from_location_id, to_location_id] {
@@ -9964,7 +9947,9 @@ impl RuntimeWorld {
     }
 
     fn apply_journal_record(&mut self, record: &JournalRecord) -> (u32, Vec<EventView>) {
-        if !focused_encounter_journal_context_is_supported(self, record) {
+        if !focused_encounter_journal_context_is_supported(self, record)
+            || !self.route_record_preconditions_hold(record)
+        {
             return (CW_ERR_RULE, Vec::new());
         }
         self.expire_transfer_offers();
@@ -10431,6 +10416,17 @@ impl RuntimeWorld {
                         }
                     }
                 }
+                ProjectionMutation::SetRouteLifecycle(transition) => {
+                    if let Some(event) = self.apply_route_lifecycle_mutation(
+                        action.actor_id,
+                        &transition.route_id,
+                        transition.expected_version,
+                        transition.lifecycle,
+                        &transition.reason,
+                    ) {
+                        events.push(event);
+                    }
+                }
                 ProjectionMutation::JourneyTransition {
                     pathway,
                     journey,
@@ -10443,6 +10439,7 @@ impl RuntimeWorld {
                         .get(&pathway.id)
                         .cloned()
                         .unwrap_or_else(|| pathway.clone());
+                    self.ensure_generated_pathway_route_records(&next_pathway);
                     for (from_location_id, to_location_id) in reveal_edges {
                         next_pathway
                             .revealed_edges
@@ -10650,17 +10647,9 @@ impl RuntimeWorld {
                     if self.seed_exit_discovered(*from_location_id, *to_location_id) {
                         continue;
                     }
-                    self.ensure_exit(exit.from_location_id, exit.to_location_id, exit.flags);
                     let reverse_exit = self
                         .seed_exit_by_locations(*to_location_id, *from_location_id)
                         .cloned();
-                    if let Some(reverse) = reverse_exit.as_ref() {
-                        self.ensure_exit(
-                            reverse.from_location_id,
-                            reverse.to_location_id,
-                            reverse.flags,
-                        );
-                    }
                     let destination = self
                         .location_name(*to_location_id)
                         .unwrap_or_else(|| format!("Location {}", to_location_id));
@@ -10722,8 +10711,8 @@ impl RuntimeWorld {
                     if self.hidden_exit_discovered(hidden_exit) {
                         continue;
                     }
-                    self.ensure_exit(hidden_exit.from_location_id, hidden_exit.to_location_id, 0);
-                    self.ensure_exit(hidden_exit.to_location_id, hidden_exit.from_location_id, 0);
+                    self.open_hidden_route(hidden_exit_id);
+                    self.rebuild_kernel_exits_from_routes();
                     let event = self.append_exit_discovered_event(
                         action.actor_id,
                         hidden_exit.from_location_id,
@@ -39385,6 +39374,10 @@ fn commit_journal_record(
     mut record: JournalRecord,
 ) -> io::Result<(u32, Vec<EventView>)> {
     bind_focused_encounter_context(runtime, &mut record);
+    runtime.bind_route_precondition(&mut record);
+    if !runtime.route_record_preconditions_hold(&record) {
+        return Ok((CW_ERR_RULE, Vec::new()));
+    }
     if hosted_guest_record_restricted(state, runtime, &record) {
         return Ok((CW_ERR_RULE, Vec::new()));
     }
@@ -55279,6 +55272,7 @@ mod tests {
                 operation: study_offer.operation,
                 rules_profile: study_offer.rules_profile,
                 state_revision: study_offer.state_revision,
+                route: study_offer.route,
                 target: study_offer.target,
                 cost: study_offer.cost,
                 payload: serde_json::json!({

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -87,6 +87,7 @@ impl RuntimeWorld {
                     && candidate.state_revision == offered.state_revision
                     && candidate.provider.id == offered.provider.id
                     && candidate.target == offered.target
+                    && candidate.route == offered.route
                     && action_offer_is_reachable(candidate)
             })
     }
@@ -217,6 +218,10 @@ impl RuntimeWorld {
             },
             exit.destination_location_name
         ));
+        offer.route = Some(RouteOfferBinding {
+            route_id: exit.route_id,
+            route_version: exit.route_version,
+        });
         offer.target = Some(target.clone());
         offer.composition_trace.target = Some(target);
         offer
@@ -383,7 +388,7 @@ mod tests {
                         .label
                         .as_deref()
                         .is_some_and(|label| offer.label.contains(label))
-            })
+            }) && offer.route.is_some()
         }));
         assert!(
             direct_offers.iter().all(|offer| {
@@ -516,6 +521,68 @@ mod tests {
     }
 
     #[test]
+    fn stale_route_offer_fails_without_mutating_world_state() {
+        let mut runtime = RuntimeWorld::seeded();
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("route actor exists")
+            .location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
+        discover_seed_exit_pair_for_test(
+            &mut runtime,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            COSY_COTTAGE_LOCATION_ID,
+        );
+        let offer = runtime
+            .legal_action_candidates(Some(RATI_ACTOR_ID), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| {
+                offer.kind == "move"
+                    && offer.target.as_ref().and_then(|target| target.id)
+                        == Some(COSY_COTTAGE_LOCATION_ID)
+            })
+            .expect("current route offer");
+        let binding = offer.route.clone().expect("route offer is version-bound");
+        assert!(runtime.transition_route(
+            &binding.route_id,
+            binding.route_version,
+            RouteLifecycle::Blocked,
+        ));
+        runtime.rebuild_kernel_exits_from_routes();
+
+        let before = serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
+            .expect("serialize route state");
+        let rejected = runtime.validate_action_offer_submission(
+            RATI_ACTOR_ID,
+            &AccessContext::default(),
+            &ActionOfferSubmissionRequest {
+                path: "/actions/move".to_string(),
+                offer_id: offer.offer_id,
+                composition_id: offer.composition_id,
+                kind: offer.kind,
+                rules_action: offer.rules_action,
+                operation: offer.operation,
+                rules_profile: offer.rules_profile,
+                state_revision: offer.state_revision,
+                route: offer.route,
+                target: offer.target,
+                cost: offer.cost,
+                payload: serde_json::json!({
+                    "actor_id": RATI_ACTOR_ID,
+                    "destination_location_id": COSY_COTTAGE_LOCATION_ID,
+                }),
+            },
+        );
+        assert!(rejected.is_err());
+        let after = serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
+            .expect("serialize rejected route state");
+        assert_eq!(after, before);
+    }
+
+    #[test]
     fn first_tale_destination_progress_survives_snapshot_and_legacy_backfill() {
         let actor_id = 5000;
         let mut runtime = RuntimeWorld::seeded();
@@ -587,6 +654,7 @@ mod tests {
                 operation: offer.operation,
                 rules_profile: offer.rules_profile,
                 state_revision: offer.state_revision,
+                route: offer.route,
                 target: offer.target,
                 cost: offer.cost,
                 payload: serde_json::Value::Object(payload),
@@ -697,6 +765,7 @@ mod tests {
             let runtime = state.inner.lock().await;
             current_offer(&runtime, "explore_path", MOONLIT_TRAIL_LOCATION_ID)
         };
+        assert!(first_scout.route.is_some());
         let first_scout_response = submit_offer_for_test(
             &state,
             &actor_session,
@@ -760,6 +829,7 @@ mod tests {
                     let runtime = state.inner.lock().await;
                     current_offer(&runtime, "explore_path", MOONLIT_TRAIL_LOCATION_ID)
                 };
+                assert!(scout.route.is_some(), "step {step} Scout route binding");
                 let scout_response = submit_offer_for_test(
                     &state,
                     &actor_session,

--- a/v2/orchestrator-rust/src/rules_context.rs
+++ b/v2/orchestrator-rust/src/rules_context.rs
@@ -446,6 +446,7 @@ mod tests {
                 operation: offered.operation,
                 rules_profile: offered.rules_profile,
                 state_revision: offered.state_revision,
+                route: offered.route,
                 target: offered.target,
                 cost: offered.cost,
                 payload: serde_json::json!({ "actor_id": 5000 }),

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -1,0 +1,541 @@
+use super::*;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum RouteLifecycle {
+    Latent,
+    #[default]
+    Open,
+    Blocked,
+    Frozen,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct RouteEdgeState {
+    pub(super) from_location_id: u64,
+    pub(super) to_location_id: u64,
+    pub(super) flags: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct RouteRecordState {
+    pub(super) id: String,
+    pub(super) edges: Vec<RouteEdgeState>,
+    pub(super) owner: String,
+    pub(super) provenance: String,
+    pub(super) lifecycle: RouteLifecycle,
+    pub(super) entity_version: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct RouteOfferBinding {
+    pub(super) route_id: String,
+    pub(super) route_version: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct RouteLifecycleMutation {
+    pub(super) route_id: String,
+    pub(super) expected_version: u64,
+    pub(super) lifecycle: RouteLifecycle,
+    pub(super) reason: String,
+}
+
+fn ordered_route_endpoints(left: u64, right: u64) -> (u64, u64) {
+    if left <= right {
+        (left, right)
+    } else {
+        (right, left)
+    }
+}
+
+fn authored_route_id(left: u64, right: u64) -> String {
+    let (left, right) = ordered_route_endpoints(left, right);
+    format!("route:authored:{left}:{right}")
+}
+
+fn hidden_route_id(hidden_exit_id: &str) -> String {
+    format!("route:hidden:{hidden_exit_id}")
+}
+
+fn generated_route_id(pathway_id: &str, left: u64, right: u64) -> String {
+    let (left, right) = ordered_route_endpoints(left, right);
+    format!("route:generated:{pathway_id}:{left}:{right}")
+}
+
+impl RouteRecordState {
+    fn contains_edge(&self, from_location_id: u64, to_location_id: u64) -> bool {
+        self.edges.iter().any(|edge| {
+            edge.from_location_id == from_location_id && edge.to_location_id == to_location_id
+        })
+    }
+}
+
+impl RuntimeWorld {
+    fn reconcile_route_record(&mut self, mut proposed: RouteRecordState) {
+        proposed
+            .edges
+            .sort_by_key(|edge| (edge.from_location_id, edge.to_location_id, edge.flags));
+        proposed.edges.dedup();
+        let Some(current) = self.routes.get_mut(&proposed.id) else {
+            proposed.entity_version = proposed.entity_version.max(1);
+            self.routes.insert(proposed.id.clone(), proposed);
+            return;
+        };
+        let structure_changed = current.edges != proposed.edges
+            || current.owner != proposed.owner
+            || current.provenance != proposed.provenance;
+        if structure_changed {
+            current.edges = proposed.edges;
+            current.owner = proposed.owner;
+            current.provenance = proposed.provenance;
+            current.entity_version = current.entity_version.saturating_add(1).max(1);
+        }
+    }
+
+    pub(super) fn ensure_authored_route_records(&mut self) {
+        let mut records = BTreeMap::<String, RouteRecordState>::new();
+        for exit in &active_content().exits {
+            let id = authored_route_id(exit.from_location_id, exit.to_location_id);
+            records
+                .entry(id.clone())
+                .or_insert_with(|| RouteRecordState {
+                    id,
+                    edges: Vec::new(),
+                    owner: format!("worldpack:{}", active_content().manifest.id),
+                    provenance: "authored_exit".to_string(),
+                    lifecycle: RouteLifecycle::Open,
+                    entity_version: 1,
+                })
+                .edges
+                .push(RouteEdgeState {
+                    from_location_id: exit.from_location_id,
+                    to_location_id: exit.to_location_id,
+                    flags: exit.flags,
+                });
+        }
+        for record in records.into_values() {
+            self.reconcile_route_record(record);
+        }
+    }
+
+    pub(super) fn ensure_hidden_route_records(&mut self) {
+        for hidden in &active_content().hidden_exits {
+            self.reconcile_route_record(RouteRecordState {
+                id: hidden_route_id(&hidden.id),
+                edges: vec![
+                    RouteEdgeState {
+                        from_location_id: hidden.from_location_id,
+                        to_location_id: hidden.to_location_id,
+                        flags: 0,
+                    },
+                    RouteEdgeState {
+                        from_location_id: hidden.to_location_id,
+                        to_location_id: hidden.from_location_id,
+                        flags: 0,
+                    },
+                ],
+                owner: format!("worldpack:{}", active_content().manifest.id),
+                provenance: hidden.source.clone(),
+                lifecycle: RouteLifecycle::Latent,
+                entity_version: 1,
+            });
+        }
+    }
+
+    pub(super) fn ensure_generated_pathway_route_records(
+        &mut self,
+        pathway: &GeneratedPathwayState,
+    ) {
+        let mut path = Vec::with_capacity(pathway.waypoints.len() + 2);
+        path.push(pathway.origin_location_id);
+        path.extend(pathway.waypoints.iter().map(|waypoint| waypoint.id));
+        path.push(pathway.destination_location_id);
+        for edge in path.windows(2) {
+            let from_location_id = edge[0];
+            let to_location_id = edge[1];
+            let lifecycle = if pathway
+                .revealed_edges
+                .contains(&pathway_edge_key(from_location_id, to_location_id))
+            {
+                RouteLifecycle::Open
+            } else {
+                RouteLifecycle::Latent
+            };
+            let id = generated_route_id(&pathway.id, from_location_id, to_location_id);
+            let owner = self
+                .canonical_ref("actor", pathway.created_by_actor_id)
+                .map(ToString::to_string)
+                .unwrap_or_else(|| format!("actor:{}", pathway.created_by_actor_id));
+            self.reconcile_route_record(RouteRecordState {
+                id,
+                edges: vec![
+                    RouteEdgeState {
+                        from_location_id,
+                        to_location_id,
+                        flags: 0,
+                    },
+                    RouteEdgeState {
+                        from_location_id: to_location_id,
+                        to_location_id: from_location_id,
+                        flags: 0,
+                    },
+                ],
+                owner,
+                provenance: format!("generated_pathway:{}", pathway.id),
+                lifecycle,
+                entity_version: 1,
+            });
+        }
+    }
+
+    pub(super) fn route_for_edge(
+        &self,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) -> Option<&RouteRecordState> {
+        self.routes
+            .values()
+            .filter(|route| route.lifecycle == RouteLifecycle::Open)
+            .find(|route| route.contains_edge(from_location_id, to_location_id))
+    }
+
+    fn route_for_edge_in_any_lifecycle(
+        &self,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) -> Option<&RouteRecordState> {
+        self.routes
+            .values()
+            .find(|route| route.contains_edge(from_location_id, to_location_id))
+    }
+
+    fn binding_for_route(route: &RouteRecordState) -> RouteOfferBinding {
+        RouteOfferBinding {
+            route_id: route.id.clone(),
+            route_version: route.entity_version,
+        }
+    }
+
+    pub(super) fn route_offer_binding(
+        &self,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) -> Option<RouteOfferBinding> {
+        self.route_for_edge(from_location_id, to_location_id)
+            .map(Self::binding_for_route)
+    }
+
+    pub(super) fn scout_route_offer_binding(
+        &self,
+        actor_id: u64,
+        destination_location_id: u64,
+    ) -> Option<RouteOfferBinding> {
+        if let Some(journey) = self.journeys.get(&actor_id) {
+            let from_location_id = *journey.path.get(journey.current_step)?;
+            let to_location_id = *journey.path.get(journey.current_step + 1)?;
+            return self
+                .route_for_edge_in_any_lifecycle(from_location_id, to_location_id)
+                .map(Self::binding_for_route);
+        }
+        let from_location_id = self.actor_by_id(actor_id)?.location_id;
+        self.route_for_edge_in_any_lifecycle(from_location_id, destination_location_id)
+            .map(Self::binding_for_route)
+    }
+
+    pub(super) fn route_binding_is_current(&self, binding: &RouteOfferBinding) -> bool {
+        self.routes
+            .get(&binding.route_id)
+            .is_some_and(|route| route.entity_version == binding.route_version)
+    }
+
+    pub(super) fn transition_route(
+        &mut self,
+        route_id: &str,
+        expected_version: u64,
+        lifecycle: RouteLifecycle,
+    ) -> bool {
+        let Some(route) = self.routes.get_mut(route_id) else {
+            return false;
+        };
+        if route.lifecycle == lifecycle {
+            return true;
+        }
+        if route.entity_version != expected_version {
+            return false;
+        }
+        route.lifecycle = lifecycle;
+        route.entity_version = route.entity_version.saturating_add(1).max(1);
+        true
+    }
+
+    pub(super) fn apply_route_lifecycle_mutation(
+        &mut self,
+        actor_id: u64,
+        route_id: &str,
+        expected_version: u64,
+        lifecycle: RouteLifecycle,
+        reason: &str,
+    ) -> Option<EventView> {
+        let changed = self
+            .routes
+            .get(route_id)
+            .is_some_and(|route| route.lifecycle != lifecycle);
+        if !self.transition_route(route_id, expected_version, lifecycle) {
+            return None;
+        }
+        self.rebuild_kernel_exits_from_routes();
+        changed.then(|| {
+            let state = match lifecycle {
+                RouteLifecycle::Latent => "latent",
+                RouteLifecycle::Open => "opened",
+                RouteLifecycle::Blocked => "blocked",
+                RouteLifecycle::Frozen => "frozen",
+            };
+            self.append_async_job_event(
+                &format!("route.{state}"),
+                actor_id,
+                None,
+                Some(format!("{route_id}:{reason}")),
+            )
+        })
+    }
+
+    pub(super) fn open_hidden_route(&mut self, hidden_exit_id: &str) {
+        let route_id = hidden_route_id(hidden_exit_id);
+        let Some(route) = self.routes.get(&route_id) else {
+            return;
+        };
+        let version = route.entity_version;
+        self.transition_route(&route_id, version, RouteLifecycle::Open);
+    }
+
+    pub(super) fn open_generated_pathway_route(
+        &mut self,
+        pathway: &GeneratedPathwayState,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) {
+        self.ensure_generated_pathway_route_records(pathway);
+        let route_id = generated_route_id(&pathway.id, from_location_id, to_location_id);
+        let Some(route) = self.routes.get(&route_id) else {
+            return;
+        };
+        let version = route.entity_version;
+        self.transition_route(&route_id, version, RouteLifecycle::Open);
+    }
+
+    pub(super) fn rebuild_kernel_exits_from_routes(&mut self) {
+        self.world.exit_count = 0;
+        let known_locations = self.world.locations[..self.world.location_count]
+            .iter()
+            .map(|location| location.id)
+            .collect::<BTreeSet<_>>();
+        let mut edges = self
+            .routes
+            .values()
+            .filter(|route| route.lifecycle == RouteLifecycle::Open)
+            .flat_map(|route| route.edges.iter().cloned())
+            .filter(|edge| {
+                known_locations.contains(&edge.from_location_id)
+                    && known_locations.contains(&edge.to_location_id)
+            })
+            .collect::<Vec<_>>();
+        edges.sort_by_key(|edge| (edge.from_location_id, edge.to_location_id, edge.flags));
+        edges.dedup();
+        for edge in edges.into_iter().take(CW_MAX_EXITS) {
+            self.world.exits[self.world.exit_count] = CwExit {
+                from_location_id: edge.from_location_id,
+                to_location_id: edge.to_location_id,
+                flags: edge.flags,
+            };
+            self.world.exit_count += 1;
+        }
+    }
+
+    pub(super) fn route_record_preconditions_hold(&self, record: &JournalRecord) -> bool {
+        if record
+            .route_binding
+            .as_ref()
+            .is_some_and(|binding| !self.route_binding_is_current(binding))
+        {
+            return false;
+        }
+        record.projection_mutations.iter().all(|mutation| {
+            let ProjectionMutation::SetRouteLifecycle(transition) = mutation else {
+                return true;
+            };
+            self.routes.get(&transition.route_id).is_some_and(|route| {
+                route.lifecycle == transition.lifecycle
+                    || route.entity_version == transition.expected_version
+            })
+        })
+    }
+
+    pub(super) fn bind_route_precondition(&self, record: &mut JournalRecord) {
+        if record.route_binding.is_some() {
+            return;
+        }
+        if let Some(binding) =
+            record
+                .projection_mutations
+                .iter()
+                .find_map(|mutation| match mutation {
+                    ProjectionMutation::JourneyTransition {
+                        pathway,
+                        reveal_edges,
+                        ..
+                    } => reveal_edges
+                        .first()
+                        .and_then(|(from_location_id, to_location_id)| {
+                            self.route_for_edge_in_any_lifecycle(*from_location_id, *to_location_id)
+                                .map(Self::binding_for_route)
+                                .or_else(|| {
+                                    let from_location_id =
+                                        self.actor_by_id(record.action.actor_id)?.location_id;
+                                    self.route_for_edge_in_any_lifecycle(
+                                        from_location_id,
+                                        pathway.destination_location_id,
+                                    )
+                                    .map(Self::binding_for_route)
+                                })
+                        }),
+                    ProjectionMutation::RendezvousActor {
+                        actor_id,
+                        location_id,
+                        ..
+                    } => {
+                        let from_location_id = self.actor_by_id(*actor_id)?.location_id;
+                        self.route_for_edge(from_location_id, *location_id)
+                            .map(Self::binding_for_route)
+                    }
+                    _ => None,
+                })
+        {
+            record.route_binding = Some(binding);
+            return;
+        }
+        if !matches!(
+            record.action.kind,
+            CW_ACTION_MOVE | CW_ACTION_FLEE | CW_ACTION_COMBAT_ESCAPE
+        ) {
+            return;
+        }
+        let Some(actor) = self.actor_by_id(record.action.actor_id) else {
+            return;
+        };
+        record.route_binding =
+            self.route_offer_binding(actor.location_id, record.action.destination_location_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_routes_compile_kernel_exits_and_survive_snapshot() {
+        let runtime = RuntimeWorld::seeded();
+        assert!(!runtime.routes.is_empty());
+        for exit in &runtime.world.exits[..runtime.world.exit_count] {
+            let route = runtime
+                .route_for_edge(exit.from_location_id, exit.to_location_id)
+                .expect("every kernel exit is compiled from an open route");
+            assert!(route.entity_version > 0);
+        }
+
+        let restored = RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .expect("route state restores");
+        assert_eq!(restored.routes, runtime.routes);
+        assert_eq!(
+            &restored.world.exits[..restored.world.exit_count],
+            &runtime.world.exits[..runtime.world.exit_count]
+        );
+    }
+
+    #[test]
+    fn route_lifecycle_transition_is_versioned_idempotent_and_atomic() {
+        let mut runtime = RuntimeWorld::seeded();
+        let route_id = runtime
+            .routes
+            .values()
+            .find(|route| route.lifecycle == RouteLifecycle::Open)
+            .expect("open seed route")
+            .id
+            .clone();
+        let version = runtime.routes[&route_id].entity_version;
+        let mut record = JournalRecord::new(CwAction::default(), 31_600);
+        record
+            .projection_mutations
+            .push(ProjectionMutation::SetRouteLifecycle(
+                RouteLifecycleMutation {
+                    route_id: route_id.clone(),
+                    expected_version: version,
+                    lifecycle: RouteLifecycle::Blocked,
+                    reason: "test".to_string(),
+                },
+            ));
+
+        let (status, _) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert_eq!(
+            runtime.routes[&route_id].entity_version,
+            version.saturating_add(1)
+        );
+        let blocked_exits = runtime.world.exit_count;
+
+        let (status, _) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert_eq!(
+            runtime.routes[&route_id].entity_version,
+            version.saturating_add(1)
+        );
+        assert_eq!(runtime.world.exit_count, blocked_exits);
+
+        let stale = JournalRecord {
+            projection_mutations: vec![ProjectionMutation::SetRouteLifecycle(
+                RouteLifecycleMutation {
+                    route_id: route_id.clone(),
+                    expected_version: version,
+                    lifecycle: RouteLifecycle::Frozen,
+                    reason: "stale".to_string(),
+                },
+            )],
+            ..JournalRecord::new(CwAction::default(), 31_601)
+        };
+        let before = runtime.clone();
+        let (status, events) = runtime.apply_journal_record(&stale);
+        assert_eq!(status, CW_ERR_RULE);
+        assert!(events.is_empty());
+        assert_eq!(runtime.routes, before.routes);
+        assert_eq!(runtime.world.exit_count, before.world.exit_count);
+    }
+
+    #[test]
+    fn memory_decay_never_changes_shared_topology() {
+        let mut runtime = RuntimeWorld::seeded();
+        runtime.search_memories.insert(
+            "route-memory".to_string(),
+            SearchMemoryState {
+                id: "route-memory".to_string(),
+                actor_id: RATI_ACTOR_ID,
+                kind: "exit".to_string(),
+                location_id: COSY_COTTAGE_LOCATION_ID,
+                subject_id: RAIN_SOFT_GARDEN_LOCATION_ID,
+                subject_key: "exit:1:2".to_string(),
+                confidence: 1,
+                salience: 1,
+                found_tick: 0,
+                last_used_tick: 0,
+                use_count: 0,
+            },
+        );
+        let routes = runtime.routes.clone();
+        let exits = runtime.world.exits[..runtime.world.exit_count].to_vec();
+        runtime.world.tick = SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS * 64;
+        runtime.decay_search_memories();
+        assert_eq!(runtime.routes, routes);
+        assert_eq!(&runtime.world.exits[..runtime.world.exit_count], exits);
+    }
+}

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -293,6 +293,8 @@ pub(super) struct FactionView {
 
 #[derive(Debug, Serialize)]
 pub(super) struct ExitView {
+    pub(super) route_id: String,
+    pub(super) route_version: u64,
     pub(super) destination_location_id: u64,
     pub(super) destination_location_name: String,
     pub(super) direction: Option<String>,
@@ -510,6 +512,8 @@ pub(super) struct ClockView {
 pub(super) struct SharedQuestionStrategyView {
     pub(super) id: String,
     pub(super) action_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) route: Option<RouteOfferBinding>,
     pub(super) label: String,
     pub(super) target_kind: String,
     pub(super) target_id: Option<String>,
@@ -742,6 +746,7 @@ pub(super) struct ActionInspectorView {
     pub(super) composition_trace: ActionCompositionTraceView,
     pub(super) composition_id: String,
     pub(super) state_revision: u64,
+    pub(super) route: Option<RouteOfferBinding>,
     pub(super) category: String,
     pub(super) label: String,
     pub(super) command: String,
@@ -1655,10 +1660,13 @@ impl RuntimeWorld {
                 self.exit_discovered_for_projection(exit.from_location_id, exit.to_location_id)
             })
             .filter(|exit| exit.flags & CW_EXIT_LOCKED == 0)
-            .map(|exit| {
+            .filter_map(|exit| {
+                let route = self.route_for_edge(exit.from_location_id, exit.to_location_id)?;
                 let access_rule = location_access_rule(exit.to_location_id);
                 let accessible = location_access_allowed(exit.to_location_id, access);
-                ExitView {
+                Some(ExitView {
+                    route_id: route.id.clone(),
+                    route_version: route.entity_version,
                     destination_location_id: exit.to_location_id,
                     destination_location_name: self
                         .location_name(exit.to_location_id)
@@ -1674,7 +1682,7 @@ impl RuntimeWorld {
                     } else {
                         access_rule.reason.map(ToString::to_string)
                     },
-                }
+                })
             })
             .collect()
     }
@@ -2064,9 +2072,15 @@ impl RuntimeWorld {
             let destination = self
                 .location_name(delivery.destination_location_id)
                 .unwrap_or_else(|| format!("Location {}", delivery.destination_location_id));
+            let route = actor_id
+                .and_then(|actor_id| self.actor_by_id(actor_id))
+                .and_then(|actor| {
+                    self.route_offer_binding(actor.location_id, delivery.destination_location_id)
+                });
             return vec![SharedQuestionStrategyView {
                 id: format!("{}:physical-delivery", job.id),
                 action_kind: "carry".to_string(),
+                route,
                 label: job.action_copy.label.clone(),
                 target_kind: "location".to_string(),
                 target_id: Some(delivery.destination_location_id.to_string()),
@@ -2154,6 +2168,7 @@ impl RuntimeWorld {
                 SharedQuestionStrategyView {
                     id: strategy.id.clone(),
                     action_kind: strategy.action_kind.clone(),
+                    route: None,
                     label: strategy.strategy_label.clone(),
                     target_kind: resolved_target
                         .as_ref()
@@ -2561,6 +2576,7 @@ impl RuntimeWorld {
             composition_trace: offer.composition_trace.clone(),
             composition_id: offer.composition_id.clone(),
             state_revision: offer.state_revision,
+            route: offer.route.clone(),
             category: offer.category.clone(),
             label: offer.label.clone(),
             command: offer.command.clone(),

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74898
+74892

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -264,6 +264,7 @@ async function submitOffer(baseUrl, offer, path, payload, compositionId = offer.
     operation: offer.operation,
     rules_profile: offer.rules_profile,
     state_revision: offer.state_revision,
+    route: offer.route,
     target: offer.target,
     cost: offer.cost,
     payload,


### PR DESCRIPTION
Closes #316. Adds durable versioned route records, compiles kernel exits from them, and rejects stale route offers atomically.