### PR TITLE
Allocate generated route identities safely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.207",
+  "version": "0.0.208",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.207",
+      "version": "0.0.208",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.206",
+  "version": "0.0.207",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.206",
+      "version": "0.0.207",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.206",
+  "version": "0.0.207",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.207",
+  "version": "0.0.208",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/core-pack-composition.test.mjs
+++ b/test/v2/core-pack-composition.test.mjs
@@ -155,6 +155,8 @@ describe("independently mountable CosyWorld Core", () => {
       }),
     ]);
     const frozen = result.snapshot.pack_mount_state.frozen["cosyworld.core"];
+    expect(frozen.removed_pack_ids).toEqual(["cosyworld.core"]);
+    expect(frozen.target_only_pack_ids).toEqual(["cosyworld.services-fixture"]);
     expect(frozen.arrays.world_items[0].value).toMatchObject({
       id: 2001,
       holder_actor_id: 1001,
@@ -581,6 +583,205 @@ describe("independently mountable CosyWorld Core", () => {
       active_rules_variants: ["variant/source"],
       active_rules_extensions: ["extension/source"],
     });
+  });
+
+  it("rejects an unmount target that removes an unrelated pack", () => {
+    const snapshot = {
+      worldpack_bundle_hash: coreRuby.manifest.bundle_hash,
+      world_actors: [],
+      world_items: [],
+      world_locations: [{ id: 1 }, { id: 11 }],
+      world_exits: [],
+    };
+    const before = structuredClone(snapshot);
+    expect(() => migratePackUnmount(
+      snapshot,
+      coreRuby,
+      "ruby-high.first-bell",
+      servicesOnly,
+    )).toThrow(/removes unrelated pack cosyworld\.core/);
+    expect(snapshot).toEqual(before);
+
+    const unrelatedAddition = structuredClone(coreOnly);
+    unrelatedAddition.manifest.packs.push({
+      id: "fixture.unrelated-world",
+      version: "1.0.0",
+      integrity: "sha256:fixture",
+      resource_counts: { actors: 1 },
+    });
+    expect(() => migratePackUnmount(
+      snapshot,
+      coreRuby,
+      "ruby-high.first-bell",
+      unrelatedAddition,
+    )).toThrow(/adds unrelated pack fixture\.unrelated-world/);
+    expect(snapshot).toEqual(before);
+  });
+
+  it("freezes and byte-stably remounts the owned generated route subgraph", () => {
+    const waypointId = 777_777;
+    const pathwayId = "generated-pathway:route://cosyworld.composition.core-ruby/authored/ruby|core@1";
+    const generatedRouteId = `${pathwayId}/route/0`;
+    const dynamicSnapshot = {
+      worldpack_bundle_hash: coreRuby.manifest.bundle_hash,
+      world_actors: [],
+      world_items: [],
+      world_locations: [{ id: 1 }, { id: 12 }, { id: 50 }, { id: waypointId }],
+      world_exits: [
+        { from_location_id: 1, to_location_id: 50 },
+        { from_location_id: 12, to_location_id: 50 },
+        { from_location_id: 12, to_location_id: waypointId },
+      ],
+      routes: {
+        "route:core": {
+          owner_pack_id: "cosyworld.core",
+          edges: [{ from_location_id: 1, to_location_id: 50 }],
+        },
+        "route:bridge": {
+          owner_pack_id: "cosyworld.composition.core-ruby",
+          edges: [{ from_location_id: 12, to_location_id: 50 }],
+        },
+        [generatedRouteId]: {
+          owner_pack_id: "cosyworld.composition.core-ruby",
+          edges: [{ from_location_id: 12, to_location_id: waypointId }],
+        },
+      },
+      generated_pathways: {
+        [pathwayId]: {
+          id: pathwayId,
+          canonical_id: pathwayId,
+          owner_pack_id: "cosyworld.composition.core-ruby",
+          owner_pack_version: "1.0.0",
+          origin_location_id: 12,
+          destination_location_id: 50,
+          waypoints: [{
+            id: waypointId,
+            canonical_id: `${pathwayId}/waypoint/0`,
+          }],
+        },
+      },
+      generated_places: {
+        [waypointId]: {
+          location_id: waypointId,
+          pathway_id: pathwayId,
+          pack_id: "cosyworld.composition.core-ruby",
+        },
+      },
+      location_names: { 1: "Cottage", 12: "Library", 50: "Trail", [waypointId]: "Bridge Verge" },
+      location_meta: { [waypointId]: { title: "Bridge Verge" } },
+      room_sheets: { [waypointId]: { location_id: waypointId } },
+      natural_affordances: { [waypointId]: { location_id: waypointId } },
+      clocks: { dynamic: { scope_id: waypointId } },
+      jobs: { dynamic: { location_ids: [waypointId] } },
+      governance_decisions: { dynamic: { location_id: waypointId } },
+      settlement_buildings: { dynamic: { location_id: waypointId } },
+      building_footprint_claims: { dynamic: { location_id: waypointId } },
+      loot_allocations: { dynamic: { location_id: waypointId } },
+      community_art_generations: {
+        dynamic: { subject_kind: "location", subject_id: waypointId },
+      },
+      canonical_identities: {
+        location_refs: { [waypointId]: `${pathwayId}/waypoint/0` },
+        entity_versions: { [`${pathwayId}/waypoint/0`]: 4 },
+      },
+      world_simulation: { locations: { [waypointId]: { weather: "rain" } }, factions: {} },
+      content_context: {
+        mapping_version: coreRuby.content_references.mapping_version,
+        references: coreRuby.content_references.entries,
+      },
+    };
+    const before = structuredClone(dynamicSnapshot);
+    const unmounted = migratePackUnmount(
+      dynamicSnapshot,
+      coreRuby,
+      "ruby-high.first-bell",
+      coreOnly,
+    );
+    expect(dynamicSnapshot).toEqual(before);
+    expect(unmounted.snapshot.world_locations).toEqual([{ id: 1 }, { id: 50 }]);
+    expect(unmounted.snapshot.generated_pathways).toEqual({});
+    expect(unmounted.snapshot.generated_places).toEqual({});
+    expect(unmounted.snapshot.routes).toEqual({
+      "route:core": before.routes["route:core"],
+    });
+    for (const field of [
+      "room_sheets",
+      "natural_affordances",
+      "clocks",
+      "jobs",
+      "governance_decisions",
+      "settlement_buildings",
+      "building_footprint_claims",
+      "loot_allocations",
+      "community_art_generations",
+    ]) expect(unmounted.snapshot[field], field).toEqual({});
+    expect(unmounted.snapshot.canonical_identities).toEqual({
+      location_refs: {},
+      entity_versions: {},
+    });
+
+    const frozen = unmounted.snapshot.pack_mount_state.frozen["ruby-high.first-bell"];
+    expect(frozen.removed_pack_ids).toEqual([
+      "ruby-high.first-bell",
+      "cosyworld.composition.core-ruby",
+    ]);
+    expect(frozen.target_only_pack_ids).toEqual([]);
+    expect(frozen.maps.generated_pathways).toHaveProperty(pathwayId);
+    expect(frozen.maps.generated_places).toHaveProperty(String(waypointId));
+    expect(frozen.maps.routes).toHaveProperty(generatedRouteId);
+    expect(frozen.canonical_identities.location_refs).toHaveProperty(String(waypointId));
+
+    const rehydrated = structuredClone(unmounted.snapshot);
+    Object.assign(
+      rehydrated.canonical_identities.entity_versions,
+      frozen.canonical_identities.entity_versions,
+    );
+    const conflicting = structuredClone(rehydrated);
+    const [conflictingRef, conflictingVersion] = Object.entries(
+      frozen.canonical_identities.entity_versions,
+    )[0];
+    conflicting.canonical_identities.entity_versions[conflictingRef] =
+      conflictingVersion + 1;
+    expect(() =>
+      migratePackRemount(
+        conflicting,
+        coreOnly,
+        "ruby-high.first-bell",
+        coreRuby,
+      )).toThrow(
+      new RegExp(
+        `canonical_identities\\.entity_versions identity ${conflictingRef}`,
+      ),
+    );
+
+    const remounted = migratePackRemount(
+      rehydrated,
+      coreOnly,
+      "ruby-high.first-bell",
+      coreRuby,
+    );
+    for (const field of [
+      "world_locations",
+      "world_exits",
+      "routes",
+      "generated_pathways",
+      "generated_places",
+      "location_names",
+      "location_meta",
+      "room_sheets",
+      "natural_affordances",
+      "clocks",
+      "jobs",
+      "governance_decisions",
+      "settlement_buildings",
+      "building_footprint_claims",
+      "loot_allocations",
+      "community_art_generations",
+      "canonical_identities",
+      "world_simulation",
+      "content_context",
+    ]) expect(remounted.snapshot[field], field).toEqual(before[field]);
+    expect(remounted.transaction.state_hash).toBe(unmounted.transaction.state_hash);
   });
 
   it("requires an exact quiescent journal checkpoint for durable CLI migration", () => {

--- a/test/v2/core-pack-composition.test.mjs
+++ b/test/v2/core-pack-composition.test.mjs
@@ -116,7 +116,22 @@ describe("independently mountable CosyWorld Core", () => {
         },
       },
       resident_continuities: { 1001: { resident_id: 1001 } },
-      resident_memories: { memory: { carrier_actor_id: 1001, kind: "item", subject_id: 2001, location_id: 3 } },
+      beliefs: {
+        memory: {
+          holder_actor_id: 1001,
+          kind: "item_location",
+          subject_id: 2001,
+          location_id: 3,
+        },
+      },
+      resident_memories: {
+        legacy: {
+          carrier_actor_id: 1001,
+          kind: "item_location",
+          subject_id: 2001,
+          location_id: 3,
+        },
+      },
       search_memories: { search: { actor_id: 5000, kind: "location", subject_id: 3, location_id: 3 } },
       tags: { tag: { scope_id: 3 } },
       world_simulation: { locations: { 3: {} }, factions: { hearthbound: {} } },
@@ -135,7 +150,7 @@ describe("independently mountable CosyWorld Core", () => {
     for (const field of ["world_evolution_tracks", "world_combat_encounters"]) {
       expect(result.snapshot[field]).toEqual([]);
     }
-    for (const field of ["actor_meta", "natural_affordances", "clocks", "jobs", "branches", "bonds", "resident_continuities", "resident_memories", "search_memories", "tags"]) {
+    for (const field of ["actor_meta", "natural_affordances", "clocks", "jobs", "branches", "bonds", "resident_continuities", "beliefs", "resident_memories", "search_memories", "tags"]) {
       expect(result.snapshot[field]).toEqual({});
     }
     expect(result.snapshot.world_simulation).toEqual({ locations: {}, factions: {} });
@@ -204,6 +219,7 @@ describe("independently mountable CosyWorld Core", () => {
       "branches",
       "bonds",
       "resident_continuities",
+      "beliefs",
       "resident_memories",
       "search_memories",
       "tags",

--- a/test/v2/core-ruby-composition.test.mjs
+++ b/test/v2/core-ruby-composition.test.mjs
@@ -124,6 +124,43 @@ describe("Core + Ruby High composition", () => {
     }
   });
 
+  it("rejects reciprocal authored exits with different owners", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cosyworld-route-owner-"));
+    const compiledRoot = path.join(tempRoot, "core-ruby");
+    try {
+      fs.cpSync(path.join(repoRoot, "v2/content/core-ruby"), compiledRoot, {
+        recursive: true,
+      });
+      const exitsPath = path.join(compiledRoot, "exits.json");
+      const registryPath = path.join(compiledRoot, "registry.json");
+      const exits = JSON.parse(fs.readFileSync(exitsPath, "utf8"));
+      const registryCopy = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+      const forward = exits.find((exit) =>
+        exit.pack_id === "cosyworld.core"
+          && exits.some((candidate) =>
+            candidate.pack_id === exit.pack_id
+              && candidate.from_location_id === exit.to_location_id
+              && candidate.to_location_id === exit.from_location_id));
+      const reverse = exits.find((exit) =>
+        exit.from_location_id === forward.to_location_id
+          && exit.to_location_id === forward.from_location_id);
+      reverse.pack_id = "ruby-high.first-bell";
+      registryCopy.resources.exits = exits;
+      fs.writeFileSync(exitsPath, `${JSON.stringify(exits, null, 2)}\n`);
+      fs.writeFileSync(registryPath, `${JSON.stringify(registryCopy, null, 2)}\n`);
+
+      const checked = spawnSync(process.execPath, [checkerPath, compiledRoot], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
+      expect(checked.status).not.toBe(0);
+      expect(checked.stderr).toContain("reciprocal exits between");
+      expect(checked.stderr).toContain("have different owners");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("rejects an evacuation destination that would disappear with its pack", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cosyworld-evacuation-policy-"));
     const compiledRoot = path.join(tempRoot, "core-ruby");

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -280,6 +280,18 @@ pinned `pack.lock.json` produces the same handles regardless of mount order.
 Duplicate canonical references, handles, legacy ids, missing pack versions, or
 non-canonical URI spellings fail before the listener opens.
 
+Runtime-generated pathways use the same ownership boundary. Their canonical
+identity binds the owning authored route identity and entity version; waypoint,
+segment-route, and generated-place identities derive from that pathway rather
+than discovery order or the discovering actor. Numeric waypoint handles occupy
+the reserved generated-location range and are derived directly from the
+canonical waypoint identity. A collision with authored or already-generated
+state fails closed instead of probing to an order-dependent replacement.
+Snapshot v12 and journal v11 records receive this identity backfill once;
+current-format persistence with missing identity fields is rejected. During the
+v12 snapshot upgrade, legacy `route:generated:*` keys are replaced by canonical
+segment keys without changing route lifecycle, discovery, or entity version.
+
 Snapshots, action-journal records, and stored world events now carry a
 `content_context` containing the mapping version, every relevant canonical
 reference, owning pack version, runtime handle, legacy id when applicable, and
@@ -304,6 +316,9 @@ frozen. The transaction changes the bundle, rules binding, canonical context,
 and mount revision atomically; on restart the runtime deterministically seeds
 the newly mounted entities and composition-owned paths without rewriting
 existing live state or identities.
+Soft unmount is the inverse: the removal set may contain only the requested
+pack and dependent composition bridges, retained pack identities cannot
+change, and a target cannot smuggle in an unrelated state-owning pack.
 
 A composition may declare a schema-version-1
 `pack_lifecycle.unmount` policy that moves every non-pack-owned occupant and
@@ -316,6 +331,11 @@ Without one unique policy, or while an occupant is in an active encounter,
 removes the pack-owned live projection and freezes the exact entities,
 item/card zones, projection maps, and canonical context in the snapshot's
 versioned `pack_mount_state`.
+This lifecycle scope includes the complete dynamically generated subgraph owned
+by a removed pack or composition bridge: pathway waypoints, segment routes,
+generated places, jobs, clocks, natural affordances, settlement/governance
+state, art state, and their canonical location identities. Remount restores
+that frozen subgraph byte-for-byte and rejects active identity collisions.
 Pending transfer offers that reference the pack become durable `invalidated`
 tombstones, and matching one-use gift policies become consumed; remount never
 revives either transient authorization. Every action composition certificate

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.206"
+version = "0.0.207"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.207"
+version = "0.0.208"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.206"
+version = "0.0.207"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.207"
+version = "0.0.208"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -105,7 +105,7 @@ mod tests {
                 _ => {}
             }
         }
-        runtime.observe_room_for_resident(RATI_ACTOR_ID, COSY_COTTAGE_LOCATION_ID);
+        runtime.observe_room_for_actor(RATI_ACTOR_ID, COSY_COTTAGE_LOCATION_ID);
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         assert_eq!(
             runtime
@@ -223,14 +223,14 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
-        runtime.resident_memories.clear();
-        runtime.remember_resident_memory(
+        runtime.beliefs.clear();
+        runtime.remember_belief(
             resident.id,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             sought_item_id,
             resident.location_id,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(resident.id),
         );
         let action = runtime

--- a/v2/orchestrator-rust/src/beliefs_tests.rs
+++ b/v2/orchestrator-rust/src/beliefs_tests.rs
@@ -1,0 +1,431 @@
+use super::*;
+
+#[test]
+fn beliefs_decay_with_time_before_autonomy() {
+    let mut runtime = RuntimeWorld::seeded();
+    runtime.world.tick = 1;
+    runtime.beliefs.clear();
+    for item in &mut runtime.world.items[..runtime.world.item_count] {
+        if item.id == STORY_BUTTON_ITEM_ID {
+            item.location_id = MOONLIT_TRAIL_LOCATION_ID;
+            item.holder_actor_id = 0;
+        }
+    }
+    runtime.remember_belief(
+        RATI_ACTOR_ID,
+        BELIEF_KIND_ITEM_LOCATION,
+        STORY_BUTTON_ITEM_ID,
+        MOONLIT_TRAIL_LOCATION_ID,
+        BELIEF_TUNING.firsthand_confidence,
+        BELIEF_TUNING.firsthand_salience,
+        Some(RATI_ACTOR_ID),
+    );
+    runtime.world.tick = 25;
+
+    runtime.decay_beliefs();
+
+    let memory_id = RuntimeWorld::belief_id(
+        RATI_ACTOR_ID,
+        BELIEF_KIND_ITEM_LOCATION,
+        STORY_BUTTON_ITEM_ID,
+    );
+    let memory = runtime
+        .beliefs
+        .get(&memory_id)
+        .expect("aged memory remains above zero");
+    assert_eq!(
+        memory.confidence,
+        BELIEF_TUNING.firsthand_confidence - (2 * BELIEF_TUNING.confidence_decay)
+    );
+    assert_eq!(
+        memory.salience,
+        BELIEF_TUNING.firsthand_salience - (2 * BELIEF_TUNING.salience_decay)
+    );
+    assert_eq!(memory.learned_tick, 25);
+}
+
+#[test]
+fn beliefs_expire_when_time_decay_exhausts_them() {
+    let mut runtime = RuntimeWorld::seeded();
+    runtime.world.tick = 1;
+    runtime.beliefs.clear();
+    runtime.remember_belief(
+        RATI_ACTOR_ID,
+        BELIEF_KIND_ITEM_LOCATION,
+        STORY_BUTTON_ITEM_ID,
+        MOONLIT_TRAIL_LOCATION_ID,
+        BELIEF_TUNING.minimum_action_confidence,
+        BELIEF_TUNING.salience_decay,
+        Some(RATI_ACTOR_ID),
+    );
+    runtime.world.tick = 13;
+
+    runtime.decay_beliefs();
+
+    let memory_id = RuntimeWorld::belief_id(
+        RATI_ACTOR_ID,
+        BELIEF_KIND_ITEM_LOCATION,
+        STORY_BUTTON_ITEM_ID,
+    );
+    assert!(runtime.beliefs.get(&memory_id).is_none());
+}
+
+#[test]
+fn legacy_search_and_resident_memories_migrate_into_canonical_beliefs() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Legacy Witness",
+    );
+    let mut snapshot = RuntimeSnapshot::from_runtime(&runtime);
+    snapshot.version = 13;
+    snapshot.beliefs.clear();
+    snapshot.resident_memories.insert(
+        "resident_memory:1001:item_location:2005".to_string(),
+        LegacyResidentMemoryState {
+            id: "resident_memory:1001:item_location:2005".to_string(),
+            carrier_actor_id: RATI_ACTOR_ID,
+            kind: BELIEF_KIND_ITEM_LOCATION.to_string(),
+            subject_id: STORY_BUTTON_ITEM_ID,
+            location_id: MOONLIT_TRAIL_LOCATION_ID,
+            confidence: 201,
+            salience: 190,
+            observed_tick: 7,
+            source_actor_id: Some(WHISKERWIND_ACTOR_ID),
+            holder_actor_id: Some(5000),
+            learned_tick: 11,
+            hops: 2,
+        },
+    );
+    snapshot.search_memories.insert(
+        "search_memory:5000:avatar:3:1002".to_string(),
+        LegacySearchMemoryState {
+            id: "search_memory:5000:avatar:3:1002".to_string(),
+            actor_id: 5000,
+            kind: "avatar".to_string(),
+            location_id: RAIN_SOFT_GARDEN_LOCATION_ID,
+            subject_id: WHISKERWIND_ACTOR_ID,
+            subject_key: WHISKERWIND_ACTOR_ID.to_string(),
+            confidence: 188,
+            salience: 177,
+            found_tick: 5,
+            last_used_tick: 9,
+            use_count: 3,
+        },
+    );
+    snapshot.search_memories.insert(
+        "search_memory:5000:hidden_exit:1:3".to_string(),
+        LegacySearchMemoryState {
+            id: "search_memory:5000:hidden_exit:1:3".to_string(),
+            actor_id: 5000,
+            kind: BELIEF_KIND_HIDDEN_EXIT.to_string(),
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            subject_id: MOONLIT_TRAIL_LOCATION_ID,
+            subject_key: "legacy-hidden-door-key-is-not-identity".to_string(),
+            confidence: 176,
+            salience: 165,
+            found_tick: 6,
+            last_used_tick: 10,
+            use_count: 2,
+        },
+    );
+    snapshot.search_memories.insert(
+        "search_memory:5000:seed_exit:3:2".to_string(),
+        LegacySearchMemoryState {
+            id: "search_memory:5000:seed_exit:3:2".to_string(),
+            actor_id: 5000,
+            kind: BELIEF_KIND_SEED_EXIT.to_string(),
+            location_id: MOONLIT_TRAIL_LOCATION_ID,
+            subject_id: RAIN_SOFT_GARDEN_LOCATION_ID,
+            subject_key: "legacy-seed-route-key-is-not-identity".to_string(),
+            confidence: 164,
+            salience: 153,
+            found_tick: 8,
+            last_used_tick: 12,
+            use_count: 4,
+        },
+    );
+
+    let restored = snapshot.into_runtime().expect("legacy beliefs migrate");
+    let resident_belief = restored
+        .beliefs
+        .get(&RuntimeWorld::belief_id(
+            RATI_ACTOR_ID,
+            BELIEF_KIND_ITEM_LOCATION,
+            STORY_BUTTON_ITEM_ID,
+        ))
+        .expect("resident memory becomes a belief");
+    assert_eq!(resident_belief.holder_actor_id, RATI_ACTOR_ID);
+    assert_eq!(resident_belief.related_actor_id, Some(5000));
+    assert_eq!(resident_belief.source_actor_id, Some(WHISKERWIND_ACTOR_ID));
+    assert_eq!(
+        (resident_belief.observed_tick, resident_belief.learned_tick),
+        (7, 11)
+    );
+    assert_eq!(resident_belief.hops, 2);
+
+    let search_belief = restored
+        .beliefs
+        .get(&RuntimeWorld::belief_id(
+            5000,
+            BELIEF_KIND_ACTOR_LOCATION,
+            WHISKERWIND_ACTOR_ID,
+        ))
+        .expect("search memory becomes the canonical kind");
+    assert_eq!(search_belief.kind, BELIEF_KIND_ACTOR_LOCATION);
+    assert_eq!(search_belief.source_actor_id, Some(5000));
+    assert_eq!(
+        (search_belief.observed_tick, search_belief.learned_tick),
+        (5, 9)
+    );
+
+    let migrated_exits = [
+        (
+            BELIEF_KIND_HIDDEN_EXIT,
+            COSY_COTTAGE_LOCATION_ID,
+            MOONLIT_TRAIL_LOCATION_ID,
+        ),
+        (
+            BELIEF_KIND_SEED_EXIT,
+            MOONLIT_TRAIL_LOCATION_ID,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+        ),
+    ];
+    for (kind, location_id, subject_id) in migrated_exits {
+        let belief_id = belief_id(5000, kind, subject_id, location_id, None);
+        let migrated = restored
+            .beliefs
+            .get(&belief_id)
+            .expect("legacy exit memory becomes a canonical belief");
+        assert_eq!(migrated.id, belief_id);
+        assert_eq!(migrated.kind, kind);
+        assert_eq!(migrated.location_id, location_id);
+        assert_eq!(migrated.subject_id, subject_id);
+    }
+
+    let current = serde_json::to_value(RuntimeSnapshot::from_runtime(&restored))
+        .expect("current snapshot serializes");
+    assert_eq!(current["version"], 14);
+    assert!(current.get("beliefs").is_some());
+    assert!(current.get("resident_memories").is_none());
+    assert!(current.get("search_memories").is_none());
+    for (kind, location_id, subject_id) in migrated_exits {
+        let belief_id = belief_id(5000, kind, subject_id, location_id, None);
+        let reserialized = &current["beliefs"][&belief_id];
+        assert_eq!(reserialized["id"], belief_id);
+        assert_eq!(reserialized["kind"], kind);
+        assert_eq!(reserialized["location_id"], location_id);
+        assert_eq!(reserialized["subject_id"], subject_id);
+    }
+}
+
+#[test]
+fn direct_and_inference_controllers_acquire_equivalent_firsthand_beliefs() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Direct Observer",
+    );
+    assert!(runtime.actor_control_mode(5000).is_direct_input());
+    assert!(runtime.actor_uses_inference(RATI_ACTOR_ID));
+    for item in &mut runtime.world.items[..runtime.world.item_count] {
+        if item.id == STORY_BUTTON_ITEM_ID {
+            item.location_id = COSY_COTTAGE_LOCATION_ID;
+            item.holder_actor_id = 0;
+        }
+    }
+    runtime.beliefs.clear();
+    runtime.world.tick = 41;
+
+    runtime.observe_room_for_actor(5000, COSY_COTTAGE_LOCATION_ID);
+    runtime.observe_room_for_actor(RATI_ACTOR_ID, COSY_COTTAGE_LOCATION_ID);
+
+    let direct = runtime
+        .beliefs
+        .get(&RuntimeWorld::belief_id(
+            5000,
+            BELIEF_KIND_ITEM_LOCATION,
+            STORY_BUTTON_ITEM_ID,
+        ))
+        .expect("direct controller observes the item");
+    let inferred = runtime
+        .beliefs
+        .get(&RuntimeWorld::belief_id(
+            RATI_ACTOR_ID,
+            BELIEF_KIND_ITEM_LOCATION,
+            STORY_BUTTON_ITEM_ID,
+        ))
+        .expect("inference controller observes the item");
+    assert_eq!(direct.kind, inferred.kind);
+    assert_eq!(direct.subject_id, inferred.subject_id);
+    assert_eq!(direct.location_id, inferred.location_id);
+    assert_eq!(direct.confidence, inferred.confidence);
+    assert_eq!(direct.salience, inferred.salience);
+    assert_eq!(direct.observed_tick, inferred.observed_tick);
+    assert_eq!(direct.learned_tick, inferred.learned_tick);
+    assert_eq!(direct.hops, inferred.hops);
+    assert_eq!(direct.source_actor_id, Some(direct.holder_actor_id));
+    assert_eq!(inferred.source_actor_id, Some(inferred.holder_actor_id));
+}
+
+#[test]
+fn unified_belief_projection_replays_byte_stably() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Replay Witness",
+    );
+    runtime.beliefs.clear();
+    for item in &mut runtime.world.items[..runtime.world.item_count] {
+        if item.id == STORY_BUTTON_ITEM_ID {
+            item.location_id = COSY_COTTAGE_LOCATION_ID;
+            item.holder_actor_id = 0;
+        }
+    }
+    runtime = RuntimeSnapshot::from_runtime(&runtime)
+        .into_runtime()
+        .expect("test setup normalizes through the snapshot boundary");
+    runtime.beliefs.clear();
+    let replay_base = RuntimeSnapshot::from_runtime(&runtime);
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            ..CwAction::default()
+        },
+        91_332,
+    );
+    record
+        .projection_mutations
+        .push(ProjectionMutation::RememberSearchItem {
+            item_id: STORY_BUTTON_ITEM_ID,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            reason: "belief_replay_test".to_string(),
+        });
+
+    assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+    let expected_choice = runtime
+        .actor_by_id(RATI_ACTOR_ID)
+        .and_then(|actor| runtime.resident_economy_autonomy_action(actor))
+        .expect("belief-driven resident choice");
+    let expected = serde_json::to_vec(&RuntimeSnapshot::from_runtime(&runtime))
+        .expect("expected snapshot serializes");
+    let mut replayed = replay_base.into_runtime().expect("replay base restores");
+    assert_eq!(replayed.apply_journal_record(&record).0, CW_OK);
+    let replayed_choice = replayed
+        .actor_by_id(RATI_ACTOR_ID)
+        .and_then(|actor| replayed.resident_economy_autonomy_action(actor))
+        .expect("replayed belief drives the same resident choice");
+    let actual = serde_json::to_vec(&RuntimeSnapshot::from_runtime(&replayed))
+        .expect("replayed snapshot serializes");
+    assert!(
+        actual == expected,
+        "replayed snapshot bytes differ (actual {}, expected {})",
+        actual.len(),
+        expected.len()
+    );
+    assert_eq!(replayed_choice.kind, expected_choice.kind);
+    assert_eq!(replayed_choice.actor_id, expected_choice.actor_id);
+    assert_eq!(replayed_choice.item_id, expected_choice.item_id);
+    assert_eq!(
+        replayed_choice.destination_location_id,
+        expected_choice.destination_location_id
+    );
+}
+
+#[test]
+fn direct_player_and_inference_actor_share_hearsay_decay_and_thresholds() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Listening Player",
+    );
+    assert!(runtime.actor_control_mode(5000).is_direct_input());
+    assert!(runtime.actor_uses_inference(RATI_ACTOR_ID));
+    runtime.beliefs.clear();
+    runtime.world.tick = 53;
+    runtime.remember_belief(
+        RATI_ACTOR_ID,
+        BELIEF_KIND_ITEM_LOCATION,
+        DEWBRIGHT_BUTTON_ITEM_ID,
+        RAIN_SOFT_GARDEN_LOCATION_ID,
+        BELIEF_TUNING.firsthand_confidence,
+        BELIEF_TUNING.firsthand_salience,
+        Some(RATI_ACTOR_ID),
+    );
+
+    runtime.exchange_beliefs_at(COSY_COTTAGE_LOCATION_ID);
+
+    let direct_belief_id =
+        RuntimeWorld::belief_id(5000, BELIEF_KIND_ITEM_LOCATION, DEWBRIGHT_BUTTON_ITEM_ID);
+    let inference_belief_id = RuntimeWorld::belief_id(
+        WHISKERWIND_ACTOR_ID,
+        BELIEF_KIND_ITEM_LOCATION,
+        DEWBRIGHT_BUTTON_ITEM_ID,
+    );
+    let hearsay = runtime
+        .beliefs
+        .get(&direct_belief_id)
+        .expect("direct player learns the co-located actor's belief")
+        .clone();
+    let inference_hearsay = runtime
+        .beliefs
+        .get(&inference_belief_id)
+        .expect("inference actor learns the same co-located belief")
+        .clone();
+    assert_eq!(hearsay.source_actor_id, Some(RATI_ACTOR_ID));
+    assert_eq!(hearsay.observed_tick, 53);
+    assert_eq!(hearsay.learned_tick, 53);
+    assert_eq!(hearsay.hops, 1);
+    assert_eq!(
+        hearsay.confidence,
+        BELIEF_TUNING.firsthand_confidence - BELIEF_TUNING.gossip_confidence_decay
+    );
+    assert_eq!(
+        hearsay.salience,
+        BELIEF_TUNING.firsthand_salience - BELIEF_TUNING.gossip_salience_decay
+    );
+    assert_eq!(inference_hearsay.kind, hearsay.kind);
+    assert_eq!(inference_hearsay.subject_id, hearsay.subject_id);
+    assert_eq!(inference_hearsay.location_id, hearsay.location_id);
+    assert_eq!(inference_hearsay.confidence, hearsay.confidence);
+    assert_eq!(inference_hearsay.salience, hearsay.salience);
+    assert_eq!(inference_hearsay.observed_tick, hearsay.observed_tick);
+    assert_eq!(inference_hearsay.learned_tick, hearsay.learned_tick);
+    assert_eq!(inference_hearsay.hops, hearsay.hops);
+
+    let steps_to_threshold = u64::from(
+        (hearsay.confidence - BELIEF_TUNING.minimum_action_confidence)
+            / BELIEF_TUNING.confidence_decay,
+    );
+    runtime.world.tick = 53 + steps_to_threshold * BELIEF_TUNING.decay_interval_ticks;
+    runtime.decay_beliefs();
+    for belief_id in [&direct_belief_id, &inference_belief_id] {
+        let belief = runtime
+            .beliefs
+            .get(belief_id)
+            .expect("belief remains at the shared action threshold");
+        assert_eq!(belief.confidence, BELIEF_TUNING.minimum_action_confidence);
+        assert!(runtime.belief_active(belief));
+    }
+
+    runtime.world.tick += BELIEF_TUNING.decay_interval_ticks;
+    runtime.decay_beliefs();
+    for belief_id in [&direct_belief_id, &inference_belief_id] {
+        let belief = runtime
+            .beliefs
+            .get(belief_id)
+            .expect("below-threshold belief remains available as weak context");
+        assert!(belief.confidence < BELIEF_TUNING.minimum_action_confidence);
+        assert!(!runtime.belief_active(belief));
+    }
+}

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -1062,9 +1062,9 @@ mod tests {
         runtime.remember_search_discovery(
             RATI_ACTOR_ID,
             from_location_id,
-            SEARCH_MEMORY_KIND_SEED_EXIT,
+            BELIEF_KIND_SEED_EXIT,
             to_location_id,
-            &seed_exit_search_memory_subject_key(from_location_id, to_location_id),
+            &seed_exit_belief_subject_key(from_location_id, to_location_id),
         );
     }
 

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -804,6 +804,8 @@ pub(super) struct SeedFeatureUseContent {
 
 #[derive(Clone, Debug, Deserialize)]
 pub(super) struct SeedExitContent {
+    #[serde(default)]
+    pub(super) pack_id: String,
     pub(super) from_location_id: u64,
     pub(super) to_location_id: u64,
     #[serde(default)]
@@ -816,6 +818,8 @@ pub(super) struct SeedExitContent {
 
 #[derive(Clone, Debug, Deserialize)]
 pub(super) struct SeedHiddenExitContent {
+    #[serde(default)]
+    pub(super) pack_id: String,
     pub(super) id: String,
     pub(super) from_location_id: u64,
     pub(super) to_location_id: u64,

--- a/v2/orchestrator-rust/src/crafting.rs
+++ b/v2/orchestrator-rust/src/crafting.rs
@@ -760,12 +760,19 @@ mod tests {
     fn test_generated_pathway(runtime: &RuntimeWorld, location_id: u64) -> GeneratedPathwayState {
         GeneratedPathwayState {
             id: "replay-pathway".to_string(),
+            identity_version: 0,
+            canonical_id: String::new(),
+            source_route_id: String::new(),
+            source_route_version: 0,
+            owner_pack_id: "cosyworld.core".to_string(),
+            owner_pack_version: runtime.active_pack_version("cosyworld.core"),
             origin_location_id: COSY_COTTAGE_LOCATION_ID,
             destination_location_id: location_id,
             distance: 1,
             created_by_actor_id: RATI_ACTOR_ID,
             waypoints: vec![GeneratedWaypointState {
                 id: location_id,
+                canonical_id: String::new(),
                 name: runtime.location_name(location_id).expect("location name"),
                 meta: runtime
                     .location_meta
@@ -1026,12 +1033,19 @@ mod tests {
 
         let pathway = GeneratedPathwayState {
             id: "test-pathway".to_string(),
+            identity_version: 0,
+            canonical_id: String::new(),
+            source_route_id: String::new(),
+            source_route_version: 0,
+            owner_pack_id: "cosyworld.core".to_string(),
+            owner_pack_version: runtime.active_pack_version("cosyworld.core"),
             origin_location_id: COSY_COTTAGE_LOCATION_ID,
             destination_location_id: location_id,
             distance: 1,
             created_by_actor_id: RATI_ACTOR_ID,
             waypoints: vec![GeneratedWaypointState {
                 id: location_id,
+                canonical_id: String::new(),
                 name: runtime.location_name(location_id).expect("location name"),
                 meta: runtime
                     .location_meta

--- a/v2/orchestrator-rust/src/generated_places.rs
+++ b/v2/orchestrator-rust/src/generated_places.rs
@@ -22,6 +22,8 @@ pub(super) struct GeneratedBuildingProposalState {
 pub(super) struct GeneratedPlaceState {
     pub(super) schema_version: u8,
     pub(super) location_id: u64,
+    #[serde(default)]
+    pub(super) canonical_id: String,
     pub(super) pathway_id: String,
     pub(super) connected_from_location_id: u64,
     pub(super) discovered_by_actor_id: u64,
@@ -211,14 +213,15 @@ impl RuntimeWorld {
         else {
             return;
         };
-        let pack_id = "cosyworld.core".to_string();
-        let pack_version = self.active_pack_version(&pack_id);
+        let pack_id = pathway.owner_pack_id.clone();
+        let pack_version = pathway.owner_pack_version.clone();
         let state =
             self.generated_places
                 .entry(location_id)
                 .or_insert_with(|| GeneratedPlaceState {
                     schema_version: GENERATED_PLACE_SCHEMA_VERSION,
                     location_id,
+                    canonical_id: waypoint.canonical_id.clone(),
                     pathway_id: pathway.id.clone(),
                     connected_from_location_id,
                     discovered_by_actor_id: pathway.created_by_actor_id,
@@ -235,12 +238,9 @@ impl RuntimeWorld {
                     building_proposal: None,
                 });
         state.schema_version = GENERATED_PLACE_SCHEMA_VERSION;
-        if state.pack_id.is_empty() {
-            state.pack_id = pack_id;
-        }
-        if state.pack_version.is_empty() {
-            state.pack_version = pack_version;
-        }
+        state.canonical_id = waypoint.canonical_id.clone();
+        state.pack_id = pack_id;
+        state.pack_version = pack_version;
         let state = state.clone();
         self.ensure_generated_place_projection(&state, &waypoint);
     }
@@ -460,6 +460,19 @@ impl RuntimeWorld {
         sheet.projects.extend(projects);
         sheet.projects.sort();
         sheet.projects.dedup();
+        for job_id in [
+            &state.anchor_job_id,
+            &state.connection_job_id,
+            &state.settlement_job_id,
+        ] {
+            if let Some(job) = self.jobs.get_mut(job_id) {
+                job.pack_id = state.pack_id.clone();
+                for strategy in &mut job.contribution_strategies {
+                    strategy.pack_id = state.pack_id.clone();
+                    strategy.pack_version = state.pack_version.clone();
+                }
+            }
+        }
     }
 
     fn reconcile_generated_place_durable_progress(&mut self, state: &GeneratedPlaceState) {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -5,6 +5,8 @@ mod actor_presence;
 mod actor_rules_facets;
 mod ai_gateway;
 mod avatar_identity;
+#[cfg(test)]
+mod beliefs_tests;
 mod canonical_journal;
 mod canonical_world;
 mod cards;
@@ -481,28 +483,40 @@ const RESIDENT_DESIRED_ITEM_SCORE: i16 = 100;
 const RESIDENT_ATTACHED_ITEM_SCORE: i16 = 120;
 const RESIDENT_USEFUL_ITEM_SCORE: i16 = 35;
 const RESIDENT_DEFAULT_ITEM_SCORE: i16 = 20;
-const RESIDENT_MEMORY_KIND_ITEM_LOCATION: &str = "item_location";
-const RESIDENT_MEMORY_KIND_ACTOR_LOCATION: &str = "actor_location";
-const RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM: &str = "actor_wants_item";
-const RESIDENT_MEMORY_CAPACITY: usize = 32;
-const RESIDENT_OBSERVED_MEMORY_CONFIDENCE: u8 = 240;
-const RESIDENT_OBSERVED_MEMORY_SALIENCE: u8 = 210;
-const RESIDENT_GOSSIP_CONFIDENCE_DECAY: u8 = 28;
-const RESIDENT_GOSSIP_SALIENCE_DECAY: u8 = 18;
-const RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE: u8 = 80;
-const RESIDENT_MEMORY_TIME_DECAY_INTERVAL_TICKS: u64 = 12;
-const RESIDENT_MEMORY_TIME_CONFIDENCE_DECAY: u8 = 6;
-const RESIDENT_MEMORY_TIME_SALIENCE_DECAY: u8 = 8;
-const SEARCH_MEMORY_KIND_SEED_EXIT: &str = "seed_exit";
-const SEARCH_MEMORY_KIND_HIDDEN_EXIT: &str = "hidden_exit";
-const SEARCH_MEMORY_KIND_AVATAR: &str = "avatar";
-const SEARCH_MEMORY_KIND_ITEM: &str = "item";
-const SEARCH_MEMORY_CONFIDENCE: u8 = 240;
-const SEARCH_MEMORY_SALIENCE: u8 = 220;
-const SEARCH_MEMORY_MIN_CONFIDENCE: u8 = 80;
-const SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS: u64 = 18;
-const SEARCH_MEMORY_TIME_CONFIDENCE_DECAY: u8 = 6;
-const SEARCH_MEMORY_TIME_SALIENCE_DECAY: u8 = 8;
+const BELIEF_KIND_ITEM_LOCATION: &str = "item_location";
+const BELIEF_KIND_ACTOR_LOCATION: &str = "actor_location";
+const BELIEF_KIND_ACTOR_WANTS_ITEM: &str = "actor_wants_item";
+const BELIEF_KIND_SEED_EXIT: &str = "seed_exit";
+const BELIEF_KIND_HIDDEN_EXIT: &str = "hidden_exit";
+
+#[derive(Clone, Copy)]
+struct BeliefTuning {
+    capacity: usize,
+    firsthand_confidence: u8,
+    firsthand_salience: u8,
+    minimum_action_confidence: u8,
+    decay_interval_ticks: u64,
+    confidence_decay: u8,
+    salience_decay: u8,
+    gossip_confidence_decay: u8,
+    gossip_salience_decay: u8,
+}
+
+// The former stores agreed on confidence, threshold, and decay amounts. The
+// unified policy keeps search's slightly stronger initial salience while using
+// resident autonomy's shorter decay interval so stale beliefs stop driving
+// actions promptly.
+const BELIEF_TUNING: BeliefTuning = BeliefTuning {
+    capacity: 32,
+    firsthand_confidence: 240,
+    firsthand_salience: 220,
+    minimum_action_confidence: 80,
+    decay_interval_ticks: 12,
+    confidence_decay: 6,
+    salience_decay: 8,
+    gossip_confidence_decay: 28,
+    gossip_salience_decay: 18,
+};
 const RESIDENT_AUTONOMY_REPEAT_EVENT_WINDOW: u64 = 96;
 const RESIDENT_REPLY_REPEAT_EVENT_WINDOW: u64 = 96;
 const RESIDENT_PLACEMENT_ROTATION_TICKS: u64 = 96;
@@ -1290,7 +1304,30 @@ struct BondState {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct ResidentMemoryState {
+struct BeliefState {
+    id: String,
+    holder_actor_id: u64,
+    kind: String,
+    subject_id: u64,
+    location_id: u64,
+    confidence: u8,
+    salience: u8,
+    observed_tick: u64,
+    #[serde(default)]
+    source_actor_id: Option<u64>,
+    #[serde(default)]
+    related_actor_id: Option<u64>,
+    #[serde(default)]
+    learned_tick: u64,
+    #[serde(default)]
+    hops: u8,
+}
+
+// Snapshot-only adapters for the two stores that preceded the unified belief
+// model. They never enter RuntimeWorld and are removed when a snapshot is
+// migrated.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct LegacyResidentMemoryState {
     id: String,
     carrier_actor_id: u64,
     kind: String,
@@ -1310,7 +1347,7 @@ struct ResidentMemoryState {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct SearchMemoryState {
+struct LegacySearchMemoryState {
     id: String,
     actor_id: u64,
     kind: String,
@@ -1324,6 +1361,70 @@ struct SearchMemoryState {
     last_used_tick: u64,
     #[serde(default)]
     use_count: u32,
+}
+
+fn belief_id(
+    holder_actor_id: u64,
+    kind: &str,
+    subject_id: u64,
+    location_id: u64,
+    related_actor_id: Option<u64>,
+) -> String {
+    match kind {
+        BELIEF_KIND_SEED_EXIT | BELIEF_KIND_HIDDEN_EXIT => {
+            format!("belief:{holder_actor_id}:{kind}:{location_id}:{subject_id}")
+        }
+        BELIEF_KIND_ACTOR_WANTS_ITEM => format!(
+            "belief:{holder_actor_id}:{kind}:{}:{subject_id}",
+            related_actor_id.unwrap_or_default()
+        ),
+        _ => format!("belief:{holder_actor_id}:{kind}:{subject_id}"),
+    }
+}
+
+fn belief_is_preferred(candidate: &BeliefState, existing: &BeliefState) -> bool {
+    candidate.observed_tick > existing.observed_tick
+        || (candidate.observed_tick == existing.observed_tick
+            && (candidate.confidence > existing.confidence
+                || (candidate.confidence == existing.confidence
+                    && candidate.learned_tick >= existing.learned_tick)))
+}
+
+fn merge_belief(beliefs: &mut BTreeMap<String, BeliefState>, mut belief: BeliefState) {
+    belief.id = belief_id(
+        belief.holder_actor_id,
+        &belief.kind,
+        belief.subject_id,
+        belief.location_id,
+        belief.related_actor_id,
+    );
+    match beliefs.get_mut(&belief.id) {
+        Some(existing) if belief_is_preferred(&belief, existing) => *existing = belief,
+        Some(existing) => existing.salience = existing.salience.max(belief.salience),
+        None => {
+            beliefs.insert(belief.id.clone(), belief);
+        }
+    }
+}
+
+fn belief_decay_at_tick(belief: &BeliefState, now: u64) -> (u64, u8, u8) {
+    let baseline = belief.learned_tick.max(belief.observed_tick);
+    let steps = if baseline == 0 {
+        0
+    } else {
+        now.saturating_sub(baseline) / BELIEF_TUNING.decay_interval_ticks
+    };
+    let confidence_loss = steps
+        .saturating_mul(BELIEF_TUNING.confidence_decay as u64)
+        .min(u8::MAX as u64) as u8;
+    let salience_loss = steps
+        .saturating_mul(BELIEF_TUNING.salience_decay as u64)
+        .min(u8::MAX as u64) as u8;
+    (
+        steps,
+        belief.confidence.saturating_sub(confidence_loss),
+        belief.salience.saturating_sub(salience_loss),
+    )
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1619,8 +1720,7 @@ struct RuntimeWorld {
     ledger_marks: BTreeMap<String, VisitLedgerMarkState>,
     advancement_spends: BTreeMap<String, AdvancementSpendState>,
     bonds: BTreeMap<String, BondState>,
-    resident_memories: BTreeMap<String, ResidentMemoryState>,
-    search_memories: BTreeMap<String, SearchMemoryState>,
+    beliefs: BTreeMap<String, BeliefState>,
     resident_continuities: BTreeMap<u64, ResidentContinuityState>,
     actor_autonomy: BTreeMap<u64, ActorAutonomyState>,
     actor_rules_facets: BTreeMap<u64, BTreeMap<String, ActorRulesFacetState>>,
@@ -1742,9 +1842,11 @@ struct RuntimeSnapshot {
     #[serde(default)]
     bonds: BTreeMap<String, BondState>,
     #[serde(default)]
-    resident_memories: BTreeMap<String, ResidentMemoryState>,
-    #[serde(default)]
-    search_memories: BTreeMap<String, SearchMemoryState>,
+    beliefs: BTreeMap<String, BeliefState>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    resident_memories: BTreeMap<String, LegacyResidentMemoryState>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    search_memories: BTreeMap<String, LegacySearchMemoryState>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     resident_continuities: BTreeMap<u64, ResidentContinuityState>,
     #[serde(default)]
@@ -6157,7 +6259,7 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 13,
+            version: 14,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
@@ -6214,8 +6316,9 @@ impl RuntimeSnapshot {
             ledger_marks: runtime.ledger_marks.clone(),
             advancement_spends: runtime.advancement_spends.clone(),
             bonds: runtime.bonds.clone(),
-            resident_memories: runtime.resident_memories.clone(),
-            search_memories: runtime.search_memories.clone(),
+            beliefs: runtime.beliefs.clone(),
+            resident_memories: BTreeMap::new(),
+            search_memories: BTreeMap::new(),
             resident_continuities: BTreeMap::new(),
             actor_autonomy: runtime.actor_autonomy.clone(),
             actor_rules_facets: runtime.snapshot_actor_rules_facets(),
@@ -6387,6 +6490,51 @@ impl RuntimeSnapshot {
             world.next_event_seq = 1;
         }
 
+        let mut beliefs = self.beliefs;
+        for legacy in self.resident_memories.into_values() {
+            merge_belief(
+                &mut beliefs,
+                BeliefState {
+                    id: String::new(),
+                    holder_actor_id: legacy.carrier_actor_id,
+                    kind: legacy.kind,
+                    subject_id: legacy.subject_id,
+                    location_id: legacy.location_id,
+                    confidence: legacy.confidence,
+                    salience: legacy.salience,
+                    observed_tick: legacy.observed_tick,
+                    source_actor_id: legacy.source_actor_id,
+                    related_actor_id: legacy.holder_actor_id,
+                    learned_tick: legacy.learned_tick,
+                    hops: legacy.hops,
+                },
+            );
+        }
+        for legacy in self.search_memories.into_values() {
+            let kind = match legacy.kind.as_str() {
+                "avatar" => BELIEF_KIND_ACTOR_LOCATION,
+                "item" => BELIEF_KIND_ITEM_LOCATION,
+                _ => legacy.kind.as_str(),
+            };
+            merge_belief(
+                &mut beliefs,
+                BeliefState {
+                    id: String::new(),
+                    holder_actor_id: legacy.actor_id,
+                    kind: kind.to_string(),
+                    subject_id: legacy.subject_id,
+                    location_id: legacy.location_id,
+                    confidence: legacy.confidence,
+                    salience: legacy.salience,
+                    observed_tick: legacy.found_tick,
+                    source_actor_id: Some(legacy.actor_id),
+                    related_actor_id: None,
+                    learned_tick: legacy.last_used_tick.max(legacy.found_tick),
+                    hops: 0,
+                },
+            );
+        }
+
         Ok(RuntimeWorld {
             world,
             canonical_identities: self.canonical_identities,
@@ -6424,8 +6572,7 @@ impl RuntimeSnapshot {
             ledger_marks: self.ledger_marks,
             advancement_spends: self.advancement_spends,
             bonds: self.bonds,
-            resident_memories: self.resident_memories,
-            search_memories: self.search_memories,
+            beliefs,
             resident_continuities: self.resident_continuities,
             actor_autonomy: self.actor_autonomy,
             actor_rules_facets: self.actor_rules_facets,
@@ -6834,8 +6981,7 @@ impl RuntimeWorld {
             ledger_marks: BTreeMap::new(),
             advancement_spends: BTreeMap::new(),
             bonds: BTreeMap::new(),
-            resident_memories: BTreeMap::new(),
-            search_memories: BTreeMap::new(),
+            beliefs: BTreeMap::new(),
             resident_continuities: BTreeMap::new(),
             actor_autonomy: BTreeMap::new(),
             actor_rules_facets: BTreeMap::new(),
@@ -10078,7 +10224,7 @@ impl RuntimeWorld {
         };
         if status == CW_OK {
             if advances_world_tick {
-                self.decay_search_memories();
+                self.decay_beliefs();
             }
             let listen_context = self.listen_context_for_action(&action, &events);
             let was_repeat_listen = listen_context
@@ -10149,7 +10295,7 @@ impl RuntimeWorld {
             events.extend(self.apply_bounded_magic_projection(&action, &committed_events));
             let committed_events = events.clone();
             events.extend(self.apply_influence_projection(&action, &committed_events));
-            self.reinforce_search_memories_from_events(&events);
+            self.reinforce_beliefs_from_search_events(&events);
             self.record_first_tale_destination_arrivals(&events);
             let committed_events = events.clone();
             events.extend(self.apply_event_lifecycle_hooks(
@@ -10215,7 +10361,7 @@ impl RuntimeWorld {
             let loot_sources = events.clone();
             events.extend(self.reconcile_quest_loot(&loot_sources));
             self.project_qualifying_deeds(&events);
-            self.apply_resident_memory_projection(&action, &events);
+            self.apply_belief_projection(&action, &events);
             if advances_world_tick {
                 let committed_events = events.clone();
                 events.extend(self.apply_player_tick_frontier_resets(&action, &committed_events));
@@ -10795,9 +10941,9 @@ impl RuntimeWorld {
                         self.remember_search_discovery_for_actor_ids(
                             &witness_actor_ids,
                             discovered_exit.from_location_id,
-                            SEARCH_MEMORY_KIND_SEED_EXIT,
+                            BELIEF_KIND_SEED_EXIT,
                             discovered_exit.to_location_id,
-                            &seed_exit_search_memory_subject_key(
+                            &seed_exit_belief_subject_key(
                                 discovered_exit.from_location_id,
                                 discovered_exit.to_location_id,
                             ),
@@ -10848,7 +10994,7 @@ impl RuntimeWorld {
                     events.push(event.clone());
                     self.remember_search_discovery_for_witnesses(
                         hidden_exit.from_location_id,
-                        SEARCH_MEMORY_KIND_HIDDEN_EXIT,
+                        BELIEF_KIND_HIDDEN_EXIT,
                         hidden_exit.to_location_id,
                         hidden_exit.id.clone(),
                     );
@@ -10893,7 +11039,7 @@ impl RuntimeWorld {
                     events.push(event.clone());
                     self.remember_search_discovery_for_witnesses(
                         *location_id,
-                        SEARCH_MEMORY_KIND_AVATAR,
+                        BELIEF_KIND_ACTOR_LOCATION,
                         *actor_id,
                         actor_id.to_string(),
                     );
@@ -10921,7 +11067,7 @@ impl RuntimeWorld {
                     };
                     self.remember_search_discovery_for_witnesses(
                         *location_id,
-                        SEARCH_MEMORY_KIND_ITEM,
+                        BELIEF_KIND_ITEM_LOCATION,
                         *item_id,
                         item_id.to_string(),
                     );
@@ -13571,7 +13717,7 @@ impl RuntimeWorld {
         }
         let from_location_id = event.location_id;
         let to_location_id = event.destination_location_id;
-        let memory = self.resident_memory_seek_target(actor)?;
+        let memory = self.belief_seek_target(actor)?;
         if self.next_unlocked_step_toward(from_location_id, memory.location_id)
             != Some(to_location_id)
         {
@@ -14818,46 +14964,33 @@ impl RuntimeWorld {
     }
 
     fn avatar_discovered(&self, actor_id: u64) -> bool {
-        self.search_memories.values().any(|memory| {
-            memory.kind == SEARCH_MEMORY_KIND_AVATAR
-                && memory.subject_id == actor_id
-                && self.search_memory_active(memory)
+        self.beliefs.values().any(|belief| {
+            belief.kind == BELIEF_KIND_ACTOR_LOCATION
+                && belief.subject_id == actor_id
+                && self.belief_active(belief)
         })
     }
 
-    fn search_memory_active(&self, memory: &SearchMemoryState) -> bool {
-        self.actor_by_id(memory.actor_id)
+    fn belief_active(&self, belief: &BeliefState) -> bool {
+        self.actor_by_id(belief.holder_actor_id)
             .is_some_and(Self::actor_is_present)
             && self
-                .search_memory_effective_values(memory)
+                .belief_effective_values(belief)
                 .is_some_and(|(confidence, salience)| {
-                    confidence >= SEARCH_MEMORY_MIN_CONFIDENCE && salience > 0
+                    confidence >= BELIEF_TUNING.minimum_action_confidence && salience > 0
                 })
     }
 
-    fn search_memory_effective_values(&self, memory: &SearchMemoryState) -> Option<(u8, u8)> {
-        let baseline = memory.last_used_tick.max(memory.found_tick);
-        if baseline == 0 {
-            return Some((memory.confidence, memory.salience));
-        }
-        let now = self.world.tick;
-        let steps = now.saturating_sub(baseline) / SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS;
-        let confidence_loss = steps
-            .saturating_mul(SEARCH_MEMORY_TIME_CONFIDENCE_DECAY as u64)
-            .min(u8::MAX as u64) as u8;
-        let salience_loss = steps
-            .saturating_mul(SEARCH_MEMORY_TIME_SALIENCE_DECAY as u64)
-            .min(u8::MAX as u64) as u8;
-        let confidence = memory.confidence.saturating_sub(confidence_loss);
-        let salience = memory.salience.saturating_sub(salience_loss);
+    fn belief_effective_values(&self, belief: &BeliefState) -> Option<(u8, u8)> {
+        let (_, confidence, salience) = belief_decay_at_tick(belief, self.world.tick);
         (confidence > 0 && salience > 0).then_some((confidence, salience))
     }
 
     fn search_item_remembered(&self, item_id: u64) -> bool {
-        self.search_memories.values().any(|memory| {
-            memory.kind == SEARCH_MEMORY_KIND_ITEM
-                && memory.subject_id == item_id
-                && self.search_memory_active(memory)
+        self.beliefs.values().any(|belief| {
+            belief.kind == BELIEF_KIND_ITEM_LOCATION
+                && belief.subject_id == item_id
+                && self.belief_active(belief)
         })
     }
 
@@ -14873,10 +15006,6 @@ impl RuntimeWorld {
             && item.location_id == location_id
             && self.search_item_found(item.id)
             && !self.search_item_remembered(item.id)
-    }
-
-    fn search_memory_id(actor_id: u64, kind: &str, location_id: u64, subject_key: &str) -> String {
-        format!("search_memory:{actor_id}:{kind}:{location_id}:{subject_key}")
     }
 
     fn search_witness_actor_ids(&self, location_id: u64) -> Vec<u64> {
@@ -14927,80 +15056,20 @@ impl RuntimeWorld {
         location_id: u64,
         kind: &str,
         subject_id: u64,
-        subject_key: &str,
+        _subject_key: &str,
     ) {
-        let Some(actor) = self.actor_by_id(actor_id) else {
-            return;
-        };
-        if !Self::actor_is_present(actor) {
-            return;
-        }
-        let id = Self::search_memory_id(actor_id, kind, location_id, subject_key);
-        let now = self.world.tick;
-        match self.search_memories.get_mut(&id) {
-            Some(memory) => {
-                memory.confidence = memory.confidence.max(SEARCH_MEMORY_CONFIDENCE);
-                memory.salience = memory.salience.max(SEARCH_MEMORY_SALIENCE);
-                memory.last_used_tick = now;
-                memory.use_count = memory.use_count.saturating_add(1);
-            }
-            None => {
-                self.search_memories.insert(
-                    id.clone(),
-                    SearchMemoryState {
-                        id,
-                        actor_id,
-                        kind: kind.to_string(),
-                        location_id,
-                        subject_id,
-                        subject_key: subject_key.to_string(),
-                        confidence: SEARCH_MEMORY_CONFIDENCE,
-                        salience: SEARCH_MEMORY_SALIENCE,
-                        found_tick: now,
-                        last_used_tick: now,
-                        use_count: 1,
-                    },
-                );
-            }
-        }
+        self.remember_belief(
+            actor_id,
+            kind,
+            subject_id,
+            location_id,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
+            Some(actor_id),
+        );
     }
 
-    fn decay_search_memories(&mut self) {
-        let now = self.world.tick;
-        let mut expired = Vec::new();
-        for memory in self.search_memories.values_mut() {
-            let baseline = memory.last_used_tick.max(memory.found_tick);
-            if baseline == 0 {
-                memory.last_used_tick = now;
-                continue;
-            }
-            if now <= baseline {
-                continue;
-            }
-            let steps = (now - baseline) / SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS;
-            if steps == 0 {
-                continue;
-            }
-            let confidence_loss = steps
-                .saturating_mul(SEARCH_MEMORY_TIME_CONFIDENCE_DECAY as u64)
-                .min(u8::MAX as u64) as u8;
-            let salience_loss = steps
-                .saturating_mul(SEARCH_MEMORY_TIME_SALIENCE_DECAY as u64)
-                .min(u8::MAX as u64) as u8;
-            memory.confidence = memory.confidence.saturating_sub(confidence_loss);
-            memory.salience = memory.salience.saturating_sub(salience_loss);
-            memory.last_used_tick = now;
-            if memory.confidence == 0 || memory.salience == 0 {
-                expired.push(memory.id.clone());
-            }
-        }
-        for memory_id in expired {
-            self.search_memories.remove(&memory_id);
-        }
-        self.return_forgotten_search_items_to_pool();
-    }
-
-    fn reinforce_search_memories_from_events(&mut self, events: &[EventView]) {
+    fn reinforce_beliefs_from_search_events(&mut self, events: &[EventView]) {
         for event in events.iter().filter(|event| event.success) {
             match event.type_name.as_str() {
                 "actor.moved" => {
@@ -15018,9 +15087,9 @@ impl RuntimeWorld {
                         self.remember_search_discovery(
                             actor_id,
                             from_location_id,
-                            SEARCH_MEMORY_KIND_SEED_EXIT,
+                            BELIEF_KIND_SEED_EXIT,
                             to_location_id,
-                            &seed_exit_search_memory_subject_key(from_location_id, to_location_id),
+                            &seed_exit_belief_subject_key(from_location_id, to_location_id),
                         );
                         if self
                             .seed_exit_by_locations(to_location_id, from_location_id)
@@ -15029,12 +15098,9 @@ impl RuntimeWorld {
                             self.remember_search_discovery(
                                 actor_id,
                                 to_location_id,
-                                SEARCH_MEMORY_KIND_SEED_EXIT,
+                                BELIEF_KIND_SEED_EXIT,
                                 from_location_id,
-                                &seed_exit_search_memory_subject_key(
-                                    to_location_id,
-                                    from_location_id,
-                                ),
+                                &seed_exit_belief_subject_key(to_location_id, from_location_id),
                             );
                         }
                     }
@@ -15044,7 +15110,7 @@ impl RuntimeWorld {
                         self.remember_search_discovery(
                             actor_id,
                             hidden_exit.from_location_id,
-                            SEARCH_MEMORY_KIND_HIDDEN_EXIT,
+                            BELIEF_KIND_HIDDEN_EXIT,
                             hidden_exit.to_location_id,
                             &hidden_exit.id,
                         );
@@ -15074,7 +15140,7 @@ impl RuntimeWorld {
                     }
                     self.remember_search_discovery_for_witnesses(
                         location_id,
-                        SEARCH_MEMORY_KIND_ITEM,
+                        BELIEF_KIND_ITEM_LOCATION,
                         item_id,
                         item_id.to_string(),
                     );
@@ -15521,12 +15587,21 @@ impl RuntimeWorld {
     }
 
     fn hide_loose_items_at_location(&mut self, location_id: u64) {
+        let hidden_item_ids = self.world.items[..self.world.item_count]
+            .iter()
+            .filter(|item| item.holder_actor_id == 0 && item.location_id == location_id)
+            .map(|item| item.id)
+            .collect::<BTreeSet<_>>();
         for item in &mut self.world.items[..self.world.item_count] {
-            if item.holder_actor_id == 0 && item.location_id == location_id {
+            if hidden_item_ids.contains(&item.id) {
                 item.location_id = 0;
                 item.held_since_tick = 0;
             }
         }
+        self.beliefs.retain(|_, belief| {
+            belief.kind != BELIEF_KIND_ITEM_LOCATION
+                || !hidden_item_ids.contains(&belief.subject_id)
+        });
     }
 
     fn resident_evolution_item_ids(&self, actor_id: u64) -> Vec<u64> {
@@ -15757,12 +15832,12 @@ impl RuntimeWorld {
         let mut sought = Vec::new();
         if self.resident_needs_medicine(resident) {
             let mut remembered_potions: Vec<_> = self
-                .resident_memories
+                .beliefs
                 .values()
                 .filter(|memory| {
-                    memory.carrier_actor_id == resident.id
-                        && memory.kind == RESIDENT_MEMORY_KIND_ITEM_LOCATION
-                        && memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE
+                    memory.holder_actor_id == resident.id
+                        && memory.kind == BELIEF_KIND_ITEM_LOCATION
+                        && memory.confidence >= BELIEF_TUNING.minimum_action_confidence
                         && !held_item_ids.contains(&memory.subject_id)
                 })
                 .filter_map(|memory| {
@@ -15819,7 +15894,7 @@ impl RuntimeWorld {
         sought
     }
 
-    fn resident_memory_seek_target(&self, resident: CwActor) -> Option<ResidentMemoryState> {
+    fn belief_seek_target(&self, resident: CwActor) -> Option<BeliefState> {
         let sought_item_ids: BTreeSet<u64> = self
             .resident_sought_item_ids(resident)
             .into_iter()
@@ -15829,12 +15904,12 @@ impl RuntimeWorld {
         }
 
         let mut memories: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
             .filter(|memory| {
-                memory.carrier_actor_id == resident.id
-                    && memory.kind == RESIDENT_MEMORY_KIND_ITEM_LOCATION
-                    && memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE
+                memory.holder_actor_id == resident.id
+                    && memory.kind == BELIEF_KIND_ITEM_LOCATION
+                    && memory.confidence >= BELIEF_TUNING.minimum_action_confidence
                     && sought_item_ids.contains(&memory.subject_id)
             })
             .cloned()
@@ -15858,25 +15933,22 @@ impl RuntimeWorld {
         memories.into_iter().next()
     }
 
-    fn resident_item_memory_resolved_by_actor_memory(
-        &self,
-        memory: ResidentMemoryState,
-    ) -> ResidentMemoryState {
-        if memory.kind != RESIDENT_MEMORY_KIND_ITEM_LOCATION {
+    fn resident_item_memory_resolved_by_actor_memory(&self, memory: BeliefState) -> BeliefState {
+        if memory.kind != BELIEF_KIND_ITEM_LOCATION {
             return memory;
         }
-        let Some(holder_actor_id) = memory.holder_actor_id else {
+        let Some(holder_actor_id) = memory.related_actor_id else {
             return memory;
         };
-        let actor_memory_id = Self::resident_memory_id(
-            memory.carrier_actor_id,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+        let actor_memory_id = Self::belief_id(
+            memory.holder_actor_id,
+            BELIEF_KIND_ACTOR_LOCATION,
             holder_actor_id,
         );
-        let Some(actor_memory) = self.resident_memories.get(&actor_memory_id) else {
+        let Some(actor_memory) = self.beliefs.get(&actor_memory_id) else {
             return memory;
         };
-        if actor_memory.confidence < RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE
+        if actor_memory.confidence < BELIEF_TUNING.minimum_action_confidence
             || actor_memory.observed_tick < memory.observed_tick
         {
             return memory;
@@ -15892,19 +15964,15 @@ impl RuntimeWorld {
         resolved
     }
 
-    fn resident_best_item_memory(
-        &self,
-        carrier_actor_id: u64,
-        item_id: u64,
-    ) -> Option<ResidentMemoryState> {
+    fn resident_best_item_memory(&self, holder_actor_id: u64, item_id: u64) -> Option<BeliefState> {
         let mut memories: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
             .filter(|memory| {
-                memory.carrier_actor_id == carrier_actor_id
-                    && memory.kind == RESIDENT_MEMORY_KIND_ITEM_LOCATION
+                memory.holder_actor_id == holder_actor_id
+                    && memory.kind == BELIEF_KIND_ITEM_LOCATION
                     && memory.subject_id == item_id
-                    && memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE
+                    && memory.confidence >= BELIEF_TUNING.minimum_action_confidence
             })
             .cloned()
             .map(|memory| self.resident_item_memory_resolved_by_actor_memory(memory))
@@ -15922,82 +15990,77 @@ impl RuntimeWorld {
 
     fn resident_has_fresh_loose_item_observation(
         &self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         item_id: u64,
         location_id: u64,
     ) -> bool {
-        let memory_id = Self::resident_memory_id(
-            carrier_actor_id,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
-            item_id,
-        );
-        self.resident_memories
-            .get(&memory_id)
-            .is_some_and(|memory| {
-                memory.location_id == location_id
-                    && memory.holder_actor_id.is_none()
-                    && memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE
-                    && memory.observed_tick == self.world.tick
-                    && memory.source_actor_id == Some(carrier_actor_id)
-            })
+        let memory_id = Self::belief_id(holder_actor_id, BELIEF_KIND_ITEM_LOCATION, item_id);
+        self.beliefs.get(&memory_id).is_some_and(|memory| {
+            memory.location_id == location_id
+                && memory.related_actor_id.is_none()
+                && memory.confidence >= BELIEF_TUNING.minimum_action_confidence
+                && memory.observed_tick == self.world.tick
+                && memory.source_actor_id == Some(holder_actor_id)
+        })
     }
 
     fn resident_actor_location_memory(
         &self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         subject_actor_id: u64,
-    ) -> Option<ResidentMemoryState> {
-        let memory_id = Self::resident_memory_id(
-            carrier_actor_id,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+    ) -> Option<BeliefState> {
+        let memory_id = Self::belief_id(
+            holder_actor_id,
+            BELIEF_KIND_ACTOR_LOCATION,
             subject_actor_id,
         );
-        self.resident_memories
+        self.beliefs
             .get(&memory_id)
-            .filter(|memory| memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE)
+            .filter(|memory| memory.confidence >= BELIEF_TUNING.minimum_action_confidence)
             .cloned()
     }
 
     fn resident_remembers_actor_at(
         &self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         subject_actor_id: u64,
         location_id: u64,
     ) -> bool {
-        self.resident_actor_location_memory(carrier_actor_id, subject_actor_id)
+        self.resident_actor_location_memory(holder_actor_id, subject_actor_id)
             .is_some_and(|memory| memory.location_id == location_id)
     }
 
     fn resident_actor_wants_item_memory(
         &self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         target_actor_id: u64,
         item_id: u64,
-    ) -> Option<ResidentMemoryState> {
-        let memory_id = Self::resident_memory_key(
-            carrier_actor_id,
-            RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM,
+    ) -> Option<BeliefState> {
+        let memory_id = Self::belief_key(
+            holder_actor_id,
+            BELIEF_KIND_ACTOR_WANTS_ITEM,
             item_id,
+            0,
             Some(target_actor_id),
         );
-        self.resident_memories
+        self.beliefs
             .get(&memory_id)
-            .filter(|memory| memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE)
+            .filter(|memory| memory.confidence >= BELIEF_TUNING.minimum_action_confidence)
             .cloned()
     }
 
     fn resident_remembers_actor_holding_item_at(
         &self,
-        carrier_actor_id: u64,
         holder_actor_id: u64,
+        related_actor_id: u64,
         item_id: u64,
         location_id: u64,
     ) -> bool {
-        self.resident_remembers_actor_at(carrier_actor_id, holder_actor_id, location_id)
+        self.resident_remembers_actor_at(holder_actor_id, related_actor_id, location_id)
             && self
-                .resident_best_item_memory(carrier_actor_id, item_id)
+                .resident_best_item_memory(holder_actor_id, item_id)
                 .is_some_and(|memory| {
-                    memory.holder_actor_id == Some(holder_actor_id)
+                    memory.related_actor_id == Some(related_actor_id)
                         && memory.location_id == location_id
                 })
     }
@@ -16005,11 +16068,11 @@ impl RuntimeWorld {
     #[cfg(test)]
     fn resident_remembers_actor_wants_item(
         &self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         target_actor_id: u64,
         item_id: u64,
     ) -> bool {
-        self.resident_actor_wants_item_memory(carrier_actor_id, target_actor_id, item_id)
+        self.resident_actor_wants_item_memory(holder_actor_id, target_actor_id, item_id)
             .is_some()
     }
 
@@ -16214,7 +16277,7 @@ impl RuntimeWorld {
             ));
         }
 
-        let memory_notes = self.resident_memory_prompt_notes(resident.id);
+        let memory_notes = self.belief_prompt_notes(resident.id);
         if !memory_notes.is_empty() {
             parts.push(format!("carried memories: {}", memory_notes.join(" | ")));
         }
@@ -16381,7 +16444,7 @@ impl RuntimeWorld {
         resident: CwActor,
         excluding_item_id: u64,
     ) -> Option<String> {
-        let memory = self.resident_memory_seek_target(resident)?;
+        let memory = self.belief_seek_target(resident)?;
         if memory.location_id != resident.location_id || memory.subject_id == excluding_item_id {
             return None;
         }
@@ -16521,13 +16584,13 @@ impl RuntimeWorld {
         }
     }
 
-    fn resident_memory_prompt_notes(&self, resident_id: u64) -> Vec<String> {
+    fn belief_prompt_notes(&self, resident_id: u64) -> Vec<String> {
         let mut memories: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
             .filter(|memory| {
-                memory.carrier_actor_id == resident_id
-                    && memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE
+                memory.holder_actor_id == resident_id
+                    && memory.confidence >= BELIEF_TUNING.minimum_action_confidence
             })
             .cloned()
             .collect();
@@ -16554,7 +16617,7 @@ impl RuntimeWorld {
                 .location_name(memory.location_id)
                 .unwrap_or_else(|| format!("Location {}", memory.location_id));
             let note = match memory.kind.as_str() {
-                RESIDENT_MEMORY_KIND_ACTOR_LOCATION => {
+                BELIEF_KIND_ACTOR_LOCATION => {
                     if memory.subject_id == resident_id {
                         continue;
                     }
@@ -16563,12 +16626,12 @@ impl RuntimeWorld {
                         .unwrap_or_else(|| format!("Resident {}", memory.subject_id));
                     format!("{route} {actor_name} near {location_name}")
                 }
-                RESIDENT_MEMORY_KIND_ITEM_LOCATION => {
+                BELIEF_KIND_ITEM_LOCATION => {
                     let item_name = self
                         .item_name(memory.subject_id)
                         .unwrap_or_else(|| format!("Item {}", memory.subject_id));
                     if let Some(holder_name) = memory
-                        .holder_actor_id
+                        .related_actor_id
                         .and_then(|holder_actor_id| self.actor_name(holder_actor_id))
                     {
                         format!("{route} {item_name} with {holder_name} near {location_name}")
@@ -16576,8 +16639,8 @@ impl RuntimeWorld {
                         format!("{route} {item_name} near {location_name}")
                     }
                 }
-                RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM => {
-                    let Some(target_actor_id) = memory.holder_actor_id else {
+                BELIEF_KIND_ACTOR_WANTS_ITEM => {
+                    let Some(target_actor_id) = memory.related_actor_id else {
                         continue;
                     };
                     let target_name = self
@@ -16922,9 +16985,9 @@ impl RuntimeWorld {
         limit: usize,
     ) -> Vec<ResidentContinuityAtom> {
         let mut memories: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
-            .filter(|memory| memory.carrier_actor_id == resident_id)
+            .filter(|memory| memory.holder_actor_id == resident_id)
             .cloned()
             .collect();
         memories.sort_by_key(|memory| {
@@ -16940,7 +17003,7 @@ impl RuntimeWorld {
         memories
             .into_iter()
             .filter_map(|memory| {
-                self.resident_memory_atom_text(&memory)
+                self.belief_atom_text(&memory)
                     .map(|text| ResidentContinuityAtom {
                         kind: memory.kind,
                         subject_id: memory.subject_id,
@@ -16954,8 +17017,8 @@ impl RuntimeWorld {
             .collect()
     }
 
-    fn resident_memory_atom_text(&self, memory: &ResidentMemoryState) -> Option<String> {
-        let route = if memory.source_actor_id == Some(memory.carrier_actor_id) && memory.hops == 0 {
+    fn belief_atom_text(&self, memory: &BeliefState) -> Option<String> {
+        let route = if memory.source_actor_id == Some(memory.holder_actor_id) && memory.hops == 0 {
             "saw"
         } else {
             "heard"
@@ -16964,8 +17027,8 @@ impl RuntimeWorld {
             .location_name(memory.location_id)
             .unwrap_or_else(|| format!("Location {}", memory.location_id));
         match memory.kind.as_str() {
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION => {
-                if memory.subject_id == memory.carrier_actor_id {
+            BELIEF_KIND_ACTOR_LOCATION => {
+                if memory.subject_id == memory.holder_actor_id {
                     return None;
                 }
                 let actor_name = self
@@ -16973,12 +17036,12 @@ impl RuntimeWorld {
                     .unwrap_or_else(|| format!("Actor {}", memory.subject_id));
                 Some(format!("{route} {actor_name} near {location_name}"))
             }
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION => {
+            BELIEF_KIND_ITEM_LOCATION => {
                 let item_name = self
                     .item_name(memory.subject_id)
                     .unwrap_or_else(|| format!("Item {}", memory.subject_id));
                 if let Some(holder_name) = memory
-                    .holder_actor_id
+                    .related_actor_id
                     .and_then(|holder_actor_id| self.actor_name(holder_actor_id))
                 {
                     Some(format!(
@@ -16988,8 +17051,8 @@ impl RuntimeWorld {
                     Some(format!("{route} {item_name} near {location_name}"))
                 }
             }
-            RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM => {
-                let target_actor_id = memory.holder_actor_id?;
+            BELIEF_KIND_ACTOR_WANTS_ITEM => {
+                let target_actor_id = memory.related_actor_id?;
                 let target_name = self
                     .actor_name(target_actor_id)
                     .unwrap_or_else(|| format!("Actor {}", target_actor_id));
@@ -17088,28 +17151,29 @@ impl RuntimeWorld {
         }
     }
 
-    fn resident_memory_id(carrier_actor_id: u64, kind: &str, subject_id: u64) -> String {
-        format!("resident_memory:{carrier_actor_id}:{kind}:{subject_id}")
+    fn belief_id(holder_actor_id: u64, kind: &str, subject_id: u64) -> String {
+        belief_id(holder_actor_id, kind, subject_id, 0, None)
     }
 
-    fn resident_memory_key(
-        carrier_actor_id: u64,
+    fn belief_key(
+        holder_actor_id: u64,
         kind: &str,
         subject_id: u64,
-        holder_actor_id: Option<u64>,
+        location_id: u64,
+        related_actor_id: Option<u64>,
     ) -> String {
-        if kind == RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM {
-            let target_actor_id = holder_actor_id.unwrap_or_default();
-            return format!(
-                "resident_memory:{carrier_actor_id}:{kind}:{target_actor_id}:{subject_id}"
-            );
-        }
-        Self::resident_memory_id(carrier_actor_id, kind, subject_id)
+        belief_id(
+            holder_actor_id,
+            kind,
+            subject_id,
+            location_id,
+            related_actor_id,
+        )
     }
 
-    fn remember_resident_memory(
+    fn remember_belief(
         &mut self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         kind: &str,
         subject_id: u64,
         location_id: u64,
@@ -17117,8 +17181,8 @@ impl RuntimeWorld {
         salience: u8,
         source_actor_id: Option<u64>,
     ) {
-        self.remember_resident_memory_with_provenance(
-            carrier_actor_id,
+        self.remember_belief_with_provenance(
+            holder_actor_id,
             kind,
             subject_id,
             location_id,
@@ -17132,26 +17196,26 @@ impl RuntimeWorld {
         );
     }
 
-    fn remember_resident_memory_with_holder(
+    fn remember_belief_with_related_actor(
         &mut self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         kind: &str,
         subject_id: u64,
         location_id: u64,
         confidence: u8,
         salience: u8,
         source_actor_id: Option<u64>,
-        holder_actor_id: Option<u64>,
+        related_actor_id: Option<u64>,
     ) {
-        self.remember_resident_memory_with_provenance(
-            carrier_actor_id,
+        self.remember_belief_with_provenance(
+            holder_actor_id,
             kind,
             subject_id,
             location_id,
             confidence,
             salience,
             source_actor_id,
-            holder_actor_id,
+            related_actor_id,
             self.world.tick,
             self.world.tick,
             0,
@@ -17160,7 +17224,7 @@ impl RuntimeWorld {
 
     fn remember_resident_wants_item_memory(
         &mut self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         wanting_actor_id: u64,
         item_id: u64,
         location_id: u64,
@@ -17171,9 +17235,9 @@ impl RuntimeWorld {
         if wanting_actor_id == 0 || item_id == 0 {
             return;
         }
-        self.remember_resident_memory_with_holder(
-            carrier_actor_id,
-            RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM,
+        self.remember_belief_with_related_actor(
+            holder_actor_id,
+            BELIEF_KIND_ACTOR_WANTS_ITEM,
             item_id,
             location_id,
             confidence,
@@ -17183,31 +17247,41 @@ impl RuntimeWorld {
         );
     }
 
-    fn remember_resident_memory_with_provenance(
+    fn remember_belief_with_provenance(
         &mut self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         kind: &str,
         subject_id: u64,
         location_id: u64,
         confidence: u8,
         salience: u8,
         source_actor_id: Option<u64>,
-        holder_actor_id: Option<u64>,
+        related_actor_id: Option<u64>,
         observed_tick: u64,
         learned_tick: u64,
         hops: u8,
     ) {
-        let Some(carrier) = self.actor_by_id(carrier_actor_id) else {
+        let Some(holder) = self.actor_by_id(holder_actor_id) else {
             return;
         };
-        if !Self::actor_can_act(carrier) || location_id == 0 {
+        if !Self::actor_is_present(holder) || location_id == 0 {
             return;
         }
 
-        let id = Self::resident_memory_key(carrier_actor_id, kind, subject_id, holder_actor_id);
-        let memory = ResidentMemoryState {
-            id: id.clone(),
-            carrier_actor_id,
+        let related_actor_id = (kind == BELIEF_KIND_ITEM_LOCATION
+            || kind == BELIEF_KIND_ACTOR_WANTS_ITEM)
+            .then_some(related_actor_id)
+            .flatten()
+            .filter(|related_id| *related_id != 0);
+        let belief = BeliefState {
+            id: Self::belief_key(
+                holder_actor_id,
+                kind,
+                subject_id,
+                location_id,
+                related_actor_id,
+            ),
+            holder_actor_id,
             kind: kind.to_string(),
             subject_id,
             location_id,
@@ -17215,39 +17289,19 @@ impl RuntimeWorld {
             salience,
             observed_tick,
             source_actor_id,
-            holder_actor_id: (kind == RESIDENT_MEMORY_KIND_ITEM_LOCATION
-                || kind == RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM)
-                .then_some(holder_actor_id)
-                .flatten()
-                .filter(|holder_id| *holder_id != 0),
+            related_actor_id,
             learned_tick,
             hops,
         };
-        match self.resident_memories.get_mut(&id) {
-            Some(existing) => {
-                if memory.observed_tick > existing.observed_tick
-                    || (memory.observed_tick == existing.observed_tick
-                        && (memory.confidence > existing.confidence
-                            || (memory.confidence == existing.confidence
-                                && memory.learned_tick >= existing.learned_tick)))
-                {
-                    *existing = memory;
-                } else {
-                    existing.salience = existing.salience.max(salience);
-                }
-            }
-            None => {
-                self.resident_memories.insert(id, memory);
-            }
-        }
-        self.prune_resident_memories(carrier_actor_id);
+        merge_belief(&mut self.beliefs, belief);
+        self.prune_beliefs(holder_actor_id);
     }
 
-    fn prune_resident_memories(&mut self, carrier_actor_id: u64) {
+    fn prune_beliefs(&mut self, holder_actor_id: u64) {
         let mut owned: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
-            .filter(|memory| memory.carrier_actor_id == carrier_actor_id)
+            .filter(|memory| memory.holder_actor_id == holder_actor_id)
             .map(|memory| {
                 (
                     memory.id.clone(),
@@ -17257,7 +17311,7 @@ impl RuntimeWorld {
                 )
             })
             .collect();
-        if owned.len() <= RESIDENT_MEMORY_CAPACITY {
+        if owned.len() <= BELIEF_TUNING.capacity {
             return;
         }
         owned.sort_by_key(|(_, salience, confidence, observed_tick)| {
@@ -17265,18 +17319,18 @@ impl RuntimeWorld {
         });
         for (id, _, _, _) in owned
             .into_iter()
-            .take(self.resident_memory_overflow_count(carrier_actor_id))
+            .take(self.belief_overflow_count(holder_actor_id))
         {
-            self.resident_memories.remove(&id);
+            self.beliefs.remove(&id);
         }
     }
 
-    fn resident_memory_overflow_count(&self, carrier_actor_id: u64) -> usize {
-        self.resident_memories
+    fn belief_overflow_count(&self, holder_actor_id: u64) -> usize {
+        self.beliefs
             .values()
-            .filter(|memory| memory.carrier_actor_id == carrier_actor_id)
+            .filter(|memory| memory.holder_actor_id == holder_actor_id)
             .count()
-            .saturating_sub(RESIDENT_MEMORY_CAPACITY)
+            .saturating_sub(BELIEF_TUNING.capacity)
     }
 
     fn item_is_observable_at_location(&self, item_id: u64, location_id: u64) -> bool {
@@ -17293,33 +17347,33 @@ impl RuntimeWorld {
             })
     }
 
-    fn item_memory_has_current_holder_location(&self, memory: &ResidentMemoryState) -> bool {
-        if memory.kind != RESIDENT_MEMORY_KIND_ITEM_LOCATION {
+    fn item_memory_has_current_holder_location(&self, memory: &BeliefState) -> bool {
+        if memory.kind != BELIEF_KIND_ITEM_LOCATION {
             return false;
         }
-        let Some(holder_actor_id) = memory.holder_actor_id else {
+        let Some(holder_actor_id) = memory.related_actor_id else {
             return false;
         };
-        let actor_memory_id = Self::resident_memory_id(
-            memory.carrier_actor_id,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+        let actor_memory_id = Self::belief_id(
+            memory.holder_actor_id,
+            BELIEF_KIND_ACTOR_LOCATION,
             holder_actor_id,
         );
-        self.resident_memories
+        self.beliefs
             .get(&actor_memory_id)
             .is_some_and(|actor_memory| {
-                actor_memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE
+                actor_memory.confidence >= BELIEF_TUNING.minimum_action_confidence
                     && actor_memory.observed_tick >= memory.observed_tick
             })
     }
 
     fn clear_disproved_item_location_memories(&mut self, resident_id: u64, location_id: u64) {
         let memory_ids: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
             .filter(|memory| {
-                memory.carrier_actor_id == resident_id
-                    && memory.kind == RESIDENT_MEMORY_KIND_ITEM_LOCATION
+                memory.holder_actor_id == resident_id
+                    && memory.kind == BELIEF_KIND_ITEM_LOCATION
                     && memory.location_id == location_id
                     && !self.item_is_observable_at_location(memory.subject_id, location_id)
                     && !self.item_memory_has_current_holder_location(memory)
@@ -17327,7 +17381,7 @@ impl RuntimeWorld {
             .map(|memory| memory.id.clone())
             .collect();
         for memory_id in memory_ids {
-            self.resident_memories.remove(&memory_id);
+            self.beliefs.remove(&memory_id);
         }
     }
 
@@ -17338,11 +17392,11 @@ impl RuntimeWorld {
         observed_actor_ids: &BTreeSet<u64>,
     ) -> BTreeSet<u64> {
         let memory_ids: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
             .filter(|memory| {
-                memory.carrier_actor_id == resident_id
-                    && memory.kind == RESIDENT_MEMORY_KIND_ACTOR_LOCATION
+                memory.holder_actor_id == resident_id
+                    && memory.kind == BELIEF_KIND_ACTOR_LOCATION
                     && memory.location_id == location_id
                     && !observed_actor_ids.contains(&memory.subject_id)
             })
@@ -17350,7 +17404,7 @@ impl RuntimeWorld {
             .collect();
         let mut disproved_actor_ids = BTreeSet::new();
         for (memory_id, subject_id) in memory_ids {
-            self.resident_memories.remove(&memory_id);
+            self.beliefs.remove(&memory_id);
             disproved_actor_ids.insert(subject_id);
         }
         disproved_actor_ids
@@ -17365,49 +17419,49 @@ impl RuntimeWorld {
             return;
         }
         let memory_ids: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
             .filter(|memory| {
-                memory.carrier_actor_id == resident_id
-                    && memory.kind == RESIDENT_MEMORY_KIND_ITEM_LOCATION
+                memory.holder_actor_id == resident_id
+                    && memory.kind == BELIEF_KIND_ITEM_LOCATION
                     && memory
-                        .holder_actor_id
+                        .related_actor_id
                         .is_some_and(|holder_actor_id| holder_actor_ids.contains(&holder_actor_id))
             })
             .map(|memory| memory.id.clone())
             .collect();
         for memory_id in memory_ids {
-            self.resident_memories.remove(&memory_id);
+            self.beliefs.remove(&memory_id);
         }
     }
 
     fn clear_disproved_actor_wants_item_memories(
         &mut self,
-        carrier_actor_id: u64,
+        holder_actor_id: u64,
         target_actor_id: u64,
         current_item_ids: &BTreeSet<u64>,
     ) {
         let memory_ids: Vec<_> = self
-            .resident_memories
+            .beliefs
             .values()
             .filter(|memory| {
-                memory.carrier_actor_id == carrier_actor_id
-                    && memory.kind == RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM
-                    && memory.holder_actor_id == Some(target_actor_id)
+                memory.holder_actor_id == holder_actor_id
+                    && memory.kind == BELIEF_KIND_ACTOR_WANTS_ITEM
+                    && memory.related_actor_id == Some(target_actor_id)
                     && !current_item_ids.contains(&memory.subject_id)
             })
             .map(|memory| memory.id.clone())
             .collect();
         for memory_id in memory_ids {
-            self.resident_memories.remove(&memory_id);
+            self.beliefs.remove(&memory_id);
         }
     }
 
-    fn observe_room_for_resident(&mut self, resident_id: u64, location_id: u64) {
+    fn observe_room_for_actor(&mut self, resident_id: u64, location_id: u64) {
         let Some(resident) = self.actor_by_id(resident_id) else {
             return;
         };
-        if !Self::actor_can_act(resident) || resident.location_id != location_id {
+        if !Self::actor_is_present(resident) || resident.location_id != location_id {
             return;
         }
 
@@ -17421,13 +17475,13 @@ impl RuntimeWorld {
             .map(|item| item.id)
             .collect();
         for item_id in loose_item_ids {
-            self.remember_resident_memory(
+            self.remember_belief(
                 resident_id,
-                RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+                BELIEF_KIND_ITEM_LOCATION,
                 item_id,
                 location_id,
-                RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-                RESIDENT_OBSERVED_MEMORY_SALIENCE,
+                BELIEF_TUNING.firsthand_confidence,
+                BELIEF_TUNING.firsthand_salience,
                 Some(resident_id),
             );
         }
@@ -17438,17 +17492,19 @@ impl RuntimeWorld {
                 actor.id != resident_id
                     && Self::actor_is_present(**actor)
                     && actor.location_id == location_id
+                    && (!self.avatar_hidden_until_discovered(**actor)
+                        || self.avatar_discovered(actor.id))
             })
             .map(|actor| actor.id)
             .collect();
         for actor_id in actor_ids.iter().copied() {
-            self.remember_resident_memory(
+            self.remember_belief(
                 resident_id,
-                RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+                BELIEF_KIND_ACTOR_LOCATION,
                 actor_id,
                 location_id,
-                RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-                RESIDENT_OBSERVED_MEMORY_SALIENCE,
+                BELIEF_TUNING.firsthand_confidence,
+                BELIEF_TUNING.firsthand_salience,
                 Some(resident_id),
             );
         }
@@ -17475,8 +17531,8 @@ impl RuntimeWorld {
                     actor.id,
                     item_id,
                     location_id,
-                    RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-                    RESIDENT_OBSERVED_MEMORY_SALIENCE,
+                    BELIEF_TUNING.firsthand_confidence,
+                    BELIEF_TUNING.firsthand_salience,
                     Some(resident_id),
                 );
             }
@@ -17496,47 +17552,47 @@ impl RuntimeWorld {
             .map(|item| (item.id, item.holder_actor_id))
             .collect();
         for (item_id, holder_actor_id) in carried_items {
-            self.remember_resident_memory_with_holder(
+            self.remember_belief_with_related_actor(
                 resident_id,
-                RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+                BELIEF_KIND_ITEM_LOCATION,
                 item_id,
                 location_id,
-                RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-                RESIDENT_OBSERVED_MEMORY_SALIENCE,
+                BELIEF_TUNING.firsthand_confidence,
+                BELIEF_TUNING.firsthand_salience,
                 Some(resident_id),
                 Some(holder_actor_id),
             );
         }
     }
 
-    fn observe_room_for_residents(&mut self, location_id: u64) {
+    fn observe_room_for_actors(&mut self, location_id: u64) {
         let resident_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
             .iter()
-            .filter(|actor| Self::actor_can_act(**actor) && actor.location_id == location_id)
+            .filter(|actor| Self::actor_is_present(**actor) && actor.location_id == location_id)
             .map(|actor| actor.id)
             .collect();
         for resident_id in resident_ids {
-            self.observe_room_for_resident(resident_id, location_id);
+            self.observe_room_for_actor(resident_id, location_id);
         }
     }
 
-    fn exchange_resident_memories_at(&mut self, location_id: u64) {
+    fn exchange_beliefs_at(&mut self, location_id: u64) {
         let resident_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
             .iter()
-            .filter(|actor| Self::actor_can_act(**actor) && actor.location_id == location_id)
+            .filter(|actor| Self::actor_is_present(**actor) && actor.location_id == location_id)
             .map(|actor| actor.id)
             .collect();
         if resident_ids.len() < 2 {
             return;
         }
 
-        let carried: Vec<(u64, Vec<ResidentMemoryState>)> = resident_ids
+        let carried: Vec<(u64, Vec<BeliefState>)> = resident_ids
             .iter()
             .map(|resident_id| {
                 let memories = self
-                    .resident_memories
+                    .beliefs
                     .values()
-                    .filter(|memory| memory.carrier_actor_id == *resident_id)
+                    .filter(|memory| memory.holder_actor_id == *resident_id)
                     .cloned()
                     .collect();
                 (*resident_id, memories)
@@ -17548,14 +17604,14 @@ impl RuntimeWorld {
                 for memory in &memories {
                     let confidence = memory
                         .confidence
-                        .saturating_sub(RESIDENT_GOSSIP_CONFIDENCE_DECAY);
+                        .saturating_sub(BELIEF_TUNING.gossip_confidence_decay);
                     let salience = memory
                         .salience
-                        .saturating_sub(RESIDENT_GOSSIP_SALIENCE_DECAY);
+                        .saturating_sub(BELIEF_TUNING.gossip_salience_decay);
                     if confidence == 0 || salience == 0 {
                         continue;
                     }
-                    self.remember_resident_memory_with_provenance(
+                    self.remember_belief_with_provenance(
                         target_id,
                         &memory.kind,
                         memory.subject_id,
@@ -17563,7 +17619,7 @@ impl RuntimeWorld {
                         confidence,
                         salience,
                         Some(source_id),
-                        memory.holder_actor_id,
+                        memory.related_actor_id,
                         memory.observed_tick,
                         self.world.tick,
                         memory.hops.saturating_add(1),
@@ -17573,7 +17629,7 @@ impl RuntimeWorld {
         }
     }
 
-    fn apply_resident_memory_projection(&mut self, action: &CwAction, events: &[EventView]) {
+    fn apply_belief_projection(&mut self, action: &CwAction, events: &[EventView]) {
         let mut locations = BTreeSet::new();
         for event in events.iter().filter(|event| event.success) {
             if let Some(location_id) = event.location_id {
@@ -17592,19 +17648,19 @@ impl RuntimeWorld {
                         .iter()
                         .filter(|actor| {
                             actor.id != actor_id
-                                && Self::actor_can_act(**actor)
+                                && Self::actor_is_present(**actor)
                                 && actor.location_id == from_location_id
                         })
                         .map(|actor| actor.id)
                         .collect();
                     for observer_id in observers.iter().copied() {
-                        self.remember_resident_memory(
+                        self.remember_belief(
                             observer_id,
-                            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+                            BELIEF_KIND_ACTOR_LOCATION,
                             actor_id,
                             to_location_id,
-                            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-                            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+                            BELIEF_TUNING.firsthand_confidence,
+                            BELIEF_TUNING.firsthand_salience,
                             Some(observer_id),
                         );
                     }
@@ -17615,13 +17671,13 @@ impl RuntimeWorld {
                         .collect();
                     for observer_id in observers.iter().copied() {
                         for item_id in &carried_item_ids {
-                            self.remember_resident_memory_with_holder(
+                            self.remember_belief_with_related_actor(
                                 observer_id,
-                                RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+                                BELIEF_KIND_ITEM_LOCATION,
                                 *item_id,
                                 to_location_id,
-                                RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-                                RESIDENT_OBSERVED_MEMORY_SALIENCE,
+                                BELIEF_TUNING.firsthand_confidence,
+                                BELIEF_TUNING.firsthand_salience,
                                 Some(observer_id),
                                 Some(actor_id),
                             );
@@ -17632,14 +17688,14 @@ impl RuntimeWorld {
         }
 
         if let Some(actor) = self.actor_by_id(action.actor_id) {
-            if Self::actor_can_act(actor) {
+            if Self::actor_is_present(actor) {
                 locations.insert(actor.location_id);
             }
         }
 
         for location_id in locations {
-            self.observe_room_for_residents(location_id);
-            self.exchange_resident_memories_at(location_id);
+            self.observe_room_for_actors(location_id);
+            self.exchange_beliefs_at(location_id);
             let resident_ids: Vec<u64> = self.world.actors[..self.world.actor_count]
                 .iter()
                 .filter(|actor| Self::actor_can_act(**actor) && actor.location_id == location_id)
@@ -20511,13 +20567,13 @@ impl RuntimeWorld {
                 continue;
             }
             let target_memories: Vec<_> = self
-                .resident_memories
+                .beliefs
                 .values()
                 .filter(|memory| {
-                    memory.carrier_actor_id == actor.id
-                        && memory.kind == RESIDENT_MEMORY_KIND_ACTOR_LOCATION
+                    memory.holder_actor_id == actor.id
+                        && memory.kind == BELIEF_KIND_ACTOR_LOCATION
                         && memory.subject_id != actor.id
-                        && memory.confidence >= RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE
+                        && memory.confidence >= BELIEF_TUNING.minimum_action_confidence
                 })
                 .cloned()
                 .collect();
@@ -21655,7 +21711,7 @@ impl RuntimeWorld {
         if waiting_for_player_gift {
             return None;
         }
-        if let Some(memory) = self.resident_memory_seek_target(actor) {
+        if let Some(memory) = self.belief_seek_target(actor) {
             if memory.location_id == actor.location_id {
                 if self.resident_has_fresh_loose_item_observation(
                     actor.id,
@@ -22581,8 +22637,8 @@ impl RuntimeWorld {
         if !Self::actor_can_act(actor) || !self.actor_uses_inference(actor.id) {
             return None;
         }
-        self.observe_room_for_resident(actor.id, actor.location_id);
-        self.exchange_resident_memories_at(actor.location_id);
+        self.observe_room_for_actor(actor.id, actor.location_id);
+        self.exchange_beliefs_at(actor.location_id);
         self.actor_by_id(actor_id)
     }
 
@@ -22967,10 +23023,10 @@ impl RuntimeWorld {
             .map(|candidate| candidate.record.action)
     }
 
-    fn decay_resident_memories_for_autonomy(&mut self) {
+    fn decay_beliefs(&mut self) {
         let now = self.world.tick;
         let mut expired = Vec::new();
-        for memory in self.resident_memories.values_mut() {
+        for memory in self.beliefs.values_mut() {
             let baseline = memory.learned_tick.max(memory.observed_tick);
             if baseline == 0 {
                 memory.learned_tick = now;
@@ -22979,41 +23035,36 @@ impl RuntimeWorld {
             if now <= baseline {
                 continue;
             }
-            let steps = (now - baseline) / RESIDENT_MEMORY_TIME_DECAY_INTERVAL_TICKS;
+            let (steps, confidence, salience) = belief_decay_at_tick(memory, now);
             if steps == 0 {
                 continue;
             }
-            let confidence_loss = steps
-                .saturating_mul(RESIDENT_MEMORY_TIME_CONFIDENCE_DECAY as u64)
-                .min(u8::MAX as u64) as u8;
-            let salience_loss = steps
-                .saturating_mul(RESIDENT_MEMORY_TIME_SALIENCE_DECAY as u64)
-                .min(u8::MAX as u64) as u8;
-            memory.confidence = memory.confidence.saturating_sub(confidence_loss);
-            memory.salience = memory.salience.saturating_sub(salience_loss);
+            memory.confidence = confidence;
+            memory.salience = salience;
             memory.learned_tick = now;
             if memory.confidence == 0 || memory.salience == 0 {
                 expired.push(memory.id.clone());
             }
         }
         for memory_id in expired {
-            self.resident_memories.remove(&memory_id);
+            self.beliefs.remove(&memory_id);
         }
+        self.return_forgotten_search_items_to_pool();
     }
 
-    fn refresh_resident_memories_for_autonomy(&mut self) {
-        self.decay_resident_memories_for_autonomy();
+    fn refresh_beliefs_for_autonomy(&mut self) {
+        self.decay_beliefs();
     }
 
     #[cfg(test)]
     fn ambient_autonomy_action(&mut self) -> Option<CwAction> {
-        self.refresh_resident_memories_for_autonomy();
+        self.refresh_beliefs_for_autonomy();
         self.resident_economy_autonomy_action_by_priority()
     }
 
     #[cfg(test)]
     fn ambient_autonomy_record(&mut self, seed: u64) -> Option<JournalRecord> {
-        self.refresh_resident_memories_for_autonomy();
+        self.refresh_beliefs_for_autonomy();
         self.resident_economy_autonomy_record_for_seed(seed)
     }
 
@@ -23025,7 +23076,7 @@ impl RuntimeWorld {
         if context.budget.resident_actions == 0 {
             return None;
         }
-        self.refresh_resident_memories_for_autonomy();
+        self.refresh_beliefs_for_autonomy();
         if let Some(mut record) = self.resident_ripple_record_for_seed(context, seed) {
             record.origin = JournalOrigin::ActorConsequence;
             record.source_world_tick = Some(self.world.tick);
@@ -29405,7 +29456,7 @@ async fn command_inner(
                     events: presence_events,
                 });
             }
-            runtime.decay_search_memories();
+            runtime.decay_beliefs();
             let candidates =
                 runtime.search_reveal_candidates_for_feature(location_id, &feature_key);
             if candidates.is_empty() && feature_key == "room" {
@@ -37589,7 +37640,7 @@ fn seed_exit_discovered_tag_id(from_location_id: u64, to_location_id: u64) -> St
     format!("seed_exit:{from_location_id}:{to_location_id}:discovered")
 }
 
-fn seed_exit_search_memory_subject_key(from_location_id: u64, to_location_id: u64) -> String {
+fn seed_exit_belief_subject_key(from_location_id: u64, to_location_id: u64) -> String {
     format!("{from_location_id}:{to_location_id}")
 }
 
@@ -45345,9 +45396,9 @@ mod tests {
         runtime.remember_search_discovery(
             RATI_ACTOR_ID,
             from_location_id,
-            SEARCH_MEMORY_KIND_SEED_EXIT,
+            BELIEF_KIND_SEED_EXIT,
             to_location_id,
-            &seed_exit_search_memory_subject_key(from_location_id, to_location_id),
+            &seed_exit_belief_subject_key(from_location_id, to_location_id),
         );
     }
 
@@ -52146,7 +52197,7 @@ mod tests {
             },
         );
         assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         let sought_item_id =
             evolution_track_item_ids(RATI_ACTOR_ID).expect("Rati has evolution items")[0];
         for item in &mut runtime.world.items[..runtime.world.item_count] {
@@ -52155,13 +52206,13 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             sought_item_id,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -52463,7 +52514,7 @@ mod tests {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Card Player");
         hide_seed_items(&mut runtime);
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for actor in &mut runtime.world.actors[..runtime.world.actor_count] {
             if actor.kind == CW_ACTOR_NPC
                 && actor.id != RATI_ACTOR_ID
@@ -52515,7 +52566,7 @@ mod tests {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Path Player");
         hide_seed_items(&mut runtime);
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for actor in &mut runtime.world.actors[..runtime.world.actor_count] {
             if actor.kind != CW_ACTOR_NPC {
                 continue;
@@ -53136,7 +53187,7 @@ mod tests {
     fn player_ripple_context_scopes_resident_candidates_to_touched_rooms() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
 
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
@@ -62450,8 +62501,8 @@ mod tests {
         runtime.world.tick = runtime
             .world
             .tick
-            .saturating_add(SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS * 64);
-        runtime.decay_search_memories();
+            .saturating_add(BELIEF_TUNING.decay_interval_ticks * 64);
+        runtime.decay_beliefs();
 
         assert!(!runtime.avatar_discovered(AZAZOTH_ACTOR_ID));
         assert!(runtime
@@ -62477,6 +62528,7 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
+        runtime.beliefs.clear();
         assert!(!runtime.world.items[..runtime.world.item_count]
             .iter()
             .any(|item| item.id == STORY_BUTTON_ITEM_ID
@@ -62524,8 +62576,8 @@ mod tests {
         runtime.world.tick = runtime
             .world
             .tick
-            .saturating_add(SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS * 64);
-        runtime.decay_search_memories();
+            .saturating_add(BELIEF_TUNING.decay_interval_ticks * 64);
+        runtime.decay_beliefs();
 
         assert!(!runtime.search_item_remembered(STORY_BUTTON_ITEM_ID));
         assert_eq!(
@@ -64037,7 +64089,7 @@ mod tests {
         assert_eq!(sought_story.holder_actor_id, Some(5000));
         assert_eq!(
             sought_story.confidence,
-            Some(RESIDENT_OBSERVED_MEMORY_CONFIDENCE)
+            Some(BELIEF_TUNING.firsthand_confidence)
         );
         assert_eq!(economy.inventory_count, 1);
         assert_eq!(economy.inventory_capacity, 0);
@@ -64486,7 +64538,7 @@ mod tests {
                 _ => {}
             }
         }
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.record_economy_disclosure(5000, RATI_ACTOR_ID);
 
         let state = runtime.state_response(Some(5000), &AccessContext::default());
@@ -64702,7 +64754,7 @@ mod tests {
                 item.holder_actor_id = 5000;
             }
         }
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
 
         let skull = runtime.actor_by_id(SKULL_ACTOR_ID).expect("Skull exists");
         let request = runtime
@@ -65080,7 +65132,7 @@ mod tests {
     fn content_authored_attachments_drive_recovery_seeking() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = runtime.world.tick.saturating_add(1);
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
                 HEARTH_TONIC_ITEM_ID => {
@@ -65465,7 +65517,7 @@ mod tests {
     fn non_track_resident_uses_attached_item_with_room_feature() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
                 item.location_id = 40;
@@ -66719,7 +66771,7 @@ mod tests {
     fn resident_economy_autonomy_can_act_without_human_presence() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         hide_seed_items(&mut runtime);
         assert!(runtime.ambient_line().is_none());
         assert!(runtime.ambient_reply_plan().is_none());
@@ -66732,13 +66784,13 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             sought_item_id,
             MOONLIT_TRAIL_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -66755,7 +66807,7 @@ mod tests {
     fn resident_economy_autonomy_record_projects_chosen_intent() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.resident_continuities.clear();
         hide_seed_items(&mut runtime);
 
@@ -66767,13 +66819,13 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             sought_item_id,
             MOONLIT_TRAIL_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -66816,7 +66868,7 @@ mod tests {
     fn resident_pending_proposed_action_executes_and_clears_after_kernel_commit() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.resident_continuities.clear();
         hide_seed_items(&mut runtime);
         discover_seed_exit_pair_for_test(
@@ -66880,7 +66932,7 @@ mod tests {
     fn resident_proposal_outside_the_enumerated_target_fails_closed() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.resident_continuities.clear();
         hide_seed_items(&mut runtime);
         discover_seed_exit_pair_for_test(
@@ -67302,7 +67354,7 @@ mod tests {
     fn resident_scout_uses_the_player_offer_and_replays_pathway_discovery() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.callings.remove(&RATI_ACTOR_ID);
         runtime
             .world
@@ -67788,7 +67840,7 @@ mod tests {
     fn ambient_autonomy_residents_notice_visible_sought_items_without_prior_memory() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
                 HEARTH_TONIC_ITEM_ID => {
@@ -67810,13 +67862,13 @@ mod tests {
         assert_eq!(action.actor_id, RATI_ACTOR_ID);
         assert_eq!(action.item_id, STORY_BUTTON_ITEM_ID);
 
-        let memory_id = RuntimeWorld::resident_memory_id(
+        let memory_id = RuntimeWorld::belief_id(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
         );
         let memory = runtime
-            .resident_memories
+            .beliefs
             .get(&memory_id)
             .expect("room observation records the visible item");
         assert_eq!(memory.location_id, COSY_COTTAGE_LOCATION_ID);
@@ -67827,7 +67879,7 @@ mod tests {
     fn ambient_autonomy_prioritizes_local_keepsake_pickup_over_remote_walking() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
 
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
@@ -67849,13 +67901,13 @@ mod tests {
                 _ => {}
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
             MOONLIT_TRAIL_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -67891,7 +67943,7 @@ mod tests {
     fn ambient_autonomy_record_residents_use_held_room_feature_items() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
                 item.location_id = 0;
@@ -67973,7 +68025,7 @@ mod tests {
         ));
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
                 item.location_id = 0;
@@ -68048,76 +68100,6 @@ mod tests {
     }
 
     #[test]
-    fn resident_memories_decay_with_time_before_autonomy() {
-        let mut runtime = RuntimeWorld::seeded();
-        runtime.world.tick = 1;
-        runtime.resident_memories.clear();
-        for item in &mut runtime.world.items[..runtime.world.item_count] {
-            if item.id == STORY_BUTTON_ITEM_ID {
-                item.location_id = MOONLIT_TRAIL_LOCATION_ID;
-                item.holder_actor_id = 0;
-            }
-        }
-        runtime.remember_resident_memory(
-            RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
-            STORY_BUTTON_ITEM_ID,
-            MOONLIT_TRAIL_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
-            Some(RATI_ACTOR_ID),
-        );
-        runtime.world.tick = 25;
-
-        runtime.decay_resident_memories_for_autonomy();
-
-        let memory_id = RuntimeWorld::resident_memory_id(
-            RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
-            STORY_BUTTON_ITEM_ID,
-        );
-        let memory = runtime
-            .resident_memories
-            .get(&memory_id)
-            .expect("aged memory remains above zero");
-        assert_eq!(
-            memory.confidence,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE - (2 * RESIDENT_MEMORY_TIME_CONFIDENCE_DECAY)
-        );
-        assert_eq!(
-            memory.salience,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE - (2 * RESIDENT_MEMORY_TIME_SALIENCE_DECAY)
-        );
-        assert_eq!(memory.learned_tick, 25);
-    }
-
-    #[test]
-    fn resident_memories_expire_when_time_decay_exhausts_them() {
-        let mut runtime = RuntimeWorld::seeded();
-        runtime.world.tick = 1;
-        runtime.resident_memories.clear();
-        runtime.remember_resident_memory(
-            RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
-            STORY_BUTTON_ITEM_ID,
-            MOONLIT_TRAIL_LOCATION_ID,
-            RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE,
-            RESIDENT_MEMORY_TIME_SALIENCE_DECAY,
-            Some(RATI_ACTOR_ID),
-        );
-        runtime.world.tick = 13;
-
-        runtime.decay_resident_memories_for_autonomy();
-
-        let memory_id = RuntimeWorld::resident_memory_id(
-            RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
-            STORY_BUTTON_ITEM_ID,
-        );
-        assert!(runtime.resident_memories.get(&memory_id).is_none());
-    }
-
-    #[test]
     fn ambient_autonomy_residents_pick_up_sought_items() {
         let mut runtime = RuntimeWorld::seeded();
         let mut create = CwAction::default();
@@ -68145,14 +68127,14 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
-        runtime.resident_memories.clear();
-        runtime.remember_resident_memory(
+        runtime.beliefs.clear();
+        runtime.remember_belief(
             actor.id,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             sought_item_id,
             actor.location_id,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(actor.id),
         );
 
@@ -68202,7 +68184,7 @@ mod tests {
     fn resident_pickup_requires_fresh_local_observation_memory() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 1;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         let actor = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let sought_item_id = runtime
             .resident_sought_item_ids(actor)
@@ -68215,13 +68197,13 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             actor.id,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             sought_item_id,
             actor.location_id,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(actor.id),
         );
         runtime.world.tick = 2;
@@ -68256,7 +68238,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
                 2004 => {
@@ -68272,13 +68254,13 @@ mod tests {
                 _ => {}
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -68327,7 +68309,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 30;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for actor in &mut runtime.world.actors[..runtime.world.actor_count] {
             if actor.kind == CW_ACTOR_NPC && actor.id != RATI_ACTOR_ID {
                 actor.status = 0;
@@ -68381,13 +68363,13 @@ mod tests {
             .expect("Rati has a non-attached item to make room");
         assert_eq!(expendable.id, DEWBRIGHT_BUTTON_ITEM_ID);
 
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             2004,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -68443,7 +68425,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 30;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
 
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
@@ -68480,13 +68462,13 @@ mod tests {
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         assert!(runtime.actor_inventory_full(RATI_ACTOR_ID));
         assert!(runtime.resident_expendable_item_for_pickup(rati).is_none());
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             2004,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -68516,7 +68498,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         hide_seed_items(&mut runtime);
         runtime
             .world
@@ -68579,7 +68561,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         hide_seed_items(&mut runtime);
         runtime
             .world
@@ -68637,7 +68619,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         hide_seed_items(&mut runtime);
         runtime
             .world
@@ -68664,13 +68646,13 @@ mod tests {
             "without a grounded memory, the inference controller does nothing"
         );
 
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             2001,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
@@ -68695,7 +68677,7 @@ mod tests {
         );
         assert_eq!(
             sought_tonic.confidence,
-            Some(RESIDENT_OBSERVED_MEMORY_CONFIDENCE)
+            Some(BELIEF_TUNING.firsthand_confidence)
         );
 
         let action = runtime
@@ -68710,7 +68692,7 @@ mod tests {
     fn remembered_healing_item_does_not_peek_at_current_charges() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -68732,19 +68714,19 @@ mod tests {
             }
         }
 
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             2001,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let memory = runtime
-            .resident_memory_seek_target(rati)
+            .belief_seek_target(rati)
             .expect("Rati trusts remembered medicine without remote charge inspection");
         assert_eq!(memory.subject_id, 2001);
         assert_eq!(memory.location_id, RAIN_SOFT_GARDEN_LOCATION_ID);
@@ -68796,20 +68778,20 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
 
         assert!(
             runtime.resident_economy_autonomy_action(actor).is_none(),
             "without a grounded memory, the inference controller does nothing"
         );
 
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             actor.id,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             sought_item_id,
             destination_location_id,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(actor.id),
         );
 
@@ -68850,7 +68832,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
 
         let actor = runtime
             .ambient_actor()
@@ -68864,13 +68846,13 @@ mod tests {
                 item.holder_actor_id = 0;
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             actor.id,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             sought_item_id,
             MOONLIT_TRAIL_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(actor.id),
         );
 
@@ -68901,33 +68883,30 @@ mod tests {
     #[test]
     fn resident_item_memories_spread_by_gossip() {
         let mut runtime = RuntimeWorld::seeded();
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.resident_continuities.clear();
 
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             DEWBRIGHT_BUTTON_ITEM_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         let observed_tick = runtime.world.tick;
-        let whiskerwind_memory_id = RuntimeWorld::resident_memory_id(
+        let whiskerwind_memory_id = RuntimeWorld::belief_id(
             WHISKERWIND_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             DEWBRIGHT_BUTTON_ITEM_ID,
         );
-        assert!(runtime
-            .resident_memories
-            .get(&whiskerwind_memory_id)
-            .is_none());
+        assert!(runtime.beliefs.get(&whiskerwind_memory_id).is_none());
 
-        runtime.exchange_resident_memories_at(COSY_COTTAGE_LOCATION_ID);
+        runtime.exchange_beliefs_at(COSY_COTTAGE_LOCATION_ID);
 
         let memory = runtime
-            .resident_memories
+            .beliefs
             .get(&whiskerwind_memory_id)
             .expect("co-located resident learns carried item memory");
         assert_eq!(memory.location_id, RAIN_SOFT_GARDEN_LOCATION_ID);
@@ -68936,7 +68915,7 @@ mod tests {
         assert_eq!(memory.hops, 1);
         assert_eq!(
             memory.confidence,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE - RESIDENT_GOSSIP_CONFIDENCE_DECAY
+            BELIEF_TUNING.firsthand_confidence - BELIEF_TUNING.gossip_confidence_decay
         );
         assert_eq!(memory.source_actor_id, Some(RATI_ACTOR_ID));
 
@@ -68957,16 +68936,16 @@ mod tests {
     #[test]
     fn resident_continuity_projects_memories_and_survives_snapshots() {
         let mut runtime = RuntimeWorld::seeded();
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.resident_continuities.clear();
 
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             WHISKERWIND_ACTOR_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         runtime.refresh_resident_continuity(RATI_ACTOR_ID);
@@ -69040,7 +69019,7 @@ mod tests {
     #[test]
     fn resident_observation_removes_disproved_item_location_memory() {
         let mut runtime = RuntimeWorld::seeded();
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -69061,44 +69040,40 @@ mod tests {
                 _ => {}
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             2004,
             MOONLIT_TRAIL_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_MEMORY_MIN_SEEK_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.minimum_action_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         assert_eq!(
             runtime
-                .resident_memory_seek_target(rati)
+                .belief_seek_target(rati)
                 .expect("stale higher-priority memory")
                 .subject_id,
             2004
         );
 
-        runtime.observe_room_for_resident(RATI_ACTOR_ID, MOONLIT_TRAIL_LOCATION_ID);
+        runtime.observe_room_for_actor(RATI_ACTOR_ID, MOONLIT_TRAIL_LOCATION_ID);
 
-        let stale_id = RuntimeWorld::resident_memory_id(
-            RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
-            2004,
-        );
-        assert!(runtime.resident_memories.get(&stale_id).is_none());
+        let stale_id = RuntimeWorld::belief_id(RATI_ACTOR_ID, BELIEF_KIND_ITEM_LOCATION, 2004);
+        assert!(runtime.beliefs.get(&stale_id).is_none());
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let next_memory = runtime
-            .resident_memory_seek_target(rati)
+            .belief_seek_target(rati)
             .expect("resident falls through to another remembered wanted item");
         assert_eq!(next_memory.subject_id, STORY_BUTTON_ITEM_ID);
         assert_eq!(next_memory.location_id, COSY_COTTAGE_LOCATION_ID);
@@ -69107,32 +69082,32 @@ mod tests {
     #[test]
     fn resident_observation_keeps_item_memory_when_holder_is_present() {
         let mut runtime = RuntimeWorld::seeded();
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
                 item.location_id = 0;
                 item.holder_actor_id = WHISKERWIND_ACTOR_ID;
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
-        runtime.observe_room_for_resident(RATI_ACTOR_ID, COSY_COTTAGE_LOCATION_ID);
+        runtime.observe_room_for_actor(RATI_ACTOR_ID, COSY_COTTAGE_LOCATION_ID);
 
-        let memory_id = RuntimeWorld::resident_memory_id(
+        let memory_id = RuntimeWorld::belief_id(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
         );
         let memory = runtime
-            .resident_memories
+            .beliefs
             .get(&memory_id)
             .expect("item memory remains true while the holder is present");
         assert_eq!(memory.location_id, COSY_COTTAGE_LOCATION_ID);
@@ -69141,7 +69116,7 @@ mod tests {
     #[test]
     fn resident_observation_remembers_items_carried_by_present_actors() {
         let mut runtime = RuntimeWorld::seeded();
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
                 item.location_id = 0;
@@ -69149,94 +69124,95 @@ mod tests {
             }
         }
 
-        runtime.observe_room_for_resident(RATI_ACTOR_ID, COSY_COTTAGE_LOCATION_ID);
+        runtime.observe_room_for_actor(RATI_ACTOR_ID, COSY_COTTAGE_LOCATION_ID);
 
-        let memory_id = RuntimeWorld::resident_memory_id(
+        let memory_id = RuntimeWorld::belief_id(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
         );
         let memory = runtime
-            .resident_memories
+            .beliefs
             .get(&memory_id)
             .expect("resident notices an item carried in the room");
         assert_eq!(memory.location_id, COSY_COTTAGE_LOCATION_ID);
         assert_eq!(memory.source_actor_id, Some(RATI_ACTOR_ID));
-        assert_eq!(memory.holder_actor_id, Some(WHISKERWIND_ACTOR_ID));
+        assert_eq!(memory.related_actor_id, Some(WHISKERWIND_ACTOR_ID));
     }
 
     #[test]
     fn resident_gossip_preserves_memory_provenance() {
         let mut runtime = RuntimeWorld::seeded();
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.world.tick = 17;
-        runtime.remember_resident_memory_with_holder(
+        runtime.remember_belief_with_related_actor(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
             Some(5000),
         );
         runtime.world.tick = 23;
 
-        runtime.exchange_resident_memories_at(COSY_COTTAGE_LOCATION_ID);
+        runtime.exchange_beliefs_at(COSY_COTTAGE_LOCATION_ID);
 
-        let memory_id = RuntimeWorld::resident_memory_id(
+        let memory_id = RuntimeWorld::belief_id(
             WHISKERWIND_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
         );
         let memory = runtime
-            .resident_memories
+            .beliefs
             .get(&memory_id)
             .expect("co-located resident learns item memory through gossip");
         assert_eq!(memory.location_id, COSY_COTTAGE_LOCATION_ID);
-        assert_eq!(memory.holder_actor_id, Some(5000));
+        assert_eq!(memory.related_actor_id, Some(5000));
         assert_eq!(memory.source_actor_id, Some(RATI_ACTOR_ID));
         assert_eq!(memory.observed_tick, 17);
         assert_eq!(memory.learned_tick, 23);
         assert_eq!(memory.hops, 1);
         assert_eq!(
             memory.confidence,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE - RESIDENT_GOSSIP_CONFIDENCE_DECAY
+            BELIEF_TUNING.firsthand_confidence - BELIEF_TUNING.gossip_confidence_decay
         );
     }
 
     #[test]
     fn resident_desire_memories_spread_by_gossip() {
         let mut runtime = RuntimeWorld::seeded();
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime.world.tick = 31;
         runtime.remember_resident_wants_item_memory(
             RATI_ACTOR_ID,
             WHISKERWIND_ACTOR_ID,
             DEWBRIGHT_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         runtime.world.tick = 37;
 
-        let memory_id = RuntimeWorld::resident_memory_key(
+        let memory_id = RuntimeWorld::belief_key(
             WHISKERWIND_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_WANTS_ITEM,
+            BELIEF_KIND_ACTOR_WANTS_ITEM,
             DEWBRIGHT_BUTTON_ITEM_ID,
+            0,
             Some(WHISKERWIND_ACTOR_ID),
         );
-        assert!(runtime.resident_memories.get(&memory_id).is_none());
+        assert!(runtime.beliefs.get(&memory_id).is_none());
 
-        runtime.exchange_resident_memories_at(COSY_COTTAGE_LOCATION_ID);
+        runtime.exchange_beliefs_at(COSY_COTTAGE_LOCATION_ID);
 
         let memory = runtime
-            .resident_memories
+            .beliefs
             .get(&memory_id)
             .expect("co-located resident learns desire memory through gossip");
         assert_eq!(memory.subject_id, DEWBRIGHT_BUTTON_ITEM_ID);
-        assert_eq!(memory.holder_actor_id, Some(WHISKERWIND_ACTOR_ID));
+        assert_eq!(memory.related_actor_id, Some(WHISKERWIND_ACTOR_ID));
         assert_eq!(memory.location_id, COSY_COTTAGE_LOCATION_ID);
         assert_eq!(memory.source_actor_id, Some(RATI_ACTOR_ID));
         assert_eq!(memory.observed_tick, 31);
@@ -69244,7 +69220,7 @@ mod tests {
         assert_eq!(memory.hops, 1);
         assert_eq!(
             memory.confidence,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE - RESIDENT_GOSSIP_CONFIDENCE_DECAY
+            BELIEF_TUNING.firsthand_confidence - BELIEF_TUNING.gossip_confidence_decay
         );
     }
 
@@ -69252,7 +69228,7 @@ mod tests {
     fn fulfilled_desire_memories_clear_for_witnesses_not_absent_residents() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 41;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -69273,8 +69249,8 @@ mod tests {
             WHISKERWIND_ACTOR_ID,
             DEWBRIGHT_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         runtime.remember_resident_wants_item_memory(
@@ -69282,8 +69258,8 @@ mod tests {
             WHISKERWIND_ACTOR_ID,
             DEWBRIGHT_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -69342,7 +69318,7 @@ mod tests {
         );
         assert_eq!(runtime.apply_journal_record(&create_record).0, CW_OK);
         runtime.world.tick = 10;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
                 item.location_id = 0;
@@ -69353,33 +69329,33 @@ mod tests {
                 item.held_since_tick = 0;
             }
         }
-        runtime.remember_resident_memory_with_holder(
+        runtime.remember_belief_with_related_actor(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
             Some(5000),
         );
         runtime.world.tick = 12;
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             5000,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(WHISKERWIND_ACTOR_ID),
         );
 
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let memory = runtime
-            .resident_memory_seek_target(rati)
+            .belief_seek_target(rati)
             .expect("Rati follows held item memory");
         assert_eq!(memory.subject_id, STORY_BUTTON_ITEM_ID);
-        assert_eq!(memory.holder_actor_id, Some(5000));
+        assert_eq!(memory.related_actor_id, Some(5000));
         assert_eq!(memory.location_id, RAIN_SOFT_GARDEN_LOCATION_ID);
         let economy = runtime
             .resident_economy_view(rati, None)
@@ -69408,7 +69384,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 10;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
 
         let rati_desired_items = evolution_track_item_ids(RATI_ACTOR_ID).unwrap_or_default();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
@@ -69425,24 +69401,24 @@ mod tests {
             }
         }
 
-        runtime.remember_resident_memory_with_holder(
+        runtime.remember_belief_with_related_actor(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
             Some(5000),
         );
         runtime.world.tick = 12;
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             5000,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -69456,10 +69432,10 @@ mod tests {
 
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let memory = runtime
-            .resident_memory_seek_target(rati)
+            .belief_seek_target(rati)
             .expect("Rati resolves held item through carried actor memory");
         assert_eq!(memory.subject_id, STORY_BUTTON_ITEM_ID);
-        assert_eq!(memory.holder_actor_id, Some(5000));
+        assert_eq!(memory.related_actor_id, Some(5000));
         assert_eq!(memory.location_id, RAIN_SOFT_GARDEN_LOCATION_ID);
         assert_eq!(
             runtime
@@ -69491,7 +69467,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 10;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
 
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
@@ -69507,33 +69483,33 @@ mod tests {
             .expect("carrier exists")
             .location_id = MOONLIT_TRAIL_LOCATION_ID;
 
-        runtime.remember_resident_memory_with_holder(
+        runtime.remember_belief_with_related_actor(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
             Some(5000),
         );
         runtime.world.tick = 12;
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             5000,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let stale = runtime
-            .resident_memory_seek_target(rati)
+            .belief_seek_target(rati)
             .expect("stale carrier memory points at Rain-Soft Garden");
         assert_eq!(stale.location_id, RAIN_SOFT_GARDEN_LOCATION_ID);
-        assert_eq!(stale.holder_actor_id, Some(5000));
+        assert_eq!(stale.related_actor_id, Some(5000));
 
         let mut rati_move = CwAction::default();
         rati_move.kind = CW_ACTION_MOVE;
@@ -69546,22 +69522,19 @@ mod tests {
             CW_OK
         );
 
-        let actor_memory_id = RuntimeWorld::resident_memory_id(
-            RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
-            5000,
-        );
+        let actor_memory_id =
+            RuntimeWorld::belief_id(RATI_ACTOR_ID, BELIEF_KIND_ACTOR_LOCATION, 5000);
         assert!(
-            runtime.resident_memories.get(&actor_memory_id).is_none(),
+            runtime.beliefs.get(&actor_memory_id).is_none(),
             "Rati should stop believing the absent carrier is in the checked room"
         );
-        let item_memory_id = RuntimeWorld::resident_memory_id(
+        let item_memory_id = RuntimeWorld::belief_id(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
         );
         assert!(
-            runtime.resident_memories.get(&item_memory_id).is_none(),
+            runtime.beliefs.get(&item_memory_id).is_none(),
             "Rati should clear held-item memory protected only by the disproved carrier rumor"
         );
     }
@@ -69579,7 +69552,7 @@ mod tests {
                 .0,
             CW_OK
         );
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
                 item.location_id = 0;
@@ -69598,26 +69571,23 @@ mod tests {
             CW_OK
         );
 
-        let actor_memory_id = RuntimeWorld::resident_memory_id(
-            RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
-            5000,
-        );
+        let actor_memory_id =
+            RuntimeWorld::belief_id(RATI_ACTOR_ID, BELIEF_KIND_ACTOR_LOCATION, 5000);
         assert_eq!(
             runtime
-                .resident_memories
+                .beliefs
                 .get(&actor_memory_id)
                 .expect("resident remembers where the carrier went")
                 .location_id,
             11
         );
-        let item_memory_id = RuntimeWorld::resident_memory_id(
+        let item_memory_id = RuntimeWorld::belief_id(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ITEM_LOCATION,
+            BELIEF_KIND_ITEM_LOCATION,
             STORY_BUTTON_ITEM_ID,
         );
         let item_memory = runtime
-            .resident_memories
+            .beliefs
             .get(&item_memory_id)
             .expect("resident remembers the carried item moved too");
         assert_eq!(item_memory.location_id, 11);
@@ -69636,7 +69606,7 @@ mod tests {
                 .0,
             CW_OK
         );
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -69656,26 +69626,17 @@ mod tests {
             CW_OK
         );
 
-        let rati_memory_id = RuntimeWorld::resident_memory_id(
-            RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
-            5000,
-        );
+        let rati_memory_id =
+            RuntimeWorld::belief_id(RATI_ACTOR_ID, BELIEF_KIND_ACTOR_LOCATION, 5000);
         let rati_memory = runtime
-            .resident_memories
+            .beliefs
             .get(&rati_memory_id)
             .expect("source-room resident observes where the player went");
         assert_eq!(rati_memory.location_id, 11);
 
-        let whiskerwind_memory_id = RuntimeWorld::resident_memory_id(
-            WHISKERWIND_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
-            5000,
-        );
-        assert!(runtime
-            .resident_memories
-            .get(&whiskerwind_memory_id)
-            .is_none());
+        let whiskerwind_memory_id =
+            RuntimeWorld::belief_id(WHISKERWIND_ACTOR_ID, BELIEF_KIND_ACTOR_LOCATION, 5000);
+        assert!(runtime.beliefs.get(&whiskerwind_memory_id).is_none());
 
         let mut rati_move = CwAction::default();
         rati_move.kind = CW_ACTION_MOVE;
@@ -69689,11 +69650,11 @@ mod tests {
         );
 
         let carried_memory = runtime
-            .resident_memories
+            .beliefs
             .get(&whiskerwind_memory_id)
             .expect("memory travels with Rati and spreads on contact");
         assert_eq!(carried_memory.location_id, 11);
-        assert!(carried_memory.confidence < RESIDENT_OBSERVED_MEMORY_CONFIDENCE);
+        assert!(carried_memory.confidence < BELIEF_TUNING.firsthand_confidence);
         assert_eq!(carried_memory.source_actor_id, Some(RATI_ACTOR_ID));
     }
 
@@ -69711,7 +69672,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
                 DEWBRIGHT_BUTTON_ITEM_ID => {
@@ -69736,13 +69697,13 @@ mod tests {
             runtime.resident_mutual_trade_candidate(actor).is_none(),
             "resident trade needs carried actor-location memory, not just live room state"
         );
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             WHISKERWIND_ACTOR_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         assert!(
@@ -69754,8 +69715,8 @@ mod tests {
             WHISKERWIND_ACTOR_ID,
             DEWBRIGHT_BUTTON_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         assert!(
@@ -69873,7 +69834,7 @@ mod tests {
     async fn ambient_autonomy_trade_without_ai_emits_no_fallback_speech() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
                 DEWBRIGHT_BUTTON_ITEM_ID => {
@@ -69945,7 +69906,7 @@ mod tests {
             CW_OK
         );
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
                 DEWBRIGHT_BUTTON_ITEM_ID => {
@@ -70211,7 +70172,7 @@ mod tests {
     fn resident_gifts_non_track_room_feature_item_from_desire_memory() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             if item.id == STORY_BUTTON_ITEM_ID {
                 item.holder_actor_id = WOODLAND_BEAR_ACTOR_ID;
@@ -70294,7 +70255,7 @@ mod tests {
     fn resident_gifts_requested_non_evolution_attachment_from_memory() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = runtime.world.tick.saturating_add(1);
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -70359,7 +70320,7 @@ mod tests {
     fn resident_delivers_requested_non_evolution_attachment_from_memory() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = runtime.world.tick.saturating_add(1);
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -70375,13 +70336,13 @@ mod tests {
                 item.charges = 1;
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             WOODLAND_BEAR_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             RATI_ACTOR_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(WOODLAND_BEAR_ACTOR_ID),
         );
         runtime.remember_resident_wants_item_memory(
@@ -70389,8 +70350,8 @@ mod tests {
             RATI_ACTOR_ID,
             HEARTH_TONIC_ITEM_ID,
             COSY_COTTAGE_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(WOODLAND_BEAR_ACTOR_ID),
         );
 
@@ -70431,7 +70392,7 @@ mod tests {
     fn resident_delivers_non_track_room_feature_item_to_remembered_want() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -70446,13 +70407,13 @@ mod tests {
                 item.held_since_tick = 0;
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             WOODLAND_BEAR_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             OLD_OAK_TREE_ACTOR_ID,
             40,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(WOODLAND_BEAR_ACTOR_ID),
         );
         runtime.remember_resident_wants_item_memory(
@@ -70460,8 +70421,8 @@ mod tests {
             OLD_OAK_TREE_ACTOR_ID,
             STORY_BUTTON_ITEM_ID,
             40,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(WOODLAND_BEAR_ACTOR_ID),
         );
 
@@ -70499,7 +70460,7 @@ mod tests {
     fn ambient_autonomy_residents_carry_sought_items_to_remembered_residents() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -70522,13 +70483,13 @@ mod tests {
                 _ => {}
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             WHISKERWIND_ACTOR_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -70542,8 +70503,8 @@ mod tests {
             WHISKERWIND_ACTOR_ID,
             DEWBRIGHT_BUTTON_ITEM_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         assert!(runtime.resident_remembers_actor_wants_item(
@@ -70589,7 +70550,7 @@ mod tests {
     fn resident_delivery_follows_stale_actor_memory_instead_of_global_truth() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         runtime
             .world
             .actors
@@ -70612,13 +70573,13 @@ mod tests {
                 _ => {}
             }
         }
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             WHISKERWIND_ACTOR_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         runtime.remember_resident_wants_item_memory(
@@ -70626,8 +70587,8 @@ mod tests {
             WHISKERWIND_ACTOR_ID,
             DEWBRIGHT_BUTTON_ITEM_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -70657,7 +70618,7 @@ mod tests {
     fn resident_delivery_uses_carried_actor_memory_not_live_target_room() {
         let mut runtime = seeded_runtime_with_discovered_exits_for_test();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
                 DEWBRIGHT_BUTTON_ITEM_ID => {
@@ -70680,13 +70641,13 @@ mod tests {
                 .location_id,
             COSY_COTTAGE_LOCATION_ID
         );
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             WHISKERWIND_ACTOR_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
         runtime.remember_resident_wants_item_memory(
@@ -70694,8 +70655,8 @@ mod tests {
             WHISKERWIND_ACTOR_ID,
             DEWBRIGHT_BUTTON_ITEM_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(RATI_ACTOR_ID),
         );
 
@@ -71133,13 +71094,13 @@ mod tests {
         );
         let (status, _) = runtime.apply_journal_record(&record);
         assert_eq!(status, CW_OK);
-        runtime.remember_resident_memory(
+        runtime.remember_belief(
             RATI_ACTOR_ID,
-            RESIDENT_MEMORY_KIND_ACTOR_LOCATION,
+            BELIEF_KIND_ACTOR_LOCATION,
             WHISKERWIND_ACTOR_ID,
             RAIN_SOFT_GARDEN_LOCATION_ID,
-            RESIDENT_OBSERVED_MEMORY_CONFIDENCE,
-            RESIDENT_OBSERVED_MEMORY_SALIENCE,
+            BELIEF_TUNING.firsthand_confidence,
+            BELIEF_TUNING.firsthand_salience,
             Some(WHISKERWIND_ACTOR_ID),
         );
         runtime.record_economy_disclosure(5000, RATI_ACTOR_ID);

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -555,6 +555,7 @@ const NARRATIVE_MOVE_SIGNATURE_TTL: Duration = Duration::from_secs(5 * 60);
 const NARRATIVE_MOVE_SIGNATURE_FUTURE_SKEW_SECS: u64 = 60;
 const NARRATIVE_MOVE_DELEGATION_MAX_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 const GENERATED_PATHWAY_LOCATION_ID_BASE: u64 = 100_000;
+const GENERATED_PATHWAY_LOCATION_ID_LIMIT: u64 = 1_000_000_000_000;
 const EXPLORER_CALLING_STATEMENT: &str = "I explore the paths nobody has named yet.";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -605,6 +606,8 @@ struct GenerationProvenance {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct GeneratedWaypointState {
     id: u64,
+    #[serde(default)]
+    canonical_id: String,
     name: String,
     meta: LocationMeta,
 }
@@ -612,6 +615,18 @@ struct GeneratedWaypointState {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct GeneratedPathwayState {
     id: String,
+    #[serde(default)]
+    identity_version: u8,
+    #[serde(default)]
+    canonical_id: String,
+    #[serde(default)]
+    source_route_id: String,
+    #[serde(default)]
+    source_route_version: u64,
+    #[serde(default)]
+    owner_pack_id: String,
+    #[serde(default)]
+    owner_pack_version: String,
     origin_location_id: u64,
     destination_location_id: u64,
     distance: u8,
@@ -1923,7 +1938,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 11;
+const JOURNAL_RECORD_VERSION: u32 = 12;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -6142,7 +6157,7 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 12,
+            version: 13,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
@@ -6434,7 +6449,11 @@ impl RuntimeSnapshot {
             next_content_id: self.next_content_id,
             next_seed: self.next_seed,
         })
-        .map(move |mut runtime| {
+        .and_then(move |mut runtime| {
+            runtime.ensure_authored_route_records();
+            runtime
+                .migrate_generated_pathways_for_snapshot(snapshot_version)
+                .map_err(snapshot_error)?;
             runtime.backfill_recent_room_lines();
             runtime.ensure_seed_topology();
             if snapshot_version < 12 {
@@ -6456,7 +6475,7 @@ impl RuntimeSnapshot {
             let mint_seed = runtime.next_seed;
             runtime.ensure_canonical_identities(mint_seed);
             runtime.refresh_all_canonical_events();
-            runtime
+            Ok(runtime)
         })
     }
 }
@@ -6559,6 +6578,17 @@ fn zone_for_safety(safety: &str) -> &'static str {
 
 impl RuntimeWorld {
     fn ensure_canonical_identities(&mut self, mint_seed: u64) {
+        let generated_location_refs = self
+            .generated_pathways
+            .values()
+            .flat_map(|pathway| {
+                pathway
+                    .waypoints
+                    .iter()
+                    .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+            })
+            .filter(|(_, canonical_id)| !canonical_id.is_empty())
+            .collect::<BTreeMap<_, _>>();
         let actor_ids = self.world.actors[..self.world.actor_count]
             .iter()
             .map(|actor| actor.id)
@@ -6618,6 +6648,7 @@ impl RuntimeWorld {
             let canonical_ref = content_registry()
                 .content_reference("location", location_id)
                 .map(|entry| entry.canonical_ref.clone())
+                .or_else(|| generated_location_refs.get(&location_id).cloned())
                 .unwrap_or_else(|| {
                     opaque_runtime_ref("location", &format!("{location_id}:{mint_seed}"))
                 });
@@ -7513,19 +7544,25 @@ impl RuntimeWorld {
     }
 
     fn ensure_revealed_generated_natural_affordances(&mut self) {
-        let location_ids = self
+        let locations = self
             .generated_pathways
             .values()
-            .flat_map(|pathway| pathway.waypoints.iter().map(|waypoint| waypoint.id))
-            .filter(|location_id| self.generated_location_is_revealed(*location_id))
+            .flat_map(|pathway| {
+                pathway.waypoints.iter().map(|waypoint| {
+                    (
+                        waypoint.id,
+                        pathway.owner_pack_id.clone(),
+                        pathway.owner_pack_version.clone(),
+                    )
+                })
+            })
+            .filter(|(location_id, _, _)| self.generated_location_is_revealed(*location_id))
             .collect::<Vec<_>>();
-        let pack_id = "cosyworld.core";
-        let pack_version = self.active_pack_version(pack_id);
-        for location_id in location_ids {
+        for (location_id, pack_id, pack_version) in locations {
             self.ensure_natural_affordance_for_location(
                 location_id,
                 "generated_environment",
-                pack_id,
+                &pack_id,
                 &pack_version,
             );
         }
@@ -7926,6 +7963,13 @@ impl RuntimeWorld {
             focused_profile: None,
             focused_encounter: None,
         });
+        if let Some(job) = self.jobs.get_mut(&job_id) {
+            job.pack_id = state.generation.pack_id.clone();
+            for strategy in &mut job.contribution_strategies {
+                strategy.pack_id = state.generation.pack_id.clone();
+                strategy.pack_version = state.generation.pack_version.clone();
+            }
+        }
         if revealed {
             if let Some(clock) = self.clocks.get_mut(&state.investigation_clock_id) {
                 clock.filled = clock.segments;
@@ -8265,9 +8309,18 @@ impl RuntimeWorld {
     fn ensure_generated_pathway_topology(&mut self) {
         let pathway_ids = self.generated_pathways.keys().cloned().collect::<Vec<_>>();
         for pathway_id in pathway_ids {
-            let Some(pathway_snapshot) = self.generated_pathways.get(&pathway_id).cloned() else {
+            let Some(mut pathway_snapshot) = self.generated_pathways.get(&pathway_id).cloned()
+            else {
                 continue;
             };
+            if self
+                .normalize_generated_pathway_identity(&mut pathway_snapshot, false)
+                .is_err()
+            {
+                continue;
+            }
+            self.generated_pathways
+                .insert(pathway_id.clone(), pathway_snapshot.clone());
             let origin_meta = self.location_meta_for(pathway_snapshot.origin_location_id);
             let destination_meta = self.location_meta_for(pathway_snapshot.destination_location_id);
             let waypoint_count = pathway_snapshot.waypoints.len();
@@ -8342,11 +8395,19 @@ impl RuntimeWorld {
             self.location_meta
                 .entry(waypoint.id)
                 .or_insert_with(|| waypoint.meta.clone());
+            self.canonical_identities
+                .location_refs
+                .entry(waypoint.id)
+                .or_insert_with(|| waypoint.canonical_id.clone());
+            self.canonical_identities
+                .entity_versions
+                .entry(waypoint.canonical_id.clone())
+                .or_insert(1);
         }
         self.open_generated_pathway_route(pathway, from_location_id, to_location_id);
         self.rebuild_kernel_exits_from_routes();
-        let pack_id = "cosyworld.core";
-        let pack_version = self.active_pack_version(pack_id);
+        let pack_id = pathway.owner_pack_id.clone();
+        let pack_version = pathway.owner_pack_version.clone();
         for location_id in [from_location_id, to_location_id] {
             if pathway
                 .waypoints
@@ -8356,9 +8417,17 @@ impl RuntimeWorld {
                 self.ensure_natural_affordance_for_location(
                     location_id,
                     "generated_environment",
-                    pack_id,
+                    &pack_id,
                     &pack_version,
                 );
+                if let Some(state) = self.natural_affordances.get_mut(&location_id) {
+                    state.generation.pack_id = pack_id.clone();
+                    state.generation.pack_version = pack_version.clone();
+                    if let Some(feature) = state.revealed_feature.as_mut() {
+                        feature.generation.pack_id = pack_id.clone();
+                        feature.generation.pack_version = pack_version.clone();
+                    }
+                }
                 let connected_from_location_id = if location_id == from_location_id {
                     to_location_id
                 } else {
@@ -10071,6 +10140,7 @@ impl RuntimeWorld {
                 &committed_events,
                 &record.projection_mutations,
                 enforce_active_contribution_contract,
+                record.version < JOURNAL_RECORD_VERSION,
             ));
             events.extend(self.apply_focused_job_record(record));
             self.refresh_craft_event_presentation(&mut events);
@@ -10192,6 +10262,7 @@ impl RuntimeWorld {
         committed_events: &[EventView],
         mutations: &[ProjectionMutation],
         enforce_active_contribution_contract: bool,
+        allow_legacy_generated_identity_backfill: bool,
     ) -> Vec<EventView> {
         let mut events = Vec::new();
         for mutation in mutations {
@@ -10375,6 +10446,15 @@ impl RuntimeWorld {
                 }
                 ProjectionMutation::RefinePathway { pathway } => {
                     let mut refined = pathway.clone();
+                    if self
+                        .normalize_generated_pathway_identity(
+                            &mut refined,
+                            allow_legacy_generated_identity_backfill,
+                        )
+                        .is_err()
+                    {
+                        continue;
+                    }
                     if let Some(current) = self.generated_pathways.get(&pathway.id) {
                         refined
                             .revealed_edges
@@ -10447,11 +10527,21 @@ impl RuntimeWorld {
                     narration,
                     event_type,
                 } => {
+                    let mut proposed_pathway = pathway.clone();
+                    if self
+                        .normalize_generated_pathway_identity(
+                            &mut proposed_pathway,
+                            allow_legacy_generated_identity_backfill,
+                        )
+                        .is_err()
+                    {
+                        continue;
+                    }
                     let mut next_pathway = self
                         .generated_pathways
-                        .get(&pathway.id)
+                        .get(&proposed_pathway.id)
                         .cloned()
-                        .unwrap_or_else(|| pathway.clone());
+                        .unwrap_or(proposed_pathway);
                     self.ensure_generated_pathway_route_records(&next_pathway);
                     for (from_location_id, to_location_id) in reveal_edges {
                         next_pathway
@@ -13658,24 +13748,6 @@ impl RuntimeWorld {
             .is_some_and(|calling| calling_statement_is_explorer(&calling.statement))
     }
 
-    fn pathway_for_anchors(
-        &self,
-        from_location_id: u64,
-        to_location_id: u64,
-    ) -> Option<&GeneratedPathwayState> {
-        self.generated_pathways
-            .get(&generated_pathway_id(from_location_id, to_location_id))
-    }
-
-    fn generated_pathway_for_location(&self, location_id: u64) -> Option<&GeneratedPathwayState> {
-        self.generated_pathways.values().find(|pathway| {
-            pathway
-                .waypoints
-                .iter()
-                .any(|waypoint| waypoint.id == location_id)
-        })
-    }
-
     fn generated_pathway_id_for_progress_clock(&self, clock_id: &str) -> Option<String> {
         self.generated_pathways
             .values()
@@ -13705,112 +13777,6 @@ impl RuntimeWorld {
             })
             .map(|exit| exit.distance.max(1))
             .unwrap_or(1)
-    }
-
-    fn generated_pathway(
-        &self,
-        actor_id: u64,
-        from_location_id: u64,
-        to_location_id: u64,
-        distance: u8,
-    ) -> GeneratedPathwayState {
-        let (origin_location_id, destination_location_id) =
-            canonical_pathway_anchors(from_location_id, to_location_id);
-        let origin_name = self
-            .location_name(origin_location_id)
-            .unwrap_or_else(|| "one known place".to_string());
-        let destination_name = self
-            .location_name(destination_location_id)
-            .unwrap_or_else(|| "another known place".to_string());
-        let origin_meta = self.location_meta_for(origin_location_id);
-        let destination_meta = self.location_meta_for(destination_location_id);
-        let pathway_id = generated_pathway_id(origin_location_id, destination_location_id);
-        let seed = stable_pathway_hash(&pathway_id);
-        let waypoint_count = usize::from(distance.saturating_sub(1));
-        let names = [
-            "Lantern Bend",
-            "Mossy Verge",
-            "Rain-Silver Crossing",
-            "Foxglove Turn",
-            "Quiet Rise",
-            "Bramble Mile",
-        ];
-        let waypoints = (0..waypoint_count)
-            .map(|index| {
-                let landmark_name = names[(seed as usize + index) % names.len()].to_string();
-                let id = generated_pathway_location_id(&pathway_id, index);
-                let art_prompt = format!(
-                    "cozy storybook landscape, {landmark_name}, a hidden waypoint along a newly explored pathway between {origin_name} and {destination_name}, stretch {step} of {distance}, {origin_biome} terrain meeting {destination_biome} terrain, {origin} meeting {destination}, no people, no characters, no creatures, no text, no logo, no watermark",
-                    step = index + 1,
-                    origin_biome = origin_meta.biome,
-                    destination_biome = destination_meta.biome,
-                    origin = origin_meta.description,
-                    destination = destination_meta.description,
-                );
-                let terrain = interpolated_pathway_terrain(
-                    &origin_meta,
-                    &destination_meta,
-                    index,
-                    waypoint_count,
-                );
-                let environment = interpolated_environment_profile(
-                    &origin_meta.environment,
-                    &destination_meta.environment,
-                    index,
-                    waypoint_count,
-                );
-                let natural_potentials = generated_potential_rules(&environment);
-                let terrain_phrase = terrain
-                    .iter()
-                    .take(3)
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let description = format!(
-                    "At {landmark_name}, {terrain_phrase} mark a half-known stretch between {origin_name} and {destination_name}; weather and footprints are still deciding what belongs."
-                );
-                GeneratedWaypointState {
-                    id,
-                    name: landmark_name.clone(),
-                    meta: LocationMeta {
-                        title: "Newly Found Path".to_string(),
-                        description,
-                        persona: format!(
-                            "{landmark_name} is unfinished geography: alert, changeable, and eager to become familiar through footsteps."
-                        ),
-                        memory: vec![format!(
-                            "An Explorer first drew this path between {origin_name} and {destination_name}."
-                        )],
-                        biome: format!("{} to {}", origin_meta.biome, destination_meta.biome),
-                        terrain,
-                        environment,
-                        natural_potentials,
-                        image_url: Some(format!("/assets/generated/pathways/{id}.svg")),
-                        art_prompt: Some(art_prompt),
-                    },
-                }
-            })
-            .collect();
-        GeneratedPathwayState {
-            id: pathway_id,
-            origin_location_id,
-            destination_location_id,
-            distance,
-            created_by_actor_id: actor_id,
-            waypoints,
-            generation: GenerationProvenance {
-                source: "deterministic_fallback".to_string(),
-                feature: PATHWAY_CONTENT_FEATURE.to_string(),
-                policy_mode: "fallback".to_string(),
-                prompt_version: PATHWAY_CONTENT_PROMPT_VERSION.to_string(),
-                provider: "none".to_string(),
-                model: "none".to_string(),
-                attempts: 0,
-            },
-            revealed_edges: BTreeSet::new(),
-            art_eligible: distance >= 2,
-            familiar: false,
-        }
     }
 
     fn pathway_path(
@@ -14026,14 +13992,15 @@ impl RuntimeWorld {
             .pathway_for_anchors(actor.location_id, requested_destination_id)
             .cloned();
         let discovering_pathway = existing_pathway.is_none();
-        let pathway = existing_pathway.unwrap_or_else(|| {
-            self.generated_pathway(
+        let pathway = match existing_pathway {
+            Some(pathway) => pathway,
+            None => self.generated_pathway(
                 actor_id,
                 actor.location_id,
                 requested_destination_id,
                 distance,
-            )
-        });
+            )?,
+        };
         let path = self.pathway_path(&pathway, actor.location_id, requested_destination_id);
         let first_edge = (path[0], path[1]);
         let next_journey = JourneyState {
@@ -37742,9 +37709,15 @@ fn canonical_pathway_anchors(left: u64, right: u64) -> (u64, u64) {
     }
 }
 
-fn generated_pathway_id(left: u64, right: u64) -> String {
-    let (origin, destination) = canonical_pathway_anchors(left, right);
-    format!("pathway:{origin}:{destination}")
+fn generated_pathway_canonical_id(source_route: &RouteRecordState) -> String {
+    format!(
+        "generated-pathway:{}@{}",
+        source_route.canonical_id, source_route.entity_version
+    )
+}
+
+fn generated_waypoint_canonical_id(pathway_id: &str, index: usize) -> String {
+    format!("{pathway_id}/waypoint/{index}")
 }
 
 fn generated_pathway_progress_clock_id(pathway_id: &str) -> String {
@@ -37853,10 +37826,9 @@ fn materialized_item_id(receipt_id: &str) -> u64 {
     MATERIALIZED_ITEM_ID_BASE + stable_pathway_hash(receipt_id) % MATERIALIZED_ITEM_ID_RANGE
 }
 
-fn generated_pathway_location_id(pathway_id: &str, index: usize) -> u64 {
-    GENERATED_PATHWAY_LOCATION_ID_BASE
-        + (stable_pathway_hash(pathway_id) % 10_000) * 16
-        + index as u64
+fn generated_pathway_location_id(waypoint_canonical_id: &str) -> u64 {
+    let range = GENERATED_PATHWAY_LOCATION_ID_LIMIT - GENERATED_PATHWAY_LOCATION_ID_BASE;
+    GENERATED_PATHWAY_LOCATION_ID_BASE + stable_pathway_hash(waypoint_canonical_id) % range
 }
 
 fn interpolated_pathway_terrain(
@@ -47297,12 +47269,14 @@ mod tests {
     #[test]
     fn generated_pathway_content_can_change_narrative_fields_only() {
         let runtime = RuntimeWorld::seeded();
-        let mut pathway = runtime.generated_pathway(
-            5000,
-            RAIN_SOFT_GARDEN_LOCATION_ID,
-            MOONLIT_TRAIL_LOCATION_ID,
-            2,
-        );
+        let mut pathway = runtime
+            .generated_pathway(
+                5000,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+                MOONLIT_TRAIL_LOCATION_ID,
+                2,
+            )
+            .expect("canonical generated pathway");
         let waypoint = pathway
             .waypoints
             .first_mut()
@@ -47903,12 +47877,14 @@ mod tests {
             &mut replay,
             &avatar_record(5000, RAIN_SOFT_GARDEN_LOCATION_ID, "Trail Builder", 910_000),
         );
-        let rejected_pathway = runtime.generated_pathway(
-            5000,
-            RAIN_SOFT_GARDEN_LOCATION_ID,
-            MOONLIT_TRAIL_LOCATION_ID,
-            2,
-        );
+        let rejected_pathway = runtime
+            .generated_pathway(
+                5000,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+                MOONLIT_TRAIL_LOCATION_ID,
+                2,
+            )
+            .expect("canonical generated pathway");
         let rejected_waypoint_id = rejected_pathway.waypoints[0].id;
         let mut rejected_record = JournalRecord::new(
             CwAction {
@@ -47946,8 +47922,7 @@ mod tests {
         search_record.projection_mutations.push(search_mutation);
         let discovery_events = apply_pair(&mut runtime, &mut replay, &search_record);
 
-        let pathway_id =
-            generated_pathway_id(RAIN_SOFT_GARDEN_LOCATION_ID, MOONLIT_TRAIL_LOCATION_ID);
+        let pathway_id = runtime.journeys[&5000].pathway_id.clone();
         let first_waypoint_id = runtime.journeys[&5000].path[1];
         let place = runtime.generated_places[&first_waypoint_id].clone();
         assert_eq!(place.schema_version, GENERATED_PLACE_SCHEMA_VERSION);
@@ -59950,12 +59925,14 @@ mod tests {
     #[test]
     fn durable_frontier_projects_never_reset_as_encounters_and_repair_from_evidence() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut pathway = runtime.generated_pathway(
-            5000,
-            RAIN_SOFT_GARDEN_LOCATION_ID,
-            MOONLIT_TRAIL_LOCATION_ID,
-            2,
-        );
+        let mut pathway = runtime
+            .generated_pathway(
+                5000,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+                MOONLIT_TRAIL_LOCATION_ID,
+                2,
+            )
+            .expect("canonical generated pathway");
         let waypoint_id = pathway.waypoints[0].id;
         pathway
             .revealed_edges
@@ -60156,12 +60133,14 @@ mod tests {
     #[test]
     fn canonical_natural_feature_restores_legacy_generated_place_projection() {
         let mut source = RuntimeWorld::seeded();
-        let mut pathway = source.generated_pathway(
-            5000,
-            RAIN_SOFT_GARDEN_LOCATION_ID,
-            MOONLIT_TRAIL_LOCATION_ID,
-            2,
-        );
+        let mut pathway = source
+            .generated_pathway(
+                5000,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+                MOONLIT_TRAIL_LOCATION_ID,
+                2,
+            )
+            .expect("canonical generated pathway");
         let waypoint = pathway.waypoints[0].clone();
         pathway
             .revealed_edges

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -307,9 +307,9 @@ mod tests {
         runtime.remember_search_discovery(
             actor_id,
             from_location_id,
-            SEARCH_MEMORY_KIND_SEED_EXIT,
+            BELIEF_KIND_SEED_EXIT,
             to_location_id,
-            &seed_exit_search_memory_subject_key(from_location_id, to_location_id),
+            &seed_exit_belief_subject_key(from_location_id, to_location_id),
         );
     }
 

--- a/v2/orchestrator-rust/src/natural_affordances.rs
+++ b/v2/orchestrator-rust/src/natural_affordances.rs
@@ -703,12 +703,14 @@ mod tests {
     #[test]
     fn generated_riverside_feature_is_hidden_then_cooperatively_revealed_and_restored() {
         let mut runtime = RuntimeWorld::seeded();
-        let pathway = runtime.generated_pathway(
-            5000,
-            RAIN_SOFT_GARDEN_LOCATION_ID,
-            MOONLIT_TRAIL_LOCATION_ID,
-            2,
-        );
+        let pathway = runtime
+            .generated_pathway(
+                5000,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+                MOONLIT_TRAIL_LOCATION_ID,
+                2,
+            )
+            .expect("canonical generated pathway");
         let waypoint_id = pathway.waypoints[0].id;
         runtime
             .generated_pathways

--- a/v2/orchestrator-rust/src/resident_offer_scoring.rs
+++ b/v2/orchestrator-rust/src/resident_offer_scoring.rs
@@ -396,7 +396,7 @@ mod tests {
     fn mutual_trade_remains_the_top_scored_room_offer() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        runtime.resident_memories.clear();
+        runtime.beliefs.clear();
         for item in &mut runtime.world.items[..runtime.world.item_count] {
             match item.id {
                 DEWBRIGHT_BUTTON_ITEM_ID => {

--- a/v2/orchestrator-rust/src/settlement_buildings.rs
+++ b/v2/orchestrator-rust/src/settlement_buildings.rs
@@ -1863,6 +1863,7 @@ mod tests {
             GeneratedPlaceState {
                 schema_version: GENERATED_PLACE_SCHEMA_VERSION,
                 location_id,
+                canonical_id: "test-generated-place".to_string(),
                 pathway_id: "test-pathway".to_string(),
                 connected_from_location_id: MOONLIT_TRAIL_LOCATION_ID,
                 discovered_by_actor_id: RATI_ACTOR_ID,

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -1335,26 +1335,27 @@ mod tests {
     #[test]
     fn memory_decay_never_changes_shared_topology() {
         let mut runtime = RuntimeWorld::seeded();
-        runtime.search_memories.insert(
-            "route-memory".to_string(),
-            SearchMemoryState {
-                id: "route-memory".to_string(),
-                actor_id: RATI_ACTOR_ID,
-                kind: "exit".to_string(),
+        merge_belief(
+            &mut runtime.beliefs,
+            BeliefState {
+                id: String::new(),
+                holder_actor_id: RATI_ACTOR_ID,
+                kind: BELIEF_KIND_SEED_EXIT.to_string(),
                 location_id: COSY_COTTAGE_LOCATION_ID,
                 subject_id: RAIN_SOFT_GARDEN_LOCATION_ID,
-                subject_key: "exit:1:2".to_string(),
                 confidence: 1,
                 salience: 1,
-                found_tick: 0,
-                last_used_tick: 0,
-                use_count: 0,
+                observed_tick: 1,
+                source_actor_id: Some(RATI_ACTOR_ID),
+                related_actor_id: None,
+                learned_tick: 1,
+                hops: 0,
             },
         );
         let routes = runtime.routes.clone();
         let exits = runtime.world.exits[..runtime.world.exit_count].to_vec();
-        runtime.world.tick = SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS * 64;
-        runtime.decay_search_memories();
+        runtime.world.tick = BELIEF_TUNING.decay_interval_ticks * 64;
+        runtime.decay_beliefs();
         assert_eq!(runtime.routes, routes);
         assert_eq!(&runtime.world.exits[..runtime.world.exit_count], exits);
     }
@@ -1405,8 +1406,8 @@ mod tests {
         runtime.world.tick = runtime
             .world
             .tick
-            .saturating_add(SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS * 64);
-        runtime.decay_search_memories();
+            .saturating_add(BELIEF_TUNING.decay_interval_ticks * 64);
+        runtime.decay_beliefs();
 
         assert!(
             runtime.seed_exit_discovered(COSY_COTTAGE_LOCATION_ID, RAIN_SOFT_GARDEN_LOCATION_ID)
@@ -1875,7 +1876,7 @@ mod tests {
             &serde_json::to_vec(&snapshot).expect("serialize downgraded fixture"),
         )
         .expect("clone downgraded fixture");
-        forged_current_snapshot.version = 13;
+        forged_current_snapshot.version = 14;
         assert!(forged_current_snapshot.into_runtime().is_err());
 
         let restored = snapshot

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -27,8 +27,14 @@ pub(super) struct RouteDiscoveryState {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(super) struct RouteRecordState {
     pub(super) id: String,
+    #[serde(default)]
+    pub(super) canonical_id: String,
     pub(super) edges: Vec<RouteEdgeState>,
     pub(super) owner: String,
+    #[serde(default)]
+    pub(super) owner_pack_id: String,
+    #[serde(default)]
+    pub(super) owner_pack_version: String,
     pub(super) provenance: String,
     pub(super) lifecycle: RouteLifecycle,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -67,13 +73,44 @@ fn hidden_route_id(hidden_exit_id: &str) -> String {
     format!("route:hidden:{hidden_exit_id}")
 }
 
-fn generated_route_id(pathway_id: &str, left: u64, right: u64) -> String {
+fn canonical_location_route_component(location_id: u64) -> String {
+    content_registry()
+        .content_reference("location", location_id)
+        .map(|entry| entry.canonical_ref.clone())
+        .unwrap_or_else(|| format!("location:{location_id}"))
+}
+
+fn canonical_authored_route_id(pack_id: &str, left: u64, right: u64) -> String {
     let (left, right) = ordered_route_endpoints(left, right);
-    format!("route:generated:{pathway_id}:{left}:{right}")
+    format!(
+        "route://{pack_id}/authored/{}|{}",
+        canonical_location_route_component(left),
+        canonical_location_route_component(right)
+    )
+}
+
+fn canonical_hidden_route_id(pack_id: &str, hidden_exit_id: &str) -> String {
+    format!("route://{pack_id}/hidden/{hidden_exit_id}")
+}
+
+fn generated_route_id(pathway: &GeneratedPathwayState, left: u64, right: u64) -> Option<String> {
+    let mut path = Vec::with_capacity(pathway.waypoints.len() + 2);
+    path.push(pathway.origin_location_id);
+    path.extend(pathway.waypoints.iter().map(|waypoint| waypoint.id));
+    path.push(pathway.destination_location_id);
+    let segment = path.windows(2).position(|edge| {
+        (edge[0] == left && edge[1] == right) || (edge[0] == right && edge[1] == left)
+    })?;
+    let pathway_id = if pathway.canonical_id.is_empty() {
+        pathway.id.as_str()
+    } else {
+        pathway.canonical_id.as_str()
+    };
+    Some(format!("{pathway_id}/route/{segment}"))
 }
 
 impl RouteRecordState {
-    fn contains_edge(&self, from_location_id: u64, to_location_id: u64) -> bool {
+    pub(super) fn contains_edge(&self, from_location_id: u64, to_location_id: u64) -> bool {
         self.edges.iter().any(|edge| {
             edge.from_location_id == from_location_id && edge.to_location_id == to_location_id
         })
@@ -81,6 +118,512 @@ impl RouteRecordState {
 }
 
 impl RuntimeWorld {
+    pub(super) fn migrate_generated_pathways_for_snapshot(
+        &mut self,
+        snapshot_version: u32,
+    ) -> Result<(), String> {
+        let pathway_ids = self.generated_pathways.keys().cloned().collect::<Vec<_>>();
+        for pathway_id in pathway_ids {
+            let mut pathway = self
+                .generated_pathways
+                .get(&pathway_id)
+                .cloned()
+                .ok_or_else(|| "generated pathway disappeared during load".to_string())?;
+            self.normalize_generated_pathway_identity(&mut pathway, snapshot_version < 13)?;
+            self.generated_pathways.insert(pathway_id, pathway);
+        }
+        self.validate_generated_pathway_identity_claims()?;
+        if snapshot_version < 13 {
+            for pathway in self
+                .generated_pathways
+                .values()
+                .cloned()
+                .collect::<Vec<_>>()
+            {
+                self.migrate_legacy_generated_route_records(&pathway)?;
+            }
+            self.routes
+                .retain(|route_id, _| !route_id.starts_with("route:generated:"));
+        } else if self
+            .routes
+            .keys()
+            .any(|route_id| route_id.starts_with("route:generated:"))
+        {
+            return Err("current snapshot contains a legacy generated route identity".to_string());
+        }
+        Ok(())
+    }
+
+    pub(super) fn pathway_for_anchors(
+        &self,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) -> Option<&GeneratedPathwayState> {
+        let (origin_location_id, destination_location_id) =
+            canonical_pathway_anchors(from_location_id, to_location_id);
+        self.generated_pathways.values().find(|pathway| {
+            pathway.origin_location_id == origin_location_id
+                && pathway.destination_location_id == destination_location_id
+        })
+    }
+
+    pub(super) fn generated_pathway_for_location(
+        &self,
+        location_id: u64,
+    ) -> Option<&GeneratedPathwayState> {
+        self.generated_pathways.values().find(|pathway| {
+            pathway
+                .waypoints
+                .iter()
+                .any(|waypoint| waypoint.id == location_id)
+        })
+    }
+
+    pub(super) fn normalize_generated_pathway_identity(
+        &self,
+        pathway: &mut GeneratedPathwayState,
+        allow_legacy_backfill: bool,
+    ) -> Result<(), String> {
+        if pathway.identity_version > 1 {
+            return Err(format!(
+                "generated pathway {} has an unsupported identity version",
+                pathway.id
+            ));
+        }
+        let identity_is_incomplete = pathway.canonical_id.is_empty()
+            || pathway.source_route_id.is_empty()
+            || pathway.source_route_version == 0
+            || pathway.owner_pack_id.is_empty()
+            || pathway.owner_pack_version.is_empty()
+            || pathway
+                .waypoints
+                .iter()
+                .any(|waypoint| waypoint.canonical_id.is_empty());
+        if pathway.identity_version == 0 {
+            let is_unversioned_shape = pathway.canonical_id.is_empty()
+                && pathway.source_route_id.is_empty()
+                && pathway.source_route_version == 0
+                && pathway.owner_pack_id.is_empty()
+                && pathway.owner_pack_version.is_empty()
+                && pathway
+                    .waypoints
+                    .iter()
+                    .all(|waypoint| waypoint.canonical_id.is_empty());
+            if identity_is_incomplete && (!allow_legacy_backfill || !is_unversioned_shape) {
+                return Err(format!(
+                    "generated pathway {} has incomplete current identity metadata",
+                    pathway.id
+                ));
+            }
+        } else if identity_is_incomplete {
+            return Err(format!(
+                "generated pathway {} has incomplete current identity metadata",
+                pathway.id
+            ));
+        }
+
+        let source_route = self
+            .routes
+            .values()
+            .find(|route| {
+                route.provenance == "authored_exit"
+                    && route
+                        .contains_edge(pathway.origin_location_id, pathway.destination_location_id)
+            })
+            .ok_or_else(|| {
+                format!(
+                    "generated pathway {} has no canonical authored source route",
+                    pathway.id
+                )
+            })?;
+        if source_route.canonical_id.is_empty()
+            || source_route.owner_pack_id.is_empty()
+            || source_route.owner_pack_version.is_empty()
+        {
+            return Err(format!(
+                "generated pathway {} source route has incomplete ownership",
+                pathway.id
+            ));
+        }
+        if pathway.source_route_id.is_empty() {
+            pathway.source_route_id = source_route.canonical_id.clone();
+        } else if pathway.source_route_id != source_route.canonical_id {
+            return Err(format!(
+                "generated pathway {} source route identity changed",
+                pathway.id
+            ));
+        }
+        if pathway.source_route_version == 0 {
+            pathway.source_route_version = source_route.entity_version;
+        } else if pathway.source_route_version > source_route.entity_version {
+            return Err(format!(
+                "generated pathway {} references a future source route version",
+                pathway.id
+            ));
+        }
+        if pathway.owner_pack_id.is_empty() {
+            pathway.owner_pack_id = source_route.owner_pack_id.clone();
+        } else if pathway.owner_pack_id != source_route.owner_pack_id {
+            return Err(format!(
+                "generated pathway {} owner pack changed",
+                pathway.id
+            ));
+        }
+        if pathway.owner_pack_version.is_empty() {
+            pathway.owner_pack_version = source_route.owner_pack_version.clone();
+        } else if pathway.owner_pack_version != source_route.owner_pack_version {
+            return Err(format!(
+                "generated pathway {} owner pack version changed",
+                pathway.id
+            ));
+        }
+        let expected_pathway_id = format!(
+            "generated-pathway:{}@{}",
+            pathway.source_route_id, pathway.source_route_version
+        );
+        if pathway.canonical_id.is_empty() {
+            pathway.canonical_id = expected_pathway_id.clone();
+        } else if pathway.canonical_id != expected_pathway_id {
+            return Err(format!(
+                "generated pathway {} canonical identity changed",
+                pathway.id
+            ));
+        }
+        if pathway.identity_version == 1 && pathway.id != pathway.canonical_id {
+            return Err(format!(
+                "generated pathway {} does not use its canonical identity",
+                pathway.id
+            ));
+        }
+
+        let mut local_handles = BTreeSet::new();
+        for (index, waypoint) in pathway.waypoints.iter_mut().enumerate() {
+            let expected_canonical_id =
+                generated_waypoint_canonical_id(&pathway.canonical_id, index);
+            if waypoint.canonical_id.is_empty() {
+                waypoint.canonical_id = expected_canonical_id.clone();
+            } else if waypoint.canonical_id != expected_canonical_id {
+                return Err(format!(
+                    "generated waypoint {} canonical identity changed",
+                    waypoint.id
+                ));
+            }
+            if pathway.identity_version == 1
+                && waypoint.id != generated_pathway_location_id(&waypoint.canonical_id)
+            {
+                return Err(format!(
+                    "generated waypoint {} does not match its canonical identity",
+                    waypoint.id
+                ));
+            }
+            if !local_handles.insert(waypoint.id) {
+                return Err(format!(
+                    "generated pathway {} aliases waypoint handle {}",
+                    pathway.id, waypoint.id
+                ));
+            }
+            if self
+                .canonical_identities
+                .location_refs
+                .get(&waypoint.id)
+                .is_some_and(|canonical_id| canonical_id != &waypoint.canonical_id)
+            {
+                return Err(format!(
+                    "generated waypoint {} collides with another canonical location",
+                    waypoint.id
+                ));
+            }
+            if active_content()
+                .locations
+                .iter()
+                .any(|location| location.id == waypoint.id)
+            {
+                return Err(format!(
+                    "generated waypoint {} collides with an authored location",
+                    waypoint.id
+                ));
+            }
+            let existing_claim = self.generated_pathways.values().find_map(|existing| {
+                existing
+                    .waypoints
+                    .iter()
+                    .find(|candidate| candidate.id == waypoint.id)
+                    .map(|candidate| (existing.id.as_str(), candidate.canonical_id.as_str()))
+            });
+            if let Some((existing_pathway_id, existing_canonical_id)) = existing_claim {
+                let same_pathway = existing_pathway_id == pathway.id;
+                let same_identity = !existing_canonical_id.is_empty()
+                    && existing_canonical_id == waypoint.canonical_id;
+                if !same_pathway && !same_identity {
+                    return Err(format!(
+                        "generated waypoint {} collides with pathway {}",
+                        waypoint.id, existing_pathway_id
+                    ));
+                }
+            } else if self.world.locations[..self.world.location_count]
+                .iter()
+                .any(|location| location.id == waypoint.id)
+            {
+                return Err(format!(
+                    "generated waypoint {} collides with an unowned runtime location",
+                    waypoint.id
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_generated_pathway_identity_claims(&self) -> Result<(), String> {
+        let mut pathway_claims = BTreeSet::new();
+        let mut waypoint_identity_claims = BTreeSet::new();
+        let mut waypoint_handle_claims = BTreeSet::new();
+        for (storage_key, pathway) in &self.generated_pathways {
+            if storage_key != &pathway.id {
+                return Err(format!(
+                    "generated pathway storage key {} aliases {}",
+                    storage_key, pathway.id
+                ));
+            }
+            if !pathway_claims.insert(pathway.canonical_id.as_str()) {
+                return Err(format!(
+                    "generated pathway {} aliases canonical pathway {}",
+                    pathway.id, pathway.canonical_id
+                ));
+            }
+            for waypoint in &pathway.waypoints {
+                if !waypoint_identity_claims.insert(waypoint.canonical_id.as_str()) {
+                    return Err(format!(
+                        "generated pathway {} aliases canonical waypoint {}",
+                        pathway.id, waypoint.canonical_id
+                    ));
+                }
+                if !waypoint_handle_claims.insert(waypoint.id) {
+                    return Err(format!(
+                        "generated pathway {} aliases waypoint handle {}",
+                        pathway.id, waypoint.id
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn migrate_legacy_generated_route_records(
+        &mut self,
+        pathway: &GeneratedPathwayState,
+    ) -> Result<(), String> {
+        let provenance = format!("generated_pathway:{}", pathway.id);
+        let legacy_route_ids = self
+            .routes
+            .iter()
+            .filter(|(route_id, route)| {
+                route_id.starts_with("route:generated:") && route.provenance == provenance
+            })
+            .map(|(route_id, _)| route_id.clone())
+            .collect::<Vec<_>>();
+        let mut path = Vec::with_capacity(pathway.waypoints.len() + 2);
+        path.push(pathway.origin_location_id);
+        path.extend(pathway.waypoints.iter().map(|waypoint| waypoint.id));
+        path.push(pathway.destination_location_id);
+        let mut migrations = Vec::new();
+        let mut canonical_route_claims = BTreeSet::new();
+        for legacy_route_id in legacy_route_ids {
+            let route = self
+                .routes
+                .get(&legacy_route_id)
+                .expect("collected legacy route remains present");
+            let matching_segments = path
+                .windows(2)
+                .filter(|edge| {
+                    route.contains_edge(edge[0], edge[1]) && route.contains_edge(edge[1], edge[0])
+                })
+                .collect::<Vec<_>>();
+            if matching_segments.len() != 1 {
+                return Err(format!(
+                    "legacy generated route {} does not identify one pathway segment",
+                    legacy_route_id
+                ));
+            }
+            let edge = matching_segments[0];
+            let canonical_route_id = generated_route_id(pathway, edge[0], edge[1])
+                .ok_or_else(|| format!("cannot canonicalize route {legacy_route_id}"))?;
+            if legacy_route_id != canonical_route_id
+                && self.routes.contains_key(&canonical_route_id)
+            {
+                return Err(format!(
+                    "legacy generated route {} aliases canonical route {}",
+                    legacy_route_id, canonical_route_id
+                ));
+            }
+            if !canonical_route_claims.insert(canonical_route_id.clone()) {
+                return Err(format!(
+                    "legacy generated route {} aliases canonical route {}",
+                    legacy_route_id, canonical_route_id
+                ));
+            }
+            migrations.push((legacy_route_id, canonical_route_id));
+        }
+        for (legacy_route_id, canonical_route_id) in migrations {
+            let mut route = self
+                .routes
+                .remove(&legacy_route_id)
+                .expect("validated legacy route remains present");
+            route.id = canonical_route_id.clone();
+            route.canonical_id = canonical_route_id.clone();
+            route.owner = format!("worldpack:{}", pathway.owner_pack_id);
+            route.owner_pack_id = pathway.owner_pack_id.clone();
+            route.owner_pack_version = pathway.owner_pack_version.clone();
+            self.routes.insert(canonical_route_id, route);
+        }
+        Ok(())
+    }
+
+    fn generated_pathway_identity_is_compatible(
+        &self,
+        pathway: &GeneratedPathwayState,
+        allow_legacy_backfill: bool,
+    ) -> bool {
+        let mut normalized = pathway.clone();
+        self.normalize_generated_pathway_identity(&mut normalized, allow_legacy_backfill)
+            .is_ok()
+    }
+
+    pub(super) fn generated_pathway(
+        &self,
+        actor_id: u64,
+        from_location_id: u64,
+        to_location_id: u64,
+        distance: u8,
+    ) -> Result<GeneratedPathwayState, String> {
+        let (origin_location_id, destination_location_id) =
+            canonical_pathway_anchors(from_location_id, to_location_id);
+        let source_route = self
+            .routes
+            .values()
+            .find(|route| {
+                route.provenance == "authored_exit"
+                    && route.contains_edge(origin_location_id, destination_location_id)
+            })
+            .ok_or_else(|| {
+                format!(
+                    "no canonical authored route owns {origin_location_id}->{destination_location_id}"
+                )
+            })?;
+        if source_route.canonical_id.is_empty()
+            || source_route.owner_pack_id.is_empty()
+            || source_route.owner_pack_version.is_empty()
+        {
+            return Err("the canonical route has incomplete ownership metadata".to_string());
+        }
+        let origin_name = self
+            .location_name(origin_location_id)
+            .unwrap_or_else(|| "one known place".to_string());
+        let destination_name = self
+            .location_name(destination_location_id)
+            .unwrap_or_else(|| "another known place".to_string());
+        let origin_meta = self.location_meta_for(origin_location_id);
+        let destination_meta = self.location_meta_for(destination_location_id);
+        let pathway_id = generated_pathway_canonical_id(source_route);
+        let seed = stable_pathway_hash(&pathway_id);
+        let waypoint_count = usize::from(distance.saturating_sub(1));
+        let names = [
+            "Lantern Bend",
+            "Mossy Verge",
+            "Rain-Silver Crossing",
+            "Foxglove Turn",
+            "Quiet Rise",
+            "Bramble Mile",
+        ];
+        let waypoints = (0..waypoint_count)
+            .map(|index| {
+                let landmark_name = names[(seed as usize + index) % names.len()].to_string();
+                let canonical_id = generated_waypoint_canonical_id(&pathway_id, index);
+                let id = generated_pathway_location_id(&canonical_id);
+                let art_prompt = format!(
+                    "cozy storybook landscape, {landmark_name}, a hidden waypoint along a newly explored pathway between {origin_name} and {destination_name}, stretch {step} of {distance}, {origin_biome} terrain meeting {destination_biome} terrain, {origin} meeting {destination}, no people, no characters, no creatures, no text, no logo, no watermark",
+                    step = index + 1,
+                    origin_biome = origin_meta.biome,
+                    destination_biome = destination_meta.biome,
+                    origin = origin_meta.description,
+                    destination = destination_meta.description,
+                );
+                let terrain = interpolated_pathway_terrain(
+                    &origin_meta,
+                    &destination_meta,
+                    index,
+                    waypoint_count,
+                );
+                let environment = interpolated_environment_profile(
+                    &origin_meta.environment,
+                    &destination_meta.environment,
+                    index,
+                    waypoint_count,
+                );
+                let natural_potentials = generated_potential_rules(&environment);
+                let terrain_phrase = terrain
+                    .iter()
+                    .take(3)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let description = format!(
+                    "At {landmark_name}, {terrain_phrase} mark a half-known stretch between {origin_name} and {destination_name}; weather and footprints are still deciding what belongs."
+                );
+                GeneratedWaypointState {
+                    id,
+                    canonical_id,
+                    name: landmark_name.clone(),
+                    meta: LocationMeta {
+                        title: "Newly Found Path".to_string(),
+                        description,
+                        persona: format!(
+                            "{landmark_name} is unfinished geography: alert, changeable, and eager to become familiar through footsteps."
+                        ),
+                        memory: vec![format!(
+                            "An Explorer first drew this path between {origin_name} and {destination_name}."
+                        )],
+                        biome: format!("{} to {}", origin_meta.biome, destination_meta.biome),
+                        terrain,
+                        environment,
+                        natural_potentials,
+                        image_url: Some(format!("/assets/generated/pathways/{id}.svg")),
+                        art_prompt: Some(art_prompt),
+                    },
+                }
+            })
+            .collect();
+        let pathway = GeneratedPathwayState {
+            id: pathway_id.clone(),
+            identity_version: 1,
+            canonical_id: pathway_id,
+            source_route_id: source_route.canonical_id.clone(),
+            source_route_version: source_route.entity_version,
+            owner_pack_id: source_route.owner_pack_id.clone(),
+            owner_pack_version: source_route.owner_pack_version.clone(),
+            origin_location_id,
+            destination_location_id,
+            distance,
+            created_by_actor_id: actor_id,
+            waypoints,
+            generation: GenerationProvenance {
+                source: "deterministic_fallback".to_string(),
+                feature: PATHWAY_CONTENT_FEATURE.to_string(),
+                policy_mode: "fallback".to_string(),
+                prompt_version: PATHWAY_CONTENT_PROMPT_VERSION.to_string(),
+                provider: "none".to_string(),
+                model: "none".to_string(),
+                attempts: 0,
+            },
+            revealed_edges: BTreeSet::new(),
+            art_eligible: distance >= 2,
+            familiar: false,
+        };
+        if !self.generated_pathway_identity_is_compatible(&pathway, false) {
+            return Err("generated pathway identity or numeric handle collides".to_string());
+        }
+        Ok(pathway)
+    }
+
     fn reconcile_route_record(&mut self, mut proposed: RouteRecordState) {
         proposed
             .edges
@@ -91,14 +634,25 @@ impl RuntimeWorld {
             self.routes.insert(proposed.id.clone(), proposed);
             return;
         };
+        let metadata_backfill = current.canonical_id.is_empty()
+            && current.owner_pack_id.is_empty()
+            && current.owner_pack_version.is_empty();
         let structure_changed = current.edges != proposed.edges
+            || current.canonical_id != proposed.canonical_id
             || current.owner != proposed.owner
+            || current.owner_pack_id != proposed.owner_pack_id
+            || current.owner_pack_version != proposed.owner_pack_version
             || current.provenance != proposed.provenance;
         if structure_changed {
             current.edges = proposed.edges;
+            current.canonical_id = proposed.canonical_id;
             current.owner = proposed.owner;
+            current.owner_pack_id = proposed.owner_pack_id;
+            current.owner_pack_version = proposed.owner_pack_version;
             current.provenance = proposed.provenance;
-            current.entity_version = current.entity_version.saturating_add(1).max(1);
+            if !metadata_backfill {
+                current.entity_version = current.entity_version.saturating_add(1).max(1);
+            }
         }
     }
 
@@ -106,12 +660,25 @@ impl RuntimeWorld {
         let mut records = BTreeMap::<String, RouteRecordState>::new();
         for exit in &active_content().exits {
             let id = authored_route_id(exit.from_location_id, exit.to_location_id);
+            let owner_pack_id = if exit.pack_id.is_empty() {
+                active_content().manifest.id.clone()
+            } else {
+                exit.pack_id.clone()
+            };
+            let owner_pack_version = self.active_pack_version(&owner_pack_id);
             records
                 .entry(id.clone())
                 .or_insert_with(|| RouteRecordState {
                     id,
+                    canonical_id: canonical_authored_route_id(
+                        &owner_pack_id,
+                        exit.from_location_id,
+                        exit.to_location_id,
+                    ),
                     edges: Vec::new(),
-                    owner: format!("worldpack:{}", active_content().manifest.id),
+                    owner: format!("worldpack:{owner_pack_id}"),
+                    owner_pack_id,
+                    owner_pack_version,
                     provenance: "authored_exit".to_string(),
                     lifecycle: RouteLifecycle::Open,
                     discovery: None,
@@ -131,8 +698,15 @@ impl RuntimeWorld {
 
     pub(super) fn ensure_hidden_route_records(&mut self) {
         for hidden in &active_content().hidden_exits {
+            let owner_pack_id = if hidden.pack_id.is_empty() {
+                active_content().manifest.id.clone()
+            } else {
+                hidden.pack_id.clone()
+            };
+            let owner_pack_version = self.active_pack_version(&owner_pack_id);
             self.reconcile_route_record(RouteRecordState {
                 id: hidden_route_id(&hidden.id),
+                canonical_id: canonical_hidden_route_id(&owner_pack_id, &hidden.id),
                 edges: vec![
                     RouteEdgeState {
                         from_location_id: hidden.from_location_id,
@@ -145,7 +719,9 @@ impl RuntimeWorld {
                         flags: 0,
                     },
                 ],
-                owner: format!("worldpack:{}", active_content().manifest.id),
+                owner: format!("worldpack:{owner_pack_id}"),
+                owner_pack_id,
+                owner_pack_version,
                 provenance: hidden.source.clone(),
                 lifecycle: RouteLifecycle::Latent,
                 discovery: None,
@@ -173,12 +749,11 @@ impl RuntimeWorld {
             } else {
                 RouteLifecycle::Latent
             };
-            let id = generated_route_id(&pathway.id, from_location_id, to_location_id);
-            let owner = self
-                .canonical_ref("actor", pathway.created_by_actor_id)
-                .map(ToString::to_string)
-                .unwrap_or_else(|| format!("actor:{}", pathway.created_by_actor_id));
+            let Some(id) = generated_route_id(pathway, from_location_id, to_location_id) else {
+                continue;
+            };
             self.reconcile_route_record(RouteRecordState {
+                canonical_id: id.clone(),
                 id,
                 edges: vec![
                     RouteEdgeState {
@@ -192,7 +767,9 @@ impl RuntimeWorld {
                         flags: 0,
                     },
                 ],
-                owner,
+                owner: format!("worldpack:{}", pathway.owner_pack_id),
+                owner_pack_id: pathway.owner_pack_id.clone(),
+                owner_pack_version: pathway.owner_pack_version.clone(),
                 provenance: format!("generated_pathway:{}", pathway.id),
                 lifecycle,
                 discovery: None,
@@ -483,6 +1060,9 @@ impl RuntimeWorld {
         let Some(route) = self.routes.get(&route_id) else {
             return;
         };
+        if route.lifecycle != RouteLifecycle::Latent {
+            return;
+        }
         let version = route.entity_version;
         self.transition_route(&route_id, version, RouteLifecycle::Open);
     }
@@ -494,10 +1074,15 @@ impl RuntimeWorld {
         to_location_id: u64,
     ) {
         self.ensure_generated_pathway_route_records(pathway);
-        let route_id = generated_route_id(&pathway.id, from_location_id, to_location_id);
+        let Some(route_id) = generated_route_id(pathway, from_location_id, to_location_id) else {
+            return;
+        };
         let Some(route) = self.routes.get(&route_id) else {
             return;
         };
+        if route.lifecycle != RouteLifecycle::Latent {
+            return;
+        }
         let version = route.entity_version;
         self.transition_route(&route_id, version, RouteLifecycle::Open);
     }
@@ -531,6 +1116,21 @@ impl RuntimeWorld {
     }
 
     pub(super) fn route_record_preconditions_hold(&self, record: &JournalRecord) -> bool {
+        if !record
+            .projection_mutations
+            .iter()
+            .all(|mutation| match mutation {
+                ProjectionMutation::JourneyTransition { pathway, .. }
+                | ProjectionMutation::RefinePathway { pathway } => self
+                    .generated_pathway_identity_is_compatible(
+                        pathway,
+                        record.version < JOURNAL_RECORD_VERSION,
+                    ),
+                _ => true,
+            })
+        {
+            return false;
+        }
         if record
             .route_binding
             .as_ref()
@@ -620,6 +1220,38 @@ impl RuntimeWorld {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn legacy_pathway(
+        runtime: &RuntimeWorld,
+        origin_location_id: u64,
+        destination_location_id: u64,
+        distance: u8,
+        legacy_id: &str,
+    ) -> GeneratedPathwayState {
+        let mut pathway = runtime
+            .generated_pathway(
+                RATI_ACTOR_ID,
+                origin_location_id,
+                destination_location_id,
+                distance,
+            )
+            .expect("canonical source route");
+        pathway.id = legacy_id.to_string();
+        pathway.identity_version = 0;
+        pathway.canonical_id.clear();
+        pathway.source_route_id.clear();
+        pathway.source_route_version = 0;
+        pathway.owner_pack_id.clear();
+        pathway.owner_pack_version.clear();
+        for (index, waypoint) in pathway.waypoints.iter_mut().enumerate() {
+            waypoint.id = GENERATED_PATHWAY_LOCATION_ID_BASE
+                + (stable_pathway_hash(legacy_id) % 10_000) * 16
+                + index as u64;
+            waypoint.canonical_id.clear();
+        }
+        pathway.revealed_edges.clear();
+        pathway
+    }
 
     #[test]
     fn canonical_routes_compile_kernel_exits_and_survive_snapshot() {
@@ -933,5 +1565,372 @@ mod tests {
         assert_eq!(discovery.actor_id, RATI_ACTOR_ID);
         assert!(discovery.event_seq > 0);
         assert_eq!(discovery.reason, "legacy_discovery_tag");
+    }
+
+    #[test]
+    fn generated_waypoint_allocation_is_mount_order_stable_and_collision_safe() {
+        let mut first_order = RuntimeWorld::seeded();
+        let core_pathway = first_order
+            .generated_pathway(RATI_ACTOR_ID, 3, 50, 3)
+            .expect("Core owns its long route");
+        first_order
+            .generated_pathways
+            .insert(core_pathway.id.clone(), core_pathway.clone());
+        let bridge_pathway = first_order
+            .generated_pathway(RATI_ACTOR_ID, 12, 50, 3)
+            .expect("the composition bridge owns its long route");
+
+        let mut reverse_order = RuntimeWorld::seeded();
+        let bridge_first = reverse_order
+            .generated_pathway(RATI_ACTOR_ID, 12, 50, 3)
+            .expect("the bridge route allocates first");
+        reverse_order
+            .generated_pathways
+            .insert(bridge_first.id.clone(), bridge_first.clone());
+        let core_second = reverse_order
+            .generated_pathway(RATI_ACTOR_ID, 3, 50, 3)
+            .expect("the Core route allocates second");
+
+        assert_eq!(core_pathway.id, core_second.id);
+        assert_eq!(core_pathway.canonical_id, core_second.canonical_id);
+        assert_eq!(
+            core_pathway
+                .waypoints
+                .iter()
+                .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+                .collect::<Vec<_>>(),
+            core_second
+                .waypoints
+                .iter()
+                .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(bridge_pathway.id, bridge_first.id);
+        assert_eq!(
+            bridge_pathway
+                .waypoints
+                .iter()
+                .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+                .collect::<Vec<_>>(),
+            bridge_first
+                .waypoints
+                .iter()
+                .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+                .collect::<Vec<_>>()
+        );
+
+        let mut collision_runtime = RuntimeWorld::seeded();
+        let target = collision_runtime
+            .generated_pathway(RATI_ACTOR_ID, 12, 50, 3)
+            .expect("target pathway");
+        let mut blocker = collision_runtime
+            .generated_pathway(RATI_ACTOR_ID, 3, 50, 3)
+            .expect("blocker pathway");
+        blocker.waypoints[0].id = target.waypoints[0].id;
+        collision_runtime
+            .generated_pathways
+            .insert(blocker.id.clone(), blocker);
+        assert!(collision_runtime
+            .generated_pathway(RATI_ACTOR_ID, 12, 50, 3)
+            .is_err());
+        assert!(!collision_runtime
+            .generated_pathways
+            .contains_key(&target.id));
+
+        let mut canonical_collision = RuntimeWorld::seeded();
+        canonical_collision
+            .canonical_identities
+            .location_refs
+            .insert(
+                target.waypoints[0].id,
+                "opaque://another-location".to_string(),
+            );
+        assert!(canonical_collision
+            .generated_pathway(RATI_ACTOR_ID, 12, 50, 3)
+            .is_err());
+    }
+
+    #[test]
+    fn cross_pack_generated_subgraph_keeps_composition_ownership() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = runtime
+            .generated_pathway(RATI_ACTOR_ID, 12, 50, 3)
+            .expect("cross-pack long route");
+        assert_eq!(pathway.owner_pack_id, "cosyworld.composition.core-ruby");
+        assert_eq!(pathway.owner_pack_version, "1.0.0");
+        assert!(pathway
+            .source_route_id
+            .starts_with("route://cosyworld.composition.core-ruby/"));
+        runtime.ensure_generated_pathway_route_records(&pathway);
+        let generated_routes = runtime
+            .routes
+            .values()
+            .filter(|route| route.provenance == format!("generated_pathway:{}", pathway.id))
+            .collect::<Vec<_>>();
+        assert_eq!(generated_routes.len(), 3);
+        assert!(generated_routes.iter().all(|route| {
+            route.owner_pack_id == "cosyworld.composition.core-ruby"
+                && route.owner == "worldpack:cosyworld.composition.core-ruby"
+        }));
+
+        let waypoint_id = pathway.waypoints[0].id;
+        runtime.ensure_generated_pathway_edge(&pathway, 12, waypoint_id);
+        let place = runtime
+            .generated_places
+            .get(&waypoint_id)
+            .expect("generated waypoint has a place projection");
+        assert_eq!(place.canonical_id, pathway.waypoints[0].canonical_id);
+        assert_eq!(place.pack_id, "cosyworld.composition.core-ruby");
+        for job_id in [
+            &place.anchor_job_id,
+            &place.connection_job_id,
+            &place.settlement_job_id,
+        ] {
+            assert_eq!(
+                runtime.jobs[job_id].pack_id,
+                "cosyworld.composition.core-ruby"
+            );
+        }
+        if let Some(natural) = runtime.natural_affordances.get(&waypoint_id) {
+            assert_eq!(
+                natural.generation.pack_id,
+                "cosyworld.composition.core-ruby"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_identity_and_ownership_replay_byte_stably() {
+        let source = RuntimeWorld::seeded();
+        let pathway = source
+            .generated_pathway(RATI_ACTOR_ID, 12, 50, 3)
+            .expect("cross-pack long route");
+        let first_waypoint_id = pathway.waypoints[0].id;
+        let record = JournalRecord {
+            projection_mutations: vec![ProjectionMutation::JourneyTransition {
+                pathway: pathway.clone(),
+                journey: None,
+                reveal_edges: vec![(12, first_waypoint_id)],
+                narration: "A stable bridge path appears.".to_string(),
+                event_type: "pathway.discovered".to_string(),
+            }],
+            ..JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_NONE,
+                    actor_id: RATI_ACTOR_ID,
+                    ..CwAction::default()
+                },
+                318_001,
+            )
+        };
+        let replay_record: JournalRecord = serde_json::from_slice(
+            &serde_json::to_vec(&record).expect("serialize canonical pathway record"),
+        )
+        .expect("deserialize canonical pathway record");
+
+        let mut committed = RuntimeWorld::seeded();
+        let mut replayed = RuntimeWorld::seeded();
+        assert_eq!(committed.apply_journal_record(&record).0, CW_OK);
+        assert_eq!(replayed.apply_journal_record(&replay_record).0, CW_OK);
+        let generated_subgraph_bytes = |runtime: &RuntimeWorld| {
+            let routes = runtime
+                .routes
+                .iter()
+                .filter(|(_, route)| route.provenance.starts_with("generated_pathway:"))
+                .map(|(id, route)| (id.clone(), route.clone()))
+                .collect::<BTreeMap<_, _>>();
+            serde_json::to_vec(&(
+                runtime.generated_pathways.clone(),
+                runtime.generated_places.clone(),
+                routes,
+            ))
+            .expect("serialize generated subgraph")
+        };
+        let committed_bytes = generated_subgraph_bytes(&committed);
+        let replayed_bytes = generated_subgraph_bytes(&replayed);
+        assert_eq!(replayed_bytes, committed_bytes);
+
+        let restarted = RuntimeSnapshot::from_runtime(&committed)
+            .into_runtime()
+            .expect("restart generated subgraph");
+        assert_eq!(generated_subgraph_bytes(&restarted), committed_bytes);
+    }
+
+    #[test]
+    fn legacy_generated_routes_migrate_without_losing_lifecycle_or_discovery() {
+        let seed = RuntimeWorld::seeded();
+        let legacy_id = "pathway:12:50";
+        let pathway = legacy_pathway(&seed, 12, 50, 3, legacy_id);
+        let first_waypoint_id = pathway.waypoints[0].id;
+        let mut legacy_record = JournalRecord {
+            version: JOURNAL_RECORD_VERSION - 1,
+            projection_mutations: vec![ProjectionMutation::JourneyTransition {
+                pathway,
+                journey: None,
+                reveal_edges: vec![(12, first_waypoint_id)],
+                narration: "A legacy bridge path appears.".to_string(),
+                event_type: "pathway.discovered".to_string(),
+            }],
+            ..JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_NONE,
+                    actor_id: RATI_ACTOR_ID,
+                    ..CwAction::default()
+                },
+                318_002,
+            )
+        };
+
+        let mut current_replay = RuntimeWorld::seeded();
+        legacy_record.version = JOURNAL_RECORD_VERSION;
+        assert_eq!(
+            current_replay.apply_journal_record(&legacy_record).0,
+            CW_ERR_RULE
+        );
+        assert!(current_replay.generated_pathways.is_empty());
+
+        legacy_record.version = JOURNAL_RECORD_VERSION - 1;
+        let mut replayed = RuntimeWorld::seeded();
+        assert_eq!(replayed.apply_journal_record(&legacy_record).0, CW_OK);
+        let generated_route_id = replayed
+            .routes
+            .iter()
+            .find(|(_, route)| route.provenance == format!("generated_pathway:{legacy_id}"))
+            .map(|(route_id, _)| route_id.clone())
+            .expect("legacy replay creates a canonical generated route");
+        let preserved_discovery = RouteDiscoveryState {
+            actor_id: RATI_ACTOR_ID,
+            event_seq: 318,
+            reason: "legacy_fixture".to_string(),
+        };
+        {
+            let route = replayed
+                .routes
+                .get_mut(&generated_route_id)
+                .expect("generated route remains present");
+            route.lifecycle = RouteLifecycle::Blocked;
+            route.discovery = Some(preserved_discovery.clone());
+            route.entity_version = 7;
+        }
+
+        let expected_pathways = replayed.generated_pathways.clone();
+        let expected_routes = replayed
+            .routes
+            .iter()
+            .filter(|(_, route)| route.provenance == format!("generated_pathway:{legacy_id}"))
+            .map(|(route_id, route)| (route_id.clone(), route.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let mut snapshot = RuntimeSnapshot::from_runtime(&replayed);
+        snapshot.version = 12;
+        let snapshot_pathway = snapshot
+            .generated_pathways
+            .get_mut(legacy_id)
+            .expect("legacy pathway is persisted");
+        snapshot_pathway.canonical_id.clear();
+        snapshot_pathway.source_route_id.clear();
+        snapshot_pathway.source_route_version = 0;
+        snapshot_pathway.owner_pack_id.clear();
+        snapshot_pathway.owner_pack_version.clear();
+        for waypoint in &mut snapshot_pathway.waypoints {
+            waypoint.canonical_id.clear();
+        }
+        let canonical_route_ids = snapshot
+            .routes
+            .iter()
+            .filter(|(_, route)| route.provenance == format!("generated_pathway:{legacy_id}"))
+            .map(|(route_id, _)| route_id.clone())
+            .collect::<Vec<_>>();
+        for canonical_route_id in canonical_route_ids {
+            let mut route = snapshot
+                .routes
+                .remove(&canonical_route_id)
+                .expect("canonical generated route is persisted");
+            let edge = route.edges.first().expect("generated route has an edge");
+            let (left, right) = ordered_route_endpoints(edge.from_location_id, edge.to_location_id);
+            let legacy_route_id = format!("route:generated:{legacy_id}:{left}:{right}");
+            route.id = legacy_route_id.clone();
+            route.canonical_id.clear();
+            route.owner = format!("actor:{}", RATI_ACTOR_ID);
+            route.owner_pack_id.clear();
+            route.owner_pack_version.clear();
+            snapshot.routes.insert(legacy_route_id, route);
+        }
+        snapshot.routes.insert(
+            "route:generated:orphan:1:2".to_string(),
+            RouteRecordState {
+                id: "route:generated:orphan:1:2".to_string(),
+                canonical_id: String::new(),
+                edges: vec![],
+                owner: "actor:1001".to_string(),
+                owner_pack_id: String::new(),
+                owner_pack_version: String::new(),
+                provenance: "generated_pathway:orphan".to_string(),
+                lifecycle: RouteLifecycle::Latent,
+                discovery: None,
+                entity_version: 1,
+            },
+        );
+
+        let mut forged_current_snapshot: RuntimeSnapshot = serde_json::from_slice(
+            &serde_json::to_vec(&snapshot).expect("serialize downgraded fixture"),
+        )
+        .expect("clone downgraded fixture");
+        forged_current_snapshot.version = 13;
+        assert!(forged_current_snapshot.into_runtime().is_err());
+
+        let restored = snapshot
+            .into_runtime()
+            .expect("v12 generated identity and route aliases migrate");
+        let restored_routes = restored
+            .routes
+            .iter()
+            .filter(|(_, route)| route.provenance == format!("generated_pathway:{legacy_id}"))
+            .map(|(route_id, route)| (route_id.clone(), route.clone()))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            serde_json::to_vec(&restored.generated_pathways).expect("serialize restored pathways"),
+            serde_json::to_vec(&expected_pathways).expect("serialize replayed pathways")
+        );
+        assert_eq!(restored_routes, expected_routes);
+        assert!(restored
+            .routes
+            .keys()
+            .all(|route_id| !route_id.starts_with("route:generated:")));
+        let restored_route = restored
+            .routes
+            .get(&generated_route_id)
+            .expect("canonical generated route replaces its alias");
+        assert_eq!(restored_route.lifecycle, RouteLifecycle::Blocked);
+        assert_eq!(restored_route.discovery, Some(preserved_discovery));
+        assert_eq!(restored_route.entity_version, 7);
+    }
+
+    #[test]
+    fn legacy_snapshot_rejects_pathway_and_waypoint_aliases() {
+        let seed = RuntimeWorld::seeded();
+        let mut canonical_alias = RuntimeSnapshot::from_runtime(&seed);
+        canonical_alias.version = 12;
+        let first = legacy_pathway(&seed, 12, 50, 3, "pathway:12:50");
+        let second = legacy_pathway(&seed, 12, 50, 3, "pathway:alias:12:50");
+        canonical_alias
+            .generated_pathways
+            .insert(first.id.clone(), first);
+        canonical_alias
+            .generated_pathways
+            .insert(second.id.clone(), second);
+        assert!(canonical_alias.into_runtime().is_err());
+
+        let mut waypoint_alias = RuntimeSnapshot::from_runtime(&seed);
+        waypoint_alias.version = 12;
+        let first = legacy_pathway(&seed, 12, 50, 3, "pathway:12:50");
+        let mut second = legacy_pathway(&seed, 3, 50, 3, "pathway:3:50");
+        second.waypoints[0].id = first.waypoints[0].id;
+        waypoint_alias
+            .generated_pathways
+            .insert(first.id.clone(), first);
+        waypoint_alias
+            .generated_pathways
+            .insert(second.id.clone(), second);
+        assert!(waypoint_alias.into_runtime().is_err());
     }
 }

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -1488,10 +1488,10 @@ impl RuntimeWorld {
             memory_location_name: memory
                 .as_ref()
                 .and_then(|memory| self.location_name(memory.location_id)),
-            holder_actor_id: memory.as_ref().and_then(|memory| memory.holder_actor_id),
+            holder_actor_id: memory.as_ref().and_then(|memory| memory.related_actor_id),
             holder_actor_name: memory
                 .as_ref()
-                .and_then(|memory| memory.holder_actor_id)
+                .and_then(|memory| memory.related_actor_id)
                 .and_then(|holder_actor_id| self.actor_name(holder_actor_id)),
             confidence: memory.as_ref().map(|memory| memory.confidence),
             salience: memory.as_ref().map(|memory| memory.salience),
@@ -1552,7 +1552,7 @@ impl RuntimeWorld {
             .map(|item_id| self.resident_sought_item_view(resident, item_id))
             .collect();
         let attached_item_ids = self.resident_attached_item_ids(resident.id);
-        let seek_memory = self.resident_memory_seek_target(resident);
+        let seek_memory = self.belief_seek_target(resident);
         let seeking_item_id = seek_memory.as_ref().map(|memory| memory.subject_id);
         let seeking_location_id = seek_memory.as_ref().map(|memory| memory.location_id);
         let seeking_location_name =
@@ -1627,7 +1627,7 @@ impl RuntimeWorld {
                 .unwrap_or_else(|| format!("Item {item_id}"));
             if let Some(holder_name) = seek_memory
                 .as_ref()
-                .and_then(|memory| memory.holder_actor_id)
+                .and_then(|memory| memory.related_actor_id)
                 .and_then(|holder_actor_id| self.actor_name(holder_actor_id))
             {
                 format!(

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -1611,6 +1611,7 @@ for (const location of locations) {
 
 const exitPairs = new Set();
 const exitDirections = new Set();
+const exitOwnerByEndpoints = new Map();
 for (const exit of exits) {
   if (!has(locationIds, exit.from_location_id) || !has(locationIds, exit.to_location_id)) {
     fail(`exit ${exit.from_location_id}->${exit.to_location_id} references missing location`);
@@ -1633,6 +1634,18 @@ for (const exit of exits) {
     fail(`duplicate exit ${pair}`);
   }
   exitPairs.add(pair);
+  const endpointKey = [
+    Number(exit.from_location_id),
+    Number(exit.to_location_id),
+  ].sort((left, right) => left - right).join(":");
+  const reciprocalOwner = exitOwnerByEndpoints.get(endpointKey);
+  if (reciprocalOwner !== undefined && reciprocalOwner !== exit.pack_id) {
+    fail(
+      `reciprocal exits between ${endpointKey} have different owners ${reciprocalOwner} and ${exit.pack_id}`,
+    );
+  } else {
+    exitOwnerByEndpoints.set(endpointKey, exit.pack_id);
+  }
   if (isNonEmptyString(exit.direction)) {
     const directionKey = `${exit.from_location_id}:${exit.direction.trim().toLowerCase()}`;
     if (exitDirections.has(directionKey)) {

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74534
+74495

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74555
+74534

--- a/v2/scripts/migrate-pack-unmount.mjs
+++ b/v2/scripts/migrate-pack-unmount.mjs
@@ -735,6 +735,22 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
     migrated.resident_continuities,
     (continuity) => hasId(actorIds, continuity.resident_id),
   );
+  maps.beliefs = takeMapValues(
+    migrated.beliefs,
+    (belief) =>
+      hasId(actorIds, belief.holder_actor_id)
+        || hasId(actorIds, belief.source_actor_id)
+        || hasId(actorIds, belief.related_actor_id)
+        || hasId(locationIds, belief.location_id)
+        || (belief.kind === "actor_location" && hasId(actorIds, belief.subject_id))
+        || (belief.kind === "item_location" && hasId(itemIds, belief.subject_id))
+        || (
+          ["seed_exit", "hidden_exit"].includes(belief.kind)
+          && hasId(locationIds, belief.subject_id)
+        ),
+  );
+  // Pre-v14 snapshots can still reach the pack migration tool before the
+  // orchestrator folds their two legacy maps into `beliefs`.
   maps.resident_memories = takeMapValues(
     migrated.resident_memories,
     (memory) =>
@@ -742,8 +758,8 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
         || hasId(actorIds, memory.source_actor_id)
         || hasId(actorIds, memory.holder_actor_id)
         || hasId(locationIds, memory.location_id)
-        || (memory.kind === "actor" && hasId(actorIds, memory.subject_id))
-        || (memory.kind === "item" && hasId(itemIds, memory.subject_id)),
+        || (memory.kind === "actor_location" && hasId(actorIds, memory.subject_id))
+        || (memory.kind === "item_location" && hasId(itemIds, memory.subject_id)),
   );
   maps.search_memories = takeMapValues(
     migrated.search_memories,

--- a/v2/scripts/migrate-pack-unmount.mjs
+++ b/v2/scripts/migrate-pack-unmount.mjs
@@ -19,6 +19,13 @@ function packResourceIds(registry, packId, resource, identity = "id") {
     .map((row) => String(row[identity])));
 }
 
+function packResourceIdsForPacks(registry, packIds, resource, identity = "id") {
+  return new Set(
+    [...packIds].flatMap((packId) =>
+      [...packResourceIds(registry, packId, resource, identity)]),
+  );
+}
+
 function hasId(ids, value) {
   return ids.has(Number(value));
 }
@@ -99,11 +106,20 @@ function restoreMapEntries(snapshot, field, frozen) {
   snapshot[field] = restored;
 }
 
-function restoreNestedMapEntries(parent, field, frozen) {
+function restoreNestedMapEntries(
+  parent,
+  parentField,
+  field,
+  frozen,
+  { allowIdentical = false } = {},
+) {
   const restored = { ...(parent[field] ?? {}) };
   for (const [key, value] of Object.entries(frozen ?? {})) {
     if (Object.hasOwn(restored, key)) {
-      throw new Error(`cannot remount: world_simulation.${field} identity ${key} is already active`);
+      if (allowIdentical && restored[key] === value) continue;
+      throw new Error(
+        `cannot remount: ${parentField}.${field} identity ${key} is already active`,
+      );
     }
     restored[key] = value;
   }
@@ -127,6 +143,16 @@ function samePackIdentity(left, right) {
     && left?.integrity === right?.integrity;
 }
 
+function packIsContentFreeCatalogMarker(pack) {
+  const counts = pack?.resource_counts;
+  return pack?.kind === "catalog"
+    && pack.default_ruleset === null
+    && (pack.entry_points ?? []).length === 0
+    && counts
+    && Object.keys(counts).length > 0
+    && Object.values(counts).every((count) => Number(count) === 0);
+}
+
 function requiredMountClosure(targetPacks, packId) {
   const required = new Set();
   const pending = [packId];
@@ -143,6 +169,106 @@ function requiredMountClosure(targetPacks, packId) {
     }
   }
   return required;
+}
+
+function subtractiveUnmountPlan(sourceRegistry, targetRegistry, packId) {
+  const sourcePacks = registryPacks(sourceRegistry);
+  const targetPacks = registryPacks(targetRegistry);
+  const targetOnlyPackIds = [];
+  if (!sourcePacks.has(packId)) {
+    throw new Error(`source registry does not mount pack ${packId}`);
+  }
+  if (targetPacks.has(packId)) {
+    throw new Error(`target registry still mounts pack ${packId}`);
+  }
+  for (const [targetPackId, targetPack] of targetPacks) {
+    const sourcePack = sourcePacks.get(targetPackId);
+    if (!sourcePack) {
+      if (packIsContentFreeCatalogMarker(targetPack)) {
+        targetOnlyPackIds.push(targetPackId);
+        continue;
+      }
+      throw new Error(`soft unmount target adds unrelated pack ${targetPackId}`);
+    }
+    if (!samePackIdentity(sourcePack, targetPack)) {
+      throw new Error(
+        `soft unmount cannot change retained pack identity ${targetPackId}`,
+      );
+    }
+  }
+
+  const allowed = new Set([packId]);
+  let foundDependentBridge = true;
+  while (foundDependentBridge) {
+    foundDependentBridge = false;
+    for (const pack of sourcePacks.values()) {
+      const composition = pack.extensions?.["x-cosyworld-composition"];
+      if (
+        allowed.has(pack.id)
+          || composition?.role !== "bridge"
+          || !(pack.dependency_closure ?? []).some((dependencyId) =>
+            allowed.has(dependencyId))
+      ) {
+        continue;
+      }
+      allowed.add(pack.id);
+      foundDependentBridge = true;
+    }
+  }
+
+  const removedPacks = (sourceRegistry.manifest?.packs ?? [])
+    .filter((pack) => !targetPacks.has(pack.id));
+  for (const pack of removedPacks) {
+    if (!allowed.has(pack.id)) {
+      throw new Error(`soft unmount target removes unrelated pack ${pack.id}`);
+    }
+  }
+  for (const allowedPackId of allowed) {
+    if (targetPacks.has(allowedPackId)) {
+      throw new Error(
+        `soft unmount target retains dependent bridge pack ${allowedPackId}`,
+      );
+    }
+  }
+  return { removedPacks, targetOnlyPackIds };
+}
+
+function restorativeRemountPlan(sourceRegistry, targetRegistry, frozen) {
+  const sourcePacks = registryPacks(sourceRegistry);
+  const targetPacks = registryPacks(targetRegistry);
+  const expectedSourceOnlyPackIds = [...(frozen.target_only_pack_ids ?? [])].sort();
+  const actualSourceOnlyPackIds = [...sourcePacks.keys()]
+    .filter((sourcePackId) => !targetPacks.has(sourcePackId))
+    .sort();
+  if (JSON.stringify(actualSourceOnlyPackIds) !== JSON.stringify(expectedSourceOnlyPackIds)) {
+    throw new Error(
+      `cannot remount ${frozen.pack_id}: source-only pack set does not match frozen state`,
+    );
+  }
+  for (const [sourcePackId, sourcePack] of sourcePacks) {
+    const targetPack = targetPacks.get(sourcePackId);
+    if (!targetPack) {
+      if (
+        expectedSourceOnlyPackIds.includes(sourcePackId)
+          && packIsContentFreeCatalogMarker(sourcePack)
+      ) continue;
+      throw new Error(`remount target removes unrelated pack ${sourcePackId}`);
+    }
+    if (!samePackIdentity(sourcePack, targetPack)) {
+      throw new Error(`remount cannot change retained pack identity ${sourcePackId}`);
+    }
+  }
+  const addedPackIds = (targetRegistry.manifest?.packs ?? [])
+    .filter((pack) => !sourcePacks.has(pack.id))
+    .map((pack) => pack.id)
+    .sort();
+  const expectedPackIds = [...(frozen.removed_pack_ids ?? [frozen.pack_id])].sort();
+  if (JSON.stringify(addedPackIds) !== JSON.stringify(expectedPackIds)) {
+    throw new Error(
+      `cannot remount ${frozen.pack_id}: target pack closure does not match frozen state`,
+    );
+  }
+  return addedPackIds;
 }
 
 function additiveMountPlan(sourceRegistry, targetRegistry, packId) {
@@ -209,13 +335,13 @@ function targetRulesets(registry) {
   });
 }
 
-function targetContentContext(current, targetRegistry, removedPackId = null) {
+function targetContentContext(current, targetRegistry, removedPackIds = new Set()) {
   const targetReferences = new Map((targetRegistry.content_references?.entries ?? [])
     .map((entry) => [entry.canonical_ref, entry]));
   return {
     mapping_version: targetRegistry.content_references?.mapping_version ?? 0,
     references: (current?.references ?? [])
-      .filter((reference) => reference.pack_id !== removedPackId)
+      .filter((reference) => !removedPackIds.has(reference.pack_id))
       .filter((reference) => targetReferences.has(reference.canonical_ref))
       .map((reference) => structuredClone(targetReferences.get(reference.canonical_ref))),
     active_rulesets: targetRulesets(targetRegistry),
@@ -409,6 +535,11 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
       `cannot unmount ${packId}: snapshot bundle does not match the source registry`,
     );
   }
+  const { removedPacks, targetOnlyPackIds } = subtractiveUnmountPlan(
+    sourceRegistry,
+    targetRegistry,
+    packId,
+  );
 
   const migrated = structuredClone(snapshot);
   const sourceRules = registryRuleBinding(sourceRegistry);
@@ -417,9 +548,32 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
     throw new Error(`pack ${packId} is already soft-unmounted`);
   }
 
-  const actorIds = packHandles(sourceRegistry, packId, "actor");
-  const authoredItemIds = packHandles(sourceRegistry, packId, "item");
-  const locationIds = packHandles(sourceRegistry, packId, "location");
+  const removedPackIds = new Set(removedPacks.map((pack) => pack.id));
+  const actorIds = new Set(
+    [...removedPackIds].flatMap((removedPackId) =>
+      [...packHandles(sourceRegistry, removedPackId, "actor")]),
+  );
+  const authoredItemIds = new Set(
+    [...removedPackIds].flatMap((removedPackId) =>
+      [...packHandles(sourceRegistry, removedPackId, "item")]),
+  );
+  const authoredLocationIds = new Set(
+    [...removedPackIds].flatMap((removedPackId) =>
+      [...packHandles(sourceRegistry, removedPackId, "location")]),
+  );
+  const ownedGeneratedPathways = Object.entries(migrated.generated_pathways ?? {})
+    .filter(([, pathway]) =>
+      removedPackIds.has(pathway.owner_pack_id)
+        || hasId(authoredLocationIds, pathway.origin_location_id)
+        || hasId(authoredLocationIds, pathway.destination_location_id));
+  const ownedGeneratedPathwayIds = new Set(
+    ownedGeneratedPathways.map(([pathwayId]) => pathwayId),
+  );
+  const generatedLocationIds = new Set(
+    ownedGeneratedPathways.flatMap(([, pathway]) =>
+      (pathway.waypoints ?? []).map((waypoint) => Number(waypoint.id))),
+  );
+  const locationIds = new Set([...authoredLocationIds, ...generatedLocationIds]);
   const occupied = (migrated.world_actors ?? [])
     .filter((actor) =>
       !hasId(actorIds, actor.id) && hasId(locationIds, actor.location_id));
@@ -509,7 +663,7 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
 
   maps.clocks = takeMapKeys(
     migrated.clocks,
-    packResourceIds(sourceRegistry, packId, "clocks"),
+    packResourceIdsForPacks(sourceRegistry, removedPackIds, "clocks"),
   );
   Object.assign(
     maps.clocks,
@@ -517,7 +671,7 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
   );
   maps.jobs = takeMapKeys(
     migrated.jobs,
-    packResourceIds(sourceRegistry, packId, "jobs"),
+    packResourceIdsForPacks(sourceRegistry, removedPackIds, "jobs"),
   );
   Object.assign(
     maps.jobs,
@@ -533,9 +687,31 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
   );
   maps.generated_pathways = takeMapValues(
     migrated.generated_pathways,
-    (pathway) =>
-      hasId(locationIds, pathway.origin_location_id)
-        || hasId(locationIds, pathway.destination_location_id),
+    (_pathway, pathwayId) => ownedGeneratedPathwayIds.has(pathwayId),
+  );
+  maps.routes = takeMapValues(
+    migrated.routes,
+    (route) =>
+      removedPackIds.has(route.owner_pack_id)
+        || (route.edges ?? []).some((edge) =>
+          hasId(locationIds, edge.from_location_id)
+            || hasId(locationIds, edge.to_location_id)),
+  );
+  for (const field of [
+    "governance_decisions",
+    "settlement_buildings",
+    "building_footprint_claims",
+    "loot_allocations",
+  ]) {
+    maps[field] = takeMapValues(
+      migrated[field],
+      (entry) => hasId(locationIds, entry.location_id),
+    );
+  }
+  maps.community_art_generations = takeMapValues(
+    migrated.community_art_generations,
+    (entry) =>
+      entry.subject_kind === "location" && hasId(locationIds, entry.subject_id),
   );
   maps.journeys = takeMapValues(
     migrated.journeys,
@@ -615,8 +791,21 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
     locations: takeMapKeys(migrated.world_simulation.locations, locationIds),
     factions: takeMapKeys(
       migrated.world_simulation.factions,
-      packResourceIds(sourceRegistry, packId, "factions"),
+      packResourceIdsForPacks(sourceRegistry, removedPackIds, "factions"),
     ),
+  };
+  migrated.canonical_identities ??= {};
+  const canonicalLocationRefs = takeMapKeys(
+    migrated.canonical_identities.location_refs,
+    locationIds,
+  );
+  const canonicalEntityVersions = takeMapKeys(
+    migrated.canonical_identities.entity_versions,
+    new Set(Object.values(canonicalLocationRefs)),
+  );
+  const canonicalIdentities = {
+    location_refs: canonicalLocationRefs,
+    entity_versions: canonicalEntityVersions,
   };
   const removed = {
     actors: before.actors - migrated.world_actors.length,
@@ -627,11 +816,14 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
   const frozen = {
     pack_id: packId,
     pack_version: packVersion(sourceRegistry, packId),
+    removed_pack_ids: [...removedPackIds],
+    target_only_pack_ids: targetOnlyPackIds,
     source_bundle_hash: sourceRegistry.manifest.bundle_hash,
     target_bundle_hash: targetRegistry.manifest.bundle_hash,
     content_context: structuredClone(migrated.content_context ?? {}),
     arrays,
     maps,
+    canonical_identities: canonicalIdentities,
     world_simulation: worldSimulation,
     invalidated: {
       transfer_offer_ids: invalidatedOfferIds,
@@ -644,13 +836,15 @@ export function migratePackUnmount(snapshot, sourceRegistry, packId, targetRegis
   migrated.content_context = targetContentContext(
     migrated.content_context,
     targetRegistry,
-    packId,
+    removedPackIds,
   );
   const targetRules = applyRegistryBinding(migrated, targetRegistry);
   const transaction = appendTransaction(mountState, {
     operation: "soft_unmount",
     pack_id: packId,
     pack_version: frozen.pack_version,
+    removed_pack_ids: frozen.removed_pack_ids,
+    target_only_pack_ids: frozen.target_only_pack_ids,
     source_bundle_hash: frozen.source_bundle_hash,
     target_bundle_hash: frozen.target_bundle_hash,
     source_rules: sourceRules,
@@ -691,6 +885,14 @@ export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegis
   if (!frozen) {
     throw new Error(`pack ${packId} has no frozen soft-unmount state`);
   }
+  if (frozen.pack_id !== packId) {
+    throw new Error(`cannot remount ${packId}: frozen state belongs to ${frozen.pack_id}`);
+  }
+  const actualAddedPackIds = restorativeRemountPlan(
+    sourceRegistry,
+    targetRegistry,
+    frozen,
+  );
   if (frozen.target_bundle_hash !== sourceRegistry.manifest.bundle_hash) {
     throw new Error(`cannot remount ${packId}: current registry does not match the unmount target`);
   }
@@ -714,9 +916,24 @@ export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegis
   for (const [field, entries] of Object.entries(frozen.maps ?? {})) {
     restoreMapEntries(migrated, field, entries);
   }
+  migrated.canonical_identities ??= {};
+  for (const [field, entries] of Object.entries(frozen.canonical_identities ?? {})) {
+    restoreNestedMapEntries(
+      migrated.canonical_identities,
+      "canonical_identities",
+      field,
+      entries,
+      { allowIdentical: field === "entity_versions" },
+    );
+  }
   migrated.world_simulation ??= {};
   for (const [field, entries] of Object.entries(frozen.world_simulation ?? {})) {
-    restoreNestedMapEntries(migrated.world_simulation, field, entries);
+    restoreNestedMapEntries(
+      migrated.world_simulation,
+      "world_simulation",
+      field,
+      entries,
+    );
   }
   migrated.content_context = structuredClone(frozen.content_context);
   const targetRules = applyRegistryBinding(migrated, targetRegistry);
@@ -731,6 +948,7 @@ export function migratePackRemount(snapshot, sourceRegistry, packId, targetRegis
     operation: "remount",
     pack_id: packId,
     pack_version: frozen.pack_version,
+    mounted_pack_ids: actualAddedPackIds,
     source_bundle_hash: sourceRegistry.manifest.bundle_hash,
     target_bundle_hash: targetRegistry.manifest.bundle_hash,
     source_rules: sourceRules,


### PR DESCRIPTION
Closes #318

Stacked on #415 so the mandatory hot-room validation uses the reviewed schema-initialization fixture; the #318 diff itself is isolated from that base.

## Summary
- bind generated pathways, waypoints, places, and segment routes to canonical authored-route identity and entity version
- reserve deterministic generated handles and fail closed on authored/generated collisions, aliases, duplicate canonical claims, and storage-key aliases
- preserve exact owning pack/composition and version across mount order, restart, snapshot, journal replay, and generated subgraph lifecycle
- migrate legacy generated route records to canonical segment keys without losing lifecycle, discovery, or entity versions
- make soft unmount operate on the exact requested/dependent pack closure and verify that closure on remount
- reject reciprocal authored exits whose two directions claim different owners

## Independent blocker review
This branch includes fixes for five findings found after the initial implementation:
1. unrelated pack removals/additions during soft unmount now fail closed
2. obsolete `route:generated:*` snapshot keys are rewritten or rejected rather than retained beside canonical routes
3. identity backfill is gated by persistence version; current records cannot silently omit metadata
4. duplicate canonical pathway/waypoint/handle/storage claims are rejected globally
5. reciprocal authored exits cannot resolve to different owners

## Hosted remount repair
The first hosted run exposed a real lifecycle edge: after soft-unmount, a Core-only restart can durably rehydrate Ruby canonical entity versions before Ruby remounts. Remount now accepts only an already-present *identical* `canonical_identities.entity_versions` value as idempotent; any divergent value still fails closed. The regression fixture proves both cases and the complete Core/Ruby soft-unmount → Core-only action → remount → Homeroom action loop.

## Validation
- full pre-push gate passed after the hosted repair
- Node: 456/456
- Rust: 552/552
- focused topology: 11/11
- focused composition/migration: 18/18, including 13/13 Core-pack lifecycle cases
- full standalone + Core/Ruby composition smoke: passed on the final diff
- worldpack/compositions/strict proof: passed
- C kernel: passed
- architecture: main.rs 74534/74534; clippy 246/246
- syntax and diff checks: passed