### PR TITLE
Clear stale room recovery status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.190",
+  "version": "0.0.191",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.190",
+      "version": "0.0.191",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.190",
+  "version": "0.0.191",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.190"
+version = "0.0.191"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.190"
+version = "0.0.191"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -3460,6 +3460,9 @@
     let stream = null;
     let refreshInFlight = null;
     let refreshQueued = false;
+    let refreshAttemptId = 0;
+    let recoveryRefreshAttemptId = 0;
+    let transientStatus = null;
     let actionBusy = false;
     let actionSlow = false;
     let actionSlowTimer = null;
@@ -3900,6 +3903,7 @@
     }
 
     async function refresh() {
+      const attemptId = ++refreshAttemptId;
       const previousLocationId = state?.location?.id || null;
       const wasTired = actorIsTired(state);
       const requestedActorId = actorId;
@@ -3949,6 +3953,10 @@
       reconcileHand();
       restoreFocusedAction();
       render();
+      if (recoveryRefreshAttemptId && attemptId >= recoveryRefreshAttemptId) {
+        recoveryRefreshAttemptId = 0;
+        clearTransientStatus("refresh");
+      }
     }
 
     function queueRefresh() {
@@ -3957,7 +3965,16 @@
         return refreshInFlight;
       }
       refreshInFlight = refresh()
-        .catch((error) => setError(String(error.message || error)))
+        .catch((error) => {
+          if (!recoveryRefreshAttemptId) {
+            setError(String(error.message || error));
+          } else if (refreshAttemptId >= recoveryRefreshAttemptId) {
+            setTransientStatus(
+              "refresh",
+              "The room could not catch up. Check your connection and reload to try again.",
+            );
+          }
+        })
         .finally(() => {
           refreshInFlight = null;
           if (refreshQueued) {
@@ -7146,6 +7163,7 @@
     function connectStream() {
       if (stream) stream.close();
       stream = new EventSource(streamPath());
+      stream.addEventListener("open", () => clearTransientStatus("stream"));
       stream.addEventListener("world", (message) => {
         let event = null;
         try {
@@ -7188,10 +7206,17 @@
         logEvents = [];
         seenSeq.clear();
         renderTimelines();
-        setError("The room changed while you were away. Catching up from the latest state.");
+        recoveryRefreshAttemptId = Math.max(
+          recoveryRefreshAttemptId,
+          refreshAttemptId + 1,
+        );
+        setTransientStatus(
+          "refresh",
+          "The room changed while you were away. Catching up from the latest state.",
+        );
         queueRefresh();
       });
-      stream.onerror = () => setError("The live room is reconnecting.");
+      stream.onerror = () => setTransientStatus("stream", "The live room is reconnecting.");
       startPresenceHeartbeat();
     }
 
@@ -11345,14 +11370,41 @@
       return String(name).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
     }
 
+    function writeStatus(message, kind = "error") {
+      const node = $("error");
+      const text = String(message || "");
+      const ok = Boolean(text) && kind === "ok";
+      if (node.textContent === text && node.classList.contains("ok") === ok) return;
+      node.textContent = text;
+      node.classList.toggle("ok", ok);
+    }
+
+    function setTransientStatus(kind, message) {
+      const next = { kind, message: String(message || "") };
+      if (
+        transientStatus?.kind === next.kind
+        && transientStatus.message === next.message
+        && $("error").textContent === next.message
+      ) return;
+      transientStatus = next;
+      writeStatus(next.message, "error");
+    }
+
+    function clearTransientStatus(kind) {
+      if (transientStatus?.kind !== kind) return;
+      const message = transientStatus.message;
+      transientStatus = null;
+      if ($("error").textContent === message) writeStatus("");
+    }
+
     function setError(message) {
-      setStatus(message, "error");
+      transientStatus = null;
+      writeStatus(message, "error");
     }
 
     function setStatus(message, kind = "error") {
-      const node = $("error");
-      node.textContent = message;
-      node.classList.toggle("ok", Boolean(message) && kind === "ok");
+      transientStatus = null;
+      writeStatus(message, kind);
     }
 
     function escapeHtml(value) {

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -7365,6 +7365,91 @@ async function main() {
     assert(layout.status.bottom <= layout.prompt.top + 0.5, `${label}: status should end before prompt begins: ${JSON.stringify(layout)}`);
   }
 
+  async function assertGapRecoveryStatusClears() {
+    await page.waitForFunction(() => refreshInFlight === null && refreshQueued === false);
+    await page.evaluate(() => {
+      stream?.close();
+      setError("");
+      window.cosyRecoveryAnnouncements = 0;
+      window.cosyRecoveryObserver?.disconnect();
+      window.cosyRecoveryObserver = new MutationObserver(() => {
+        window.cosyRecoveryAnnouncements += 1;
+      });
+      window.cosyRecoveryObserver.observe(document.querySelector("#error"), {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+    });
+
+    let releaseFirst;
+    let releaseRecovery;
+    const firstGate = new Promise((resolve) => { releaseFirst = resolve; });
+    const recoveryGate = new Promise((resolve) => { releaseRecovery = resolve; });
+    let stateRequests = 0;
+    const holdStateRefreshes = async (route) => {
+      stateRequests += 1;
+      if (stateRequests === 1) await firstGate;
+      if (stateRequests === 2) await recoveryGate;
+      await route.continue();
+    };
+    await page.route(/\/state(?:\?|$)/, holdStateRefreshes);
+
+    try {
+      await page.evaluate(() => { void queueRefresh(); });
+      await page.waitForFunction(() => refreshInFlight !== null);
+      await page.evaluate(() => {
+        const gap = new MessageEvent("gap", {
+          data: JSON.stringify({ through_seq: Number(state?.state_revision || 0) + 1 }),
+        });
+        stream.dispatchEvent(gap);
+        stream.dispatchEvent(gap);
+      });
+      await page.waitForFunction(() => (
+        document.querySelector("#error")?.textContent
+          === "The room changed while you were away. Catching up from the latest state."
+      ));
+      const active = await page.evaluate(() => ({
+        announcements: window.cosyRecoveryAnnouncements,
+        display: getComputedStyle(document.querySelector("#error")).display,
+        height: document.querySelector("#error").getBoundingClientRect().height,
+      }));
+      assert(
+        active.announcements === 1 && active.display !== "none" && active.height > 0,
+        `gap recovery should show and announce one active status: ${JSON.stringify(active)}`,
+      );
+
+      releaseFirst();
+      await page.waitForFunction(() => refreshAttemptId >= recoveryRefreshAttemptId);
+      const queued = await page.locator("#error").textContent();
+      assert(
+        queued.includes("Catching up"),
+        `a pre-gap refresh must not clear the queued recovery status: ${queued}`,
+      );
+
+      releaseRecovery();
+      await page.waitForFunction(() => refreshInFlight === null && refreshQueued === false);
+      const recovered = await page.evaluate(() => ({
+        text: document.querySelector("#error")?.textContent || "",
+        display: getComputedStyle(document.querySelector("#error")).display,
+        height: document.querySelector("#error").getBoundingClientRect().height,
+      }));
+      assert(
+        recovered.text === "" && recovered.display === "none" && recovered.height === 0,
+        `successful recovery should clear the status row completely: ${JSON.stringify(recovered)}`,
+      );
+      steps.push({ label: "gap recovery status clears", announcements: active.announcements });
+    } finally {
+      releaseFirst?.();
+      releaseRecovery?.();
+      await page.unroute(/\/state(?:\?|$)/, holdStateRefreshes);
+      await page.evaluate(() => {
+        window.cosyRecoveryObserver?.disconnect();
+        connectStream();
+      });
+    }
+  }
+
   async function assertJournalModeContract(label) {
     await page.evaluate(() => setJournalOpen(false));
     const room = await page.evaluate(() => {
@@ -8674,6 +8759,7 @@ async function main() {
   await assertFailureCopyStaysContextual();
   await assertCompactDescriptionAndCardModal();
   await assertRoomSummaryStaysFlatAndMechanical();
+  await assertGapRecoveryStatusClears();
   await assertStatusBarDoesNotOverlayTranscript("mobile status row");
   await assertJournalModeContract("mobile Journal");
   await assertJournalTickerLayout();


### PR DESCRIPTION
## Summary

- track refresh recovery independently from ordinary errors and success copy
- clear catching-up status only after the correct queued refresh succeeds
- replace failed recovery with actionable connection copy
- clear reconnect status on EventSource open and deduplicate live-region writes
- verify the empty status row reserves no vertical space

## Root cause

The SSE gap and error handlers wrote recovery copy through the permanent error setter, with no lifecycle tying that copy to the refresh or reconnect that should clear it.

## Impact

The chatroom no longer retains a stale pink warning after state is healthy, and duplicate gap events do not repeatedly announce the same message.

## Validation

- `COSYWORLD_V2_PORT=3129 COSYWORLD_V2_SCREEN_SESSION=cosyworld-issue-299 COSYWORLD_V2_LOG=/tmp/cosyworld-issue-299.log bash v2/mvp.sh check`
- 528 Rust tests
- main and stress browser smoke, including gap recovery lifecycle
- `npm run check:version`
- `git diff --check`

Closes #299