### PR TITLE
Expose image contracts on generated pathways

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.194",
+  "version": "0.0.195",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.194",
+      "version": "0.0.195",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.194",
+  "version": "0.0.195",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.194"
+version = "0.0.195"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.194"
+version = "0.0.195"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -19530,11 +19530,7 @@ impl RuntimeWorld {
                 }
                 if let Some(pathway) = self.generated_pathway_for_location(subject_id) {
                     return (pathway.art_eligible
-                        && self
-                            .generated_places
-                            .get(&subject_id)
-                            .and_then(|place| place.building_proposal.as_ref())
-                            .is_some())
+                        && self.generated_places.contains_key(&subject_id))
                     .then_some(1);
                 }
                 Some(1)
@@ -47755,6 +47751,9 @@ mod tests {
         let after_first_search = runtime.state_response(Some(5000), &AccessContext::default());
         assert!(after_first_search.cards.locations[&first_waypoint_id]
             .community_art
+            .is_some());
+        assert!(runtime
+            .community_art_subject_level("location", second_waypoint_id)
             .is_none());
         assert!(after_first_search
             .exits

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74723
+74722

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4256,6 +4256,59 @@ async function main() {
       await closeCardModal();
     }
 
+    const pathwayContract = await page.evaluate(() => {
+      const previousState = state;
+      const pathwayId = 990001;
+      const pathwayCard = {
+        card_id: "generated-pathway-contract-smoke",
+        display_name: "Mossy Verge",
+        title: "Newly Found Path",
+        blurb: "A revealed stretch whose community image is waiting to be funded.",
+        rarity: "everyday",
+        role: "location",
+        aspect: "wide",
+        image_url: `/assets/generated/pathways/${pathwayId}.svg`,
+        community_art: {
+          level: 1,
+          required_orbs: 1,
+          funded_orbs: 0,
+          remaining_orbs: 1,
+          status: "available",
+        },
+      };
+      try {
+        state = {
+          ...previousState,
+          economy: { ...(previousState?.economy || {}), orbs: 4 },
+          cards: {
+            ...(previousState?.cards || {}),
+            locations: {
+              ...(previousState?.cards?.locations || {}),
+              [pathwayId]: pathwayCard,
+            },
+          },
+        };
+        openCardModal(pathwayCard);
+        const button = document.querySelector("#card-modal [data-fund-community-image]");
+        return {
+          subject: button?.getAttribute("data-fund-community-image") || "",
+          label: button?.textContent?.trim() || "",
+          disabled: button?.disabled ?? true,
+          copy: document.querySelector("#card-modal-economy")?.textContent?.replace(/\s+/g, " ").trim() || "",
+        };
+      } finally {
+        closeCardModal();
+        state = previousState;
+      }
+    });
+    assert(
+      pathwayContract.subject === "location:990001"
+        && pathwayContract.label === "add one Orb · 0/1"
+        && pathwayContract.disabled === false
+        && pathwayContract.copy.includes("1 Orb still needed from the community"),
+      `a revealed generated pathway keepsake should expose its Orb image contract: ${JSON.stringify(pathwayContract)}`,
+    );
+
     await page.locator(".room-avatar-pfp[data-card-key]").first().click();
     await page.waitForSelector("#card-modal:not([hidden])");
     const actorCardName = await page.locator("#card-modal-name").innerText();


### PR DESCRIPTION
## Summary

- expose a level-one community image contract as soon as an art-eligible generated waypoint is revealed
- keep hidden and non-art-eligible pathway locations ineligible
- reuse the existing location community-art subject and funding endpoint
- cover the live Garden → Trail projection and the pathway keepsake modal

Closes #329

## Root cause

Pathway community art was projected only when a generated place also had a building proposal. Building state is unrelated to funding location landscape art, so newly discovered pathway cards silently lost their Orb contract.

## Player impact

Discovered eligible pathway cards now show funding progress and the add-one-Orb action while fallback art is active. Hidden waypoints remain undisclosed.

## Validation

- `cargo test segmented_pathways_alternate_search_and_travel_into_shared_world_state -- --nocapture` — 1 passed
- `npm run check:local` — 453 JS tests, 528 Rust tests, production profile, normal browser, and stress browser passed
- pre-push `npm run check` — passed
- `npm run check:version` — passed
- `git diff --check origin/main...HEAD` — passed

## Release

- version: 0.0.195
- `main.rs`: 74,722 lines, ceiling lowered to 74,722