### PR TITLE
Prevent duplicate community image charges

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -249,8 +249,17 @@ CosyWorld should generalize that into Rust rather than copying the Ruby High Typ
 - A contribution buys no ownership, access, power, or private control over the prompt.
 - Each `{subject kind, subject id, level}` generation is unique and replay-safe. Multiple avatars may pool its exact level-sized cost.
 - The prompt captures public card history through a committed sequence. When the card reaches a later level, its one newly unlocked image can evolve in response to everything that happened since.
-- Fully funded jobs may be retried without another Orb debit. Provider-unavailable requests fail before funding.
-- Location art is published only after a strict vision-policy review finds no people, characters, creatures, text, logos, or watermarks; rejection, review failure, and missing review configuration all leave the deterministic landscape fallback visible.
+- Fully funded jobs may be retried without another Orb debit. A location job
+  first runs the exact base64-image plus strict-schema policy capability
+  preflight, so a missing or incompatible reviewer fails before either funding
+  or a billable Replicate request.
+- Location art is published only after a strict vision-policy review finds no
+  people, characters, creatures, text, logos, or watermarks. The downloaded
+  candidate is durably stored before review; reviewer outages and restarts
+  reuse those bytes rather than purchasing another image. Actual provider
+  generation attempts are journal-counted and capped at three per
+  `{subject kind, subject id, level}`. Rejection, review failure, and missing
+  review configuration all leave the deterministic landscape fallback visible.
 - Current implementation stores a durable funding/status projection and serves the ready shared asset from the generated-card route. A generalized object-store-backed `media_jobs` service remains the scaling step.
 
 ## Combat Replaces Quizzes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.197",
+  "version": "0.0.198",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.197",
+      "version": "0.0.198",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.197",
+  "version": "0.0.198",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -411,9 +411,15 @@ class or classless state, level, calling, location, and carried/equipped items.
 Item and location generations likewise include their authoritative card and
 world details plus committed public history. Location images are withheld until
 the configured vision model confirms that they contain no people, characters,
-creatures, text, logos, or watermarks. Rejected candidates are regenerated up
-to three times; unavailable or invalid review leaves the deterministic
-landscape fallback visible.
+creatures, text, logos, or watermarks. Before funding can complete, the server
+checks that the configured reviewer accepts the exact base64-image and strict
+JSON-schema request. Each downloaded candidate is stored before review, so a
+review outage or restart retries the saved bytes without another Replicate
+prediction. Policy-rejected candidates may be replaced, but provider attempts
+are journaled and capped at three for that card level; after the cap, the
+browser disables retry and states that no more provider credits will be used.
+Unavailable or invalid review leaves the deterministic landscape fallback
+visible.
 
 `Chat` appears only when the avatar has banked advancement and an eligible nearby resident can become a new friend. Playing it spends one advancement point, creates the Bond, and passes the room turn; it never accepts human text or spends Orbs. Human-authored room speech is the separate moderated, turn-exempt `say` path.
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.197"
+version = "0.0.198"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.197"
+version = "0.0.198"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -443,6 +443,11 @@ async fn request_completion(
         });
         if let Some(response_format) = response_format {
             payload["response_format"] = response_format.clone();
+            if response_format.get("type").and_then(Value::as_str) == Some("json_schema")
+                && config.base_url.contains("openrouter.ai")
+            {
+                payload["provider"] = json!({ "require_parameters": true });
+            }
         }
         if let Some(reasoning_effort) = config.reasoning_effort.as_deref() {
             payload["reasoning"] = json!({ "effort": reasoning_effort });
@@ -486,9 +491,16 @@ async fn request_completion(
                 sleep(retry_delay(attempt)).await;
                 continue;
             }
+            let detail = provider_error_detail(response).await;
             return Err(AiGatewayError {
                 kind: AiFailureKind::Provider,
-                message: format!("{feature} provider returned HTTP {status}"),
+                message: format!(
+                    "{feature} provider returned HTTP {status}{}",
+                    detail
+                        .as_deref()
+                        .map(|detail| format!(": {detail}"))
+                        .unwrap_or_default()
+                ),
                 attempts: attempt,
                 latency: started_at.elapsed(),
             });
@@ -532,6 +544,37 @@ async fn request_completion(
     }
 
     unreachable!("the bounded AI attempt loop always returns")
+}
+
+async fn provider_error_detail(response: reqwest::Response) -> Option<String> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > 64 * 1024)
+    {
+        return Some("provider error body exceeded the diagnostic limit".to_string());
+    }
+    let body = response.text().await.ok()?;
+    let value = serde_json::from_str::<Value>(&body).ok()?;
+    let message = value
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .or_else(|| value.pointer("/error/code").and_then(Value::as_str))
+        .or_else(|| value.get("message").and_then(Value::as_str))?;
+    let summary = message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(320)
+        .collect::<String>();
+    if summary.is_empty() {
+        None
+    } else if summary.contains("data:image") || summary.contains("Bearer ") {
+        Some("provider rejected the request; sensitive echoed input was redacted".to_string())
+    } else {
+        Some(summary)
+    }
 }
 
 fn retry_delay(attempt: u8) -> Duration {
@@ -797,6 +840,58 @@ mod tests {
         assert!(!decision.allowed);
         assert_eq!(decision.violations, vec!["person"]);
         assert!(request_seen.load(Ordering::SeqCst));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn provider_4xx_includes_safe_image_policy_diagnostics() {
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|| async {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "error": {
+                            "code": "unsupported_capability",
+                            "message": "test-vision-model does not support image_url with json_schema"
+                        }
+                    })),
+                )
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind image policy diagnostic server");
+        let addr = listener.local_addr().expect("AI gateway test address");
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        let config = AiConfig {
+            api_key: "test".to_string(),
+            base_url: format!("http://{addr}"),
+            model: "test-model".to_string(),
+            vision_model: "test-vision-model".to_string(),
+            reasoning_effort: None,
+        };
+
+        let error = request_image_policy_decision(
+            &config,
+            ImagePolicyRequest {
+                feature: "media.location_image_policy",
+                image_url: "data:image/png;base64,dGVzdA==",
+                policy: "Landscape only.",
+                timeout: Duration::from_secs(2),
+                max_attempts: 1,
+                referer: "http://127.0.0.1",
+            },
+        )
+        .await
+        .expect_err("provider capability mismatch must fail closed");
+        let message = error.to_string();
+
+        assert!(message.contains("HTTP 400 Bad Request"));
+        assert!(message.contains("does not support image_url with json_schema"));
+        assert!(!message.contains("dGVzdA=="));
         server.abort();
     }
 

--- a/v2/orchestrator-rust/src/cards.rs
+++ b/v2/orchestrator-rust/src/cards.rs
@@ -73,6 +73,9 @@ pub(super) struct CommunityArtView {
     pub(super) remaining_orbs: i32,
     pub(super) status: String,
     pub(super) history_through_seq: u64,
+    pub(super) provider_attempts: u8,
+    pub(super) max_provider_attempts: u8,
+    pub(super) retryable_without_orbs: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -1,7 +1,9 @@
 use std::{
+    collections::{BTreeMap, BTreeSet},
     fs, io,
     path::{Path, PathBuf},
-    time::Duration,
+    sync::{Mutex as StdMutex, OnceLock},
+    time::{Duration, Instant},
 };
 
 use axum::{
@@ -9,14 +11,73 @@ use axum::{
     http::{header, StatusCode},
     response::{IntoResponse, Response},
 };
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::warn;
 
 use crate::{
-    is_safe_image_content_type, now_millis, request_image_policy_decision, request_replicate_art,
-    AiConfig, AppState, CommunityArtPlan, DownloadedReplicateImage, ImagePolicyRequest,
-    ReplicateAvatarArtConfig,
+    broadcast_events, commit_journal_record, is_safe_image_content_type, now_millis,
+    record_ai_usage_for_provider, request_image_policy_decision, request_replicate_art, AiConfig,
+    AppState, CwAction, EventView, ImagePolicyRequest, JournalRecord, ProjectionMutation,
+    ReplicateAvatarArtConfig, RuntimeWorld, CW_ACTION_NONE, CW_OK,
 };
 
-const POLICY_GENERATION_ATTEMPTS: u8 = 3;
+pub(super) const MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS: u8 = 3;
+const COMMUNITY_ART_CANDIDATE_SCHEMA_VERSION: u8 = 1;
+const POLICY_PREFLIGHT_IMAGE_URL: &str =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XqgWAAAAAElFTkSuQmCC";
+
+pub(super) fn community_art_generation_key(
+    subject_kind: &str,
+    subject_id: u64,
+    level: u8,
+) -> String {
+    format!("{subject_kind}:{subject_id}:level:{level}")
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct DownloadedReplicateImage {
+    pub(super) bytes: Vec<u8>,
+    pub(super) content_type: String,
+    pub(super) source_url: String,
+    pub(super) prediction_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct CommunityArtGenerationState {
+    pub(super) subject_kind: String,
+    pub(super) subject_id: u64,
+    pub(super) level: u8,
+    pub(super) required_orbs: i32,
+    pub(super) funded_orbs: i32,
+    #[serde(default)]
+    pub(super) contributions: BTreeMap<u64, i32>,
+    #[serde(default)]
+    pub(super) funding_intent_ids: BTreeSet<String>,
+    pub(super) status: String,
+    pub(super) history_through_seq: u64,
+    #[serde(default)]
+    pub(super) revision: u32,
+    #[serde(default)]
+    pub(super) provider_attempts: u8,
+    #[serde(default)]
+    pub(super) last_prediction_id: Option<String>,
+    #[serde(default)]
+    pub(super) last_error_code: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct CommunityArtPlan {
+    pub(super) subject_kind: String,
+    pub(super) subject_id: u64,
+    pub(super) level: u8,
+    pub(super) required_orbs: i32,
+    pub(super) history_through_seq: u64,
+    pub(super) prompt: String,
+    pub(super) aspect_ratio: &'static str,
+    pub(super) image_policy: Option<CommunityArtImagePolicy>,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum CommunityArtImagePolicy {
@@ -41,6 +102,16 @@ impl CommunityArtImagePolicy {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CommunityArtCandidateMetadata {
+    schema_version: u8,
+    content_type: String,
+    source_url: String,
+    #[serde(default)]
+    prediction_id: Option<String>,
+    sha256: String,
+}
+
 #[derive(Debug)]
 pub(super) enum CommunityArtGenerationError {
     Provider(String),
@@ -53,8 +124,10 @@ pub(super) enum CommunityArtGenerationError {
 impl CommunityArtGenerationError {
     pub(super) fn status(&self) -> &'static str {
         match self {
-            Self::PolicyRejected(_) => "rejected",
-            _ => "failed",
+            Self::PolicyUnavailable => "review_unavailable",
+            Self::PolicyReview(_) => "review_failed",
+            Self::PolicyRejected(_) => "policy_rejected",
+            Self::Provider(_) | Self::Storage(_) => "failed",
         }
     }
 
@@ -88,39 +161,264 @@ impl CommunityArtGenerationError {
     }
 }
 
+#[derive(Debug)]
+pub(super) struct CommunityArtGenerationOutcome {
+    pub(super) result: Result<(), CommunityArtGenerationError>,
+    pub(super) prediction_id: Option<String>,
+    pub(super) reused_candidate: bool,
+}
+
+pub(super) fn community_art_generation_retryable(
+    generation: &CommunityArtGenerationState,
+    candidate_exists: bool,
+) -> bool {
+    if generation.funded_orbs < generation.required_orbs {
+        return false;
+    }
+    match generation.status.as_str() {
+        "ready" => false,
+        "review_failed" | "review_unavailable" if candidate_exists => true,
+        "funded" | "generating" | "reviewing" | "failed" | "rejected" | "policy_rejected" => {
+            candidate_exists || generation.provider_attempts < MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
+        }
+        _ => false,
+    }
+}
+
+impl RuntimeWorld {
+    #[allow(clippy::too_many_arguments)] // Mirrors the durable funding mutation fields.
+    pub(super) fn apply_fund_community_art_projection(
+        &mut self,
+        subject_kind: &str,
+        subject_id: u64,
+        level: u8,
+        required_orbs: i32,
+        contributor_actor_id: u64,
+        intent_id: &str,
+        amount: i32,
+        history_through_seq: u64,
+    ) -> Option<EventView> {
+        let key = community_art_generation_key(subject_kind, subject_id, level);
+        let generation = self
+            .community_art_generations
+            .entry(key)
+            .or_insert_with(|| CommunityArtGenerationState {
+                subject_kind: subject_kind.to_string(),
+                subject_id,
+                level,
+                required_orbs: required_orbs.max(1),
+                funded_orbs: 0,
+                contributions: BTreeMap::new(),
+                funding_intent_ids: BTreeSet::new(),
+                status: "funding".to_string(),
+                history_through_seq,
+                revision: 0,
+                provider_attempts: 0,
+                last_prediction_id: None,
+                last_error_code: None,
+            });
+        if !intent_id.is_empty() && !generation.funding_intent_ids.insert(intent_id.to_string()) {
+            return None;
+        }
+        let accepted = amount.max(0).min(
+            generation
+                .required_orbs
+                .saturating_sub(generation.funded_orbs),
+        );
+        if accepted > 0 {
+            generation.funded_orbs += accepted;
+            *generation
+                .contributions
+                .entry(contributor_actor_id)
+                .or_insert(0) += accepted;
+            generation.history_through_seq =
+                generation.history_through_seq.max(history_through_seq);
+            if generation.funded_orbs >= generation.required_orbs {
+                generation.status = "funded".to_string();
+            }
+        }
+        let funding_reason = format!(
+            "{}:{}:level:{}:{}/{}",
+            subject_kind, subject_id, level, generation.funded_orbs, generation.required_orbs
+        );
+        Some(self.append_async_job_event(
+            "community_art.funded",
+            contributor_actor_id,
+            None,
+            Some(funding_reason),
+        ))
+    }
+
+    pub(super) fn apply_legacy_community_art_status_projection(
+        &mut self,
+        action_actor_id: u64,
+        subject_kind: &str,
+        subject_id: u64,
+        level: u8,
+        status: &str,
+    ) -> Option<EventView> {
+        let key = community_art_generation_key(subject_kind, subject_id, level);
+        let generation = self.community_art_generations.get_mut(&key)?;
+        if generation.status != status && matches!(status, "ready" | "rejected") {
+            generation.revision = generation.revision.saturating_add(1);
+        }
+        if matches!(status, "failed" | "rejected") {
+            generation.provider_attempts = MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS;
+            generation.last_error_code = Some("legacy_community_art_failure".to_string());
+        }
+        generation.status = status.to_string();
+        Some(self.append_async_job_event(
+            &format!("community_art.{status}"),
+            action_actor_id,
+            None,
+            Some(format!("{subject_kind}:{subject_id}:level:{level}")),
+        ))
+    }
+
+    pub(super) fn apply_begin_community_art_generation_projection(
+        &mut self,
+        action_actor_id: u64,
+        subject_kind: &str,
+        subject_id: u64,
+        level: u8,
+        provider_attempt: bool,
+    ) -> Option<EventView> {
+        let key = community_art_generation_key(subject_kind, subject_id, level);
+        let generation = self.community_art_generations.get_mut(&key)?;
+        if provider_attempt {
+            generation.provider_attempts = generation.provider_attempts.saturating_add(1);
+        }
+        generation.status = if provider_attempt {
+            "generating".to_string()
+        } else {
+            "reviewing".to_string()
+        };
+        generation.last_error_code = None;
+        Some(self.append_async_job_event(
+            if provider_attempt {
+                "community_art.generating"
+            } else {
+                "community_art.reviewing"
+            },
+            action_actor_id,
+            None,
+            Some(format!("{subject_kind}:{subject_id}:level:{level}")),
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)] // Mirrors the durable completion mutation fields.
+    pub(super) fn apply_complete_community_art_generation_projection(
+        &mut self,
+        action_actor_id: u64,
+        subject_kind: &str,
+        subject_id: u64,
+        level: u8,
+        status: &str,
+        prediction_id: Option<&str>,
+        error_code: Option<&str>,
+    ) -> Option<EventView> {
+        let key = community_art_generation_key(subject_kind, subject_id, level);
+        let generation = self.community_art_generations.get_mut(&key)?;
+        if generation.status != status && matches!(status, "ready" | "rejected" | "policy_rejected")
+        {
+            generation.revision = generation.revision.saturating_add(1);
+        }
+        generation.status = status.to_string();
+        generation.last_prediction_id = prediction_id.map(ToString::to_string);
+        generation.last_error_code = error_code.map(ToString::to_string);
+        Some(self.append_async_job_event(
+            &format!("community_art.{status}"),
+            action_actor_id,
+            None,
+            Some(format!("{subject_kind}:{subject_id}:level:{level}")),
+        ))
+    }
+}
+
+pub(super) async fn preflight_community_art_policy(
+    config: Option<&AiConfig>,
+    policy: CommunityArtImagePolicy,
+) -> Result<(), CommunityArtGenerationError> {
+    let config = config.ok_or(CommunityArtGenerationError::PolicyUnavailable)?;
+    let decision = request_image_policy_decision(
+        config,
+        ImagePolicyRequest {
+            feature: "media.location_image_policy_preflight",
+            image_url: POLICY_PREFLIGHT_IMAGE_URL,
+            policy: policy.review(),
+            timeout: Duration::from_secs(10),
+            max_attempts: 1,
+            referer: "https://cosyworld.fly.dev",
+        },
+    )
+    .await
+    .map_err(|error| CommunityArtGenerationError::PolicyReview(error.to_string()))?;
+    if !decision.allowed {
+        return Err(CommunityArtGenerationError::PolicyReview(format!(
+            "the empty policy preflight image was rejected: {}",
+            if decision.violations.is_empty() {
+                "unspecified violation".to_string()
+            } else {
+                decision.violations.join(", ")
+            }
+        )));
+    }
+    Ok(())
+}
+
 pub(super) async fn generate_and_store_community_art(
     config: &ReplicateAvatarArtConfig,
     policy_config: Option<&AiConfig>,
     generated_asset_dir: &Path,
     plan: &CommunityArtPlan,
-) -> Result<(), CommunityArtGenerationError> {
-    let attempts = if plan.image_policy.is_some() {
-        POLICY_GENERATION_ATTEMPTS
-    } else {
-        1
+) -> CommunityArtGenerationOutcome {
+    let (image, reused_candidate) = match load_community_art_candidate(generated_asset_dir, plan) {
+        Ok(Some(image)) => (image, true),
+        Ok(None) => {
+            let prompt =
+                crate::compact_whitespace(&format!("{}, {}", config.prompt_prefix, plan.prompt));
+            let image = match request_replicate_art(config, prompt, plan.aspect_ratio).await {
+                Ok(image) => image,
+                Err(error) => {
+                    return CommunityArtGenerationOutcome {
+                        result: Err(CommunityArtGenerationError::Provider(error)),
+                        prediction_id: None,
+                        reused_candidate: false,
+                    };
+                }
+            };
+            if plan.image_policy.is_some() {
+                if let Err(error) = store_community_art_candidate(generated_asset_dir, plan, &image)
+                {
+                    return CommunityArtGenerationOutcome {
+                        prediction_id: image.prediction_id.clone(),
+                        result: Err(CommunityArtGenerationError::Storage(error)),
+                        reused_candidate: false,
+                    };
+                }
+            }
+            (image, false)
+        }
+        Err(error) => {
+            return CommunityArtGenerationOutcome {
+                result: Err(CommunityArtGenerationError::Storage(error)),
+                prediction_id: None,
+                reused_candidate: true,
+            };
+        }
     };
-    let mut last_violations = Vec::new();
-    for attempt in 1..=attempts {
-        let retry_constraint = if attempt > 1 {
-            "The previous candidate failed publication review. Keep the scene strictly empty of every forbidden subject."
-        } else {
-            ""
-        };
-        let prompt = crate::compact_whitespace(&format!(
-            "{}, {} {}",
-            config.prompt_prefix, plan.prompt, retry_constraint
-        ));
-        let image = request_replicate_art(config, prompt, plan.aspect_ratio)
-            .await
-            .map_err(CommunityArtGenerationError::Provider)?;
+
+    let prediction_id = image.prediction_id.clone();
+    let result = async {
         if let Some(policy) = plan.image_policy {
             let policy_config =
                 policy_config.ok_or(CommunityArtGenerationError::PolicyUnavailable)?;
+            let image_url = community_art_candidate_data_url(&image)?;
             let decision = request_image_policy_decision(
                 policy_config,
                 ImagePolicyRequest {
                     feature: "media.location_image_policy",
-                    image_url: &image.source_url,
+                    image_url: &image_url,
                     policy: policy.review(),
                     timeout: Duration::from_secs(30),
                     max_attempts: 2,
@@ -130,56 +428,379 @@ pub(super) async fn generate_and_store_community_art(
             .await
             .map_err(|error| CommunityArtGenerationError::PolicyReview(error.to_string()))?;
             if !decision.allowed {
-                last_violations = decision.violations;
-                continue;
+                remove_community_art_candidate(generated_asset_dir, plan)
+                    .map_err(CommunityArtGenerationError::Storage)?;
+                return Err(CommunityArtGenerationError::PolicyRejected(
+                    decision.violations,
+                ));
             }
         }
-        store_community_art_image(generated_asset_dir, plan, image)
-            .map_err(CommunityArtGenerationError::Storage)?;
-        return Ok(());
+        store_community_art_image(generated_asset_dir, plan, &image)
+            .map_err(CommunityArtGenerationError::Storage)
     }
-    Err(CommunityArtGenerationError::PolicyRejected(last_violations))
+    .await;
+
+    CommunityArtGenerationOutcome {
+        result,
+        prediction_id,
+        reused_candidate,
+    }
+}
+
+static COMMUNITY_ART_JOBS: OnceLock<StdMutex<BTreeSet<String>>> = OnceLock::new();
+
+fn community_art_jobs() -> &'static StdMutex<BTreeSet<String>> {
+    COMMUNITY_ART_JOBS.get_or_init(|| StdMutex::new(BTreeSet::new()))
+}
+
+async fn begin_community_art_generation(
+    state: &AppState,
+    actor_id: u64,
+    plan: &CommunityArtPlan,
+    candidate_exists: bool,
+) -> Option<bool> {
+    let mut runtime = state.inner.lock().await;
+    let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
+    let generation = runtime.community_art_generations.get(&key)?;
+    if !community_art_generation_retryable(generation, candidate_exists) {
+        return None;
+    }
+    let provider_attempt = !candidate_exists;
+    if provider_attempt && generation.provider_attempts >= MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS {
+        return None;
+    }
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    );
+    record
+        .projection_mutations
+        .push(ProjectionMutation::BeginCommunityArtGeneration {
+            subject_kind: plan.subject_kind.clone(),
+            subject_id: plan.subject_id,
+            level: plan.level,
+            provider_attempt,
+        });
+    let (commit_status, events) = commit_journal_record(state, &mut runtime, record).ok()?;
+    drop(runtime);
+    if commit_status == CW_OK {
+        broadcast_events(state, &events);
+        Some(provider_attempt)
+    } else {
+        None
+    }
+}
+
+async fn complete_community_art_generation(
+    state: &AppState,
+    actor_id: u64,
+    plan: &CommunityArtPlan,
+    status: &str,
+    prediction_id: Option<&str>,
+    error_code: Option<&str>,
+) -> Option<Vec<EventView>> {
+    let mut runtime = state.inner.lock().await;
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    );
+    record
+        .projection_mutations
+        .push(ProjectionMutation::CompleteCommunityArtGeneration {
+            subject_kind: plan.subject_kind.clone(),
+            subject_id: plan.subject_id,
+            level: plan.level,
+            status: status.to_string(),
+            prediction_id: prediction_id.map(ToString::to_string),
+            error_code: error_code.map(ToString::to_string),
+        });
+    let (commit_status, events) = commit_journal_record(state, &mut runtime, record).ok()?;
+    drop(runtime);
+    if commit_status == CW_OK {
+        broadcast_events(state, &events);
+        Some(events)
+    } else {
+        None
+    }
+}
+
+pub(super) fn schedule_community_art_generation(
+    state: &AppState,
+    actor_id: u64,
+    plan: CommunityArtPlan,
+) {
+    let Some(config) = state.avatar_art_config.as_ref().clone() else {
+        return;
+    };
+    let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
+    if let Ok(mut jobs) = community_art_jobs().lock() {
+        if !jobs.insert(key.clone()) {
+            return;
+        }
+    }
+    let state = state.clone();
+    tokio::spawn(async move {
+        let candidate_exists = community_art_candidate_exists(&state.generated_asset_dir, &plan);
+        let Some(provider_attempt) =
+            begin_community_art_generation(&state, actor_id, &plan, candidate_exists).await
+        else {
+            if let Ok(mut jobs) = community_art_jobs().lock() {
+                jobs.remove(&key);
+            }
+            return;
+        };
+        let started_at = Instant::now();
+        let outcome = generate_and_store_community_art(
+            &config,
+            state.ai_config.as_ref().as_ref(),
+            &state.generated_asset_dir,
+            &plan,
+        )
+        .await;
+        let (status, error_code) = match &outcome.result {
+            Ok(()) => ("ready", None),
+            Err(error) => {
+                warn!(
+                    provider_attempt,
+                    reused_candidate = outcome.reused_candidate,
+                    prediction_id = outcome.prediction_id.as_deref().unwrap_or("unknown"),
+                    "community art generation failed for {}: {}",
+                    key,
+                    error.message()
+                );
+                (error.status(), Some(error.code()))
+            }
+        };
+        let events = complete_community_art_generation(
+            &state,
+            actor_id,
+            &plan,
+            status,
+            outcome.prediction_id.as_deref(),
+            error_code,
+        )
+        .await;
+        if status == "ready" && events.is_some() {
+            if let Err(error) = remove_community_art_candidate(&state.generated_asset_dir, &plan) {
+                warn!(
+                    "failed to remove published community art candidate for {}: {}",
+                    key, error
+                );
+            }
+        }
+        record_ai_usage_for_provider(
+            &state,
+            Some(actor_id),
+            "community_image_generation",
+            "community_orbs",
+            "replicate",
+            &config.model,
+            if status == "ready" { "ok" } else { "failed" },
+            events
+                .as_ref()
+                .and_then(|events| events.first())
+                .map(|event| event.seq),
+            0,
+            error_code,
+            started_at.elapsed(),
+        );
+        if let Ok(mut jobs) = community_art_jobs().lock() {
+            jobs.remove(&key);
+        }
+    });
 }
 
 fn store_community_art_image(
     generated_asset_dir: &Path,
     plan: &CommunityArtPlan,
-    image: DownloadedReplicateImage,
+    image: &DownloadedReplicateImage,
 ) -> Result<(), String> {
     let path =
         stored_community_art_image_path(generated_asset_dir, &plan.subject_kind, plan.subject_id);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
-    }
     let content_type_path = stored_community_art_content_type_path(
         generated_asset_dir,
         &plan.subject_kind,
         plan.subject_id,
     );
+    let metadata_path = stored_community_art_metadata_path(
+        generated_asset_dir,
+        &plan.subject_kind,
+        plan.subject_id,
+    );
+    store_community_art_bundle(&path, &content_type_path, &metadata_path, image)
+}
+
+pub(super) fn store_community_art_candidate(
+    generated_asset_dir: &Path,
+    plan: &CommunityArtPlan,
+    image: &DownloadedReplicateImage,
+) -> Result<(), String> {
+    store_community_art_bundle(
+        &community_art_candidate_image_path(generated_asset_dir, plan),
+        &community_art_candidate_content_type_path(generated_asset_dir, plan),
+        &community_art_candidate_metadata_path(generated_asset_dir, plan),
+        image,
+    )
+}
+
+fn store_community_art_bundle(
+    path: &Path,
+    content_type_path: &Path,
+    metadata_path: &Path,
+    image: &DownloadedReplicateImage,
+) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let metadata =
+        serde_json::to_vec(&community_art_candidate_metadata(image)).map_err(|e| e.to_string())?;
     let temporary_suffix = format!("{}-{}", std::process::id(), now_millis());
+    let file_stem = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("community-art");
     let temporary_image_path =
-        path.with_file_name(format!(".{}.image.tmp-{temporary_suffix}", plan.subject_id));
-    let temporary_content_type_path = content_type_path.with_file_name(format!(
-        ".{}.content-type.tmp-{temporary_suffix}",
-        plan.subject_id
-    ));
+        path.with_file_name(format!(".{file_stem}.image.tmp-{temporary_suffix}"));
+    let temporary_content_type_path =
+        path.with_file_name(format!(".{file_stem}.content-type.tmp-{temporary_suffix}"));
+    let temporary_metadata_path =
+        path.with_file_name(format!(".{file_stem}.metadata.tmp-{temporary_suffix}"));
     let stored = (|| -> io::Result<()> {
-        fs::write(&temporary_image_path, image.bytes)?;
-        fs::write(&temporary_content_type_path, image.content_type)?;
-        fs::rename(&temporary_content_type_path, &content_type_path)?;
-        fs::rename(&temporary_image_path, &path)?;
+        fs::write(&temporary_image_path, &image.bytes)?;
+        fs::write(&temporary_content_type_path, &image.content_type)?;
+        fs::write(&temporary_metadata_path, metadata)?;
+        fs::rename(&temporary_metadata_path, metadata_path)?;
+        fs::rename(&temporary_content_type_path, content_type_path)?;
+        fs::rename(&temporary_image_path, path)?;
         Ok(())
     })();
     if let Err(error) = stored {
         let _ = fs::remove_file(&temporary_image_path);
         let _ = fs::remove_file(&temporary_content_type_path);
+        let _ = fs::remove_file(&temporary_metadata_path);
         return Err(error.to_string());
+    }
+    Ok(())
+}
+
+fn community_art_candidate_metadata(
+    image: &DownloadedReplicateImage,
+) -> CommunityArtCandidateMetadata {
+    CommunityArtCandidateMetadata {
+        schema_version: COMMUNITY_ART_CANDIDATE_SCHEMA_VERSION,
+        content_type: image.content_type.clone(),
+        source_url: image.source_url.clone(),
+        prediction_id: image.prediction_id.clone(),
+        sha256: format!("{:x}", Sha256::digest(&image.bytes)),
+    }
+}
+
+fn load_community_art_candidate(
+    generated_asset_dir: &Path,
+    plan: &CommunityArtPlan,
+) -> Result<Option<DownloadedReplicateImage>, String> {
+    let image_path = community_art_candidate_image_path(generated_asset_dir, plan);
+    if !image_path.exists() {
+        return Ok(None);
+    }
+    let content_type_path = community_art_candidate_content_type_path(generated_asset_dir, plan);
+    let metadata_path = community_art_candidate_metadata_path(generated_asset_dir, plan);
+    let bytes = fs::read(&image_path).map_err(|error| error.to_string())?;
+    let content_type = fs::read_to_string(&content_type_path)
+        .map_err(|error| error.to_string())?
+        .trim()
+        .to_ascii_lowercase();
+    if !is_safe_image_content_type(&content_type) {
+        return Err("stored community-art candidate has an unsafe content type".to_string());
+    }
+    let metadata = serde_json::from_slice::<CommunityArtCandidateMetadata>(
+        &fs::read(metadata_path).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    if metadata.schema_version != COMMUNITY_ART_CANDIDATE_SCHEMA_VERSION
+        || metadata.content_type != content_type
+        || metadata.sha256 != format!("{:x}", Sha256::digest(&bytes))
+    {
+        return Err("stored community-art candidate metadata did not match its image".to_string());
+    }
+    Ok(Some(DownloadedReplicateImage {
+        bytes,
+        content_type,
+        source_url: metadata.source_url,
+        prediction_id: metadata.prediction_id,
+    }))
+}
+
+fn community_art_candidate_data_url(
+    image: &DownloadedReplicateImage,
+) -> Result<String, CommunityArtGenerationError> {
+    if !is_safe_image_content_type(&image.content_type) {
+        return Err(CommunityArtGenerationError::Storage(
+            "stored community-art candidate has an unsafe content type".to_string(),
+        ));
+    }
+    Ok(format!(
+        "data:{};base64,{}",
+        image.content_type,
+        BASE64_STANDARD.encode(&image.bytes)
+    ))
+}
+
+pub(super) fn community_art_candidate_exists(
+    generated_asset_dir: &Path,
+    plan: &CommunityArtPlan,
+) -> bool {
+    community_art_candidate_image_path(generated_asset_dir, plan).is_file()
+        && community_art_candidate_content_type_path(generated_asset_dir, plan).is_file()
+        && community_art_candidate_metadata_path(generated_asset_dir, plan).is_file()
+}
+
+pub(super) fn remove_community_art_candidate(
+    generated_asset_dir: &Path,
+    plan: &CommunityArtPlan,
+) -> Result<(), String> {
+    for path in [
+        community_art_candidate_image_path(generated_asset_dir, plan),
+        community_art_candidate_content_type_path(generated_asset_dir, plan),
+        community_art_candidate_metadata_path(generated_asset_dir, plan),
+    ] {
+        if let Err(error) = fs::remove_file(path) {
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(error.to_string());
+            }
+        }
     }
     Ok(())
 }
 
 fn community_art_dir(root: &Path, subject_kind: &str) -> PathBuf {
     root.join("community-art").join(subject_kind)
+}
+
+fn community_art_candidate_dir(root: &Path, plan: &CommunityArtPlan) -> PathBuf {
+    root.join("community-art-candidates")
+        .join(&plan.subject_kind)
+        .join(plan.subject_id.to_string())
+}
+
+fn community_art_candidate_image_path(root: &Path, plan: &CommunityArtPlan) -> PathBuf {
+    community_art_candidate_dir(root, plan).join(format!("level-{}.image", plan.level))
+}
+
+fn community_art_candidate_content_type_path(root: &Path, plan: &CommunityArtPlan) -> PathBuf {
+    community_art_candidate_dir(root, plan).join(format!("level-{}.content-type", plan.level))
+}
+
+fn community_art_candidate_metadata_path(root: &Path, plan: &CommunityArtPlan) -> PathBuf {
+    community_art_candidate_dir(root, plan).join(format!("level-{}.metadata.json", plan.level))
 }
 
 pub(super) fn stored_community_art_image_path(
@@ -196,6 +817,14 @@ pub(super) fn stored_community_art_content_type_path(
     subject_id: u64,
 ) -> PathBuf {
     community_art_dir(root, subject_kind).join(format!("{subject_id}.content-type"))
+}
+
+pub(super) fn stored_community_art_metadata_path(
+    root: &Path,
+    subject_kind: &str,
+    subject_id: u64,
+) -> PathBuf {
+    community_art_dir(root, subject_kind).join(format!("{subject_id}.metadata.json"))
 }
 
 pub(super) fn stored_community_art_content_type(

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -1,4 +1,9 @@
 use super::*;
+use axum::{response::IntoResponse as _, routing::post, Router};
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc,
+};
 
 fn test_art_config() -> ReplicateAvatarArtConfig {
     ReplicateAvatarArtConfig {
@@ -66,6 +71,339 @@ async fn location_art_funding_fails_before_debit_without_policy_review() {
     assert!(!runtime
         .community_art_generations
         .contains_key(&community_art_generation_key("location", waypoint_id, 1)));
+}
+
+#[tokio::test]
+async fn location_policy_400_fails_before_orb_debit_or_replicate_schedule() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        RAIN_SOFT_GARDEN_LOCATION_ID,
+        "Preflight Patron",
+    );
+    runtime.callings.insert(
+        5000,
+        CallingState {
+            actor_id: 5000,
+            statement: EXPLORER_CALLING_STATEMENT.to_string(),
+            source_event_seq: None,
+        },
+    );
+    let (search, mutation, _) = runtime
+        .plan_journey_move(5000, MOONLIT_TRAIL_LOCATION_ID)
+        .expect("pathway planning succeeds")
+        .expect("long route begins with discovery");
+    let mut discovery = JournalRecord::new(search, 7054);
+    discovery.projection_mutations.push(mutation);
+    assert_eq!(runtime.apply_journal_record(&discovery).0, CW_OK);
+    let waypoint_id = runtime.journeys[&5000].path[1];
+
+    let policy_requests = Arc::new(AtomicUsize::new(0));
+    let preflight_shape_seen = Arc::new(AtomicBool::new(false));
+    let app = Router::new().route(
+        "/chat/completions",
+        post({
+            let policy_requests = policy_requests.clone();
+            let preflight_shape_seen = preflight_shape_seen.clone();
+            move |Json(body): Json<serde_json::Value>| {
+                let policy_requests = policy_requests.clone();
+                let preflight_shape_seen = preflight_shape_seen.clone();
+                async move {
+                    policy_requests.fetch_add(1, Ordering::SeqCst);
+                    let image_url = body
+                        .pointer("/messages/1/content/1/image_url/url")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default();
+                    preflight_shape_seen.store(
+                        body.get("model").and_then(serde_json::Value::as_str)
+                            == Some("test-vision-model")
+                            && body
+                                .pointer("/response_format/json_schema/name")
+                                .and_then(serde_json::Value::as_str)
+                                == Some("cosyworld_image_policy")
+                            && image_url.starts_with("data:image/png;base64,"),
+                        Ordering::SeqCst,
+                    );
+                    (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "error": {
+                                "message": "configured model cannot combine image_url and json_schema"
+                            }
+                        })),
+                    )
+                }
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind policy preflight fixture");
+    let address = listener.local_addr().expect("policy preflight address");
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let mut state = test_app_state(runtime, None);
+    state.avatar_art_config = Arc::new(Some(test_art_config()));
+    state.ai_config = Arc::new(Some(AiConfig {
+        api_key: "test".to_string(),
+        base_url: format!("http://{address}"),
+        model: "test-model".to_string(),
+        vision_model: "test-vision-model".to_string(),
+        reasoning_effort: None,
+    }));
+    let (actor_session, _) = issue_actor_session(&state, 5000);
+
+    let response = fund_community_image(
+        ConnectInfo("127.0.0.1:44992".parse().expect("client address")),
+        State(state.clone()),
+        Json(FundCommunityImageRequest {
+            actor_id: 5000,
+            actor_session: Some(actor_session),
+            subject_kind: "location".to_string(),
+            subject_id: waypoint_id,
+            intent_id: "test-location-policy-400".to_string(),
+        }),
+    )
+    .await
+    .0;
+
+    assert!(!response.ok);
+    assert_eq!(response.status, 503);
+    assert!(response.events.is_empty());
+    assert_eq!(policy_requests.load(Ordering::SeqCst), 1);
+    assert!(preflight_shape_seen.load(Ordering::SeqCst));
+    let runtime = state.inner.lock().await;
+    assert_eq!(runtime.orb_balance(5000), STARTING_ORBS);
+    assert!(!runtime
+        .community_art_generations
+        .contains_key(&community_art_generation_key("location", waypoint_id, 1)));
+    drop(runtime);
+    assert!(!community_art_candidate_exists(
+        &state.generated_asset_dir,
+        &CommunityArtPlan {
+            subject_kind: "location".to_string(),
+            subject_id: waypoint_id,
+            level: 1,
+            required_orbs: 1,
+            history_through_seq: 0,
+            prompt: String::new(),
+            aspect_ratio: "16:9",
+            image_policy: Some(CommunityArtImagePolicy::LocationLandscape),
+        }
+    ));
+    server.abort();
+}
+
+#[tokio::test]
+async fn policy_retry_reuses_the_saved_candidate_without_calling_replicate() {
+    let policy_requests = Arc::new(AtomicUsize::new(0));
+    let app = Router::new().route(
+        "/chat/completions",
+        post({
+            let policy_requests = policy_requests.clone();
+            move |Json(body): Json<serde_json::Value>| {
+                let policy_requests = policy_requests.clone();
+                async move {
+                    let image_url = body
+                        .pointer("/messages/1/content/1/image_url/url")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default();
+                    assert!(image_url.starts_with("data:image/png;base64,"));
+                    if policy_requests.fetch_add(1, Ordering::SeqCst) == 0 {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(serde_json::json!({
+                                "error": { "message": "temporary structured vision mismatch" }
+                            })),
+                        )
+                            .into_response();
+                    }
+                    Json(serde_json::json!({
+                        "choices": [{
+                            "message": {
+                                "content": r#"{"allowed":true,"violations":[],"summary":"An empty landscape contains no forbidden subjects."}"#
+                            }
+                        }]
+                    }))
+                    .into_response()
+                }
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind retained candidate fixture");
+    let address = listener.local_addr().expect("retained candidate address");
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let generated_dir = std::env::temp_dir().join(format!(
+        "cosyworld-retained-candidate-{}-{}",
+        std::process::id(),
+        now_seed()
+    ));
+    let _ = fs::remove_dir_all(&generated_dir);
+    let plan = CommunityArtPlan {
+        subject_kind: "location".to_string(),
+        subject_id: 181_728,
+        level: 1,
+        required_orbs: 1,
+        history_through_seq: 99,
+        prompt: "A quiet rain-soft path with no figures.".to_string(),
+        aspect_ratio: "16:9",
+        image_policy: Some(CommunityArtImagePolicy::LocationLandscape),
+    };
+    let image_bytes = BASE64_STANDARD
+        .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XqgWAAAAAElFTkSuQmCC")
+        .expect("decode retained PNG fixture");
+    store_community_art_candidate(
+        &generated_dir,
+        &plan,
+        &DownloadedReplicateImage {
+            bytes: image_bytes.clone(),
+            content_type: "image/png".to_string(),
+            source_url: "https://replicate.delivery/pbxt/test.png".to_string(),
+            prediction_id: Some("prediction-retained-1".to_string()),
+        },
+    )
+    .expect("persist candidate before review");
+    let policy_config = AiConfig {
+        api_key: "test".to_string(),
+        base_url: format!("http://{address}"),
+        model: "test-model".to_string(),
+        vision_model: "test-vision-model".to_string(),
+        reasoning_effort: None,
+    };
+
+    let first = generate_and_store_community_art(
+        &test_art_config(),
+        Some(&policy_config),
+        &generated_dir,
+        &plan,
+    )
+    .await;
+    assert!(first.reused_candidate);
+    assert_eq!(
+        first.prediction_id.as_deref(),
+        Some("prediction-retained-1")
+    );
+    assert!(matches!(
+        first.result,
+        Err(CommunityArtGenerationError::PolicyReview(_))
+    ));
+    assert!(community_art_candidate_exists(&generated_dir, &plan));
+    assert!(!stored_community_art_image_path(&generated_dir, "location", plan.subject_id).exists());
+
+    let second = generate_and_store_community_art(
+        &test_art_config(),
+        Some(&policy_config),
+        &generated_dir,
+        &plan,
+    )
+    .await;
+    assert!(second.reused_candidate);
+    assert!(second.result.is_ok());
+    assert_eq!(policy_requests.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        fs::read(stored_community_art_image_path(
+            &generated_dir,
+            "location",
+            plan.subject_id
+        ))
+        .expect("read published retained candidate"),
+        image_bytes
+    );
+
+    remove_community_art_candidate(&generated_dir, &plan).expect("remove retained fixture");
+    let _ = fs::remove_dir_all(generated_dir);
+    server.abort();
+}
+
+#[test]
+fn provider_attempt_budget_is_journaled_and_survives_serialization() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Budget Patron",
+    );
+    let mut funding = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            ..CwAction::default()
+        },
+        7055,
+    );
+    funding
+        .projection_mutations
+        .push(ProjectionMutation::FundCommunityArt {
+            subject_kind: "actor".to_string(),
+            subject_id: 5000,
+            level: 1,
+            required_orbs: 1,
+            contributor_actor_id: 5000,
+            intent_id: "test-provider-budget".to_string(),
+            amount: 1,
+            history_through_seq: 7055,
+        });
+    assert_eq!(runtime.apply_journal_record(&funding).0, CW_OK);
+
+    for attempt in 1..=MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS {
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: 5000,
+                ..CwAction::default()
+            },
+            7055 + u64::from(attempt),
+        );
+        record
+            .projection_mutations
+            .push(ProjectionMutation::BeginCommunityArtGeneration {
+                subject_kind: "actor".to_string(),
+                subject_id: 5000,
+                level: 1,
+                provider_attempt: true,
+            });
+        record
+            .projection_mutations
+            .push(ProjectionMutation::CompleteCommunityArtGeneration {
+                subject_kind: "actor".to_string(),
+                subject_id: 5000,
+                level: 1,
+                status: "failed".to_string(),
+                prediction_id: Some(format!("prediction-{attempt}")),
+                error_code: Some("community_art_generation_failed".to_string()),
+            });
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+    }
+
+    let key = community_art_generation_key("actor", 5000, 1);
+    let generation = &runtime.community_art_generations[&key];
+    assert_eq!(
+        generation.provider_attempts,
+        MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
+    );
+    assert_eq!(
+        generation.last_prediction_id.as_deref(),
+        Some("prediction-3")
+    );
+    assert!(!community_art_generation_retryable(generation, false));
+
+    let serialized =
+        serde_json::to_string(&runtime.community_art_generations).expect("serialize art budget");
+    let restored: BTreeMap<String, CommunityArtGenerationState> =
+        serde_json::from_str(&serialized).expect("restore art budget");
+    assert_eq!(
+        restored[&key].provider_attempts,
+        MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
+    );
+    assert!(!community_art_generation_retryable(&restored[&key], false));
 }
 
 #[tokio::test]

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -9759,20 +9759,37 @@
       const funded = Math.max(0, Number(art.funded_orbs || 0));
       const remaining = Math.max(0, Number(art.remaining_orbs ?? (required - funded)));
       const status = String(art.status || "available");
+      const providerAttempts = Math.max(0, Number(art.provider_attempts || 0));
+      const maxProviderAttempts = Math.max(1, Number(art.max_provider_attempts || 3));
+      const retryableWithoutOrbs = Boolean(art.retryable_without_orbs);
       if (status === "ready") {
         return `<div class="economy-row"><span>community image</span><strong>level ${level} complete</strong></div><div class="economy-row"><span>next image</span><strong>unlocks at the next level</strong></div>`;
       }
       const balance = Math.max(0, Number(state?.economy?.orbs || 0));
       const needsOrb = remaining > 0;
+      const working = status === "generating" || status === "reviewing";
       const buttonLabel = needsOrb
         ? `add one Orb · ${funded}/${required}`
-        : (status === "rejected"
-          ? "try a different image"
-          : (status === "failed" ? "try the image again" : "nudge the image workshop"));
-      const disabled = needsOrb && balance < 1;
+        : (working
+          ? (status === "reviewing" ? "check the saved image review" : "check the image workshop")
+          : (status === "review_failed" || status === "review_unavailable"
+            ? (retryableWithoutOrbs ? "retry the saved image review" : "image review unavailable")
+            : (status === "rejected" || status === "policy_rejected"
+              ? (retryableWithoutOrbs ? "try a different image" : "image withheld")
+              : (status === "failed"
+                ? (retryableWithoutOrbs ? "try the image again" : "image workshop unavailable")
+                : "start the image workshop"))));
+      const disabled = (needsOrb && balance < 1)
+        || (!needsOrb && !retryableWithoutOrbs);
       const detail = needsOrb
         ? `${remaining} ${remaining === 1 ? "Orb" : "Orbs"} still needed from the community`
-        : "fully funded; no more Orbs will be taken";
+        : (working
+          ? "fully funded; the saved job is still in progress"
+          : (status === "review_failed" || status === "review_unavailable"
+            ? "candidate saved; no new image will be bought while review is unavailable"
+            : (!retryableWithoutOrbs && providerAttempts >= maxProviderAttempts
+              ? `stopped after ${providerAttempts} image ${providerAttempts === 1 ? "attempt" : "attempts"}; no more provider credits will be used`
+              : "fully funded; no more Orbs will be taken")));
       return `<div class="economy-row"><span>level ${level} image</span><strong>${escapeHtml(detail)}</strong></div><button class="account-button" type="button" data-fund-community-image="${escapeAttr(subject.kind)}:${subject.id}"${disabled ? " disabled" : ""}>${escapeHtml(buttonLabel)}</button>`;
     }
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -377,12 +377,6 @@ struct ReplicateAvatarArtConfig {
     output_format: String,
 }
 
-struct DownloadedReplicateImage {
-    bytes: Vec<u8>,
-    content_type: String,
-    source_url: String,
-}
-
 #[cfg(test)]
 #[derive(Clone, Debug)]
 struct AmbientConfig {
@@ -631,35 +625,6 @@ struct GeneratedPathwayState {
     art_eligible: bool,
     #[serde(default)]
     familiar: bool,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct CommunityArtGenerationState {
-    subject_kind: String,
-    subject_id: u64,
-    level: u8,
-    required_orbs: i32,
-    funded_orbs: i32,
-    #[serde(default)]
-    contributions: BTreeMap<u64, i32>,
-    #[serde(default)]
-    funding_intent_ids: BTreeSet<String>,
-    status: String,
-    history_through_seq: u64,
-    #[serde(default)]
-    revision: u32,
-}
-
-#[derive(Clone, Debug)]
-struct CommunityArtPlan {
-    subject_kind: String,
-    subject_id: u64,
-    level: u8,
-    required_orbs: i32,
-    history_through_seq: u64,
-    prompt: String,
-    aspect_ratio: &'static str,
-    image_policy: Option<CommunityArtImagePolicy>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -992,6 +957,22 @@ enum ProjectionMutation {
         subject_id: u64,
         level: u8,
         status: String,
+    },
+    BeginCommunityArtGeneration {
+        subject_kind: String,
+        subject_id: u64,
+        level: u8,
+        provider_attempt: bool,
+    },
+    CompleteCommunityArtGeneration {
+        subject_kind: String,
+        subject_id: u64,
+        level: u8,
+        status: String,
+        #[serde(default)]
+        prediction_id: Option<String>,
+        #[serde(default)]
+        error_code: Option<String>,
     },
     RefinePathway {
         pathway: GeneratedPathwayState,
@@ -10323,60 +10304,18 @@ impl RuntimeWorld {
                     amount,
                     history_through_seq,
                 } => {
-                    let key = community_art_generation_key(subject_kind, *subject_id, *level);
-                    let funding_reason = {
-                        let generation =
-                            self.community_art_generations
-                                .entry(key)
-                                .or_insert_with(|| CommunityArtGenerationState {
-                                    subject_kind: subject_kind.clone(),
-                                    subject_id: *subject_id,
-                                    level: *level,
-                                    required_orbs: (*required_orbs).max(1),
-                                    funded_orbs: 0,
-                                    contributions: BTreeMap::new(),
-                                    funding_intent_ids: BTreeSet::new(),
-                                    status: "funding".to_string(),
-                                    history_through_seq: *history_through_seq,
-                                    revision: 0,
-                                });
-                        if !intent_id.is_empty()
-                            && !generation.funding_intent_ids.insert(intent_id.clone())
-                        {
-                            continue;
-                        }
-                        let accepted = (*amount).max(0).min(
-                            generation
-                                .required_orbs
-                                .saturating_sub(generation.funded_orbs),
-                        );
-                        if accepted > 0 {
-                            generation.funded_orbs += accepted;
-                            *generation
-                                .contributions
-                                .entry(*contributor_actor_id)
-                                .or_insert(0) += accepted;
-                            generation.history_through_seq =
-                                generation.history_through_seq.max(*history_through_seq);
-                            if generation.funded_orbs >= generation.required_orbs {
-                                generation.status = "funded".to_string();
-                            }
-                        }
-                        format!(
-                            "{}:{}:level:{}:{}/{}",
-                            subject_kind,
-                            subject_id,
-                            level,
-                            generation.funded_orbs,
-                            generation.required_orbs
-                        )
-                    };
-                    events.push(self.append_async_job_event(
-                        "community_art.funded",
+                    if let Some(event) = self.apply_fund_community_art_projection(
+                        subject_kind,
+                        *subject_id,
+                        *level,
+                        *required_orbs,
                         *contributor_actor_id,
-                        None,
-                        Some(funding_reason),
-                    ));
+                        intent_id,
+                        *amount,
+                        *history_through_seq,
+                    ) {
+                        events.push(event);
+                    }
                 }
                 ProjectionMutation::SetCommunityArtStatus {
                     subject_kind,
@@ -10384,22 +10323,51 @@ impl RuntimeWorld {
                     level,
                     status,
                 } => {
-                    let key = community_art_generation_key(subject_kind, *subject_id, *level);
-                    let Some(generation) = self.community_art_generations.get_mut(&key) else {
-                        continue;
-                    };
-                    if generation.status != *status
-                        && matches!(status.as_str(), "ready" | "rejected")
-                    {
-                        generation.revision = generation.revision.saturating_add(1);
-                    }
-                    generation.status = status.clone();
-                    events.push(self.append_async_job_event(
-                        &format!("community_art.{status}"),
+                    if let Some(event) = self.apply_legacy_community_art_status_projection(
                         action.actor_id,
-                        None,
-                        Some(format!("{}:{}:level:{}", subject_kind, subject_id, level)),
-                    ));
+                        subject_kind,
+                        *subject_id,
+                        *level,
+                        status,
+                    ) {
+                        events.push(event);
+                    }
+                }
+                ProjectionMutation::BeginCommunityArtGeneration {
+                    subject_kind,
+                    subject_id,
+                    level,
+                    provider_attempt,
+                } => {
+                    if let Some(event) = self.apply_begin_community_art_generation_projection(
+                        action.actor_id,
+                        subject_kind,
+                        *subject_id,
+                        *level,
+                        *provider_attempt,
+                    ) {
+                        events.push(event);
+                    }
+                }
+                ProjectionMutation::CompleteCommunityArtGeneration {
+                    subject_kind,
+                    subject_id,
+                    level,
+                    status,
+                    prediction_id,
+                    error_code,
+                } => {
+                    if let Some(event) = self.apply_complete_community_art_generation_projection(
+                        action.actor_id,
+                        subject_kind,
+                        *subject_id,
+                        *level,
+                        status,
+                        prediction_id.as_deref(),
+                        error_code.as_deref(),
+                    ) {
+                        events.push(event);
+                    }
                 }
                 ProjectionMutation::RefinePathway { pathway } => {
                     let mut refined = pathway.clone();
@@ -19471,6 +19439,17 @@ impl RuntimeWorld {
         let status = generation
             .map(|state| state.status.clone())
             .unwrap_or_else(|| "available".to_string());
+        let provider_attempts = generation
+            .map(|state| state.provider_attempts)
+            .unwrap_or_default();
+        let retryable_without_orbs = funded_orbs >= required_orbs
+            && match status.as_str() {
+                "review_failed" | "review_unavailable" | "reviewing" => true,
+                "funded" | "generating" | "failed" | "rejected" | "policy_rejected" => {
+                    provider_attempts < MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
+                }
+                _ => false,
+            };
         if status == "ready" {
             card.image_url = Some(community_art_image_url(
                 subject_kind,
@@ -19491,6 +19470,9 @@ impl RuntimeWorld {
             history_through_seq: generation
                 .map(|state| state.history_through_seq)
                 .unwrap_or_else(|| self.world.next_event_seq.saturating_sub(1)),
+            provider_attempts,
+            max_provider_attempts: MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS,
+            retryable_without_orbs,
         });
         card
     }
@@ -23877,10 +23859,6 @@ fn stored_avatar_content_type(root: &Path, actor_id: u64) -> String {
         .unwrap_or_else(|| "image/png".to_string())
 }
 
-fn community_art_generation_key(subject_kind: &str, subject_id: u64, level: u8) -> String {
-    format!("{subject_kind}:{subject_id}:level:{level}")
-}
-
 fn is_safe_image_content_type(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 96
@@ -26583,6 +26561,65 @@ async fn fund_community_image(
         });
     }
 
+    let initial_plan = {
+        let runtime = state.inner.lock().await;
+        if !client_actor_authorized_for_state(
+            &runtime,
+            &state,
+            payload.actor_id,
+            payload.actor_session.as_deref(),
+        ) {
+            return client_actor_rejected_response();
+        }
+        match runtime.community_art_plan(
+            payload.actor_id,
+            payload.subject_kind.trim(),
+            payload.subject_id,
+        ) {
+            Ok(plan) => plan,
+            Err(_) => {
+                return Json(ActionResponse {
+                    ok: false,
+                    status: 404,
+                    events: Vec::new(),
+                });
+            }
+        }
+    };
+    if let Some(policy) = initial_plan.image_policy {
+        let started_at = Instant::now();
+        if let Err(error) =
+            preflight_community_art_policy(state.ai_config.as_ref().as_ref(), policy).await
+        {
+            warn!(
+                "community art policy preflight failed for {}: {}",
+                community_art_generation_key(
+                    &initial_plan.subject_kind,
+                    initial_plan.subject_id,
+                    initial_plan.level
+                ),
+                error.message()
+            );
+            record_ai_usage(
+                &state,
+                Some(payload.actor_id),
+                "community_image_policy_preflight",
+                "cosyworld_system",
+                state.ai_config.as_ref().as_ref(),
+                "failed",
+                None,
+                0,
+                Some(error.code()),
+                started_at.elapsed(),
+            );
+            return Json(ActionResponse {
+                ok: false,
+                status: 503,
+                events: Vec::new(),
+            });
+        }
+    }
+
     let mut runtime = state.inner.lock().await;
     if !client_actor_authorized_for_state(
         &runtime,
@@ -26606,18 +26643,12 @@ async fn fund_community_image(
             });
         }
     };
-    if plan.image_policy.is_some() && state.ai_config.as_ref().is_none() {
-        return Json(ActionResponse {
-            ok: false,
-            status: 503,
-            events: Vec::new(),
-        });
-    }
     let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
     let existing = runtime.community_art_generations.get(&key);
+    let candidate_exists = community_art_candidate_exists(&state.generated_asset_dir, &plan);
     if existing.is_some_and(|generation| generation.funding_intent_ids.contains(intent_id)) {
         let retry_generation = existing.is_some_and(|generation| {
-            generation.status != "ready" && generation.funded_orbs >= generation.required_orbs
+            community_art_generation_retryable(generation, candidate_exists)
         });
         drop(runtime);
         if retry_generation {
@@ -26630,6 +26661,16 @@ async fn fund_community_image(
         });
     }
     if existing.is_some_and(|generation| generation.status == "ready") {
+        return Json(ActionResponse {
+            ok: false,
+            status: 409,
+            events: Vec::new(),
+        });
+    }
+    if existing.is_some_and(|generation| {
+        generation.funded_orbs >= generation.required_orbs
+            && !community_art_generation_retryable(generation, candidate_exists)
+    }) {
         return Json(ActionResponse {
             ok: false,
             status: 409,
@@ -26697,7 +26738,7 @@ async fn fund_community_image(
     let fully_funded = runtime
         .community_art_generations
         .get(&key)
-        .is_some_and(|generation| generation.funded_orbs >= generation.required_orbs);
+        .is_some_and(|generation| community_art_generation_retryable(generation, candidate_exists));
     drop(runtime);
     if !events.is_empty() {
         broadcast_events(&state, &events);
@@ -32165,97 +32206,6 @@ async fn request_ai_avatar_identity(
         .ok_or_else(|| "AI avatar identity response was not usable JSON".to_string())
 }
 
-static COMMUNITY_ART_JOBS: OnceLock<StdMutex<BTreeSet<String>>> = OnceLock::new();
-
-fn community_art_jobs() -> &'static StdMutex<BTreeSet<String>> {
-    COMMUNITY_ART_JOBS.get_or_init(|| StdMutex::new(BTreeSet::new()))
-}
-
-async fn commit_community_art_status(
-    state: &AppState,
-    actor_id: u64,
-    plan: &CommunityArtPlan,
-    status: &str,
-) -> Vec<EventView> {
-    let mut runtime = state.inner.lock().await;
-    let mut record = JournalRecord::new(
-        CwAction {
-            kind: CW_ACTION_NONE,
-            actor_id,
-            ..CwAction::default()
-        },
-        runtime.next_seed_value(),
-    );
-    record
-        .projection_mutations
-        .push(ProjectionMutation::SetCommunityArtStatus {
-            subject_kind: plan.subject_kind.clone(),
-            subject_id: plan.subject_id,
-            level: plan.level,
-            status: status.to_string(),
-        });
-    let Ok((commit_status, events)) = commit_journal_record(state, &mut runtime, record) else {
-        return Vec::new();
-    };
-    drop(runtime);
-    if commit_status == CW_OK {
-        broadcast_events(state, &events);
-        events
-    } else {
-        Vec::new()
-    }
-}
-
-fn schedule_community_art_generation(state: &AppState, actor_id: u64, plan: CommunityArtPlan) {
-    let Some(config) = state.avatar_art_config.as_ref().clone() else {
-        return;
-    };
-    let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
-    if let Ok(mut jobs) = community_art_jobs().lock() {
-        if !jobs.insert(key.clone()) {
-            return;
-        }
-    }
-    let state = state.clone();
-    tokio::spawn(async move {
-        let started_at = Instant::now();
-        let result = generate_and_store_community_art(
-            &config,
-            state.ai_config.as_ref().as_ref(),
-            &state.generated_asset_dir,
-            &plan,
-        )
-        .await;
-        let (status, error_code) = match result {
-            Ok(()) => ("ready", None),
-            Err(error) => {
-                warn!(
-                    "community art generation failed for {}: {}",
-                    key,
-                    error.message()
-                );
-                (error.status(), Some(error.code()))
-            }
-        };
-        let events = commit_community_art_status(&state, actor_id, &plan, status).await;
-        record_ai_usage(
-            &state,
-            Some(actor_id),
-            "community_image_generation",
-            "community_orbs",
-            None,
-            if status == "ready" { "ok" } else { "failed" },
-            events.first().map(|event| event.seq),
-            0,
-            error_code,
-            started_at.elapsed(),
-        );
-        if let Ok(mut jobs) = community_art_jobs().lock() {
-            jobs.remove(&key);
-        }
-    });
-}
-
 const MAX_REPLICATE_AVATAR_IMAGE_BYTES: u64 = 8 * 1024 * 1024;
 
 async fn request_replicate_art(
@@ -32323,7 +32273,13 @@ async fn request_replicate_art(
 
     for _ in 0..30 {
         if let Some(output_url) = replicate_output_url(&prediction) {
-            return download_replicate_image(&client, &output_url).await;
+            let prediction_id = prediction
+                .get("id")
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string);
+            let mut image = download_replicate_image(&client, &output_url).await?;
+            image.prediction_id = prediction_id;
+            return Ok(image);
         }
         let status = prediction
             .get("status")
@@ -32438,6 +32394,7 @@ async fn download_replicate_image(
         bytes,
         content_type,
         source_url: output_url.to_string(),
+        prediction_id: None,
     })
 }
 
@@ -38895,6 +38852,35 @@ fn record_ai_usage(
     error_code: Option<&str>,
     latency: Duration,
 ) {
+    record_ai_usage_for_provider(
+        state,
+        actor_id,
+        feature,
+        payer_mode,
+        ai_provider_name(config),
+        &ai_model_name(config),
+        status,
+        source_event_id,
+        orb_delta,
+        error_code,
+        latency,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_ai_usage_for_provider(
+    state: &AppState,
+    actor_id: Option<u64>,
+    feature: &str,
+    payer_mode: &str,
+    provider: &str,
+    model: &str,
+    status: &str,
+    source_event_id: Option<u64>,
+    orb_delta: i32,
+    error_code: Option<&str>,
+    latency: Duration,
+) {
     let Some(path) = state.event_store_path.as_deref() else {
         return;
     };
@@ -38906,8 +38892,8 @@ fn record_ai_usage(
         actor_id,
         feature: feature.to_string(),
         payer_mode: payer_mode.to_string(),
-        provider: ai_provider_name(config).to_string(),
-        model: ai_model_name(config),
+        provider: provider.to_string(),
+        model: model.to_string(),
         status: status.to_string(),
         source_event_id,
         orb_delta,
@@ -48992,6 +48978,10 @@ mod tests {
         assert!(!INDEX_HTML.contains("one Orb for the whole exchange"));
         assert!(INDEX_HTML.contains("/actions/fund-image"));
         assert!(INDEX_HTML.contains("fund community images only"));
+        assert!(INDEX_HTML.contains("retry the saved image review"));
+        assert!(INDEX_HTML.contains("no new image will be bought while review is unavailable"));
+        assert!(INDEX_HTML.contains("no more provider credits will be used"));
+        assert!(INDEX_HTML.contains("art.retryable_without_orbs"));
         assert!(INDEX_HTML.contains("Inspect ${searchTarget} for one hidden thing."));
         assert!(INDEX_HTML.contains("into your keeping"));
         assert!(INDEX_HTML.contains("function smallNumberWord"));

--- a/v2/orchestrator-rust/src/moderation.rs
+++ b/v2/orchestrator-rust/src/moderation.rs
@@ -16,10 +16,11 @@ use crate::{
     event_replay_limit, event_store_scan_limit, init_event_store, no_store_headers, now_millis,
     now_unix_secs, open_event_store, persist_actor_suspension, read_economy_audit,
     read_event_store, resolve_economy_reconciliation, sqlite_error,
-    stored_community_art_content_type_path, stored_community_art_image_path, tail_event_replay,
-    ActorSuspension, AiUsageLedgerAuditView, AppState, AvatarPackOpeningView, CwAction,
-    EconomyReconciliationView, EventView, JournalRecord, OrbLedgerAuditView, ProjectionMutation,
-    WoodenBoxReceiptView, CW_ACTION_NONE, CW_OK, MAX_EVENT_STORE_SCAN, MODERATION_HTML,
+    stored_community_art_content_type_path, stored_community_art_image_path,
+    stored_community_art_metadata_path, tail_event_replay, ActorSuspension, AiUsageLedgerAuditView,
+    AppState, AvatarPackOpeningView, CwAction, EconomyReconciliationView, EventView, JournalRecord,
+    OrbLedgerAuditView, ProjectionMutation, WoodenBoxReceiptView, CW_ACTION_NONE, CW_OK,
+    MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS, MAX_EVENT_STORE_SCAN, MODERATION_HTML,
 };
 
 pub(crate) const MAX_REPORT_REASON_CHARS: usize = 500;
@@ -711,7 +712,9 @@ pub(crate) async fn moderation_reject_community_art(
             );
         };
         let generation_status = generation.status.clone();
-        let retryable_without_orbs = generation.funded_orbs >= generation.required_orbs;
+        let last_prediction_id = generation.last_prediction_id.clone();
+        let retryable_without_orbs = generation.funded_orbs >= generation.required_orbs
+            && generation.provider_attempts < MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS;
         if generation_status == "rejected" {
             (level, retryable_without_orbs, Vec::new())
         } else {
@@ -735,11 +738,13 @@ pub(crate) async fn moderation_reject_community_art(
             );
             record
                 .projection_mutations
-                .push(ProjectionMutation::SetCommunityArtStatus {
+                .push(ProjectionMutation::CompleteCommunityArtGeneration {
                     subject_kind: subject_kind.clone(),
                     subject_id,
                     level,
                     status: "rejected".to_string(),
+                    prediction_id: last_prediction_id,
+                    error_code: Some("community_art_moderation_rejected".to_string()),
                 });
             let Ok((commit_status, events)) = commit_journal_record(&state, &mut runtime, record)
             else {
@@ -773,7 +778,9 @@ pub(crate) async fn moderation_reject_community_art(
         &subject_kind,
         subject_id,
     );
-    for path in [&image_path, &content_type_path] {
+    let metadata_path =
+        stored_community_art_metadata_path(&state.generated_asset_dir, &subject_kind, subject_id);
+    for path in [&image_path, &content_type_path, &metadata_path] {
         if let Err(error) = fs::remove_file(path) {
             if error.kind() != io::ErrorKind::NotFound {
                 warn!(

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74582
+74572


### PR DESCRIPTION
## Summary

- preflight exact location-art policy before Orb debit or Replicate generation
- persist generated candidate bytes and reuse them when downstream policy review fails
- journal and cap provider attempts so replay/retry cannot create another paid generation
- surface honest retry/terminal UI states and safe provider diagnostics
- correct Replicate usage attribution and bump the release to `0.0.198`

Closes #386

## Root cause

Replicate completed successfully, then the downstream OpenRouter policy review returned HTTP 400. The generated bytes were discarded and the UI offered another generation, causing another Replicate charge for the same intent.

## Validation

- `git diff --check`
- `npm run check:version`
- `npm run check:local` — 453 Node tests, 541 Rust tests, both browser smokes
- `npm run v2:architecture` — `main.rs` 74572/74572; clippy 246/246
- focused community-art regression suite — 6 tests
- AI provider diagnostic regression test — 1 test
- pre-push `npm run check` — worldpack, kernel, Rust, architecture, and syntax gates green

## Deployment / compatibility

- existing failed/rejected journal states are treated as exhausted, preventing a production replay from spending again
- candidate metadata is additive; no destructive data migration is required
- merge to `main` triggers the canonical Fly production deployment workflow

## Review checklist

- [x] no secrets or runtime artifacts included
- [x] exact 14-file P0 scope reviewed
- [x] duplicate charge path covered by regression tests
- [x] release version updated consistently