### PR TITLE
Surface front premise and stakes in ordinary play

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.208",
+      "version": "0.0.209",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.208"
+version = "0.0.209"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.208"
+version = "0.0.209"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -324,6 +324,43 @@
       border-color: rgba(226, 187, 121, 0.28);
       background: rgba(24, 19, 10, 0.66);
     }
+    .story-front {
+      border-color: rgba(226, 187, 121, 0.34);
+      background:
+        linear-gradient(110deg, rgba(45, 31, 13, 0.45), rgba(8, 19, 12, 0.76));
+    }
+    .story-front.persisted,
+    .story-front.escalated {
+      border-color: rgba(226, 187, 121, 0.5);
+    }
+    .story-front-stakes {
+      margin-top: 8px;
+      display: grid;
+      gap: 5px;
+    }
+    .story-front-question,
+    .story-front-reference,
+    .story-front-outcome {
+      margin: 0;
+      font-size: 12px;
+      line-height: 1.4;
+      overflow-wrap: anywhere;
+    }
+    .story-front-question {
+      color: var(--text);
+      font-weight: 700;
+    }
+    .story-front-reference {
+      margin-top: 8px;
+      color: var(--dim);
+    }
+    .story-front-outcome {
+      margin-top: 8px;
+      border-top: 1px solid rgba(226, 187, 121, 0.2);
+      padding-top: 7px;
+      color: var(--amber);
+      font-weight: 700;
+    }
     .shared-question-heading {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
@@ -3753,7 +3790,7 @@
         </div>
         <button class="room-log-latest" id="room-log-latest" type="button" aria-controls="journal-view" hidden><span class="room-log-latest-track" id="room-log-latest-track"></span></button>
         <div class="room-copy" id="location-copy"></div>
-        <section class="shared-questions" id="promoted-question" aria-live="polite" aria-label="Current shared question" hidden></section>
+        <section class="shared-questions" id="promoted-question" aria-live="polite" aria-label="Current story and shared question" hidden></section>
       </section>
       <section class="journal-view" id="journal-view" aria-label="Journal" hidden>
         <header class="journal-heading">
@@ -8166,6 +8203,46 @@
         .slice(0, 1);
     }
 
+    function frontsForPresentation(view = state) {
+      const fronts = Array.isArray(view?.fronts) ? view.fronts : [];
+      return fronts.filter((front) => front.presentation_state !== "dormant");
+    }
+
+    function narrativeNames(names) {
+      const values = (names || []).map((name) => String(name || "").trim()).filter(Boolean);
+      if (values.length < 2) return values[0] || "";
+      if (values.length === 2) return `${values[0]} and ${values[1]}`;
+      return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+    }
+
+    function promotedFrontHtml(front, index = 0) {
+      const stateName = String(front.presentation_state || "active");
+      const idBase = `story-front-${String(front.id || index).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+      const titleId = `${idBase}-title`;
+      const stakes = (front.stakes_questions || []).filter(Boolean);
+      const stakeIds = stakes.map((_, stakeIndex) => `${idBase}-stake-${stakeIndex + 1}`);
+      const names = narrativeNames(front.participant_names);
+      const referenceId = names ? `${idBase}-reference` : "";
+      const outcome = String(front.outcome_statement || "").trim();
+      const outcomeId = outcome ? `${idBase}-outcome` : "";
+      const describedBy = [...stakeIds, referenceId, outcomeId].filter(Boolean).join(" ");
+      const kicker = {
+        persisted: "the larger trouble persists",
+        resolved: "the larger trouble is resolved",
+        escalated: "the larger trouble has escalated",
+      }[stateName] || "larger trouble";
+      const stakeHtml = stakes.length
+        ? `<div class="story-front-stakes">${stakes.map((stake, stakeIndex) => `<p class="story-front-question" id="${stakeIds[stakeIndex]}">${escapeHtml(stake)}</p>`).join("")}</div>`
+        : "";
+      const referenceHtml = names
+        ? `<p class="story-front-reference" id="${referenceId}">${escapeHtml(`The answer still matters to ${names}.`)}</p>`
+        : "";
+      const outcomeHtml = outcome
+        ? `<p class="story-front-outcome" id="${outcomeId}">${escapeHtml(outcome)}</p>`
+        : "";
+      return `<article class="shared-question story-front ${escapeAttr(stateName)}" role="region" aria-labelledby="${titleId}"${describedBy ? ` aria-describedby="${describedBy}"` : ""}><span class="shared-question-kicker">${escapeHtml(kicker)}</span><h2 id="${titleId}">${escapeHtml(front.premise)}</h2>${stakeHtml}${referenceHtml}${outcomeHtml}</article>`;
+    }
+
     function sharedQuestionHtml(question) {
       const completed = question.presentation_state === "completed_memory";
       const rhythm = String(question.rhythm || "shared").replaceAll("_", " ");
@@ -8261,9 +8338,13 @@
 
     function renderPromotedQuestion() {
       const panel = $("promoted-question");
+      const fronts = frontsForPresentation();
       const questions = sharedQuestionsForPresentation();
-      panel.hidden = questions.length === 0;
-      panel.innerHTML = questions.slice(0, 1).map(promotedQuestionHtml).join("");
+      panel.hidden = fronts.length === 0 && questions.length === 0;
+      panel.innerHTML = [
+        ...fronts.slice(0, 1).map(promotedFrontHtml),
+        ...questions.slice(0, 1).map(promotedQuestionHtml),
+      ].join("");
       if (questions.length) scheduleVisibleClockPresentationReceipts();
     }
 

--- a/v2/orchestrator-rust/src/lantern_keeper_tests.rs
+++ b/v2/orchestrator-rust/src/lantern_keeper_tests.rs
@@ -548,6 +548,23 @@ fn lantern_journey_evidence_unlocks_one_controller_neutral_finale() {
     let (mut runtime, expected_evidence) = runtime_ready_for_lantern_finale();
     assert_eq!(runtime.clocks[LANTERN_PROGRESS_CLOCK_ID].filled, 0);
 
+    let before_finale_view =
+        runtime.state_response(Some(FINAL_ACTOR_ID), &AccessContext::default());
+    let encountered_front = before_finale_view
+        .fronts
+        .iter()
+        .find(|front| front.id == "lantern-keeper:hollow-light")
+        .expect("the Lantern journey reaches its larger trouble before the finale");
+    assert_eq!(encountered_front.presentation_state, "active");
+    assert_eq!(
+        encountered_front.premise,
+        "The beacon's shadow has learned Rowan's shape and wants every road lamp to recognize it as keeper."
+    );
+    assert!(encountered_front.stakes_questions.iter().any(|question| {
+        question
+            == "Can Rowan be separated from the shadow without extinguishing the keeper's ember?"
+    }));
+
     assert_tag_source(
         &runtime,
         &room_feature_search_tag_id(800, "failing_lantern"),
@@ -637,6 +654,18 @@ fn lantern_journey_evidence_unlocks_one_controller_neutral_finale() {
     assert_eq!(
         runtime.job_status(&runtime.jobs[LANTERN_JOB_ID]),
         "completed"
+    );
+    let after_finale_view = runtime.state_response(Some(FINAL_ACTOR_ID), &AccessContext::default());
+    let persisted_front = after_finale_view
+        .fronts
+        .iter()
+        .find(|front| front.id == "lantern-keeper:hollow-light")
+        .expect("the larger trouble remains visible after the beacon work");
+    assert_eq!(persisted_front.status, "active");
+    assert_eq!(persisted_front.presentation_state, "persisted");
+    assert_eq!(
+        persisted_front.outcome_statement,
+        "The immediate work is done, but the larger trouble remains unresolved."
     );
     assert!(runtime
         .tags
@@ -731,6 +760,16 @@ fn lantern_journey_evidence_unlocks_one_controller_neutral_finale() {
         "completed"
     );
     assert_eq!(reconnected.orb_balance(FINAL_ACTOR_ID), before_orbs + 2);
+    let reconnected_front = reconnected
+        .state_response(Some(FINAL_ACTOR_ID), &AccessContext::default())
+        .fronts
+        .into_iter()
+        .find(|front| front.id == "lantern-keeper:hollow-light")
+        .expect("persisted larger trouble survives reconnect");
+    assert_eq!(reconnected_front.presentation_state, "persisted");
+    assert!(reconnected_front
+        .outcome_statement
+        .contains("remains unresolved"));
 }
 
 #[test]
@@ -765,6 +804,16 @@ fn lantern_combat_is_evidence_and_danger_resolves_once() {
     );
     assert_eq!(runtime.apply_journal_record(&fail_record).0, CW_OK);
     assert_eq!(runtime.job_status(&runtime.jobs[LANTERN_JOB_ID]), "failed");
+    let escalated_front = runtime
+        .state_response(Some(FINAL_ACTOR_ID), &AccessContext::default())
+        .fronts
+        .into_iter()
+        .find(|front| front.id == "lantern-keeper:hollow-light")
+        .expect("failed beacon work escalates the larger trouble");
+    assert_eq!(escalated_front.presentation_state, "escalated");
+    assert!(escalated_front
+        .outcome_statement
+        .starts_with("The larger trouble has escalated."));
     assert!(runtime
         .tags
         .get("room:804:black_beacon")

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -641,6 +641,8 @@ pub(super) struct FrontView {
     pub(super) premise: String,
     pub(super) zone: String,
     pub(super) status: String,
+    pub(super) presentation_state: String,
+    pub(super) outcome_statement: String,
     pub(super) location_ids: Vec<u64>,
     pub(super) participant_ids: Vec<u64>,
     pub(super) participant_names: Vec<String>,
@@ -648,6 +650,31 @@ pub(super) struct FrontView {
     pub(super) portent_clock_id: String,
     pub(super) job_ids: Vec<String>,
     pub(super) impending_outcome: String,
+}
+
+fn front_presentation(
+    authored_status: &str,
+    has_completed_job: bool,
+    has_failed_job: bool,
+    impending_outcome: &str,
+) -> (&'static str, String) {
+    let presentation_state = match authored_status {
+        "completed" => "resolved",
+        "failed" => "escalated",
+        "dormant" => "dormant",
+        _ if has_failed_job => "escalated",
+        _ if has_completed_job => "persisted",
+        _ => "active",
+    };
+    let outcome_statement = match presentation_state {
+        "resolved" => "The larger trouble is resolved.".to_string(),
+        "persisted" => {
+            "The immediate work is done, but the larger trouble remains unresolved.".to_string()
+        }
+        "escalated" => format!("The larger trouble has escalated. {impending_outcome}"),
+        _ => String::new(),
+    };
+    (presentation_state, outcome_statement)
 }
 
 #[derive(Debug, Serialize)]
@@ -2623,25 +2650,41 @@ impl RuntimeWorld {
             .fronts
             .iter()
             .filter(|front| front.location_ids.contains(&location_id))
-            .map(|front| FrontView {
-                id: front.id.clone(),
-                premise: front.premise.clone(),
-                zone: front.zone.clone(),
-                status: front.status.clone(),
-                location_ids: front.location_ids.clone(),
-                participant_ids: front.participant_ids.clone(),
-                participant_names: front
-                    .participant_ids
+            .map(|front| {
+                let job_statuses = front
+                    .job_ids
                     .iter()
-                    .map(|actor_id| {
-                        self.actor_name(*actor_id)
-                            .unwrap_or_else(|| format!("Actor {actor_id}"))
-                    })
-                    .collect(),
-                stakes_questions: front.stakes_questions.clone(),
-                portent_clock_id: front.portent_clock_id.clone(),
-                job_ids: front.job_ids.clone(),
-                impending_outcome: front.impending_outcome.clone(),
+                    .filter_map(|job_id| self.jobs.get(job_id))
+                    .map(|job| self.job_status(job))
+                    .collect::<Vec<_>>();
+                let (presentation_state, outcome_statement) = front_presentation(
+                    &front.status,
+                    job_statuses.iter().any(|status| status == "completed"),
+                    job_statuses.iter().any(|status| status == "failed"),
+                    &front.impending_outcome,
+                );
+                FrontView {
+                    id: front.id.clone(),
+                    premise: front.premise.clone(),
+                    zone: front.zone.clone(),
+                    status: front.status.clone(),
+                    presentation_state: presentation_state.to_string(),
+                    outcome_statement,
+                    location_ids: front.location_ids.clone(),
+                    participant_ids: front.participant_ids.clone(),
+                    participant_names: front
+                        .participant_ids
+                        .iter()
+                        .map(|actor_id| {
+                            self.actor_name(*actor_id)
+                                .unwrap_or_else(|| format!("Actor {actor_id}"))
+                        })
+                        .collect(),
+                    stakes_questions: front.stakes_questions.clone(),
+                    portent_clock_id: front.portent_clock_id.clone(),
+                    job_ids: front.job_ids.clone(),
+                    impending_outcome: front.impending_outcome.clone(),
+                }
             })
             .collect()
     }
@@ -3372,5 +3415,38 @@ impl RuntimeWorld {
             simulation: self.world_simulation_view(),
             locations,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::front_presentation;
+
+    #[test]
+    fn front_presentation_names_active_persisted_resolved_and_escalated_truths() {
+        let impending = "Every road lamp accepts the shadow as keeper.";
+        assert_eq!(
+            front_presentation("active", false, false, impending),
+            ("active", String::new())
+        );
+        assert_eq!(
+            front_presentation("active", true, false, impending),
+            (
+                "persisted",
+                "The immediate work is done, but the larger trouble remains unresolved."
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            front_presentation("completed", false, false, impending),
+            ("resolved", "The larger trouble is resolved.".to_string())
+        );
+        assert_eq!(
+            front_presentation("active", false, true, impending),
+            (
+                "escalated",
+                format!("The larger trouble has escalated. {impending}")
+            )
+        );
     }
 }

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -5582,6 +5582,18 @@ async function main() {
         branch: null,
         location: { ...(state?.location || {}), id: 804, name: "Lantern Tower" },
         primary_action: { kind: "act", options: [{ kind: "use_feature" }, { kind: "rest" }] },
+        fronts: [{
+          id: "lantern-keeper:hollow-light",
+          premise: "The beacon's shadow has learned Rowan's shape and wants every road lamp to recognize it as keeper.",
+          status: "active",
+          presentation_state: "active",
+          outcome_statement: "",
+          participant_names: ["Pip Thistle", "Moth-Eaten Knight", "Rowan Vale"],
+          stakes_questions: [
+            "Can Rowan be separated from the shadow without extinguishing the keeper's ember?",
+            "Will the party restore a guiding light or merely another weapon against the dark?",
+          ],
+        }],
         shared_questions: [{
           job_id: "lantern-keeper:rekindle-the-beacon",
           question: "Can the Mothwood beacon be relit before the road goes fully dark?",
@@ -5646,7 +5658,8 @@ async function main() {
       focusedKey = "";
       playerPromotedHandKey = "";
       render();
-      const question = document.querySelector("#promoted-question .shared-question");
+      const front = document.querySelector("#promoted-question .story-front");
+      const question = document.querySelector("#promoted-question .active-question");
       const meters = [...question.querySelectorAll('[role="progressbar"]')].map((meter) => ({
         label: meter.getAttribute("aria-label"),
         now: meter.getAttribute("aria-valuenow"),
@@ -5663,6 +5676,15 @@ async function main() {
         };
       });
       return {
+        frontText: front?.textContent || "",
+        frontLabelledBy: front?.getAttribute("aria-labelledby") || "",
+        frontDescribedBy: front?.getAttribute("aria-describedby") || "",
+        frontDescription: (front?.getAttribute("aria-describedby") || "")
+          .split(/\s+/)
+          .filter(Boolean)
+          .map((id) => document.getElementById(id)?.textContent || "")
+          .join(" "),
+        frontRosterLists: front?.querySelectorAll("ul, ol").length || 0,
         questionText: question?.textContent || "",
         questionAria: question?.getAttribute("aria-label") || "",
         meters,
@@ -5671,6 +5693,15 @@ async function main() {
           .map((item) => item.getAttribute("aria-label") || ""),
       };
     });
+    assert(
+      evidence.frontText.includes("beacon's shadow has learned Rowan's shape")
+        && evidence.frontText.includes("Can Rowan be separated from the shadow")
+        && evidence.frontText.includes("Will the party restore a guiding light")
+        && evidence.frontText.includes("The answer still matters to Pip Thistle, Moth-Eaten Knight, and Rowan Vale.")
+        && evidence.frontDescription.includes("Can Rowan be separated from the shadow")
+        && evidence.frontRosterLists === 0,
+      `ordinary scene should present the front as accessible narrative, not a roster: ${JSON.stringify(evidence)}`,
+    );
     assert(evidence.questionText.includes("Progress2/6") && evidence.questionText.includes("Danger1/6"), `ordinary scene should show both exact clocks: ${JSON.stringify(evidence)}`);
     assert(evidence.questionText.includes("Completion changes") && evidence.questionText.includes("If danger fills"), `ordinary scene should explain both outcomes: ${JSON.stringify(evidence)}`);
     assert(
@@ -5695,10 +5726,60 @@ async function main() {
     );
     await page.setViewportSize({ width: 1100, height: 900 });
     await page.screenshot({ path: screenshotPath, fullPage: false });
+    evidence.frontOutcomes = await page.evaluate(() => {
+      const cases = [
+        {
+          presentation_state: "persisted",
+          outcome_statement: "The immediate work is done, but the larger trouble remains unresolved.",
+        },
+        {
+          presentation_state: "resolved",
+          outcome_statement: "The larger trouble is resolved.",
+        },
+        {
+          presentation_state: "escalated",
+          outcome_statement: "The larger trouble has escalated. Every road lamp accepts the shadow as keeper.",
+        },
+      ];
+      return cases.map((frontCase) => {
+        state = {
+          ...state,
+          fronts: [{ ...state.fronts[0], ...frontCase }],
+        };
+        render();
+        const front = document.querySelector("#promoted-question .story-front");
+        const describedBy = front?.getAttribute("aria-describedby") || "";
+        return {
+          presentationState: frontCase.presentation_state,
+          text: front?.textContent || "",
+          describedText: describedBy
+            .split(/\s+/)
+            .filter(Boolean)
+            .map((id) => document.getElementById(id)?.textContent || "")
+            .join(" "),
+        };
+      });
+    });
+    assert(
+      evidence.frontOutcomes.every((outcome) => (
+        outcome.text.includes(outcome.presentationState === "persisted"
+          ? "remains unresolved"
+          : `larger trouble ${outcome.presentationState === "resolved" ? "is resolved" : "has escalated"}`)
+        && outcome.describedText.includes(outcome.presentationState === "persisted"
+          ? "remains unresolved"
+          : `larger trouble ${outcome.presentationState === "resolved" ? "is resolved" : "has escalated"}`)
+      )),
+      `front outcomes should keep their visible and described story truth aligned: ${JSON.stringify(evidence)}`,
+    );
     evidence.terminal = await page.evaluate(() => {
       const activeQuestion = state.shared_questions[0];
       state = {
         ...state,
+        fronts: [{
+          ...state.fronts[0],
+          presentation_state: "persisted",
+          outcome_statement: "The immediate work is done, but the larger trouble remains unresolved.",
+        }],
         shared_questions: [{
           ...activeQuestion,
           promoted: false,
@@ -5710,15 +5791,18 @@ async function main() {
         }],
       };
       render();
+      const front = document.querySelector("#promoted-question .story-front");
       const memory = document.querySelector("#promoted-question .completed-memory");
       return {
+        frontText: front?.textContent || "",
         text: memory?.textContent || "",
         progressbars: memory?.querySelectorAll('[role="progressbar"]').length || 0,
         suggestions: memory?.querySelectorAll(".shared-question-suggestions li").length || 0,
       };
     });
     assert(
-      evidence.terminal.text.includes("road went fully dark")
+      evidence.terminal.frontText.includes("the larger trouble remains unresolved")
+        && evidence.terminal.text.includes("road went fully dark")
         && evidence.terminal.text.includes("Contributors: Mara Wick, Road Reader")
         && evidence.terminal.progressbars === 0
         && evidence.terminal.suggestions === 0,


### PR DESCRIPTION
Closes #410

## Outcome
- presents the active front premise and stakes directly above the promoted campaign question in the ordinary room scene
- keeps participant names in narrative prose and projects the same visible copy through labelled/described screen-reader structure
- derives active, persisted, resolved, and escalated states, including an explicit unresolved beat when a job completes while its front remains active

## Evidence
- full Rust suite: 557/557 passed
- browser/UI-focused tests: 3/3 passed
- JavaScript suite: 453/453 passed in the successful pre-push run
- architecture: main.rs 74,540/74,540; Clippy 246/246
- formatting, diff, version, and syntax gates passed
- real browser journey: Cosy Cottage → campaign rules → Human / Wayside Inn → Travel → Mothwood Path; accessibility DOM contained the exact Lantern Keeper premise, both stakes questions, narrative participant sentence, and campaign question in the ordinary room region

Screenshot note: the live in-app browser journey succeeded, but the browser screenshot endpoint repeatedly returned `Unable to capture screenshot`; no synthetic screenshot is substituted. Exact accessibility-tree evidence is recorded above.