### PR TITLE
Keep generated location art truthful

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -250,6 +250,7 @@ CosyWorld should generalize that into Rust rather than copying the Ruby High Typ
 - Each `{subject kind, subject id, level}` generation is unique and replay-safe. Multiple avatars may pool its exact level-sized cost.
 - The prompt captures public card history through a committed sequence. When the card reaches a later level, its one newly unlocked image can evolve in response to everything that happened since.
 - Fully funded jobs may be retried without another Orb debit. Provider-unavailable requests fail before funding.
+- Location art is published only after a strict vision-policy review finds no people, characters, creatures, text, logos, or watermarks; rejection, review failure, and missing review configuration all leave the deterministic landscape fallback visible.
 - Current implementation stores a durable funding/status projection and serves the ready shared asset from the generated-card route. A generalized object-store-backed `media_jobs` service remains the scaling step.
 
 ## Combat Replaces Quizzes

--- a/docs/systems/09-cosyworld-rpg-system.md
+++ b/docs/systems/09-cosyworld-rpg-system.md
@@ -569,6 +569,8 @@ Two economies, kept strictly separate so the core loop is never gated.
 
 Their sole spend is community image generation for eligible generated cards. A card unlocks one generation at each authoritative level, the community pools exactly that level in Orbs, and the prompt incorporates committed public history so later images can evolve with the world. Contributions buy no ownership or rules authority; a fully funded retry costs nothing.
 
+Location imagery is non-authoritative and fails closed: prompts prohibit people, characters, creatures, text, logos, and watermarks; a separate vision-policy decision must approve visible pixels before publication; rejected or unavailable review keeps the deterministic landscape fallback. Moderation can invalidate a ready image without changing topology, presence, funding, or any other world mechanic.
+
 Chat, Say, resident heartbeats, Listen/Notice, Help, bond, travel, combat, access, and progression never spend Orbs. Chat instead spends one banked advancement point to create a new Bond. Reward rules remain claim-key gated and idempotent (next section), so identical actions never mint unlimited Orbs. The negative ledger is equally strict: new actions may use only `community_image_generation`, capped by `{subject, level}`.
 
 ## Claim Keys And Idempotency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.195",
+  "version": "0.0.196",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.195",
+      "version": "0.0.196",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.195",
+  "version": "0.0.196",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -361,6 +361,7 @@ Optional overrides:
 ```sh
 COSYWORLD_AI_BASE_URL=https://api.openai.com/v1
 COSYWORLD_AI_PROVIDER=openrouter
+COSYWORLD_AI_VISION_MODEL=openai/gpt-5.6-luna
 ```
 
 Server-side generative world content is separately controlled and defaults to
@@ -408,7 +409,11 @@ Avatar art prompts start with the configured LoRA trigger and combine a stable,
 persisted physical description with the avatar's current species, origin,
 class or classless state, level, calling, location, and carried/equipped items.
 Item and location generations likewise include their authoritative card and
-world details plus committed public history.
+world details plus committed public history. Location images are withheld until
+the configured vision model confirms that they contain no people, characters,
+creatures, text, logos, or watermarks. Rejected candidates are regenerated up
+to three times; unavailable or invalid review leaves the deterministic
+landscape fallback visible.
 
 `Chat` appears only when the avatar has banked advancement and an eligible nearby resident can become a new friend. Playing it spends one advancement point, creates the Bond, and passes the room turn; it never accepts human text or spends Orbs. Human-authored room speech is the separate moderated, turn-exempt `say` path.
 
@@ -710,6 +715,7 @@ Dialogue prompts keep the latest 16 spoken lines per room in a bounded, snapshot
 - `GET /moderation/reports?after=12&limit=80` with `Authorization: Bearer <COSYWORLD_MODERATION_TOKEN>`
 - `POST /moderation/reports/{report_id}/resolve` with `Authorization: Bearer <COSYWORLD_MODERATION_TOKEN>`
 - `POST /moderation/reports/{report_id}/delete` with `Authorization: Bearer <COSYWORLD_MODERATION_TOKEN>`
+- `POST /moderation/community-art/{subject_kind}/{subject_id}/reject` with `Authorization: Bearer <COSYWORLD_MODERATION_TOKEN>`
 - `POST /moderation/actors/{actor_id}/suspend` with `Authorization: Bearer <COSYWORLD_MODERATION_TOKEN>`
 - `POST /moderation/actors/{actor_id}/unsuspend` with `Authorization: Bearer <COSYWORLD_MODERATION_TOKEN>`
 - `GET /stream`
@@ -810,6 +816,11 @@ exclusions.
 `/health` is intentionally minimal readiness. `/meta` is the deploy/smoke metadata endpoint: package version, debug/release build profile, deployment profile, canonical `world_id`/`world_epoch`, capacity `process_id`, matching legacy `shard_id`, non-secret dialogue and client-authored-speech feature flags, persistence mode, moderation report retention, ownership-feed mode, current world counters, compiled kernel capacities, and the mounted packs' exact license records. `GET /licenses` exposes those pack versions, license links, provenance, modification notices, and bundled attribution text without authentication. `./v2/mvp.sh status` prints a one-line summary from `/meta`.
 
 Protected operator audit routes require `Authorization: Bearer <COSYWORLD_MODERATION_TOKEN>`. `/moderation` serves a no-store operator console that stores the bearer token in local browser storage and uses the protected report endpoints; loading the page alone does not expose report data. The console can resolve reports, delete resolved reports, suspend the reporter attached to an open report, and suspend a reported target when that target is a human avatar. Report suspension actions also resolve the report with a suspension note, so the open queue reflects the operator action. Report details show current reporter/target suspension state and can unsuspend suspended human actors from open or resolved reports. `/moderation/events` returns bounded all-room event replay, `/moderation/reports` returns bounded player report queue entries, `/moderation/reports/{report_id}/resolve` closes a report with resolution metadata, `/moderation/reports/{report_id}/delete` removes a resolved report, `/moderation/activation` returns first-session activation evidence plus privacy-safe seventh-visit cohorts, return-signal comparisons, and world-health diagnostics, `/moderation/activation/{player_ref}/delete` deletes one pseudonymous player's story-metric rows, and `/moderation/economy` returns bounded Orb ledger, AI usage ledger, Wooden Box receipt, and avatar pack opening rows without exposing player OpenRouter keys.
+
+`POST /moderation/community-art/{subject_kind}/{subject_id}/reject` invalidates
+ready generated art, removes its served bytes, restores the deterministic
+fallback, and preserves full funding so the community can retry without
+spending another Orb.
 
 Public action endpoints accept active human actors only when the matching `actor_session` is present. The Rust orchestrator can commit resident `SAY` events internally for contextual heartbeat replies and audited resident beats. Browser-submitted `say` is limited to the caller's own human avatar, is normalized through the same cozy text hygiene used by other player-authored statements, and cannot act as Rati, Whiskerwind, Skull, other residents, or another human avatar by id alone.
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.195"
+version = "0.0.196"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.195"
+version = "0.0.196"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -1,3 +1,4 @@
+use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{collections::BTreeMap, fmt, time::Duration};
 use tokio::time::{sleep, Instant};
@@ -99,6 +100,7 @@ pub(crate) struct AiConfig {
     pub(crate) api_key: String,
     pub(crate) base_url: String,
     pub(crate) model: String,
+    pub(crate) vision_model: String,
     pub(crate) reasoning_effort: Option<String>,
 }
 
@@ -138,6 +140,13 @@ impl AiConfig {
                     DEFAULT_OPENAI_CHAT_MODEL.to_string()
                 }
             });
+        let vision_model = std::env::var("COSYWORLD_AI_VISION_MODEL")
+            .ok()
+            .or_else(|| std::env::var("OPENROUTER_VISION_MODEL").ok())
+            .or_else(|| std::env::var("OPENAI_VISION_MODEL").ok())
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| model.clone());
         let reasoning_effort = using_openrouter
             .then(|| std::env::var("OPENROUTER_REASONING_EFFORT").ok())
             .flatten()
@@ -148,6 +157,7 @@ impl AiConfig {
             api_key,
             base_url,
             model,
+            vision_model,
             reasoning_effort,
         })
     }
@@ -241,34 +251,197 @@ pub(crate) struct AiCompletion {
     pub(crate) latency: Duration,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ImagePolicyRequest<'a> {
+    pub(crate) feature: &'static str,
+    pub(crate) image_url: &'a str,
+    pub(crate) policy: &'a str,
+    pub(crate) timeout: Duration,
+    pub(crate) max_attempts: u8,
+    pub(crate) referer: &'a str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ImagePolicyDecision {
+    pub(crate) allowed: bool,
+    pub(crate) violations: Vec<String>,
+    pub(crate) summary: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawImagePolicyDecision {
+    allowed: bool,
+    violations: Vec<String>,
+    summary: String,
+}
+
 pub(crate) async fn request_chat_completion(
     config: &AiConfig,
     request: ChatCompletionRequest<'_>,
 ) -> Result<AiCompletion, AiGatewayError> {
+    request_completion(
+        config,
+        request.feature,
+        request.system,
+        Value::String(request.user.to_string()),
+        request.temperature,
+        request.max_tokens,
+        request.timeout,
+        request.max_attempts,
+        request.referer,
+        request.response_format,
+        &config.model,
+    )
+    .await
+}
+
+pub(crate) async fn request_image_policy_decision(
+    config: &AiConfig,
+    request: ImagePolicyRequest<'_>,
+) -> Result<ImagePolicyDecision, AiGatewayError> {
+    let response_format = json!({
+        "type": "json_schema",
+        "json_schema": {
+            "name": "cosyworld_image_policy",
+            "strict": true,
+            "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "allowed": { "type": "boolean" },
+                    "violations": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "person",
+                                "character",
+                                "creature",
+                                "text",
+                                "logo",
+                                "watermark",
+                                "other"
+                            ]
+                        }
+                    },
+                    "summary": { "type": "string", "maxLength": 240 }
+                },
+                "required": ["allowed", "violations", "summary"]
+            }
+        }
+    });
+    let user_content = json!([
+        {
+            "type": "text",
+            "text": format!(
+                "Review this generated image against the following publication policy. Reject ambiguous silhouettes or marks rather than guessing they are harmless. Policy: {}",
+                request.policy
+            )
+        },
+        {
+            "type": "image_url",
+            "image_url": { "url": request.image_url }
+        }
+    ]);
+    let completion = request_completion(
+        config,
+        request.feature,
+        "You are a strict image publication gate. Inspect only visible pixels. Return the required JSON and no prose.",
+        user_content,
+        0.0,
+        120,
+        request.timeout,
+        request.max_attempts,
+        request.referer,
+        Some(&response_format),
+        &config.vision_model,
+    )
+    .await?;
+    parse_image_policy_decision(&completion.text).map_err(|message| AiGatewayError {
+        kind: AiFailureKind::InvalidResponse,
+        message,
+        attempts: completion.attempts,
+        latency: completion.latency,
+    })
+}
+
+fn parse_image_policy_decision(value: &str) -> Result<ImagePolicyDecision, String> {
+    let raw: RawImagePolicyDecision = serde_json::from_str(value.trim())
+        .map_err(|error| format!("image policy response was not valid strict JSON: {error}"))?;
+    let summary = raw.summary.split_whitespace().collect::<Vec<_>>().join(" ");
+    if summary.is_empty()
+        || summary.chars().count() > 240
+        || summary
+            .chars()
+            .any(|character| character.is_control() && !character.is_whitespace())
+    {
+        return Err("image policy response had an invalid summary".to_string());
+    }
+    const ALLOWED_VIOLATIONS: &[&str] = &[
+        "person",
+        "character",
+        "creature",
+        "text",
+        "logo",
+        "watermark",
+        "other",
+    ];
+    if raw
+        .violations
+        .iter()
+        .any(|violation| !ALLOWED_VIOLATIONS.contains(&violation.as_str()))
+    {
+        return Err("image policy response named an unknown violation".to_string());
+    }
+    if raw.allowed != raw.violations.is_empty() {
+        return Err("image policy response contradicted its violation list".to_string());
+    }
+    Ok(ImagePolicyDecision {
+        allowed: raw.allowed,
+        violations: raw.violations,
+        summary,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn request_completion(
+    config: &AiConfig,
+    feature: &'static str,
+    system: &str,
+    user_content: Value,
+    temperature: f64,
+    max_tokens: u32,
+    timeout: Duration,
+    max_attempts: u8,
+    referer: &str,
+    response_format: Option<&Value>,
+    model: &str,
+) -> Result<AiCompletion, AiGatewayError> {
     let started_at = Instant::now();
     let client = reqwest::Client::builder()
-        .timeout(request.timeout)
+        .timeout(timeout)
         .build()
         .map_err(|error| AiGatewayError {
             kind: AiFailureKind::Client,
-            message: format!("{} client setup failed: {error}", request.feature),
+            message: format!("{feature} client setup failed: {error}"),
             attempts: 0,
             latency: started_at.elapsed(),
         })?;
     let url = format!("{}/chat/completions", config.base_url);
-    let max_attempts = request.max_attempts.max(1);
+    let max_attempts = max_attempts.max(1);
 
     for attempt in 1..=max_attempts {
         let mut payload = json!({
-            "model": config.model,
+            "model": model,
             "messages": [
-                { "role": "system", "content": request.system },
-                { "role": "user", "content": request.user }
+                { "role": "system", "content": system },
+                { "role": "user", "content": user_content }
             ],
-            "temperature": request.temperature,
-            "max_tokens": request.max_tokens
+            "temperature": temperature,
+            "max_tokens": max_tokens
         });
-        if let Some(response_format) = request.response_format {
+        if let Some(response_format) = response_format {
             payload["response_format"] = response_format.clone();
         }
         if let Some(reasoning_effort) = config.reasoning_effort.as_deref() {
@@ -277,7 +450,7 @@ pub(crate) async fn request_chat_completion(
         let response = client
             .post(&url)
             .bearer_auth(&config.api_key)
-            .header("HTTP-Referer", request.referer)
+            .header("HTTP-Referer", referer)
             .header("X-OpenRouter-Title", "CosyWorld v2")
             .header("X-Title", "CosyWorld v2")
             .json(&payload)
@@ -299,7 +472,7 @@ pub(crate) async fn request_chat_completion(
                 }
                 return Err(AiGatewayError {
                     kind,
-                    message: format!("{} request failed: {error}", request.feature),
+                    message: format!("{feature} request failed: {error}"),
                     attempts: attempt,
                     latency: started_at.elapsed(),
                 });
@@ -315,7 +488,7 @@ pub(crate) async fn request_chat_completion(
             }
             return Err(AiGatewayError {
                 kind: AiFailureKind::Provider,
-                message: format!("{} provider returned HTTP {status}", request.feature),
+                message: format!("{feature} provider returned HTTP {status}"),
                 attempts: attempt,
                 latency: started_at.elapsed(),
             });
@@ -323,7 +496,7 @@ pub(crate) async fn request_chat_completion(
 
         let body: serde_json::Value = response.json().await.map_err(|error| AiGatewayError {
             kind: AiFailureKind::InvalidResponse,
-            message: format!("{} response was not valid JSON: {error}", request.feature),
+            message: format!("{feature} response was not valid JSON: {error}"),
             attempts: attempt,
             latency: started_at.elapsed(),
         })?;
@@ -338,18 +511,15 @@ pub(crate) async fn request_chat_completion(
             .map(ToString::to_string)
             .ok_or_else(|| AiGatewayError {
                 kind: AiFailureKind::InvalidResponse,
-                message: format!(
-                    "{} response did not include message content",
-                    request.feature
-                ),
+                message: format!("{feature} response did not include message content"),
                 attempts: attempt,
                 latency: started_at.elapsed(),
             })?;
 
         tracing::info!(
-            feature = request.feature,
+            feature,
             provider = ai_provider_name(Some(config)),
-            model = config.model,
+            model,
             attempts = attempt,
             latency_ms = started_at.elapsed().as_millis() as u64,
             "CosyWorld AI inference completed"
@@ -397,6 +567,7 @@ pub(crate) fn ai_model_name(config: Option<&AiConfig>) -> String {
 mod tests {
     use super::*;
     use axum::{http::StatusCode, response::IntoResponse, routing::post, Json, Router};
+    use base64::Engine;
     use std::sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
@@ -409,6 +580,7 @@ mod tests {
             api_key: "test".to_string(),
             base_url: base_url.to_string(),
             model: "test-model".to_string(),
+            vision_model: "test-vision-model".to_string(),
             reasoning_effort: None,
         };
         assert_eq!(
@@ -518,6 +690,7 @@ mod tests {
             api_key: "test".to_string(),
             base_url: format!("http://{addr}"),
             model: "test-model".to_string(),
+            vision_model: "test-vision-model".to_string(),
             reasoning_effort: Some("none".to_string()),
         };
         let response_format = json!({
@@ -552,5 +725,90 @@ mod tests {
         assert!(structured_format_seen.load(Ordering::SeqCst));
         assert!(reasoning_none_seen.load(Ordering::SeqCst));
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn visible_person_fixture_fails_the_pathway_image_policy() {
+        let request_seen = Arc::new(AtomicBool::new(false));
+        let app = Router::new().route(
+            "/chat/completions",
+            post({
+                let request_seen = request_seen.clone();
+                move |Json(body): Json<Value>| {
+                    let request_seen = request_seen.clone();
+                    async move {
+                        let image_url = body
+                            .pointer("/messages/1/content/1/image_url/url")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default();
+                        let correct_request = body.get("model").and_then(Value::as_str)
+                            == Some("test-vision-model")
+                            && body
+                                .pointer("/response_format/json_schema/name")
+                                .and_then(Value::as_str)
+                                == Some("cosyworld_image_policy")
+                            && image_url.starts_with("data:image/svg+xml;base64,");
+                        request_seen.store(correct_request, Ordering::SeqCst);
+                        Json(json!({
+                            "choices": [{
+                                "message": {
+                                    "content": r#"{"allowed":false,"violations":["person"],"summary":"A standing human figure is visible beside the path."}"#
+                                }
+                            }]
+                        }))
+                    }
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind image policy test server");
+        let addr = listener.local_addr().expect("image policy test address");
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        let fixture = include_bytes!("test-fixtures/pathway-visible-person.svg");
+        let image_url = format!(
+            "data:image/svg+xml;base64,{}",
+            base64::engine::general_purpose::STANDARD.encode(fixture)
+        );
+        let config = AiConfig {
+            api_key: "test".to_string(),
+            base_url: format!("http://{addr}"),
+            model: "test-model".to_string(),
+            vision_model: "test-vision-model".to_string(),
+            reasoning_effort: None,
+        };
+
+        let decision = request_image_policy_decision(
+            &config,
+            ImagePolicyRequest {
+                feature: "media.pathway_policy",
+                image_url: &image_url,
+                policy: "Landscape only; no people, characters, or creatures.",
+                timeout: Duration::from_secs(2),
+                max_attempts: 1,
+                referer: "http://127.0.0.1",
+            },
+        )
+        .await
+        .expect("fixture review should return a strict decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(decision.violations, vec!["person"]);
+        assert!(request_seen.load(Ordering::SeqCst));
+        server.abort();
+    }
+
+    #[test]
+    fn image_policy_decision_fails_closed_on_contradictory_json() {
+        assert!(parse_image_policy_decision(
+            r#"{"allowed":true,"violations":["person"],"summary":"A person is visible."}"#
+        )
+        .is_err());
+        assert!(parse_image_policy_decision(
+            r#"{"allowed":false,"violations":[],"summary":"Nothing visible."}"#
+        )
+        .is_err());
     }
 }

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -1,0 +1,278 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use axum::{
+    extract::{Path as AxumPath, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+};
+
+use crate::{
+    is_safe_image_content_type, now_millis, request_image_policy_decision, request_replicate_art,
+    AiConfig, AppState, CommunityArtPlan, DownloadedReplicateImage, ImagePolicyRequest,
+    ReplicateAvatarArtConfig,
+};
+
+const POLICY_GENERATION_ATTEMPTS: u8 = 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum CommunityArtImagePolicy {
+    LocationLandscape,
+}
+
+impl CommunityArtImagePolicy {
+    pub(super) fn prompt(self) -> &'static str {
+        match self {
+            Self::LocationLandscape => {
+                "Landscape only. No people, human figures, humanoids, characters, animals, creatures, silhouettes, faces, body parts, statues, portraits, text, letters, numbers, logos, watermarks, UI, or card borders."
+            }
+        }
+    }
+
+    fn review(self) -> &'static str {
+        match self {
+            Self::LocationLandscape => {
+                "Publish only a landscape with no visible or implied people, human figures, humanoids, characters, animals, creatures, silhouettes, faces, body parts, statues, portraits, readable text, letters, numbers, logos, or watermarks."
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum CommunityArtGenerationError {
+    Provider(String),
+    PolicyUnavailable,
+    PolicyReview(String),
+    PolicyRejected(Vec<String>),
+    Storage(String),
+}
+
+impl CommunityArtGenerationError {
+    pub(super) fn status(&self) -> &'static str {
+        match self {
+            Self::PolicyRejected(_) => "rejected",
+            _ => "failed",
+        }
+    }
+
+    pub(super) fn code(&self) -> &'static str {
+        match self {
+            Self::Provider(_) => "community_art_generation_failed",
+            Self::PolicyUnavailable => "community_art_policy_unconfigured",
+            Self::PolicyReview(_) => "community_art_policy_review_failed",
+            Self::PolicyRejected(_) => "community_art_policy_rejected",
+            Self::Storage(_) => "community_art_storage_failed",
+        }
+    }
+
+    pub(super) fn message(&self) -> String {
+        match self {
+            Self::Provider(error) => format!("provider generation failed: {error}"),
+            Self::PolicyUnavailable => {
+                "location art policy review is not configured; output withheld".to_string()
+            }
+            Self::PolicyReview(error) => format!("image policy review failed: {error}"),
+            Self::PolicyRejected(violations) => format!(
+                "image policy rejected all candidates: {}",
+                if violations.is_empty() {
+                    "unspecified violation".to_string()
+                } else {
+                    violations.join(", ")
+                }
+            ),
+            Self::Storage(error) => format!("validated image storage failed: {error}"),
+        }
+    }
+}
+
+pub(super) async fn generate_and_store_community_art(
+    config: &ReplicateAvatarArtConfig,
+    policy_config: Option<&AiConfig>,
+    generated_asset_dir: &Path,
+    plan: &CommunityArtPlan,
+) -> Result<(), CommunityArtGenerationError> {
+    let attempts = if plan.image_policy.is_some() {
+        POLICY_GENERATION_ATTEMPTS
+    } else {
+        1
+    };
+    let mut last_violations = Vec::new();
+    for attempt in 1..=attempts {
+        let retry_constraint = if attempt > 1 {
+            "The previous candidate failed publication review. Keep the scene strictly empty of every forbidden subject."
+        } else {
+            ""
+        };
+        let prompt = crate::compact_whitespace(&format!(
+            "{}, {} {}",
+            config.prompt_prefix, plan.prompt, retry_constraint
+        ));
+        let image = request_replicate_art(config, prompt, plan.aspect_ratio)
+            .await
+            .map_err(CommunityArtGenerationError::Provider)?;
+        if let Some(policy) = plan.image_policy {
+            let policy_config =
+                policy_config.ok_or(CommunityArtGenerationError::PolicyUnavailable)?;
+            let decision = request_image_policy_decision(
+                policy_config,
+                ImagePolicyRequest {
+                    feature: "media.location_image_policy",
+                    image_url: &image.source_url,
+                    policy: policy.review(),
+                    timeout: Duration::from_secs(30),
+                    max_attempts: 2,
+                    referer: "https://cosyworld.fly.dev",
+                },
+            )
+            .await
+            .map_err(|error| CommunityArtGenerationError::PolicyReview(error.to_string()))?;
+            if !decision.allowed {
+                last_violations = decision.violations;
+                continue;
+            }
+        }
+        store_community_art_image(generated_asset_dir, plan, image)
+            .map_err(CommunityArtGenerationError::Storage)?;
+        return Ok(());
+    }
+    Err(CommunityArtGenerationError::PolicyRejected(last_violations))
+}
+
+fn store_community_art_image(
+    generated_asset_dir: &Path,
+    plan: &CommunityArtPlan,
+    image: DownloadedReplicateImage,
+) -> Result<(), String> {
+    let path =
+        stored_community_art_image_path(generated_asset_dir, &plan.subject_kind, plan.subject_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let content_type_path = stored_community_art_content_type_path(
+        generated_asset_dir,
+        &plan.subject_kind,
+        plan.subject_id,
+    );
+    let temporary_suffix = format!("{}-{}", std::process::id(), now_millis());
+    let temporary_image_path =
+        path.with_file_name(format!(".{}.image.tmp-{temporary_suffix}", plan.subject_id));
+    let temporary_content_type_path = content_type_path.with_file_name(format!(
+        ".{}.content-type.tmp-{temporary_suffix}",
+        plan.subject_id
+    ));
+    let stored = (|| -> io::Result<()> {
+        fs::write(&temporary_image_path, image.bytes)?;
+        fs::write(&temporary_content_type_path, image.content_type)?;
+        fs::rename(&temporary_content_type_path, &content_type_path)?;
+        fs::rename(&temporary_image_path, &path)?;
+        Ok(())
+    })();
+    if let Err(error) = stored {
+        let _ = fs::remove_file(&temporary_image_path);
+        let _ = fs::remove_file(&temporary_content_type_path);
+        return Err(error.to_string());
+    }
+    Ok(())
+}
+
+fn community_art_dir(root: &Path, subject_kind: &str) -> PathBuf {
+    root.join("community-art").join(subject_kind)
+}
+
+pub(super) fn stored_community_art_image_path(
+    root: &Path,
+    subject_kind: &str,
+    subject_id: u64,
+) -> PathBuf {
+    community_art_dir(root, subject_kind).join(format!("{subject_id}.image"))
+}
+
+pub(super) fn stored_community_art_content_type_path(
+    root: &Path,
+    subject_kind: &str,
+    subject_id: u64,
+) -> PathBuf {
+    community_art_dir(root, subject_kind).join(format!("{subject_id}.content-type"))
+}
+
+pub(super) fn stored_community_art_content_type(
+    root: &Path,
+    subject_kind: &str,
+    subject_id: u64,
+) -> String {
+    fs::read_to_string(stored_community_art_content_type_path(
+        root,
+        subject_kind,
+        subject_id,
+    ))
+    .ok()
+    .map(|value| value.trim().to_ascii_lowercase())
+    .filter(|value| is_safe_image_content_type(value))
+    .unwrap_or_else(|| "image/png".to_string())
+}
+
+pub(super) fn community_art_image_url(
+    subject_kind: &str,
+    subject_id: u64,
+    level: u8,
+    revision: u32,
+) -> String {
+    format!(
+        "/assets/generated/community/{subject_kind}/{subject_id}.image?level={level}&revision={revision}"
+    )
+}
+
+pub(super) async fn generated_community_art_asset(
+    State(state): State<AppState>,
+    AxumPath((subject_kind, asset_file)): AxumPath<(String, String)>,
+) -> Response {
+    if !matches!(subject_kind.as_str(), "actor" | "item" | "location") {
+        return (StatusCode::NOT_FOUND, "unknown community artwork").into_response();
+    }
+    let Some(subject_id) = asset_file
+        .strip_suffix(".image")
+        .and_then(|value| value.parse::<u64>().ok())
+    else {
+        return (StatusCode::NOT_FOUND, "unknown community artwork").into_response();
+    };
+    let ready = {
+        let runtime = state.inner.lock().await;
+        runtime
+            .community_art_subject_level(&subject_kind, subject_id)
+            .and_then(|level| {
+                runtime
+                    .community_art_generations
+                    .get(&crate::community_art_generation_key(
+                        &subject_kind,
+                        subject_id,
+                        level,
+                    ))
+            })
+            .is_some_and(|generation| generation.status == "ready")
+    };
+    if !ready {
+        return (StatusCode::NOT_FOUND, "community artwork is not ready").into_response();
+    }
+    let path =
+        stored_community_art_image_path(&state.generated_asset_dir, &subject_kind, subject_id);
+    let Ok(bytes) = fs::read(path) else {
+        return (StatusCode::NOT_FOUND, "community artwork is not ready").into_response();
+    };
+    let content_type =
+        stored_community_art_content_type(&state.generated_asset_dir, &subject_kind, subject_id);
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, content_type),
+            (
+                header::CACHE_CONTROL,
+                "public, no-cache, must-revalidate".to_string(),
+            ),
+        ],
+        bytes,
+    )
+        .into_response()
+}

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -1,0 +1,238 @@
+use super::*;
+
+fn test_art_config() -> ReplicateAvatarArtConfig {
+    ReplicateAvatarArtConfig {
+        api_token: "test-token".to_string(),
+        model: "test/model".to_string(),
+        version: None,
+        lora_url: None,
+        lora_input_key: "lora_weights".to_string(),
+        lora_scale_input_key: "lora_scale".to_string(),
+        lora_scale: 1.0,
+        prompt_prefix: "cozy card art".to_string(),
+        output_format: "png".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn location_art_funding_fails_before_debit_without_policy_review() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        RAIN_SOFT_GARDEN_LOCATION_ID,
+        "Careful Patron",
+    );
+    runtime.callings.insert(
+        5000,
+        CallingState {
+            actor_id: 5000,
+            statement: EXPLORER_CALLING_STATEMENT.to_string(),
+            source_event_seq: None,
+        },
+    );
+    let (search, mutation, _) = runtime
+        .plan_journey_move(5000, MOONLIT_TRAIL_LOCATION_ID)
+        .expect("pathway planning succeeds")
+        .expect("long route begins with discovery");
+    let mut discovery = JournalRecord::new(search, 7049);
+    discovery.projection_mutations.push(mutation);
+    assert_eq!(runtime.apply_journal_record(&discovery).0, CW_OK);
+    let waypoint_id = runtime.journeys[&5000].path[1];
+    let mut state = test_app_state(runtime, None);
+    state.avatar_art_config = Arc::new(Some(test_art_config()));
+    assert!(state.ai_config.as_ref().is_none());
+    let (actor_session, _) = issue_actor_session(&state, 5000);
+
+    let response = fund_community_image(
+        ConnectInfo("127.0.0.1:44991".parse().expect("client address")),
+        State(state.clone()),
+        Json(FundCommunityImageRequest {
+            actor_id: 5000,
+            actor_session: Some(actor_session),
+            subject_kind: "location".to_string(),
+            subject_id: waypoint_id,
+            intent_id: "test-location-policy-unconfigured".to_string(),
+        }),
+    )
+    .await
+    .0;
+
+    assert!(!response.ok);
+    assert_eq!(response.status, 503);
+    assert!(response.events.is_empty());
+    let runtime = state.inner.lock().await;
+    assert_eq!(runtime.orb_balance(5000), STARTING_ORBS);
+    assert!(!runtime
+        .community_art_generations
+        .contains_key(&community_art_generation_key("location", waypoint_id, 1)));
+}
+
+#[tokio::test]
+async fn moderation_rejects_pathway_art_to_the_fallback_without_refunding() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        RAIN_SOFT_GARDEN_LOCATION_ID,
+        "Art Ranger",
+    );
+    runtime.callings.insert(
+        5000,
+        CallingState {
+            actor_id: 5000,
+            statement: EXPLORER_CALLING_STATEMENT.to_string(),
+            source_event_seq: None,
+        },
+    );
+    let (search, mutation, _) = runtime
+        .plan_journey_move(5000, MOONLIT_TRAIL_LOCATION_ID)
+        .expect("pathway planning succeeds")
+        .expect("long route begins with discovery");
+    let mut discovery = JournalRecord::new(search, 7051);
+    discovery.projection_mutations.push(mutation);
+    assert_eq!(runtime.apply_journal_record(&discovery).0, CW_OK);
+    let waypoint_id = runtime.journeys[&5000].path[1];
+
+    let mut funding = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            ..CwAction::default()
+        },
+        7052,
+    );
+    funding
+        .projection_mutations
+        .push(ProjectionMutation::FundCommunityArt {
+            subject_kind: "location".to_string(),
+            subject_id: waypoint_id,
+            level: 1,
+            required_orbs: 1,
+            contributor_actor_id: 5000,
+            intent_id: "test-pathway-policy-funding".to_string(),
+            amount: 1,
+            history_through_seq: 7052,
+        });
+    assert_eq!(runtime.apply_journal_record(&funding).0, CW_OK);
+    let mut ready = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            ..CwAction::default()
+        },
+        7053,
+    );
+    ready
+        .projection_mutations
+        .push(ProjectionMutation::SetCommunityArtStatus {
+            subject_kind: "location".to_string(),
+            subject_id: waypoint_id,
+            level: 1,
+            status: "ready".to_string(),
+        });
+    assert_eq!(runtime.apply_journal_record(&ready).0, CW_OK);
+    assert_eq!(
+        runtime
+            .state_response(Some(5000), &AccessContext::default())
+            .cards
+            .locations[&waypoint_id]
+            .image_url
+            .as_deref(),
+        Some(
+            format!("/assets/generated/community/location/{waypoint_id}.image?level=1&revision=1")
+                .as_str()
+        )
+    );
+    let before_world_tick = runtime.world.tick;
+    let before_exit_count = runtime.world.exit_count;
+    let before_journey = runtime.journeys[&5000].clone();
+
+    let generated_dir = std::env::temp_dir().join(format!(
+        "cosyworld-pathway-policy-{}-{}",
+        std::process::id(),
+        now_seed()
+    ));
+    let _ = fs::remove_dir_all(&generated_dir);
+    let mut state = test_app_state(runtime, None);
+    state.generated_asset_dir = Arc::new(generated_dir.clone());
+    state.moderation_token = Some(Arc::new("test-moderator".to_string()));
+    let image_path = stored_community_art_image_path(&generated_dir, "location", waypoint_id);
+    let content_type_path =
+        stored_community_art_content_type_path(&generated_dir, "location", waypoint_id);
+    fs::create_dir_all(image_path.parent().expect("community art parent"))
+        .expect("create community art fixture directory");
+    fs::write(&image_path, b"reviewed fixture bytes").expect("write ready art fixture");
+    fs::write(&content_type_path, "image/png").expect("write ready art type fixture");
+    let legacy_pathway_dir = generated_dir.join("pathways");
+    fs::create_dir_all(&legacy_pathway_dir).expect("create legacy pathway directory");
+    fs::write(
+        legacy_pathway_dir.join(format!("{waypoint_id}.image")),
+        b"legacy person-bearing image",
+    )
+    .expect("write legacy pathway fixture");
+
+    let legacy_response =
+        generated_pathway_asset(State(state.clone()), AxumPath(format!("{waypoint_id}.svg")))
+            .await
+            .into_response();
+    assert_eq!(legacy_response.status(), StatusCode::OK);
+    assert_eq!(
+        legacy_response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("image/svg+xml; charset=utf-8"),
+        "legacy pathway bitmaps must never override the deterministic fallback"
+    );
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::AUTHORIZATION,
+        "Bearer test-moderator".parse().expect("moderation header"),
+    );
+    let rejected = moderation_reject_community_art(
+        headers,
+        State(state.clone()),
+        AxumPath(("location".to_string(), waypoint_id)),
+    )
+    .await
+    .0;
+    assert!(rejected.ok);
+    assert_eq!(rejected.art_status.as_deref(), Some("rejected"));
+    assert!(rejected.retryable_without_orbs);
+    assert!(!image_path.exists());
+    assert!(!content_type_path.exists());
+
+    let runtime = state.inner.lock().await;
+    let card = &runtime
+        .state_response(Some(5000), &AccessContext::default())
+        .cards
+        .locations[&waypoint_id];
+    assert_eq!(card.asset_status, "generated_pathway_art");
+    assert_eq!(
+        card.image_url.as_deref(),
+        Some(format!("/assets/generated/pathways/{waypoint_id}.svg").as_str())
+    );
+    let generation = &runtime.community_art_generations
+        [&community_art_generation_key("location", waypoint_id, 1)];
+    assert_eq!(generation.status, "rejected");
+    assert_eq!(generation.funded_orbs, generation.required_orbs);
+    assert_eq!(generation.revision, 2);
+    assert_eq!(runtime.world.tick, before_world_tick);
+    assert_eq!(runtime.world.exit_count, before_exit_count);
+    let journey = &runtime.journeys[&5000];
+    assert_eq!(journey.pathway_id, before_journey.pathway_id);
+    assert_eq!(journey.path, before_journey.path);
+    assert_eq!(journey.current_step, before_journey.current_step);
+    drop(runtime);
+
+    let rejected_asset = generated_community_art_asset(
+        State(state),
+        AxumPath(("location".to_string(), format!("{waypoint_id}.image"))),
+    )
+    .await
+    .into_response();
+    assert_eq!(rejected_asset.status(), StatusCode::NOT_FOUND);
+    let _ = fs::remove_dir_all(generated_dir);
+}

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -9766,7 +9766,9 @@
       const needsOrb = remaining > 0;
       const buttonLabel = needsOrb
         ? `add one Orb · ${funded}/${required}`
-        : (status === "failed" ? "try the image again" : "nudge the image workshop");
+        : (status === "rejected"
+          ? "try a different image"
+          : (status === "failed" ? "try the image again" : "nudge the image workshop"));
       const disabled = needsOrb && balance < 1;
       const detail = needsOrb
         ? `${remaining} ${remaining === 1 ? "Orb" : "Orbs"} still needed from the community`

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -10,6 +10,9 @@ mod canonical_world;
 mod cards;
 mod combat;
 mod communal_governance;
+mod community_art;
+#[cfg(test)]
+mod community_art_tests;
 mod composition;
 mod content_load;
 mod content_packs;
@@ -68,6 +71,7 @@ use canonical_world::*;
 use cards::*;
 use combat::*;
 use communal_governance::*;
+use community_art::*;
 use content_load::*;
 use content_packs::*;
 use content_policy::*;
@@ -374,6 +378,7 @@ struct ReplicateAvatarArtConfig {
 struct DownloadedReplicateImage {
     bytes: Vec<u8>,
     content_type: String,
+    source_url: String,
 }
 
 #[cfg(test)]
@@ -639,6 +644,8 @@ struct CommunityArtGenerationState {
     funding_intent_ids: BTreeSet<String>,
     status: String,
     history_through_seq: u64,
+    #[serde(default)]
+    revision: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -650,6 +657,7 @@ struct CommunityArtPlan {
     history_through_seq: u64,
     prompt: String,
     aspect_ratio: &'static str,
+    image_policy: Option<CommunityArtImagePolicy>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10311,6 +10319,7 @@ impl RuntimeWorld {
                                     funding_intent_ids: BTreeSet::new(),
                                     status: "funding".to_string(),
                                     history_through_seq: *history_through_seq,
+                                    revision: 0,
                                 });
                         if !intent_id.is_empty()
                             && !generation.funding_intent_ids.insert(intent_id.clone())
@@ -10360,6 +10369,11 @@ impl RuntimeWorld {
                     let Some(generation) = self.community_art_generations.get_mut(&key) else {
                         continue;
                     };
+                    if generation.status != *status
+                        && matches!(status.as_str(), "ready" | "rejected")
+                    {
+                        generation.revision = generation.revision.saturating_add(1);
+                    }
                     generation.status = status.clone();
                     events.push(self.append_async_job_event(
                         &format!("community_art.{status}"),
@@ -13713,7 +13727,7 @@ impl RuntimeWorld {
                 let landmark_name = names[(seed as usize + index) % names.len()].to_string();
                 let id = generated_pathway_location_id(&pathway_id, index);
                 let art_prompt = format!(
-                    "cozy storybook landscape, {landmark_name}, a hidden waypoint along a newly explored pathway between {origin_name} and {destination_name}, stretch {step} of {distance}, {origin_biome} terrain meeting {destination_biome} terrain, {origin} meeting {destination}, no people, no text",
+                    "cozy storybook landscape, {landmark_name}, a hidden waypoint along a newly explored pathway between {origin_name} and {destination_name}, stretch {step} of {distance}, {origin_biome} terrain meeting {destination_biome} terrain, {origin} meeting {destination}, no people, no characters, no creatures, no text, no logo, no watermark",
                     step = index + 1,
                     origin_biome = origin_meta.biome,
                     destination_biome = destination_meta.biome,
@@ -19556,7 +19570,12 @@ impl RuntimeWorld {
             .map(|state| state.status.clone())
             .unwrap_or_else(|| "available".to_string());
         if status == "ready" {
-            card.image_url = Some(community_art_image_url(subject_kind, subject_id, level));
+            card.image_url = Some(community_art_image_url(
+                subject_kind,
+                subject_id,
+                level,
+                generation.map(|state| state.revision).unwrap_or(0),
+            ));
             card.asset_status = "community_art".to_string();
         }
         card.level = level;
@@ -19683,6 +19702,14 @@ impl RuntimeWorld {
         if !meta.terrain.is_empty() {
             facts.push(format!("terrain: {}", meta.terrain.join(", ")));
         }
+        if let Some(art_prompt) = meta
+            .art_prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            facts.push(format!("reviewed landscape brief: {art_prompt}"));
+        }
         if let Some(sheet) = self.room_sheets.get(&location_id) {
             if !sheet.aspects.is_empty() {
                 facts.push(format!("defining aspects: {}", sheet.aspects.join(", ")));
@@ -19710,7 +19737,7 @@ impl RuntimeWorld {
         let level = self
             .community_art_subject_level(subject_kind, subject_id)
             .ok_or_else(|| "That card does not have community-generated art.".to_string())?;
-        let (card, visible, aspect_ratio, subject_details) = match subject_kind {
+        let (card, visible, aspect_ratio, subject_details, image_policy) = match subject_kind {
             "actor" => {
                 let actor = self
                     .actor_by_id(subject_id)
@@ -19733,6 +19760,7 @@ impl RuntimeWorld {
                     actor.location_id == contributor.location_id,
                     "2:3",
                     self.actor_community_art_details(subject_id, &card),
+                    None,
                 )
             }
             "item" => {
@@ -19754,6 +19782,7 @@ impl RuntimeWorld {
                             && item.location_id == contributor.location_id),
                     "1:1",
                     self.item_community_art_details(*item),
+                    None,
                 )
             }
             "location" => {
@@ -19772,6 +19801,7 @@ impl RuntimeWorld {
                     visible,
                     "16:9",
                     self.location_community_art_details(subject_id),
+                    Some(CommunityArtImagePolicy::LocationLandscape),
                 )
             }
             _ => return Err("Unknown community-art subject.".to_string()),
@@ -19816,8 +19846,11 @@ impl RuntimeWorld {
         } else {
             history
         };
+        let image_constraints = image_policy
+            .map(CommunityArtImagePolicy::prompt)
+            .unwrap_or("No words, logo, watermark, UI, gore, or photorealism.");
         let prompt = compact_whitespace(&format!(
-            "Collectible card art for {kind} {name}, titled {title}. {blurb}. Authoritative level {level}. Canonical visual facts: {subject_details}. Let the image visibly remember this public history without adding text: {history}. Preserve the subject's established identity across later levels. No words, logo, watermark, UI, gore, or photorealism.",
+            "Collectible card art for {kind} {name}, titled {title}. {blurb}. Authoritative level {level}. Canonical visual facts: {subject_details}. Let the image visibly remember this public history without adding text: {history}. Preserve the subject's established identity across later levels. {image_constraints}",
             kind = subject_kind,
             name = card.display_name,
             title = card.title,
@@ -19831,6 +19864,7 @@ impl RuntimeWorld {
             history_through_seq,
             prompt,
             aspect_ratio,
+            image_policy,
         })
     }
 
@@ -23941,60 +23975,8 @@ fn stored_avatar_content_type(root: &Path, actor_id: u64) -> String {
         .unwrap_or_else(|| "image/png".to_string())
 }
 
-fn generated_pathway_dir(root: &Path) -> PathBuf {
-    root.join("pathways")
-}
-
 fn community_art_generation_key(subject_kind: &str, subject_id: u64, level: u8) -> String {
     format!("{subject_kind}:{subject_id}:level:{level}")
-}
-
-fn community_art_dir(root: &Path, subject_kind: &str) -> PathBuf {
-    root.join("community-art").join(subject_kind)
-}
-
-fn stored_community_art_image_path(root: &Path, subject_kind: &str, subject_id: u64) -> PathBuf {
-    community_art_dir(root, subject_kind).join(format!("{subject_id}.image"))
-}
-
-fn stored_community_art_content_type_path(
-    root: &Path,
-    subject_kind: &str,
-    subject_id: u64,
-) -> PathBuf {
-    community_art_dir(root, subject_kind).join(format!("{subject_id}.content-type"))
-}
-
-fn stored_community_art_content_type(root: &Path, subject_kind: &str, subject_id: u64) -> String {
-    fs::read_to_string(stored_community_art_content_type_path(
-        root,
-        subject_kind,
-        subject_id,
-    ))
-    .ok()
-    .map(|value| value.trim().to_ascii_lowercase())
-    .filter(|value| is_safe_image_content_type(value))
-    .unwrap_or_else(|| "image/png".to_string())
-}
-
-fn community_art_image_url(subject_kind: &str, subject_id: u64, level: u8) -> String {
-    format!("/assets/generated/community/{subject_kind}/{subject_id}.image?level={level}")
-}
-
-fn stored_pathway_image_path(root: &Path, location_id: u64) -> PathBuf {
-    generated_pathway_dir(root).join(format!("{location_id}.image"))
-}
-
-fn stored_pathway_content_type_path(root: &Path, location_id: u64) -> PathBuf {
-    generated_pathway_dir(root).join(format!("{location_id}.content-type"))
-}
-
-fn stored_pathway_content_type(root: &Path, location_id: u64) -> String {
-    fs::read_to_string(stored_pathway_content_type_path(root, location_id))
-        .ok()
-        .map(|value| value.trim().to_ascii_lowercase())
-        .filter(|value| is_safe_image_content_type(value))
-        .unwrap_or_else(|| "image/png".to_string())
 }
 
 fn is_safe_image_content_type(value: &str) -> bool {
@@ -26722,6 +26704,13 @@ async fn fund_community_image(
             });
         }
     };
+    if plan.image_policy.is_some() && state.ai_config.as_ref().is_none() {
+        return Json(ActionResponse {
+            ok: false,
+            status: 503,
+            events: Vec::new(),
+        });
+    }
     let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
     let existing = runtime.community_art_generations.get(&key);
     if existing.is_some_and(|generation| generation.funding_intent_ids.contains(intent_id)) {
@@ -32280,31 +32269,6 @@ fn community_art_jobs() -> &'static StdMutex<BTreeSet<String>> {
     COMMUNITY_ART_JOBS.get_or_init(|| StdMutex::new(BTreeSet::new()))
 }
 
-async fn generate_and_store_community_art(
-    config: &ReplicateAvatarArtConfig,
-    generated_asset_dir: &Path,
-    plan: &CommunityArtPlan,
-) -> Result<(), String> {
-    let prompt = compact_whitespace(&format!("{}, {}", config.prompt_prefix, plan.prompt));
-    let image = request_replicate_art(config, prompt, plan.aspect_ratio).await?;
-    let path =
-        stored_community_art_image_path(generated_asset_dir, &plan.subject_kind, plan.subject_id);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
-    }
-    fs::write(&path, image.bytes).map_err(|error| error.to_string())?;
-    fs::write(
-        stored_community_art_content_type_path(
-            generated_asset_dir,
-            &plan.subject_kind,
-            plan.subject_id,
-        ),
-        image.content_type,
-    )
-    .map_err(|error| error.to_string())?;
-    Ok(())
-}
-
 async fn commit_community_art_status(
     state: &AppState,
     actor_id: u64,
@@ -32353,13 +32317,22 @@ fn schedule_community_art_generation(state: &AppState, actor_id: u64, plan: Comm
     let state = state.clone();
     tokio::spawn(async move {
         let started_at = Instant::now();
-        let result =
-            generate_and_store_community_art(&config, &state.generated_asset_dir, &plan).await;
+        let result = generate_and_store_community_art(
+            &config,
+            state.ai_config.as_ref().as_ref(),
+            &state.generated_asset_dir,
+            &plan,
+        )
+        .await;
         let (status, error_code) = match result {
             Ok(()) => ("ready", None),
             Err(error) => {
-                warn!("community art generation failed for {}: {}", key, error);
-                ("failed", Some("community_art_generation_failed"))
+                warn!(
+                    "community art generation failed for {}: {}",
+                    key,
+                    error.message()
+                );
+                (error.status(), Some(error.code()))
             }
         };
         let events = commit_community_art_status(&state, actor_id, &plan, status).await;
@@ -32562,6 +32535,7 @@ async fn download_replicate_image(
     Ok(DownloadedReplicateImage {
         bytes,
         content_type,
+        source_url: output_url.to_string(),
     })
 }
 
@@ -32992,7 +32966,7 @@ fn apply_generated_waypoint_content(
     waypoint.meta.description = content.description;
     waypoint.meta.persona = content.persona;
     waypoint.meta.art_prompt = Some(format!(
-        "cozy storybook landscape, {detail}, {name}, {biome}, terrain of {terrain}, no people, no character, no text, no logo, no watermark",
+        "cozy storybook landscape, {detail}, {name}, {biome}, terrain of {terrain}, no people, no characters, no creatures, no text, no logo, no watermark",
         detail = content.visual_detail,
         name = content.name,
         biome = waypoint.meta.biome,
@@ -37252,21 +37226,6 @@ async fn generated_pathway_asset(
     if location_id < GENERATED_PATHWAY_LOCATION_ID_BASE {
         return (StatusCode::NOT_FOUND, "unknown pathway").into_response();
     }
-    if let Ok(bytes) = fs::read(stored_pathway_image_path(
-        &state.generated_asset_dir,
-        location_id,
-    )) {
-        let content_type = stored_pathway_content_type(&state.generated_asset_dir, location_id);
-        return (
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, content_type),
-                (header::CACHE_CONTROL, "public, max-age=86400".to_string()),
-            ],
-            bytes,
-        )
-            .into_response();
-    }
     let waypoint = {
         let runtime = state.inner.lock().await;
         runtime
@@ -37297,37 +37256,6 @@ async fn generated_pathway_asset(
             (header::CACHE_CONTROL, "public, max-age=86400"),
         ],
         svg,
-    )
-        .into_response()
-}
-
-async fn generated_community_art_asset(
-    State(state): State<AppState>,
-    AxumPath((subject_kind, asset_file)): AxumPath<(String, String)>,
-) -> impl IntoResponse {
-    if !matches!(subject_kind.as_str(), "actor" | "item" | "location") {
-        return (StatusCode::NOT_FOUND, "unknown community artwork").into_response();
-    }
-    let Some(subject_id) = asset_file
-        .strip_suffix(".image")
-        .and_then(|value| value.parse::<u64>().ok())
-    else {
-        return (StatusCode::NOT_FOUND, "unknown community artwork").into_response();
-    };
-    let path =
-        stored_community_art_image_path(&state.generated_asset_dir, &subject_kind, subject_id);
-    let Ok(bytes) = fs::read(path) else {
-        return (StatusCode::NOT_FOUND, "community artwork is not ready").into_response();
-    };
-    let content_type =
-        stored_community_art_content_type(&state.generated_asset_dir, &subject_kind, subject_id);
-    (
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, content_type),
-            (header::CACHE_CONTROL, "public, max-age=86400".to_string()),
-        ],
-        bytes,
     )
         .into_response()
 }
@@ -47540,7 +47468,11 @@ mod tests {
             .as_deref()
             .expect("validated visual detail becomes a bounded art prompt");
         assert!(art_prompt.contains("no people"));
+        assert!(art_prompt.contains("no characters"));
+        assert!(art_prompt.contains("no creatures"));
         assert!(art_prompt.contains("no text"));
+        assert!(art_prompt.contains("no logo"));
+        assert!(art_prompt.contains("no watermark"));
         assert!(art_prompt.contains(&biome));
 
         set_pathway_generation_provenance(&mut pathway, GenerationMode::AutoBounded, None, "ai", 2);
@@ -47617,6 +47549,7 @@ mod tests {
             api_key: "test".to_string(),
             base_url: format!("http://{address}"),
             model: "test-structured-model".to_string(),
+            vision_model: "test-vision-model".to_string(),
             reasoning_effort: None,
         }));
         state.generation_controls = Arc::new(
@@ -47748,6 +47681,27 @@ mod tests {
             first_card.image_url.as_deref(),
             Some(format!("/assets/generated/pathways/{first_waypoint_id}.svg").as_str())
         );
+        let first_art_plan = runtime
+            .community_art_plan(5000, "location", first_waypoint_id)
+            .expect("revealed pathway builds a location-art plan");
+        assert_eq!(
+            first_art_plan.image_policy,
+            Some(CommunityArtImagePolicy::LocationLandscape)
+        );
+        for forbidden in [
+            "No people",
+            "characters",
+            "creatures",
+            "text",
+            "logos",
+            "watermarks",
+        ] {
+            assert!(
+                first_art_plan.prompt.contains(forbidden),
+                "pathway location prompt should forbid {forbidden}: {}",
+                first_art_plan.prompt
+            );
+        }
         let after_first_search = runtime.state_response(Some(5000), &AccessContext::default());
         assert!(after_first_search.cards.locations[&first_waypoint_id]
             .community_art
@@ -54040,7 +53994,7 @@ mod tests {
         assert_eq!(card.community_art.as_ref().map(|art| art.level), Some(2));
         assert_eq!(
             card.image_url.as_deref(),
-            Some("/assets/generated/community/actor/5000.image?level=2")
+            Some("/assets/generated/community/actor/5000.image?level=2&revision=1")
         );
     }
 

--- a/v2/orchestrator-rust/src/moderation.rs
+++ b/v2/orchestrator-rust/src/moderation.rs
@@ -6,18 +6,20 @@ use axum::{
 };
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
-use std::{io, path::Path, time::Duration};
+use std::{fs, io, path::Path, time::Duration};
 use tracing::{error, info, warn};
 
 use crate::{
-    active_actor_ids_for_state, clear_actor_sessions_for_actor, commit_presence_event,
+    active_actor_ids_for_state, broadcast_events, clear_actor_sessions_for_actor,
+    commit_journal_record, commit_presence_event, community_art_generation_key,
     delete_actor_sessions_for_actor, delete_actor_suspension, deployment_config_error,
     event_replay_limit, event_store_scan_limit, init_event_store, no_store_headers, now_millis,
     now_unix_secs, open_event_store, persist_actor_suspension, read_economy_audit,
-    read_event_store, resolve_economy_reconciliation, sqlite_error, tail_event_replay,
-    ActorSuspension, AiUsageLedgerAuditView, AppState, AvatarPackOpeningView,
-    EconomyReconciliationView, EventView, OrbLedgerAuditView, WoodenBoxReceiptView,
-    MAX_EVENT_STORE_SCAN, MODERATION_HTML,
+    read_event_store, resolve_economy_reconciliation, sqlite_error,
+    stored_community_art_content_type_path, stored_community_art_image_path, tail_event_replay,
+    ActorSuspension, AiUsageLedgerAuditView, AppState, AvatarPackOpeningView, CwAction,
+    EconomyReconciliationView, EventView, JournalRecord, OrbLedgerAuditView, ProjectionMutation,
+    WoodenBoxReceiptView, CW_ACTION_NONE, CW_OK, MAX_EVENT_STORE_SCAN, MODERATION_HTML,
 };
 
 pub(crate) const MAX_REPORT_REASON_CHARS: usize = 500;
@@ -506,6 +508,18 @@ pub(crate) struct ModerationActorResponse {
     pub(crate) error: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub(crate) struct ModerationCommunityArtResponse {
+    pub(crate) ok: bool,
+    pub(crate) status: u16,
+    pub(crate) subject_kind: String,
+    pub(crate) subject_id: u64,
+    pub(crate) level: Option<u8>,
+    pub(crate) art_status: Option<String>,
+    pub(crate) retryable_without_orbs: bool,
+    pub(crate) error: Option<String>,
+}
+
 pub(crate) async fn moderation_events_view(
     headers: HeaderMap,
     State(state): State<AppState>,
@@ -628,6 +642,159 @@ pub(crate) async fn moderation_economy_view(
             })
         }
     }
+}
+
+pub(crate) async fn moderation_reject_community_art(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    AxumPath((subject_kind, subject_id)): AxumPath<(String, u64)>,
+) -> Json<ModerationCommunityArtResponse> {
+    let response = |ok,
+                    status,
+                    level,
+                    art_status: Option<&str>,
+                    retryable_without_orbs,
+                    error: Option<&str>| {
+        Json(ModerationCommunityArtResponse {
+            ok,
+            status,
+            subject_kind: subject_kind.clone(),
+            subject_id,
+            level,
+            art_status: art_status.map(ToString::to_string),
+            retryable_without_orbs,
+            error: error.map(ToString::to_string),
+        })
+    };
+    if !moderation_authorized(&state, &headers) {
+        return response(
+            false,
+            403,
+            None,
+            None,
+            false,
+            Some("moderation bearer token required"),
+        );
+    }
+    if subject_id == 0 || !matches!(subject_kind.as_str(), "actor" | "item" | "location") {
+        return response(
+            false,
+            400,
+            None,
+            None,
+            false,
+            Some("valid community-art subject required"),
+        );
+    }
+
+    let (level, retryable_without_orbs, events) = {
+        let mut runtime = state.inner.lock().await;
+        let Some(level) = runtime.community_art_subject_level(&subject_kind, subject_id) else {
+            return response(
+                false,
+                404,
+                None,
+                None,
+                false,
+                Some("community artwork was not found"),
+            );
+        };
+        let key = community_art_generation_key(&subject_kind, subject_id, level);
+        let Some(generation) = runtime.community_art_generations.get(&key) else {
+            return response(
+                false,
+                404,
+                Some(level),
+                None,
+                false,
+                Some("community artwork was not funded"),
+            );
+        };
+        let generation_status = generation.status.clone();
+        let retryable_without_orbs = generation.funded_orbs >= generation.required_orbs;
+        if generation_status == "rejected" {
+            (level, retryable_without_orbs, Vec::new())
+        } else {
+            if generation_status != "ready" {
+                return response(
+                    false,
+                    409,
+                    Some(level),
+                    Some(&generation_status),
+                    retryable_without_orbs,
+                    Some("only ready community artwork can be rejected"),
+                );
+            }
+            let mut record = JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_NONE,
+                    actor_id: 0,
+                    ..CwAction::default()
+                },
+                runtime.next_seed_value(),
+            );
+            record
+                .projection_mutations
+                .push(ProjectionMutation::SetCommunityArtStatus {
+                    subject_kind: subject_kind.clone(),
+                    subject_id,
+                    level,
+                    status: "rejected".to_string(),
+                });
+            let Ok((commit_status, events)) = commit_journal_record(&state, &mut runtime, record)
+            else {
+                return response(
+                    false,
+                    500,
+                    Some(level),
+                    Some("ready"),
+                    retryable_without_orbs,
+                    Some("community artwork rejection could not be committed"),
+                );
+            };
+            if commit_status != CW_OK {
+                return response(
+                    false,
+                    500,
+                    Some(level),
+                    Some("ready"),
+                    retryable_without_orbs,
+                    Some("community artwork rejection was refused"),
+                );
+            }
+            (level, retryable_without_orbs, events)
+        }
+    };
+
+    let image_path =
+        stored_community_art_image_path(&state.generated_asset_dir, &subject_kind, subject_id);
+    let content_type_path = stored_community_art_content_type_path(
+        &state.generated_asset_dir,
+        &subject_kind,
+        subject_id,
+    );
+    for path in [&image_path, &content_type_path] {
+        if let Err(error) = fs::remove_file(path) {
+            if error.kind() != io::ErrorKind::NotFound {
+                warn!(
+                    "failed to remove rejected community artwork {}: {}",
+                    path.display(),
+                    error
+                );
+            }
+        }
+    }
+    if !events.is_empty() {
+        broadcast_events(&state, &events);
+    }
+    response(
+        true,
+        200,
+        Some(level),
+        Some("rejected"),
+        retryable_without_orbs,
+        None,
+    )
 }
 
 pub(crate) async fn moderation_resolve_economy_reconciliation(

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -117,6 +117,10 @@ pub(super) fn app_router(state: AppState) -> Router {
         )
         .route("/moderation/economy", get(moderation_economy_view))
         .route(
+            "/moderation/community-art/{subject_kind}/{subject_id}/reject",
+            post(moderation_reject_community_art),
+        )
+        .route(
             "/moderation/economy/reconciliations/{run_id}/resolve",
             post(moderation_resolve_economy_reconciliation),
         )

--- a/v2/orchestrator-rust/src/test-fixtures/pathway-visible-person.svg
+++ b/v2/orchestrator-rust/src/test-fixtures/pathway-visible-person.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360">
+  <rect width="640" height="360" fill="#b8d3c2"/>
+  <path d="M0 245 Q180 180 320 238 T640 220 V360 H0Z" fill="#42664b"/>
+  <path d="M268 360 C282 300 316 268 350 228" fill="none" stroke="#d9c795" stroke-width="54"/>
+  <circle cx="492" cy="171" r="18" fill="#181c1a"/>
+  <path d="M492 190 L492 258 M492 212 L462 240 M492 213 L520 245 M492 258 L467 311 M492 258 L516 311"
+        fill="none" stroke="#181c1a" stroke-width="13" stroke-linecap="round"/>
+</svg>

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74722
+74676


### PR DESCRIPTION
Closes #304

## What changed

- validate generated location images before publication and regenerate rejected candidates
- keep the deterministic pathway fallback visible until approval, including after moderator rejection
- invalidate legacy or rejected art without changing topology, journey progress, funding, or world mechanics
- persist revisioned generation state and serve only the currently approved revision
- add a moderator rejection endpoint and concise retry state
- document the location-art safety contract and add a visible-person regression fixture

## Why

Location artwork could depict a person who was absent from authoritative room state, falsely implying an actor or encounter. The generation pipeline published provider output without a location-specific review gate, and legacy stored bitmaps could continue to override the truthful fallback.

## Impact

Room art now remains a truthful projection of world state. Unreviewed or rejected imagery is withheld while the existing deterministic landscape remains usable, and contributors are not charged again for moderation-driven regeneration.

## Checks

- `npm run check:local`
- 453 JavaScript tests
- 532 orchestrator tests
- kernel, replay, production-profile, browser, mobile, and full living-world smoke tests
- Cargo formatting and `git diff --check`