### PR TITLE
Make avatar item actions truthful

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -75,6 +75,7 @@ Official OpenRouter docs confirm the integration shape:
 - One user-paid action can benefit everyone present because the output is a public event.
 - Autonomous resident actions and swarm jobs use the server budget unless an admin explicitly runs them.
 - The client never decides Orb affordability, image eligibility, model access, combat outcomes, rewards, or inventory use.
+- Another avatar's held items remain absent until an authoritative successful Notice or explicit item speech records disclosure. The inspector renders only those disclosed items, and each item carries the server-computed request, trade, or theft actions that are valid for the current viewer; unknown holdings and invalid consent routes are never inferred in the browser.
 - Orbs may be debited only by the authoritative community-image funding route.
 - No raw OpenRouter key is ever written to logs, event payloads, screenshots, or analytics.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.201",
+  "version": "0.0.202",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.201",
+      "version": "0.0.202",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.201",
+  "version": "0.0.202",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.201"
+version = "0.0.202"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.201"
+version = "0.0.202"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2342,6 +2342,115 @@
     .avatar-controls button {
       min-height: 36px;
     }
+    .avatar-interactions {
+      display: grid;
+      gap: 8px;
+      border-top: 1px solid rgba(129, 255, 167, 0.18);
+      padding-top: 8px;
+    }
+    .avatar-action-strip,
+    .avatar-safety-strip,
+    .avatar-item-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .avatar-safety-strip {
+      padding-top: 6px;
+      border-top: 1px solid rgba(129, 255, 167, 0.12);
+    }
+    .avatar-icon-action.account-button {
+      min-height: 30px;
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 4px 7px;
+      font-size: 11px;
+      line-height: 1;
+    }
+    .avatar-icon-action .ui-icon {
+      width: 15px;
+      height: 15px;
+    }
+    .avatar-safety-strip .avatar-icon-action {
+      color: var(--dim);
+      border-color: rgba(129, 255, 167, 0.24);
+      background: transparent;
+    }
+    .avatar-known-items,
+    .nearby-keepsakes {
+      display: grid;
+      gap: 6px;
+    }
+    .avatar-items-label,
+    .nearby-keepsakes-label {
+      color: var(--amber);
+      font-size: 11px;
+      font-weight: 900;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .avatar-item-rail,
+    .nearby-keepsake-rail {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 7px;
+    }
+    .avatar-item-chip,
+    .nearby-keepsake-chip {
+      width: 50px;
+      min-width: 50px;
+      height: 50px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: var(--terminal-2);
+      color: var(--text);
+      padding: 3px;
+      overflow: hidden;
+    }
+    .avatar-item-chip:hover,
+    .avatar-item-chip[aria-expanded="true"],
+    .nearby-keepsake-chip:hover {
+      border-color: var(--amber);
+      box-shadow: 0 0 0 1px rgba(255, 211, 106, 0.2);
+    }
+    .avatar-item-art,
+    .nearby-keepsake-art {
+      width: 100%;
+      height: 100%;
+      display: grid;
+      place-items: center;
+      border-radius: 3px;
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: cover;
+    }
+    .avatar-item-art .ui-icon,
+    .nearby-keepsake-art .ui-icon {
+      width: 22px;
+      height: 22px;
+    }
+    .avatar-item-detail {
+      display: grid;
+      gap: 6px;
+      border: 1px solid rgba(255, 211, 106, 0.28);
+      border-radius: 5px;
+      background: rgba(255, 211, 106, 0.05);
+      padding: 7px;
+    }
+    .avatar-item-detail[hidden] {
+      display: none;
+    }
+    .avatar-item-detail strong {
+      color: var(--text);
+      font-size: 12px;
+    }
+    .avatar-item-detail small,
+    .avatar-items-empty {
+      color: var(--dim);
+      font-size: 11px;
+      line-height: 1.35;
+    }
     .avatar-offer {
       border-top: 1px solid rgba(129, 255, 167, 0.18);
       padding-top: 7px;
@@ -10297,23 +10406,69 @@
       )) || null;
     }
 
+    function itemActionForActor(kind, targetActorId, itemId) {
+      const actorKey = `actor:${Number(targetActorId || 0)}`;
+      const itemKey = `item:${Number(itemId || 0)}`;
+      return (actions || []).find((candidate) => {
+        if (String(candidate?.label || "").toLowerCase() !== kind) return false;
+        if (kind === "steal") {
+          return candidate?.focusKey === `theft:${Number(targetActorId || 0)}:${Number(itemId || 0)}`;
+        }
+        const focusKeys = candidate?.focusKeys || [];
+        return focusKeys.includes(actorKey) && focusKeys.includes(itemKey);
+      }) || null;
+    }
+
+    function avatarKnownItemsHtml(actor, giftRequests) {
+      if (!actor?.economy) return "";
+      const actorNumericId = Number(actor.id || 0);
+      const heldItems = Array.isArray(actor.economy.held_items) ? actor.economy.held_items : [];
+      if (!heldItems.length) {
+        return `<div class="avatar-known-items"><span class="avatar-items-label">known items</span><span class="avatar-items-empty">No carried keepsakes have been disclosed.</span></div>`;
+      }
+      const chips = [];
+      const details = [];
+      for (const held of heldItems) {
+        const itemId = Number(held.item_id || 0);
+        if (!itemId) continue;
+        const itemName = itemNameForId(itemId);
+        const itemCard = cardForItem(itemId) || {
+          display_name: itemName,
+          role: "item",
+          aspect: "square",
+        };
+        const image = cardImage(itemCard) || fallbackCardImage(itemCard);
+        const actionsAvailable = new Set(held.available_actions || []);
+        const existingRequest = giftRequests.find((request) => Number(request.item_id || 0) === itemId);
+        const actionButtons = [];
+        if (actionsAvailable.has("request")) {
+          actionButtons.push(`<button class="account-button avatar-icon-action" type="button" data-avatar-gift-request="${itemId}" data-avatar-id="${actorNumericId}"${existingRequest ? " disabled" : ""}>${iconSvg("request")}<span>${escapeHtml(existingRequest ? "requested" : "request")}</span></button>`);
+        }
+        if (actionsAvailable.has("trade") && itemActionForActor("trade", actorNumericId, itemId)) {
+          actionButtons.push(`<button class="account-button avatar-icon-action" type="button" data-avatar-item-action="trade" data-avatar-id="${actorNumericId}" data-avatar-item-id="${itemId}">${iconSvg("trade")}<span>trade</span></button>`);
+        }
+        if (actionsAvailable.has("steal") && itemActionForActor("steal", actorNumericId, itemId)) {
+          actionButtons.push(`<button class="account-button avatar-icon-action" type="button" data-avatar-item-action="steal" data-avatar-id="${actorNumericId}" data-avatar-item-id="${itemId}">${iconSvg("steal")}<span>steal</span></button>`);
+        }
+        chips.push(`<button class="avatar-item-chip" type="button" data-avatar-item-toggle="${itemId}" aria-expanded="false" aria-controls="avatar-item-detail-${actorNumericId}-${itemId}" aria-label="${escapeAttr(`Actions for ${itemName}`)}" title="${escapeAttr(itemName)}"><span class="avatar-item-art" aria-hidden="true" style="background-image:url('${escapeAttr(image)}')"></span></button>`);
+        const disposition = cleanEconomyText(held.disposition || "kept close");
+        const reason = cleanEconomyText(held.reason || "");
+        details.push(`<div class="avatar-item-detail" id="avatar-item-detail-${actorNumericId}-${itemId}" data-avatar-item-detail="${itemId}" hidden><strong>${escapeHtml(itemName)}</strong>${disposition || reason ? `<small>${escapeHtml([disposition, reason].filter(Boolean).join(" · "))}</small>` : ""}${actionButtons.length ? `<div class="avatar-item-actions">${actionButtons.join("")}</div>` : `<span class="avatar-items-empty">No action is available for this keepsake right now.</span>`}</div>`);
+      }
+      return `<div class="avatar-known-items"><span class="avatar-items-label">known items</span><div class="avatar-item-rail">${chips.join("")}</div>${details.join("")}</div>`;
+    }
+
     function actorSafetyPanelHtml(actor) {
       if (!actor || Number(actor.id || 0) === Number(actorId || 0)) return "";
       const actorNumericId = Number(actor.id || 0);
       const economyKnown = Boolean(actor?.economy);
       const giftAvailable = Boolean(transferActionForActor("give", actorNumericId));
-      const tradeAvailable = Boolean(transferActionForActor("trade", actorNumericId));
       const incoming = (state?.safety?.incoming_offers || [])
         .filter((offer) => Number(offer.offered_by_actor_id || 0) === actorNumericId);
       const outgoing = (state?.safety?.outgoing_offers || [])
         .filter((offer) => Number(offer.offered_to_actor_id || 0) === actorNumericId);
       const giftRequests = (state?.safety?.gift_auto_accepts || [])
         .filter((request) => Number(request.offered_by_actor_id || 0) === actorNumericId);
-      const giftRequestHtml = (actor?.economy?.held_items || []).map((held) => {
-        const itemId = Number(held.item_id || 0);
-        const existing = giftRequests.find((request) => Number(request.item_id || 0) === itemId);
-        return `<button class="account-button" type="button" data-avatar-gift-request="${itemId}" data-avatar-id="${actorNumericId}"${existing ? " disabled" : ""}>${escapeHtml(existing ? `${itemNameForId(itemId)} requested` : `request ${itemNameForId(itemId)}`)}</button>`;
-      }).join("");
       const offerHtml = [
         ...incoming.map((offer) => {
           const exchange = offer.requested_item_name ? ` for ${offer.requested_item_name}` : "";
@@ -10328,11 +10483,12 @@
       const blockVerb = actor.blocked_by_you ? "unblock" : "block";
       const noticeButton = economyKnown
         ? ""
-        : `<button class="account-button" type="button" data-avatar-notice="${actorNumericId}">notice</button>`;
-      const tradeButton = economyKnown
-        ? `<button class="account-button" type="button" data-avatar-transfer="trade" data-avatar-id="${actorNumericId}"${tradeAvailable ? "" : " disabled"}>offer trade</button>`
+        : `<button class="account-button avatar-icon-action" type="button" data-avatar-notice="${actorNumericId}">${iconSvg("notice")}<span>notice</span></button>`;
+      const giftButton = giftAvailable
+        ? `<button class="account-button avatar-icon-action" type="button" data-avatar-transfer="give" data-avatar-id="${actorNumericId}">${iconSvg("gift")}<span>gift</span></button>`
         : "";
-      return `${offerHtml}<div class="avatar-controls" aria-label="Controls for ${escapeAttr(actorLabel(actor))}">${noticeButton}<button class="account-button" type="button" data-avatar-transfer="give" data-avatar-id="${actorNumericId}"${giftAvailable ? "" : " disabled"}>offer gift</button>${tradeButton}${giftRequestHtml}<button class="account-button" type="button" data-avatar-safety="${muteVerb}" data-avatar-id="${actorNumericId}">${muteVerb}</button><button class="account-button" type="button" data-avatar-safety="${blockVerb}" data-avatar-id="${actorNumericId}">${blockVerb}</button><button class="account-button" type="button" data-avatar-report="${actorNumericId}">report</button></div>`;
+      const primaryActions = `${noticeButton}${giftButton}`;
+      return `${offerHtml}<div class="avatar-interactions" aria-label="Interactions with ${escapeAttr(actorLabel(actor))}">${primaryActions ? `<div class="avatar-action-strip">${primaryActions}</div>` : ""}${avatarKnownItemsHtml(actor, giftRequests)}<div class="avatar-safety-strip" aria-label="Safety controls"><button class="account-button avatar-icon-action" type="button" data-avatar-safety="${muteVerb}" data-avatar-id="${actorNumericId}">${iconSvg("mute")}<span>${muteVerb}</span></button><button class="account-button avatar-icon-action" type="button" data-avatar-safety="${blockVerb}" data-avatar-id="${actorNumericId}">${iconSvg("block")}<span>${blockVerb}</span></button><button class="account-button avatar-icon-action" type="button" data-avatar-report="${actorNumericId}">${iconSvg("report")}<span>report</span></button></div></div>`;
     }
 
     function actorEconomyPanelHtml(actor) {
@@ -10378,18 +10534,23 @@
         const itemName = itemNameForId(soughtItem.item_id);
         rows.push(economyRowHtml("seeks", economyItemSummaryHtml(itemName, soughtItemTags(soughtItem))));
       }
-      for (const heldItem of Array.isArray(economy.held_items) ? economy.held_items : []) {
-        const itemName = itemNameForId(heldItem.item_id);
-        const disposition = String(heldItem.disposition || "held").trim();
-        const dispositionLabel = {
-          attached: "treasured",
-          medicine: "medicine",
-          useful: "useful here",
-          tradeable: "open to trade",
-        }[disposition] || "kept close";
-        rows.push(economyRowHtml("carries", economyItemSummaryHtml(itemName, [dispositionLabel])));
-      }
       return `${rows.join("")}${actorSafetyPanelHtml(actor)}`;
+    }
+
+    function nearbyLocationPanelHtml(card) {
+      const subject = communityArtSubject(card);
+      if (subject?.kind !== "location" || Number(subject.id) !== Number(state?.location?.id || 0)) {
+        return "";
+      }
+      const nearby = (state?.exits || [])
+        .map((exit) => cardForLocation(Number(exit.destination_location_id || 0)))
+        .filter(Boolean);
+      if (!nearby.length) return "";
+      const chips = nearby.map((nearbyCard) => {
+        const image = cardImage(nearbyCard) || fallbackCardImage(nearbyCard);
+        return `<button class="nearby-keepsake-chip" type="button"${cardDataAttr(nearbyCard)} aria-label="${escapeAttr(`Open ${nearbyCard.display_name || "nearby location"} keepsake`)}" title="${escapeAttr(nearbyCard.display_name || "Nearby location")}"><span class="nearby-keepsake-art" aria-hidden="true" style="background-image:url('${escapeAttr(image)}')"></span></button>`;
+      }).join("");
+      return `<div class="nearby-keepsakes"><span class="nearby-keepsakes-label">nearby</span><div class="nearby-keepsake-rail">${chips}</div></div>`;
     }
 
     function openCardModal(card) {
@@ -10417,7 +10578,7 @@
       $("card-modal-keepsake").innerHTML = promise
         ? `<span>when kept close</span>${escapeHtml(promise)}`
         : "";
-      $("card-modal-economy").innerHTML = `${actorEconomyPanelHtml(actor)}${communityArtPanelHtml(card)}`;
+      $("card-modal-economy").innerHTML = `${actorEconomyPanelHtml(actor)}${nearbyLocationPanelHtml(card)}${communityArtPanelHtml(card)}`;
       openModal("card-modal", $("card-modal").querySelector(".card-close"));
       if (dialog) dialog.scrollTop = 0;
       const copy = dialog?.querySelector(".card-copy");
@@ -10461,6 +10622,12 @@
         train: "<circle cx='12' cy='12' r='8.5'/><circle cx='12' cy='12' r='4'/><path d='M12 3.5V7M20.5 12H17M12 20.5V17M3.5 12H7'/>",
         evolve: "<path d='M12 20V10M12 14c-4 0-6-2-6-6 4 0 6 2 6 6zM12 11c4 0 6-2 6-6-4 0-6 2-6 6z'/>",
         trade: "<path d='M4 8h14l-3-3M20 16H6l3 3'/>",
+        gift: "<path d='M4 10h16v10H4zM3 7h18v4H3zM12 7v13'/><path d='M12 7c-2.7 0-5-.7-5-2.3C7 3.5 8 3 9 3c1.6 0 2.5 1.5 3 4zM12 7c2.7 0 5-.7 5-2.3C17 3.5 16 3 15 3c-1.6 0-2.5 1.5-3 4z'/>",
+        request: "<path d='M5 5h14v10H9l-4 4z'/><path d='M9 9h6M12 6v6'/>",
+        steal: "<path d='M7 9V7a5 5 0 0 1 10 0v2M5 9h14l-1 11H6z'/><path d='M9 14h6'/>",
+        mute: "<path d='M4 10h4l5-4v12l-5-4H4zM17 9l4 6M21 9l-4 6'/>",
+        block: "<circle cx='12' cy='12' r='9'/><path d='M6 6l12 12'/>",
+        report: "<path d='M5 21V4h12l-2 4 2 4H5'/><path d='M9 16h6'/>",
         bank: "<path d='M12 3l8 4H4zM6 9v8M10 9v8M14 9v8M18 9v8M4 20h16'/>",
         craft: "<path d='M14.5 5.5l4 4M13 7l4-4 4 4-4 4zM4 20l9-9M3 17l4 4'/>",
         project: "<path d='M5 20V5h11l-2 3 2 3H5'/>",
@@ -12106,6 +12273,49 @@
         runAction(transferAction);
         return;
       }
+      const itemToggle = event.target.closest("[data-avatar-item-toggle]");
+      if (itemToggle) {
+        event.preventDefault();
+        event.stopPropagation();
+        const itemId = String(itemToggle.getAttribute("data-avatar-item-toggle") || "");
+        const controls = itemToggle.closest(".avatar-known-items");
+        if (!controls || !itemId) return;
+        const opening = itemToggle.getAttribute("aria-expanded") !== "true";
+        controls.querySelectorAll("[data-avatar-item-toggle]").forEach((button) => {
+          button.setAttribute("aria-expanded", String(opening && button === itemToggle));
+        });
+        controls.querySelectorAll("[data-avatar-item-detail]").forEach((detail) => {
+          detail.hidden = !(opening && detail.getAttribute("data-avatar-item-detail") === itemId);
+        });
+        return;
+      }
+      const itemActionControl = event.target.closest("[data-avatar-item-action]");
+      if (itemActionControl) {
+        event.preventDefault();
+        event.stopPropagation();
+        const kind = String(itemActionControl.getAttribute("data-avatar-item-action") || "");
+        const targetActorId = Number(itemActionControl.getAttribute("data-avatar-id") || 0);
+        const itemId = Number(itemActionControl.getAttribute("data-avatar-item-id") || 0);
+        const itemAction = itemActionForActor(kind, targetActorId, itemId);
+        if (!itemAction) {
+          setError("That item option is no longer available. The known items were refreshed.");
+          refresh().then(() => {
+            const updated = cardForActor(targetActorId);
+            if (updated) openCardModal(updated);
+          });
+          return;
+        }
+        if (kind === "trade" && Array.isArray(itemAction.choices)) {
+          const choice = itemAction.choices.find((candidate) => {
+            const [candidateActorId, , candidateItemId] = String(candidate?.value || "").split(":");
+            return Number(candidateActorId) === targetActorId && Number(candidateItemId) === itemId;
+          });
+          if (choice) itemAction.selectedChoice = choice.value;
+        }
+        closeCardModal();
+        runAction(itemAction);
+        return;
+      }
       const offerDecision = event.target.closest("[data-transfer-offer-decision]");
       if (offerDecision) {
         event.preventDefault();
@@ -12170,7 +12380,7 @@
         event.stopPropagation();
         const targetActorId = Number(report.getAttribute("data-avatar-report") || 0);
         const target = actorForId(targetActorId);
-        const controls = report.closest(".avatar-controls");
+        const controls = report.closest(".avatar-interactions, .avatar-controls");
         if (!controls || controls.querySelector("[data-avatar-report-form]")) return;
         report.hidden = true;
         controls.insertAdjacentHTML("beforeend", `<form class="avatar-report-form" data-avatar-report-form="${targetActorId}"><label for="avatar-report-reason-${targetActorId}">Why are you reporting ${escapeHtml(actorLabel(target))}?</label><input id="avatar-report-reason-${targetActorId}" name="reason" required maxlength="240" autocomplete="off"><button class="account-button" type="submit">send report</button></form>`);

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -34223,23 +34223,11 @@ async fn request_gift_auto_accept(
     ) {
         return client_actor_rejected_response();
     }
-    let valid = runtime
-        .actor_by_id(payload.actor_id)
-        .zip(runtime.actor_by_id(payload.offered_by_actor_id))
-        .zip(runtime.item_by_id(payload.item_id))
-        .is_some_and(|((recipient, holder), item)| {
-            recipient.id != holder.id
-                && RuntimeWorld::actor_can_act(recipient)
-                && RuntimeWorld::actor_can_act(holder)
-                && runtime.actor_control_mode(recipient.id).is_direct_input()
-                && runtime.actor_control_mode(holder.id).is_direct_input()
-                && recipient.location_id == holder.location_id
-                && item.holder_actor_id == holder.id
-                && !runtime.actors_blocked(recipient.id, holder.id)
-                && runtime.economy_known_by(recipient.id, holder.id)
-                && runtime.actor_can_receive_item(recipient, item.id)
-        });
-    if !valid {
+    if !runtime.gift_request_is_valid(
+        payload.actor_id,
+        payload.offered_by_actor_id,
+        payload.item_id,
+    ) {
         return action_offer_rejected(
             "That exact item and avatar are not available for a gift request.",
         );
@@ -42827,9 +42815,10 @@ mod tests {
         for contract in [
             "data-avatar-notice=",
             "nothing known yet",
-            "target_actor_id: targetActorId",
             "data-avatar-transfer=\"give\"",
-            "data-avatar-transfer=\"trade\"",
+            "data-avatar-item-toggle=",
+            "data-avatar-item-action=\"trade\"",
+            "data-avatar-item-action=\"steal\"",
             "data-avatar-safety=",
             "data-avatar-report=",
             "data-avatar-gift-request=",
@@ -65064,7 +65053,7 @@ mod tests {
             .item_by_id(HEARTH_TONIC_ITEM_ID)
             .expect("Hearth Tonic exists");
         assert!(runtime.resident_item_is_attached(RATI_ACTOR_ID, hearth_tonic));
-        let held_tonic = runtime.resident_held_item_view(rati, hearth_tonic);
+        let held_tonic = runtime.resident_held_item_view(rati, hearth_tonic, None);
         assert_eq!(held_tonic.disposition, "attached");
         assert!(held_tonic.reason.contains("first warm cup"));
 
@@ -65432,7 +65421,7 @@ mod tests {
             .item_by_id(WATCH_BELL_ITEM_ID)
             .expect("Watch Bell exists");
         assert!(!runtime.resident_item_is_attached(RATI_ACTOR_ID, watch_bell));
-        let held_watch = runtime.resident_held_item_view(rati, watch_bell);
+        let held_watch = runtime.resident_held_item_view(rati, watch_bell, None);
         assert_eq!(held_watch.disposition, "tradeable");
         assert!(held_watch.reason.contains("may trade Watch Bell"));
         runtime.world.tick = 20;
@@ -65488,7 +65477,7 @@ mod tests {
             .item_by_id(THREADBARE_MAP_SCRAP_ITEM_ID)
             .expect("Threadbare Map Scrap exists");
         assert!(runtime.resident_item_is_attached(RATI_ACTOR_ID, map));
-        let held_map = runtime.resident_held_item_view(rati, map);
+        let held_map = runtime.resident_held_item_view(rati, map, None);
         assert_eq!(held_map.disposition, "keepsake");
         assert!(held_map.reason.contains("mattered in a room moment"));
     }
@@ -65602,7 +65591,7 @@ mod tests {
         let old_oak = runtime
             .actor_by_id(OLD_OAK_TREE_ACTOR_ID)
             .expect("Old Oak remains present");
-        let held_story = runtime.resident_held_item_view(old_oak, story_button);
+        let held_story = runtime.resident_held_item_view(old_oak, story_button, None);
         assert_eq!(held_story.disposition, "attached");
         assert!(held_story.reason.contains("protects Story Button"));
         assert!(held_story.reason.contains("Hollow"));

--- a/v2/orchestrator-rust/src/transfers.rs
+++ b/v2/orchestrator-rust/src/transfers.rs
@@ -8,6 +8,29 @@ struct TransferOfferKey {
 }
 
 impl RuntimeWorld {
+    pub(super) fn gift_request_is_valid(
+        &self,
+        recipient_actor_id: u64,
+        offered_by_actor_id: u64,
+        item_id: u64,
+    ) -> bool {
+        self.actor_by_id(recipient_actor_id)
+            .zip(self.actor_by_id(offered_by_actor_id))
+            .zip(self.item_by_id(item_id))
+            .is_some_and(|((recipient, holder), item)| {
+                recipient.id != holder.id
+                    && Self::actor_can_act(recipient)
+                    && Self::actor_can_act(holder)
+                    && self.actor_control_mode(recipient.id).is_direct_input()
+                    && self.actor_control_mode(holder.id).is_direct_input()
+                    && recipient.location_id == holder.location_id
+                    && item.holder_actor_id == holder.id
+                    && !self.actors_blocked(recipient.id, holder.id)
+                    && self.economy_known_by(recipient.id, holder.id)
+                    && self.actor_can_receive_item(recipient, item.id)
+            })
+    }
+
     pub(super) fn has_actor_gift(&self, actor_id: u64) -> bool {
         self.actor_give_candidate(actor_id).is_some()
     }
@@ -420,6 +443,49 @@ mod tests {
             },
         );
         assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+    }
+
+    #[test]
+    fn disclosed_item_actions_never_offer_player_consent_for_inference_holders() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_transfer_test_actor(&mut runtime, 5000, "Request Viewer");
+        create_transfer_test_actor(&mut runtime, 5001, "Direct Holder");
+        for item in &mut runtime.world.items[..runtime.world.item_count] {
+            let holder_actor_id = match item.id {
+                STORY_BUTTON_ITEM_ID => Some(5001),
+                DEWBRIGHT_BUTTON_ITEM_ID => Some(RATI_ACTOR_ID),
+                _ => None,
+            };
+            if let Some(holder_actor_id) = holder_actor_id {
+                item.location_id = 0;
+                item.holder_actor_id = holder_actor_id;
+                item.held_since_tick = runtime.world.tick;
+            }
+        }
+        runtime.record_economy_disclosure(5000, 5001);
+        runtime.record_economy_disclosure(5000, RATI_ACTOR_ID);
+        let state = runtime.state_response(Some(5000), &AccessContext::default());
+        let actions_for = |actor_id, item_id| {
+            state
+                .actors
+                .iter()
+                .find(|actor| actor.id == actor_id)
+                .and_then(|actor| actor.resident_economy.as_ref())
+                .and_then(|economy| {
+                    economy
+                        .held_items
+                        .iter()
+                        .find(|item| item.item_id == item_id)
+                })
+                .map(|item| item.available_actions.clone())
+                .unwrap_or_default()
+        };
+        assert!(actions_for(5001, STORY_BUTTON_ITEM_ID)
+            .iter()
+            .any(|action| action == "request"));
+        assert!(actions_for(RATI_ACTOR_ID, DEWBRIGHT_BUTTON_ITEM_ID)
+            .iter()
+            .all(|action| action != "request"));
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -395,6 +395,7 @@ pub(super) struct ResidentHeldItemView {
     pub(super) disposition: String,
     pub(super) reason: String,
     pub(super) keep_score: i16,
+    pub(super) available_actions: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1344,6 +1345,7 @@ impl RuntimeWorld {
         &self,
         resident: CwActor,
         item: CwItem,
+        client_actor_id: Option<u64>,
     ) -> ResidentHeldItemView {
         let resident_name = self
             .actor_name(resident.id)
@@ -1400,11 +1402,35 @@ impl RuntimeWorld {
                 format!("{resident_name} may trade {item_name} for something more useful."),
             )
         };
+        let mut available_actions = Vec::new();
+        if let Some(viewer_actor_id) = client_actor_id {
+            if self.gift_request_is_valid(viewer_actor_id, resident.id, item.id) {
+                available_actions.push("request".to_string());
+            }
+            if self
+                .accepted_item_trade_candidates(viewer_actor_id)
+                .into_iter()
+                .any(|candidate| {
+                    candidate.target.id == resident.id && candidate.target_item.id == item.id
+                })
+            {
+                available_actions.push("trade".to_string());
+            }
+            if self
+                .default_theft_candidate(viewer_actor_id)
+                .is_some_and(|(target, candidate)| {
+                    target.id == resident.id && candidate.id == item.id
+                })
+            {
+                available_actions.push("steal".to_string());
+            }
+        }
         ResidentHeldItemView {
             item_id: item.id,
             disposition: disposition.to_string(),
             reason,
             keep_score,
+            available_actions,
         }
     }
 
@@ -1516,7 +1542,7 @@ impl RuntimeWorld {
         let held_items = held_items_raw
             .iter()
             .copied()
-            .map(|item| self.resident_held_item_view(resident, item))
+            .map(|item| self.resident_held_item_view(resident, item, client_actor_id))
             .collect();
         let desired_item_ids = self.resident_desired_item_ids(resident);
         let sought_item_ids = self.resident_sought_item_ids(resident);

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74566
+74555

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -2944,6 +2944,112 @@ async function main() {
     assert(JSON.stringify(result.giveKindsBeforeRename) === JSON.stringify(result.giveKindsAfterRename), `renaming display copy must not change semantic execution: ${JSON.stringify(result)}`);
   }
 
+  async function assertAvatarItemsUseDisclosureAndExactActions() {
+    const result = await page.evaluate(() => {
+      const previousState = state;
+      const previousActorId = actorId;
+      const previousActions = actions;
+      try {
+        actorId = 5000;
+        const itemCard = {
+          card_id: "known-brass-key",
+          display_name: "Keeper's Brass Key",
+          role: "item",
+          aspect: "square",
+          image_url: "/known-brass-key.png",
+        };
+        state = {
+          location: { id: 1, name: "The Cosy Cottage" },
+          exits: [{ destination_location_id: 2, destination_location_name: "Rain-Soft Garden" }],
+          actors: [{ id: 5000, name: "Viewer" }],
+          items: [{ id: 9001, name: "Keeper's Brass Key", holder_actor_id: 5001 }],
+          safety: { incoming_offers: [], outgoing_offers: [], gift_auto_accepts: [] },
+          cards: {
+            actors: {},
+            items: { 9001: itemCard },
+            locations: {
+              1: { card_id: "cottage", display_name: "The Cosy Cottage", role: "location", aspect: "wide" },
+              2: { card_id: "garden", display_name: "Rain-Soft Garden", role: "location", aspect: "wide" },
+            },
+          },
+        };
+        actions = [{
+          label: "trade",
+          focusKeys: ["actor:5001", "item:9001"],
+        }, {
+          label: "steal",
+          focusKey: "theft:5002:9001",
+        }];
+        const renderPanel = (actor) => {
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = actorSafetyPanelHtml(actor);
+          return {
+            chips: wrapper.querySelectorAll("[data-avatar-item-toggle]").length,
+            requests: wrapper.querySelectorAll("[data-avatar-gift-request]").length,
+            trades: wrapper.querySelectorAll('[data-avatar-item-action="trade"]').length,
+            steals: wrapper.querySelectorAll('[data-avatar-item-action="steal"]').length,
+            notices: wrapper.querySelectorAll("[data-avatar-notice]").length,
+            safety: wrapper.querySelectorAll(".avatar-safety-strip [data-avatar-safety], .avatar-safety-strip [data-avatar-report]").length,
+            itemText: wrapper.querySelector(".avatar-item-detail")?.textContent.replace(/\s+/g, " ").trim() || "",
+          };
+        };
+        const direct = renderPanel({
+          id: 5001,
+          name: "Direct Holder",
+          control_mode: "direct_input",
+          economy: {
+            held_items: [{
+              item_id: 9001,
+              disposition: "tradeable",
+              reason: "The key was openly shown.",
+              available_actions: ["request", "trade"],
+            }],
+          },
+        });
+        const inference = renderPanel({
+          id: 5002,
+          name: "Resident Holder",
+          control_mode: "reactive_ai",
+          economy: {
+            held_items: [{
+              item_id: 9001,
+              disposition: "attached",
+              reason: "The key was noticed.",
+              available_actions: ["steal"],
+            }],
+          },
+        });
+        const unknown = renderPanel({
+          id: 5003,
+          name: "Unknown Holder",
+          control_mode: "reactive_ai",
+          economy: null,
+        });
+        const nearbyWrapper = document.createElement("div");
+        nearbyWrapper.innerHTML = nearbyLocationPanelHtml(state.cards.locations[1]);
+        return {
+          direct,
+          inference,
+          unknown,
+          nearby: {
+            chips: nearbyWrapper.querySelectorAll(".nearby-keepsake-chip").length,
+            target: nearbyWrapper.querySelector(".nearby-keepsake-chip")?.getAttribute("data-card-key") || "",
+          },
+        };
+      } finally {
+        state = previousState;
+        actorId = previousActorId;
+        actions = previousActions;
+      }
+    });
+    assert(result.direct.chips === 1 && result.direct.requests === 1 && result.direct.trades === 1, `a disclosed direct-player item should become one icon with exact consent actions: ${JSON.stringify(result)}`);
+    assert(result.inference.chips === 1 && result.inference.requests === 0 && result.inference.steals === 1, `an inference-held item must not expose the invalid direct-player request route: ${JSON.stringify(result)}`);
+    assert(result.unknown.chips === 0 && result.unknown.requests === 0 && result.unknown.notices === 1, `unknown holdings must stay hidden behind Notice: ${JSON.stringify(result)}`);
+    assert(result.direct.safety === 3 && result.inference.safety === 3, `safety controls should stay separate from item actions: ${JSON.stringify(result)}`);
+    assert(result.direct.itemText.includes("Keeper's Brass Key") && !result.direct.itemText.includes("request Keeper's Brass Key"), `the item picker should keep names in the selected detail instead of giant verb buttons: ${JSON.stringify(result)}`);
+    assert(result.nearby.chips === 1 && result.nearby.target.includes("garden"), `current location details should expose adjacent keepsakes for image-workshop access: ${JSON.stringify(result)}`);
+  }
+
   async function assertDiscoverySettlementDoesNotSurfaceGrowAction() {
     const result = await page.evaluate(() => {
       const previousState = state;
@@ -8876,6 +8982,7 @@ async function main() {
   await assertKeepsakeLoadoutShapesSceneDeal();
   await assertCarriedDeckUsesWeightLanguage();
   await assertGiveTradeCanBeDrawnFromShuffledDeck();
+  await assertAvatarItemsUseDisclosureAndExactActions();
   await assertDiscoverySettlementDoesNotSurfaceGrowAction();
   await assertCharmSlotExpansionIsDemandDriven();
   await assertBondSurfacesAsCompactRelationshipAction();


### PR DESCRIPTION
## Summary
- render disclosed actor holdings as compact image-backed item chips with contextual request, trade, and steal actions
- keep unknown holdings absent and move per-item action validity into the server projection
- stop offering direct-player request consent against AI residents and keep safety controls separate
- expose adjacent location keepsakes so funded Image Workshop jobs can be reopened

## Root cause
The browser mapped every disclosed held item to `/actions/request-gift`, but that route intentionally supports only direct-player consent. Pip Thistle is a reactive AI resident, so every generated request button was invalid before it was clicked.

## Validation
- `npm run v2:check` (546 Rust tests plus normal/stress browser journeys and production-profile checks)
- `npm run check` via the pre-push hook
- `npm run check:version`
- `PYTHONPYCACHEPREFIX=/tmp/cosyworld-pycache npm run v2:syntax`
- `cargo fmt --all -- --check`
- `git diff --check`