### PR TITLE
Make Mara's first Chat an earned relationship beat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.208",
+      "version": "0.0.209",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.207",
+  "version": "0.0.208",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.207",
+      "version": "0.0.208",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.207",
+  "version": "0.0.208",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/cli/cosy_cli.py
+++ b/v2/cli/cosy_cli.py
@@ -836,7 +836,8 @@ class Game:
             return f"[{seq}] {actor} banks the Visit Ledger: {event_label_tail(event)}."
         if type_name == "bond.created":
             target = event.get("target_actor_name") or "someone"
-            return f"[{seq}] {actor} writes a Bond with {target}."
+            status = "forming" if ":forming:" in str(event.get("content") or "") else "active"
+            return f"[{seq}] {actor} writes a {status} Bond with {target}."
         if type_name == "bond.revised":
             target = event.get("target_actor_name") or "someone"
             return f"[{seq}] {actor} revises a Bond with {target}."
@@ -846,6 +847,13 @@ class Game:
         if type_name == "bond.resolved":
             target = event.get("target_actor_name") or "someone"
             return f"[{seq}] {actor} settles a Bond with {target}."
+        if type_name == "relationship.beat":
+            return f"[{seq}] Relationship beat: {event.get('content') or 'a connection begins to form'}"
+        if type_name == "relationship.advanced":
+            return f"[{seq}] Relationship advanced: {event.get('content') or 'earned trust changes the relationship'}"
+        if type_name == "dialogue.unavailable":
+            target = event.get("target_actor_name") or "the resident"
+            return f"[{seq}] Dialogue unavailable with {target}; no substitute speech was created."
         if type_name == "combat.defend":
             return f"[{seq}] {actor} defends."
         if type_name == "combat.attack.attempt":

--- a/v2/cli/test_cosy_cli.py
+++ b/v2/cli/test_cosy_cli.py
@@ -115,6 +115,37 @@ class SemanticStoryReceiptTests(unittest.TestCase):
         self.assertNotIn("Suggestion 3", rendered)
         self.assertNotRegex(rendered, r"action \d+ of \d+")
 
+    def test_cli_keeps_forming_relationship_and_dialogue_failure_explicit(self) -> None:
+        game = Game(CosyClient("http://127.0.0.1:3102"), 42, "session")
+        forming = game.format_event(
+            {
+                "seq": 21,
+                "type": "bond.created",
+                "actor_name": "Kit Featherstep",
+                "target_actor_name": "Mara Wick",
+                "content": "bond:42:8301:1:forming:advancement",
+            }
+        )
+        beat = game.format_event(
+            {
+                "seq": 22,
+                "type": "relationship.beat",
+                "content": "Mara places Rowan's empty key hook on the bar.",
+            }
+        )
+        unavailable = game.format_event(
+            {
+                "seq": 23,
+                "type": "dialogue.unavailable",
+                "target_actor_name": "Mara Wick",
+            }
+        )
+        self.assertIn("forming Bond with Mara Wick", forming)
+        self.assertNotIn("friend", forming.lower())
+        self.assertIn("empty key hook", beat)
+        self.assertIn("Dialogue unavailable with Mara Wick", unavailable)
+        self.assertIn("no substitute speech", unavailable)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/v2/content/official/actors.json
+++ b/v2/content/official/actors.json
@@ -961,6 +961,14 @@
         "reason": "Rowan carried the tower key, and its return would mean the trail is real"
       }
     ],
+    "relationship": {
+      "intent": "Begin a cautious acquaintance by accepting Mara's request about Rowan and the failed lamps.",
+      "statement": "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key.",
+      "first_beat": "Mara places Rowan's empty key hook on the bar between you. Her request is clear: follow the failed lamps and bring the Keeper's Brass Key back.",
+      "reply_prompt": "Acknowledge the empty key hook and ask the traveler to follow the failed lamps and return Rowan's Keeper Brass Key.",
+      "active_on_gift_item_id": 8401,
+      "active_beat": "Returning Rowan's Keeper Brass Key turns Mara's cautious request into earned trust."
+    },
     "stats": {
       "strength": 12,
       "dexterity": 10,

--- a/v2/content/official/character_creation.json
+++ b/v2/content/official/character_creation.json
@@ -1,7 +1,7 @@
 [
   {
     "pack_id": "cosyworld.campaign.the-lantern-keeper",
-    "pack_version": "0.1.7",
+    "pack_version": "0.1.8",
     "profiles": [
       {
         "schema_version": 2,

--- a/v2/content/official/content_refs.json
+++ b/v2/content/official/content_refs.json
@@ -5,7 +5,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8301",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "actor",
       "local_id": "8301",
       "legacy_runtime_id": 8301,
@@ -14,7 +14,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8302",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "actor",
       "local_id": "8302",
       "legacy_runtime_id": 8302,
@@ -23,7 +23,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8303",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "actor",
       "local_id": "8303",
       "legacy_runtime_id": 8303,
@@ -32,7 +32,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8304",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "actor",
       "local_id": "8304",
       "legacy_runtime_id": 8304,
@@ -41,7 +41,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-barrow",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-barrow",
       "runtime_handle": 2693745143565876
@@ -49,7 +49,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-chapel",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-chapel",
       "runtime_handle": 485182594396993
@@ -57,7 +57,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-dawn-oil",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-dawn-oil",
       "runtime_handle": 2918403238373891
@@ -65,7 +65,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-ember",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-ember",
       "runtime_handle": 6023960511621204
@@ -73,7 +73,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-inn",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-inn",
       "runtime_handle": 2167662595818650
@@ -81,7 +81,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-key",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-key",
       "runtime_handle": 8905115040499656
@@ -89,7 +89,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-knight",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-knight",
       "runtime_handle": 7581163987072796
@@ -97,7 +97,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mara",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-mara",
       "runtime_handle": 2237714680835428
@@ -105,7 +105,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothglass",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-mothglass",
       "runtime_handle": 5170986584558554
@@ -113,7 +113,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothwood",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-mothwood",
       "runtime_handle": 1673786737892201
@@ -121,7 +121,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-pip",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-pip",
       "runtime_handle": 6288898560895936
@@ -129,7 +129,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-rowan",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-rowan",
       "runtime_handle": 1658308598845697
@@ -137,7 +137,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-tower",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "card",
       "local_id": "lantern-keeper-tower",
       "runtime_handle": 5850818207762215
@@ -145,7 +145,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/character-profile/the-lantern-keeper",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "character-profile",
       "local_id": "the-lantern-keeper",
       "runtime_handle": 6074007409727657
@@ -153,7 +153,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.darkness",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "clock",
       "local_id": "lantern-keeper.darkness",
       "runtime_handle": 3497107257475399
@@ -161,7 +161,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.light",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "clock",
       "local_id": "lantern-keeper.light",
       "runtime_handle": 1743073783466389
@@ -169,7 +169,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/front/lantern-keeper%3Ahollow-light",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "front",
       "local_id": "lantern-keeper:hollow-light",
       "runtime_handle": 8897349519357189
@@ -177,7 +177,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8401",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "item",
       "local_id": "8401",
       "legacy_runtime_id": 8401,
@@ -186,7 +186,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8402",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "item",
       "local_id": "8402",
       "legacy_runtime_id": 8402,
@@ -195,7 +195,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8403",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "item",
       "local_id": "8403",
       "legacy_runtime_id": 8403,
@@ -204,7 +204,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8404",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "item",
       "local_id": "8404",
       "legacy_runtime_id": 8404,
@@ -213,7 +213,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/job/lantern-keeper%3Arekindle-the-beacon",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "job",
       "local_id": "lantern-keeper:rekindle-the-beacon",
       "runtime_handle": 3517284423041433
@@ -221,7 +221,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/800",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "location",
       "local_id": "800",
       "legacy_runtime_id": 800,
@@ -230,7 +230,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/801",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "location",
       "local_id": "801",
       "legacy_runtime_id": 801,
@@ -239,7 +239,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/802",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "location",
       "local_id": "802",
       "legacy_runtime_id": 802,
@@ -248,7 +248,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/803",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "location",
       "local_id": "803",
       "legacy_runtime_id": 803,
@@ -257,7 +257,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/804",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "location",
       "local_id": "804",
       "legacy_runtime_id": 804,
@@ -266,7 +266,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A800",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "room-sheet",
       "local_id": "room:800",
       "runtime_handle": 485005815750293
@@ -274,7 +274,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A801",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "room-sheet",
       "local_id": "room:801",
       "runtime_handle": 5114262777545579
@@ -282,7 +282,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A802",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "room-sheet",
       "local_id": "room:802",
       "runtime_handle": 3932833224947827
@@ -290,7 +290,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A803",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "room-sheet",
       "local_id": "room:803",
       "runtime_handle": 7094111250995550
@@ -298,7 +298,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A804",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "kind": "room-sheet",
       "local_id": "room:804",
       "runtime_handle": 112964325215682

--- a/v2/content/official/jobs.json
+++ b/v2/content/official/jobs.json
@@ -857,7 +857,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7"
+        "pack_version": "0.1.8"
       },
       {
         "version": 1,
@@ -939,7 +939,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7"
+        "pack_version": "0.1.8"
       }
     ],
     "narrated_thresholds": [

--- a/v2/content/official/licenses.json
+++ b/v2/content/official/licenses.json
@@ -84,7 +84,7 @@
   {
     "pack_id": "cosyworld.campaign.the-lantern-keeper",
     "name": "The Lantern Keeper",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "license_identifier": "CC-BY-4.0",
     "license_url": "https://creativecommons.org/licenses/by/4.0/",
     "provenance": {

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -656,7 +656,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:7c25a5ffcec350dba6f9211c3e2866ad4c9bc77173b415e46e023214242eb1fe",
+    "bundle_hash": "sha256:507277ab49e6b60d82cba79655c4cc0b5f5341376379cc639522f79f16c10762",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1807,7 +1807,7 @@
         "id": "cosyworld.campaign.the-lantern-keeper",
         "name": "The Lantern Keeper",
         "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
-        "version": "0.1.7",
+        "version": "0.1.8",
         "kind": "campaign",
         "license": "CC-BY-4.0",
         "license_url": "https://creativecommons.org/licenses/by/4.0/",
@@ -1905,7 +1905,7 @@
           "type": "workspace",
           "path": "../../content/the-lantern-keeper"
         },
-        "integrity": "sha256:6b693f267141d66f55e03871ebfc35751eaae2e753a60357e15c78eb2f59ef8c"
+        "integrity": "sha256:ae261fb1e3745f560912c0d449860c4a3bbe37d478be58bd982ded8bea2e9461"
       },
       {
         "id": "cosyworld.the-holy-land",
@@ -3503,6 +3503,14 @@
             "reason": "Rowan carried the tower key, and its return would mean the trail is real"
           }
         ],
+        "relationship": {
+          "intent": "Begin a cautious acquaintance by accepting Mara's request about Rowan and the failed lamps.",
+          "statement": "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key.",
+          "first_beat": "Mara places Rowan's empty key hook on the bar between you. Her request is clear: follow the failed lamps and bring the Keeper's Brass Key back.",
+          "reply_prompt": "Acknowledge the empty key hook and ask the traveler to follow the failed lamps and return Rowan's Keeper Brass Key.",
+          "active_on_gift_item_id": 8401,
+          "active_beat": "Returning Rowan's Keeper Brass Key turns Mara's cautious request into earned trust."
+        },
         "stats": {
           "strength": 12,
           "dexterity": 10,
@@ -9224,7 +9232,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.campaign.the-lantern-keeper",
-            "pack_version": "0.1.7"
+            "pack_version": "0.1.8"
           },
           {
             "version": 1,
@@ -9306,7 +9314,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.campaign.the-lantern-keeper",
-            "pack_version": "0.1.7"
+            "pack_version": "0.1.8"
           }
         ],
         "narrated_thresholds": [
@@ -15016,7 +15024,7 @@
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license_identifier": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "provenance": {
@@ -15740,7 +15748,7 @@
   "character_creation": [
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.7",
+      "pack_version": "0.1.8",
       "profiles": [
         {
           "schema_version": 2,
@@ -15845,7 +15853,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8301",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "actor",
         "local_id": "8301",
         "legacy_runtime_id": 8301,
@@ -15854,7 +15862,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8302",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "actor",
         "local_id": "8302",
         "legacy_runtime_id": 8302,
@@ -15863,7 +15871,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8303",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "actor",
         "local_id": "8303",
         "legacy_runtime_id": 8303,
@@ -15872,7 +15880,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8304",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "actor",
         "local_id": "8304",
         "legacy_runtime_id": 8304,
@@ -15881,7 +15889,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-barrow",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-barrow",
         "runtime_handle": 2693745143565876
@@ -15889,7 +15897,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-chapel",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-chapel",
         "runtime_handle": 485182594396993
@@ -15897,7 +15905,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-dawn-oil",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-dawn-oil",
         "runtime_handle": 2918403238373891
@@ -15905,7 +15913,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-ember",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-ember",
         "runtime_handle": 6023960511621204
@@ -15913,7 +15921,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-inn",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-inn",
         "runtime_handle": 2167662595818650
@@ -15921,7 +15929,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-key",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-key",
         "runtime_handle": 8905115040499656
@@ -15929,7 +15937,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-knight",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-knight",
         "runtime_handle": 7581163987072796
@@ -15937,7 +15945,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mara",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-mara",
         "runtime_handle": 2237714680835428
@@ -15945,7 +15953,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothglass",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-mothglass",
         "runtime_handle": 5170986584558554
@@ -15953,7 +15961,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothwood",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-mothwood",
         "runtime_handle": 1673786737892201
@@ -15961,7 +15969,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-pip",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-pip",
         "runtime_handle": 6288898560895936
@@ -15969,7 +15977,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-rowan",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-rowan",
         "runtime_handle": 1658308598845697
@@ -15977,7 +15985,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-tower",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "card",
         "local_id": "lantern-keeper-tower",
         "runtime_handle": 5850818207762215
@@ -15985,7 +15993,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/character-profile/the-lantern-keeper",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "character-profile",
         "local_id": "the-lantern-keeper",
         "runtime_handle": 6074007409727657
@@ -15993,7 +16001,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.darkness",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "clock",
         "local_id": "lantern-keeper.darkness",
         "runtime_handle": 3497107257475399
@@ -16001,7 +16009,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.light",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "clock",
         "local_id": "lantern-keeper.light",
         "runtime_handle": 1743073783466389
@@ -16009,7 +16017,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/front/lantern-keeper%3Ahollow-light",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "front",
         "local_id": "lantern-keeper:hollow-light",
         "runtime_handle": 8897349519357189
@@ -16017,7 +16025,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8401",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "item",
         "local_id": "8401",
         "legacy_runtime_id": 8401,
@@ -16026,7 +16034,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8402",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "item",
         "local_id": "8402",
         "legacy_runtime_id": 8402,
@@ -16035,7 +16043,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8403",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "item",
         "local_id": "8403",
         "legacy_runtime_id": 8403,
@@ -16044,7 +16052,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8404",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "item",
         "local_id": "8404",
         "legacy_runtime_id": 8404,
@@ -16053,7 +16061,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/job/lantern-keeper%3Arekindle-the-beacon",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "job",
         "local_id": "lantern-keeper:rekindle-the-beacon",
         "runtime_handle": 3517284423041433
@@ -16061,7 +16069,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/800",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "location",
         "local_id": "800",
         "legacy_runtime_id": 800,
@@ -16070,7 +16078,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/801",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "location",
         "local_id": "801",
         "legacy_runtime_id": 801,
@@ -16079,7 +16087,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/802",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "location",
         "local_id": "802",
         "legacy_runtime_id": 802,
@@ -16088,7 +16096,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/803",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "location",
         "local_id": "803",
         "legacy_runtime_id": 803,
@@ -16097,7 +16105,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/804",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "location",
         "local_id": "804",
         "legacy_runtime_id": 804,
@@ -16106,7 +16114,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A800",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "room-sheet",
         "local_id": "room:800",
         "runtime_handle": 485005815750293
@@ -16114,7 +16122,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A801",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "room-sheet",
         "local_id": "room:801",
         "runtime_handle": 5114262777545579
@@ -16122,7 +16130,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A802",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "room-sheet",
         "local_id": "room:802",
         "runtime_handle": 3932833224947827
@@ -16130,7 +16138,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A803",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "room-sheet",
         "local_id": "room:803",
         "runtime_handle": 7094111250995550
@@ -16138,7 +16146,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A804",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7",
+        "pack_version": "0.1.8",
         "kind": "room-sheet",
         "local_id": "room:804",
         "runtime_handle": 112964325215682

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -654,7 +654,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:7c25a5ffcec350dba6f9211c3e2866ad4c9bc77173b415e46e023214242eb1fe",
+  "bundle_hash": "sha256:507277ab49e6b60d82cba79655c4cc0b5f5341376379cc639522f79f16c10762",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1805,7 +1805,7 @@
       "id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
       "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "kind": "campaign",
       "license": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
@@ -1903,7 +1903,7 @@
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:6b693f267141d66f55e03871ebfc35751eaae2e753a60357e15c78eb2f59ef8c"
+      "integrity": "sha256:ae261fb1e3745f560912c0d449860c4a3bbe37d478be58bd982ded8bea2e9461"
     },
     {
       "id": "cosyworld.the-holy-land",

--- a/v2/content/the-lantern-keeper/actors.json
+++ b/v2/content/the-lantern-keeper/actors.json
@@ -8,6 +8,14 @@
     "ambient_autonomy": false,
     "location_id": 800,
     "desires": [{ "item_id": 8401, "reason": "Rowan carried the tower key, and its return would mean the trail is real" }],
+    "relationship": {
+      "intent": "Begin a cautious acquaintance by accepting Mara's request about Rowan and the failed lamps.",
+      "statement": "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key.",
+      "first_beat": "Mara places Rowan's empty key hook on the bar between you. Her request is clear: follow the failed lamps and bring the Keeper's Brass Key back.",
+      "reply_prompt": "Acknowledge the empty key hook and ask the traveler to follow the failed lamps and return Rowan's Keeper Brass Key.",
+      "active_on_gift_item_id": 8401,
+      "active_beat": "Returning Rowan's Keeper Brass Key turns Mara's cautious request into earned trust."
+    },
     "stats": { "strength": 12, "dexterity": 10, "constitution": 14, "intelligence": 11, "wisdom": 15, "charisma": 13, "hp_base": 12, "level": 2 }
   },
   {

--- a/v2/content/the-lantern-keeper/jobs.json
+++ b/v2/content/the-lantern-keeper/jobs.json
@@ -97,7 +97,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7"
+        "pack_version": "0.1.8"
       },
       {
         "version": 1,
@@ -179,7 +179,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.7"
+        "pack_version": "0.1.8"
       }
     ],
     "narrated_thresholds": [

--- a/v2/content/the-lantern-keeper/pack.json
+++ b/v2/content/the-lantern-keeper/pack.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "cosyworld.campaign.the-lantern-keeper",
   "name": "The Lantern Keeper",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "kind": "campaign",
   "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
   "license": "CC-BY-4.0",

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.208"
+version = "0.0.209"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.207"
+version = "0.0.208"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.208"
+version = "0.0.209"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.207"
+version = "0.0.208"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -664,6 +664,8 @@ pub(super) struct SeedActorContent {
     pub(super) desires: Vec<SeedResidentDesireContent>,
     #[serde(default)]
     pub(super) attachments: Vec<SeedResidentAttachmentContent>,
+    #[serde(default)]
+    pub(super) relationship: Option<SeedRelationshipContent>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -2156,6 +2158,20 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
                 return Err(format!(
                     "seed actor {} has invalid attachment to item {}",
                     actor.id, attachment.item_id
+                ));
+            }
+        }
+        if let Some(relationship) = actor.relationship.as_ref() {
+            if relationship.intent.trim().is_empty()
+                || relationship.statement.trim().is_empty()
+                || relationship.first_beat.trim().is_empty()
+                || relationship.reply_prompt.trim().is_empty()
+                || relationship.active_beat.trim().is_empty()
+                || !item_ids.contains(&relationship.active_on_gift_item_id)
+            {
+                return Err(format!(
+                    "seed actor {} has an invalid authored relationship",
+                    actor.id
                 ));
             }
         }

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -4903,6 +4903,8 @@
         const firstChat = chatCandidates[0];
         const oneChat = chatCandidates.length === 1;
         const firstTargetName = firstChat.name || actorLabel(firstChat);
+        const firstRelationship = firstChat.relationship || null;
+        const authoredRelationship = firstRelationship?.initial_status === "forming";
         const chatAction = {
           ...semanticAction(chatOffer, "chat"),
           kind: "advancement-chat",
@@ -4921,11 +4923,16 @@
           targetName: oneChat ? firstTargetName : "",
           modalTitle: oneChat ? `chat with ${firstTargetName}` : "choose someone to chat with",
           modalSummary: oneChat
-            ? `Use one advancement point to begin a friendship with ${firstTargetName}.`
+            ? (authoredRelationship
+              ? `Use one advancement point to begin this forming relationship: “${firstRelationship.statement}”`
+              : `Use one advancement point to begin a friendship with ${firstTargetName}.`)
             : "Choose someone nearby. Chat uses one advancement point and begins a friendship.",
           effect: oneChat
-            ? `your friendship with ${firstTargetName} begins`
+            ? (authoredRelationship
+              ? firstRelationship.deterministic_consequence
+              : `your friendship with ${firstTargetName} begins`)
             : "a new friendship begins",
+          relationship: firstRelationship,
           ...(oneChat ? {} : {
             choices: chatCandidates.map((actor) => {
               const card = cardForActor(actor.id);
@@ -4945,7 +4952,7 @@
         chatAction.selectedPayload = () => ({
           actor_id: actorId,
           target_actor_id: Number(chatAction.selectedTarget().id),
-          statement: defaultBondStatement(
+          statement: chatAction.selectedTarget().relationship?.statement || defaultBondStatement(
             chatAction.selectedTarget().name || actorLabel(chatAction.selectedTarget())
           ),
         });
@@ -7278,6 +7285,9 @@
       "pathway.discovered",
       "pathway.familiarized",
       "chat.failed",
+      "dialogue.unavailable",
+      "relationship.beat",
+      "relationship.advanced",
       "ability_check.rolled",
       "study.resolved",
       "feature.searched",
@@ -7593,6 +7603,7 @@
         || event.type === "actor.presence"
         || event.type === "chat.queued"
         || event.type === "chat.completed"
+        || event.type === "dialogue.delivered"
         || event.type === "avatar.refined"
         || event.type === "pathway.refined";
     }
@@ -7619,6 +7630,10 @@
         || event.type === "turn.timeout_passed"
         || event.type === "message.created"
         || event.type === "chat.failed"
+        || event.type === "dialogue.unavailable"
+        || event.type === "dialogue.delivered"
+        || event.type === "relationship.beat"
+        || event.type === "relationship.advanced"
         || event.type === "avatar.refined"
         || event.type === "pathway.refined"
         || event.type === "move.blocked"
@@ -8651,6 +8666,15 @@
       if (event.type === "skill.stepped") {
         return { kind: "skill", label: "ability", text: cleanStatusText(skillEventLabel(event)) };
       }
+      if (event.type === "relationship.beat") {
+        return { kind: "bond", label: "relationship", text: cleanStatusText(event.content || "a relationship begins to form") };
+      }
+      if (event.type === "relationship.advanced") {
+        return { kind: "bond", label: "relationship", text: cleanStatusText(event.content || "earned trust changes the relationship") };
+      }
+      if (event.type === "dialogue.unavailable") {
+        return { kind: "bond", label: "dialogue unavailable", text: "The promised resident reply could not run. No substitute speech was created." };
+      }
       if (event.type === "calling.set") {
         if (event.actor_id === actorId) {
           return { kind: "calling", label: "purpose", text: `What draws you in: ${cleanStatusText(callingEventLabel(event))}` };
@@ -8667,7 +8691,10 @@
         return { kind: "bond", label: "friendship", text: `closer to ${event.target_actor_name || "someone"}` };
       }
       if (event.type === "bond.created") {
-        return { kind: "bond", label: "friendship", text: `${event.target_actor_name || "someone"} now matters to you` };
+        const forming = String(event.content || "").includes(":forming:");
+        return forming
+          ? { kind: "bond", label: "relationship", text: `a connection with ${event.target_actor_name || "someone"} is forming` }
+          : { kind: "bond", label: "friendship", text: `${event.target_actor_name || "someone"} now matters to you` };
       }
       if (event.type === "bond.revised") {
         return { kind: "bond", label: "friendship", text: `what ${event.target_actor_name || "someone"} means to you changed` };
@@ -9344,10 +9371,12 @@
         return `${charm.name} — ${skill}${bonus ? ` +${bonus}` : ""}`;
       }).join(", ") : "find a skill charm, then wear it from Deck"));
       const bonds = Array.isArray(state?.bonds) ? state.bonds : [];
-      rows.push(accountRow("friends", bonds.length ? bonds.map((bond) => {
+      rows.push(accountRow("relationships", bonds.length ? bonds.map((bond) => {
         const name = String(bond.target_actor_name || "someone").trim();
         const statement = String(bond.statement || "").trim();
-        const closeness = Number(bond.strength || 0) >= 3 ? "close friend" : (Number(bond.strength || 0) >= 2 ? "getting closer" : "new friend");
+        const closeness = bond.status === "forming"
+          ? "forming acquaintance"
+          : (Number(bond.strength || 0) >= 3 ? "close friend" : (Number(bond.strength || 0) >= 2 ? "getting closer" : "new friend"));
         return `${name} — ${statement || closeness}${statement ? ` (${closeness})` : ""}`;
       }).join(" · ") : "someone new is waiting to meet you"));
       const marks = Array.isArray(ledger.unbanked_marks) ? ledger.unbanked_marks : [];
@@ -9551,6 +9580,12 @@
       if (type === "chat.failed") {
         return "The conversation slipped away before it could begin. Your Orb came back.";
       }
+      if (type === "dialogue.unavailable") {
+        return "Dialogue unavailable: Mara's promised reply could not run. The authored relationship beat still stands, and no substitute speech was created.";
+      }
+      if (type === "relationship.beat" || type === "relationship.advanced") {
+        return finishSentence(cleanStatusText(event.content || "The relationship changes through a visible deed"));
+      }
       if (type === "world.weather.shifted") {
         return finishSentence(cleanStatusText(event.content || "The weather changes its mind"));
       }
@@ -9658,6 +9693,9 @@
         return `${actor} finds a truer answer to what draws them in: ${withoutFinalPeriod(callingEventLabel(event))}.`;
       }
       if (type === "bond.created") {
+        if (String(event.content || "").includes(":forming:")) {
+          return `A cautious connection begins forming between ${actor} and ${event.target_actor_name || "someone new"}; friendship has not been claimed.`;
+        }
         return `Somewhere between ${actor} and ${event.target_actor_name || "someone new"}, a friendship begins.`;
       }
       if (type === "bond.revised") {
@@ -9987,7 +10025,13 @@
       if (event.type === "skill_charm.unequipped") return `removes ${event.item_name || "a skill charm"}.`;
       if (event.type === "skill.stepped") return `${skillEventLabel(event)}.`;
       if (event.type === "bond.deepened") return `grows closer to ${event.target_actor_name || "someone"}.`;
-      if (event.type === "bond.created") return `became friends with ${event.target_actor_name || "someone"}.`;
+      if (event.type === "relationship.beat" || event.type === "relationship.advanced") return finishSentence(cleanStatusText(event.content || "the relationship changes"));
+      if (event.type === "dialogue.unavailable") return "Dialogue unavailable; no substitute speech was created.";
+      if (event.type === "bond.created") {
+        return String(event.content || "").includes(":forming:")
+          ? `began a forming relationship with ${event.target_actor_name || "someone"}.`
+          : `became friends with ${event.target_actor_name || "someone"}.`;
+      }
       if (event.type === "bond.revised") return `sees ${event.target_actor_name || "someone"} a little differently.`;
       if (event.type === "bond.resolved") return `keeps what mattered with ${event.target_actor_name || "someone"}.`;
       if (event.type === "job.updated") return `${jobEventLabel(event)}.`;
@@ -11079,6 +11123,16 @@
         ].filter((row) => String(row[1] || "").trim());
       }
       if (String(action?.label || "").toLowerCase() === "chat") {
+        const selectedRelationship = action?.selectedTarget?.()?.relationship || action?.relationship;
+        if (selectedRelationship?.initial_status === "forming") {
+          return [
+            ["Relationship", selectedRelationship.statement],
+            ["Status", "forming acquaintance; this does not claim friendship"],
+            ["Campaign beat", selectedRelationship.deterministic_consequence],
+            ["Spend", "one advancement point"],
+            ["Dialogue", selectedRelationship.dialogue_contract],
+          ];
+        }
         if (action?.choices?.length) {
           return [
             ["Choose", "who you want to begin a friendship with"],
@@ -11180,6 +11234,21 @@
       ].filter((row) => String(row[1] || "").trim());
     }
 
+    function renderActionModalRows(action) {
+      const selectedRelationship = action?.selectedTarget?.()?.relationship || action?.relationship;
+      const authoredRelationship = String(action?.label || "").toLowerCase() === "chat"
+        && selectedRelationship?.initial_status === "forming";
+      const rows = (authoredRelationship ? actionModalRows(action) : [])
+        .filter((row) => String(row?.[0] || "").trim() && String(row?.[1] || "").trim());
+      const meta = $("action-modal-meta");
+      meta.innerHTML = rows.map(([key, value]) => {
+        const label = String(key).trim();
+        const detail = String(value).trim();
+        const risk = /^watch for$/i.test(label) ? " risk" : "";
+        return `<div class="action-row${risk}" role="group" aria-label="${escapeAttr(label)}"><span class="action-row-key">${escapeHtml(label)}</span><span class="action-row-value">${escapeHtml(detail)}</span></div>`;
+      }).join("");
+    }
+
     function actionSummary(action) {
       if (action?.modalSummary) return String(action.modalSummary);
       if (["nudge", "ping"].includes(String(action?.label || "").toLowerCase())) {
@@ -11248,7 +11317,7 @@
       syncActionChoicePreview(action, selectedChoice);
       $("action-modal-title").textContent = label;
       $("action-modal-summary").textContent = journalSentence(actionSummary(action));
-      $("action-modal-meta").innerHTML = "";
+      renderActionModalRows(action);
       renderActionChoices(action);
       $("action-modal-confirm").textContent = actionConfirmLabel(action);
       $("action-modal-cancel").textContent = action?.creationStage === "origin" ? "back" : "cancel";
@@ -11311,6 +11380,7 @@
       action.selectedChoice = choice.value;
       renderActionChoices(action);
       syncActionChoicePreview(action, choice);
+      renderActionModalRows(action);
     }
 
     function closeActionModal() {

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -324,6 +324,43 @@
       border-color: rgba(226, 187, 121, 0.28);
       background: rgba(24, 19, 10, 0.66);
     }
+    .story-front {
+      border-color: rgba(226, 187, 121, 0.34);
+      background:
+        linear-gradient(110deg, rgba(45, 31, 13, 0.45), rgba(8, 19, 12, 0.76));
+    }
+    .story-front.persisted,
+    .story-front.escalated {
+      border-color: rgba(226, 187, 121, 0.5);
+    }
+    .story-front-stakes {
+      margin-top: 8px;
+      display: grid;
+      gap: 5px;
+    }
+    .story-front-question,
+    .story-front-reference,
+    .story-front-outcome {
+      margin: 0;
+      font-size: 12px;
+      line-height: 1.4;
+      overflow-wrap: anywhere;
+    }
+    .story-front-question {
+      color: var(--text);
+      font-weight: 700;
+    }
+    .story-front-reference {
+      margin-top: 8px;
+      color: var(--dim);
+    }
+    .story-front-outcome {
+      margin-top: 8px;
+      border-top: 1px solid rgba(226, 187, 121, 0.2);
+      padding-top: 7px;
+      color: var(--amber);
+      font-weight: 700;
+    }
     .shared-question-heading {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
@@ -3753,7 +3790,7 @@
         </div>
         <button class="room-log-latest" id="room-log-latest" type="button" aria-controls="journal-view" hidden><span class="room-log-latest-track" id="room-log-latest-track"></span></button>
         <div class="room-copy" id="location-copy"></div>
-        <section class="shared-questions" id="promoted-question" aria-live="polite" aria-label="Current shared question" hidden></section>
+        <section class="shared-questions" id="promoted-question" aria-live="polite" aria-label="Current story and shared question" hidden></section>
       </section>
       <section class="journal-view" id="journal-view" aria-label="Journal" hidden>
         <header class="journal-heading">
@@ -8166,6 +8203,46 @@
         .slice(0, 1);
     }
 
+    function frontsForPresentation(view = state) {
+      const fronts = Array.isArray(view?.fronts) ? view.fronts : [];
+      return fronts.filter((front) => front.presentation_state !== "dormant");
+    }
+
+    function narrativeNames(names) {
+      const values = (names || []).map((name) => String(name || "").trim()).filter(Boolean);
+      if (values.length < 2) return values[0] || "";
+      if (values.length === 2) return `${values[0]} and ${values[1]}`;
+      return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+    }
+
+    function promotedFrontHtml(front, index = 0) {
+      const stateName = String(front.presentation_state || "active");
+      const idBase = `story-front-${String(front.id || index).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+      const titleId = `${idBase}-title`;
+      const stakes = (front.stakes_questions || []).filter(Boolean);
+      const stakeIds = stakes.map((_, stakeIndex) => `${idBase}-stake-${stakeIndex + 1}`);
+      const names = narrativeNames(front.participant_names);
+      const referenceId = names ? `${idBase}-reference` : "";
+      const outcome = String(front.outcome_statement || "").trim();
+      const outcomeId = outcome ? `${idBase}-outcome` : "";
+      const describedBy = [...stakeIds, referenceId, outcomeId].filter(Boolean).join(" ");
+      const kicker = {
+        persisted: "the larger trouble persists",
+        resolved: "the larger trouble is resolved",
+        escalated: "the larger trouble has escalated",
+      }[stateName] || "larger trouble";
+      const stakeHtml = stakes.length
+        ? `<div class="story-front-stakes">${stakes.map((stake, stakeIndex) => `<p class="story-front-question" id="${stakeIds[stakeIndex]}">${escapeHtml(stake)}</p>`).join("")}</div>`
+        : "";
+      const referenceHtml = names
+        ? `<p class="story-front-reference" id="${referenceId}">${escapeHtml(`The answer still matters to ${names}.`)}</p>`
+        : "";
+      const outcomeHtml = outcome
+        ? `<p class="story-front-outcome" id="${outcomeId}">${escapeHtml(outcome)}</p>`
+        : "";
+      return `<article class="shared-question story-front ${escapeAttr(stateName)}" role="region" aria-labelledby="${titleId}"${describedBy ? ` aria-describedby="${describedBy}"` : ""}><span class="shared-question-kicker">${escapeHtml(kicker)}</span><h2 id="${titleId}">${escapeHtml(front.premise)}</h2>${stakeHtml}${referenceHtml}${outcomeHtml}</article>`;
+    }
+
     function sharedQuestionHtml(question) {
       const completed = question.presentation_state === "completed_memory";
       const rhythm = String(question.rhythm || "shared").replaceAll("_", " ");
@@ -8261,9 +8338,13 @@
 
     function renderPromotedQuestion() {
       const panel = $("promoted-question");
+      const fronts = frontsForPresentation();
       const questions = sharedQuestionsForPresentation();
-      panel.hidden = questions.length === 0;
-      panel.innerHTML = questions.slice(0, 1).map(promotedQuestionHtml).join("");
+      panel.hidden = fronts.length === 0 && questions.length === 0;
+      panel.innerHTML = [
+        ...fronts.slice(0, 1).map(promotedFrontHtml),
+        ...questions.slice(0, 1).map(promotedQuestionHtml),
+      ].join("");
       if (questions.length) scheduleVisibleClockPresentationReceipts();
     }
 

--- a/v2/orchestrator-rust/src/lantern_keeper_tests.rs
+++ b/v2/orchestrator-rust/src/lantern_keeper_tests.rs
@@ -535,7 +535,7 @@ fn previous_epoch_snapshot_refreshes_the_finale_contract_and_shared_evidence() {
         .expect("active finale strategy replaces the old snapshot contract");
     assert_eq!(restored_strategy.requirements.len(), 10);
     assert_eq!(restored_strategy.baseline_progress, 6);
-    assert_eq!(restored_strategy.pack_version, "0.1.7");
+    assert_eq!(restored_strategy.pack_version, "0.1.8");
     assert_eq!(
         restored.tags[&room_feature_use_tag_id(801, "cold_lamp_post", 8402)].source_event_seq,
         Some(321)

--- a/v2/orchestrator-rust/src/lantern_keeper_tests.rs
+++ b/v2/orchestrator-rust/src/lantern_keeper_tests.rs
@@ -548,6 +548,23 @@ fn lantern_journey_evidence_unlocks_one_controller_neutral_finale() {
     let (mut runtime, expected_evidence) = runtime_ready_for_lantern_finale();
     assert_eq!(runtime.clocks[LANTERN_PROGRESS_CLOCK_ID].filled, 0);
 
+    let before_finale_view =
+        runtime.state_response(Some(FINAL_ACTOR_ID), &AccessContext::default());
+    let encountered_front = before_finale_view
+        .fronts
+        .iter()
+        .find(|front| front.id == "lantern-keeper:hollow-light")
+        .expect("the Lantern journey reaches its larger trouble before the finale");
+    assert_eq!(encountered_front.presentation_state, "active");
+    assert_eq!(
+        encountered_front.premise,
+        "The beacon's shadow has learned Rowan's shape and wants every road lamp to recognize it as keeper."
+    );
+    assert!(encountered_front.stakes_questions.iter().any(|question| {
+        question
+            == "Can Rowan be separated from the shadow without extinguishing the keeper's ember?"
+    }));
+
     assert_tag_source(
         &runtime,
         &room_feature_search_tag_id(800, "failing_lantern"),
@@ -637,6 +654,18 @@ fn lantern_journey_evidence_unlocks_one_controller_neutral_finale() {
     assert_eq!(
         runtime.job_status(&runtime.jobs[LANTERN_JOB_ID]),
         "completed"
+    );
+    let after_finale_view = runtime.state_response(Some(FINAL_ACTOR_ID), &AccessContext::default());
+    let persisted_front = after_finale_view
+        .fronts
+        .iter()
+        .find(|front| front.id == "lantern-keeper:hollow-light")
+        .expect("the larger trouble remains visible after the beacon work");
+    assert_eq!(persisted_front.status, "active");
+    assert_eq!(persisted_front.presentation_state, "persisted");
+    assert_eq!(
+        persisted_front.outcome_statement,
+        "The immediate work is done, but the larger trouble remains unresolved."
     );
     assert!(runtime
         .tags
@@ -731,6 +760,16 @@ fn lantern_journey_evidence_unlocks_one_controller_neutral_finale() {
         "completed"
     );
     assert_eq!(reconnected.orb_balance(FINAL_ACTOR_ID), before_orbs + 2);
+    let reconnected_front = reconnected
+        .state_response(Some(FINAL_ACTOR_ID), &AccessContext::default())
+        .fronts
+        .into_iter()
+        .find(|front| front.id == "lantern-keeper:hollow-light")
+        .expect("persisted larger trouble survives reconnect");
+    assert_eq!(reconnected_front.presentation_state, "persisted");
+    assert!(reconnected_front
+        .outcome_statement
+        .contains("remains unresolved"));
 }
 
 #[test]
@@ -765,6 +804,16 @@ fn lantern_combat_is_evidence_and_danger_resolves_once() {
     );
     assert_eq!(runtime.apply_journal_record(&fail_record).0, CW_OK);
     assert_eq!(runtime.job_status(&runtime.jobs[LANTERN_JOB_ID]), "failed");
+    let escalated_front = runtime
+        .state_response(Some(FINAL_ACTOR_ID), &AccessContext::default())
+        .fronts
+        .into_iter()
+        .find(|front| front.id == "lantern-keeper:hollow-light")
+        .expect("failed beacon work escalates the larger trouble");
+    assert_eq!(escalated_front.presentation_state, "escalated");
+    assert!(escalated_front
+        .outcome_statement
+        .starts_with("The larger trouble has escalated."));
     assert!(runtime
         .tags
         .get("room:804:black_beacon")

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -36,6 +36,7 @@ mod ownership;
 mod prompts;
 mod quest_loot;
 mod rate_limit;
+mod relationships;
 mod resident_offer_scoring;
 mod routes;
 mod rpg;
@@ -97,6 +98,7 @@ use qrcode::{render::svg, QrCode};
 use quest_loot::*;
 use rand::{rngs::OsRng, RngCore};
 use rate_limit::*;
+use relationships::*;
 use rpg::*;
 use rules_context::*;
 use rusqlite::{params, Connection, OptionalExtension};
@@ -926,6 +928,12 @@ enum ProjectionMutation {
         status: String,
         reason: String,
     },
+    SetRelationshipDialogueStatus {
+        relationship_actor_id: u64,
+        target_actor_id: u64,
+        status: String,
+        reason: String,
+    },
     RefreshAvatarIdentity {
         actor_id: u64,
         #[serde(default)]
@@ -1248,20 +1256,6 @@ struct AdvancementSpendState {
     label: String,
     cost: u8,
     source_event_seq: u64,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct BondState {
-    id: String,
-    actor_id: u64,
-    target_actor_id: u64,
-    statement: String,
-    strength: u8,
-    status: String,
-    #[serde(default)]
-    source_event_seq: Option<u64>,
-    #[serde(default)]
-    updated_event_seq: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2114,6 +2108,8 @@ struct PlayerTickObservation {
     allow_ordinary_speech: bool,
     source_events: Vec<EventView>,
     ripple_source: Option<RippleSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    relationship_reply: Option<RelationshipReplyExpectation>,
 }
 
 #[derive(Clone, Debug)]
@@ -9763,7 +9759,10 @@ impl RuntimeWorld {
             destination_location_id: None,
             destination_location_name: None,
             content_id: None,
-            content: Some(format!("{}:{}:{reason}", bond.id, bond.strength)),
+            content: Some(format!(
+                "{}:{}:{}:{reason}",
+                bond.id, bond.strength, bond.status
+            )),
             item_id: None,
             item_name: None,
             target_item_id: None,
@@ -10268,6 +10267,19 @@ impl RuntimeWorld {
                         action.actor_id,
                         Some(*target_actor_id),
                         Some(reason.clone()),
+                    ));
+                }
+                ProjectionMutation::SetRelationshipDialogueStatus {
+                    relationship_actor_id,
+                    target_actor_id,
+                    status,
+                    reason,
+                } => {
+                    events.extend(self.set_relationship_dialogue_status(
+                        *relationship_actor_id,
+                        *target_actor_id,
+                        status,
+                        reason,
                     ));
                 }
                 ProjectionMutation::RefreshAvatarIdentity {
@@ -11544,6 +11556,8 @@ impl RuntimeWorld {
                 status: "active".to_string(),
                 source_event_seq: Some(source_event_seq),
                 updated_event_seq: None,
+                dialogue_status: String::new(),
+                dialogue_event_seq: None,
             });
             bond.strength = bond.strength.saturating_add(1).min(3);
             bond.status = "active".to_string();
@@ -11575,14 +11589,23 @@ impl RuntimeWorld {
             else {
                 continue;
             };
-            projected.extend(self.deepen_bond_from_event(
+            if let Some(events) = self.deepen_authored_relationship_from_gift(
                 actor_id,
                 target_actor_id,
+                item_id,
                 event.seq,
-                gift_bond_claim_key(actor_id, target_actor_id, item_id),
-                "resident_gift",
-                &format!("gift:{actor_id}:{target_actor_id}:{item_id}:bond"),
-            ));
+            ) {
+                projected.extend(events);
+            } else {
+                projected.extend(self.deepen_bond_from_event(
+                    actor_id,
+                    target_actor_id,
+                    event.seq,
+                    gift_bond_claim_key(actor_id, target_actor_id, item_id),
+                    "resident_gift",
+                    &format!("gift:{actor_id}:{target_actor_id}:{item_id}:bond"),
+                ));
+            }
         }
         projected
     }
@@ -12579,105 +12602,6 @@ impl RuntimeWorld {
         };
         self.callings.insert(actor_id, calling.clone());
         events.push(self.append_calling_event("calling.revised", &calling, reason));
-        events
-    }
-
-    fn create_bond(
-        &mut self,
-        actor_id: u64,
-        target_actor_id: u64,
-        statement: &str,
-        cost: u8,
-        reason: &str,
-    ) -> Vec<EventView> {
-        let id = bond_id(actor_id, target_actor_id);
-        if cost == 0
-            || self.advancement_points_available(actor_id) < usize::from(cost)
-            || self.active_bond(actor_id, target_actor_id).is_some()
-        {
-            return Vec::new();
-        }
-
-        let spend_seq = self.world.next_event_seq;
-        let target_name = self
-            .actor_name(target_actor_id)
-            .unwrap_or_else(|| format!("Resident {target_actor_id}"));
-        let spend = AdvancementSpendState {
-            id: advancement_spend_id(actor_id, "bond_slot", spend_seq),
-            actor_id,
-            kind: "bond_slot".to_string(),
-            label: format!("Friendship with {target_name}"),
-            cost,
-            source_event_seq: spend_seq,
-        };
-        if self.advancement_spends.contains_key(&spend.id) {
-            return Vec::new();
-        }
-        self.advancement_spends
-            .insert(spend.id.clone(), spend.clone());
-        let mut events = vec![self.append_advancement_event("advancement.spent", &spend, reason)];
-
-        let bond = BondState {
-            id: id.clone(),
-            actor_id,
-            target_actor_id,
-            statement: statement.to_string(),
-            strength: 1,
-            status: "active".to_string(),
-            source_event_seq: Some(self.world.next_event_seq),
-            updated_event_seq: Some(self.world.next_event_seq),
-        };
-        self.bonds.insert(id, bond.clone());
-        events.push(self.append_bond_event("bond.created", &bond, reason));
-        events
-    }
-
-    fn revise_bond(
-        &mut self,
-        actor_id: u64,
-        target_actor_id: u64,
-        statement: &str,
-        cost: u8,
-        reason: &str,
-    ) -> Vec<EventView> {
-        let id = bond_id(actor_id, target_actor_id);
-        if cost == 0 || self.advancement_points_available(actor_id) < usize::from(cost) {
-            return Vec::new();
-        }
-        let Some(existing) = self.bonds.get(&id) else {
-            return Vec::new();
-        };
-        if existing.status == "resolved"
-            || existing.strength == 0
-            || existing.statement == statement
-        {
-            return Vec::new();
-        }
-
-        let spend_seq = self.world.next_event_seq;
-        let spend = AdvancementSpendState {
-            id: advancement_spend_id(actor_id, "bond_revision", spend_seq),
-            actor_id,
-            kind: "bond_revision".to_string(),
-            label: "Friendship changed".to_string(),
-            cost,
-            source_event_seq: spend_seq,
-        };
-        if self.advancement_spends.contains_key(&spend.id) {
-            return Vec::new();
-        }
-        self.advancement_spends
-            .insert(spend.id.clone(), spend.clone());
-        let mut events = vec![self.append_advancement_event("advancement.spent", &spend, reason)];
-
-        let Some(bond) = self.bonds.get_mut(&id) else {
-            return events;
-        };
-        bond.statement = statement.to_string();
-        bond.status = "active".to_string();
-        bond.updated_event_seq = Some(self.world.next_event_seq);
-        let bond = bond.clone();
-        events.push(self.append_bond_event("bond.revised", &bond, reason));
         events
     }
 
@@ -16931,10 +16855,15 @@ impl RuntimeWorld {
                 .actor_name(other_id)
                 .unwrap_or_else(|| format!("Actor {}", other_id));
             let statement = bond.statement.trim();
+            let relationship_label = if bond.status == "forming" {
+                "Forming relationship"
+            } else {
+                "Friendship"
+            };
             let text = if statement.is_empty() {
                 format!("{other_name} matters to them.")
             } else {
-                format!("Friendship with {other_name}: {statement}")
+                format!("{relationship_label} with {other_name}: {statement}")
             };
             notes.insert(other_id, text);
         }
@@ -30148,7 +30077,11 @@ async fn command_inner(
     }
 }
 
-async fn complete_avatar_reply(state: &AppState, plan: AvatarReplyPlan) -> Result<(), String> {
+async fn complete_avatar_reply(
+    state: &AppState,
+    plan: AvatarReplyPlan,
+    relationship_reply: Option<&RelationshipReplyExpectation>,
+) -> Result<bool, String> {
     let proposal = match avatar_reply_intent(state.ai_config.as_ref().as_ref(), &plan).await {
         Ok(proposal) => proposal,
         Err(error) => {
@@ -30157,12 +30090,14 @@ async fn complete_avatar_reply(state: &AppState, plan: AvatarReplyPlan) -> Resul
         }
     };
     let mut runtime = state.inner.lock().await;
-    let Some(events) = commit_resident_reply_record(state, &mut runtime, &plan, proposal) else {
-        return Ok(());
+    let Some(events) =
+        commit_resident_reply_record(state, &mut runtime, &plan, proposal, relationship_reply)
+    else {
+        return Ok(false);
     };
     drop(runtime);
     broadcast_events(state, &events);
-    Ok(())
+    Ok(true)
 }
 
 async fn complete_orb_chat_exchange(
@@ -30184,7 +30119,7 @@ async fn complete_orb_chat_exchange(
         };
     let first_reply_events = {
         let mut runtime = state.inner.lock().await;
-        commit_resident_reply_record(state, &mut runtime, &first_reply_plan, first_proposal)
+        commit_resident_reply_record(state, &mut runtime, &first_reply_plan, first_proposal, None)
     };
     let Some(first_reply_events) = first_reply_events else {
         return;
@@ -30293,7 +30228,7 @@ async fn complete_orb_chat_exchange(
         };
     let closing_events = {
         let mut runtime = state.inner.lock().await;
-        commit_resident_reply_record(state, &mut runtime, &closing_plan, closing_proposal)
+        commit_resident_reply_record(state, &mut runtime, &closing_plan, closing_proposal, None)
     };
     if let Some(events) = closing_events {
         broadcast_events(state, &events);
@@ -30305,6 +30240,7 @@ fn commit_resident_reply_record(
     runtime: &mut RuntimeWorld,
     plan: &AvatarReplyPlan,
     mut proposal: AvatarIntentProposal,
+    relationship_reply: Option<&RelationshipReplyExpectation>,
 ) -> Option<Vec<EventView>> {
     let speaker = runtime.actor_by_id(plan.speaker_actor_id)?;
     if !RuntimeWorld::actor_can_act(speaker) {
@@ -30331,13 +30267,23 @@ fn commit_resident_reply_record(
     record
         .content_upserts
         .insert(content_id, proposal.speech.clone());
-    if runtime.actor_uses_inference(speaker.id) {
+    if runtime.actor_uses_inference(speaker.id) && relationship_reply.is_none() {
         record
             .projection_mutations
             .push(ProjectionMutation::UpdateResidentContinuity {
                 resident_id: plan.speaker_actor_id,
                 proposal,
                 reason: "resident_intent".to_string(),
+            });
+    }
+    if let Some(expectation) = relationship_reply {
+        record
+            .projection_mutations
+            .push(ProjectionMutation::SetRelationshipDialogueStatus {
+                relationship_actor_id: expectation.actor_id,
+                target_actor_id: expectation.target_actor_id,
+                status: RELATIONSHIP_DIALOGUE_DELIVERED.to_string(),
+                reason: "one grounded resident reply was delivered".to_string(),
             });
     }
     let Ok((status, events)) = commit_journal_record(state, runtime, record) else {
@@ -30432,24 +30378,42 @@ fn player_tick_observation(
         allow_ordinary_speech,
         source_events: events.to_vec(),
         ripple_source,
+        relationship_reply: relationship_reply_expectation(runtime, actor_id, events),
     })
 }
 
 async fn complete_player_tick_observation(
     state: &AppState,
     observation: PlayerTickObservation,
-) -> Result<Option<AvatarReplyPlan>, String> {
+) -> Result<
+    (
+        Option<AvatarReplyPlan>,
+        Option<RelationshipReplyExpectation>,
+    ),
+    String,
+> {
+    let relationship_reply = observation.relationship_reply.clone();
     let active_direct_actor_ids = active_actor_ids_for_state(state);
     let (ripple_events, reply_plan) = {
         let mut runtime = state.inner.lock().await;
         // A worker may be reclaimed after its reaction committed but before the
         // outbox row was acknowledged. The source tick is globally unique, so
         // an already-recorded autonomous result makes the retry a no-op.
-        if runtime.player_tick_already_has_autonomous_result(observation.source_world_tick) {
-            return Ok(None);
+        if relationship_reply
+            .as_ref()
+            .is_some_and(|expectation| !runtime.relationship_reply_pending(expectation))
+        {
+            return Ok((None, relationship_reply));
+        }
+        if relationship_reply.is_none()
+            && runtime.player_tick_already_has_autonomous_result(observation.source_world_tick)
+        {
+            return Ok((None, None));
         }
         runtime.observe_player_tick_for_autonomy(&observation);
-        let card_reaction_plan = if observation.allow_ordinary_speech {
+        let card_reaction_plan = if relationship_reply.is_some() {
+            runtime.relationship_reply_plan(&observation)
+        } else if observation.allow_ordinary_speech {
             runtime
                 .next_room_card_reaction_plan(
                     observation.source_actor_id,
@@ -30534,7 +30498,7 @@ async fn complete_player_tick_observation(
     if !ripple_events.is_empty() {
         broadcast_events(state, &ripple_events);
     }
-    Ok(reply_plan)
+    Ok((reply_plan, relationship_reply))
 }
 
 fn schedule_player_tick_observation(state: &AppState, observation: PlayerTickObservation) {
@@ -30548,28 +30512,33 @@ fn schedule_player_tick_observation(state: &AppState, observation: PlayerTickObs
     let Some(location_id) = observation.source_location_id else {
         return;
     };
-    let heartbeat_armed = state
-        .room_chat_heartbeats
-        .lock()
-        .map(|mut rooms| rooms.insert(location_id))
-        .unwrap_or(false);
+    let dedicated_relationship_heartbeat = observation.relationship_reply.is_some();
+    let heartbeat_armed = dedicated_relationship_heartbeat
+        || state
+            .room_chat_heartbeats
+            .lock()
+            .map(|mut rooms| rooms.insert(location_id))
+            .unwrap_or(false);
     if !heartbeat_armed {
         return;
     }
     let state = state.clone();
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(CARD_REACTION_HEARTBEAT_DELAY_MS)).await;
-        match complete_player_tick_observation(&state, observation).await {
-            Ok(Some(plan)) => {
-                if let Err(error) = complete_avatar_reply(&state, plan).await {
+        match complete_player_tick_observation(&state, observation.clone()).await {
+            Ok((plan, relationship_reply)) => {
+                if let Err(error) =
+                    complete_player_tick_reply(&state, &observation, plan, relationship_reply).await
+                {
                     warn!("asynchronous resident dialogue failed: {}", error);
                 }
             }
-            Ok(None) => {}
             Err(error) => warn!("resident turn failed: {}", error),
         }
-        if let Ok(mut rooms) = state.room_chat_heartbeats.lock() {
-            rooms.remove(&location_id);
+        if !dedicated_relationship_heartbeat {
+            if let Ok(mut rooms) = state.room_chat_heartbeats.lock() {
+                rooms.remove(&location_id);
+            }
         }
     });
 }
@@ -30703,12 +30672,22 @@ async fn run_actor_job_worker(state: AppState, claimed_kind: &'static str) {
                         if job.actor_id == observation.source_actor_id =>
                     {
                         match complete_player_tick_observation(&state, observation.clone()).await {
-                            Ok(Some(plan)) => {
+                            Ok((plan, relationship_reply))
+                                if plan.is_some() || relationship_reply.is_some() =>
+                            {
                                 let reply_state = state.clone();
                                 let reply_path = path.to_path_buf();
                                 let reply_job = job.clone();
+                                let reply_observation = observation.clone();
                                 tokio::spawn(async move {
-                                    match complete_avatar_reply(&reply_state, plan).await {
+                                    match complete_player_tick_reply(
+                                        &reply_state,
+                                        &reply_observation,
+                                        plan,
+                                        relationship_reply,
+                                    )
+                                    .await
+                                    {
                                         Ok(()) => {
                                             if let Err(error) =
                                                 complete_actor_job(&reply_path, reply_job.id)
@@ -30739,7 +30718,7 @@ async fn run_actor_job_worker(state: AppState, claimed_kind: &'static str) {
                                 });
                                 Ok(false)
                             }
-                            Ok(None) => Ok(true),
+                            Ok(_) => Ok(true),
                             Err(error) => Err(error),
                         }
                     }
@@ -30900,7 +30879,7 @@ async fn maybe_emit_ambient_event(state: AppState) {
             broadcast_events(&state, &events);
         }
         if let Some(plan) = reply_plan {
-            let _ = complete_avatar_reply(&state, plan).await;
+            let _ = complete_avatar_reply(&state, plan, None).await;
         }
         return;
     }
@@ -40088,17 +40067,19 @@ fn actor_job_dedupe_key(observation: &PlayerTickObservation) -> String {
 }
 
 fn insert_actor_job(conn: &Connection, observation: &PlayerTickObservation) -> io::Result<bool> {
-    if let Some(location_id) = observation.source_location_id {
-        let active_heartbeat_count: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM actor_jobs
+    if observation.relationship_reply.is_none() {
+        if let Some(location_id) = observation.source_location_id {
+            let active_heartbeat_count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM actor_jobs
                  WHERE kind = ?1 AND location_id = ?2 AND status IN ('pending', 'running')",
-                params![ACTOR_JOB_KIND_PLAYER_TICK, location_id as i64],
-                |row| row.get(0),
-            )
-            .map_err(sqlite_error)?;
-        if active_heartbeat_count > 0 {
-            return Ok(false);
+                    params![ACTOR_JOB_KIND_PLAYER_TICK, location_id as i64],
+                    |row| row.get(0),
+                )
+                .map_err(sqlite_error)?;
+            if active_heartbeat_count > 0 {
+                return Ok(false);
+            }
         }
     }
     let payload = ActorJobPayload::PlayerTick(observation.clone());
@@ -51857,6 +51838,7 @@ mod tests {
             allow_ordinary_speech: true,
             source_events: Vec::new(),
             ripple_source: None,
+            relationship_reply: None,
         };
         let first_observation = observation(41, 401);
         let second_observation = observation(42, 402);
@@ -51936,6 +51918,7 @@ mod tests {
             allow_ordinary_speech: true,
             source_events: Vec::new(),
             ripple_source: None,
+            relationship_reply: None,
         };
         assert!(append_actor_job(&path, &observation).expect("queue gameplay turn"));
 
@@ -62789,6 +62772,8 @@ mod tests {
                 status: "active".to_string(),
                 source_event_seq: Some(90_002),
                 updated_event_seq: Some(90_002),
+                dialogue_status: String::new(),
+                dialogue_event_seq: None,
             },
         );
         let friendship_state =

--- a/v2/orchestrator-rust/src/relationships.rs
+++ b/v2/orchestrator-rust/src/relationships.rs
@@ -1,0 +1,1058 @@
+use super::*;
+
+pub(super) const RELATIONSHIP_DIALOGUE_PENDING: &str = "pending";
+pub(super) const RELATIONSHIP_DIALOGUE_DELIVERED: &str = "delivered";
+pub(super) const RELATIONSHIP_DIALOGUE_UNAVAILABLE: &str = "unavailable";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct SeedRelationshipContent {
+    pub(super) intent: String,
+    pub(super) statement: String,
+    pub(super) first_beat: String,
+    pub(super) reply_prompt: String,
+    pub(super) active_on_gift_item_id: u64,
+    pub(super) active_beat: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct RelationshipPreviewView {
+    pub(super) intent: String,
+    pub(super) statement: String,
+    pub(super) initial_status: &'static str,
+    pub(super) deterministic_consequence: String,
+    pub(super) dialogue_contract: &'static str,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct RelationshipReplyExpectation {
+    pub(super) actor_id: u64,
+    pub(super) target_actor_id: u64,
+    pub(super) relationship_event_seq: u64,
+    pub(super) user_text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct BondState {
+    pub(super) id: String,
+    pub(super) actor_id: u64,
+    pub(super) target_actor_id: u64,
+    pub(super) statement: String,
+    pub(super) strength: u8,
+    pub(super) status: String,
+    #[serde(default)]
+    pub(super) source_event_seq: Option<u64>,
+    #[serde(default)]
+    pub(super) updated_event_seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub(super) dialogue_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) dialogue_event_seq: Option<u64>,
+}
+
+impl RuntimeWorld {
+    pub(super) fn relationship_contract(
+        &self,
+        target_actor_id: u64,
+    ) -> Option<&SeedRelationshipContent> {
+        active_content()
+            .actors
+            .iter()
+            .find(|actor| actor.id == target_actor_id)
+            .and_then(|actor| actor.relationship.as_ref())
+    }
+
+    pub(super) fn relationship_preview(
+        &self,
+        target_actor_id: u64,
+    ) -> Option<RelationshipPreviewView> {
+        self.relationship_contract(target_actor_id)
+            .map(|relationship| RelationshipPreviewView {
+                intent: relationship.intent.clone(),
+                statement: relationship.statement.clone(),
+                initial_status: "forming",
+                deterministic_consequence: relationship.first_beat.clone(),
+                dialogue_contract:
+                    "one grounded reply if dialogue is available; otherwise one explicit unavailable result",
+            })
+    }
+
+    pub(super) fn create_bond(
+        &mut self,
+        actor_id: u64,
+        target_actor_id: u64,
+        submitted_statement: &str,
+        cost: u8,
+        reason: &str,
+    ) -> Vec<EventView> {
+        let id = bond_id(actor_id, target_actor_id);
+        if cost == 0
+            || self.advancement_points_available(actor_id) < usize::from(cost)
+            || self.active_bond(actor_id, target_actor_id).is_some()
+        {
+            return Vec::new();
+        }
+
+        let authored = self.relationship_contract(target_actor_id).cloned();
+        let target_name = self
+            .actor_name(target_actor_id)
+            .unwrap_or_else(|| format!("Resident {target_actor_id}"));
+        let spend_seq = self.world.next_event_seq;
+        let spend = AdvancementSpendState {
+            id: advancement_spend_id(actor_id, "bond_slot", spend_seq),
+            actor_id,
+            kind: "bond_slot".to_string(),
+            label: if authored.is_some() {
+                format!("A forming relationship with {target_name}")
+            } else {
+                format!("Friendship with {target_name}")
+            },
+            cost,
+            source_event_seq: spend_seq,
+        };
+        if self.advancement_spends.contains_key(&spend.id) {
+            return Vec::new();
+        }
+        self.advancement_spends
+            .insert(spend.id.clone(), spend.clone());
+        let mut events = vec![self.append_advancement_event("advancement.spent", &spend, reason)];
+
+        let statement = authored
+            .as_ref()
+            .map(|relationship| relationship.statement.as_str())
+            .unwrap_or(submitted_statement);
+        let status = if authored.is_some() {
+            "forming"
+        } else {
+            "active"
+        };
+        let bond = BondState {
+            id: id.clone(),
+            actor_id,
+            target_actor_id,
+            statement: statement.to_string(),
+            strength: 1,
+            status: status.to_string(),
+            source_event_seq: Some(self.world.next_event_seq),
+            updated_event_seq: Some(self.world.next_event_seq),
+            dialogue_status: authored
+                .as_ref()
+                .map(|_| RELATIONSHIP_DIALOGUE_PENDING.to_string())
+                .unwrap_or_default(),
+            dialogue_event_seq: None,
+        };
+        self.bonds.insert(id, bond.clone());
+        let bond_event = self.append_bond_event("bond.created", &bond, reason);
+        let bond_event_seq = bond_event.seq;
+        events.push(bond_event);
+
+        if let Some(relationship) = authored {
+            events.push(self.append_relationship_event(
+                "relationship.beat",
+                actor_id,
+                target_actor_id,
+                relationship.first_beat,
+                true,
+                Some(bond_event_seq),
+            ));
+        }
+        events
+    }
+
+    pub(super) fn revise_bond(
+        &mut self,
+        actor_id: u64,
+        target_actor_id: u64,
+        statement: &str,
+        cost: u8,
+        reason: &str,
+    ) -> Vec<EventView> {
+        let id = bond_id(actor_id, target_actor_id);
+        if cost == 0 || self.advancement_points_available(actor_id) < usize::from(cost) {
+            return Vec::new();
+        }
+        let Some(existing) = self.bonds.get(&id) else {
+            return Vec::new();
+        };
+        if existing.status == "resolved"
+            || existing.strength == 0
+            || existing.statement == statement
+        {
+            return Vec::new();
+        }
+
+        let spend_seq = self.world.next_event_seq;
+        let spend = AdvancementSpendState {
+            id: advancement_spend_id(actor_id, "bond_revision", spend_seq),
+            actor_id,
+            kind: "bond_revision".to_string(),
+            label: "Friendship changed".to_string(),
+            cost,
+            source_event_seq: spend_seq,
+        };
+        if self.advancement_spends.contains_key(&spend.id) {
+            return Vec::new();
+        }
+        self.advancement_spends
+            .insert(spend.id.clone(), spend.clone());
+        let mut events = vec![self.append_advancement_event("advancement.spent", &spend, reason)];
+
+        let Some(bond) = self.bonds.get_mut(&id) else {
+            return events;
+        };
+        bond.statement = statement.to_string();
+        bond.status = "active".to_string();
+        bond.updated_event_seq = Some(self.world.next_event_seq);
+        let bond = bond.clone();
+        events.push(self.append_bond_event("bond.revised", &bond, reason));
+        events
+    }
+
+    fn append_relationship_event(
+        &mut self,
+        type_name: &str,
+        actor_id: u64,
+        target_actor_id: u64,
+        content: String,
+        success: bool,
+        caused_by_event_seq: Option<u64>,
+    ) -> EventView {
+        let location_id = self
+            .actor_by_id(actor_id)
+            .or_else(|| self.actor_by_id(target_actor_id))
+            .map(|actor| actor.location_id);
+        let event = EventView {
+            seq: self.world.next_event_seq,
+            type_name: type_name.to_string(),
+            success,
+            actor_id: Some(actor_id),
+            actor_name: self.actor_name(actor_id),
+            target_actor_id: Some(target_actor_id),
+            target_actor_name: self.actor_name(target_actor_id),
+            location_id,
+            location_name: location_id.and_then(|id| self.location_name(id)),
+            content: Some(content),
+            caused_by_event_seq,
+            source_location_id: location_id,
+            ..EventView::default()
+        };
+        self.world.next_event_seq += 1;
+        self.push_projected_event(event.clone());
+        event
+    }
+
+    pub(super) fn set_relationship_dialogue_status(
+        &mut self,
+        actor_id: u64,
+        target_actor_id: u64,
+        status: &str,
+        reason: &str,
+    ) -> Vec<EventView> {
+        let id = bond_id(actor_id, target_actor_id);
+        let Some(bond) = self.bonds.get_mut(&id) else {
+            return Vec::new();
+        };
+        if bond.dialogue_status != RELATIONSHIP_DIALOGUE_PENDING {
+            return Vec::new();
+        }
+        let event_seq = self.world.next_event_seq;
+        bond.dialogue_status = status.to_string();
+        bond.dialogue_event_seq = Some(event_seq);
+        bond.updated_event_seq = Some(event_seq);
+        let event_type = if status == RELATIONSHIP_DIALOGUE_DELIVERED {
+            "dialogue.delivered"
+        } else {
+            "dialogue.unavailable"
+        };
+        vec![self.append_relationship_event(
+            event_type,
+            actor_id,
+            target_actor_id,
+            reason.to_string(),
+            status == RELATIONSHIP_DIALOGUE_DELIVERED,
+            None,
+        )]
+    }
+
+    pub(super) fn relationship_reply_pending(
+        &self,
+        expectation: &RelationshipReplyExpectation,
+    ) -> bool {
+        self.active_bond(expectation.actor_id, expectation.target_actor_id)
+            .is_some_and(|bond| bond.dialogue_status == RELATIONSHIP_DIALOGUE_PENDING)
+    }
+
+    pub(super) fn relationship_reply_plan(
+        &self,
+        observation: &PlayerTickObservation,
+    ) -> Option<AvatarReplyPlan> {
+        let expectation = observation.relationship_reply.as_ref()?;
+        self.resident_reply_plan_for_target(
+            expectation.actor_id,
+            expectation.target_actor_id,
+            &expectation.user_text,
+        )
+        .map(|plan| plan.with_observation(observation))
+    }
+
+    pub(super) fn deepen_authored_relationship_from_gift(
+        &mut self,
+        actor_id: u64,
+        target_actor_id: u64,
+        item_id: u64,
+        source_event_seq: u64,
+    ) -> Option<Vec<EventView>> {
+        let relationship = self.relationship_contract(target_actor_id)?.clone();
+        if relationship.active_on_gift_item_id != item_id {
+            return None;
+        }
+        let was_forming = self
+            .active_bond(actor_id, target_actor_id)
+            .is_some_and(|bond| bond.status == "forming");
+        let mut events = self.deepen_bond_from_event(
+            actor_id,
+            target_actor_id,
+            source_event_seq,
+            gift_bond_claim_key(actor_id, target_actor_id, item_id),
+            "authored_relationship_gift",
+            &format!("gift:{actor_id}:{target_actor_id}:{item_id}:bond"),
+        );
+        if !events.is_empty() && was_forming {
+            events.push(self.append_relationship_event(
+                "relationship.advanced",
+                actor_id,
+                target_actor_id,
+                relationship.active_beat,
+                true,
+                Some(source_event_seq),
+            ));
+        }
+        Some(events)
+    }
+}
+
+pub(super) fn relationship_reply_expectation(
+    runtime: &RuntimeWorld,
+    actor_id: u64,
+    events: &[EventView],
+) -> Option<RelationshipReplyExpectation> {
+    let event = events.iter().find(|event| {
+        event.success && event.actor_id == Some(actor_id) && event.type_name == "relationship.beat"
+    })?;
+    let target_actor_id = event.target_actor_id?;
+    let reply_prompt = runtime
+        .relationship_contract(target_actor_id)
+        .map(|relationship| relationship.reply_prompt.as_str())
+        .unwrap_or("Respond directly to the visible relationship beat.");
+    Some(RelationshipReplyExpectation {
+        actor_id,
+        target_actor_id,
+        relationship_event_seq: event.seq,
+        user_text: format!(
+            "This authored relationship beat just happened: {} Authored reply direction: {} Do not change the request or invent another reward.",
+            event.content.as_deref().unwrap_or("a clear request was made"),
+            reply_prompt,
+        ),
+    })
+}
+
+pub(super) async fn relationship_reply_evidence_exists(
+    state: &AppState,
+    expectation: &RelationshipReplyExpectation,
+) -> bool {
+    state.inner.lock().await.event_log.iter().any(|event| {
+        event.success
+            && event.type_name == "message.created"
+            && event.actor_id == Some(expectation.target_actor_id)
+            && event.caused_by_event_seq == Some(expectation.relationship_event_seq)
+    })
+}
+
+pub(super) async fn commit_relationship_dialogue_outcome(
+    state: &AppState,
+    expectation: &RelationshipReplyExpectation,
+    status: &str,
+    reason: &str,
+    source_world_tick: u64,
+    observed_through_seq: u64,
+    source_location_id: Option<u64>,
+) -> Result<Vec<EventView>, String> {
+    let mut runtime = state.inner.lock().await;
+    if !runtime.relationship_reply_pending(expectation) {
+        return Ok(Vec::new());
+    }
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: expectation.actor_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    );
+    record.caused_by_event_seq = Some(expectation.relationship_event_seq);
+    record.source_world_tick = Some(source_world_tick);
+    record.observed_through_seq = Some(observed_through_seq);
+    record.source_location_id = source_location_id;
+    record
+        .projection_mutations
+        .push(ProjectionMutation::SetRelationshipDialogueStatus {
+            relationship_actor_id: expectation.actor_id,
+            target_actor_id: expectation.target_actor_id,
+            status: status.to_string(),
+            reason: reason.to_string(),
+        });
+    let (commit_status, events) =
+        commit_journal_record(state, &mut runtime, record).map_err(|error| error.to_string())?;
+    drop(runtime);
+    if commit_status != CW_OK {
+        return Err("relationship dialogue outcome did not commit".to_string());
+    }
+    if !events.is_empty() {
+        broadcast_events(state, &events);
+    }
+    Ok(events)
+}
+
+pub(super) async fn complete_player_tick_reply(
+    state: &AppState,
+    observation: &PlayerTickObservation,
+    plan: Option<AvatarReplyPlan>,
+    relationship_reply: Option<RelationshipReplyExpectation>,
+) -> Result<(), String> {
+    let Some(expectation) = relationship_reply else {
+        if let Some(plan) = plan {
+            complete_avatar_reply(state, plan, None).await?;
+        }
+        return Ok(());
+    };
+
+    if relationship_reply_evidence_exists(state, &expectation).await {
+        commit_relationship_dialogue_outcome(
+            state,
+            &expectation,
+            RELATIONSHIP_DIALOGUE_DELIVERED,
+            "a previously committed grounded reply was recovered",
+            observation.source_world_tick,
+            observation.observed_through_seq,
+            observation.source_location_id,
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let reason = match plan {
+        Some(plan) => match complete_avatar_reply(state, plan, Some(&expectation)).await {
+            Ok(true) => return Ok(()),
+            Ok(false) => "resident dialogue was unavailable; no substitute line was created",
+            Err(error) => {
+                warn!(
+                    "authored relationship dialogue unavailable after heartbeat: {}",
+                    error
+                );
+                "resident dialogue was unavailable; no substitute line was created"
+            }
+        },
+        None => "resident dialogue was unavailable; no substitute line was created",
+    };
+    commit_relationship_dialogue_outcome(
+        state,
+        &expectation,
+        RELATIONSHIP_DIALOGUE_UNAVAILABLE,
+        reason,
+        observation.source_world_tick,
+        observation.observed_through_seq,
+        observation.source_location_id,
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{routing::post, Router};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const TEST_ACTOR_ID: u64 = 5000;
+    const MARA_ACTOR_ID: u64 = 8301;
+    const MARA_LOCATION_ID: u64 = 800;
+    const KEEPER_KEY_ITEM_ID: u64 = 8401;
+
+    fn relationship_record(_runtime: &mut RuntimeWorld, seed: u64) -> JournalRecord {
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: TEST_ACTOR_ID,
+                ..CwAction::default()
+            },
+            seed,
+        )
+        .into_player_card();
+        record
+            .projection_mutations
+            .push(ProjectionMutation::CreateBond {
+                target_actor_id: MARA_ACTOR_ID,
+                statement: "a submitted generic friendship statement".to_string(),
+                cost: BOND_SLOT_COST,
+                reason: "advancement".to_string(),
+            });
+        record
+    }
+
+    fn relationship_runtime() -> RuntimeWorld {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            TEST_ACTOR_ID,
+            MARA_LOCATION_ID,
+            "Road Listener",
+        );
+        let source_seq = runtime.world.next_event_seq;
+        assert!(runtime
+            .mark_visit_ledger(
+                TEST_ACTOR_ID,
+                "learned_truth",
+                "The road lamps have failed.",
+                source_seq,
+                "test:mara-relationship",
+            )
+            .is_some());
+        assert!(runtime
+            .bank_visit_ledger(TEST_ACTOR_ID, "test:mara-relationship")
+            .is_some());
+        runtime
+    }
+
+    fn commit_relationship(runtime: &mut RuntimeWorld) -> (JournalRecord, Vec<EventView>) {
+        let record = relationship_record(runtime, 362_001);
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.type_name == "bond.created")
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.type_name == "relationship.beat")
+                .count(),
+            1
+        );
+        (record, events)
+    }
+
+    fn relationship_observation(
+        runtime: &RuntimeWorld,
+        events: &[EventView],
+    ) -> PlayerTickObservation {
+        player_tick_observation(
+            runtime,
+            Some(MARA_LOCATION_ID),
+            TEST_ACTOR_ID,
+            CW_OK,
+            events,
+        )
+        .expect("authored relationship arms a heartbeat")
+    }
+
+    #[test]
+    fn mara_chat_commits_one_forming_bond_and_one_deterministic_request() {
+        let mut runtime = relationship_runtime();
+        let (_record, events) = commit_relationship(&mut runtime);
+        let bond = runtime
+            .active_bond(TEST_ACTOR_ID, MARA_ACTOR_ID)
+            .expect("Mara relationship exists");
+        assert_eq!(bond.status, "forming");
+        assert_eq!(bond.strength, 1);
+        assert_eq!(bond.dialogue_status, RELATIONSHIP_DIALOGUE_PENDING);
+        assert_eq!(
+            bond.statement,
+            "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key."
+        );
+        let beat = events
+            .iter()
+            .find(|event| event.type_name == "relationship.beat")
+            .expect("deterministic beat");
+        assert!(beat
+            .content
+            .as_deref()
+            .is_some_and(|text| text.contains("empty key hook") && text.contains("Brass Key")));
+        assert!(events.iter().all(|event| {
+            event.type_name != "ledger.marked"
+                && !(event.type_name == "message.created" && event.actor_id == Some(MARA_ACTOR_ID))
+        }));
+        let reply = relationship_reply_expectation(&runtime, TEST_ACTOR_ID, &events)
+            .expect("authored reply direction");
+        assert!(reply.user_text.contains("empty key hook"));
+        assert!(reply.user_text.contains("Do not change the request"));
+
+        let retry = relationship_record(&mut runtime, 362_002);
+        let (_status, retry_events) = runtime.apply_journal_record(&retry);
+        assert!(!retry_events.iter().any(|event| matches!(
+            event.type_name.as_str(),
+            "bond.created" | "relationship.beat" | "advancement.spent"
+        )));
+        assert_eq!(
+            runtime
+                .bonds
+                .values()
+                .filter(|bond| {
+                    bond.actor_id == TEST_ACTOR_ID && bond.target_actor_id == MARA_ACTOR_ID
+                })
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn unavailable_provider_emits_one_typed_result_and_no_substitute_line() {
+        let mut runtime = relationship_runtime();
+        let (_record, events) = commit_relationship(&mut runtime);
+        let observation = relationship_observation(&runtime, &events);
+        let beat_seq = observation
+            .relationship_reply
+            .as_ref()
+            .expect("reply expectation")
+            .relationship_event_seq;
+        let state = test_app_state(runtime, None);
+
+        let (plan, relationship_reply) =
+            complete_player_tick_observation(&state, observation.clone())
+                .await
+                .expect("heartbeat planning succeeds");
+        assert!(
+            plan.is_some(),
+            "the authored beat has a grounded reply plan"
+        );
+        complete_player_tick_reply(&state, &observation, plan, relationship_reply)
+            .await
+            .expect("unavailable outcome commits");
+
+        let runtime = state.inner.lock().await;
+        let unavailable: Vec<_> = runtime
+            .event_log
+            .iter()
+            .filter(|event| event.type_name == "dialogue.unavailable")
+            .collect();
+        assert_eq!(unavailable.len(), 1);
+        assert_eq!(unavailable[0].caused_by_event_seq, Some(beat_seq));
+        assert!(!runtime.event_log.iter().any(|event| {
+            event.seq > beat_seq
+                && event.type_name == "message.created"
+                && event.actor_id == Some(MARA_ACTOR_ID)
+        }));
+        let bond = runtime
+            .active_bond(TEST_ACTOR_ID, MARA_ACTOR_ID)
+            .expect("forming bond survives provider failure");
+        assert_eq!(bond.status, "forming");
+        assert_eq!(bond.dialogue_status, RELATIONSHIP_DIALOGUE_UNAVAILABLE);
+        drop(runtime);
+
+        complete_player_tick_reply(
+            &state,
+            &observation,
+            None,
+            observation.relationship_reply.clone(),
+        )
+        .await
+        .expect("worker retry is idempotent");
+        assert_eq!(
+            state
+                .inner
+                .lock()
+                .await
+                .event_log
+                .iter()
+                .filter(|event| event.type_name == "dialogue.unavailable")
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn fake_provider_delivers_one_grounded_mara_reply_without_fallback() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let app = Router::new().route(
+            "/chat/completions",
+            post({
+                let requests = requests.clone();
+                move || {
+                    let requests = requests.clone();
+                    async move {
+                        requests.fetch_add(1, Ordering::SeqCst);
+                        Json(serde_json::json!({
+                            "choices": [{
+                                "message": {
+                                    "content": r#"{"speech":"Bring Rowan's Keeper Brass Key back to this empty hook, and I will know the road is still ours.","intent":"wait for the key","belief":null,"desire":"Rowan's Keeper Brass Key returned","promise":null,"refusal":null,"proposed_action":{"kind":"wait","target_actor_id":null,"item_id":null,"destination_location_id":null,"reason":"the traveler must follow the failed lamps first"}}"#
+                                }
+                            }]
+                        }))
+                    }
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake dialogue provider");
+        let address = listener.local_addr().expect("fake provider address");
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let mut runtime = relationship_runtime();
+        let (_record, events) = commit_relationship(&mut runtime);
+        let observation = relationship_observation(&runtime, &events);
+        let beat_seq = observation
+            .relationship_reply
+            .as_ref()
+            .expect("reply expectation")
+            .relationship_event_seq;
+        let mut state = test_app_state(runtime, None);
+        state.ai_config = Arc::new(Some(AiConfig {
+            api_key: "test".to_string(),
+            base_url: format!("http://{address}"),
+            model: "test-dialogue".to_string(),
+            vision_model: "test-vision".to_string(),
+            ..AiConfig::default()
+        }));
+
+        let (plan, relationship_reply) =
+            complete_player_tick_observation(&state, observation.clone())
+                .await
+                .expect("heartbeat planning succeeds");
+        complete_player_tick_reply(&state, &observation, plan, relationship_reply)
+            .await
+            .expect("grounded reply commits");
+
+        let runtime = state.inner.lock().await;
+        let replies: Vec<_> = runtime
+            .event_log
+            .iter()
+            .filter(|event| {
+                event.seq > beat_seq
+                    && event.type_name == "message.created"
+                    && event.actor_id == Some(MARA_ACTOR_ID)
+            })
+            .collect();
+        assert_eq!(replies.len(), 1);
+        assert!(
+            replies[0]
+                .content
+                .as_deref()
+                .is_some_and(|text| text.contains("Brass Key") && text.contains("empty hook")),
+            "grounded reply was {:?}",
+            replies[0].content
+        );
+        assert_eq!(replies[0].caused_by_event_seq, Some(beat_seq));
+        assert_eq!(
+            runtime
+                .event_log
+                .iter()
+                .filter(|event| event.type_name == "dialogue.delivered")
+                .count(),
+            1
+        );
+        assert!(!runtime
+            .event_log
+            .iter()
+            .any(|event| event.type_name == "dialogue.unavailable"));
+        assert_eq!(
+            runtime
+                .active_bond(TEST_ACTOR_ID, MARA_ACTOR_ID)
+                .expect("bond")
+                .dialogue_status,
+            RELATIONSHIP_DIALOGUE_DELIVERED
+        );
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+        drop(runtime);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn reply_commit_gap_recovers_delivered_without_provider_or_duplicate_speech() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let app = Router::new().route(
+            "/chat/completions",
+            post({
+                let requests = requests.clone();
+                move || {
+                    let requests = requests.clone();
+                    async move {
+                        requests.fetch_add(1, Ordering::SeqCst);
+                        Json(serde_json::json!({
+                            "choices": [{
+                                "message": {
+                                    "content": r#"{"speech":"This provider must not be called during recovery.","intent":null,"belief":null,"desire":null,"promise":null,"refusal":null,"proposed_action":null}"#
+                                }
+                            }]
+                        }))
+                    }
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind recovery provider");
+        let address = listener.local_addr().expect("recovery provider address");
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let mut runtime = relationship_runtime();
+        let (_record, events) = commit_relationship(&mut runtime);
+        let observation = relationship_observation(&runtime, &events);
+        let beat_seq = observation
+            .relationship_reply
+            .as_ref()
+            .expect("reply expectation")
+            .relationship_event_seq;
+        let mut state = test_app_state(runtime, None);
+        state.ai_config = Arc::new(Some(AiConfig {
+            api_key: "test".to_string(),
+            base_url: format!("http://{address}"),
+            model: "test-dialogue".to_string(),
+            vision_model: "test-vision".to_string(),
+            ..AiConfig::default()
+        }));
+        let (plan, relationship_reply) =
+            complete_player_tick_observation(&state, observation.clone())
+                .await
+                .expect("heartbeat planning succeeds");
+        let plan = plan.expect("grounded reply plan");
+
+        // Model the old crash window: speech reached the journal, but the
+        // relationship status mutation did not. Recovery must trust the
+        // causally linked durable message instead of asking the provider again.
+        {
+            let mut runtime = state.inner.lock().await;
+            let events = commit_resident_reply_record(
+                &state,
+                &mut runtime,
+                &plan,
+                AvatarIntentProposal {
+                    speech: "Bring Rowan's Keeper Brass Key back to this empty hook.".to_string(),
+                    intent: None,
+                    belief: None,
+                    desire: None,
+                    promise: None,
+                    refusal: None,
+                    proposed_action: None,
+                },
+                None,
+            )
+            .expect("legacy reply commit");
+            assert_eq!(
+                events
+                    .iter()
+                    .filter(|event| event.type_name == "message.created")
+                    .count(),
+                1
+            );
+            assert_eq!(
+                runtime
+                    .active_bond(TEST_ACTOR_ID, MARA_ACTOR_ID)
+                    .expect("forming bond")
+                    .dialogue_status,
+                RELATIONSHIP_DIALOGUE_PENDING
+            );
+        }
+
+        complete_player_tick_reply(
+            &state,
+            &observation,
+            Some(plan.clone()),
+            relationship_reply.clone(),
+        )
+        .await
+        .expect("legacy gap recovers");
+        complete_player_tick_reply(&state, &observation, Some(plan), relationship_reply)
+            .await
+            .expect("recovery retry is idempotent");
+
+        let runtime = state.inner.lock().await;
+        assert_eq!(requests.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            runtime
+                .event_log
+                .iter()
+                .filter(|event| {
+                    event.type_name == "message.created"
+                        && event.actor_id == Some(MARA_ACTOR_ID)
+                        && event.caused_by_event_seq == Some(beat_seq)
+                })
+                .count(),
+            1
+        );
+        assert_eq!(
+            runtime
+                .event_log
+                .iter()
+                .filter(|event| event.type_name == "dialogue.delivered")
+                .count(),
+            1
+        );
+        assert!(!runtime
+            .event_log
+            .iter()
+            .any(|event| event.type_name == "dialogue.unavailable"));
+        assert_eq!(
+            runtime
+                .active_bond(TEST_ACTOR_ID, MARA_ACTOR_ID)
+                .expect("recovered bond")
+                .dialogue_status,
+            RELATIONSHIP_DIALOGUE_DELIVERED
+        );
+        drop(runtime);
+        server.abort();
+    }
+
+    #[test]
+    fn returning_rowans_key_activates_the_relationship_once_and_explains_why() {
+        let mut runtime = relationship_runtime();
+        commit_relationship(&mut runtime);
+        let key = runtime
+            .world
+            .items
+            .iter_mut()
+            .take(runtime.world.item_count)
+            .find(|item| item.id == KEEPER_KEY_ITEM_ID)
+            .expect("Keeper's Brass Key");
+        key.holder_actor_id = TEST_ACTOR_ID;
+        key.location_id = 0;
+        let gift = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_GIVE_ITEM,
+                actor_id: TEST_ACTOR_ID,
+                target_actor_id: MARA_ACTOR_ID,
+                item_id: KEEPER_KEY_ITEM_ID,
+                ..CwAction::default()
+            },
+            362_003,
+        );
+        let (status, events) = runtime.apply_journal_record(&gift);
+        assert_eq!(status, CW_OK);
+        let bond = runtime
+            .active_bond(TEST_ACTOR_ID, MARA_ACTOR_ID)
+            .expect("relationship remains active");
+        assert_eq!(bond.status, "active");
+        assert_eq!(bond.strength, 2);
+        assert!(events.iter().any(|event| {
+            event.type_name == "relationship.advanced"
+                && event
+                    .content
+                    .as_deref()
+                    .is_some_and(|text| text.contains("earned trust"))
+        }));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.type_name == "bond.deepened")
+                .count(),
+            1
+        );
+
+        let (_status, repeated) = runtime.apply_journal_record(&gift);
+        assert!(!repeated.iter().any(|event| matches!(
+            event.type_name.as_str(),
+            "bond.deepened" | "relationship.advanced" | "ledger.marked"
+        )));
+    }
+
+    #[test]
+    fn replay_snapshot_and_reconnect_keep_relationship_causality_inspectable() {
+        let mut original = relationship_runtime();
+        let replay_base = RuntimeSnapshot::from_runtime(&original);
+        let (record, events) = commit_relationship(&mut original);
+        let expected = original
+            .active_bond(TEST_ACTOR_ID, MARA_ACTOR_ID)
+            .expect("original bond")
+            .clone();
+
+        let mut replayed = replay_base.into_runtime().expect("restore replay base");
+        assert_eq!(replayed.apply_journal_record(&record).0, CW_OK);
+        let actual = replayed
+            .active_bond(TEST_ACTOR_ID, MARA_ACTOR_ID)
+            .expect("replayed bond");
+        assert_eq!(actual.statement, expected.statement);
+        assert_eq!(actual.status, expected.status);
+        assert_eq!(actual.source_event_seq, expected.source_event_seq);
+        assert_eq!(actual.dialogue_status, expected.dialogue_status);
+
+        let reconnect = original.state_response(Some(TEST_ACTOR_ID), &AccessContext::default());
+        let bond = reconnect
+            .bonds
+            .iter()
+            .find(|bond| bond.target_actor_id == MARA_ACTOR_ID)
+            .expect("bond appears after reconnect");
+        assert_eq!(bond.status, "forming");
+        assert_eq!(
+            bond.source_event_seq,
+            events
+                .iter()
+                .find(|event| event.type_name == "bond.created")
+                .map(|event| event.seq)
+        );
+        assert_eq!(bond.dialogue_status, RELATIONSHIP_DIALOGUE_PENDING);
+        let mara = reconnect
+            .actors
+            .iter()
+            .find(|actor| actor.id == MARA_ACTOR_ID)
+            .expect("Mara appears after reconnect");
+        assert!(mara.relationship.as_ref().is_some_and(|relationship| {
+            relationship.initial_status == "forming"
+                && relationship.statement.contains("failed lamps")
+        }));
+    }
+
+    #[test]
+    fn durable_relationship_heartbeat_is_not_lost_to_room_coalescing() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-relationship-heartbeat-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        init_event_store(&path).expect("initialize outbox");
+
+        let ordinary = PlayerTickObservation {
+            source_actor_id: TEST_ACTOR_ID,
+            source_world_tick: 40,
+            caused_by_event_seq: Some(400),
+            observed_through_seq: 400,
+            source_location_id: Some(MARA_LOCATION_ID),
+            allow_ordinary_speech: true,
+            source_events: Vec::new(),
+            ripple_source: None,
+            relationship_reply: None,
+        };
+        let relationship = PlayerTickObservation {
+            source_actor_id: TEST_ACTOR_ID,
+            source_world_tick: 41,
+            caused_by_event_seq: Some(401),
+            observed_through_seq: 401,
+            source_location_id: Some(MARA_LOCATION_ID),
+            allow_ordinary_speech: false,
+            source_events: Vec::new(),
+            ripple_source: None,
+            relationship_reply: Some(RelationshipReplyExpectation {
+                actor_id: TEST_ACTOR_ID,
+                target_actor_id: MARA_ACTOR_ID,
+                relationship_event_seq: 401,
+                user_text: "Mara made the authored request.".to_string(),
+            }),
+        };
+        assert!(append_actor_job(&path, &ordinary).expect("queue ordinary heartbeat"));
+        assert!(
+            append_actor_job(&path, &relationship).expect("queue promised relationship heartbeat"),
+            "the promised reply must not be discarded by an already-armed room heartbeat"
+        );
+        assert!(
+            !append_actor_job(&path, &relationship).expect("dedupe relationship retry"),
+            "the same promised reply is queued once"
+        );
+        let _ = fs::remove_file(path);
+    }
+}

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -641,6 +641,8 @@ pub(super) struct FrontView {
     pub(super) premise: String,
     pub(super) zone: String,
     pub(super) status: String,
+    pub(super) presentation_state: String,
+    pub(super) outcome_statement: String,
     pub(super) location_ids: Vec<u64>,
     pub(super) participant_ids: Vec<u64>,
     pub(super) participant_names: Vec<String>,
@@ -648,6 +650,31 @@ pub(super) struct FrontView {
     pub(super) portent_clock_id: String,
     pub(super) job_ids: Vec<String>,
     pub(super) impending_outcome: String,
+}
+
+fn front_presentation(
+    authored_status: &str,
+    has_completed_job: bool,
+    has_failed_job: bool,
+    impending_outcome: &str,
+) -> (&'static str, String) {
+    let presentation_state = match authored_status {
+        "completed" => "resolved",
+        "failed" => "escalated",
+        "dormant" => "dormant",
+        _ if has_failed_job => "escalated",
+        _ if has_completed_job => "persisted",
+        _ => "active",
+    };
+    let outcome_statement = match presentation_state {
+        "resolved" => "The larger trouble is resolved.".to_string(),
+        "persisted" => {
+            "The immediate work is done, but the larger trouble remains unresolved.".to_string()
+        }
+        "escalated" => format!("The larger trouble has escalated. {impending_outcome}"),
+        _ => String::new(),
+    };
+    (presentation_state, outcome_statement)
 }
 
 #[derive(Debug, Serialize)]
@@ -2623,25 +2650,41 @@ impl RuntimeWorld {
             .fronts
             .iter()
             .filter(|front| front.location_ids.contains(&location_id))
-            .map(|front| FrontView {
-                id: front.id.clone(),
-                premise: front.premise.clone(),
-                zone: front.zone.clone(),
-                status: front.status.clone(),
-                location_ids: front.location_ids.clone(),
-                participant_ids: front.participant_ids.clone(),
-                participant_names: front
-                    .participant_ids
+            .map(|front| {
+                let job_statuses = front
+                    .job_ids
                     .iter()
-                    .map(|actor_id| {
-                        self.actor_name(*actor_id)
-                            .unwrap_or_else(|| format!("Actor {actor_id}"))
-                    })
-                    .collect(),
-                stakes_questions: front.stakes_questions.clone(),
-                portent_clock_id: front.portent_clock_id.clone(),
-                job_ids: front.job_ids.clone(),
-                impending_outcome: front.impending_outcome.clone(),
+                    .filter_map(|job_id| self.jobs.get(job_id))
+                    .map(|job| self.job_status(job))
+                    .collect::<Vec<_>>();
+                let (presentation_state, outcome_statement) = front_presentation(
+                    &front.status,
+                    job_statuses.iter().any(|status| status == "completed"),
+                    job_statuses.iter().any(|status| status == "failed"),
+                    &front.impending_outcome,
+                );
+                FrontView {
+                    id: front.id.clone(),
+                    premise: front.premise.clone(),
+                    zone: front.zone.clone(),
+                    status: front.status.clone(),
+                    presentation_state: presentation_state.to_string(),
+                    outcome_statement,
+                    location_ids: front.location_ids.clone(),
+                    participant_ids: front.participant_ids.clone(),
+                    participant_names: front
+                        .participant_ids
+                        .iter()
+                        .map(|actor_id| {
+                            self.actor_name(*actor_id)
+                                .unwrap_or_else(|| format!("Actor {actor_id}"))
+                        })
+                        .collect(),
+                    stakes_questions: front.stakes_questions.clone(),
+                    portent_clock_id: front.portent_clock_id.clone(),
+                    job_ids: front.job_ids.clone(),
+                    impending_outcome: front.impending_outcome.clone(),
+                }
             })
             .collect()
     }
@@ -3372,5 +3415,38 @@ impl RuntimeWorld {
             simulation: self.world_simulation_view(),
             locations,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::front_presentation;
+
+    #[test]
+    fn front_presentation_names_active_persisted_resolved_and_escalated_truths() {
+        let impending = "Every road lamp accepts the shadow as keeper.";
+        assert_eq!(
+            front_presentation("active", false, false, impending),
+            ("active", String::new())
+        );
+        assert_eq!(
+            front_presentation("active", true, false, impending),
+            (
+                "persisted",
+                "The immediate work is done, but the larger trouble remains unresolved."
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            front_presentation("completed", false, false, impending),
+            ("resolved", "The larger trouble is resolved.".to_string())
+        );
+        assert_eq!(
+            front_presentation("active", false, true, impending),
+            (
+                "escalated",
+                format!("The larger trouble has escalated. {impending}")
+            )
+        );
     }
 }

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -323,6 +323,8 @@ pub(super) struct ActorView {
     pub(super) muted_by_you: bool,
     pub(super) blocked_by_you: bool,
     pub(super) location_id: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) relationship: Option<RelationshipPreviewView>,
     pub(super) factions: Vec<FactionRefView>,
     #[serde(rename = "economy")]
     pub(super) resident_economy: Option<ResidentEconomyView>,
@@ -716,6 +718,10 @@ pub(super) struct BondView {
     pub(super) statement: String,
     pub(super) strength: u8,
     pub(super) status: String,
+    pub(super) source_event_seq: Option<u64>,
+    pub(super) updated_event_seq: Option<u64>,
+    pub(super) dialogue_status: String,
+    pub(super) dialogue_event_seq: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1219,6 +1225,7 @@ impl RuntimeWorld {
                     .is_some_and(|safety| safety.blocked_actor_ids.contains(&actor.id))
             }),
             location_id: actor.location_id,
+            relationship: self.relationship_preview(actor.id),
             factions: faction_refs_for_actor(actor.id),
             resident_economy: self.resident_economy_view(actor, client_actor_id),
             hp: unsafe { cw_actor_current_hp(&actor) },
@@ -3152,6 +3159,10 @@ impl RuntimeWorld {
                 statement: bond.statement.clone(),
                 strength: bond.strength,
                 status: bond.status.clone(),
+                source_event_seq: bond.source_event_seq,
+                updated_event_seq: bond.updated_event_seq,
+                dialogue_status: bond.dialogue_status.clone(),
+                dialogue_event_seq: bond.dialogue_event_seq,
             })
             .collect();
         bonds.sort_by(|a, b| {

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -1450,6 +1450,22 @@ for (const actor of actors) {
     }
   }
   const desiredItemIds = new Set();
+  if (actor.relationship !== undefined) {
+    if (!isObject(actor.relationship)) {
+      fail(`actor ${actor.id} has invalid relationship`);
+    } else {
+      validateRequiredStrings(`actor ${actor.id} relationship`, actor.relationship, [
+        "intent",
+        "statement",
+        "first_beat",
+        "reply_prompt",
+        "active_beat",
+      ]);
+      if (!has(itemIds, actor.relationship.active_on_gift_item_id)) {
+        fail(`actor ${actor.id} relationship references missing gift item ${actor.relationship.active_on_gift_item_id}`);
+      }
+    }
+  }
   for (const desire of actor.desires ?? []) {
     if (!has(itemIds, desire.item_id) || !isNonEmptyString(desire.reason) || desiredItemIds.has(desire.item_id)) {
       fail(`actor ${actor.id} has invalid desire for item ${desire.item_id}`);

--- a/v2/scripts/content-pack-contract.mjs
+++ b/v2/scripts/content-pack-contract.mjs
@@ -30,6 +30,7 @@ const WORLD_ENTITY_FIELDS = Object.freeze({
     "stats",
     "desires",
     "attachments",
+    "relationship",
   ]),
   items: new Set([
     "pack_id",

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74555
+74540

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -5582,6 +5582,18 @@ async function main() {
         branch: null,
         location: { ...(state?.location || {}), id: 804, name: "Lantern Tower" },
         primary_action: { kind: "act", options: [{ kind: "use_feature" }, { kind: "rest" }] },
+        fronts: [{
+          id: "lantern-keeper:hollow-light",
+          premise: "The beacon's shadow has learned Rowan's shape and wants every road lamp to recognize it as keeper.",
+          status: "active",
+          presentation_state: "active",
+          outcome_statement: "",
+          participant_names: ["Pip Thistle", "Moth-Eaten Knight", "Rowan Vale"],
+          stakes_questions: [
+            "Can Rowan be separated from the shadow without extinguishing the keeper's ember?",
+            "Will the party restore a guiding light or merely another weapon against the dark?",
+          ],
+        }],
         shared_questions: [{
           job_id: "lantern-keeper:rekindle-the-beacon",
           question: "Can the Mothwood beacon be relit before the road goes fully dark?",
@@ -5646,7 +5658,8 @@ async function main() {
       focusedKey = "";
       playerPromotedHandKey = "";
       render();
-      const question = document.querySelector("#promoted-question .shared-question");
+      const front = document.querySelector("#promoted-question .story-front");
+      const question = document.querySelector("#promoted-question .active-question");
       const meters = [...question.querySelectorAll('[role="progressbar"]')].map((meter) => ({
         label: meter.getAttribute("aria-label"),
         now: meter.getAttribute("aria-valuenow"),
@@ -5663,6 +5676,15 @@ async function main() {
         };
       });
       return {
+        frontText: front?.textContent || "",
+        frontLabelledBy: front?.getAttribute("aria-labelledby") || "",
+        frontDescribedBy: front?.getAttribute("aria-describedby") || "",
+        frontDescription: (front?.getAttribute("aria-describedby") || "")
+          .split(/\s+/)
+          .filter(Boolean)
+          .map((id) => document.getElementById(id)?.textContent || "")
+          .join(" "),
+        frontRosterLists: front?.querySelectorAll("ul, ol").length || 0,
         questionText: question?.textContent || "",
         questionAria: question?.getAttribute("aria-label") || "",
         meters,
@@ -5671,6 +5693,15 @@ async function main() {
           .map((item) => item.getAttribute("aria-label") || ""),
       };
     });
+    assert(
+      evidence.frontText.includes("beacon's shadow has learned Rowan's shape")
+        && evidence.frontText.includes("Can Rowan be separated from the shadow")
+        && evidence.frontText.includes("Will the party restore a guiding light")
+        && evidence.frontText.includes("The answer still matters to Pip Thistle, Moth-Eaten Knight, and Rowan Vale.")
+        && evidence.frontDescription.includes("Can Rowan be separated from the shadow")
+        && evidence.frontRosterLists === 0,
+      `ordinary scene should present the front as accessible narrative, not a roster: ${JSON.stringify(evidence)}`,
+    );
     assert(evidence.questionText.includes("Progress2/6") && evidence.questionText.includes("Danger1/6"), `ordinary scene should show both exact clocks: ${JSON.stringify(evidence)}`);
     assert(evidence.questionText.includes("Completion changes") && evidence.questionText.includes("If danger fills"), `ordinary scene should explain both outcomes: ${JSON.stringify(evidence)}`);
     assert(
@@ -5695,10 +5726,60 @@ async function main() {
     );
     await page.setViewportSize({ width: 1100, height: 900 });
     await page.screenshot({ path: screenshotPath, fullPage: false });
+    evidence.frontOutcomes = await page.evaluate(() => {
+      const cases = [
+        {
+          presentation_state: "persisted",
+          outcome_statement: "The immediate work is done, but the larger trouble remains unresolved.",
+        },
+        {
+          presentation_state: "resolved",
+          outcome_statement: "The larger trouble is resolved.",
+        },
+        {
+          presentation_state: "escalated",
+          outcome_statement: "The larger trouble has escalated. Every road lamp accepts the shadow as keeper.",
+        },
+      ];
+      return cases.map((frontCase) => {
+        state = {
+          ...state,
+          fronts: [{ ...state.fronts[0], ...frontCase }],
+        };
+        render();
+        const front = document.querySelector("#promoted-question .story-front");
+        const describedBy = front?.getAttribute("aria-describedby") || "";
+        return {
+          presentationState: frontCase.presentation_state,
+          text: front?.textContent || "",
+          describedText: describedBy
+            .split(/\s+/)
+            .filter(Boolean)
+            .map((id) => document.getElementById(id)?.textContent || "")
+            .join(" "),
+        };
+      });
+    });
+    assert(
+      evidence.frontOutcomes.every((outcome) => (
+        outcome.text.includes(outcome.presentationState === "persisted"
+          ? "remains unresolved"
+          : `larger trouble ${outcome.presentationState === "resolved" ? "is resolved" : "has escalated"}`)
+        && outcome.describedText.includes(outcome.presentationState === "persisted"
+          ? "remains unresolved"
+          : `larger trouble ${outcome.presentationState === "resolved" ? "is resolved" : "has escalated"}`)
+      )),
+      `front outcomes should keep their visible and described story truth aligned: ${JSON.stringify(evidence)}`,
+    );
     evidence.terminal = await page.evaluate(() => {
       const activeQuestion = state.shared_questions[0];
       state = {
         ...state,
+        fronts: [{
+          ...state.fronts[0],
+          presentation_state: "persisted",
+          outcome_statement: "The immediate work is done, but the larger trouble remains unresolved.",
+        }],
         shared_questions: [{
           ...activeQuestion,
           promoted: false,
@@ -5710,15 +5791,18 @@ async function main() {
         }],
       };
       render();
+      const front = document.querySelector("#promoted-question .story-front");
       const memory = document.querySelector("#promoted-question .completed-memory");
       return {
+        frontText: front?.textContent || "",
         text: memory?.textContent || "",
         progressbars: memory?.querySelectorAll('[role="progressbar"]').length || 0,
         suggestions: memory?.querySelectorAll(".shared-question-suggestions li").length || 0,
       };
     });
     assert(
-      evidence.terminal.text.includes("road went fully dark")
+      evidence.terminal.frontText.includes("the larger trouble remains unresolved")
+        && evidence.terminal.text.includes("road went fully dark")
         && evidence.terminal.text.includes("Contributors: Mara Wick, Road Reader")
         && evidence.terminal.progressbars === 0
         && evidence.terminal.suggestions === 0,

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -1917,6 +1917,7 @@ async function main() {
             })),
             selectedChoice: entry.selectedChoice || "",
             focusKeys: entry.focusKeys || [],
+            payload: entry.selectedPayload?.() || null,
             alternateTargetId: entry.choices?.[1]
               ? (() => {
                 const selected = entry.selectedChoice;
@@ -1956,6 +1957,51 @@ async function main() {
           command: entry.command || "",
         }));
       };
+      const renderedMaraModal = () => {
+        const fakeState = {
+          ...baseState,
+          action_offers: [{
+            ...baseState.action_offers[0],
+            target: { kind: "actor", id: 1001, label: "Rati" },
+            command: "chat Rati",
+          }],
+          actors: [
+            baseState.actors[0],
+            { id: 1001, name: "Rati", kind: "npc", status: "active", stats: { level: 1 } },
+            {
+              id: 8301,
+              name: "Mara Wick",
+              kind: "npc",
+              status: "active",
+              stats: { level: 2 },
+              relationship: {
+                intent: "Begin a cautious acquaintance by accepting Mara's request.",
+                statement: "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key.",
+                initial_status: "forming",
+                deterministic_consequence: "Mara places Rowan's empty key hook on the bar and asks for the Keeper's Brass Key.",
+                dialogue_contract: "one grounded reply if dialogue is available; otherwise one explicit unavailable result",
+              },
+            },
+          ],
+        };
+        state = fakeState;
+        actorId = 5000;
+        const action = buildActions(fakeState).find((entry) => entry.label === "chat");
+        openActionModal(action);
+        const before = [...document.querySelectorAll("#action-modal-meta .action-row")]
+          .map((node) => node.textContent.trim().replace(/\s+/g, " "));
+        const maraIndex = action.choices.findIndex((choice) => choice.label === "Mara Wick");
+        chooseActionModalChoice(maraIndex);
+        const selected = [...document.querySelectorAll("#action-modal-meta .action-row")]
+          .map((node) => ({
+            label: node.querySelector(".action-row-key")?.textContent?.trim() || "",
+            value: node.querySelector(".action-row-value")?.textContent?.trim() || "",
+            ariaLabel: node.getAttribute("aria-label") || "",
+          }));
+        const payload = action.selectedPayload?.() || null;
+        closeActionModal();
+        return { before, selected, payload };
+      };
       try {
         return {
           serverPaid: chatActionFor({}),
@@ -1990,6 +2036,31 @@ async function main() {
               },
             },
           }),
+          mara: chatActionFor({
+            action_offers: [{
+              ...baseState.action_offers[0],
+              target: { kind: "actor", id: 8301, label: "Mara Wick" },
+              command: "chat Mara Wick",
+            }],
+            actors: [
+              baseState.actors[0],
+              {
+                id: 8301,
+                name: "Mara Wick",
+                kind: "npc",
+                status: "active",
+                stats: { level: 2 },
+                relationship: {
+                  intent: "Begin a cautious acquaintance by accepting Mara's request.",
+                  statement: "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key.",
+                  initial_status: "forming",
+                  deterministic_consequence: "Mara places Rowan's empty key hook on the bar and asks for the Keeper's Brass Key.",
+                  dialogue_contract: "one grounded reply if dialogue is available; otherwise one explicit unavailable result",
+                },
+              },
+            ],
+          }),
+          renderedMara: renderedMaraModal(),
         };
       } finally {
         state = previousState;
@@ -2017,6 +2088,54 @@ async function main() {
     assert(!String(result.serverPaid?.detail || "").includes("lv"), `chat cards should let the evolved art and title carry character growth: ${JSON.stringify(result)}`);
     assert(!String(result.serverPaid?.detail || "").includes("/"), `chat detail should not include card title chrome: ${JSON.stringify(result)}`);
     assert(!String(result.staleConnectedHint?.detail || "").includes("/"), `stale OpenRouter chat detail should not include card title chrome: ${JSON.stringify(result)}`);
+    assert(result.mara?.summary.includes("forming relationship") && result.mara?.summary.includes("Mara is watching"), `Mara Chat should preview the forming relationship statement: ${JSON.stringify(result)}`);
+    assert(result.mara?.rows?.some((row) => row[0] === "Status" && row[1].includes("does not claim friendship")), `Mara Chat must not present an established friendship: ${JSON.stringify(result)}`);
+    assert(result.mara?.rows?.some((row) => row[0] === "Campaign beat" && row[1].includes("empty key hook")), `Mara Chat should preview its deterministic campaign beat: ${JSON.stringify(result)}`);
+    assert(result.mara?.rows?.some((row) => row[0] === "Dialogue" && row[1].includes("explicit unavailable result")), `Mara Chat should distinguish optional dialogue from the relationship mutation: ${JSON.stringify(result)}`);
+    assert(result.mara?.payload?.statement === "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key.", `Mara Chat must submit the confirmed authored statement: ${JSON.stringify(result)}`);
+    assert(result.renderedMara?.before?.length === 0, `an ordinary Chat target should keep the existing compact modal: ${JSON.stringify(result.renderedMara)}`);
+    assert(
+      result.renderedMara?.selected?.map((row) => row.label).join(",")
+        === "Relationship,Status,Campaign beat,Spend,Dialogue",
+      `selecting Mara must replace the modal DOM with all five relationship rows: ${JSON.stringify(result.renderedMara)}`,
+    );
+    assert(result.renderedMara?.selected?.every((row) => row.ariaLabel === row.label), `rendered relationship rows need accessible labels: ${JSON.stringify(result.renderedMara)}`);
+    assert(result.renderedMara?.selected?.some((row) => row.label === "Status" && row.value.includes("does not claim friendship")), `rendered Mara status must stay visibly forming: ${JSON.stringify(result.renderedMara)}`);
+    assert(result.renderedMara?.selected?.some((row) => row.label === "Campaign beat" && row.value.includes("empty key hook")), `rendered Mara modal must show the deterministic campaign beat: ${JSON.stringify(result.renderedMara)}`);
+    assert(result.renderedMara?.payload?.target_actor_id === 8301 && result.renderedMara?.payload?.statement === result.mara?.payload?.statement, `the DOM-selected Mara payload must keep the authored relationship statement: ${JSON.stringify(result.renderedMara)}`);
+  }
+
+  async function assertMaraRelationshipEventsStayTruthful() {
+    const result = await page.evaluate(() => {
+      const forming = {
+        type: "bond.created",
+        actor_name: "Lantern Stitch",
+        target_actor_name: "Mara Wick",
+        content: "bond:5000:8301:1:forming:advancement",
+      };
+      const beat = {
+        type: "relationship.beat",
+        actor_name: "Lantern Stitch",
+        target_actor_name: "Mara Wick",
+        content: "Mara places Rowan's empty key hook on the bar and asks for the Keeper's Brass Key.",
+      };
+      const unavailable = {
+        type: "dialogue.unavailable",
+        actor_name: "Lantern Stitch",
+        target_actor_name: "Mara Wick",
+        content: "resident dialogue was unavailable; no substitute line was created",
+      };
+      return {
+        forming: sceneCardEventText(forming),
+        beat: sceneCardEventText(beat),
+        unavailable: sceneCardEventText(unavailable),
+        unavailableStatus: statusUpdateMeta(unavailable),
+      };
+    });
+    assert(/connection begins forming/i.test(result.forming) && /friendship has not been claimed/i.test(result.forming), `forming Bond presentation must not claim friendship: ${JSON.stringify(result)}`);
+    assert(result.beat.includes("empty key hook") && result.beat.includes("Keeper's Brass Key"), `the authored campaign consequence should remain visible without dialogue: ${JSON.stringify(result)}`);
+    assert(/Dialogue unavailable/i.test(result.unavailable) && /no substitute speech/i.test(result.unavailable), `provider-offline failure must be explicit and truthful: ${JSON.stringify(result)}`);
+    assert(result.unavailableStatus?.label === "dialogue unavailable", `typed dialogue failure should keep its visible event label: ${JSON.stringify(result)}`);
   }
 
   async function assertGiftPrimaryUsesCompactVerb() {
@@ -9402,6 +9521,7 @@ async function main() {
   await assertProjectFeatureUseRequiresServerEffect();
   await assertFeatureAndCareShareOneUseCard();
   await assertChatPrimaryUsesCompactActorDetail();
+  await assertMaraRelationshipEventsStayTruthful();
   await assertGiftPrimaryUsesCompactVerb();
   await assertGiftChoicesCollapseIntoOneCard();
   await assertTravelChoicesCollapseIntoOneCard();

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -162,12 +162,12 @@
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "source": {
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:6b693f267141d66f55e03871ebfc35751eaae2e753a60357e15c78eb2f59ef8c",
+      "integrity": "sha256:ae261fb1e3745f560912c0d449860c4a3bbe37d478be58bd982ded8bea2e9461",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -562,7 +562,7 @@
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license_identifier": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "provenance": {


### PR DESCRIPTION
Closes #362

Stacked on #430 / agent/issue-361 so the required Lantern Keeper campaign journey is present exactly.

Summary:
- author Mara's first relationship intent as a forming acquaintance, not instant friendship
- show the exact relationship statement, forming status, empty-hook and Keeper Brass Key campaign beat, one-point spend, and dialogue availability contract before confirmation
- commit the deterministic relationship beat independently of optional inference
- emit exactly one grounded Mara reply when inference succeeds, or one typed dialogue.unavailable event without substitute speech when it does not
- atomically commit reply speech and delivered status, with legacy crash-gap recovery from durable causal reply evidence and no second provider call
- deepen the relationship to active only when Rowan's Keeper Brass Key is meaningfully returned
- preserve replay, reconnect, retry, CLI, campaign content, and inspectable causal state

Evidence:
- screenshot: /Users/ratimics/.codex/visualizations/2026/07/26/019fa0b6-597f-74a1-9f5f-b20b1f8a4558/issue-362-mara-forming-relationship.png
- relationship acceptance suite: 7/7 passed
- pre-push JavaScript suite: 453/453 passed
- pre-push Rust suite: 556/556 passed
- worldpacks, strict proof world, kernel, architecture, clippy ceiling, and syntax passed
- main.rs: 74,540 lines at the exact lowered ceiling
- exact diff: 1,870 changed lines, 530 below the 2,400 hard stop

The real browser walkthrough began a campaign avatar through ordinary guest onboarding, selected Mara in Chat, and verified the five visible accessible rows. Ordinary and creation modals retain their prior behavior; the additional rows are scoped only to the authored forming-relationship target.