### PR TITLE
Gate every generated image before publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.210",
+  "version": "0.0.211",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -270,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.210"
+version = "0.0.211"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -314,6 +320,7 @@ dependencies = [
  "cc",
  "cosyworld-ai-model",
  "ed25519-dalek",
+ "image",
  "qrcode",
  "rand 0.8.6",
  "reqwest",
@@ -494,6 +501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +646,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -883,8 +909,24 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -1165,6 +1207,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1266,12 @@ checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 dependencies = [
  "image",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -2238,6 +2299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,4 +2630,19 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.210"
+version = "0.0.211"
 edition = "2021"
 publish = false
 
@@ -13,6 +13,7 @@ base64 = "0.22"
 bs58 = "0.5"
 cosyworld-ai-model = { path = "../ai-model-rust" }
 ed25519-dalek = "2"
+image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 qrcode = "0.14"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -329,9 +329,20 @@ pub(crate) async fn request_image_policy_decision(
                                 "person",
                                 "character",
                                 "creature",
+                                "safety",
                                 "text",
                                 "logo",
-                                "watermark"
+                                "watermark",
+                                "system_leak",
+                                "ui_chrome",
+                                "missing_subject",
+                                "extra_subject",
+                                "identity_drift",
+                                "missing_item",
+                                "wrong_holder",
+                                "wrong_environment",
+                                "bad_crop",
+                                "pack_negative"
                             ]
                         }
                     },
@@ -393,9 +404,20 @@ fn parse_image_policy_decision(value: &str) -> Result<ImagePolicyDecision, Strin
         "person",
         "character",
         "creature",
+        "safety",
         "text",
         "logo",
         "watermark",
+        "system_leak",
+        "ui_chrome",
+        "missing_subject",
+        "extra_subject",
+        "identity_drift",
+        "missing_item",
+        "wrong_holder",
+        "wrong_environment",
+        "bad_crop",
+        "pack_negative",
     ];
     if raw
         .violations

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -16,6 +16,12 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::warn;
 
+use crate::media_recipes::media_verdict::{
+    make_visual_verdict, media_candidate_approved, media_candidate_digest,
+    media_candidate_violations, media_provider_route_available, prepare_media_candidate,
+    record_media_provider_failure, record_media_review_unavailable, record_media_visual_verdict,
+    FrozenMediaBrief, MediaCandidateInput, MediaVerdictDisposition, MediaViolation,
+};
 use crate::{
     active_content, backfill_legacy_community_asset, broadcast_events,
     canonical_community_media_asset_bytes, commit_journal_record, evolution_rollout_route,
@@ -866,6 +872,8 @@ pub(super) async fn generate_and_store_community_art(
     generated_asset_dir: &Path,
     plan: &CommunityArtPlan,
 ) -> CommunityArtGenerationOutcome {
+    let media_brief = community_art_media_brief(plan);
+    let job_key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
     let evolution_route = match plan.evolution_job.as_ref() {
         Some(job) => match evolution_runtime_observation(&job.evaluation_profile)
             .and_then(|observation| evolution_rollout_route(job, observation.as_ref()))
@@ -892,6 +900,18 @@ pub(super) async fn generate_and_store_community_art(
         ) {
             Ok(Some((image, stored_evolution_canary))) => (image, true, stored_evolution_canary),
             Ok(None) => {
+                if !media_provider_route_available(generated_asset_dir, &job_key).unwrap_or(false) {
+                    return CommunityArtGenerationOutcome {
+                        result: Err(CommunityArtGenerationError::Provider(
+                            "generated-image provider route is cooling down or disabled"
+                                .to_string(),
+                        )),
+                        prediction_id: None,
+                        reused_candidate: false,
+                        asset_id: None,
+                        evolution_canary: selected_evolution_canary,
+                    };
+                }
                 let prompt = community_art_generation_request(config, plan);
                 let evolution_reference =
                     plan.evolution_job.as_ref().map(frozen_evolution_reference);
@@ -939,6 +959,15 @@ pub(super) async fn generate_and_store_community_art(
                 let image = match request {
                     Ok(image) => image,
                     Err(error) => {
+                        let _ = record_media_provider_failure(
+                            generated_asset_dir,
+                            media_brief.clone(),
+                            if selected_evolution_canary {
+                                "replicate-evolution-canary"
+                            } else {
+                                "replicate-primary"
+                            },
+                        );
                         return CommunityArtGenerationOutcome {
                             result: Err(CommunityArtGenerationError::Provider(error)),
                             prediction_id: None,
@@ -948,26 +977,24 @@ pub(super) async fn generate_and_store_community_art(
                         };
                     }
                 };
-                if plan.image_policy.is_some() || plan.evolution_job.is_some() {
-                    let stored = if selected_evolution_canary {
-                        store_community_art_candidate_with_route(
-                            generated_asset_dir,
-                            plan,
-                            &image,
-                            true,
-                        )
-                    } else {
-                        store_community_art_candidate(generated_asset_dir, plan, &image)
+                let stored = if selected_evolution_canary {
+                    store_community_art_candidate_with_route(
+                        generated_asset_dir,
+                        plan,
+                        &image,
+                        true,
+                    )
+                } else {
+                    store_community_art_candidate(generated_asset_dir, plan, &image)
+                };
+                if let Err(error) = stored {
+                    return CommunityArtGenerationOutcome {
+                        prediction_id: image.prediction_id.clone(),
+                        result: Err(CommunityArtGenerationError::Storage(error)),
+                        reused_candidate: false,
+                        asset_id: None,
+                        evolution_canary: selected_evolution_canary,
                     };
-                    if let Err(error) = stored {
-                        return CommunityArtGenerationOutcome {
-                            prediction_id: image.prediction_id.clone(),
-                            result: Err(CommunityArtGenerationError::Storage(error)),
-                            reused_candidate: false,
-                            asset_id: None,
-                            evolution_canary: selected_evolution_canary,
-                        };
-                    }
                 }
                 (image, false, selected_evolution_canary)
             }
@@ -984,30 +1011,113 @@ pub(super) async fn generate_and_store_community_art(
 
     let prediction_id = image.prediction_id.clone();
     let result = async {
-        if let Some(policy) = plan.image_policy {
-            let policy_config =
-                policy_config.ok_or(CommunityArtGenerationError::PolicyUnavailable)?;
-            let image_url = community_art_candidate_data_url(&image)?;
-            let decision = request_image_policy_decision(
-                policy_config,
-                ImagePolicyRequest {
-                    feature: "media.location_image_policy",
-                    image_url: &image_url,
-                    policy: policy.review(),
-                    timeout: Duration::from_secs(30),
-                    max_attempts: 2,
-                    referer: "https://cosyworld.fly.dev",
-                },
-            )
-            .await
-            .map_err(|error| CommunityArtGenerationError::PolicyReview(error.to_string()))?;
-            if !decision.allowed {
-                remove_community_art_candidate(generated_asset_dir, plan)
-                    .map_err(CommunityArtGenerationError::Storage)?;
+        let prior_public = fs::read(stored_community_art_image_path(
+            generated_asset_dir,
+            &plan.subject_kind,
+            plan.subject_id,
+        ))
+        .ok();
+        let disposition = prepare_media_candidate(
+            generated_asset_dir,
+            media_brief.clone(),
+            MediaCandidateInput {
+                image: &image,
+                provider: "replicate",
+                model: &config.model,
+                claimed_digest: None,
+                prior_public_bytes: prior_public.as_deref(),
+            },
+        )
+        .map_err(CommunityArtGenerationError::Storage)?;
+        let candidate_digest = media_candidate_digest(generated_asset_dir, &job_key)
+            .map_err(CommunityArtGenerationError::Storage)?
+            .ok_or_else(|| {
+                CommunityArtGenerationError::Storage(
+                    "generated-image gate lost its active candidate".to_string(),
+                )
+            })?;
+        match disposition {
+            MediaVerdictDisposition::Rejected => {
                 return Err(CommunityArtGenerationError::PolicyRejected(
-                    decision.violations,
+                    media_candidate_violations(generated_asset_dir, &job_key, &candidate_digest)
+                        .map_err(CommunityArtGenerationError::Storage)?,
                 ));
             }
+            MediaVerdictDisposition::Disabled | MediaVerdictDisposition::ReplaceRequested => {
+                return Err(CommunityArtGenerationError::PolicyReview(
+                    "generated-image recipe is disabled or awaiting replacement".to_string(),
+                ));
+            }
+            MediaVerdictDisposition::Approved => {}
+            MediaVerdictDisposition::ReviewPending => {
+                let policy_config =
+                    policy_config.ok_or(CommunityArtGenerationError::PolicyUnavailable)?;
+                let mut review_policy = media_brief.review_policy();
+                if let Some(policy) = plan.image_policy {
+                    review_policy.push(' ');
+                    review_policy.push_str(policy.review());
+                }
+                let image_url = community_art_candidate_data_url(&image)?;
+                let decision = request_image_policy_decision(
+                    policy_config,
+                    ImagePolicyRequest {
+                        feature: "media.generated_image_verdict",
+                        image_url: &image_url,
+                        policy: &review_policy,
+                        timeout: Duration::from_secs(30),
+                        max_attempts: 2,
+                        referer: "https://cosyworld.fly.dev",
+                    },
+                )
+                .await
+                .map_err(|error| {
+                    let _ = record_media_review_unavailable(
+                        generated_asset_dir,
+                        &job_key,
+                        &candidate_digest,
+                        &error.to_string(),
+                    );
+                    CommunityArtGenerationError::PolicyReview(error.to_string())
+                })?;
+                let violations = decision
+                    .violations
+                    .iter()
+                    .map(|violation| media_violation_from_policy(violation))
+                    .collect::<Vec<_>>();
+                let verdict = make_visual_verdict(
+                    &media_brief,
+                    candidate_digest.clone(),
+                    "openai-compatible-vision",
+                    &policy_config.vision_model,
+                    decision.allowed,
+                    violations,
+                    decision.summary,
+                    1,
+                    0,
+                    0,
+                )
+                .map_err(CommunityArtGenerationError::Storage)?;
+                let disposition =
+                    record_media_visual_verdict(generated_asset_dir, &job_key, verdict)
+                        .map_err(CommunityArtGenerationError::Storage)?;
+                if disposition != MediaVerdictDisposition::Approved {
+                    return Err(CommunityArtGenerationError::PolicyRejected(
+                        media_candidate_violations(
+                            generated_asset_dir,
+                            &job_key,
+                            &candidate_digest,
+                        )
+                        .map_err(CommunityArtGenerationError::Storage)?,
+                    ));
+                }
+            }
+        }
+        if !media_candidate_approved(generated_asset_dir, &job_key, &candidate_digest)
+            .map_err(CommunityArtGenerationError::Storage)?
+        {
+            return Err(CommunityArtGenerationError::PolicyReview(
+                "generated-image candidate has no durable approving verdict".to_string(),
+            ));
         }
         if plan.evolution_job.is_none() {
             store_community_art_image(generated_asset_dir, plan, &image)
@@ -1114,6 +1224,68 @@ fn community_art_asset_provenance(
         prediction_id,
         source_event_seq: None,
         history_through_seq: plan.history_through_seq,
+    }
+}
+
+fn community_art_media_brief(plan: &CommunityArtPlan) -> FrozenMediaBrief {
+    let mut brief = FrozenMediaBrief::new(
+        community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level),
+        format!(
+            "cosyworld.community-art/{}/{}",
+            plan.generation_profile_version,
+            if plan.evolution_job.is_some() {
+                "evolution"
+            } else {
+                "base"
+            }
+        ),
+        format!("public {} progression art", plan.subject_kind),
+        &plan.prompt,
+        plan.aspect_ratio,
+    );
+    brief.required_subjects = if plan.subject_kind == "location" {
+        Vec::new()
+    } else {
+        vec![format!(
+            "{} {} ({})",
+            plan.subject_kind, plan.persisted_identity, plan.persisted_visual_description
+        )]
+    };
+    if plan.subject_kind == "location" {
+        brief.required_environment = vec![
+            plan.persisted_identity.clone(),
+            plan.persisted_visual_description.clone(),
+        ];
+        brief
+            .forbidden
+            .push("people, characters, creatures, silhouettes, faces, or body parts".to_string());
+    }
+    brief.pack_negative_constraints = plan.stable_traits.clone();
+    if let Some(job) = &plan.evolution_job {
+        brief
+            .approved_reference_digests
+            .push(job.prior_asset_digest.clone());
+    }
+    brief
+}
+
+fn media_violation_from_policy(value: &str) -> MediaViolation {
+    match value {
+        "safety" => MediaViolation::Safety,
+        "text" => MediaViolation::Text,
+        "logo" => MediaViolation::Logo,
+        "watermark" => MediaViolation::Watermark,
+        "system_leak" => MediaViolation::SystemLeak,
+        "ui_chrome" => MediaViolation::UiChrome,
+        "missing_subject" => MediaViolation::MissingSubject,
+        "identity_drift" => MediaViolation::IdentityDrift,
+        "missing_item" => MediaViolation::MissingItem,
+        "wrong_holder" => MediaViolation::WrongHolder,
+        "wrong_environment" => MediaViolation::WrongEnvironment,
+        "bad_crop" => MediaViolation::BadCrop,
+        "pack_negative" => MediaViolation::PackNegative,
+        "person" | "character" | "creature" | "extra_subject" => MediaViolation::ExtraSubject,
+        _ => MediaViolation::Safety,
     }
 }
 
@@ -1615,6 +1787,34 @@ pub(super) fn remove_community_art_candidate(
         }
     }
     Ok(())
+}
+
+pub(super) fn request_community_art_candidate_replacement(
+    root: &Path,
+    job_key: &str,
+) -> Result<bool, String> {
+    let parts = job_key.split(':').collect::<Vec<_>>();
+    if parts.len() != 4
+        || !matches!(parts[0], "actor" | "item" | "location")
+        || parts[2] != "level"
+        || parts[1].parse::<u64>().is_err()
+        || parts[3].parse::<u8>().is_err()
+    {
+        return Ok(false);
+    }
+    let stem = root
+        .join("community-art-candidates")
+        .join(parts[0])
+        .join(parts[1])
+        .join(format!("level-{}", parts[3]));
+    for extension in ["image", "content-type", "metadata.json"] {
+        if let Err(error) = fs::remove_file(stem.with_extension(extension)) {
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(error.to_string());
+            }
+        }
+    }
+    Ok(true)
 }
 
 fn community_art_dir(root: &Path, subject_kind: &str) -> PathBuf {

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -1,10 +1,14 @@
 use super::*;
 use axum::{response::IntoResponse as _, routing::post, Router};
 use base64::Engine as _;
+use image::{DynamicImage, ImageBuffer, ImageFormat, Rgba};
 use sha2::{Digest as _, Sha256};
-use std::sync::{
-    atomic::{AtomicBool, AtomicUsize, Ordering},
-    Arc,
+use std::{
+    io::Cursor,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
 };
 
 fn test_art_config() -> ReplicateAvatarArtConfig {
@@ -19,6 +23,22 @@ fn test_art_config() -> ReplicateAvatarArtConfig {
         prompt_prefix: "cozy card art".to_string(),
         output_format: "png".to_string(),
     }
+}
+
+fn gate_png() -> Vec<u8> {
+    let pixels = ImageBuffer::from_fn(16, 9, |x, y| {
+        Rgba([
+            (x as u8).wrapping_mul(17),
+            (y as u8).wrapping_mul(29),
+            (x as u8 ^ y as u8).wrapping_mul(11),
+            255,
+        ])
+    });
+    let mut bytes = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(pixels)
+        .write_to(&mut bytes, ImageFormat::Png)
+        .expect("encode gate PNG");
+    bytes.into_inner()
 }
 
 #[test]
@@ -501,9 +521,7 @@ async fn policy_retry_reuses_the_saved_candidate_without_calling_replicate() {
         public_history: Vec::new(),
         evolution_job: None,
     };
-    let image_bytes = BASE64_STANDARD
-        .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XqgWAAAAAElFTkSuQmCC")
-        .expect("decode retained PNG fixture");
+    let image_bytes = gate_png();
     store_community_art_candidate(
         &generated_dir,
         &plan,

--- a/v2/orchestrator-rust/src/media_recipes.rs
+++ b/v2/orchestrator-rust/src/media_recipes.rs
@@ -18,6 +18,7 @@ use crate::{
 
 #[allow(dead_code)]
 mod assets;
+pub(crate) mod media_verdict;
 pub(super) use self::assets::{
     backfill_legacy_community_asset, canonical_community_media_asset_bytes,
     freeze_approved_community_media_reference, hold_community_media_asset_references,

--- a/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
+++ b/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
@@ -1,0 +1,1134 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard, OnceLock},
+};
+
+use axum::{
+    extract::{Path as AxumPath, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use image::{DynamicImage, ImageFormat};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    moderation_authorized, request_community_art_candidate_replacement,
+    request_room_scene_candidate_replacement, AppState, DownloadedReplicateImage,
+};
+
+const MEDIA_VERDICT_SCHEMA_VERSION: u8 = 1;
+const MEDIA_CHECKER_VERSION: &str = "cosyworld.media-deterministic/1";
+const MEDIA_OPERATOR_REVIEWER_VERSION: &str = "cosyworld.media-operator/1";
+const MEDIA_VERDICT_DIR: &str = "media-verdicts/v1";
+const MAX_CANDIDATES_PER_JOB: usize = 4;
+const MAX_REVIEW_FAILURES: u8 = 3;
+const PROVIDER_COOLDOWN_FAILURES: u8 = 3;
+const PROVIDER_COOLDOWN_MS: u64 = 5 * 60 * 1000;
+
+static MEDIA_VERDICT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct FrozenMediaBrief {
+    pub(crate) schema_version: u8,
+    pub(crate) job_key: String,
+    pub(crate) recipe: String,
+    pub(crate) intended_use: String,
+    pub(crate) prompt_digest: String,
+    pub(crate) expected_content_types: Vec<String>,
+    pub(crate) expected_aspect_ratio: String,
+    pub(crate) min_width: u32,
+    pub(crate) min_height: u32,
+    pub(crate) max_width: u32,
+    pub(crate) max_height: u32,
+    pub(crate) required_subjects: Vec<String>,
+    pub(crate) required_environment: Vec<String>,
+    pub(crate) required_item_holder: Option<String>,
+    pub(crate) crop: String,
+    pub(crate) safe_areas: Vec<String>,
+    pub(crate) forbidden: Vec<String>,
+    pub(crate) pack_negative_constraints: Vec<String>,
+    pub(crate) approved_reference_digests: Vec<String>,
+}
+
+impl FrozenMediaBrief {
+    pub(crate) fn new(
+        job_key: impl Into<String>,
+        recipe: impl Into<String>,
+        intended_use: impl Into<String>,
+        prompt: &str,
+        expected_aspect_ratio: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: MEDIA_VERDICT_SCHEMA_VERSION,
+            job_key: job_key.into(),
+            recipe: recipe.into(),
+            intended_use: intended_use.into(),
+            prompt_digest: sha256_hex(prompt.as_bytes()),
+            expected_content_types: vec![
+                "image/png".to_string(),
+                "image/jpeg".to_string(),
+                "image/webp".to_string(),
+            ],
+            expected_aspect_ratio: expected_aspect_ratio.into(),
+            min_width: 1,
+            min_height: 1,
+            max_width: 8192,
+            max_height: 8192,
+            required_subjects: Vec::new(),
+            required_environment: Vec::new(),
+            required_item_holder: None,
+            crop: "full_frame".to_string(),
+            safe_areas: Vec::new(),
+            forbidden: universal_forbidden_constraints(),
+            pack_negative_constraints: Vec::new(),
+            approved_reference_digests: Vec::new(),
+        }
+    }
+
+    pub(crate) fn digest(&self) -> Result<String, String> {
+        serde_json::to_vec(self)
+            .map(|bytes| sha256_hex(&bytes))
+            .map_err(|error| error.to_string())
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.schema_version != MEDIA_VERDICT_SCHEMA_VERSION
+            || self.job_key.trim().is_empty()
+            || self.job_key.len() > 240
+            || self.recipe.trim().is_empty()
+            || self.intended_use.trim().is_empty()
+            || self.prompt_digest.len() != 64
+            || self.expected_content_types.is_empty()
+            || self.expected_content_types.len() > 4
+            || self.min_width == 0
+            || self.min_height == 0
+            || self.max_width < self.min_width
+            || self.max_height < self.min_height
+        {
+            return Err("generated-image frozen brief is invalid".to_string());
+        }
+        parse_aspect_ratio(&self.expected_aspect_ratio)?;
+        for value in self
+            .required_subjects
+            .iter()
+            .chain(&self.required_environment)
+            .chain(self.required_item_holder.iter())
+            .chain(&self.safe_areas)
+            .chain(&self.forbidden)
+            .chain(&self.pack_negative_constraints)
+        {
+            if value.trim().is_empty() || value.len() > 240 {
+                return Err("generated-image frozen brief has an invalid constraint".to_string());
+            }
+        }
+        if self
+            .approved_reference_digests
+            .iter()
+            .any(|digest| !valid_digest(digest))
+        {
+            return Err("generated-image frozen brief has an invalid reference digest".to_string());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn review_policy(&self) -> String {
+        format!(
+            "Frozen brief digest {}. Intended use: {}. Required subjects: [{}]. Required environment: [{}]. Required item/holder: {}. Crop: {}. Safe areas: [{}]. Forbidden: [{}]. Pack negatives: [{}]. References, in frozen order: [{}].",
+            self.digest().unwrap_or_else(|_| "invalid".to_string()),
+            self.intended_use,
+            self.required_subjects.join("; "),
+            self.required_environment.join("; "),
+            self.required_item_holder.as_deref().unwrap_or("none"),
+            self.crop,
+            self.safe_areas.join("; "),
+            self.forbidden.join("; "),
+            self.pack_negative_constraints.join("; "),
+            self.approved_reference_digests.join(", "),
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MediaVerdictDisposition {
+    ReviewPending,
+    Approved,
+    Rejected,
+    ReplaceRequested,
+    Disabled,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MediaViolation {
+    Corrupt,
+    Blank,
+    Format,
+    Dimensions,
+    AspectRatio,
+    Digest,
+    Safety,
+    Text,
+    Logo,
+    Watermark,
+    SystemLeak,
+    UiChrome,
+    MissingSubject,
+    ExtraSubject,
+    IdentityDrift,
+    MissingItem,
+    WrongHolder,
+    WrongEnvironment,
+    BadCrop,
+    NearDuplicate,
+    PackNegative,
+    OperatorRejected,
+}
+
+impl MediaViolation {
+    pub(crate) fn code(self) -> &'static str {
+        match self {
+            Self::Corrupt => "corrupt",
+            Self::Blank => "blank",
+            Self::Format => "format",
+            Self::Dimensions => "dimensions",
+            Self::AspectRatio => "aspect_ratio",
+            Self::Digest => "digest",
+            Self::Safety => "safety",
+            Self::Text => "text",
+            Self::Logo => "logo",
+            Self::Watermark => "watermark",
+            Self::SystemLeak => "system_leak",
+            Self::UiChrome => "ui_chrome",
+            Self::MissingSubject => "missing_subject",
+            Self::ExtraSubject => "extra_subject",
+            Self::IdentityDrift => "identity_drift",
+            Self::MissingItem => "missing_item",
+            Self::WrongHolder => "wrong_holder",
+            Self::WrongEnvironment => "wrong_environment",
+            Self::BadCrop => "bad_crop",
+            Self::NearDuplicate => "near_duplicate",
+            Self::PackNegative => "pack_negative",
+            Self::OperatorRejected => "operator_rejected",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct MediaVisualVerdict {
+    pub(crate) schema_version: u8,
+    pub(crate) brief_digest: String,
+    pub(crate) candidate_digest: String,
+    pub(crate) reviewer: String,
+    pub(crate) reviewer_version: String,
+    pub(crate) approved: bool,
+    pub(crate) violations: Vec<MediaViolation>,
+    pub(crate) summary: String,
+    pub(crate) reference_digests: Vec<String>,
+    pub(crate) attempts: u8,
+    pub(crate) latency_ms: u64,
+    pub(crate) cost_microusd: u64,
+    pub(crate) reviewed_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct DeterministicMediaVerdict {
+    checker_version: String,
+    checked_at_ms: u64,
+    digest: String,
+    width: Option<u32>,
+    height: Option<u32>,
+    perceptual_hash: Option<u64>,
+    violations: Vec<MediaViolation>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct MediaCandidateProvenance {
+    digest: String,
+    content_type: String,
+    source_url: String,
+    prediction_id: Option<String>,
+    provider: String,
+    model: String,
+    recipe: String,
+    received_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct MediaCandidateVerdict {
+    provenance: MediaCandidateProvenance,
+    deterministic: DeterministicMediaVerdict,
+    visual: Option<MediaVisualVerdict>,
+    disposition: MediaVerdictDisposition,
+    review_failures: u8,
+    last_review_error: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct PersistedMediaVerdict {
+    schema_version: u8,
+    pub(crate) record_id: String,
+    pub(crate) brief: FrozenMediaBrief,
+    pub(crate) brief_digest: String,
+    active_candidate_digest: Option<String>,
+    candidates: Vec<MediaCandidateVerdict>,
+    provider_failures: u8,
+    provider_cooldown_until_ms: Option<u64>,
+    provider_route: String,
+    disabled: bool,
+    updated_at_ms: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MediaCandidateInput<'a> {
+    pub(crate) image: &'a DownloadedReplicateImage,
+    pub(crate) provider: &'a str,
+    pub(crate) model: &'a str,
+    pub(crate) claimed_digest: Option<&'a str>,
+    pub(crate) prior_public_bytes: Option<&'a [u8]>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct MediaVerdictSlice {
+    dimension: String,
+    value: String,
+    candidates: u64,
+    approved: u64,
+    rejected: u64,
+    pending: u64,
+    review_retries: u64,
+    latency_ms: u64,
+    cost_microusd: u64,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct MediaVerdictDashboard {
+    records: u64,
+    candidates: u64,
+    approved: u64,
+    rejected: u64,
+    pending: u64,
+    pass_rate_basis_points: u64,
+    cost_per_approved_microusd: u64,
+    review_latency_ms: u64,
+    retry_spend_microusd: u64,
+    review_retries: u64,
+    provider_failures: u64,
+    cooldown_routes: u64,
+    slices: Vec<MediaVerdictSlice>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct MediaVerdictActionRequest {
+    candidate_digest: String,
+    action: MediaVerdictAction,
+    reason: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum MediaVerdictAction {
+    Approve,
+    Reject,
+    Replace,
+    Disable,
+}
+
+pub(crate) fn prepare_media_candidate(
+    root: &Path,
+    brief: FrozenMediaBrief,
+    input: MediaCandidateInput<'_>,
+) -> Result<MediaVerdictDisposition, String> {
+    brief.validate()?;
+    let brief_digest = brief.digest()?;
+    let digest = sha256_hex(&input.image.bytes);
+    let _guard = media_verdict_lock()?;
+    let mut record = load_or_create_record(root, brief, &brief_digest)?;
+    if record.disabled {
+        return Ok(MediaVerdictDisposition::Disabled);
+    }
+    if let Some(candidate) = record
+        .candidates
+        .iter()
+        .find(|candidate| candidate.provenance.digest == digest)
+    {
+        return Ok(candidate.disposition);
+    }
+    let deterministic = deterministic_verdict(&record.brief, &digest, &input)?;
+    store_candidate_object(root, &record.record_id, &digest, input.image)?;
+    let disposition = if deterministic.violations.is_empty() {
+        MediaVerdictDisposition::ReviewPending
+    } else {
+        MediaVerdictDisposition::Rejected
+    };
+    record.active_candidate_digest = Some(digest.clone());
+    record.provider_failures = 0;
+    record.provider_cooldown_until_ms = None;
+    record.candidates.push(MediaCandidateVerdict {
+        provenance: MediaCandidateProvenance {
+            digest,
+            content_type: input.image.content_type.to_ascii_lowercase(),
+            source_url: input.image.source_url.clone(),
+            prediction_id: input.image.prediction_id.clone(),
+            provider: input.provider.to_string(),
+            model: input.model.to_string(),
+            recipe: record.brief.recipe.clone(),
+            received_at_ms: crate::now_millis(),
+        },
+        deterministic,
+        visual: None,
+        disposition,
+        review_failures: 0,
+        last_review_error: None,
+    });
+    if record.candidates.len() > MAX_CANDIDATES_PER_JOB {
+        record.candidates.remove(0);
+    }
+    store_record(root, &record)?;
+    Ok(disposition)
+}
+
+pub(crate) fn record_media_visual_verdict(
+    root: &Path,
+    job_key: &str,
+    verdict: MediaVisualVerdict,
+) -> Result<MediaVerdictDisposition, String> {
+    let _guard = media_verdict_lock()?;
+    let mut record = load_record_by_job(root, job_key)?;
+    validate_visual_verdict(&record, &verdict)?;
+    let candidate = find_candidate_mut(&mut record, &verdict.candidate_digest)?;
+    candidate.disposition = if verdict.approved {
+        MediaVerdictDisposition::Approved
+    } else {
+        MediaVerdictDisposition::Rejected
+    };
+    candidate.visual = Some(verdict);
+    candidate.last_review_error = None;
+    let disposition = candidate.disposition;
+    store_record(root, &record)?;
+    Ok(disposition)
+}
+
+pub(crate) fn record_media_review_unavailable(
+    root: &Path,
+    job_key: &str,
+    candidate_digest: &str,
+    error: &str,
+) -> Result<(), String> {
+    let _guard = media_verdict_lock()?;
+    let mut record = load_record_by_job(root, job_key)?;
+    let candidate = find_candidate_mut(&mut record, candidate_digest)?;
+    if candidate.disposition == MediaVerdictDisposition::ReviewPending {
+        candidate.review_failures = candidate
+            .review_failures
+            .saturating_add(1)
+            .min(MAX_REVIEW_FAILURES);
+        candidate.last_review_error = Some(bounded_text(error, 240));
+    }
+    store_record(root, &record)
+}
+
+pub(crate) fn media_candidate_digest(root: &Path, job_key: &str) -> Result<Option<String>, String> {
+    Ok(load_record_by_job(root, job_key)?.active_candidate_digest)
+}
+
+pub(crate) fn media_candidate_approved(
+    root: &Path,
+    job_key: &str,
+    candidate_digest: &str,
+) -> Result<bool, String> {
+    let record = load_record_by_job(root, job_key)?;
+    Ok(record.candidates.iter().any(|candidate| {
+        candidate.provenance.digest == candidate_digest
+            && candidate.disposition == MediaVerdictDisposition::Approved
+            && candidate.visual.is_some()
+            && candidate.deterministic.violations.is_empty()
+    }))
+}
+
+pub(crate) fn media_candidate_violations(
+    root: &Path,
+    job_key: &str,
+    candidate_digest: &str,
+) -> Result<Vec<String>, String> {
+    let record = load_record_by_job(root, job_key)?;
+    let candidate = record
+        .candidates
+        .iter()
+        .find(|candidate| candidate.provenance.digest == candidate_digest)
+        .ok_or_else(|| "media verdict candidate was not found".to_string())?;
+    Ok(candidate
+        .deterministic
+        .violations
+        .iter()
+        .chain(
+            candidate
+                .visual
+                .iter()
+                .flat_map(|verdict| &verdict.violations),
+        )
+        .map(|violation| violation.code().to_string())
+        .collect())
+}
+
+pub(crate) fn record_media_provider_failure(
+    root: &Path,
+    brief: FrozenMediaBrief,
+    route: &str,
+) -> Result<(), String> {
+    brief.validate()?;
+    let digest = brief.digest()?;
+    let _guard = media_verdict_lock()?;
+    let mut record = load_or_create_record(root, brief, &digest)?;
+    record.provider_route = bounded_text(route, 120);
+    record.provider_failures = record.provider_failures.saturating_add(1);
+    if record.provider_failures >= PROVIDER_COOLDOWN_FAILURES {
+        record.provider_cooldown_until_ms =
+            Some(crate::now_millis().saturating_add(PROVIDER_COOLDOWN_MS));
+    }
+    store_record(root, &record)
+}
+
+pub(crate) fn media_provider_route_available(root: &Path, job_key: &str) -> Result<bool, String> {
+    match load_record_by_job(root, job_key) {
+        Ok(record) => Ok(!record.disabled
+            && record
+                .provider_cooldown_until_ms
+                .is_none_or(|until| until <= crate::now_millis())),
+        Err(error) if error.contains("not found") => Ok(true),
+        Err(error) => Err(error),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn make_visual_verdict(
+    brief: &FrozenMediaBrief,
+    candidate_digest: String,
+    reviewer: impl Into<String>,
+    reviewer_version: impl Into<String>,
+    approved: bool,
+    violations: Vec<MediaViolation>,
+    summary: impl Into<String>,
+    attempts: u8,
+    latency_ms: u64,
+    cost_microusd: u64,
+) -> Result<MediaVisualVerdict, String> {
+    Ok(MediaVisualVerdict {
+        schema_version: MEDIA_VERDICT_SCHEMA_VERSION,
+        brief_digest: brief.digest()?,
+        candidate_digest,
+        reviewer: reviewer.into(),
+        reviewer_version: reviewer_version.into(),
+        approved,
+        violations,
+        summary: bounded_text(&summary.into(), 240),
+        reference_digests: brief.approved_reference_digests.clone(),
+        attempts,
+        latency_ms,
+        cost_microusd,
+        reviewed_at_ms: crate::now_millis(),
+    })
+}
+
+pub(crate) fn media_verdict_dashboard(root: &Path) -> Result<MediaVerdictDashboard, String> {
+    let records = list_records(root)?;
+    let mut dashboard = MediaVerdictDashboard {
+        records: records.len() as u64,
+        ..MediaVerdictDashboard::default()
+    };
+    let mut slices = BTreeMap::<(String, String), MediaVerdictSlice>::new();
+    for record in records {
+        dashboard.provider_failures += u64::from(record.provider_failures);
+        dashboard.cooldown_routes += u64::from(
+            record
+                .provider_cooldown_until_ms
+                .is_some_and(|until| until > crate::now_millis()),
+        );
+        for candidate in record.candidates {
+            dashboard.candidates += 1;
+            dashboard.review_retries += u64::from(candidate.review_failures);
+            tally_outcome(
+                candidate.disposition,
+                &mut dashboard.approved,
+                &mut dashboard.rejected,
+                &mut dashboard.pending,
+            );
+            let reviewer = candidate
+                .visual
+                .as_ref()
+                .map(|verdict| verdict.reviewer.as_str())
+                .unwrap_or("pending");
+            for (dimension, value) in [
+                ("provider", candidate.provenance.provider.as_str()),
+                ("model", candidate.provenance.model.as_str()),
+                ("recipe", candidate.provenance.recipe.as_str()),
+                ("profile", record.brief.recipe.as_str()),
+                ("intended_use", record.brief.intended_use.as_str()),
+                ("reviewer", reviewer),
+                ("outcome", disposition_name(candidate.disposition)),
+            ] {
+                let slice = slices
+                    .entry((dimension.to_string(), value.to_string()))
+                    .or_insert_with(|| MediaVerdictSlice {
+                        dimension: dimension.to_string(),
+                        value: value.to_string(),
+                        candidates: 0,
+                        approved: 0,
+                        rejected: 0,
+                        pending: 0,
+                        review_retries: 0,
+                        latency_ms: 0,
+                        cost_microusd: 0,
+                    });
+                slice.candidates += 1;
+                slice.review_retries += u64::from(candidate.review_failures);
+                tally_outcome(
+                    candidate.disposition,
+                    &mut slice.approved,
+                    &mut slice.rejected,
+                    &mut slice.pending,
+                );
+                if let Some(verdict) = &candidate.visual {
+                    slice.latency_ms += verdict.latency_ms;
+                    slice.cost_microusd += verdict.cost_microusd;
+                }
+            }
+            for violation in candidate.deterministic.violations.iter().chain(
+                candidate
+                    .visual
+                    .iter()
+                    .flat_map(|verdict| &verdict.violations),
+            ) {
+                let key = ("violation".to_string(), violation.code().to_string());
+                let slice = slices
+                    .entry(key.clone())
+                    .or_insert_with(|| MediaVerdictSlice {
+                        dimension: key.0,
+                        value: key.1,
+                        candidates: 0,
+                        approved: 0,
+                        rejected: 0,
+                        pending: 0,
+                        review_retries: 0,
+                        latency_ms: 0,
+                        cost_microusd: 0,
+                    });
+                slice.candidates += 1;
+                tally_outcome(
+                    candidate.disposition,
+                    &mut slice.approved,
+                    &mut slice.rejected,
+                    &mut slice.pending,
+                );
+            }
+            if let Some(verdict) = &candidate.visual {
+                dashboard.review_latency_ms += verdict.latency_ms;
+                dashboard.cost_per_approved_microusd += verdict.cost_microusd;
+                dashboard.retry_spend_microusd += verdict
+                    .cost_microusd
+                    .saturating_mul(u64::from(verdict.attempts.saturating_sub(1)))
+                    / u64::from(verdict.attempts);
+            }
+        }
+    }
+    dashboard.pass_rate_basis_points = dashboard
+        .approved
+        .saturating_mul(10_000)
+        .checked_div(dashboard.candidates)
+        .unwrap_or(0);
+    dashboard.cost_per_approved_microusd = dashboard
+        .cost_per_approved_microusd
+        .checked_div(dashboard.approved)
+        .unwrap_or(0);
+    dashboard.slices = slices.into_values().collect();
+    Ok(dashboard)
+}
+
+pub(crate) async fn moderation_media_verdicts(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Response {
+    if !moderation_authorized(&state, &headers) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    match media_verdict_dashboard(&state.generated_asset_dir) {
+        Ok(dashboard) => Json(dashboard).into_response(),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+    }
+}
+
+pub(crate) async fn moderation_media_verdict(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    AxumPath(record_id): AxumPath<String>,
+) -> Response {
+    if !moderation_authorized(&state, &headers) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    match load_record(&state.generated_asset_dir, &record_id) {
+        Ok(record) => Json(record).into_response(),
+        Err(error) => (StatusCode::NOT_FOUND, error).into_response(),
+    }
+}
+
+pub(crate) async fn moderation_update_media_verdict(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    AxumPath(record_id): AxumPath<String>,
+    Json(action): Json<MediaVerdictActionRequest>,
+) -> Response {
+    if !moderation_authorized(&state, &headers) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    let replace = action.action == MediaVerdictAction::Replace;
+    let reason = action.reason.clone();
+    match apply_operator_action(&state.generated_asset_dir, &record_id, action) {
+        Ok(record) => {
+            if replace
+                && request_room_scene_candidate_replacement(
+                    &state.generated_asset_dir,
+                    &record.brief.job_key,
+                    &reason,
+                )
+                .and_then(|room_scene| {
+                    if room_scene {
+                        Ok(true)
+                    } else {
+                        request_community_art_candidate_replacement(
+                            &state.generated_asset_dir,
+                            &record.brief.job_key,
+                        )
+                    }
+                })
+                .is_err()
+            {
+                return (
+                    StatusCode::CONFLICT,
+                    "replacement could not reset the private candidate",
+                )
+                    .into_response();
+            }
+            Json(record).into_response()
+        }
+        Err(error) => (StatusCode::CONFLICT, error).into_response(),
+    }
+}
+
+fn apply_operator_action(
+    root: &Path,
+    record_id: &str,
+    action: MediaVerdictActionRequest,
+) -> Result<PersistedMediaVerdict, String> {
+    // Operator approval records a verdict only. The owning job must retry and
+    // atomically publish after `media_candidate_approved`; this endpoint never
+    // mutates the public asset graph.
+    let _guard = media_verdict_lock()?;
+    let mut record = load_record(root, record_id)?;
+    let brief = record.brief.clone();
+    if matches!(action.action, MediaVerdictAction::Disable) {
+        record.disabled = true;
+    }
+    let candidate = find_candidate_mut(&mut record, &action.candidate_digest)?;
+    match action.action {
+        MediaVerdictAction::Approve | MediaVerdictAction::Reject => {
+            if !candidate.deterministic.violations.is_empty() {
+                return Err("operator cannot override deterministic image failures".to_string());
+            }
+            let approved = matches!(action.action, MediaVerdictAction::Approve);
+            let verdict = make_visual_verdict(
+                &brief,
+                action.candidate_digest,
+                "operator",
+                MEDIA_OPERATOR_REVIEWER_VERSION,
+                approved,
+                (!approved)
+                    .then_some(MediaViolation::OperatorRejected)
+                    .into_iter()
+                    .collect(),
+                action.reason,
+                1,
+                0,
+                0,
+            )?;
+            candidate.visual = Some(verdict);
+            candidate.disposition = if approved {
+                MediaVerdictDisposition::Approved
+            } else {
+                MediaVerdictDisposition::Rejected
+            };
+        }
+        MediaVerdictAction::Replace => {
+            candidate.disposition = MediaVerdictDisposition::ReplaceRequested;
+            candidate.last_review_error = Some(bounded_text(&action.reason, 240));
+        }
+        MediaVerdictAction::Disable => {
+            candidate.disposition = MediaVerdictDisposition::Disabled;
+        }
+    }
+    store_record(root, &record)?;
+    Ok(record)
+}
+
+fn deterministic_verdict(
+    brief: &FrozenMediaBrief,
+    digest: &str,
+    input: &MediaCandidateInput<'_>,
+) -> Result<DeterministicMediaVerdict, String> {
+    let content_type = input.image.content_type.trim().to_ascii_lowercase();
+    let mut violations = Vec::new();
+    if input
+        .claimed_digest
+        .is_some_and(|claimed| claimed != digest)
+    {
+        violations.push(MediaViolation::Digest);
+    }
+    let expected_format = format_for_mime(&content_type);
+    if !brief.expected_content_types.contains(&content_type) || expected_format.is_none() {
+        violations.push(MediaViolation::Format);
+    }
+    if expected_format.is_some()
+        && image::guess_format(&input.image.bytes)
+            .ok()
+            .is_some_and(|actual| Some(actual) != expected_format)
+    {
+        violations.push(MediaViolation::Format);
+    }
+    let decoded = expected_format
+        .and_then(|format| image::load_from_memory_with_format(&input.image.bytes, format).ok());
+    let (width, height, perceptual_hash) = match decoded.as_ref() {
+        Some(image) => {
+            let (width, height) = (image.width(), image.height());
+            if width < brief.min_width
+                || height < brief.min_height
+                || width > brief.max_width
+                || height > brief.max_height
+            {
+                violations.push(MediaViolation::Dimensions);
+            }
+            let (aspect_width, aspect_height) = parse_aspect_ratio(&brief.expected_aspect_ratio)?;
+            let expected = f64::from(aspect_width) / f64::from(aspect_height);
+            let actual = f64::from(width) / f64::from(height);
+            if ((actual - expected) / expected).abs() > 0.03 {
+                violations.push(MediaViolation::AspectRatio);
+            }
+            if image_is_blank(image) {
+                violations.push(MediaViolation::Blank);
+            }
+            (Some(width), Some(height), Some(perceptual_hash64(image)))
+        }
+        None => {
+            violations.push(MediaViolation::Corrupt);
+            (None, None, None)
+        }
+    };
+    if let (Some(prior), Some(candidate_hash)) = (input.prior_public_bytes, perceptual_hash) {
+        if let Ok(prior_image) = image::load_from_memory(prior) {
+            if (candidate_hash ^ perceptual_hash64(&prior_image)).count_ones() <= 2 {
+                violations.push(MediaViolation::NearDuplicate);
+            }
+        }
+    }
+    violations.sort();
+    violations.dedup();
+    Ok(DeterministicMediaVerdict {
+        checker_version: MEDIA_CHECKER_VERSION.to_string(),
+        checked_at_ms: crate::now_millis(),
+        digest: digest.to_string(),
+        width,
+        height,
+        perceptual_hash,
+        violations,
+    })
+}
+
+fn validate_visual_verdict(
+    record: &PersistedMediaVerdict,
+    verdict: &MediaVisualVerdict,
+) -> Result<(), String> {
+    if verdict.schema_version != MEDIA_VERDICT_SCHEMA_VERSION
+        || verdict.brief_digest != record.brief_digest
+        || verdict.reviewer.trim().is_empty()
+        || verdict.reviewer.len() > 120
+        || verdict.reviewer_version.trim().is_empty()
+        || verdict.reviewer_version.len() > 120
+        || verdict.summary.trim().is_empty()
+        || verdict.summary.len() > 240
+        || verdict.attempts == 0
+        || verdict.attempts > MAX_REVIEW_FAILURES
+        || verdict.approved != verdict.violations.is_empty()
+        || verdict.reference_digests != record.brief.approved_reference_digests
+    {
+        return Err(
+            "visual reviewer verdict is invalid or not bound to the frozen brief".to_string(),
+        );
+    }
+    if !record
+        .candidates
+        .iter()
+        .any(|candidate| candidate.provenance.digest == verdict.candidate_digest)
+    {
+        return Err("visual reviewer verdict names an unknown candidate".to_string());
+    }
+    Ok(())
+}
+
+fn image_is_blank(image: &DynamicImage) -> bool {
+    let rgba = image.thumbnail_exact(32, 32).to_rgba8();
+    let mut minimum = [u8::MAX; 4];
+    let mut maximum = [u8::MIN; 4];
+    for pixel in rgba.pixels() {
+        for channel in 0..4 {
+            minimum[channel] = minimum[channel].min(pixel[channel]);
+            maximum[channel] = maximum[channel].max(pixel[channel]);
+        }
+    }
+    (0..3).all(|channel| maximum[channel].saturating_sub(minimum[channel]) <= 2)
+}
+
+fn perceptual_hash64(image: &DynamicImage) -> u64 {
+    let gray = image.thumbnail_exact(8, 8).to_luma8();
+    let average =
+        gray.pixels().map(|pixel| u64::from(pixel[0])).sum::<u64>() / gray.pixels().len() as u64;
+    gray.pixels()
+        .enumerate()
+        .fold(0_u64, |hash, (index, pixel)| {
+            hash | (u64::from(u64::from(pixel[0]) >= average) << index)
+        })
+}
+
+fn format_for_mime(content_type: &str) -> Option<ImageFormat> {
+    match content_type {
+        "image/png" => Some(ImageFormat::Png),
+        "image/jpeg" => Some(ImageFormat::Jpeg),
+        "image/webp" => Some(ImageFormat::WebP),
+        "image/gif" => Some(ImageFormat::Gif),
+        _ => None,
+    }
+}
+
+fn parse_aspect_ratio(value: &str) -> Result<(u32, u32), String> {
+    let (width, height) = value
+        .split_once(':')
+        .ok_or_else(|| "generated-image aspect ratio must be W:H".to_string())?;
+    let width = width
+        .parse::<u32>()
+        .map_err(|_| "generated-image aspect ratio width is invalid".to_string())?;
+    let height = height
+        .parse::<u32>()
+        .map_err(|_| "generated-image aspect ratio height is invalid".to_string())?;
+    if width == 0 || height == 0 {
+        return Err("generated-image aspect ratio cannot contain zero".to_string());
+    }
+    Ok((width, height))
+}
+
+fn load_or_create_record(
+    root: &Path,
+    brief: FrozenMediaBrief,
+    brief_digest: &str,
+) -> Result<PersistedMediaVerdict, String> {
+    let record_id = sha256_hex(brief.job_key.as_bytes());
+    match load_record(root, &record_id) {
+        Ok(record) => {
+            if record.brief_digest != brief_digest || record.brief != brief {
+                return Err("generated-image frozen brief changed for an existing job".to_string());
+            }
+            Ok(record)
+        }
+        Err(error) if error.contains("not found") => Ok(PersistedMediaVerdict {
+            schema_version: MEDIA_VERDICT_SCHEMA_VERSION,
+            record_id,
+            brief,
+            brief_digest: brief_digest.to_string(),
+            active_candidate_digest: None,
+            candidates: Vec::new(),
+            provider_failures: 0,
+            provider_cooldown_until_ms: None,
+            provider_route: "primary".to_string(),
+            disabled: false,
+            updated_at_ms: crate::now_millis(),
+        }),
+        Err(error) => Err(error),
+    }
+}
+
+fn load_record_by_job(root: &Path, job_key: &str) -> Result<PersistedMediaVerdict, String> {
+    load_record(root, &sha256_hex(job_key.as_bytes()))
+}
+
+fn load_record(root: &Path, record_id: &str) -> Result<PersistedMediaVerdict, String> {
+    if !valid_digest(record_id) {
+        return Err("media verdict record id is invalid".to_string());
+    }
+    let path = record_path(root, record_id);
+    let bytes = fs::read(&path).map_err(|error| {
+        format!(
+            "media verdict record not found at {}: {error}",
+            path.display()
+        )
+    })?;
+    let record: PersistedMediaVerdict =
+        serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
+    if record.schema_version != MEDIA_VERDICT_SCHEMA_VERSION
+        || record.record_id != record_id
+        || record.brief.digest()? != record.brief_digest
+    {
+        return Err("media verdict record failed its identity check".to_string());
+    }
+    Ok(record)
+}
+
+fn list_records(root: &Path) -> Result<Vec<PersistedMediaVerdict>, String> {
+    let directory = root.join(MEDIA_VERDICT_DIR);
+    let Ok(entries) = fs::read_dir(directory) else {
+        return Ok(Vec::new());
+    };
+    let mut records = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let Some(record_id) = entry.file_name().to_str().map(ToString::to_string) else {
+            continue;
+        };
+        if valid_digest(&record_id) && entry.path().is_dir() {
+            records.push(load_record(root, &record_id)?);
+        }
+    }
+    Ok(records)
+}
+
+fn store_record(root: &Path, record: &PersistedMediaVerdict) -> Result<(), String> {
+    let mut record = record.clone();
+    record.updated_at_ms = crate::now_millis();
+    atomic_write(
+        &record_path(root, &record.record_id),
+        &serde_json::to_vec(&record).map_err(|error| error.to_string())?,
+    )
+}
+
+fn store_candidate_object(
+    root: &Path,
+    record_id: &str,
+    digest: &str,
+    image: &DownloadedReplicateImage,
+) -> Result<(), String> {
+    let directory = record_dir(root, record_id).join("candidates");
+    atomic_write(&directory.join(format!("{digest}.image")), &image.bytes)?;
+    atomic_write(
+        &directory.join(format!("{digest}.metadata.json")),
+        &serde_json::to_vec(&serde_json::json!({
+            "schema_version": MEDIA_VERDICT_SCHEMA_VERSION,
+            "digest": digest,
+            "content_type": image.content_type,
+            "source_url": image.source_url,
+            "prediction_id": image.prediction_id,
+        }))
+        .map_err(|error| error.to_string())?,
+    )
+}
+
+fn find_candidate_mut<'a>(
+    record: &'a mut PersistedMediaVerdict,
+    digest: &str,
+) -> Result<&'a mut MediaCandidateVerdict, String> {
+    record
+        .candidates
+        .iter_mut()
+        .find(|candidate| candidate.provenance.digest == digest)
+        .ok_or_else(|| "media verdict candidate was not found".to_string())
+}
+
+fn media_verdict_lock() -> Result<MutexGuard<'static, ()>, String> {
+    MEDIA_VERDICT_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| "media verdict lock was poisoned".to_string())
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "media verdict path has no parent".to_string())?;
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let temporary = path.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        crate::now_millis()
+    ));
+    fs::write(&temporary, bytes).map_err(|error| error.to_string())?;
+    fs::rename(&temporary, path).map_err(|error| error.to_string())
+}
+
+fn record_dir(root: &Path, record_id: &str) -> PathBuf {
+    root.join(MEDIA_VERDICT_DIR).join(record_id)
+}
+
+fn record_path(root: &Path, record_id: &str) -> PathBuf {
+    record_dir(root, record_id).join("record.json")
+}
+
+fn universal_forbidden_constraints() -> Vec<String> {
+    [
+        "unsafe or sexual content",
+        "visible text",
+        "logo",
+        "watermark",
+        "system prompt or private data",
+        "application UI or screenshot chrome",
+        "unrequested subjects or props",
+    ]
+    .into_iter()
+    .map(ToString::to_string)
+    .collect()
+}
+
+fn disposition_name(disposition: MediaVerdictDisposition) -> &'static str {
+    match disposition {
+        MediaVerdictDisposition::ReviewPending => "review_pending",
+        MediaVerdictDisposition::Approved => "approved",
+        MediaVerdictDisposition::Rejected => "rejected",
+        MediaVerdictDisposition::ReplaceRequested => "replace_requested",
+        MediaVerdictDisposition::Disabled => "disabled",
+    }
+}
+
+fn tally_outcome(
+    disposition: MediaVerdictDisposition,
+    approved: &mut u64,
+    rejected: &mut u64,
+    pending: &mut u64,
+) {
+    match disposition {
+        MediaVerdictDisposition::Approved => *approved += 1,
+        MediaVerdictDisposition::Rejected => *rejected += 1,
+        MediaVerdictDisposition::ReviewPending
+        | MediaVerdictDisposition::ReplaceRequested
+        | MediaVerdictDisposition::Disabled => *pending += 1,
+    }
+}
+
+fn bounded_text(value: &str, maximum: usize) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(maximum)
+        .collect()
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
+}
+
+#[cfg(test)]
+#[path = "../media_verdict_tests.rs"]
+mod tests;

--- a/v2/orchestrator-rust/src/media_verdict_tests.rs
+++ b/v2/orchestrator-rust/src/media_verdict_tests.rs
@@ -1,0 +1,445 @@
+use super::*;
+use image::{DynamicImage, ImageBuffer, ImageFormat, Rgba};
+use std::{
+    io::Cursor,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+static NEXT_ROOT: AtomicU64 = AtomicU64::new(1);
+
+fn root(label: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "cosyworld-media-verdict-{label}-{}-{}",
+        std::process::id(),
+        NEXT_ROOT.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_dir_all(&root);
+    root
+}
+
+fn patterned_png(width: u32, height: u32, seed: u8) -> Vec<u8> {
+    let pixels = ImageBuffer::from_fn(width, height, |x, y| {
+        Rgba([
+            (x as u8).wrapping_mul(17).wrapping_add(seed),
+            (y as u8).wrapping_mul(29).wrapping_add(seed),
+            (x as u8 ^ y as u8).wrapping_mul(11),
+            255,
+        ])
+    });
+    let mut bytes = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(pixels)
+        .write_to(&mut bytes, ImageFormat::Png)
+        .expect("encode patterned PNG");
+    bytes.into_inner()
+}
+
+fn solid_png(width: u32, height: u32) -> Vec<u8> {
+    let pixels = ImageBuffer::from_pixel(width, height, Rgba([12, 12, 12, 255]));
+    let mut bytes = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(pixels)
+        .write_to(&mut bytes, ImageFormat::Png)
+        .expect("encode solid PNG");
+    bytes.into_inner()
+}
+
+fn image(bytes: Vec<u8>, content_type: &str, prediction: &str) -> DownloadedReplicateImage {
+    DownloadedReplicateImage {
+        bytes,
+        content_type: content_type.to_string(),
+        source_url: format!("https://provider.invalid/{prediction}"),
+        prediction_id: Some(prediction.to_string()),
+    }
+}
+
+fn brief(job: &str) -> FrozenMediaBrief {
+    let mut brief = FrozenMediaBrief::new(
+        job,
+        "cosyworld.test-recipe/1",
+        "public test image",
+        "A two-subject scene in a rainy cottage, without text.",
+        "16:9",
+    );
+    brief.required_subjects = vec!["actor 1".to_string(), "actor 2".to_string()];
+    brief.required_environment = vec!["rainy cottage".to_string()];
+    brief.required_item_holder = Some("lantern held by actor 1".to_string());
+    brief.crop = "full room, heads and lantern visible".to_string();
+    brief.safe_areas = vec!["faces inside center 80%".to_string()];
+    brief.pack_negative_constraints = vec!["no modern electronics".to_string()];
+    brief
+}
+
+fn prepare(
+    root: &Path,
+    brief: FrozenMediaBrief,
+    image: &DownloadedReplicateImage,
+    claimed_digest: Option<&str>,
+    prior: Option<&[u8]>,
+) -> MediaVerdictDisposition {
+    prepare_media_candidate(
+        root,
+        brief,
+        MediaCandidateInput {
+            image,
+            provider: "fixture-provider",
+            model: "fixture-model",
+            claimed_digest,
+            prior_public_bytes: prior,
+        },
+    )
+    .expect("prepare candidate")
+}
+
+#[test]
+fn deterministic_gate_rejects_corrupt_blank_format_dimensions_aspect_digest_and_duplicate() {
+    struct Case {
+        name: &'static str,
+        bytes: Vec<u8>,
+        content_type: &'static str,
+        mutate: fn(&mut FrozenMediaBrief),
+        claimed: Option<String>,
+        prior: Option<Vec<u8>>,
+        violation: MediaViolation,
+    }
+    let good = patterned_png(16, 9, 3);
+    let cases = vec![
+        Case {
+            name: "corrupt",
+            bytes: b"not an image".to_vec(),
+            content_type: "image/png",
+            mutate: |_| {},
+            claimed: None,
+            prior: None,
+            violation: MediaViolation::Corrupt,
+        },
+        Case {
+            name: "blank",
+            bytes: solid_png(16, 9),
+            content_type: "image/png",
+            mutate: |_| {},
+            claimed: None,
+            prior: None,
+            violation: MediaViolation::Blank,
+        },
+        Case {
+            name: "format",
+            bytes: good.clone(),
+            content_type: "image/jpeg",
+            mutate: |_| {},
+            claimed: None,
+            prior: None,
+            violation: MediaViolation::Format,
+        },
+        Case {
+            name: "dimensions",
+            bytes: good.clone(),
+            content_type: "image/png",
+            mutate: |brief| brief.min_width = 32,
+            claimed: None,
+            prior: None,
+            violation: MediaViolation::Dimensions,
+        },
+        Case {
+            name: "aspect",
+            bytes: good.clone(),
+            content_type: "image/png",
+            mutate: |brief| brief.expected_aspect_ratio = "1:1".to_string(),
+            claimed: None,
+            prior: None,
+            violation: MediaViolation::AspectRatio,
+        },
+        Case {
+            name: "digest",
+            bytes: good.clone(),
+            content_type: "image/png",
+            mutate: |_| {},
+            claimed: Some("0".repeat(64)),
+            prior: None,
+            violation: MediaViolation::Digest,
+        },
+        Case {
+            name: "near-duplicate",
+            bytes: good.clone(),
+            content_type: "image/png",
+            mutate: |_| {},
+            claimed: None,
+            prior: Some(good),
+            violation: MediaViolation::NearDuplicate,
+        },
+    ];
+    for case in cases {
+        let root = root(case.name);
+        let job = format!("deterministic-{}", case.name);
+        let mut frozen = brief(&job);
+        (case.mutate)(&mut frozen);
+        let candidate = image(case.bytes, case.content_type, case.name);
+        assert_eq!(
+            prepare(
+                &root,
+                frozen,
+                &candidate,
+                case.claimed.as_deref(),
+                case.prior.as_deref()
+            ),
+            MediaVerdictDisposition::Rejected,
+            "{} must fail closed",
+            case.name
+        );
+        assert!(
+            media_candidate_violations(&root, &job, &sha256_hex(&candidate.bytes))
+                .expect("read deterministic verdict")
+                .contains(&case.violation.code().to_string()),
+            "{} verdict must name {:?}",
+            case.name,
+            case.violation
+        );
+        assert!(
+            record_dir(&root, &sha256_hex(job.as_bytes()))
+                .join("candidates")
+                .join(format!("{}.image", sha256_hex(&candidate.bytes)))
+                .exists(),
+            "failed candidate remains privately inspectable"
+        );
+    }
+}
+
+#[test]
+fn visual_verdict_is_versioned_bounded_and_covers_semantic_failure_taxonomy() {
+    let root = root("semantic");
+    let frozen = brief("semantic-job");
+    let candidate = image(patterned_png(16, 9, 8), "image/png", "semantic");
+    assert_eq!(
+        prepare(&root, frozen.clone(), &candidate, None, None),
+        MediaVerdictDisposition::ReviewPending
+    );
+    let digest = sha256_hex(&candidate.bytes);
+    let violations = vec![
+        MediaViolation::Safety,
+        MediaViolation::Text,
+        MediaViolation::Logo,
+        MediaViolation::Watermark,
+        MediaViolation::SystemLeak,
+        MediaViolation::UiChrome,
+        MediaViolation::MissingSubject,
+        MediaViolation::ExtraSubject,
+        MediaViolation::IdentityDrift,
+        MediaViolation::MissingItem,
+        MediaViolation::WrongHolder,
+        MediaViolation::WrongEnvironment,
+        MediaViolation::BadCrop,
+        MediaViolation::PackNegative,
+    ];
+    let verdict = make_visual_verdict(
+        &frozen,
+        digest.clone(),
+        "fixture-reviewer",
+        "fixture-reviewer/7",
+        false,
+        violations.clone(),
+        "Visible semantic violations against the frozen brief.",
+        2,
+        170,
+        25,
+    )
+    .expect("build verdict");
+    assert_eq!(
+        record_media_visual_verdict(&root, "semantic-job", verdict),
+        Ok(MediaVerdictDisposition::Rejected)
+    );
+    let codes = media_candidate_violations(&root, "semantic-job", &digest).unwrap();
+    for violation in violations {
+        assert!(codes.contains(&violation.code().to_string()));
+    }
+    let dashboard = media_verdict_dashboard(&root).unwrap();
+    assert_eq!(dashboard.review_latency_ms, 170);
+    assert_eq!(dashboard.retry_spend_microusd, 12);
+    for (dimension, value) in [
+        ("model", "fixture-model"),
+        ("profile", "cosyworld.test-recipe/1"),
+        ("intended_use", "public test image"),
+        ("violation", "wrong_holder"),
+    ] {
+        assert!(dashboard
+            .slices
+            .iter()
+            .any(|slice| slice.dimension == dimension && slice.value == value));
+    }
+    assert!(!media_candidate_approved(&root, "semantic-job", &digest).unwrap());
+}
+
+#[test]
+fn approved_verdict_survives_restart_and_is_bound_to_brief_candidate_and_references() {
+    let root = root("restart");
+    let mut frozen = brief("restart-job");
+    frozen.approved_reference_digests = vec!["a".repeat(64), "b".repeat(64)];
+    let candidate = image(patterned_png(16, 9, 11), "image/png", "restart");
+    assert_eq!(
+        prepare(&root, frozen.clone(), &candidate, None, None),
+        MediaVerdictDisposition::ReviewPending
+    );
+    let digest = sha256_hex(&candidate.bytes);
+    assert!(
+        !media_candidate_approved(&root, "restart-job", &digest).unwrap(),
+        "publication is impossible before a persisted visual verdict"
+    );
+    let verdict = make_visual_verdict(
+        &frozen,
+        digest.clone(),
+        "fixture-reviewer",
+        "fixture-reviewer/1",
+        true,
+        Vec::new(),
+        "Candidate matches the frozen brief and both references.",
+        1,
+        42,
+        9,
+    )
+    .unwrap();
+    record_media_visual_verdict(&root, "restart-job", verdict).unwrap();
+    assert!(media_candidate_approved(&root, "restart-job", &digest).unwrap());
+    let dashboard = media_verdict_dashboard(&root).unwrap();
+    assert_eq!(dashboard.pass_rate_basis_points, 10_000);
+    assert_eq!(dashboard.cost_per_approved_microusd, 9);
+    assert_eq!(dashboard.review_latency_ms, 42);
+    assert_eq!(dashboard.retry_spend_microusd, 0);
+    assert_eq!(
+        prepare(&root, frozen.clone(), &candidate, None, None),
+        MediaVerdictDisposition::Approved,
+        "idempotent replay reuses the durable verdict"
+    );
+    let mut changed = frozen.clone();
+    changed.crop = "different crop".to_string();
+    assert!(prepare_media_candidate(
+        &root,
+        changed,
+        MediaCandidateInput {
+            image: &candidate,
+            provider: "fixture-provider",
+            model: "fixture-model",
+            claimed_digest: None,
+            prior_public_bytes: None,
+        }
+    )
+    .is_err());
+    let mut wrong = make_visual_verdict(
+        &frozen,
+        "f".repeat(64),
+        "fixture-reviewer",
+        "fixture-reviewer/1",
+        true,
+        Vec::new(),
+        "Wrong candidate.",
+        1,
+        0,
+        0,
+    )
+    .unwrap();
+    wrong.reference_digests.reverse();
+    assert!(record_media_visual_verdict(&root, "restart-job", wrong).is_err());
+}
+
+#[test]
+fn reviewer_outage_reuses_one_candidate_and_provider_failures_enter_cooldown() {
+    let root = root("outage");
+    let frozen = brief("outage-job");
+    let candidate = image(patterned_png(16, 9, 17), "image/png", "outage");
+    assert_eq!(
+        prepare(&root, frozen.clone(), &candidate, None, None),
+        MediaVerdictDisposition::ReviewPending
+    );
+    let digest = sha256_hex(&candidate.bytes);
+    for attempt in 0..7 {
+        record_media_review_unavailable(
+            &root,
+            "outage-job",
+            &digest,
+            &format!("review transport unavailable {attempt}"),
+        )
+        .unwrap();
+        assert_eq!(
+            prepare(&root, frozen.clone(), &candidate, None, None),
+            MediaVerdictDisposition::ReviewPending
+        );
+    }
+    for _ in 0..PROVIDER_COOLDOWN_FAILURES {
+        record_media_provider_failure(&root, frozen.clone(), "primary").unwrap();
+    }
+    assert!(!media_provider_route_available(&root, "outage-job").unwrap());
+    let dashboard = media_verdict_dashboard(&root).unwrap();
+    assert_eq!(dashboard.candidates, 1);
+    assert_eq!(dashboard.review_retries, u64::from(MAX_REVIEW_FAILURES));
+    assert_eq!(dashboard.cooldown_routes, 1);
+    assert!(dashboard
+        .slices
+        .iter()
+        .any(|slice| slice.dimension == "provider" && slice.value == "fixture-provider"));
+}
+
+#[test]
+fn operator_can_approve_reject_replace_or_disable_without_publication_side_effects() {
+    for (name, action, expected) in [
+        (
+            "approve",
+            MediaVerdictAction::Approve,
+            MediaVerdictDisposition::Approved,
+        ),
+        (
+            "reject",
+            MediaVerdictAction::Reject,
+            MediaVerdictDisposition::Rejected,
+        ),
+        (
+            "replace",
+            MediaVerdictAction::Replace,
+            MediaVerdictDisposition::ReplaceRequested,
+        ),
+        (
+            "disable",
+            MediaVerdictAction::Disable,
+            MediaVerdictDisposition::Disabled,
+        ),
+    ] {
+        let root = root(name);
+        let job = format!("operator-{name}");
+        let frozen = brief(&job);
+        let candidate = image(patterned_png(16, 9, name.len() as u8), "image/png", name);
+        assert_eq!(
+            prepare(&root, frozen, &candidate, None, None),
+            MediaVerdictDisposition::ReviewPending
+        );
+        let digest = sha256_hex(&candidate.bytes);
+        let record = apply_operator_action(
+            &root,
+            &sha256_hex(job.as_bytes()),
+            MediaVerdictActionRequest {
+                candidate_digest: digest.clone(),
+                action,
+                reason: format!("operator {name} fixture"),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            record
+                .candidates
+                .iter()
+                .find(|candidate| candidate.provenance.digest == digest)
+                .unwrap()
+                .disposition,
+            expected
+        );
+        if action == MediaVerdictAction::Approve {
+            assert!(media_candidate_approved(&root, &job, &digest).unwrap());
+        }
+        assert!(
+            !root.join("media-assets/graph-v1.json").exists(),
+            "operator approval is verdict-only; a separate job retry publishes atomically"
+        );
+    }
+}
+
+#[tokio::test]
+async fn moderation_dashboard_requires_authentication() {
+    let mut state = crate::test_app_state(crate::RuntimeWorld::seeded(), None);
+    state.generated_asset_dir = std::sync::Arc::new(root("auth"));
+    let response = moderation_media_verdicts(State(state), HeaderMap::new()).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/v2/orchestrator-rust/src/room_scene.rs
+++ b/v2/orchestrator-rust/src/room_scene.rs
@@ -17,6 +17,12 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::media_recipes::media_verdict::{
+    make_visual_verdict, media_candidate_approved, media_candidate_violations,
+    media_provider_route_available, prepare_media_candidate, record_media_provider_failure,
+    record_media_visual_verdict, FrozenMediaBrief, MediaCandidateInput, MediaVerdictDisposition,
+    MediaViolation,
+};
 use crate::{
     active_content, allow_actor_mutation, client_actor_authorized_for_state,
     event_visible_in_location, execute_replicate_art, freeze_approved_community_media_reference,
@@ -189,6 +195,73 @@ struct RoomSceneProjection<'a> {
     selected_item: &'a Option<FrozenRoomSceneItem>,
     public_beat_type: &'a str,
     public_beat: &'a str,
+}
+
+fn room_scene_media_brief(job: &FrozenRoomSceneJob) -> FrozenMediaBrief {
+    let mut brief = FrozenMediaBrief::new(
+        job.job_id.clone(),
+        format!(
+            "{}/{}",
+            job.recipe.recipe_id, job.recipe.prompt_template_version
+        ),
+        job.intended_use.clone(),
+        &job.prompt,
+        job.aspect_ratio.clone(),
+    );
+    brief.required_subjects = job
+        .actors
+        .iter()
+        .map(|actor| format!("actor {} ({})", actor.actor_id, actor.name))
+        .collect();
+    brief.required_environment = std::iter::once(job.location_name.clone())
+        .chain(job.environmental_facts.iter().cloned())
+        .collect();
+    brief.required_item_holder = job.selected_item.as_ref().map(|item| {
+        format!(
+            "item {} ({}) held by {}",
+            item.item_id,
+            item.name,
+            item.holder_actor_id
+                .map(|actor_id| actor_id.to_string())
+                .unwrap_or_else(|| "room floor".to_string())
+        )
+    });
+    brief.crop = job.crop.clone();
+    brief.safe_areas = job.safe_areas.clone();
+    brief.forbidden.extend(job.forbidden_facts.clone());
+    brief
+        .pack_negative_constraints
+        .extend(job.style_constraints.clone());
+    brief.approved_reference_digests = job
+        .references
+        .iter()
+        .map(|reference| reference.reference.content_digest.clone())
+        .collect();
+    brief
+}
+
+fn prepare_room_scene_verdict(
+    root: &Path,
+    job: &FrozenRoomSceneJob,
+    image: &DownloadedReplicateImage,
+) -> Result<MediaVerdictDisposition, String> {
+    let prior_public = job.references.first().and_then(|reference| {
+        immutable_media_asset_bytes(root, &reference.reference.asset_id)
+            .ok()
+            .map(|(bytes, _)| bytes)
+    });
+    let digest = candidate_digest(image);
+    prepare_media_candidate(
+        root,
+        room_scene_media_brief(job),
+        MediaCandidateInput {
+            image,
+            provider: "replicate",
+            model: &format!("{}/{}", job.recipe.model_owner, job.recipe.model_name),
+            claimed_digest: Some(&digest),
+            prior_public_bytes: prior_public.as_deref(),
+        },
+    )
 }
 
 impl FrozenRoomSceneRecipe {
@@ -806,11 +879,28 @@ where
             return Err("rejected room-scene jobs cannot be regenerated".to_string());
         }
         if let Some(candidate) = load_room_scene_candidate(root, &state.job)? {
-            state.lifecycle = RoomSceneLifecycle::ReviewPending;
+            let disposition = prepare_room_scene_verdict(root, &state.job, &candidate)?;
+            state.lifecycle = if disposition == MediaVerdictDisposition::Rejected {
+                RoomSceneLifecycle::Rejected
+            } else {
+                RoomSceneLifecycle::ReviewPending
+            };
             state.candidate_digest = Some(candidate_digest(&candidate));
             state.prediction_id = candidate.prediction_id;
+            state.last_error = (disposition == MediaVerdictDisposition::Rejected).then(|| {
+                media_candidate_violations(
+                    root,
+                    &state.job.job_id,
+                    state.candidate_digest.as_deref().unwrap_or_default(),
+                )
+                .unwrap_or_else(|error| vec![error])
+                .join(", ")
+            });
             store_room_scene(root, &state)?;
             return Ok(true);
+        }
+        if !media_provider_route_available(root, &state.job.job_id)? {
+            return Err("room-scene provider route is cooling down or disabled".to_string());
         }
         let resolved = state.job.resolve(root)?;
         let attempt = state.provider_attempts.saturating_add(1);
@@ -833,11 +923,23 @@ where
     let image = match tokio::time::timeout(timeout, provider(resolved)).await {
         Ok(Ok(image)) => image,
         Ok(Err(error)) => {
+            let state = load_room_scene(root, job_id)?;
+            let _ = record_media_provider_failure(
+                root,
+                room_scene_media_brief(&state.job),
+                "replicate-primary",
+            );
             fail_room_scene_generation(root, job_id, attempt, &error)?;
             return Err(error);
         }
         Err(_) => {
             let error = "room-scene provider timed out".to_string();
+            let state = load_room_scene(root, job_id)?;
+            let _ = record_media_provider_failure(
+                root,
+                room_scene_media_brief(&state.job),
+                "replicate-primary",
+            );
             fail_room_scene_generation(root, job_id, attempt, &error)?;
             return Err(error);
         }
@@ -857,10 +959,23 @@ where
         released?;
         return Err(error);
     }
-    state.lifecycle = RoomSceneLifecycle::ReviewPending;
     state.candidate_digest = Some(candidate_digest(&image));
     state.prediction_id = image.prediction_id.clone();
-    state.last_error = None;
+    let disposition = prepare_room_scene_verdict(root, &state.job, &image)?;
+    if disposition == MediaVerdictDisposition::Rejected {
+        state.lifecycle = RoomSceneLifecycle::Rejected;
+        state.last_error = Some(
+            media_candidate_violations(
+                root,
+                &state.job.job_id,
+                state.candidate_digest.as_deref().unwrap_or_default(),
+            )?
+            .join(", "),
+        );
+    } else {
+        state.lifecycle = RoomSceneLifecycle::ReviewPending;
+        state.last_error = None;
+    }
     let stored = store_room_scene(root, &state);
     let released = release_room_scene_generation(root, job_id, attempt);
     stored?;
@@ -906,8 +1021,27 @@ fn review_room_scene_candidate(
         return Err("room-scene review cannot precede the frozen projection".to_string());
     }
     let review_reason = crate::compact_whitespace(reason);
+    let image = load_room_scene_candidate(root, &state.job)?
+        .ok_or_else(|| "room-scene candidate bytes are missing".to_string())?;
+    let digest = candidate_digest(&image);
+    let brief = room_scene_media_brief(&state.job);
+    let verdict = make_visual_verdict(
+        &brief,
+        digest.clone(),
+        "operator",
+        "cosyworld.room-scene-moderation/1",
+        approved,
+        (!approved)
+            .then_some(MediaViolation::OperatorRejected)
+            .into_iter()
+            .collect(),
+        review_reason.clone(),
+        1,
+        0,
+        0,
+    )?;
+    let disposition = record_media_visual_verdict(root, &state.job.job_id, verdict)?;
     if !approved {
-        remove_room_scene_candidate(root, &state.job)?;
         state.lifecycle = RoomSceneLifecycle::Rejected;
         state.review_event_seq = Some(review_event_seq);
         state.review_reason = Some(review_reason.clone());
@@ -915,8 +1049,11 @@ fn review_room_scene_candidate(
         store_room_scene(root, &state)?;
         return Ok(state);
     }
-    let image = load_room_scene_candidate(root, &state.job)?
-        .ok_or_else(|| "room-scene candidate bytes are missing".to_string())?;
+    if disposition != MediaVerdictDisposition::Approved
+        || !media_candidate_approved(root, &state.job.job_id, &digest)?
+    {
+        return Err("room-scene candidate has no durable approving verdict".to_string());
+    }
     let references = state
         .job
         .references
@@ -1235,6 +1372,28 @@ fn remove_room_scene_candidate(root: &Path, job: &FrozenRoomSceneJob) -> Result<
         }
     }
     Ok(())
+}
+
+pub(super) fn request_room_scene_candidate_replacement(
+    root: &Path,
+    job_id: &str,
+    reason: &str,
+) -> Result<bool, String> {
+    if validate_job_id(job_id).is_err() || !room_scene_state_path(root, job_id).exists() {
+        return Ok(false);
+    }
+    let _claim = room_scene_lock()?;
+    let mut state = load_room_scene(root, job_id)?;
+    if state.lifecycle == RoomSceneLifecycle::Ready {
+        return Err("a published room scene requires a new frozen job".to_string());
+    }
+    remove_room_scene_candidate(root, &state.job)?;
+    state.lifecycle = RoomSceneLifecycle::Failed;
+    state.candidate_digest = None;
+    state.prediction_id = None;
+    state.last_error = Some(crate::compact_whitespace(reason));
+    store_room_scene(root, &state)?;
+    Ok(true)
 }
 
 fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {

--- a/v2/orchestrator-rust/src/room_scene_tests.rs
+++ b/v2/orchestrator-rust/src/room_scene_tests.rs
@@ -1,10 +1,13 @@
 use super::*;
 use crate::*;
 use axum::{body::to_bytes, extract::Path as AxumPath};
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
+use image::{DynamicImage, ImageBuffer, ImageFormat, Rgba};
+use std::{
+    io::Cursor,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 
 const ACTOR_A: u64 = 5000;
@@ -20,15 +23,31 @@ struct SceneFixture {
 }
 
 fn png() -> Vec<u8> {
-    BASE64_STANDARD
-        .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XqgWAAAAAElFTkSuQmCC")
-        .expect("decode PNG fixture")
+    patterned_png(3)
 }
 
 fn scene_png() -> Vec<u8> {
-    let mut bytes = png();
-    bytes.extend([7, 8]);
-    bytes
+    patterned_png(71)
+}
+
+fn patterned_png(seed: u8) -> Vec<u8> {
+    let pixels = ImageBuffer::from_fn(16, 9, |x, y| {
+        Rgba([
+            (x as u8)
+                .wrapping_mul(17)
+                .wrapping_add((y as u8).wrapping_mul(seed)),
+            (y as u8)
+                .wrapping_mul(29)
+                .wrapping_add((x as u8).wrapping_mul(seed)),
+            (x as u8 ^ y as u8).wrapping_mul(11).wrapping_add(seed),
+            255,
+        ])
+    });
+    let mut bytes = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(pixels)
+        .write_to(&mut bytes, ImageFormat::Png)
+        .expect("encode PNG fixture");
+    bytes.into_inner()
 }
 
 fn temp_root(label: &str) -> PathBuf {
@@ -630,7 +649,7 @@ async fn provider_timeout_is_retryable_without_duplicate_job_or_world_mutation()
         Duration::from_secs(1),
         |_| async {
             Ok(DownloadedReplicateImage {
-                bytes: png(),
+                bytes: scene_png(),
                 content_type: "image/png".to_string(),
                 source_url: "https://replicate.delivery/pbxt/retry.png".to_string(),
                 prediction_id: Some("retry".to_string()),

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -121,6 +121,15 @@ pub(super) fn app_router(state: AppState) -> Router {
         )
         .route("/moderation/economy", get(moderation_economy_view))
         .route(
+            "/moderation/media-verdicts",
+            get(media_recipes::media_verdict::moderation_media_verdicts),
+        )
+        .route(
+            "/moderation/media-verdicts/{record_id}",
+            get(media_recipes::media_verdict::moderation_media_verdict)
+                .post(media_recipes::media_verdict::moderation_update_media_verdict),
+        )
+        .route(
             "/moderation/community-art/{subject_kind}/{subject_id}/reject",
             post(moderation_reject_community_art),
         )


### PR DESCRIPTION
Closes #402

## Outcome
- stores every generated image as a private, digest-bound candidate with a frozen media brief before publication
- applies one persisted deterministic/visual verdict gate to community art and room scenes; rejected or pending candidates cannot replace the truthful public asset
- supports bounded review retry, provider cooldown, moderator approve/reject/replace/disable actions, and a shared dashboard with pass rate, failure taxonomy, approval cost, review latency, retry spend, and provider/model/recipe/profile/intent/reviewer/outcome slices
- keeps operator approval verdict-only; the owning job performs the later atomic publication, so moderation never mutates world mechanics or the public graph directly

## Evidence
- complete successful pre-push run: JavaScript 453/453; Rust 585/585; worldpack/composition/proof/kernel gates passed
- focused shared verdict gate: 6/6 passed
- community art: 13/13 passed; room scenes: 5/5 passed
- media recipe schema: 2/2 passed
- architecture: main.rs 74,001/74,001; Clippy 246/246
- formatting, diff, version, and syntax gates passed
- diff: 2,224 changed lines, under the 2,400 cap

Screenshot note: this is a backend persisted-lifecycle/API change with no player-facing visual surface. The PR evidence is the persisted verdict fixtures, endpoint authorization tests, publication-isolation tests, and complete gate output.