### PR TITLE
Submit room-feature offers through typed Use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.205",
+      "version": "0.0.206",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -26,4 +26,15 @@ describe("two-action browser hand", () => {
     expect(browser).toContain('event.type === "hand.shuffled"');
     expect(browser).toMatch(/function handCapacity\(\) \{\s+return 2;\s+\}/);
   });
+
+  it("submits room-feature Use offers through the typed item endpoint", () => {
+    const featureUseBlock = browser.slice(
+      browser.indexOf('if (options.has("use_feature"))'),
+      browser.indexOf("const routeExits"),
+    );
+    expect(featureUseBlock).toContain('action("/actions/use-item", {');
+    expect(featureUseBlock).toContain("location_id: currentLocationId");
+    expect(featureUseBlock).toContain("feature_key: featureKey");
+    expect(featureUseBlock).not.toContain("runCommandText(command)");
+  });
 });

--- a/v2/README.md
+++ b/v2/README.md
@@ -765,6 +765,11 @@ Dialogue prompts keep the latest 16 spoken lines per room in a bounded, snapshot
 - `POST /collection/unmaterialize`
 - `POST /commands`
 
+`POST /actions/use-item` accepts either an actor use (`item_id` plus
+`target_actor_id`) or an exact room-feature use (`item_id`, `location_id`, and
+`feature_key`). Both forms must match a current authoritative offer; typed
+clients never need to round-trip a `use_feature` offer through command prose.
+
 `POST /commands` is the canonical mutation gateway. New callers send the
 authenticated numeric actor handle plus the stable envelope advertised by
 `/state`:

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -10,6 +10,7 @@ fn submitted_payload_target(
         ("/actions/craft", "recipe") => "recipe_id",
         ("/actions/pick-up" | "/actions/drop", "item") => "item_id",
         ("/actions/trade-item" | "/actions/theft", "item") => "target_item_id",
+        ("/actions/use-item", "feature") => "location_id",
         (
             "/actions/chat"
             | "/actions/attack"
@@ -17,13 +18,40 @@ fn submitted_payload_target(
             | "/actions/create-bond"
             | "/actions/resolve-bond"
             | "/actions/cast-spell"
-            | "/actions/influence"
-            | "/actions/use-item",
+            | "/actions/influence",
             "actor",
         ) => "target_actor_id",
+        ("/actions/use-item", "actor") => "target_actor_id",
         _ => return None,
     };
     payload.get(key).and_then(serde_json::Value::as_u64)
+}
+
+fn submitted_feature_binding_matches(
+    offer: &RankedActionOffer,
+    payload: &serde_json::Value,
+) -> bool {
+    if offer.kind != "use_feature" {
+        return true;
+    }
+    let Some(rest) = offer.id.strip_prefix("use_feature:") else {
+        return false;
+    };
+    let mut parts = rest.splitn(3, ':');
+    let (Some(item_id), Some(location_id), Some(feature_key)) =
+        (parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    payload.get("item_id").and_then(serde_json::Value::as_u64) == item_id.parse::<u64>().ok()
+        && payload
+            .get("location_id")
+            .and_then(serde_json::Value::as_u64)
+            == location_id.parse::<u64>().ok()
+        && payload
+            .get("feature_key")
+            .and_then(serde_json::Value::as_str)
+            == Some(feature_key)
 }
 
 fn submitted_offer_legacy_id(submission: &ActionOfferSubmissionRequest) -> Option<&str> {
@@ -93,6 +121,8 @@ impl RuntimeWorld {
                 .is_some_and(|submitted| target.id != Some(submitted))
         }) {
             Err("submitted payload target does not match the authoritative offer")
+        } else if !submitted_feature_binding_matches(offer, &submission.payload) {
+            Err("submitted feature binding does not match the authoritative offer")
         } else if offer.project.as_ref().is_some_and(|project| {
             submission
                 .payload

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5493,7 +5493,12 @@
               modalTitle: `use ${item.name} with ${featureName}`,
               modalSummary: `See what ${item.name} awakens in ${featureName}.`,
               effect,
-              run: () => runCommandText(command),
+              run: () => action("/actions/use-item", {
+                actor_id: actorId,
+                item_id: item.id,
+                location_id: currentLocationId,
+                feature_key: featureKey,
+              }),
             });
           }
         }
@@ -6649,7 +6654,9 @@
       };
       if (path === "/actions/use-item") {
         const selected = actionCard?.selectedMode?.()?.source || actionCard;
-        return (selected?.offerKinds || []).filter((kind) => kind === "use_item");
+        return (selected?.offerKinds || []).filter((kind) => (
+          kind === "use_item" || kind === "use_feature"
+        ));
       }
       const explicitKinds = new Set(actionCard?.offerKinds || []);
       return (byPath[path] || []).filter((kind) => explicitKinds.has(kind));
@@ -6669,6 +6676,9 @@
           && targetKind === "actor") {
         return Number(payload.target_actor_id || 0);
       }
+      if (path === "/actions/use-item" && targetKind === "feature") {
+        return Number(payload.location_id || 0);
+      }
       return 0;
     }
 
@@ -6686,7 +6696,14 @@
           || Number(offer.target.id) === submittedTarget;
         const providerMatches = path !== "/actions/use-item"
           || offer?.provider?.id === `item:${Number(payload.item_id || 0)}`;
-        return contributionMatches && targetMatches && providerMatches;
+        const featureMatches = path !== "/actions/use-item"
+          || offer.kind !== "use_feature"
+          || String(offer.id || "").startsWith(
+            `use_feature:${Number(payload.item_id || 0)}:${Number(payload.location_id || 0)}:`
+          ) && String(offer.id || "").slice(
+            `use_feature:${Number(payload.item_id || 0)}:${Number(payload.location_id || 0)}:`.length
+          ) === String(payload.feature_key || "");
+        return contributionMatches && targetMatches && providerMatches && featureMatches;
       }) || null;
     }
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -131,6 +131,7 @@ use tokio_stream::{
 use topology::*;
 use tracing::{error, info, warn};
 use turns::*;
+use uses::*;
 use views::*;
 use world_causality::*;
 use world_simulation::*;
@@ -3507,6 +3508,16 @@ struct ItemRequest {
     item_id: u64,
     target_item_id: Option<u64>,
     target_actor_id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UseItemRequest {
+    actor_id: u64,
+    actor_session: Option<String>,
+    item_id: u64,
+    target_actor_id: Option<u64>,
+    location_id: Option<u64>,
+    feature_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -26193,7 +26204,7 @@ fn action_path_accepts_kind(path: &str, kind: &str) -> bool {
         "/actions/cast-spell" => kind == "cast_spell",
         "/actions/pick-up" => kind == "pick_up",
         "/actions/drop" => kind == "drop_item",
-        "/actions/use-item" => kind == "use_item",
+        "/actions/use-item" => matches!(kind, "use_item" | "use_feature"),
         "/actions/give-item" => kind == "give_item",
         "/actions/trade-item" => kind == "trade_item",
         "/actions/theft" => kind == "theft",
@@ -26369,7 +26380,7 @@ async fn submit_action_offer(
             use_item(
                 ConnectInfo(client_addr),
                 State(state),
-                Json(parsed!(ItemRequest)),
+                Json(parsed!(UseItemRequest)),
             )
             .await
         }
@@ -29376,12 +29387,13 @@ async fn command_inner(
             let Json(response) = use_item(
                 ConnectInfo(client_addr),
                 State(state),
-                Json(ItemRequest {
+                Json(UseItemRequest {
                     actor_id: payload.actor_id,
                     actor_session: payload.actor_session,
                     item_id,
-                    target_item_id: None,
                     target_actor_id: Some(target_actor_id),
+                    location_id: None,
+                    feature_key: None,
                 }),
             )
             .await;
@@ -29520,117 +29532,36 @@ async fn command_inner(
             feature_key,
             output,
         } => {
-            if !allow_actor_mutation(
+            let outcome = execute_feature_use_action(
                 &state,
                 client_addr,
                 payload.actor_id,
-                "action-actor",
-                GENERAL_ACTION_LIMIT,
-            ) {
-                return command_rate_limited_response_with_events(resolved, presence_events);
-            }
-            let mut runtime = state.inner.lock().await;
-            if !client_actor_authorized_for_state(
-                &runtime,
-                &state,
-                payload.actor_id,
                 payload.actor_session.as_deref(),
-            ) {
-                return Json(CommandResponse {
-                    ok: false,
-                    status: 403,
-                    command: resolved.command,
-                    verb: resolved.verb,
-                    output: Some(
-                        "Your avatar slipped out of reach. Begin again or reconnect your account."
-                            .to_string(),
-                    ),
-                    action: resolved.action,
-                    receipt: None,
-                    events: presence_events,
-                });
-            }
-            let candidate = match runtime.plan_feature_use_choice(
-                payload.actor_id,
                 item_id,
                 location_id,
                 &feature_key,
-            ) {
-                Ok(candidate) => candidate,
-                Err(reason) => {
-                    return Json(CommandResponse {
-                        ok: false,
-                        status: 409,
-                        command: resolved.command,
-                        verb: resolved.verb,
-                        output: Some(reason),
-                        action: resolved.action,
-                        receipt: None,
-                        events: presence_events,
-                    });
-                }
-            };
-            debug_assert_eq!(output, candidate.content);
-            let output = candidate.content.clone();
-            let mut record = JournalRecord::new(
-                CwAction {
-                    kind: CW_ACTION_NONE,
-                    actor_id: payload.actor_id,
-                    ..CwAction::default()
-                },
-                runtime.next_seed_value(),
             )
-            .into_player_card();
-            record.bind_offer_kind("use_feature");
-            record
-                .projection_mutations
-                .push(ProjectionMutation::UseFeature {
-                    item_id: candidate.item_id,
-                    location_id: candidate.location_id,
-                    feature_key: candidate.feature_key,
-                    content: candidate.content,
-                    reason: "use_feature".to_string(),
-                });
-            let Ok((status, mut events)) = commit_journal_record(&state, &mut runtime, record)
-            else {
-                return Json(CommandResponse {
-                    ok: false,
-                    status: 500,
-                    command: resolved.command,
-                    verb: resolved.verb,
-                    output: Some(
-                        "That choice got lost before the room could answer. Try once more."
-                            .to_string(),
-                    ),
-                    action: resolved.action,
-                    receipt: None,
-                    events: presence_events,
-                });
-            };
-            let ripple_reply_plan = advance_turn_and_capture_player_tick_observation(
-                &state,
-                &mut runtime,
-                Some(location_id),
-                payload.actor_id,
-                status,
-                &mut events,
-            );
-            drop(runtime);
-            broadcast_events(&state, &events);
-            if let Some(plan) = ripple_reply_plan {
-                schedule_player_tick_observation(&state, plan);
-            }
-            let response = ActionResponse {
-                ok: status == CW_OK && !events.is_empty(),
-                status: if events.is_empty() { 409 } else { status },
-                events,
-            };
-            command_action_response_with_prefix_and_events(
+            .await;
+            debug_assert!(outcome
+                .output
+                .as_deref()
+                .is_none_or(|value| value == output));
+            let success_output = outcome
+                .response
+                .ok
+                .then(|| outcome.output.clone())
+                .flatten();
+            let rejected_output = (!outcome.response.ok).then_some(outcome.output).flatten();
+            let mut response = command_action_response_with_prefix_and_events(
                 resolved,
-                response,
-                Some(output),
+                outcome.response,
+                success_output,
                 presence_events,
-            )
+            );
+            if let Some(output) = rejected_output {
+                response.0.output = Some(output);
+            }
+            response
         }
         CommandDispatch::GiveItem {
             item_id,
@@ -33583,8 +33514,31 @@ async fn drop_item(
 async fn use_item(
     ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
-    Json(payload): Json<ItemRequest>,
+    Json(payload): Json<UseItemRequest>,
 ) -> Json<ActionResponse> {
+    match (payload.location_id, payload.feature_key.as_deref()) {
+        (Some(location_id), Some(feature_key)) if payload.target_actor_id.is_none() => {
+            return Json(
+                execute_feature_use_action(
+                    &state,
+                    client_addr,
+                    payload.actor_id,
+                    payload.actor_session.as_deref(),
+                    payload.item_id,
+                    location_id,
+                    feature_key,
+                )
+                .await
+                .response,
+            );
+        }
+        (None, None) => {}
+        _ => {
+            return action_offer_rejected(
+                "Use needs either one avatar target or one exact room-feature binding.",
+            );
+        }
+    }
     if !allow_actor_mutation(
         &state,
         client_addr,
@@ -45604,10 +45558,7 @@ mod tests {
         ));
         assert!(!action_path_accepts_kind("/actions/explore-path", "search"));
         assert!(action_path_accepts_kind("/actions/use-item", "use_item"));
-        assert!(!action_path_accepts_kind(
-            "/actions/use-item",
-            "use_feature"
-        ));
+        assert!(action_path_accepts_kind("/actions/use-item", "use_feature"));
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/uses.rs
+++ b/v2/orchestrator-rust/src/uses.rs
@@ -25,6 +25,106 @@ enum UseOfferKey {
     },
 }
 
+pub(super) struct FeatureUseActionOutcome {
+    pub(super) response: ActionResponse,
+    pub(super) output: Option<String>,
+}
+
+pub(super) async fn execute_feature_use_action(
+    state: &AppState,
+    client_addr: SocketAddr,
+    actor_id: u64,
+    actor_session: Option<&str>,
+    item_id: u64,
+    location_id: u64,
+    feature_key: &str,
+) -> FeatureUseActionOutcome {
+    if !allow_actor_mutation(
+        state,
+        client_addr,
+        actor_id,
+        "action-actor",
+        GENERAL_ACTION_LIMIT,
+    ) {
+        return FeatureUseActionOutcome {
+            response: action_rate_limited_response().0,
+            output: None,
+        };
+    }
+    let mut runtime = state.inner.lock().await;
+    if !client_actor_authorized_for_state(&runtime, state, actor_id, actor_session) {
+        return FeatureUseActionOutcome {
+            response: ActionResponse {
+                ok: false,
+                status: 403,
+                events: Vec::new(),
+            },
+            output: None,
+        };
+    }
+    let candidate =
+        match runtime.plan_feature_use_choice(actor_id, item_id, location_id, feature_key) {
+            Ok(candidate) => candidate,
+            Err(reason) => {
+                return FeatureUseActionOutcome {
+                    response: action_offer_rejected(reason.clone()).0,
+                    output: Some(reason),
+                };
+            }
+        };
+    let output = candidate.content.clone();
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    )
+    .into_player_card();
+    record.bind_offer_kind("use_feature");
+    record
+        .projection_mutations
+        .push(ProjectionMutation::UseFeature {
+            item_id: candidate.item_id,
+            location_id: candidate.location_id,
+            feature_key: candidate.feature_key,
+            content: candidate.content,
+            reason: "use_feature".to_string(),
+        });
+    let Ok((status, mut events)) = commit_journal_record(state, &mut runtime, record) else {
+        return FeatureUseActionOutcome {
+            response: ActionResponse {
+                ok: false,
+                status: 500,
+                events: Vec::new(),
+            },
+            output: None,
+        };
+    };
+    let ripple_reply_plan = advance_turn_and_capture_player_tick_observation(
+        state,
+        &mut runtime,
+        Some(location_id),
+        actor_id,
+        status,
+        &mut events,
+    );
+    drop(runtime);
+    broadcast_events(state, &events);
+    if let Some(plan) = ripple_reply_plan {
+        schedule_player_tick_observation(state, plan);
+    }
+    FeatureUseActionOutcome {
+        response: ActionResponse {
+            ok: status == CW_OK && !events.is_empty(),
+            status: if events.is_empty() { 409 } else { status },
+            events,
+        },
+        output: Some(output),
+    }
+}
+
 impl RuntimeWorld {
     fn feature_use_matches(
         &self,
@@ -671,6 +771,115 @@ mod tests {
         );
         assert!(runtime
             .plan_use_item_offer_action(5000, &item_offer)
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn feature_offer_submits_through_typed_use_item_endpoint() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_use_test_actor(&mut runtime, 5000, "Typed Use Maker");
+        let story_button = runtime.world.items[..runtime.world.item_count]
+            .iter_mut()
+            .find(|item| item.id == STORY_BUTTON_ITEM_ID)
+            .expect("Story Button is seeded");
+        story_button.location_id = 0;
+        story_button.holder_actor_id = 5000;
+        story_button.held_since_tick = runtime.world.tick;
+        runtime.actor_autonomy.entry(5000).or_default().control_mode =
+            ActorControlMode::DirectInput;
+
+        let candidate = runtime
+            .default_player_feature_use_candidate(5000)
+            .expect("the held Story Button can target a room feature");
+        let offer = runtime
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| {
+                RuntimeWorld::use_offer_matches_feature(
+                    offer,
+                    candidate.item_id,
+                    candidate.location_id,
+                    &candidate.feature_key,
+                )
+            })
+            .expect("the exact room-feature offer is projected");
+        let state = test_app_state(runtime, None);
+        let (actor_session, _) = issue_actor_session(&state, 5000);
+
+        let forged_submission = ActionOfferSubmissionRequest {
+            path: "/actions/use-item".to_string(),
+            offer_id: offer.offer_id.clone(),
+            composition_id: offer.composition_id.clone(),
+            kind: offer.kind.clone(),
+            rules_action: offer.rules_action.clone(),
+            operation: offer.operation.clone(),
+            rules_profile: offer.rules_profile.clone(),
+            state_revision: offer.state_revision,
+            route: offer.route.clone(),
+            target: offer.target.clone(),
+            cost: offer.cost.clone(),
+            payload: serde_json::json!({
+                "actor_id": 5000,
+                "actor_session": actor_session,
+                "item_id": candidate.item_id,
+                "location_id": candidate.location_id,
+                "feature_key": "forged_feature"
+            }),
+        };
+        {
+            let runtime = state.inner.lock().await;
+            assert_eq!(
+                runtime.validate_action_offer_submission(
+                    5000,
+                    &AccessContext::default(),
+                    &forged_submission,
+                ),
+                Err("submitted feature binding does not match the authoritative offer")
+            );
+        }
+
+        let response = submit_action_offer(
+            ConnectInfo("127.0.0.1:44270".parse().expect("client address")),
+            State(state.clone()),
+            Json(ActionOfferSubmissionRequest {
+                path: "/actions/use-item".to_string(),
+                offer_id: offer.offer_id,
+                composition_id: offer.composition_id,
+                kind: offer.kind,
+                rules_action: offer.rules_action,
+                operation: offer.operation,
+                rules_profile: offer.rules_profile,
+                state_revision: offer.state_revision,
+                route: offer.route,
+                target: offer.target,
+                cost: offer.cost,
+                payload: serde_json::json!({
+                    "actor_id": 5000,
+                    "actor_session": actor_session,
+                    "item_id": candidate.item_id,
+                    "location_id": candidate.location_id,
+                    "feature_key": candidate.feature_key
+                }),
+            }),
+        )
+        .await
+        .0;
+        assert!(response.ok);
+        assert_eq!(response.status, CW_OK);
+        assert!(response.events.iter().any(|event| {
+            event.type_name == "item.used"
+                && event.actor_id == Some(5000)
+                && event.item_id == Some(STORY_BUTTON_ITEM_ID)
+        }));
+        let runtime = state.inner.lock().await;
+        assert!(runtime
+            .plan_feature_use_choice(
+                5000,
+                candidate.item_id,
+                candidate.location_id,
+                &candidate.feature_key,
+            )
             .is_err());
     }
 }

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74555
+74506


### PR DESCRIPTION
## Summary
- make `/actions/use-item` accept both actor-targeted item use and exact room-feature bindings
- submit browser `use_feature` cards through the typed action endpoint instead of command prose
- validate item, location, and feature-key identity against the authoritative offer before mutation
- share one journaled feature-use execution path between typed submissions and command compatibility

Closes #370

## Validation
- full pre-push `npm run check` passed
- 454/454 Node tests passed
- 548/548 Rust tests passed
- focused typed endpoint test proves forged feature-key rejection, one accepted `item.used` event, and offer consumption
- complete `npm run v2:check` passed, including desktop/mobile browser smoke, living-world stress, production profile, standalone compositions, CLI, kernel, architecture, and syntax
- architecture passed at `main.rs` 74,506/74,506 and clippy 246/246

## Compatibility
Existing actor-targeted `/actions/use-item` payloads are unchanged. The legacy `use_feature` command still routes through the same executor, while historical journal records retain their existing replay behavior.

## Checklist
- [x] package and Cargo versions bumped together
- [x] typed browser and server contracts documented
- [x] stale and forged offer bindings fail closed
- [x] full repository and browser validation passed