### PR TITLE
Return durable local leads from Influence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.205",
+      "version": "0.0.206",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/core-only/assets.json
+++ b/v2/content/core-only/assets.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.10",
-    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+    "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -15,7 +15,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.10",
-    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+    "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/core-only/contributions.json
+++ b/v2/content/core-only/contributions.json
@@ -18,6 +18,11 @@
         },
         "label": "Ask for a local lead",
         "target_predicate": "active_npc_same_location",
+        "cooperation": {
+          "kind": "local_lead",
+          "destination_location_id": 2,
+          "destination_hint": "the rain-soft garden beyond the eastern cottage door"
+        },
         "source_reference": "CosyWorld Core — Blue Cottage bounded cooperation"
       }
     ],

--- a/v2/content/core-only/registry.json
+++ b/v2/content/core-only/registry.json
@@ -592,7 +592,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:e2eb8afc02eacea57562cbe8d662793d3baad6b1d6df8bc04059ec0be6d7a907",
+    "bundle_hash": "sha256:cb30416670fe6959ff6c0ef3cec833ac800581bc34e89d60ba9d06bf421c11b5",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1662,7 +1662,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
+        "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd"
       }
     ],
     "files": {
@@ -8289,7 +8289,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.10",
-      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -8302,7 +8302,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.10",
-      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",
@@ -9713,6 +9713,11 @@
           },
           "label": "Ask for a local lead",
           "target_predicate": "active_npc_same_location",
+          "cooperation": {
+            "kind": "local_lead",
+            "destination_location_id": 2,
+            "destination_hint": "the rain-soft garden beyond the eastern cottage door"
+          },
           "source_reference": "CosyWorld Core — Blue Cottage bounded cooperation"
         }
       ],

--- a/v2/content/core-only/worldpack.json
+++ b/v2/content/core-only/worldpack.json
@@ -590,7 +590,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:e2eb8afc02eacea57562cbe8d662793d3baad6b1d6df8bc04059ec0be6d7a907",
+  "bundle_hash": "sha256:cb30416670fe6959ff6c0ef3cec833ac800581bc34e89d60ba9d06bf421c11b5",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1660,7 +1660,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
+      "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd"
     }
   ],
   "files": {

--- a/v2/content/core-ruby/assets.json
+++ b/v2/content/core-ruby/assets.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.10",
-    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+    "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -15,7 +15,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.10",
-    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+    "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/core-ruby/contributions.json
+++ b/v2/content/core-ruby/contributions.json
@@ -18,6 +18,11 @@
         },
         "label": "Ask for a local lead",
         "target_predicate": "active_npc_same_location",
+        "cooperation": {
+          "kind": "local_lead",
+          "destination_location_id": 2,
+          "destination_hint": "the rain-soft garden beyond the eastern cottage door"
+        },
         "source_reference": "CosyWorld Core — Blue Cottage bounded cooperation"
       }
     ],

--- a/v2/content/core-ruby/registry.json
+++ b/v2/content/core-ruby/registry.json
@@ -606,7 +606,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:710d9bc1c3c8af1828ca0e54beb66ad7053a3c2105623eb80915342e77d14cca",
+    "bundle_hash": "sha256:fa486ea93c8018491038c5aeba2f700dda96aad85116f03f7c3d750a6a00979c",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1676,7 +1676,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
+        "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd"
       },
       {
         "id": "ruby-high.first-bell",
@@ -9648,7 +9648,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.10",
-      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -9661,7 +9661,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.10",
-      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",
@@ -11085,6 +11085,11 @@
           },
           "label": "Ask for a local lead",
           "target_predicate": "active_npc_same_location",
+          "cooperation": {
+            "kind": "local_lead",
+            "destination_location_id": 2,
+            "destination_hint": "the rain-soft garden beyond the eastern cottage door"
+          },
           "source_reference": "CosyWorld Core — Blue Cottage bounded cooperation"
         }
       ],

--- a/v2/content/core-ruby/worldpack.json
+++ b/v2/content/core-ruby/worldpack.json
@@ -604,7 +604,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:710d9bc1c3c8af1828ca0e54beb66ad7053a3c2105623eb80915342e77d14cca",
+  "bundle_hash": "sha256:fa486ea93c8018491038c5aeba2f700dda96aad85116f03f7c3d750a6a00979c",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1674,7 +1674,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
+      "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd"
     },
     {
       "id": "ruby-high.first-bell",

--- a/v2/content/core/offers.json
+++ b/v2/content/core/offers.json
@@ -6,6 +6,11 @@
     "context": {"requires_visible_subject": true, "requires_combat": false},
     "label": "Ask for a local lead",
     "target_predicate": "active_npc_same_location",
+    "cooperation": {
+      "kind": "local_lead",
+      "destination_location_id": 2,
+      "destination_hint": "the rain-soft garden beyond the eastern cottage door"
+    },
     "source_reference": "CosyWorld Core — Blue Cottage bounded cooperation"
   }
 ]

--- a/v2/content/official/assets.json
+++ b/v2/content/official/assets.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.10",
-    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+    "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -15,7 +15,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.10",
-    "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+    "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/official/contributions.json
+++ b/v2/content/official/contributions.json
@@ -18,6 +18,11 @@
         },
         "label": "Ask for a local lead",
         "target_predicate": "active_npc_same_location",
+        "cooperation": {
+          "kind": "local_lead",
+          "destination_location_id": 2,
+          "destination_hint": "the rain-soft garden beyond the eastern cottage door"
+        },
         "source_reference": "CosyWorld Core — Blue Cottage bounded cooperation"
       }
     ],

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -656,7 +656,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:3e6c6a329d1b0ffd28cbc1fe138edd5825185fe0c29ad20af9b9d14c552e11d9",
+    "bundle_hash": "sha256:d107e944fcf740ef7dc2a19e02e39109998fe45c90fea7d75198a094d91fa088",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1726,7 +1726,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
+        "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd"
       },
       {
         "id": "cosyworld.rules-srd-5.1",
@@ -13051,7 +13051,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.10",
-      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -13064,7 +13064,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.10",
-      "pack_integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "pack_integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",
@@ -14831,6 +14831,11 @@
           },
           "label": "Ask for a local lead",
           "target_predicate": "active_npc_same_location",
+          "cooperation": {
+            "kind": "local_lead",
+            "destination_location_id": 2,
+            "destination_hint": "the rain-soft garden beyond the eastern cottage door"
+          },
           "source_reference": "CosyWorld Core — Blue Cottage bounded cooperation"
         }
       ],

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -654,7 +654,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:3e6c6a329d1b0ffd28cbc1fe138edd5825185fe0c29ad20af9b9d14c552e11d9",
+  "bundle_hash": "sha256:d107e944fcf740ef7dc2a19e02e39109998fe45c90fea7d75198a094d91fa088",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1724,7 +1724,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f"
+      "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd"
     },
     {
       "id": "cosyworld.rules-srd-5.1",

--- a/v2/docs/action-pack-authoring.md
+++ b/v2/docs/action-pack-authoring.md
@@ -45,6 +45,23 @@ An offer says why an existing action is relevant to an authored noun:
 The runtime still composes legality and resolves Study authoritatively. The
 offer cannot grant the location, item, skill charm, or reward it references.
 
+Influence offers may attach one bounded `cooperation` payload of kind
+`local_lead`. It names an authored destination and a presentation-only hint:
+
+```json
+{
+  "cooperation": {
+    "kind": "local_lead",
+    "destination_location_id": 2,
+    "destination_hint": "the rain-soft garden beyond the eastern cottage door"
+  }
+}
+```
+
+The payload can record actionable knowledge after a successful Influence
+check. It does not create, reveal, close, or otherwise mutate a route; following
+the resulting Scout offer still uses the ordinary topology resolver.
+
 ## Justified variant
 
 A variant is a new, versioned rule identity. It declares its complete delta,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -137,6 +137,7 @@ impl RuntimeWorld {
                 offer.based_on == rules_action
                     && offer.subject.kind == "location"
                     && offer.subject.id == location_id
+                    && self.contextual_cooperation_available(actor_id, offer)
             })
             .collect::<Vec<_>>();
         reskins.sort_by(|left, right| left.id.cmp(&right.id));
@@ -380,6 +381,10 @@ impl RuntimeWorld {
         offers = self.expand_transfer_action_offers(actor_id, offers);
         offers = self.expand_route_action_offers(actor_id, access, offers);
         if let Some(target) = self.scout_action_offer_target(actor_id, access) {
+            let local_lead = self
+                .actionable_local_lead(actor_id)
+                .filter(|lead| target.id == Some(lead.destination_location_id))
+                .cloned();
             let kind = "explore_path";
             let binding = resolved_action_binding(kind)
                 .expect("explore_path must resolve through the SRD search action");
@@ -396,7 +401,12 @@ impl RuntimeWorld {
             let state_revision = self.world.next_event_seq.saturating_sub(1);
             let source_collectible = self.location_source_collectible(actor_id);
             let source_card_instances = source_collectible.clone().into_iter().collect();
-            let legacy_id = format!("explore_path:{}", target.id.clone().unwrap_or_default());
+            let legacy_id = local_lead
+                .as_ref()
+                .map(|lead| local_lead_offer_id(&lead.id))
+                .unwrap_or_else(|| {
+                    format!("explore_path:{}", target.id.clone().unwrap_or_default())
+                });
             let offer_id = format!(
                 "{}:{}:{}",
                 active_content().manifest.rules_profile,
@@ -446,16 +456,38 @@ impl RuntimeWorld {
                 disabled: false,
                 disabled_reason: None,
                 zone: zone.clone(),
-                source: "journey+exit_projection".to_string(),
+                source: if local_lead.is_some() {
+                    "local_lead+exit_projection".to_string()
+                } else {
+                    "journey+exit_projection".to_string()
+                },
                 provider,
                 target: Some(target),
                 project: None,
                 cost: None,
                 risk: None,
-                effect: Some("reveals the next adjacent route segment without moving".to_string()),
+                effect: Some(
+                    local_lead
+                        .as_ref()
+                        .map(|lead| {
+                            format!(
+                                "follows the lead from {}: {}",
+                                self.actor_name(lead.source_actor_id)
+                                    .unwrap_or_else(|| "a local resident".to_string()),
+                                lead.destination_hint
+                            )
+                        })
+                        .unwrap_or_else(|| {
+                            "reveals the next adjacent route segment without moving".to_string()
+                        }),
+                ),
                 progress: None,
-                claim_key: None,
-                reason: "ranked from an unrevealed journey edge or long route".to_string(),
+                claim_key: local_lead.as_ref().map(|lead| lead.id.clone()),
+                reason: if local_lead.is_some() {
+                    "ranked from durable authored local-lead knowledge".to_string()
+                } else {
+                    "ranked from an unrevealed journey edge or long route".to_string()
+                },
             });
         }
         for offer in &mut offers {
@@ -945,6 +977,13 @@ impl RuntimeWorld {
         access: &AccessContext,
     ) -> Option<ActionTargetView> {
         let actor = self.actor_by_id(actor_id)?;
+        if let Some(lead) = self.actionable_local_lead(actor_id) {
+            return Some(ActionTargetView {
+                kind: "location".to_string(),
+                id: Some(lead.destination_location_id),
+                label: self.location_name(lead.destination_location_id),
+            });
+        }
         let exits = self.exit_views(actor.location_id, access);
         if let Some(journey) = self.journey_view(actor_id) {
             let next_is_revealed = journey.next_location_id.is_some_and(|next_id| {

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -267,7 +267,18 @@ pub(super) struct SeedContextualActionOffer {
     pub(super) context: serde_json::Value,
     pub(super) label: String,
     pub(super) target_predicate: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) cooperation: Option<SeedCooperationPayload>,
     pub(super) source_reference: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(super) enum SeedCooperationPayload {
+    LocalLead {
+        destination_location_id: u64,
+        destination_hint: String,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1861,11 +1872,35 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
             }
         }
         for offer in &bundle.offers {
+            let cooperation_is_valid =
+                offer
+                    .cooperation
+                    .as_ref()
+                    .is_none_or(|payload| match payload {
+                        SeedCooperationPayload::LocalLead {
+                            destination_location_id,
+                            destination_hint,
+                        } => {
+                            offer.based_on == "srd5.2.1:influence"
+                                && offer.subject.kind == "location"
+                                && offer.subject.id != *destination_location_id
+                                && content
+                                    .locations
+                                    .iter()
+                                    .any(|location| location.id == *destination_location_id)
+                                && !destination_hint.trim().is_empty()
+                                && content.exits.iter().any(|exit| {
+                                    exit.from_location_id == offer.subject.id
+                                        && exit.to_location_id == *destination_location_id
+                                })
+                        }
+                    });
             if !offer.id.starts_with(&format!("{}:", bundle.pack_id))
                 || !action_ids.contains(offer.based_on.as_str())
                 || offer.label.trim().is_empty()
                 || offer.target_predicate.trim().is_empty()
                 || !offer.context.is_object()
+                || !cooperation_is_valid
                 || !matches!(
                     offer.subject.kind.as_str(),
                     "location" | "feature" | "actor" | "item" | "project"

--- a/v2/orchestrator-rust/src/local_leads.rs
+++ b/v2/orchestrator-rust/src/local_leads.rs
@@ -1,0 +1,593 @@
+use super::*;
+
+pub(super) const LOCAL_LEAD_MEMORY_KIND: &str = "local_lead";
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(super) struct LocalLeadState {
+    pub(super) id: String,
+    pub(super) actor_id: u64,
+    pub(super) source_actor_id: u64,
+    pub(super) source_offer_id: String,
+    pub(super) source_reference: String,
+    pub(super) source_event_seq: u64,
+    pub(super) origin_location_id: u64,
+    pub(super) destination_location_id: u64,
+    pub(super) destination_hint: String,
+    pub(super) received_tick: u64,
+    #[serde(default)]
+    pub(super) consumed: bool,
+    #[serde(default)]
+    pub(super) settled: bool,
+    #[serde(default)]
+    pub(super) forgotten: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) consumed_event_seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) settled_event_seq: Option<u64>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct AuthoredLocalLead<'a> {
+    pub(super) offer: &'a SeedContextualActionOffer,
+    pub(super) destination_location_id: u64,
+    pub(super) destination_hint: &'a str,
+}
+
+impl RuntimeWorld {
+    pub(super) fn contextual_cooperation_available(
+        &self,
+        actor_id: u64,
+        offer: &SeedContextualActionOffer,
+    ) -> bool {
+        let Some(payload) = offer.cooperation.as_ref() else {
+            return true;
+        };
+        match payload {
+            SeedCooperationPayload::LocalLead {
+                destination_location_id,
+                ..
+            } => {
+                offer.subject.kind == "location"
+                    && self.actor_by_id(actor_id).is_some_and(|actor| {
+                        actor.location_id == offer.subject.id
+                            && !self
+                                .seed_exit_discovered(actor.location_id, *destination_location_id)
+                    })
+                    && !self.local_leads.values().any(|lead| {
+                        lead.actor_id == actor_id
+                            && lead.source_offer_id == offer.id
+                            && !lead.consumed
+                            && !lead.settled
+                            && !lead.forgotten
+                    })
+            }
+        }
+    }
+
+    pub(super) fn apply_influence_projection(
+        &mut self,
+        action: &CwAction,
+        events: &[EventView],
+    ) -> Vec<EventView> {
+        if action.kind != CW_ACTION_RULES_INFLUENCE {
+            return Vec::new();
+        }
+        let Some(target) = self.actor_by_id(action.target_actor_id) else {
+            return Vec::new();
+        };
+        if !Self::actor_can_act(target) {
+            return Vec::new();
+        }
+        let Some(check) = events.iter().find(|event| {
+            event.type_name == "ability_check.rolled" && event.actor_id == Some(action.actor_id)
+        }) else {
+            return Vec::new();
+        };
+        let succeeded = check
+            .total
+            .zip(check.dc)
+            .is_some_and(|(total, dc)| total >= dc);
+        let outcome = if succeeded { "cooperates" } else { "declines" };
+        let attitude = if succeeded { "cooperative" } else { "cautious" };
+        let key = format!("{}:{}", action.actor_id, action.target_actor_id);
+        let attempts = self
+            .npc_cooperation
+            .get(&key)
+            .map(|state| state.attempts.saturating_add(1))
+            .unwrap_or(1);
+        self.npc_cooperation.insert(
+            key,
+            NpcCooperationState {
+                actor_id: action.actor_id,
+                target_actor_id: action.target_actor_id,
+                desired_cooperation: "share one useful local lead".to_string(),
+                attitude: attitude.to_string(),
+                outcome: outcome.to_string(),
+                attempts,
+                source_event_seq: check.seq,
+            },
+        );
+        let target_name = self
+            .actor_name(action.target_actor_id)
+            .unwrap_or_else(|| format!("Resident {}", action.target_actor_id));
+        let committed = self.append_async_job_event(
+            "influence.committed",
+            action.actor_id,
+            Some(action.target_actor_id),
+            Some(format!(
+                "{target_name} {outcome}: the authored request was to share one useful local lead."
+            )),
+        );
+        let mut projected = vec![committed.clone()];
+        if succeeded {
+            if let Some(received) = self.receive_authored_local_lead(
+                action.actor_id,
+                action.target_actor_id,
+                committed.seq,
+            ) {
+                projected.push(received);
+            }
+        }
+        projected
+    }
+
+    pub(super) fn authored_local_lead_for_actor(
+        &self,
+        actor_id: u64,
+    ) -> Option<AuthoredLocalLead<'static>> {
+        let location_id = self.actor_by_id(actor_id)?.location_id;
+        let mut authored = active_content()
+            .contributions
+            .iter()
+            .flat_map(|bundle| bundle.offers.iter())
+            .filter_map(|offer| {
+                let SeedCooperationPayload::LocalLead {
+                    destination_location_id,
+                    destination_hint,
+                } = offer.cooperation.as_ref()?;
+                (offer.based_on == "srd5.2.1:influence"
+                    && offer.subject.kind == "location"
+                    && offer.subject.id == location_id)
+                    .then_some(AuthoredLocalLead {
+                        offer,
+                        destination_location_id: *destination_location_id,
+                        destination_hint,
+                    })
+            })
+            .collect::<Vec<_>>();
+        authored.sort_by(|left, right| left.offer.id.cmp(&right.offer.id));
+        authored.into_iter().next()
+    }
+
+    pub(super) fn actionable_local_lead(&self, actor_id: u64) -> Option<&LocalLeadState> {
+        let actor = self.actor_by_id(actor_id)?;
+        self.local_leads
+            .values()
+            .filter(|lead| {
+                lead.actor_id == actor_id
+                    && lead.origin_location_id == actor.location_id
+                    && !lead.consumed
+                    && !lead.settled
+                    && !lead.forgotten
+                    && !self
+                        .seed_exit_discovered(lead.origin_location_id, lead.destination_location_id)
+            })
+            .max_by_key(|lead| (lead.source_event_seq, lead.id.as_str()))
+    }
+
+    pub(super) fn local_lead_for_offer<'a>(
+        &'a self,
+        actor_id: u64,
+        offer: &RankedActionOffer,
+    ) -> Option<&'a LocalLeadState> {
+        self.actionable_local_lead(actor_id)
+            .filter(|lead| offer.id == local_lead_offer_id(&lead.id))
+    }
+
+    pub(super) fn receive_authored_local_lead(
+        &mut self,
+        actor_id: u64,
+        source_actor_id: u64,
+        source_event_seq: u64,
+    ) -> Option<EventView> {
+        let actor = self.actor_by_id(actor_id)?;
+        let authored = self.authored_local_lead_for_actor(actor_id)?;
+        if authored.destination_location_id == actor.location_id
+            || self
+                .seed_exit_by_locations(actor.location_id, authored.destination_location_id)
+                .is_none()
+            || !self.contextual_cooperation_available(actor_id, authored.offer)
+        {
+            return None;
+        }
+        let lead_id = local_lead_id(actor_id, &authored.offer.id, source_event_seq);
+        if self.local_leads.contains_key(&lead_id) {
+            return None;
+        }
+        let state = LocalLeadState {
+            id: lead_id.clone(),
+            actor_id,
+            source_actor_id,
+            source_offer_id: authored.offer.id.clone(),
+            source_reference: authored.offer.source_reference.clone(),
+            source_event_seq,
+            origin_location_id: actor.location_id,
+            destination_location_id: authored.destination_location_id,
+            destination_hint: authored.destination_hint.to_string(),
+            received_tick: self.world.tick,
+            consumed: false,
+            settled: false,
+            forgotten: false,
+            consumed_event_seq: None,
+            settled_event_seq: None,
+        };
+        self.local_leads.insert(lead_id.clone(), state);
+        self.remember_search_discovery(
+            actor_id,
+            actor.location_id,
+            LOCAL_LEAD_MEMORY_KIND,
+            authored.destination_location_id,
+            &lead_id,
+        );
+        let destination_name = self
+            .location_name(authored.destination_location_id)
+            .unwrap_or_else(|| format!("Location {}", authored.destination_location_id));
+        let mut event = self.append_async_job_event(
+            "local_lead.received",
+            actor_id,
+            Some(source_actor_id),
+            Some(format!(
+                "{destination_name}: {} [{lead_id}]",
+                authored.destination_hint
+            )),
+        );
+        event.caused_by_event_seq = Some(source_event_seq);
+        self.replace_projected_event(&event);
+        Some(event)
+    }
+
+    pub(super) fn settle_local_leads_for_route(
+        &mut self,
+        discovering_actor_id: u64,
+        from_location_id: u64,
+        to_location_id: u64,
+        reason: &str,
+        event_seq: u64,
+    ) {
+        let followed_id = reason.strip_prefix("follow_local_lead:");
+        for lead in self.local_leads.values_mut().filter(|lead| {
+            lead.origin_location_id == from_location_id
+                && lead.destination_location_id == to_location_id
+                && !lead.settled
+        }) {
+            if followed_id == Some(lead.id.as_str()) && lead.actor_id == discovering_actor_id {
+                lead.consumed = true;
+                lead.consumed_event_seq = Some(event_seq);
+            }
+            lead.settled = true;
+            lead.settled_event_seq = Some(event_seq);
+        }
+    }
+
+    pub(super) fn forget_local_lead_memory(&mut self, lead_id: &str) {
+        if let Some(lead) = self.local_leads.get_mut(lead_id) {
+            if !lead.consumed && !lead.settled {
+                lead.forgotten = true;
+            }
+        }
+    }
+}
+
+pub(super) fn local_lead_id(actor_id: u64, offer_id: &str, source_event_seq: u64) -> String {
+    format!("local-lead:{actor_id}:{offer_id}:{source_event_seq}")
+}
+
+pub(super) fn local_lead_offer_id(lead_id: &str) -> String {
+    format!("local_lead:{lead_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_ACTOR_ID: u64 = 5000;
+
+    fn influence_ready_runtime() -> RuntimeWorld {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            TEST_ACTOR_ID,
+            COSY_COTTAGE_LOCATION_ID,
+            "Lead Listener",
+        );
+        let mut greeting = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_SAY,
+                actor_id: TEST_ACTOR_ID,
+                content_id: 91_320,
+                ..CwAction::default()
+            },
+            320_001,
+        );
+        greeting
+            .content_upserts
+            .insert(91_320, "Hello, Rati.".to_string());
+        assert_eq!(runtime.apply_journal_record(&greeting).0, CW_OK);
+        runtime
+    }
+
+    fn successful_influence_seed(runtime: &RuntimeWorld) -> u64 {
+        (1..=256)
+            .find(|seed| {
+                let mut candidate = runtime.clone();
+                let record = JournalRecord::new(
+                    candidate
+                        .plan_influence_action(TEST_ACTOR_ID, RATI_ACTOR_ID)
+                        .expect("authored Influence is legal"),
+                    *seed,
+                );
+                candidate
+                    .apply_journal_record(&record)
+                    .1
+                    .iter()
+                    .any(|event| event.type_name == "local_lead.received")
+            })
+            .expect("the deterministic check range contains a success")
+    }
+
+    #[test]
+    fn successful_influence_records_one_actionable_lead_without_topology_authority() {
+        let mut runtime = influence_ready_runtime();
+        let access = AccessContext::default();
+        let before_offer = runtime
+            .state_response(Some(TEST_ACTOR_ID), &access)
+            .action_offers
+            .into_iter()
+            .find(|offer| {
+                offer.kind == "explore_path"
+                    && offer
+                        .target
+                        .as_ref()
+                        .is_some_and(|target| target.id == Some(RAIN_SOFT_GARDEN_LOCATION_ID))
+            })
+            .expect("the ordinary authored route can be scouted");
+        assert!(before_offer.id.starts_with("explore_path:"));
+        let routes_before = runtime.routes.clone();
+        let exits_before = runtime.world.exits[..runtime.world.exit_count].to_vec();
+        let replay_base = RuntimeSnapshot::from_runtime(&runtime);
+        let record = JournalRecord::new(
+            runtime
+                .plan_influence_action(TEST_ACTOR_ID, RATI_ACTOR_ID)
+                .expect("Influence plans"),
+            successful_influence_seed(&runtime),
+        );
+
+        let (status, events) = runtime.apply_journal_record(&record);
+
+        assert_eq!(status, CW_OK);
+        assert!(events
+            .iter()
+            .any(|event| event.type_name == "local_lead.received"));
+        assert_eq!(runtime.routes, routes_before);
+        assert_eq!(
+            &runtime.world.exits[..runtime.world.exit_count],
+            exits_before.as_slice()
+        );
+        assert_eq!(runtime.local_leads.len(), 1);
+        let lead = runtime.local_leads.values().next().expect("one local lead");
+        assert_eq!(lead.actor_id, TEST_ACTOR_ID);
+        assert_eq!(lead.source_actor_id, RATI_ACTOR_ID);
+        assert_eq!(
+            lead.source_offer_id,
+            "cosyworld.core:cottage-ask-local-lead"
+        );
+        assert_eq!(lead.origin_location_id, COSY_COTTAGE_LOCATION_ID);
+        assert_eq!(lead.destination_location_id, RAIN_SOFT_GARDEN_LOCATION_ID);
+        assert!(!lead.consumed && !lead.settled && !lead.forgotten);
+        let lead_id = lead.id.clone();
+        let after_offer = runtime
+            .state_response(Some(TEST_ACTOR_ID), &access)
+            .action_offers
+            .into_iter()
+            .find(|offer| offer.id == local_lead_offer_id(&lead_id))
+            .expect("the next legal Scout choice carries the durable lead identity");
+        assert_eq!(after_offer.command, "scout Rain-Soft Garden");
+        assert_eq!(after_offer.source, "local_lead+exit_projection");
+        assert!(after_offer
+            .effect
+            .as_deref()
+            .is_some_and(|effect| effect.contains("Rati")));
+        assert_ne!(after_offer.id, before_offer.id);
+        assert!(!runtime
+            .state_response(Some(TEST_ACTOR_ID), &access)
+            .action_offers
+            .iter()
+            .any(|offer| offer.kind == "influence"));
+
+        let expected_leads = runtime.local_leads.clone();
+        let mut replayed = replay_base.into_runtime().expect("base snapshot restores");
+        assert_eq!(replayed.apply_journal_record(&record).0, CW_OK);
+        assert_eq!(replayed.local_leads.len(), 1);
+        assert_eq!(replayed.local_leads, expected_leads);
+        assert_eq!(
+            replayed
+                .event_log
+                .iter()
+                .filter(|event| event.type_name == "local_lead.received")
+                .map(|event| (event.seq, event.content.clone(), event.caused_by_event_seq))
+                .collect::<Vec<_>>(),
+            runtime
+                .event_log
+                .iter()
+                .filter(|event| event.type_name == "local_lead.received")
+                .map(|event| (event.seq, event.content.clone(), event.caused_by_event_seq))
+                .collect::<Vec<_>>()
+        );
+
+        runtime.world.tick = runtime
+            .world
+            .tick
+            .saturating_add(SEARCH_MEMORY_TIME_DECAY_INTERVAL_TICKS * 64);
+        runtime.decay_search_memories();
+        assert!(runtime.local_leads[&lead_id].forgotten);
+        assert_eq!(runtime.routes, routes_before);
+        assert_eq!(
+            &runtime.world.exits[..runtime.world.exit_count],
+            exits_before.as_slice()
+        );
+    }
+
+    #[test]
+    fn following_the_lead_consumes_it_through_the_existing_route_resolver() {
+        let mut runtime = influence_ready_runtime();
+        let record = JournalRecord::new(
+            runtime
+                .plan_influence_action(TEST_ACTOR_ID, RATI_ACTOR_ID)
+                .expect("Influence plans"),
+            successful_influence_seed(&runtime),
+        );
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+        let lead_id = runtime
+            .local_leads
+            .keys()
+            .next()
+            .expect("successful Influence yields a lead")
+            .clone();
+        let offer = runtime
+            .state_response(Some(TEST_ACTOR_ID), &AccessContext::default())
+            .action_offers
+            .into_iter()
+            .find(|offer| offer.id == local_lead_offer_id(&lead_id))
+            .expect("lead exposes its Scout offer");
+        let (action, mutation, _) = runtime
+            .plan_scout_offer(TEST_ACTOR_ID, &offer)
+            .expect("the ordinary Scout planner accepts the lead");
+        assert!(matches!(
+            &mutation,
+            ProjectionMutation::DiscoverSeedExit { reason, .. }
+                if reason == &format!("follow_local_lead:{lead_id}")
+        ));
+        let mut follow = JournalRecord::new(action, 320_002);
+        follow.bind_offer_kind("explore_path");
+        follow.projection_mutations.push(mutation);
+
+        assert_eq!(runtime.apply_journal_record(&follow).0, CW_OK);
+
+        let lead = &runtime.local_leads[&lead_id];
+        assert!(lead.consumed && lead.settled && !lead.forgotten);
+        assert_eq!(lead.consumed_event_seq, lead.settled_event_seq);
+        assert!(
+            runtime.seed_exit_discovered(COSY_COTTAGE_LOCATION_ID, RAIN_SOFT_GARDEN_LOCATION_ID)
+        );
+        let restored = RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .expect("settled lead restores");
+        assert_eq!(restored.local_leads[&lead_id], *lead);
+    }
+
+    #[tokio::test]
+    async fn canonical_command_and_offer_submission_return_the_same_lead_identity() {
+        let base = influence_ready_runtime();
+        let mut command_result = None;
+        for seed in 1..=256 {
+            let mut candidate = base.clone();
+            candidate.next_seed = seed;
+            let state = test_app_state(candidate, None);
+            let (session, _) = issue_actor_session(&state, TEST_ACTOR_ID);
+            let response = command(
+                ConnectInfo("127.0.0.1:43200".parse().expect("client address")),
+                State(state.clone()),
+                Json(CommandRequest {
+                    actor_id: TEST_ACTOR_ID,
+                    actor_session: Some(session),
+                    command: "influence Rati".to_string(),
+                    wallet_address: None,
+                    wallet: None,
+                    wallet_session: None,
+                    owned_card_ids: None,
+                    cards: None,
+                    envelope: None,
+                }),
+            )
+            .await
+            .0;
+            let leads = state.inner.lock().await.local_leads.clone();
+            if !leads.is_empty() {
+                command_result = Some((response, leads));
+                break;
+            }
+        }
+        let (command_response, command_leads) =
+            command_result.expect("the command path eventually returns the authored lead");
+        let mut offered_result = None;
+        for seed in 1..=256 {
+            let mut candidate = base.clone();
+            candidate.next_seed = seed;
+            let state = test_app_state(candidate, None);
+            let (session, _) = issue_actor_session(&state, TEST_ACTOR_ID);
+            let offer = {
+                let runtime = state.inner.lock().await;
+                runtime
+                    .state_response(Some(TEST_ACTOR_ID), &AccessContext::default())
+                    .action_offers
+                    .into_iter()
+                    .find(|offer| offer.kind == "influence")
+                    .expect("the authored Influence offer is visible")
+            };
+            assert_eq!(offer.label, "Ask for a local lead");
+            assert_eq!(offer.command, "influence Rati");
+            let response = submit_action_offer(
+                ConnectInfo("127.0.0.1:43201".parse().expect("client address")),
+                State(state.clone()),
+                Json(ActionOfferSubmissionRequest {
+                    path: "/actions/influence".to_string(),
+                    offer_id: offer.offer_id,
+                    composition_id: offer.composition_id,
+                    kind: offer.kind,
+                    rules_action: offer.rules_action,
+                    operation: offer.operation,
+                    rules_profile: offer.rules_profile,
+                    state_revision: offer.state_revision,
+                    route: offer.route,
+                    target: offer.target,
+                    cost: offer.cost,
+                    payload: serde_json::json!({
+                        "actor_id": TEST_ACTOR_ID,
+                        "actor_session": session,
+                        "target_actor_id": RATI_ACTOR_ID
+                    }),
+                }),
+            )
+            .await
+            .0;
+            let leads = state.inner.lock().await.local_leads.clone();
+            if !leads.is_empty() {
+                offered_result = Some((response, leads));
+                break;
+            }
+        }
+        let (offered_response, offered_leads) =
+            offered_result.expect("the offer path eventually returns the authored lead");
+
+        assert!(command_response.ok, "{command_response:?}");
+        assert!(offered_response.ok, "{offered_response:?}");
+        assert_eq!(
+            command_response
+                .action
+                .as_ref()
+                .map(|action| action.command.as_str()),
+            Some("influence Rati")
+        );
+        assert_eq!(command_leads.len(), 1);
+        assert_eq!(offered_leads.len(), 1);
+        let command_lead = command_leads.values().next().expect("command lead");
+        let offered_lead = offered_leads.values().next().expect("offered lead");
+        assert_eq!(command_lead.source_offer_id, offered_lead.source_offer_id);
+        assert_eq!(
+            command_lead.destination_location_id,
+            offered_lead.destination_location_id
+        );
+        assert_eq!(command_lead.destination_hint, offered_lead.destination_hint);
+        assert_eq!(command_lead.source_reference, offered_lead.source_reference);
+    }
+}

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -28,6 +28,7 @@ mod kernel;
 #[cfg(test)]
 mod lantern_keeper_tests;
 mod legacy_import;
+mod local_leads;
 mod moderation;
 mod movement;
 mod mud;
@@ -87,6 +88,7 @@ use hosted_access::*;
 use jobs::*;
 use kernel::*;
 use legacy_import::*;
+use local_leads::*;
 use moderation::*;
 use movement::*;
 use mud::*;
@@ -1598,6 +1600,7 @@ struct RuntimeWorld {
     equipped_charms: BTreeMap<u64, BTreeSet<u64>>,
     prepared_spells: BTreeMap<u64, BTreeSet<u64>>,
     npc_cooperation: BTreeMap<String, NpcCooperationState>,
+    local_leads: BTreeMap<String, LocalLeadState>,
     item_provenance: BTreeMap<u64, ItemProvenanceState>,
     materialization_receipts: BTreeMap<String, MaterializationReceiptState>,
     craft_receipts: BTreeMap<String, CraftReceiptState>,
@@ -1714,6 +1717,8 @@ struct RuntimeSnapshot {
     prepared_spells: BTreeMap<u64, BTreeSet<u64>>,
     #[serde(default)]
     npc_cooperation: BTreeMap<String, NpcCooperationState>,
+    #[serde(default)]
+    local_leads: BTreeMap<String, LocalLeadState>,
     #[serde(default)]
     item_provenance: BTreeMap<u64, ItemProvenanceState>,
     #[serde(default)]
@@ -6193,6 +6198,7 @@ impl RuntimeSnapshot {
             equipped_charms: runtime.equipped_charms.clone(),
             prepared_spells: runtime.prepared_spells.clone(),
             npc_cooperation: runtime.npc_cooperation.clone(),
+            local_leads: runtime.local_leads.clone(),
             item_provenance: runtime.item_provenance.clone(),
             materialization_receipts: runtime.materialization_receipts.clone(),
             craft_receipts: runtime.craft_receipts.clone(),
@@ -6403,6 +6409,7 @@ impl RuntimeSnapshot {
             equipped_charms: self.equipped_charms,
             prepared_spells: self.prepared_spells,
             npc_cooperation: self.npc_cooperation,
+            local_leads: self.local_leads,
             item_provenance: self.item_provenance,
             materialization_receipts: self.materialization_receipts,
             craft_receipts: self.craft_receipts,
@@ -6797,6 +6804,7 @@ impl RuntimeWorld {
             equipped_charms: BTreeMap::new(),
             prepared_spells: BTreeMap::new(),
             npc_cooperation: BTreeMap::new(),
+            local_leads: BTreeMap::new(),
             item_provenance: BTreeMap::new(),
             materialization_receipts: BTreeMap::new(),
             craft_receipts: BTreeMap::new(),
@@ -10689,6 +10697,13 @@ impl RuntimeWorld {
                         event.seq,
                         reason,
                     );
+                    self.settle_local_leads_for_route(
+                        action.actor_id,
+                        *from_location_id,
+                        *to_location_id,
+                        reason,
+                        event.seq,
+                    );
                     events.push(event.clone());
 
                     let mut discovered_exits = vec![exit];
@@ -11907,62 +11922,6 @@ impl RuntimeWorld {
         )
         .into_iter()
         .collect()
-    }
-
-    fn apply_influence_projection(
-        &mut self,
-        action: &CwAction,
-        events: &[EventView],
-    ) -> Vec<EventView> {
-        if action.kind != CW_ACTION_RULES_INFLUENCE {
-            return Vec::new();
-        }
-        let Some(target) = self.actor_by_id(action.target_actor_id) else {
-            return Vec::new();
-        };
-        if !Self::actor_can_act(target) {
-            return Vec::new();
-        }
-        let Some(check) = events.iter().find(|event| {
-            event.type_name == "ability_check.rolled" && event.actor_id == Some(action.actor_id)
-        }) else {
-            return Vec::new();
-        };
-        let succeeded = check
-            .total
-            .zip(check.dc)
-            .is_some_and(|(total, dc)| total >= dc);
-        let outcome = if succeeded { "cooperates" } else { "declines" };
-        let attitude = if succeeded { "cooperative" } else { "cautious" };
-        let key = format!("{}:{}", action.actor_id, action.target_actor_id);
-        let attempts = self
-            .npc_cooperation
-            .get(&key)
-            .map(|state| state.attempts.saturating_add(1))
-            .unwrap_or(1);
-        self.npc_cooperation.insert(
-            key,
-            NpcCooperationState {
-                actor_id: action.actor_id,
-                target_actor_id: action.target_actor_id,
-                desired_cooperation: "share one useful local lead".to_string(),
-                attitude: attitude.to_string(),
-                outcome: outcome.to_string(),
-                attempts,
-                source_event_seq: check.seq,
-            },
-        );
-        let target_name = self
-            .actor_name(action.target_actor_id)
-            .unwrap_or_else(|| format!("Resident {}", action.target_actor_id));
-        vec![self.append_async_job_event(
-            "influence.committed",
-            action.actor_id,
-            Some(action.target_actor_id),
-            Some(format!(
-                "{target_name} {outcome}: the authored request was to share one useful local lead."
-            )),
-        )]
     }
 
     fn apply_listen_ledger_projection(
@@ -14395,9 +14354,14 @@ impl RuntimeWorld {
             }
             return self.plan_pathway_search(actor_id);
         }
-        if let Some(plan) =
+        if let Some(mut plan) =
             self.plan_direct_authored_route_discovery(actor_id, destination_location_id)
         {
+            if let Some(lead) = self.local_lead_for_offer(actor_id, &current_offer) {
+                if let ProjectionMutation::DiscoverSeedExit { reason, .. } = &mut plan.1 {
+                    *reason = format!("follow_local_lead:{}", lead.id);
+                }
+            }
             return Ok(plan);
         }
         self.plan_journey_move(actor_id, destination_location_id)?
@@ -15028,6 +14992,12 @@ impl RuntimeWorld {
             }
         }
         for memory_id in expired {
+            if let Some(memory) = self.search_memories.get(&memory_id) {
+                if memory.kind == LOCAL_LEAD_MEMORY_KIND {
+                    let lead_id = memory.subject_key.clone();
+                    self.forget_local_lead_memory(&lead_id);
+                }
+            }
             self.search_memories.remove(&memory_id);
         }
         self.return_forgotten_search_items_to_pool();

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -966,6 +966,16 @@ for (const bundle of contributionBundles) {
         if (!isObject(row.subject) || !isObject(row.context) || !isNonEmptyString(row.label)) {
           fail(`contextual offer ${row.id} is incomplete`);
         }
+        if (row.cooperation !== undefined
+          && (!isObject(row.cooperation)
+            || row.cooperation.kind !== "local_lead"
+            || row.based_on !== "srd5.2.1:influence"
+            || row.subject?.kind !== "location"
+            || !Number.isSafeInteger(row.cooperation.destination_location_id)
+            || row.cooperation.destination_location_id <= 0
+            || !isNonEmptyString(row.cooperation.destination_hint))) {
+          fail(`contextual offer ${row.id} has an invalid typed cooperation payload`);
+        }
       } else if (kind === "variants") {
         compiledVariants.push(row.id);
         if (!/^.+\/\d+$/.test(row.id) || !isObject(row.exact_delta) || !Object.keys(row.exact_delta).length || !Array.isArray(row.fixtures) || !row.fixtures.length) {
@@ -1639,6 +1649,19 @@ for (const exit of exits) {
       fail(`duplicate direction ${exit.direction} from location ${exit.from_location_id}`);
     }
     exitDirections.add(directionKey);
+  }
+}
+
+for (const bundle of contributionBundles) {
+  for (const offer of bundle.offers ?? []) {
+    if (offer.cooperation?.kind !== "local_lead") continue;
+    const destinationId = offer.cooperation.destination_location_id;
+    const originId = Number(offer.subject?.id);
+    if (!has(locationIds, destinationId)
+        || originId === destinationId
+        || !exitPairs.has(`${originId}->${destinationId}`)) {
+      fail(`contextual offer ${offer.id} local lead must name an authored outbound destination`);
+    }
   }
 }
 

--- a/v2/scripts/compile-worldpack.mjs
+++ b/v2/scripts/compile-worldpack.mjs
@@ -513,6 +513,19 @@ function validateContributions(pack, rowsByKind, knownActionIds) {
         assert(typeof row.subject.id === "string" || Number.isSafeInteger(row.subject.id), `offer ${row.id} requires subject.id`);
         assert(row.context && typeof row.context === "object" && !Array.isArray(row.context), `offer ${row.id} requires context predicates`);
         assert(typeof row.label === "string" && row.label.trim(), `offer ${row.id} requires a presentation label`);
+        if (row.cooperation !== undefined) {
+          assert(
+            row.cooperation
+              && row.cooperation.kind === "local_lead"
+              && row.based_on === "srd5.2.1:influence"
+              && row.subject.kind === "location"
+              && Number.isSafeInteger(row.cooperation.destination_location_id)
+              && row.cooperation.destination_location_id > 0
+              && typeof row.cooperation.destination_hint === "string"
+              && row.cooperation.destination_hint.trim(),
+            `offer ${row.id} has an invalid typed cooperation payload`,
+          );
+        }
       } else if (kind === "variants") {
         assert(/^.+\/\d+$/.test(row.id), `variant ${row.id} must be versioned`);
         assert(row.exact_delta && typeof row.exact_delta === "object" && !Array.isArray(row.exact_delta) && Object.keys(row.exact_delta).length, `variant ${row.id} requires exact_delta`);

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74555
+74525

--- a/v2/worlds/core-only/pack.lock.json
+++ b/v2/worlds/core-only/pack.lock.json
@@ -83,7 +83,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",

--- a/v2/worlds/core-ruby/pack.lock.json
+++ b/v2/worlds/core-ruby/pack.lock.json
@@ -85,7 +85,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -90,7 +90,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:0804c5ae39cf5f6cc24e0bbcc2ae8422dbeb23291c8be199d0dfcbd6e923a35f",
+      "integrity": "sha256:d0b83fd083003dff495c8ba2b2891f057a380acff5ebf1aa7e2cfb54077a03cd",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",


### PR DESCRIPTION
Closes #320

## Summary
- adds a typed, pack-authored `local_lead` cooperation payload to Influence
- persists lead identity, provenance, destination hint, consumed/settled/forgotten state through snapshot and replay
- changes the next Scout offer to carry the durable lead while leaving topology authority in the existing route resolver
- keeps canonical command and action-offer submission behavior equivalent
- validates authored destinations in both JavaScript and Rust worldpack paths

## Evidence
- `npm run check`: 453/453 JS, all worldpacks + strict proof, kernel, 550/550 Rust, architecture, syntax
- focused local-lead contract: 3/3
- existing Influence regressions: 2/2
- existing direct authored route resolver: 1/1
- `main.rs`: 74,525 / 74,525
- clippy: 246 / 246 warning ceiling
- `npm run check:version`, `git diff --check`: pass
- browser evidence captured for the authored “Ask for a local lead” offer and the causal `influence.committed` → `local_lead.received` journal receipt

## Scope
28 files, +820/-95. Receipt or memory decay never creates, reveals, closes, or otherwise mutates a route.