### PR TITLE
Hide offers for lapsed room actors

### DIFF
--- a/docs/actor-action-surface.md
+++ b/docs/actor-action-surface.md
@@ -17,6 +17,12 @@ checks, inventory rules, bonds, combat participation, evolution, or deed
 projection. Session ownership decides who may submit a direct choice; it is an
 authorization boundary, not an RPG rule.
 
+Actor-targeted offers and the room roster share one projection-visibility
+policy. A `direct_input` avatar whose presence has lapsed is absent from both;
+an offer issued while they were active fails closed if submitted after they
+leave. Present co-located avatars and inference-controlled residents remain
+targetable when the underlying world rule allows the action.
+
 Room-card reactions rotate through every present active avatar in stable card
 order. An inference controller may speak and update its own continuity. A
 generated line for a `direct_input` avatar is public proxy speech on that

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.205",
+      "version": "0.0.206",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -48,6 +48,64 @@ impl RuntimeWorld {
     }
 }
 
+impl RuntimeWorld {
+    pub(super) fn default_bondable_resident_with_presence(
+        &self,
+        actor_id: u64,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
+    ) -> Option<CwActor> {
+        let actor = self.actor_by_id(actor_id)?;
+        if self.advancement_points_available(actor_id) < usize::from(BOND_SLOT_COST) {
+            return None;
+        }
+        self.world.actors[..self.world.actor_count]
+            .iter()
+            .copied()
+            .find(|target| {
+                target.id != actor_id
+                    && Self::actor_can_act(*target)
+                    && target.location_id == actor.location_id
+                    && !self.actors_blocked(actor_id, target.id)
+                    && self.actor_visible_in_projection(
+                        *target,
+                        Some(actor_id),
+                        active_direct_actor_ids,
+                    )
+                    && self.active_bond(actor_id, target.id).is_none()
+            })
+    }
+
+    pub(super) fn validate_offer(
+        &self,
+        actor_id: u64,
+        access: &AccessContext,
+        submission: &ActionOfferSubmissionRequest,
+        active_direct_actor_ids: &BTreeSet<u64>,
+    ) -> Result<(), &'static str> {
+        self.validate_action_offer_submission_with_presence(
+            actor_id,
+            access,
+            submission,
+            Some(active_direct_actor_ids),
+        )
+    }
+
+    pub(super) fn actor_offer_target_visible(
+        &self,
+        actor: CwActor,
+        target: CwActor,
+        active_direct_actor_ids: &BTreeSet<u64>,
+    ) -> bool {
+        RuntimeWorld::actor_can_act(target)
+            && target.location_id == actor.location_id
+            && self.actor_visible_in_projection(
+                target,
+                Some(actor.id),
+                Some(active_direct_actor_ids),
+            )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,6 +256,194 @@ mod tests {
                     && item.holder_actor_id == 5001
                     && item.location_id == 0
             }));
+    }
+
+    #[tokio::test]
+    async fn lapsed_direct_avatar_offer_cannot_spend_advancement() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Bond Seeker",
+        );
+        create_test_human(
+            &mut runtime,
+            5001,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Visible Neighbor",
+        );
+        create_test_human(
+            &mut runtime,
+            5002,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Remaining Neighbor",
+        );
+        runtime.ledger_marks.insert(
+            "test:lapsed-offer-advancement".to_string(),
+            VisitLedgerMarkState {
+                id: "test:lapsed-offer-advancement".to_string(),
+                actor_id: 5000,
+                category: "witness".to_string(),
+                label: "Found a reason to grow".to_string(),
+                source_event_seq: runtime.world.next_event_seq,
+                banked: true,
+            },
+        );
+
+        let state = test_app_state(runtime, None);
+        let (seeker_session, _) = issue_actor_session(&state, 5000);
+        let (neighbor_session, _) = issue_actor_session(&state, 5001);
+        let (remaining_session, _) = issue_actor_session(&state, 5002);
+        assert_eq!(
+            ping_actor_session_for_actor(&state.actor_sessions, 5000, &seeker_session),
+            Some(false)
+        );
+        assert_eq!(
+            ping_actor_session_for_actor(&state.actor_sessions, 5001, &neighbor_session),
+            Some(false)
+        );
+        assert_eq!(
+            ping_actor_session_for_actor(&state.actor_sessions, 5002, &remaining_session),
+            Some(false)
+        );
+
+        let issued_offer = {
+            let active_direct_actor_ids = active_actor_ids_for_state(&state);
+            let runtime = state.inner.lock().await;
+            let projected = runtime.state_response_with_presence(
+                Some(5000),
+                &AccessContext::default(),
+                Some(&active_direct_actor_ids),
+                false,
+            );
+            assert!(projected.actors.iter().any(|actor| actor.id == 5001));
+            projected
+                .action_offers
+                .into_iter()
+                .find(|offer| {
+                    offer.kind == "create_bond"
+                        && offer
+                            .target
+                            .as_ref()
+                            .is_some_and(|target| target.id == Some(5001))
+                })
+                .expect("visible co-located direct avatar is a legal bond target")
+        };
+
+        assert!(mark_actor_session_inactive(
+            &state.actor_sessions,
+            5001,
+            &neighbor_session,
+        ));
+        {
+            let active_direct_actor_ids = active_actor_ids_for_state(&state);
+            let runtime = state.inner.lock().await;
+            let projected = runtime.state_response_with_presence(
+                Some(5000),
+                &AccessContext::default(),
+                Some(&active_direct_actor_ids),
+                false,
+            );
+            assert!(!projected.actors.iter().any(|actor| actor.id == 5001));
+            assert!(projected.actors.iter().any(|actor| actor.id == 5002));
+            assert!(!projected.action_offers.iter().any(|offer| {
+                offer
+                    .target
+                    .as_ref()
+                    .is_some_and(|target| target.kind == "actor" && target.id == Some(5001))
+            }));
+            let replacement_offer = projected
+                .action_offers
+                .iter()
+                .find(|offer| offer.kind == "create_bond")
+                .expect("same-kind bond offer survives for the remaining visible neighbor");
+            assert_eq!(
+                replacement_offer
+                    .target
+                    .as_ref()
+                    .and_then(|target| target.id),
+                Some(5002)
+            );
+            let replacement_option = projected
+                .primary_action
+                .options
+                .iter()
+                .find(|option| option.kind == "create_bond")
+                .expect("primary options retain the visible same-kind bond action");
+            assert_eq!(replacement_option.command, replacement_offer.command);
+            assert!(!replacement_option
+                .command
+                .to_ascii_lowercase()
+                .contains("visible neighbor"));
+            assert!(!projected
+                .primary_action
+                .command
+                .to_ascii_lowercase()
+                .contains("visible neighbor"));
+            assert!(!serde_json::to_string(&projected.primary_action)
+                .expect("primary action serializes")
+                .to_ascii_lowercase()
+                .contains("visible neighbor"));
+        }
+
+        let rejected_offer = submit_action_offer(
+            ConnectInfo("127.0.0.1:44136".parse().expect("client address")),
+            State(state.clone()),
+            Json(ActionOfferSubmissionRequest {
+                path: "/actions/create-bond".to_string(),
+                offer_id: issued_offer.offer_id,
+                composition_id: issued_offer.composition_id,
+                kind: issued_offer.kind,
+                rules_action: issued_offer.rules_action,
+                operation: issued_offer.operation,
+                rules_profile: issued_offer.rules_profile,
+                state_revision: issued_offer.state_revision,
+                route: issued_offer.route,
+                target: issued_offer.target,
+                cost: issued_offer.cost,
+                payload: serde_json::json!({
+                    "actor_id": 5000,
+                    "actor_session": seeker_session.clone(),
+                    "target_actor_id": 5001,
+                    "statement": "We always make room for each other."
+                }),
+            }),
+        )
+        .await
+        .0;
+        assert!(!rejected_offer.ok);
+        assert_eq!(rejected_offer.status, 409);
+        assert!(rejected_offer.events.iter().any(|event| {
+            event.type_name == "action.offer_rejected"
+                && event
+                    .content
+                    .as_deref()
+                    .is_some_and(|content| content.contains("offer expired"))
+        }));
+
+        let rejected_direct = create_bond(
+            ConnectInfo("127.0.0.1:44137".parse().expect("client address")),
+            State(state.clone()),
+            Json(ReviseBondRequest {
+                actor_id: 5000,
+                actor_session: Some(seeker_session),
+                target_actor_id: 5001,
+                statement: "We always make room for each other.".to_string(),
+            }),
+        )
+        .await
+        .0;
+        assert!(!rejected_direct.ok);
+        assert_eq!(rejected_direct.status, 409);
+        assert!(rejected_direct.events.is_empty());
+
+        let runtime = state.inner.lock().await;
+        assert_eq!(runtime.advancement_points_available(5000), 1);
+        assert!(runtime.active_bond(5000, 5001).is_none());
+        assert!(!runtime.event_log.iter().any(|event| {
+            event.type_name == "advancement.spent" && event.actor_id == Some(5000)
+        }));
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -34,6 +34,13 @@ fn submitted_offer_legacy_id(submission: &ActionOfferSubmissionRequest) -> Optio
     submission.offer_id.strip_prefix(&prefix)
 }
 
+fn action_offer_kind_requires_actor_target(kind: &str) -> bool {
+    matches!(
+        kind,
+        "chat" | "influence" | "attack" | "defend" | "give_item" | "create_bond" | "resolve_bond"
+    )
+}
+
 fn offer_composition_matches_at_submitted_revision(
     offer: &RankedActionOffer,
     submission: &ActionOfferSubmissionRequest,
@@ -52,13 +59,28 @@ fn offer_composition_matches_at_submitted_revision(
 }
 
 impl RuntimeWorld {
+    #[cfg(test)]
     pub(super) fn validate_action_offer_submission(
         &self,
         actor_id: u64,
         access: &AccessContext,
         submission: &ActionOfferSubmissionRequest,
     ) -> Result<(), &'static str> {
-        let (_, offers) = self.legal_action_candidates(Some(actor_id), access);
+        self.validate_action_offer_submission_with_presence(actor_id, access, submission, None)
+    }
+
+    pub(super) fn validate_action_offer_submission_with_presence(
+        &self,
+        actor_id: u64,
+        access: &AccessContext,
+        submission: &ActionOfferSubmissionRequest,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
+    ) -> Result<(), &'static str> {
+        let (_, offers) = self.legal_action_candidates_with_presence(
+            Some(actor_id),
+            access,
+            active_direct_actor_ids,
+        );
         let exact_offer = offers
             .iter()
             .find(|offer| offer.offer_id == submission.offer_id);
@@ -180,17 +202,82 @@ impl RuntimeWorld {
         actor_id: Option<u64>,
         access: &AccessContext,
     ) -> (PrimaryAction, Vec<RankedActionOffer>) {
+        self.legal_action_candidates_with_presence(actor_id, access, None)
+    }
+
+    pub(super) fn legal_action_candidates_with_presence(
+        &self,
+        actor_id: Option<u64>,
+        access: &AccessContext,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
+    ) -> (PrimaryAction, Vec<RankedActionOffer>) {
         let mut primary_action = self.primary_action(actor_id, access);
-        let mut action_offers = self.ranked_action_offers(actor_id, access, &primary_action);
+        let mut action_offers =
+            self.ranked_action_offers(actor_id, access, &primary_action, active_direct_actor_ids);
+        action_offers.retain(|offer| {
+            if action_offer_kind_requires_actor_target(&offer.kind)
+                && !offer
+                    .target
+                    .as_ref()
+                    .is_some_and(|target| target.kind == "actor" && target.id.is_some())
+            {
+                return false;
+            }
+            let Some(target) = offer
+                .target
+                .as_ref()
+                .filter(|target| target.kind == "actor")
+            else {
+                return true;
+            };
+            target
+                .id
+                .and_then(|target_actor_id| self.actor_by_id(target_actor_id))
+                .is_some_and(|target_actor| {
+                    self.actor_visible_in_projection(
+                        target_actor,
+                        actor_id,
+                        active_direct_actor_ids,
+                    )
+                })
+        });
+
+        primary_action.options.retain_mut(|option| {
+            let Some(offer) = action_offers.iter().find(|offer| offer.kind == option.kind) else {
+                return false;
+            };
+            if option.kind == "create_bond" {
+                option.command = offer.command.clone();
+            }
+            true
+        });
         let primary_offer_kind = match primary_action.kind.as_str() {
             "travel" => "move",
             kind => kind,
         };
-        if let Some(offer) = action_offers
+        let selected_offer = action_offers
             .iter()
             .find(|offer| offer.kind == primary_offer_kind)
-        {
+            .or_else(|| action_offers.first());
+        if let Some(offer) = selected_offer {
+            if offer.kind != primary_offer_kind {
+                primary_action.kind = match offer.kind.as_str() {
+                    "move" => "travel",
+                    kind => kind,
+                }
+                .to_string();
+                primary_action.label = offer.verb.clone();
+                primary_action.disabled = offer.disabled;
+            }
             primary_action.command = offer.command.clone();
+        } else {
+            primary_action = PrimaryAction {
+                kind: "wait".to_string(),
+                label: "Wait".to_string(),
+                command: "wait".to_string(),
+                disabled: true,
+                options: Vec::new(),
+            };
         }
         for offer in &mut action_offers {
             offer.composition_trace.focused_encounter = actor_id
@@ -205,6 +292,7 @@ impl RuntimeWorld {
         actor_id: Option<u64>,
         access: &AccessContext,
         primary_action: &PrimaryAction,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> Vec<RankedActionOffer> {
         let Some(actor_id) = actor_id else {
             return vec![self.ranked_offer_from_parts(
@@ -263,8 +351,22 @@ impl RuntimeWorld {
                     .map(|action_id| self.contextual_action_contributions(actor_id, action_id))
                     .unwrap_or_default();
                 let rank = self.action_offer_rank_for_actor(&option.kind, actor_id);
-                let target = self.action_offer_target(&option.kind, actor_id, access);
-                let project = self.action_offer_project(&option.kind, &option.command, actor_id);
+                let target = self.action_offer_target(
+                    &option.kind,
+                    actor_id,
+                    access,
+                    active_direct_actor_ids,
+                );
+                let command = if option.kind == "create_bond" {
+                    target
+                        .as_ref()
+                        .and_then(|target| target.label.as_deref())
+                        .map(|label| format!("chat {label}"))
+                        .unwrap_or_else(|| option.command.clone())
+                } else {
+                    option.command.clone()
+                };
+                let project = self.action_offer_project(&option.kind, &command, actor_id);
                 let intention = action_offer_intention(&option.kind).to_string();
                 let verb = self.action_offer_verb(&option.kind, actor_id);
                 let label = self.action_offer_label(
@@ -284,9 +386,11 @@ impl RuntimeWorld {
                 );
                 let cost = self.action_offer_cost(&option.kind, actor_id);
                 let risk = self.action_offer_risk(&option.kind, actor_id);
-                let effect = self.action_offer_effect(&option.kind, actor_id);
+                let effect =
+                    self.action_offer_effect(&option.kind, actor_id, active_direct_actor_ids);
                 let progress = self.action_offer_progress(&option.kind, actor_id);
-                let claim_key = self.action_offer_claim_key(&option.kind, actor_id);
+                let claim_key =
+                    self.action_offer_claim_key(&option.kind, actor_id, active_direct_actor_ids);
                 let provider = self.action_offer_provider(
                     &option.kind,
                     actor_id,
@@ -306,11 +410,7 @@ impl RuntimeWorld {
                         source_card_instances.push(location_source);
                     }
                 }
-                let legacy_id = format!(
-                    "{}:{}",
-                    option.kind,
-                    normalize_command_text(&option.command)
-                );
+                let legacy_id = format!("{}:{}", option.kind, normalize_command_text(&command));
                 let offer_id = format!(
                     "{}:{}:{}",
                     active_content().manifest.rules_profile,
@@ -354,7 +454,7 @@ impl RuntimeWorld {
                     label,
                     accessible_label,
 
-                    command: option.command,
+                    command,
                     rank,
                     disabled: primary_action.disabled,
                     disabled_reason: primary_action
@@ -1136,6 +1236,7 @@ impl RuntimeWorld {
         kind: &str,
         actor_id: u64,
         access: &AccessContext,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
     ) -> Option<ActionTargetView> {
         let actor = self.actor_by_id(actor_id)?;
         match kind {
@@ -1298,14 +1399,13 @@ impl RuntimeWorld {
                         label: Some(exit.destination_location_name),
                     })
             }
-            "create_bond" => {
-                self.default_bondable_resident(actor_id)
-                    .map(|target| ActionTargetView {
-                        kind: "actor".to_string(),
-                        id: Some(target.id),
-                        label: self.actor_name(target.id),
-                    })
-            }
+            "create_bond" => self
+                .default_bondable_resident_with_presence(actor_id, active_direct_actor_ids)
+                .map(|target| ActionTargetView {
+                    kind: "actor".to_string(),
+                    id: Some(target.id),
+                    label: self.actor_name(target.id),
+                }),
             "resolve_bond" => self
                 .default_resolvable_bond(actor_id)
                 .map(|bond| ActionTargetView {
@@ -1416,7 +1516,12 @@ impl RuntimeWorld {
         }
     }
 
-    pub(super) fn action_offer_effect(&self, kind: &str, actor_id: u64) -> Option<String> {
+    pub(super) fn action_offer_effect(
+        &self,
+        kind: &str,
+        actor_id: u64,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
+    ) -> Option<String> {
         let actor = self.actor_by_id(actor_id)?;
         match kind {
             "chat" => self
@@ -1583,10 +1688,12 @@ impl RuntimeWorld {
                     format!("creates {output} from the two present keepsakes")
                 }
             }),
-            "create_bond" => self.default_bondable_resident(actor_id).and_then(|target| {
-                self.actor_name(target.id)
-                    .map(|name| format!("a friendship with {name} begins"))
-            }),
+            "create_bond" => self
+                .default_bondable_resident_with_presence(actor_id, active_direct_actor_ids)
+                .and_then(|target| {
+                    self.actor_name(target.id)
+                        .map(|name| format!("a friendship with {name} begins"))
+                }),
             "resolve_bond" => self.default_resolvable_bond(actor_id).and_then(|bond| {
                 self.actor_name(bond.target_actor_id)
                     .map(|name| format!("keeps what mattered with {name}; leaves you something to remember"))
@@ -1667,7 +1774,12 @@ impl RuntimeWorld {
         }
     }
 
-    pub(super) fn action_offer_claim_key(&self, kind: &str, actor_id: u64) -> Option<String> {
+    pub(super) fn action_offer_claim_key(
+        &self,
+        kind: &str,
+        actor_id: u64,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
+    ) -> Option<String> {
         let actor = self.actor_by_id(actor_id)?;
         match kind {
             "chat" => None,
@@ -1706,7 +1818,7 @@ impl RuntimeWorld {
                 .map(|(target, item)| format!("theft:{}:{}:{}", actor_id, target.id, item.id)),
             "rest" => Some(tired_tag_id(actor_id)),
             "create_bond" => self
-                .default_bondable_resident(actor_id)
+                .default_bondable_resident_with_presence(actor_id, active_direct_actor_ids)
                 .map(|target| bond_id(actor_id, target.id)),
             "resolve_bond" => self
                 .default_resolvable_bond(actor_id)

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -19245,21 +19245,7 @@ impl RuntimeWorld {
     }
 
     fn default_bondable_resident(&self, actor_id: u64) -> Option<CwActor> {
-        let actor = self.actor_by_id(actor_id)?;
-        if self.advancement_points_available(actor_id) < usize::from(BOND_SLOT_COST) {
-            return None;
-        }
-        self.world.actors[..self.world.actor_count]
-            .iter()
-            .copied()
-            .find(|target| {
-                target.id != actor_id
-                    && Self::actor_can_act(*target)
-                    && target.location_id == actor.location_id
-                    && !self.actors_blocked(actor_id, target.id)
-                    && self.actor_visible_in_projection(*target, Some(actor_id), None)
-                    && self.active_bond(actor_id, target.id).is_none()
-            })
+        self.default_bondable_resident_with_presence(actor_id, None)
     }
 
     fn default_bond_command(&self, actor_id: u64) -> Option<String> {
@@ -26267,10 +26253,10 @@ async fn submit_action_offer(
         &state.wallet_sessions,
         state.allow_unsigned_wallet_claims,
     );
-    let validation = {
-        let runtime = state.inner.lock().await;
-        runtime.validate_action_offer_submission(actor_id, &access, &submission)
-    };
+    let active_direct_actors = active_actor_ids_for_state(&state);
+    let runtime = state.inner.lock().await;
+    let validation = runtime.validate_offer(actor_id, &access, &submission, &active_direct_actors);
+    drop(runtime);
     if let Err(reason) = validation {
         return action_offer_rejected(reason);
     }
@@ -35929,6 +35915,7 @@ async fn create_bond(
         });
     };
 
+    let active_direct_actors = active_actor_ids_for_state(&state);
     let mut runtime = state.inner.lock().await;
     if !client_actor_authorized_for_state(
         &runtime,
@@ -35959,8 +35946,7 @@ async fn create_bond(
         });
     };
     if target.id == actor.id
-        || !RuntimeWorld::actor_can_act(target)
-        || target.location_id != actor.location_id
+        || !runtime.actor_offer_target_visible(actor, target, &active_direct_actors)
         || runtime.actors_blocked(actor.id, target.id)
         || runtime
             .active_bond(payload.actor_id, payload.target_actor_id)

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -1779,7 +1779,11 @@ impl RuntimeWorld {
         let chat_bond_claimed_target_ids = client_actor_id
             .map(|id| self.chat_bond_claimed_target_ids(id, location_id))
             .unwrap_or_default();
-        let (primary_action, action_offers) = self.legal_action_candidates(client_actor_id, access);
+        let (primary_action, action_offers) = self.legal_action_candidates_with_presence(
+            client_actor_id,
+            access,
+            active_direct_actor_ids,
+        );
         let action_hand = compose_action_hand(&action_offers);
         let inspector = self.inspector_view(
             location_id,

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74555
+74541


### PR DESCRIPTION
## Summary
- remove lapsed direct-controlled actors from room roster projection while retaining inference-controlled and knocked-out residents
- filter actor-targeted offers against the same presence boundary used by the room projection
- retarget surviving bond offers and their primary-action command to a visible co-located actor
- reject stale offer and direct action submissions before advancement can be spent

Closes #368

## Root cause
Presence expiry was enforced by the roster projection, but ranked action offers and direct actor-targeted submissions still resolved against the raw room actor set. That allowed a lapsed direct avatar to remain actionable after disappearing from the visible room.

## Validation
- full repository pre-push hook: passed
- Node/Vitest: 453 passed
- worldpack compositions and strict proof world: passed
- C kernel: passed
- Rust: 548 passed
- architecture: `main.rs` 74541/74541; clippy 246/246 ceiling
- syntax, formatting, version, and diff checks: passed
- focused lapse regression plus primary-option compatibility tests: passed

## Compatibility
Snapshot and API shapes remain backward compatible. Presence filtering is applied only when the server supplies the active direct-actor set; legacy/test callers without presence context retain the previous projection behavior.

## Review checklist
- [x] actor presence and offer visibility share one rule
- [x] stale submissions fail before advancement spend
- [x] visible alternative bond targets are preserved and retargeted
- [x] non-actor primary-option labels and commands remain stable
- [x] package and Rust versions bumped together
