### PR TITLE
Stop vision catch-all from burning paid art

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -77,6 +77,7 @@ Official OpenRouter docs confirm the integration shape:
 - The client never decides Orb affordability, image eligibility, model access, combat outcomes, rewards, or inventory use.
 - Another avatar's held items remain absent until an authoritative successful Notice or explicit item speech records disclosure. The inspector renders only those disclosed items, and each item carries the server-computed request, trade, or theft actions that are valid for the current viewer; unknown holdings and invalid consent routes are never inferred in the browser.
 - Orbs may be debited only by the authoritative community-image funding route.
+- The community-image vision gate may reject only concrete visible policy categories. An unspecified or style-only concern cannot discard a paid candidate or consume another provider attempt.
 - No raw OpenRouter key is ever written to logs, event payloads, screenshots, or analytics.
 
 ## Payment Modes

--- a/fly.lonelyforest.toml
+++ b/fly.lonelyforest.toml
@@ -32,6 +32,7 @@ primary_region = "sjc"
   COSYWORLD_REPLICATE_AVATAR_PROMPT_PREFIX = "MRQ, cozy storybook trading-card portrait"
   COSYWORLD_AI_PROVIDER = "openrouter"
   OPENROUTER_CHAT_MODEL = "openai/gpt-5.6-luna"
+  COSYWORLD_AI_VISION_MODEL = "openai/gpt-5-image-mini"
   OPENROUTER_REASONING_EFFORT = "none"
   RUST_LOG = "cosyworld_orchestrator=info,tower_http=warn"
 

--- a/fly.toml
+++ b/fly.toml
@@ -23,6 +23,7 @@ primary_region = "sjc"
   COSYWORLD_REPLICATE_AVATAR_LORA_INPUT = "lora_weights"
   COSYWORLD_REPLICATE_AVATAR_LORA_SCALE_INPUT = "lora_scale"
   COSYWORLD_REPLICATE_AVATAR_PROMPT_PREFIX = "MRQ, cozy storybook trading-card portrait"
+  COSYWORLD_AI_VISION_MODEL = "openai/gpt-5-image-mini"
   RUST_LOG = "cosyworld_orchestrator=info,tower_http=warn"
 
 # Required production secrets:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.202",
+  "version": "0.0.203",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.202",
+      "version": "0.0.203",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.202",
+  "version": "0.0.203",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -52,6 +52,8 @@ describe('deploy workflow', () => {
     const loraScaleInput = 'COSYWORLD_REPLICATE_AVATAR_LORA_SCALE_INPUT = "lora_scale"';
     const trigger =
       'COSYWORLD_REPLICATE_AVATAR_PROMPT_PREFIX = "MRQ, cozy storybook trading-card portrait"';
+    const visionModel =
+      'COSYWORLD_AI_VISION_MODEL = "openai/gpt-5-image-mini"';
 
     for (const config of [primaryFlyConfig, lonelyForestFlyConfig]) {
       expect(config).toContain(model);
@@ -59,6 +61,7 @@ describe('deploy workflow', () => {
       expect(config).toContain(loraInput);
       expect(config).toContain(loraScaleInput);
       expect(config).toContain(trigger);
+      expect(config).toContain(visionModel);
     }
   });
 });

--- a/v2/README.md
+++ b/v2/README.md
@@ -361,7 +361,7 @@ Optional overrides:
 ```sh
 COSYWORLD_AI_BASE_URL=https://api.openai.com/v1
 COSYWORLD_AI_PROVIDER=openrouter
-COSYWORLD_AI_VISION_MODEL=openai/gpt-5.6-luna
+COSYWORLD_AI_VISION_MODEL=openai/gpt-5-image-mini
 ```
 
 Server-side generative world content is separately controlled and defaults to

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.202"
+version = "0.0.203"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.202"
+version = "0.0.203"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -320,8 +320,7 @@ pub(crate) async fn request_image_policy_decision(
                                 "creature",
                                 "text",
                                 "logo",
-                                "watermark",
-                                "other"
+                                "watermark"
                             ]
                         }
                     },
@@ -335,7 +334,7 @@ pub(crate) async fn request_image_policy_decision(
         {
             "type": "text",
             "text": format!(
-                "Review this generated image against the following publication policy. Reject ambiguous silhouettes or marks rather than guessing they are harmless. Policy: {}",
+                "Review this generated image against the following publication policy. Reject only clearly visible listed violations; do not invent a catch-all violation or infer one from style alone. Policy: {}",
                 request.policy
             )
         },
@@ -385,7 +384,6 @@ fn parse_image_policy_decision(value: &str) -> Result<ImagePolicyDecision, Strin
         "text",
         "logo",
         "watermark",
-        "other",
     ];
     if raw
         .violations
@@ -903,6 +901,10 @@ mod tests {
         .is_err());
         assert!(parse_image_policy_decision(
             r#"{"allowed":false,"violations":[],"summary":"Nothing visible."}"#
+        )
+        .is_err());
+        assert!(parse_image_policy_decision(
+            r#"{"allowed":false,"violations":["other"],"summary":"An unspecified concern."}"#
         )
         .is_err());
     }

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -25,7 +25,7 @@ use crate::{
 
 pub(super) const MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS: u8 = 3;
 pub(super) const LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION: u8 = 1;
-pub(super) const LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION: u8 = 2;
+pub(super) const LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION: u8 = 3;
 pub(super) const LOCATION_LANDSCAPE_PROMPT_PREFIX: &str =
     "MRQ, cozy storybook landscape, wide environment establishing view";
 const COMMUNITY_ART_CANDIDATE_SCHEMA_VERSION: u8 = 1;


### PR DESCRIPTION
## Summary
- remove the unconstrained `other` violation from the image-policy classifier
- require concrete visible person/character/creature/text/logo/watermark violations
- pin both Fly tenants' image moderation to `openai/gpt-5-image-mini`
- require the deployment regression test to preserve that vision-model pin
- bump the location review profile so exhausted paid jobs reopen without another Orb
- release as `0.0.203`

## Production evidence
Quiet Rise generated a clean 16:9 landscape with the Mirquo LoRA and landscape-only prompt. Gemini 3.1 Flash Lite rejected that clean candidate as `other`, then the job burned through the remaining provider attempts. A later candidate did contain a tiny generated signature and was correctly rejected as `watermark`; concrete checks therefore remain enforced.

OpenRouter's live model catalog reports `openai/gpt-5-image-mini` with image input plus `response_format` and `structured_outputs`, matching the existing strict-schema moderation request.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/cosyworld-pycache npm run v2:check` (546 Rust tests, production profile, normal/stress browser journeys)
- `npm test` (453 tests)
- `npx vitest run test/infrastructure/deploy-workflow.test.mjs` (3 tests)
- `npm run check` via the pre-push hook
- focused image-policy parser test
- focused exhausted paid-location profile retry test
- `cargo fmt --all -- --check`
- `npm run check:version`
- `git diff --check`

## Review checklist
- [x] Required local tests pass
- [x] Deployment profiles pin the same moderation model
- [x] No generated artifacts or secrets changed
- [x] Version is bumped and the branch is ready for CI