### PR TITLE
Explain every kernel rejection actionably

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.205",
+      "version": "0.0.206",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/cli/cosy_cli.py
+++ b/v2/cli/cosy_cli.py
@@ -800,7 +800,10 @@ class Game:
         if type_name == "combat.flee.success":
             return f"[{seq}] {actor} flees from {location} to {destination}."
         if type_name == "rule.rejected":
-            return f"[{seq}] Rule rejected for {actor} (reason {event.get('reason')})."
+            reason = " ".join(str(event.get("content") or "").split())
+            if not reason:
+                reason = "That action could not be completed. Refresh the room and try again."
+            return f"[{seq}] {reason}"
         label = str(type_name or "event").replace(".", " ")
         content = " ".join(str(event.get("content") or "").split())
         if content and not content.startswith(("{", "[")):

--- a/v2/core-c/include/cosy_kernel.h
+++ b/v2/core-c/include/cosy_kernel.h
@@ -32,6 +32,33 @@ typedef enum {
   CW_ERR_RULE = 4
 } cw_status;
 
+/* Append-only rejection values persisted in `cw_event.reason`. */
+typedef enum {
+  CW_REASON_NONE = 0,
+  CW_REASON_INVALID_ACTION = 1,
+  CW_REASON_ACTOR_NOT_FOUND = 2,
+  CW_REASON_ACTOR_INACTIVE = 3,
+  CW_REASON_LOCATION_NOT_FOUND = 4,
+  CW_REASON_ITEM_NOT_FOUND = 5,
+  CW_REASON_ITEM_NOT_AVAILABLE = 6,
+  CW_REASON_TARGET_NOT_FOUND = 7,
+  CW_REASON_TARGET_UNAVAILABLE = 8,
+  CW_REASON_NOT_SAME_LOCATION = 9,
+  CW_REASON_COMBAT_NOT_ALLOWED = 10,
+  CW_REASON_SELF_TARGET = 11,
+  CW_REASON_NO_EXIT = 12,
+  CW_REASON_EXIT_LOCKED = 13,
+  CW_REASON_ENCOUNTER_NOT_FOUND = 14,
+  CW_REASON_ENCOUNTER_FULL = 15,
+  CW_REASON_NOT_PARTICIPANT = 16,
+  CW_REASON_NOT_CURRENT_TURN = 17,
+  CW_REASON_NOT_HOSTILE = 18,
+  CW_REASON_ENCOUNTER_ACTIVE = 19,
+  CW_REASON_COMBAT_ACTION_REQUIRED = 20,
+  CW_REASON_CAPACITY_EXCEEDED = 21,
+  CW_REASON_COUNT
+} cw_rejection_reason;
+
 typedef enum {
   CW_ACTOR_NONE = 0,
   CW_ACTOR_HUMAN = 1,
@@ -407,6 +434,7 @@ cw_status cw_world_set_evolution_track(cw_world *world, cw_id actor_id, const cw
 cw_status cw_world_apply(cw_world *world, const cw_action *action, uint64_t seed, cw_event_buffer *out_events);
 cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uint64_t seed, uint8_t advance_tick, cw_event_buffer *out_events);
 cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_offers *out_offers);
+uint16_t cw_rejection_reason_max(void);
 const char *cw_event_type_name(uint8_t type);
 int16_t cw_actor_current_hp(const cw_actor *actor);
 int cw_actor_is_bloodied(const cw_actor *actor);

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -2,31 +2,6 @@
 
 #include <string.h>
 
-enum {
-  CW_REASON_NONE = 0,
-  CW_REASON_INVALID_ACTION = 1,
-  CW_REASON_ACTOR_NOT_FOUND = 2,
-  CW_REASON_ACTOR_INACTIVE = 3,
-  CW_REASON_LOCATION_NOT_FOUND = 4,
-  CW_REASON_ITEM_NOT_FOUND = 5,
-  CW_REASON_ITEM_NOT_AVAILABLE = 6,
-  CW_REASON_TARGET_NOT_FOUND = 7,
-  CW_REASON_TARGET_UNAVAILABLE = 8,
-  CW_REASON_NOT_SAME_LOCATION = 9,
-  CW_REASON_COMBAT_NOT_ALLOWED = 10,
-  CW_REASON_SELF_TARGET = 11,
-  CW_REASON_NO_EXIT = 12,
-  CW_REASON_EXIT_LOCKED = 13,
-  CW_REASON_ENCOUNTER_NOT_FOUND = 14,
-  CW_REASON_ENCOUNTER_FULL = 15,
-  CW_REASON_NOT_PARTICIPANT = 16,
-  CW_REASON_NOT_CURRENT_TURN = 17,
-  CW_REASON_NOT_HOSTILE = 18,
-  CW_REASON_ENCOUNTER_ACTIVE = 19,
-  CW_REASON_COMBAT_ACTION_REQUIRED = 20,
-  CW_REASON_CAPACITY_EXCEEDED = 21
-};
-
 static uint64_t splitmix64(uint64_t *state) {
   uint64_t z = (*state += 0x9E3779B97F4A7C15ull);
   z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
@@ -2398,4 +2373,8 @@ const char *cw_event_type_name(uint8_t type) {
     case CW_EVENT_ITEM_REVEALED: return "item.revealed";
     default: return "unknown";
   }
+}
+
+uint16_t cw_rejection_reason_max(void) {
+  return (uint16_t)(CW_REASON_COUNT - 1);
 }

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -9835,7 +9835,10 @@
       if (event.type === "combat.knockout") return `${event.target_actor_name}'s light falls quiet for now.`;
       if (event.type === "combat.flee.success") return `flees to ${event.destination_location_name}, carrying the trail's silver hush.`;
       if (event.type === "encounter.reset") return `${event.target_actor_name || "The frontier"} stirs again in ${event.location_name || "the frontier"}.`;
-      if (event.type === "rule.rejected") return `hesitates.`;
+      if (event.type === "rule.rejected") {
+        return String(event.content || "").trim()
+          || "That action could not be completed. Refresh the room and try again.";
+      }
       return event.type;
     }
 

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -6,6 +6,9 @@ use std::os::raw::c_char;
 
 use serde::{Deserialize, Serialize};
 
+mod rejections;
+pub(crate) use rejections::*;
+
 pub const CW_MAX_ACTORS: usize = 512;
 pub const CW_MAX_ITEMS: usize = 1024;
 pub const CW_MAX_LOCATIONS: usize = 256;
@@ -113,6 +116,7 @@ pub const CW_EVENT_ITEM_PICKED_UP: u8 = 7;
 pub const CW_EVENT_ITEM_USED: u8 = 8;
 pub const CW_EVENT_COMBAT_ATTACK_HIT: u8 = 11;
 pub const CW_EVENT_COMBAT_KNOCKOUT: u8 = 13;
+pub const CW_EVENT_RULE_REJECTED: u8 = 14;
 pub const CW_EVENT_ACTOR_MOVED: u8 = 15;
 pub const CW_EVENT_ITEM_GIVEN: u8 = 16;
 pub const CW_EVENT_AVATAR_EVOLVED: u8 = 17;
@@ -138,6 +142,32 @@ pub const CW_EVENT_ITEM_EXHAUSTED: u8 = 37;
 pub const CW_EVENT_ITEM_TRANSFORMED: u8 = 38;
 pub const CW_EVENT_EXIT_UNLOCKED: u8 = 39;
 pub const CW_EVENT_ITEM_REVEALED: u8 = 40;
+
+// These append-only values mirror the authoritative `CW_REASON_*` enum in
+// core-c. The numeric value remains the replay contract; player-facing copy is
+// derived by the orchestrator and is never written back into a kernel action.
+pub const CW_REASON_INVALID_ACTION: u16 = 1;
+pub const CW_REASON_ACTOR_NOT_FOUND: u16 = 2;
+pub const CW_REASON_ACTOR_INACTIVE: u16 = 3;
+pub const CW_REASON_LOCATION_NOT_FOUND: u16 = 4;
+pub const CW_REASON_ITEM_NOT_FOUND: u16 = 5;
+pub const CW_REASON_ITEM_NOT_AVAILABLE: u16 = 6;
+pub const CW_REASON_TARGET_NOT_FOUND: u16 = 7;
+pub const CW_REASON_TARGET_UNAVAILABLE: u16 = 8;
+pub const CW_REASON_NOT_SAME_LOCATION: u16 = 9;
+pub const CW_REASON_COMBAT_NOT_ALLOWED: u16 = 10;
+pub const CW_REASON_SELF_TARGET: u16 = 11;
+pub const CW_REASON_NO_EXIT: u16 = 12;
+pub const CW_REASON_EXIT_LOCKED: u16 = 13;
+pub const CW_REASON_ENCOUNTER_NOT_FOUND: u16 = 14;
+pub const CW_REASON_ENCOUNTER_FULL: u16 = 15;
+pub const CW_REASON_NOT_PARTICIPANT: u16 = 16;
+pub const CW_REASON_NOT_CURRENT_TURN: u16 = 17;
+pub const CW_REASON_NOT_HOSTILE: u16 = 18;
+pub const CW_REASON_ENCOUNTER_ACTIVE: u16 = 19;
+pub const CW_REASON_COMBAT_ACTION_REQUIRED: u16 = 20;
+pub const CW_REASON_CAPACITY_EXCEEDED: u16 = 21;
+pub const CW_REASON_MAX_KNOWN: u16 = CW_REASON_CAPACITY_EXCEEDED;
 
 pub const CW_CRAFT_INPUT_PERSISTS: u8 = 0;
 pub const CW_CRAFT_INPUT_CONSUMED: u8 = 1;

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -478,6 +478,7 @@ extern "C" {
         actor_id: u64,
         out_offers: *mut CwActionOffers,
     ) -> u32;
+    pub fn cw_rejection_reason_max() -> u16;
     pub fn cw_event_type_name(type_: u8) -> *const c_char;
     pub fn cw_actor_current_hp(actor: *const CwActor) -> i16;
     pub fn cw_actor_is_bloodied(actor: *const CwActor) -> i32;

--- a/v2/orchestrator-rust/src/kernel/rejections.rs
+++ b/v2/orchestrator-rust/src/kernel/rejections.rs
@@ -1,0 +1,176 @@
+use super::*;
+
+pub(crate) const UNKNOWN_KERNEL_REJECTION_MESSAGE: &str =
+    "That action could not be completed. Refresh the room and try again.";
+
+pub(crate) fn kernel_rejection_message(reason: u16) -> &'static str {
+    match reason {
+        CW_REASON_INVALID_ACTION => {
+            "That action is not available. Choose one of the actions shown and try again."
+        }
+        CW_REASON_ACTOR_NOT_FOUND => {
+            "That traveler is no longer here. Refresh the room and try again."
+        }
+        CW_REASON_ACTOR_INACTIVE => {
+            "You cannot act right now. Return when your traveler is active."
+        }
+        CW_REASON_LOCATION_NOT_FOUND => {
+            "That place is no longer available. Refresh the room and choose another destination."
+        }
+        CW_REASON_ITEM_NOT_FOUND => {
+            "That item is no longer here. Refresh the room and choose another item."
+        }
+        CW_REASON_ITEM_NOT_AVAILABLE => {
+            "That item has moved or cannot be used right now. Refresh the room and try again."
+        }
+        CW_REASON_TARGET_NOT_FOUND => {
+            "That person is no longer here. Refresh the room and choose someone nearby."
+        }
+        CW_REASON_TARGET_UNAVAILABLE => {
+            "That person cannot take part right now. Choose someone else or try again later."
+        }
+        CW_REASON_NOT_SAME_LOCATION => {
+            "You need to be in the same place to do that. Move closer and try again."
+        }
+        CW_REASON_COMBAT_NOT_ALLOWED => "Combat is not allowed here. Choose a non-combat action.",
+        CW_REASON_SELF_TARGET => "Choose someone other than yourself for that action.",
+        CW_REASON_NO_EXIT => "There is no path that way. Choose one of the available exits.",
+        CW_REASON_EXIT_LOCKED => {
+            "That way is locked. Find a way to unlock it or choose another exit."
+        }
+        CW_REASON_ENCOUNTER_NOT_FOUND => {
+            "That scuffle has already ended or is no longer here. Refresh the room and try again."
+        }
+        CW_REASON_ENCOUNTER_FULL => {
+            "That scuffle has no room for another participant. Wait for it to end."
+        }
+        CW_REASON_NOT_PARTICIPANT => {
+            "You are not part of that scuffle. Join it before choosing a combat action."
+        }
+        CW_REASON_NOT_CURRENT_TURN => "It is not your turn yet. Wait for your turn before acting.",
+        CW_REASON_NOT_HOSTILE => "That target is not an opponent. Choose a hostile participant.",
+        CW_REASON_ENCOUNTER_ACTIVE => {
+            "That scuffle is already underway. Choose an action available in the current scuffle."
+        }
+        CW_REASON_COMBAT_ACTION_REQUIRED => {
+            "Finish the current scuffle before doing that. Choose a combat action now."
+        }
+        CW_REASON_CAPACITY_EXCEEDED => {
+            "You cannot carry that much. Make room in your inventory and try again."
+        }
+        _ => UNKNOWN_KERNEL_REJECTION_MESSAGE,
+    }
+}
+
+pub(crate) fn rule_rejection_content(event: &CwEvent) -> Option<String> {
+    (event.type_ == CW_EVENT_RULE_REJECTED)
+        .then(|| kernel_rejection_message(event.reason).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn kernel_rejection_messages_cover_the_current_reason_contract() {
+        let messages = (1..=CW_REASON_MAX_KNOWN)
+            .map(kernel_rejection_message)
+            .collect::<Vec<_>>();
+
+        assert_eq!(messages.len(), 21);
+        assert_eq!(messages.iter().copied().collect::<HashSet<_>>().len(), 21);
+        assert!(messages
+            .iter()
+            .all(|message| *message != UNKNOWN_KERNEL_REJECTION_MESSAGE));
+        assert!(messages.iter().all(|message| {
+            let message = message.to_ascii_lowercase();
+            !message.contains("kernel")
+                && !message.contains("reason code")
+                && !message.contains("cw_reason")
+        }));
+
+        assert_eq!(
+            kernel_rejection_message(CW_REASON_INVALID_ACTION),
+            "That action is not available. Choose one of the actions shown and try again."
+        );
+        assert_eq!(
+            kernel_rejection_message(CW_REASON_ACTOR_INACTIVE),
+            "You cannot act right now. Return when your traveler is active."
+        );
+        assert_eq!(
+            kernel_rejection_message(CW_REASON_EXIT_LOCKED),
+            "That way is locked. Find a way to unlock it or choose another exit."
+        );
+        assert_eq!(
+            kernel_rejection_message(CW_REASON_CAPACITY_EXCEEDED),
+            "You cannot carry that much. Make room in your inventory and try again."
+        );
+        assert_eq!(
+            kernel_rejection_message(CW_REASON_NOT_CURRENT_TURN),
+            "It is not your turn yet. Wait for your turn before acting."
+        );
+
+        for unknown in [0, CW_REASON_MAX_KNOWN + 1, u16::MAX] {
+            assert_eq!(
+                kernel_rejection_message(unknown),
+                UNKNOWN_KERNEL_REJECTION_MESSAGE
+            );
+        }
+    }
+
+    #[test]
+    fn rule_rejection_view_adds_copy_without_changing_the_canonical_reason() {
+        let runtime = RuntimeWorld::seeded();
+        let view = runtime.event_view(&CwEvent {
+            type_: CW_EVENT_RULE_REJECTED,
+            success: 0,
+            reason: CW_REASON_ITEM_NOT_AVAILABLE,
+            actor_id: 5000,
+            ..CwEvent::default()
+        });
+
+        assert_eq!(view.type_name, "rule.rejected");
+        assert_eq!(view.reason, CW_REASON_ITEM_NOT_AVAILABLE);
+        assert_eq!(
+            view.content.as_deref(),
+            Some(
+                "That item has moved or cannot be used right now. Refresh the room and try again."
+            )
+        );
+    }
+
+    #[test]
+    fn rule_rejection_consumers_prefer_projected_copy_and_fall_back_safely() {
+        let projected = EventView {
+            type_name: "rule.rejected".to_string(),
+            reason: CW_REASON_NO_EXIT,
+            content: Some("Choose another visible path.".to_string()),
+            ..EventView::default()
+        };
+        let legacy_unknown = EventView {
+            type_name: "rule.rejected".to_string(),
+            reason: u16::MAX,
+            content: None,
+            ..EventView::default()
+        };
+
+        assert_eq!(
+            command_event_output(&projected).as_deref(),
+            Some("Choose another visible path.")
+        );
+        assert_eq!(
+            command_event_output(&legacy_unknown).as_deref(),
+            Some(UNKNOWN_KERNEL_REJECTION_MESSAGE)
+        );
+        assert!(INDEX_HTML.contains(
+            "return String(event.content || \"\").trim()\n          || \"That action could not be completed. Refresh the room and try again.\";"
+        ));
+
+        let cli = include_str!("../../../cli/cosy_cli.py");
+        assert!(cli.contains("reason = \" \".join(str(event.get(\"content\") or \"\").split())"));
+        assert!(cli.contains(UNKNOWN_KERNEL_REJECTION_MESSAGE));
+        assert!(!cli.contains("Rule rejected for {actor} (reason"));
+    }
+}

--- a/v2/orchestrator-rust/src/kernel/rejections.rs
+++ b/v2/orchestrator-rust/src/kernel/rejections.rs
@@ -75,6 +75,11 @@ mod tests {
 
     #[test]
     fn kernel_rejection_messages_cover_the_current_reason_contract() {
+        assert_eq!(
+            unsafe { cw_rejection_reason_max() },
+            CW_REASON_MAX_KNOWN,
+            "a new authoritative kernel rejection needs player-facing copy"
+        );
         let messages = (1..=CW_REASON_MAX_KNOWN)
             .map(kernel_rejection_message)
             .collect::<Vec<_>>();

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -13566,7 +13566,7 @@ impl RuntimeWorld {
             destination_location_id: opt_id(event.destination_location_id),
             destination_location_name: self.location_name(event.destination_location_id),
             content_id: opt_id(event.content_id),
-            content: self.event_content(event),
+            content: rule_rejection_content(event).or_else(|| self.event_content(event)),
             item_id: opt_id(event.item_id),
             item_name: self.item_name(event.item_id),
             target_item_id: opt_id(event.target_item_id),

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -1125,7 +1125,15 @@ pub(crate) fn command_event_output(event: &EventView) -> Option<String> {
         } else {
             "The scuffle is over for now.".to_string()
         }),
-        "rule.rejected" => Some("The room will not let that happen just now.".to_string()),
+        "rule.rejected" => Some(
+            event
+                .content
+                .as_deref()
+                .map(str::trim)
+                .filter(|content| !content.is_empty())
+                .unwrap_or_else(|| kernel_rejection_message(event.reason))
+                .to_string(),
+        ),
         _ => None,
     }
 }


### PR DESCRIPTION
Closes #369

## Outcome
- preserves the kernel’s canonical numeric rejection reason while projecting one deterministic actionable player message
- makes browser, MUD, and CLI consume the same projected copy with a safe unknown-code fallback and no numeric/internal vocabulary leak
- exposes the append-only C reason enum and read-only maximum so the Rust copy-coverage test fails when a future authoritative reason lacks presentation

## Evidence
- full Rust suite: 550/550 passed in the authorized lane run
- focused C-authority/rejection suite: 3/3 passed; C kernel suite passed
- direct CLI: `[42] That way is locked. Find another exit.`; unknown 999 uses the safe refresh-and-retry fallback without leaking 999
- all current C reasons 1–21 have unique non-generic copy; unknown 0/22/u16::MAX fall back safely
- architecture: main.rs 74,555/74,555; Clippy 246/246
- formatting, diff, Python compile, browser-script syntax, version, and kernel gates passed
- diff: 276 changed lines across 12 files

## Flake record
Two unchanged pre-push reruns reached 549/550 Rust tests and failed only on the pre-existing timing-sensitive `hot_room_and_regional_chaos_preserve_one_committed_world` race (once timeout-marked, once canonical-authority ordering). The exact fixture immediately passed 1/1 in isolation, and the prior authorized full run passed 550/550. The final C-authority follow-up was separately verified by the C kernel and focused Rust suites before push.