### PR TITLE
Make image moderation request provider compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.204",
+  "version": "0.0.205",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.204",
+      "version": "0.0.205",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.204",
+  "version": "0.0.205",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.204"
+version = "0.0.205"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.204"
+version = "0.0.205"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -295,7 +295,7 @@ pub(crate) async fn request_chat_completion(
         request.feature,
         request.system,
         Value::String(request.user.to_string()),
-        request.temperature,
+        Some(request.temperature),
         request.max_tokens,
         request.timeout,
         request.max_attempts,
@@ -359,7 +359,7 @@ pub(crate) async fn request_image_policy_decision(
         request.feature,
         "You are a strict image publication gate. Inspect only visible pixels. Return the required JSON and no prose.",
         user_content,
-        0.0,
+        None,
         IMAGE_POLICY_MAX_TOKENS,
         request.timeout,
         request.max_attempts,
@@ -420,7 +420,7 @@ async fn request_completion(
     feature: &'static str,
     system: &str,
     user_content: Value,
-    temperature: f64,
+    temperature: Option<f64>,
     max_tokens: u32,
     timeout: Duration,
     max_attempts: u8,
@@ -449,9 +449,11 @@ async fn request_completion(
                 { "role": "system", "content": system },
                 { "role": "user", "content": user_content }
             ],
-            "temperature": temperature,
             "max_tokens": max_tokens
         });
+        if let Some(temperature) = temperature {
+            payload["temperature"] = json!(temperature);
+        }
         if let Some(response_format) = response_format {
             payload["response_format"] = response_format.clone();
             if response_format.get("type").and_then(Value::as_str) == Some("json_schema")
@@ -799,6 +801,7 @@ mod tests {
                             .unwrap_or_default();
                         let correct_request = body.get("model").and_then(Value::as_str)
                             == Some("test-vision-model")
+                            && body.get("temperature").is_none()
                             && body.get("max_tokens").and_then(Value::as_u64)
                                 == Some(u64::from(IMAGE_POLICY_MAX_TOKENS))
                             && body.pointer("/reasoning/effort").and_then(Value::as_str)

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -30,7 +30,7 @@ pub(super) const LOCATION_LANDSCAPE_PROMPT_PREFIX: &str =
     "MRQ, cozy storybook landscape, wide environment establishing view";
 const COMMUNITY_ART_CANDIDATE_SCHEMA_VERSION: u8 = 1;
 pub(super) const POLICY_PREFLIGHT_IMAGE_URL: &str =
-    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XqgWAAAAAElFTkSuQmCC";
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABAAQMAAACQp+OdAAAAA1BMVEUA/wA0XsCoAAAAD0lEQVQoz2NgGAWjgHwAAAJAAAGMxat3AAAAAElFTkSuQmCC";
 
 pub(super) fn legacy_community_art_generation_profile_version() -> u8 {
     LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use axum::{response::IntoResponse as _, routing::post, Router};
+use base64::Engine as _;
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     Arc,
@@ -17,6 +18,20 @@ fn test_art_config() -> ReplicateAvatarArtConfig {
         prompt_prefix: "cozy card art".to_string(),
         output_format: "png".to_string(),
     }
+}
+
+#[test]
+fn policy_preflight_fixture_is_a_real_sized_png() {
+    let encoded = POLICY_PREFLIGHT_IMAGE_URL
+        .strip_prefix("data:image/png;base64,")
+        .expect("preflight fixture is an inline PNG");
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .expect("preflight fixture decodes");
+    assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+    assert_eq!(&bytes[12..16], b"IHDR");
+    assert_eq!(u32::from_be_bytes(bytes[16..20].try_into().unwrap()), 64);
+    assert_eq!(u32::from_be_bytes(bytes[20..24].try_into().unwrap()), 64);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- omit sampling temperature from reasoning-based image moderation requests while preserving it for chat
- replace the 1×1 capability probe with a valid solid-green 64×64 PNG
- test both the exact vision payload shape and the PNG IHDR dimensions
- keep strict structured output, low reasoning, concrete policy categories, and fail-closed behavior intact
- release as `0.0.205`

## Production evidence
On live `0.0.204`, the prior mandatory-reasoning error disappeared, but OpenRouter still returned a scrubbed provider HTTP 400 during the known-safe preflight. The request still combined reasoning with `temperature: 0` and sent a 1×1 input image. Both are removed as provider incompatibilities before any Replicate call; the failed retry preserved the avatar's 5-Orb balance.

## Validation
- `npm run check` via the successful pre-push hook
- 453 Vitest tests
- 547 Rust tests
- focused image-policy request test asserting no temperature, low reasoning, strict schema, and sufficient output budget
- focused PNG fixture test asserting signature, IHDR, and 64×64 dimensions
- worldpack, kernel, architecture, clippy ceiling, and syntax checks
- `npm run check:version`
- `git diff --check`

## Review checklist
- [x] Required local tests pass
- [x] Chat sampling behavior remains unchanged
- [x] Strict/fail-closed moderation remains intact
- [x] No secrets or generated runtime artifacts changed
- [x] Version is bumped and ready for CI