### PR TITLE
Repair location art generation

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -262,6 +262,11 @@ CosyWorld should generalize that into Rust rather than copying the Ruby High Typ
   generation attempts are journal-counted and capped at three per
   `{subject kind, subject id, level}`. Rejection, review failure, and missing
   review configuration all leave the deterministic landscape fallback visible.
+- Location generation keeps the configured CosyWorld style LoRA but replaces
+  the avatar portrait/card prefix with a landscape-only prefix and reduces
+  public history to environmental traces without actor names or dialogue.
+  Prompt profiles are versioned; advancing a profile reopens one bounded
+  provider budget for an already-funded job without another Orb debit.
 - Current implementation stores a durable funding/status projection and serves the ready shared asset from the generated-card route. A generalized object-store-backed `media_jobs` service remains the scaling step.
 
 ## Combat Replaces Quizzes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.200",
+  "version": "0.0.201",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.200",
+      "version": "0.0.201",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.200",
+  "version": "0.0.201",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.200"
+version = "0.0.201"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.200"
+version = "0.0.201"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -24,9 +24,25 @@ use crate::{
 };
 
 pub(super) const MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS: u8 = 3;
+pub(super) const LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION: u8 = 1;
+pub(super) const LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION: u8 = 2;
+pub(super) const LOCATION_LANDSCAPE_PROMPT_PREFIX: &str =
+    "MRQ, cozy storybook landscape, wide environment establishing view";
 const COMMUNITY_ART_CANDIDATE_SCHEMA_VERSION: u8 = 1;
 pub(super) const POLICY_PREFLIGHT_IMAGE_URL: &str =
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XqgWAAAAAElFTkSuQmCC";
+
+pub(super) fn legacy_community_art_generation_profile_version() -> u8 {
+    LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION
+}
+
+pub(super) fn community_art_generation_profile_version(subject_kind: &str) -> u8 {
+    if subject_kind == "location" {
+        LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION
+    } else {
+        LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION
+    }
+}
 
 pub(super) fn community_art_generation_key(
     subject_kind: &str,
@@ -49,6 +65,8 @@ pub(super) struct CommunityArtGenerationState {
     pub(super) subject_kind: String,
     pub(super) subject_id: u64,
     pub(super) level: u8,
+    #[serde(default = "legacy_community_art_generation_profile_version")]
+    pub(super) generation_profile_version: u8,
     pub(super) required_orbs: i32,
     pub(super) funded_orbs: i32,
     #[serde(default)]
@@ -72,11 +90,26 @@ pub(super) struct CommunityArtPlan {
     pub(super) subject_kind: String,
     pub(super) subject_id: u64,
     pub(super) level: u8,
+    pub(super) generation_profile_version: u8,
     pub(super) required_orbs: i32,
     pub(super) history_through_seq: u64,
     pub(super) prompt: String,
     pub(super) aspect_ratio: &'static str,
     pub(super) image_policy: Option<CommunityArtImagePolicy>,
+}
+
+impl CommunityArtPlan {
+    pub(super) fn generation_retryable(
+        &self,
+        generation: &CommunityArtGenerationState,
+        candidate_exists: bool,
+    ) -> bool {
+        community_art_generation_retryable_for_profile(
+            generation,
+            candidate_exists,
+            self.generation_profile_version,
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -106,6 +139,12 @@ impl CommunityArtImagePolicy {
             Self::LocationLandscape => {
                 "Allow this image only if it is a uniform solid-green square with no visible person, character, creature, text, logo, or watermark."
             }
+        }
+    }
+
+    fn generation_prompt_prefix(self) -> &'static str {
+        match self {
+            Self::LocationLandscape => LOCATION_LANDSCAPE_PROMPT_PREFIX,
         }
     }
 }
@@ -193,6 +232,62 @@ pub(super) fn community_art_generation_retryable(
     }
 }
 
+pub(super) fn community_art_generation_retryable_for_profile(
+    generation: &CommunityArtGenerationState,
+    candidate_exists: bool,
+    generation_profile_version: u8,
+) -> bool {
+    generation.funded_orbs >= generation.required_orbs
+        && (generation_profile_version > generation.generation_profile_version
+            || community_art_generation_retryable(generation, candidate_exists))
+}
+
+pub(super) fn community_art_prompt_history(
+    subject_kind: &str,
+    history_entries: &[String],
+) -> String {
+    if subject_kind == "location" {
+        if history_entries.is_empty() {
+            "newly revealed terrain with no depicted travelers".to_string()
+        } else {
+            format!(
+                "{} recent public moments have left subtle environmental traces such as path wear, tended ground, and changing weather; depict no traveler or written record",
+                history_entries.len()
+            )
+        }
+    } else if history_entries.is_empty() {
+        "newly arrived in the shared world".to_string()
+    } else {
+        history_entries.join("; ")
+    }
+}
+
+#[allow(clippy::too_many_arguments)] // Mirrors the bounded prompt components.
+pub(super) fn build_community_art_prompt(
+    subject_kind: &str,
+    name: &str,
+    title: &str,
+    blurb: &str,
+    level: u8,
+    subject_details: &str,
+    history: &str,
+    image_policy: Option<CommunityArtImagePolicy>,
+) -> String {
+    let image_constraints = image_policy
+        .map(CommunityArtImagePolicy::prompt)
+        .unwrap_or("No words, logo, watermark, UI, gore, or photorealism.");
+    let prompt = if image_policy == Some(CommunityArtImagePolicy::LocationLandscape) {
+        format!(
+            "Wide environment illustration of {name}. {blurb}. Authoritative landscape level {level}. Canonical landscape facts: {subject_details}. Let the terrain and weather remember public history only through environmental detail: {history}. Preserve the established geography across later levels. {image_constraints}"
+        )
+    } else {
+        format!(
+            "Collectible card art for {subject_kind} {name}, titled {title}. {blurb}. Authoritative level {level}. Canonical visual facts: {subject_details}. Let the image visibly remember this public history without adding text: {history}. Preserve the subject's established identity across later levels. {image_constraints}"
+        )
+    };
+    crate::compact_whitespace(&prompt)
+}
+
 impl RuntimeWorld {
     #[allow(clippy::too_many_arguments)] // Mirrors the durable funding mutation fields.
     pub(super) fn apply_fund_community_art_projection(
@@ -214,6 +309,7 @@ impl RuntimeWorld {
                 subject_kind: subject_kind.to_string(),
                 subject_id,
                 level,
+                generation_profile_version: community_art_generation_profile_version(subject_kind),
                 required_orbs: required_orbs.max(1),
                 funded_orbs: 0,
                 contributions: BTreeMap::new(),
@@ -290,9 +386,14 @@ impl RuntimeWorld {
         subject_id: u64,
         level: u8,
         provider_attempt: bool,
+        generation_profile_version: u8,
     ) -> Option<EventView> {
         let key = community_art_generation_key(subject_kind, subject_id, level);
         let generation = self.community_art_generations.get_mut(&key)?;
+        if generation_profile_version > generation.generation_profile_version {
+            generation.generation_profile_version = generation_profile_version;
+            generation.provider_attempts = 0;
+        }
         if provider_attempt {
             generation.provider_attempts = generation.provider_attempts.saturating_add(1);
         }
@@ -383,8 +484,7 @@ pub(super) async fn generate_and_store_community_art(
     let (image, reused_candidate) = match load_community_art_candidate(generated_asset_dir, plan) {
         Ok(Some(image)) => (image, true),
         Ok(None) => {
-            let prompt =
-                crate::compact_whitespace(&format!("{}, {}", config.prompt_prefix, plan.prompt));
+            let prompt = community_art_generation_request(config, plan);
             let image = match request_replicate_art(config, prompt, plan.aspect_ratio).await {
                 Ok(image) => image,
                 Err(error) => {
@@ -455,6 +555,17 @@ pub(super) async fn generate_and_store_community_art(
     }
 }
 
+pub(super) fn community_art_generation_request(
+    config: &ReplicateAvatarArtConfig,
+    plan: &CommunityArtPlan,
+) -> String {
+    let prompt_prefix = plan
+        .image_policy
+        .map(CommunityArtImagePolicy::generation_prompt_prefix)
+        .unwrap_or(&config.prompt_prefix);
+    crate::compact_whitespace(&format!("{prompt_prefix}, {}", plan.prompt))
+}
+
 static COMMUNITY_ART_JOBS: OnceLock<StdMutex<BTreeSet<String>>> = OnceLock::new();
 
 fn community_art_jobs() -> &'static StdMutex<BTreeSet<String>> {
@@ -470,11 +581,14 @@ async fn begin_community_art_generation(
     let mut runtime = state.inner.lock().await;
     let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
     let generation = runtime.community_art_generations.get(&key)?;
-    if !community_art_generation_retryable(generation, candidate_exists) {
+    if !plan.generation_retryable(generation, candidate_exists) {
         return None;
     }
     let provider_attempt = !candidate_exists;
-    if provider_attempt && generation.provider_attempts >= MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS {
+    if provider_attempt
+        && plan.generation_profile_version <= generation.generation_profile_version
+        && generation.provider_attempts >= MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
+    {
         return None;
     }
     let mut record = JournalRecord::new(
@@ -492,6 +606,7 @@ async fn begin_community_art_generation(
             subject_id: plan.subject_id,
             level: plan.level,
             provider_attempt,
+            generation_profile_version: plan.generation_profile_version,
         });
     let (commit_status, events) = commit_journal_record(state, &mut runtime, record).ok()?;
     drop(runtime);

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -139,6 +139,54 @@ async fn location_policy_preflight_uses_a_known_safe_capability_contract() {
     server.abort();
 }
 
+#[test]
+fn location_generation_replaces_portrait_prompt_without_disabling_the_style_lora() {
+    let mut config = test_art_config();
+    config.prompt_prefix = "MRQ, cozy storybook trading-card portrait".to_string();
+    config.lora_url = Some("immanencer/mirquo".to_string());
+    let history = community_art_prompt_history(
+        "location",
+        &[
+            "Mara Bramblebrook leaves Foxglove Turn behind.".to_string(),
+            "Quiet Rise has chalk in my boots already.".to_string(),
+        ],
+    );
+    let plan = CommunityArtPlan {
+        subject_kind: "location".to_string(),
+        subject_id: 181_730,
+        level: 1,
+        generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
+        required_orbs: 1,
+        history_through_seq: 99,
+        prompt: build_community_art_prompt(
+            "location",
+            "Quiet Rise",
+            "Newly Found Path",
+            "Chalky lanes meet a reed-fringed river.",
+            1,
+            "chalky lanes, reed beds, river stones",
+            &history,
+            Some(CommunityArtImagePolicy::LocationLandscape),
+        ),
+        aspect_ratio: "16:9",
+        image_policy: Some(CommunityArtImagePolicy::LocationLandscape),
+    };
+
+    let prompt = community_art_generation_request(&config, &plan);
+
+    assert!(prompt.starts_with(LOCATION_LANDSCAPE_PROMPT_PREFIX));
+    assert!(!prompt.contains("trading-card portrait"));
+    for portrait_leak in [
+        "Collectible card art",
+        "titled",
+        "Mara Bramblebrook",
+        "chalk in my boots",
+    ] {
+        assert!(!prompt.contains(portrait_leak), "{portrait_leak}: {prompt}");
+    }
+    assert_eq!(config.lora_url.as_deref(), Some("immanencer/mirquo"));
+}
+
 #[tokio::test]
 async fn location_policy_400_fails_before_orb_debit_or_replicate_schedule() {
     let mut runtime = RuntimeWorld::seeded();
@@ -253,6 +301,7 @@ async fn location_policy_400_fails_before_orb_debit_or_replicate_schedule() {
             subject_kind: "location".to_string(),
             subject_id: waypoint_id,
             level: 1,
+            generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
             required_orbs: 1,
             history_through_seq: 0,
             prompt: String::new(),
@@ -316,6 +365,7 @@ async fn policy_retry_reuses_the_saved_candidate_without_calling_replicate() {
         subject_kind: "location".to_string(),
         subject_id: 181_728,
         level: 1,
+        generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
         required_orbs: 1,
         history_through_seq: 99,
         prompt: "A quiet rain-soft path with no figures.".to_string(),
@@ -435,6 +485,7 @@ fn provider_attempt_budget_is_journaled_and_survives_serialization() {
                 subject_id: 5000,
                 level: 1,
                 provider_attempt: true,
+                generation_profile_version: LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION,
             });
         record
             .projection_mutations
@@ -470,6 +521,141 @@ fn provider_attempt_budget_is_journaled_and_survives_serialization() {
         MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
     );
     assert!(!community_art_generation_retryable(&restored[&key], false));
+}
+
+#[test]
+fn newer_location_prompt_profile_reopens_a_paid_exhausted_job() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Recovered Patron",
+    );
+    let subject_id = 181_730;
+    let mut funding = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            ..CwAction::default()
+        },
+        7060,
+    );
+    funding
+        .projection_mutations
+        .push(ProjectionMutation::FundCommunityArt {
+            subject_kind: "location".to_string(),
+            subject_id,
+            level: 1,
+            required_orbs: 1,
+            contributor_actor_id: 5000,
+            intent_id: "test-paid-location-recovery".to_string(),
+            amount: 1,
+            history_through_seq: 7060,
+        });
+    assert_eq!(runtime.apply_journal_record(&funding).0, CW_OK);
+
+    let key = community_art_generation_key("location", subject_id, 1);
+    runtime
+        .community_art_generations
+        .get_mut(&key)
+        .expect("funded generation")
+        .generation_profile_version = LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION;
+    for attempt in 1..=MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS {
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: 5000,
+                ..CwAction::default()
+            },
+            7060 + u64::from(attempt),
+        );
+        record
+            .projection_mutations
+            .push(ProjectionMutation::BeginCommunityArtGeneration {
+                subject_kind: "location".to_string(),
+                subject_id,
+                level: 1,
+                provider_attempt: true,
+                generation_profile_version: LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION,
+            });
+        record
+            .projection_mutations
+            .push(ProjectionMutation::CompleteCommunityArtGeneration {
+                subject_kind: "location".to_string(),
+                subject_id,
+                level: 1,
+                status: "policy_rejected".to_string(),
+                prediction_id: Some(format!("legacy-prediction-{attempt}")),
+                error_code: Some("community_art_policy_rejected".to_string()),
+            });
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+    }
+
+    let exhausted = &runtime.community_art_generations[&key];
+    assert_eq!(exhausted.funded_orbs, exhausted.required_orbs);
+    assert_eq!(
+        exhausted.provider_attempts,
+        MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
+    );
+    assert!(!community_art_generation_retryable(exhausted, false));
+    assert!(community_art_generation_retryable_for_profile(
+        exhausted,
+        false,
+        LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION
+    ));
+
+    let mut retry = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            ..CwAction::default()
+        },
+        7064,
+    );
+    retry
+        .projection_mutations
+        .push(ProjectionMutation::BeginCommunityArtGeneration {
+            subject_kind: "location".to_string(),
+            subject_id,
+            level: 1,
+            provider_attempt: true,
+            generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
+        });
+    assert_eq!(runtime.apply_journal_record(&retry).0, CW_OK);
+
+    let recovered = &runtime.community_art_generations[&key];
+    assert_eq!(
+        recovered.generation_profile_version,
+        LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION
+    );
+    assert_eq!(recovered.provider_attempts, 1);
+    assert_eq!(recovered.funded_orbs, recovered.required_orbs);
+    assert_eq!(recovered.status, "generating");
+}
+
+#[test]
+fn legacy_begin_generation_journal_defaults_to_the_original_prompt_profile() {
+    let mutation: ProjectionMutation = serde_json::from_value(serde_json::json!({
+        "kind": "begin_community_art_generation",
+        "subject_kind": "location",
+        "subject_id": 181730,
+        "level": 1,
+        "provider_attempt": true
+    }))
+    .expect("legacy begin-generation journal remains readable");
+
+    let ProjectionMutation::BeginCommunityArtGeneration {
+        generation_profile_version,
+        ..
+    } = mutation
+    else {
+        panic!("legacy mutation retains its variant");
+    };
+    assert_eq!(
+        generation_profile_version,
+        LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION
+    );
 }
 
 #[tokio::test]

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -963,6 +963,8 @@ enum ProjectionMutation {
         subject_id: u64,
         level: u8,
         provider_attempt: bool,
+        #[serde(default = "legacy_community_art_generation_profile_version")]
+        generation_profile_version: u8,
     },
     CompleteCommunityArtGeneration {
         subject_kind: String,
@@ -10338,6 +10340,7 @@ impl RuntimeWorld {
                     subject_id,
                     level,
                     provider_attempt,
+                    generation_profile_version,
                 } => {
                     if let Some(event) = self.apply_begin_community_art_generation_projection(
                         action.actor_id,
@@ -10345,6 +10348,7 @@ impl RuntimeWorld {
                         *subject_id,
                         *level,
                         *provider_attempt,
+                        *generation_profile_version,
                     ) {
                         events.push(event);
                     }
@@ -19436,20 +19440,15 @@ impl RuntimeWorld {
         let generation = self.community_art_generations.get(&key);
         let required_orbs = i32::from(level.max(1));
         let funded_orbs = generation.map(|state| state.funded_orbs).unwrap_or(0);
-        let status = generation
-            .map(|state| state.status.clone())
-            .unwrap_or_else(|| "available".to_string());
+        let status =
+            generation.map_or_else(|| "available".to_string(), |state| state.status.clone());
         let provider_attempts = generation
             .map(|state| state.provider_attempts)
             .unwrap_or_default();
-        let retryable_without_orbs = funded_orbs >= required_orbs
-            && match status.as_str() {
-                "review_failed" | "review_unavailable" | "reviewing" => true,
-                "funded" | "generating" | "failed" | "rejected" | "policy_rejected" => {
-                    provider_attempts < MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
-                }
-                _ => false,
-            };
+        let generation_profile_version = community_art_generation_profile_version(subject_kind);
+        let retryable_without_orbs = generation.is_some_and(|state| {
+            community_art_generation_retryable_for_profile(state, false, generation_profile_version)
+        });
         if status == "ready" {
             card.image_url = Some(community_art_image_url(
                 subject_kind,
@@ -19694,7 +19693,7 @@ impl RuntimeWorld {
             return Err("That card is not visible from here.".to_string());
         }
         let history_through_seq = self.world.next_event_seq.saturating_sub(1);
-        let history = self
+        let history_entries = self
             .event_log
             .iter()
             .rev()
@@ -19723,27 +19722,23 @@ impl RuntimeWorld {
             .collect::<Vec<_>>()
             .into_iter()
             .rev()
-            .collect::<Vec<_>>()
-            .join("; ");
-        let history = if history.is_empty() {
-            "newly arrived in the shared world".to_string()
-        } else {
-            history
-        };
-        let image_constraints = image_policy
-            .map(CommunityArtImagePolicy::prompt)
-            .unwrap_or("No words, logo, watermark, UI, gore, or photorealism.");
-        let prompt = compact_whitespace(&format!(
-            "Collectible card art for {kind} {name}, titled {title}. {blurb}. Authoritative level {level}. Canonical visual facts: {subject_details}. Let the image visibly remember this public history without adding text: {history}. Preserve the subject's established identity across later levels. {image_constraints}",
-            kind = subject_kind,
-            name = card.display_name,
-            title = card.title,
-            blurb = card.blurb,
-        ));
+            .collect::<Vec<_>>();
+        let history = community_art_prompt_history(subject_kind, &history_entries);
+        let prompt = build_community_art_prompt(
+            subject_kind,
+            &card.display_name,
+            &card.title,
+            &card.blurb,
+            level,
+            &subject_details,
+            &history,
+            image_policy,
+        );
         Ok(CommunityArtPlan {
             subject_kind: subject_kind.to_string(),
             subject_id,
             level,
+            generation_profile_version: community_art_generation_profile_version(subject_kind),
             required_orbs: i32::from(level.max(1)),
             history_through_seq,
             prompt,
@@ -26647,9 +26642,8 @@ async fn fund_community_image(
     let existing = runtime.community_art_generations.get(&key);
     let candidate_exists = community_art_candidate_exists(&state.generated_asset_dir, &plan);
     if existing.is_some_and(|generation| generation.funding_intent_ids.contains(intent_id)) {
-        let retry_generation = existing.is_some_and(|generation| {
-            community_art_generation_retryable(generation, candidate_exists)
-        });
+        let retry_generation = existing
+            .is_some_and(|generation| plan.generation_retryable(generation, candidate_exists));
         drop(runtime);
         if retry_generation {
             schedule_community_art_generation(&state, payload.actor_id, plan);
@@ -26669,7 +26663,7 @@ async fn fund_community_image(
     }
     if existing.is_some_and(|generation| {
         generation.funded_orbs >= generation.required_orbs
-            && !community_art_generation_retryable(generation, candidate_exists)
+            && !plan.generation_retryable(generation, candidate_exists)
     }) {
         return Json(ActionResponse {
             ok: false,
@@ -26738,7 +26732,7 @@ async fn fund_community_image(
     let fully_funded = runtime
         .community_art_generations
         .get(&key)
-        .is_some_and(|generation| community_art_generation_retryable(generation, candidate_exists));
+        .is_some_and(|generation| plan.generation_retryable(generation, candidate_exists));
     drop(runtime);
     if !events.is_empty() {
         broadcast_events(&state, &events);

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74572
+74566


### PR DESCRIPTION
## Summary
- replace the avatar/card location prompt with a landscape-only prefix while preserving the configured Mirquo style LoRA
- strip actor names and dialogue from location history while retaining environmental traces
- version location generation prompts so already-funded exhausted jobs can retry without another Orb

## Root cause
Production location prompts combined portrait/card/title language and actor dialogue with a landscape-only policy. Replicate outputs genuinely contained watermarks, then a person and fake text, and strict review correctly rejected them.

## Impact
Restores the Image Workshop path for location art and makes `location:181730:level:1` retryable without another Orb after deployment. Strict publication policy remains unchanged.

## Validation
- focused community art tests (10 passed)
- `npm run v2:rust:test` (545 passed)
- `npm run v2:check` (full smoke passed)
- `npm run check` (pre-push: 453 JS tests plus 545 Rust tests and architecture checks)
- `npm run check:version`
- `npm run v2:architecture`
- `git diff --check`

## Review checklist
- [x] Style LoRA remains enabled
- [x] Legacy journal and snapshot records default to prompt profile 1
- [x] No secrets, runtime files, or generated visual baselines