### PR TITLE
Scope project cleanup smoke assertion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.191",
+  "version": "0.0.192",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.191",
+      "version": "0.0.192",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.191",
+  "version": "0.0.192",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/smoke-project-tags.test.mjs
+++ b/test/v2/smoke-project-tags.test.mjs
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { spentPreparationTagBelongsToJob } from "../../v2/scripts/smoke-project-tags.mjs";
+
+const moonlitJob = {
+  location_ids: [3],
+  progress_clock_id: "moonlit-trail.progress",
+};
+
+describe("browser smoke project-tag ownership", () => {
+  it("matches preparation spent on the project being checked", () => {
+    expect(spentPreparationTagBelongsToJob({
+      id: "actor:5000:prepared_spent:3:moonlit-trail.progress",
+      label: "spent preparation",
+      expires: "when_job_resolves",
+    }, moonlitJob)).toBe(true);
+  });
+
+  it("keeps preparation for another unresolved project out of the check", () => {
+    expect(spentPreparationTagBelongsToJob({
+      id: "actor:5000:prepared_spent:2:rain-soft-garden.trustworthy-path",
+      label: "spent preparation",
+      expires: "when_job_resolves",
+    }, moonlitJob)).toBe(false);
+  });
+
+  it("does not treat unrelated or malformed tags as project preparation", () => {
+    expect(spentPreparationTagBelongsToJob({
+      id: "actor:5000:prepared_spent:3:moonlit-trail.progress",
+      label: "prepared",
+      expires: "when_job_resolves",
+    }, moonlitJob)).toBe(false);
+    expect(spentPreparationTagBelongsToJob({
+      id: "actor:5000:prepared_spent",
+      label: "spent preparation",
+      expires: "when_job_resolves",
+    }, moonlitJob)).toBe(false);
+  });
+});

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.191"
+version = "0.0.192"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.191"
+version = "0.0.192"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4,6 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spentPreparationTagBelongsToJob } from "./smoke-project-tags.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const defaultUrl = "http://127.0.0.1:3102/?wallet=dev-wallet&reset=1";
@@ -9171,9 +9172,9 @@ async function main() {
     ));
     assert(
       !(completedProjectState.tags || []).some(
-        (tag) => tag.label === "spent preparation",
+        (tag) => spentPreparationTagBelongsToJob(tag, completedMoonlitJob),
       ),
-      `resolved projects should clear spent-preparation helper tags: ${JSON.stringify(completedProjectState.tags)}`,
+      `resolved projects should clear their spent-preparation helper tags: ${JSON.stringify(completedProjectState.tags)}`,
     );
     assert(
       !(completedProjectState.primary_action?.options || []).some((option) =>

--- a/v2/scripts/smoke-project-tags.mjs
+++ b/v2/scripts/smoke-project-tags.mjs
@@ -1,0 +1,14 @@
+export function spentPreparationTagBelongsToJob(tag, job) {
+  if (
+    tag?.label !== "spent preparation"
+    || tag?.expires !== "when_job_resolves"
+    || !job?.progress_clock_id
+    || !Array.isArray(job.location_ids)
+  ) {
+    return false;
+  }
+  const match = /^actor:\d+:prepared_spent:(\d+):(.+)$/.exec(String(tag.id || ""));
+  if (!match || match[2] !== String(job.progress_clock_id)) return false;
+  const locationId = Number(match[1]);
+  return job.location_ids.some((candidate) => Number(candidate) === locationId);
+}


### PR DESCRIPTION
## Summary

- match spent-preparation tags to the completed job's location and progress clock
- keep valid helper state from other unfinished projects out of the assertion
- cover matching, cross-project, and malformed tags independently of browser timing

## Validation

- `COSYWORLD_V2_PORT=3134 COSYWORLD_V2_SCREEN_SESSION=cosyworld-issue-342 COSYWORLD_V2_LOG=/tmp/cosyworld-issue-342.log bash v2/mvp.sh check`
- 528 Rust tests
- main and living-world browser smoke
- 3 focused ownership tests
- pre-push `npm run check`

Closes #342