### PR TITLE
Restore community image policy preflight

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -250,9 +250,11 @@ CosyWorld should generalize that into Rust rather than copying the Ruby High Typ
 - Each `{subject kind, subject id, level}` generation is unique and replay-safe. Multiple avatars may pool its exact level-sized cost.
 - The prompt captures public card history through a committed sequence. When the card reaches a later level, its one newly unlocked image can evolve in response to everything that happened since.
 - Fully funded jobs may be retried without another Orb debit. A location job
-  first runs the exact base64-image plus strict-schema policy capability
-  preflight, so a missing or incompatible reviewer fails before either funding
-  or a billable Replicate request.
+  first runs a known-safe solid-color base64 fixture through a matching
+  capability policy and the strict-schema review path, so a missing or
+  incompatible reviewer fails before either funding or a billable Replicate
+  request. The generated image still receives the full landscape publication
+  policy below.
 - Location art is published only after a strict vision-policy review finds no
   people, characters, creatures, text, logos, or watermarks. The downloaded
   candidate is durably stored before review; reviewer outages and restarts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.199",
+  "version": "0.0.200",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.199",
+      "version": "0.0.200",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.199",
+  "version": "0.0.200",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.199"
+version = "0.0.200"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.199"
+version = "0.0.200"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -25,7 +25,7 @@ use crate::{
 
 pub(super) const MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS: u8 = 3;
 const COMMUNITY_ART_CANDIDATE_SCHEMA_VERSION: u8 = 1;
-const POLICY_PREFLIGHT_IMAGE_URL: &str =
+pub(super) const POLICY_PREFLIGHT_IMAGE_URL: &str =
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XqgWAAAAAElFTkSuQmCC";
 
 pub(super) fn community_art_generation_key(
@@ -97,6 +97,14 @@ impl CommunityArtImagePolicy {
         match self {
             Self::LocationLandscape => {
                 "Publish only a landscape with no visible or implied people, human figures, humanoids, characters, animals, creatures, silhouettes, faces, body parts, statues, portraits, readable text, letters, numbers, logos, or watermarks."
+            }
+        }
+    }
+
+    fn preflight_review(self) -> &'static str {
+        match self {
+            Self::LocationLandscape => {
+                "Allow this image only if it is a uniform solid-green square with no visible person, character, creature, text, logo, or watermark."
             }
         }
     }
@@ -345,7 +353,7 @@ pub(super) async fn preflight_community_art_policy(
         ImagePolicyRequest {
             feature: "media.location_image_policy_preflight",
             image_url: POLICY_PREFLIGHT_IMAGE_URL,
-            policy: policy.review(),
+            policy: policy.preflight_review(),
             timeout: Duration::from_secs(10),
             max_attempts: 1,
             referer: "https://cosyworld.fly.dev",
@@ -355,7 +363,7 @@ pub(super) async fn preflight_community_art_policy(
     .map_err(|error| CommunityArtGenerationError::PolicyReview(error.to_string()))?;
     if !decision.allowed {
         return Err(CommunityArtGenerationError::PolicyReview(format!(
-            "the empty policy preflight image was rejected: {}",
+            "the known-safe policy preflight image was rejected: {}",
             if decision.violations.is_empty() {
                 "unspecified violation".to_string()
             } else {

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -74,6 +74,72 @@ async fn location_art_funding_fails_before_debit_without_policy_review() {
 }
 
 #[tokio::test]
+async fn location_policy_preflight_uses_a_known_safe_capability_contract() {
+    let capability_contract_seen = Arc::new(AtomicBool::new(false));
+    let app = Router::new().route(
+        "/chat/completions",
+        post({
+            let capability_contract_seen = capability_contract_seen.clone();
+            move |Json(body): Json<serde_json::Value>| {
+                let capability_contract_seen = capability_contract_seen.clone();
+                async move {
+                    let image_url = body
+                        .pointer("/messages/1/content/1/image_url/url")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default();
+                    let review = body
+                        .pointer("/messages/1/content/0/text")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default();
+                    capability_contract_seen.store(
+                        body.get("model").and_then(serde_json::Value::as_str)
+                            == Some("test-vision-model")
+                            && body
+                                .pointer("/response_format/json_schema/name")
+                                .and_then(serde_json::Value::as_str)
+                                == Some("cosyworld_image_policy")
+                            && image_url == POLICY_PREFLIGHT_IMAGE_URL
+                            && review.contains("uniform solid-green square")
+                            && !review.contains("Publish only a landscape"),
+                        Ordering::SeqCst,
+                    );
+                    Json(serde_json::json!({
+                        "choices": [{
+                            "message": {
+                                "content": r#"{"allowed":true,"violations":[],"summary":"The known-safe capability fixture matches."}"#
+                            }
+                        }]
+                    }))
+                }
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind successful policy preflight fixture");
+    let address = listener
+        .local_addr()
+        .expect("successful policy preflight address");
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let config = AiConfig {
+        api_key: "test".to_string(),
+        base_url: format!("http://{address}"),
+        model: "test-model".to_string(),
+        vision_model: "test-vision-model".to_string(),
+        reasoning_effort: None,
+    };
+
+    preflight_community_art_policy(Some(&config), CommunityArtImagePolicy::LocationLandscape)
+        .await
+        .expect("known-safe preflight fixture is accepted");
+
+    assert!(capability_contract_seen.load(Ordering::SeqCst));
+    server.abort();
+}
+
+#[tokio::test]
 async fn location_policy_400_fails_before_orb_debit_or_replicate_schedule() {
     let mut runtime = RuntimeWorld::seeded();
     create_test_human(


### PR DESCRIPTION
## Summary

- use a known-safe solid-green fixture with a capability-specific policy for the pre-debit vision reviewer check
- keep the full landscape publication policy unchanged for generated location images
- add a regression test that verifies the exact image, vision model, strict JSON schema, and capability prompt
- bump the release version to 0.0.200

## Root cause

The production reviewer was moved from `x-ai/grok-4.5` to the cheaper `google/gemini-3.1-flash-lite` model after Grok rejected disabled reasoning. A live provider smoke then showed that the existing one-pixel preflight image was a solid green square, while the preflight asked the reviewer to approve only landscapes. Gemini correctly rejected that contradictory contract, so the workshop still failed closed before taking an Orb.

The preflight now tests transport and schema capability against a policy the known-safe fixture actually satisfies. Generated location candidates still receive the original strict landscape review.

## Validation

- live OpenRouter smoke with the production request shape: HTTP success, strict JSON, `allowed: true`, zero reasoning tokens, cost $0.0003425
- `cargo test location_policy_preflight_uses_a_known_safe_capability_contract -- --nocapture`: 1 passed
- `npm run check:version`: passed
- `npm run v2:rust:test`: 542 passed
- `npm run v2:check`: passed, including production-profile, browser, persistence, multiplayer, and visual smoke
- pre-push `npm run check`: 453 JavaScript tests, worldpack/proof-world, kernel, 542 Rust tests, architecture/clippy ceilings, and syntax checks passed
- `git diff --check`: passed

## Deployment and compatibility

Merging to `main` deploys Fly. The production Fly secret `OPENROUTER_VISION_MODEL` is already set to `google/gemini-3.1-flash-lite`. No journal, snapshot, worldpack, or API migration is required. Failed preflights continue to debit zero Orbs.

## Review checklist

- [x] Scoped to the community-image policy preflight
- [x] Generated-image publication policy remains fail-closed
- [x] No secrets or runtime artifacts are included
- [x] Versions and lockfiles are aligned
- [x] Required local and pre-push gates pass
