### PR TITLE
Route advancement gates to reachable actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.205",
+      "version": "0.0.206",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -71428,7 +71428,7 @@ mod tests {
         match blocked_revision.dispatch {
             CommandDispatch::Disabled { status, output } => {
                 assert_eq!(status, 409);
-                assert!(output.contains("Earn advancement first"));
+                assert!(output.contains("one banked advancement point"));
             }
             other => panic!("unbanked bond revision should be disabled, got {other:?}"),
         }

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -207,6 +207,13 @@ pub(crate) fn normalize_command_text(input: &str) -> String {
         .join(" ")
 }
 
+const ADVANCEMENT_NEXT_STEP: &str =
+    "Try listen or study; a successful discovery banks advancement automatically.";
+
+fn advancement_gate_output(subject: &str) -> String {
+    format!("{subject} needs one banked advancement point. {ADVANCEMENT_NEXT_STEP}")
+}
+
 fn normalize_emote_message(input: &str) -> Option<String> {
     let mut content = normalize_human_message(input)?;
     let has_terminal_punctuation = content
@@ -2319,9 +2326,9 @@ impl RuntimeWorld {
                         action: Some(command_action("create_bond", "Chat", &chat_command)),
                         dispatch: CommandDispatch::Disabled {
                             status: 409,
-                            output: format!(
-                                "Earn advancement first, then Chat can begin a friendship with {target_name}."
-                            ),
+                            output: advancement_gate_output(&format!(
+                                "Chat with {target_name}"
+                            )),
                         },
                     });
                 }
@@ -2623,7 +2630,9 @@ impl RuntimeWorld {
                     verb,
                     action: None,
                     dispatch: CommandDispatch::Read {
-                        output: "That standalone progress command has retired. A successful Notice or Study records and settles earned advancement in the same action; older unsettled memories join that settlement once.".to_string(),
+                        output: format!(
+                            "That standalone progress command has retired. {ADVANCEMENT_NEXT_STEP}"
+                        ),
                     },
                 })
             }
@@ -2736,8 +2745,7 @@ impl RuntimeWorld {
                         action: Some(command_action("revise_calling", "Change Purpose", &payload.command)),
                         dispatch: CommandDispatch::Disabled {
                             status: 409,
-                            output: "Earn advancement first, then you can choose a new purpose."
-                                .to_string(),
+                            output: advancement_gate_output("Choosing a new purpose"),
                         },
                     });
                 }
@@ -2828,9 +2836,9 @@ impl RuntimeWorld {
                             )),
                             dispatch: CommandDispatch::Disabled {
                                 status: 409,
-                                output: format!(
-                                    "Earn advancement first, then you can grow closer to {target_name}."
-                                ),
+                                output: advancement_gate_output(&format!(
+                                    "Growing closer to {target_name}"
+                                )),
                             },
                         });
                     }
@@ -2859,8 +2867,9 @@ impl RuntimeWorld {
                         )),
                         dispatch: CommandDispatch::Disabled {
                             status: 409,
-                            output: "Earn advancement first, then you can see this friendship differently."
-                                .to_string(),
+                            output: advancement_gate_output(
+                                "Seeing this friendship differently",
+                            ),
                         },
                     });
                 }
@@ -3710,5 +3719,115 @@ impl RuntimeWorld {
             .into_iter()
             .find(|exit| exit.accessible)
             .map(|exit| exit.destination_location_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::create_test_human;
+
+    fn command_request(command: &str) -> CommandRequest {
+        CommandRequest {
+            actor_id: 5000,
+            actor_session: None,
+            command: command.to_string(),
+            wallet_address: None,
+            wallet: None,
+            wallet_session: None,
+            owned_card_ids: None,
+            cards: None,
+            envelope: None,
+        }
+    }
+
+    fn disabled_output(runtime: &RuntimeWorld, command: &str) -> String {
+        let resolved = runtime
+            .resolve_command(&command_request(command), &AccessContext::default())
+            .unwrap_or_else(|error| panic!("{command} should resolve: {error:?}"));
+        match resolved.dispatch {
+            CommandDispatch::Disabled { status, output } => {
+                assert_eq!(status, 409, "{command} should be advancement-gated");
+                output
+            }
+            other => panic!("{command} should be disabled, got {other:?}"),
+        }
+    }
+
+    fn assert_actionable_advancement_gate(output: &str) {
+        assert!(output.contains("one banked advancement point"));
+        assert!(output.contains("listen or study"));
+        assert!(output.contains("banks advancement automatically"));
+        assert!(!output.contains("Grow first"));
+    }
+
+    #[test]
+    fn zero_point_social_and_calling_gates_name_a_reachable_next_action() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "New Friend");
+        assert_eq!(runtime.advancement_points_available(5000), 0);
+
+        for command in [
+            "chat Rati",
+            "purpose I listen for odd jobs.",
+            "friendship Rati: I bring small kindnesses to Rati.",
+        ] {
+            assert_actionable_advancement_gate(&disabled_output(&runtime, command));
+        }
+
+        let friendship_id = bond_id(5000, RATI_ACTOR_ID);
+        runtime.bonds.insert(
+            friendship_id.clone(),
+            BondState {
+                id: friendship_id,
+                actor_id: 5000,
+                target_actor_id: RATI_ACTOR_ID,
+                statement: "I bring small kindnesses to Rati.".to_string(),
+                strength: 1,
+                status: "active".to_string(),
+                source_event_seq: Some(90_407),
+                updated_event_seq: Some(90_407),
+            },
+        );
+        assert_actionable_advancement_gate(&disabled_output(
+            &runtime,
+            "friendship Rati: I listen when Rati needs company.",
+        ));
+    }
+
+    #[test]
+    fn retired_growth_aliases_are_actionable_but_absent_from_help() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Journal Reader",
+        );
+
+        for command in ["grow", "bank"] {
+            let resolved = runtime
+                .resolve_command(&command_request(command), &AccessContext::default())
+                .unwrap_or_else(|error| panic!("{command} should resolve: {error:?}"));
+            match resolved.dispatch {
+                CommandDispatch::Read { output } => {
+                    assert!(output.contains("has retired"));
+                    assert!(output.contains("listen or study"));
+                    assert!(output.contains("banks advancement automatically"));
+                }
+                other => panic!("{command} should explain its retirement, got {other:?}"),
+            }
+        }
+
+        let help = runtime
+            .resolve_command(&command_request("help"), &AccessContext::default())
+            .expect("help should resolve");
+        match help.dispatch {
+            CommandDispatch::Read { output } => {
+                assert!(!output.contains(", grow"));
+                assert!(!output.contains(", bank"));
+            }
+            other => panic!("help should be read-only, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- replace advancement gates that merely say “Earn advancement” with one actionable contract
- name the required banked advancement point and reachable `listen` or `study` actions
- keep legacy `grow`/`bank` aliases as compatibility explanations while omitting them from help
- cover zero-point Chat, calling, bond creation/deepening, and bond revision paths

Closes #407

## Validation

- `cargo test --manifest-path v2/orchestrator-rust/Cargo.toml mud::tests` — 2 passed
- `npm run v2:rust:test` — 549 passed
- `npm run v2:architecture` — passed at the current main.rs and clippy warning ceilings
- `npm run check:version` — passed
- `git diff --check` — passed
- repository pre-push `npm run check` — 453 Node tests, worldpack/proof checks, C kernel checks, 549 Rust tests, architecture checks, and syntax checks all passed

## Compatibility

No journal, snapshot, schema, or command identifier changes. Retired `grow` and `bank` parser aliases remain readable for older clients.

## Review checklist

- [x] Issue acceptance paths have direct regression tests
- [x] Version bumped from 0.0.205 to 0.0.206
- [x] Generated/lock artifacts are limited to version metadata
- [x] No secrets or runtime files are included
