### PR TITLE
Give image moderation its own reasoning budget

### DIFF
--- a/fly.lonelyforest.toml
+++ b/fly.lonelyforest.toml
@@ -33,6 +33,7 @@ primary_region = "sjc"
   COSYWORLD_AI_PROVIDER = "openrouter"
   OPENROUTER_CHAT_MODEL = "openai/gpt-5.6-luna"
   COSYWORLD_AI_VISION_MODEL = "openai/gpt-5-image-mini"
+  COSYWORLD_AI_VISION_REASONING_EFFORT = "low"
   OPENROUTER_REASONING_EFFORT = "none"
   RUST_LOG = "cosyworld_orchestrator=info,tower_http=warn"
 

--- a/fly.toml
+++ b/fly.toml
@@ -24,6 +24,7 @@ primary_region = "sjc"
   COSYWORLD_REPLICATE_AVATAR_LORA_SCALE_INPUT = "lora_scale"
   COSYWORLD_REPLICATE_AVATAR_PROMPT_PREFIX = "MRQ, cozy storybook trading-card portrait"
   COSYWORLD_AI_VISION_MODEL = "openai/gpt-5-image-mini"
+  COSYWORLD_AI_VISION_REASONING_EFFORT = "low"
   RUST_LOG = "cosyworld_orchestrator=info,tower_http=warn"
 
 # Required production secrets:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.203",
+  "version": "0.0.204",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.203",
+      "version": "0.0.204",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.203",
+  "version": "0.0.204",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -54,6 +54,8 @@ describe('deploy workflow', () => {
       'COSYWORLD_REPLICATE_AVATAR_PROMPT_PREFIX = "MRQ, cozy storybook trading-card portrait"';
     const visionModel =
       'COSYWORLD_AI_VISION_MODEL = "openai/gpt-5-image-mini"';
+    const visionReasoning =
+      'COSYWORLD_AI_VISION_REASONING_EFFORT = "low"';
 
     for (const config of [primaryFlyConfig, lonelyForestFlyConfig]) {
       expect(config).toContain(model);
@@ -62,6 +64,7 @@ describe('deploy workflow', () => {
       expect(config).toContain(loraScaleInput);
       expect(config).toContain(trigger);
       expect(config).toContain(visionModel);
+      expect(config).toContain(visionReasoning);
     }
   });
 });

--- a/v2/README.md
+++ b/v2/README.md
@@ -362,6 +362,7 @@ Optional overrides:
 COSYWORLD_AI_BASE_URL=https://api.openai.com/v1
 COSYWORLD_AI_PROVIDER=openrouter
 COSYWORLD_AI_VISION_MODEL=openai/gpt-5-image-mini
+COSYWORLD_AI_VISION_REASONING_EFFORT=low
 ```
 
 Server-side generative world content is separately controlled and defaults to

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.203"
+version = "0.0.204"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.203"
+version = "0.0.204"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -7,6 +7,7 @@ pub(crate) const DEFAULT_OPENROUTER_CHAT_MODEL: &str = "openai/gpt-5.6-luna";
 pub(crate) const DEFAULT_OPENAI_CHAT_MODEL: &str = "openai/gpt-5.6-luna";
 pub(crate) const GENERATION_DEFAULT_MODE_ENV: &str = "COSYWORLD_GENERATION_DEFAULT_MODE";
 pub(crate) const GENERATION_FEATURE_MODES_ENV: &str = "COSYWORLD_GENERATION_FEATURE_MODES_JSON";
+const IMAGE_POLICY_MAX_TOKENS: u32 = 2_048;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) enum GenerationMode {
@@ -95,13 +96,14 @@ impl GenerationControls {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct AiConfig {
     pub(crate) api_key: String,
     pub(crate) base_url: String,
     pub(crate) model: String,
     pub(crate) vision_model: String,
     pub(crate) reasoning_effort: Option<String>,
+    pub(crate) vision_reasoning_effort: Option<String>,
 }
 
 impl AiConfig {
@@ -152,6 +154,13 @@ impl AiConfig {
             .flatten()
             .map(|effort| effort.trim().to_ascii_lowercase())
             .filter(|effort| !effort.is_empty());
+        let vision_reasoning_effort = std::env::var("COSYWORLD_AI_VISION_REASONING_EFFORT")
+            .ok()
+            .or_else(|| std::env::var("OPENROUTER_VISION_REASONING_EFFORT").ok())
+            .or_else(|| std::env::var("OPENAI_VISION_REASONING_EFFORT").ok())
+            .map(|effort| effort.trim().to_ascii_lowercase())
+            .filter(|effort| !effort.is_empty())
+            .or_else(|| reasoning_effort.clone());
 
         Some(Self {
             api_key,
@@ -159,6 +168,7 @@ impl AiConfig {
             model,
             vision_model,
             reasoning_effort,
+            vision_reasoning_effort,
         })
     }
 }
@@ -292,6 +302,7 @@ pub(crate) async fn request_chat_completion(
         request.referer,
         request.response_format,
         &config.model,
+        config.reasoning_effort.as_deref(),
     )
     .await
 }
@@ -349,12 +360,13 @@ pub(crate) async fn request_image_policy_decision(
         "You are a strict image publication gate. Inspect only visible pixels. Return the required JSON and no prose.",
         user_content,
         0.0,
-        120,
+        IMAGE_POLICY_MAX_TOKENS,
         request.timeout,
         request.max_attempts,
         request.referer,
         Some(&response_format),
         &config.vision_model,
+        config.vision_reasoning_effort.as_deref(),
     )
     .await?;
     parse_image_policy_decision(&completion.text).map_err(|message| AiGatewayError {
@@ -415,6 +427,7 @@ async fn request_completion(
     referer: &str,
     response_format: Option<&Value>,
     model: &str,
+    reasoning_effort: Option<&str>,
 ) -> Result<AiCompletion, AiGatewayError> {
     let started_at = Instant::now();
     let client = reqwest::Client::builder()
@@ -447,7 +460,7 @@ async fn request_completion(
                 payload["provider"] = json!({ "require_parameters": true });
             }
         }
-        if let Some(reasoning_effort) = config.reasoning_effort.as_deref() {
+        if let Some(reasoning_effort) = reasoning_effort {
             payload["reasoning"] = json!({ "effort": reasoning_effort });
         }
         let response = client
@@ -623,6 +636,7 @@ mod tests {
             model: "test-model".to_string(),
             vision_model: "test-vision-model".to_string(),
             reasoning_effort: None,
+            vision_reasoning_effort: None,
         };
         assert_eq!(
             ai_provider_name(Some(&config("https://openrouter.ai/api/v1"))),
@@ -733,6 +747,7 @@ mod tests {
             model: "test-model".to_string(),
             vision_model: "test-vision-model".to_string(),
             reasoning_effort: Some("none".to_string()),
+            vision_reasoning_effort: Some("low".to_string()),
         };
         let response_format = json!({
             "type": "json_schema",
@@ -784,6 +799,10 @@ mod tests {
                             .unwrap_or_default();
                         let correct_request = body.get("model").and_then(Value::as_str)
                             == Some("test-vision-model")
+                            && body.get("max_tokens").and_then(Value::as_u64)
+                                == Some(u64::from(IMAGE_POLICY_MAX_TOKENS))
+                            && body.pointer("/reasoning/effort").and_then(Value::as_str)
+                                == Some("low")
                             && body
                                 .pointer("/response_format/json_schema/name")
                                 .and_then(Value::as_str)
@@ -819,6 +838,7 @@ mod tests {
             model: "test-model".to_string(),
             vision_model: "test-vision-model".to_string(),
             reasoning_effort: None,
+            vision_reasoning_effort: Some("low".to_string()),
         };
 
         let decision = request_image_policy_decision(
@@ -870,6 +890,7 @@ mod tests {
             model: "test-model".to_string(),
             vision_model: "test-vision-model".to_string(),
             reasoning_effort: None,
+            vision_reasoning_effort: None,
         };
 
         let error = request_image_policy_decision(

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -129,6 +129,7 @@ async fn location_policy_preflight_uses_a_known_safe_capability_contract() {
         model: "test-model".to_string(),
         vision_model: "test-vision-model".to_string(),
         reasoning_effort: None,
+        vision_reasoning_effort: None,
     };
 
     preflight_community_art_policy(Some(&config), CommunityArtImagePolicy::LocationLandscape)
@@ -267,6 +268,7 @@ async fn location_policy_400_fails_before_orb_debit_or_replicate_schedule() {
         model: "test-model".to_string(),
         vision_model: "test-vision-model".to_string(),
         reasoning_effort: None,
+        vision_reasoning_effort: None,
     }));
     let (actor_session, _) = issue_actor_session(&state, 5000);
 
@@ -392,6 +394,7 @@ async fn policy_retry_reuses_the_saved_candidate_without_calling_replicate() {
         model: "test-model".to_string(),
         vision_model: "test-vision-model".to_string(),
         reasoning_effort: None,
+        vision_reasoning_effort: None,
     };
 
     let first = generate_and_store_community_art(

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -47421,7 +47421,7 @@ mod tests {
             base_url: format!("http://{address}"),
             model: "test-structured-model".to_string(),
             vision_model: "test-vision-model".to_string(),
-            reasoning_effort: None,
+            ..AiConfig::default()
         }));
         state.generation_controls = Arc::new(
             GenerationControls::from_values(


### PR DESCRIPTION
## Summary
- give vision requests a reasoning-effort override independent of the chat model
- run `openai/gpt-5-image-mini` moderation at `low` reasoning on both Fly tenants while ordinary chat remains at `none`
- increase the strict image-policy completion budget enough to accommodate mandatory GPT-5 reasoning and its JSON decision
- enforce the model and reasoning pins in the deployment regression test
- release as `0.0.204`

## Production evidence
After `0.0.203` deployed, Quiet Rise correctly reopened as fully funded and preserved the avatar's 5-Orb balance. Its live preflight then failed before Replicate with OpenRouter HTTP 400: `Reasoning is mandatory for this endpoint and cannot be disabled.` This patch separates vision reasoning from the existing chat setting and uses the provider-supported `low` effort.

## Validation
- `npm run check` via the successful pre-push hook
- 453 Vitest tests
- 546 Rust tests
- focused AI gateway module tests, including distinct chat `none` and vision `low` request payloads
- focused Fly deployment regression test
- isolated rerun of the unrelated SQLite race test after one transient setup failure
- worldpack, kernel, architecture, clippy ceiling, and syntax checks
- `npm run check:version`
- `git diff --check`

## Review checklist
- [x] Required local tests pass
- [x] Chat cost behavior remains unchanged
- [x] Both Fly tenants pin the same vision reasoning setting
- [x] No secrets or generated runtime artifacts changed
- [x] Version is bumped and ready for CI