### PR TITLE
Ground generated route names in direction and ecology

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.208",
+      "version": "0.0.209",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.208"
+version = "0.0.209"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.208"
+version = "0.0.209"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -1,6 +1,15 @@
+use super::{
+    compact_whitespace, AppState, GeneratedPathwayState, GeneratedWaypointState,
+    GenerationProvenance, LocationMeta, NaturalPotentialPolicy, PATHWAY_CONTENT_FEATURE,
+    PATHWAY_CONTENT_PROMPT_VERSION,
+};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::{collections::BTreeMap, fmt, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    time::Duration,
+};
 use tokio::time::{sleep, Instant};
 
 pub(crate) const DEFAULT_OPENROUTER_CHAT_MODEL: &str = "openai/gpt-5.6-luna";
@@ -619,9 +628,402 @@ pub(crate) fn ai_model_name(config: Option<&AiConfig>) -> String {
         .unwrap_or_else(|| "none".to_string())
 }
 
+pub(super) struct PathwayContentPromptContext {
+    pub(super) prompt: String,
+    pub(super) origin_name: String,
+    pub(super) destination_name: String,
+    pub(super) occupied_names: BTreeSet<String>,
+}
+
+fn ecosystem_labels(meta: &LocationMeta) -> Vec<&'static str> {
+    meta.natural_potentials
+        .iter()
+        .filter(|potential| potential.policy != NaturalPotentialPolicy::Impossible)
+        .map(|potential| potential.resource_kind.label())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn ecosystem_label_subset<'a>(labels: &'a [&'static str], accepted: &[&str]) -> Vec<&'a str> {
+    labels
+        .iter()
+        .copied()
+        .filter(|label| accepted.iter().any(|needle| label.contains(needle)))
+        .collect()
+}
+
+fn pathway_ecosystem_context(meta: &LocationMeta) -> String {
+    let environment = serde_json::to_value(&meta.environment).unwrap_or_else(|_| json!({}));
+    let list = |key: &str| {
+        environment
+            .get(key)
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "none authored".to_string())
+    };
+    let labels = ecosystem_labels(meta);
+    let vegetation = ecosystem_label_subset(&labels, &["woodland", "herb", "soil"]);
+    let fauna = ecosystem_label_subset(&labels, &["fish"]);
+    let joined_or_none = |values: &[&str]| {
+        if values.is_empty() {
+            "none authored".to_string()
+        } else {
+            values.join(", ")
+        }
+    };
+    format!(
+        "biome: {biome}; terrain: {terrain}; climate: {climate}; landforms: {landforms}; geology: {geology}; hydrology: {hydrology}; vegetation cues: {vegetation}; fauna cues: {fauna}; ecosystem/resource cues: {ecosystem}",
+        biome = meta.biome,
+        terrain = if meta.terrain.is_empty() {
+            "none authored".to_string()
+        } else {
+            meta.terrain.join(", ")
+        },
+        climate = environment
+            .get("climate")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown"),
+        landforms = list("landforms"),
+        geology = list("geology"),
+        hydrology = list("hydrology"),
+        vegetation = joined_or_none(&vegetation),
+        fauna = joined_or_none(&fauna),
+        ecosystem = joined_or_none(&labels),
+    )
+}
+
+struct PathwayRoutePromptContext<'a> {
+    route_id: &'a str,
+    route_version: u64,
+    origin_name: &'a str,
+    destination_name: &'a str,
+    direction: &'a str,
+    origin_meta: &'a LocationMeta,
+    destination_meta: &'a LocationMeta,
+}
+
+fn generated_pathway_content_prompt(
+    pathway: &GeneratedPathwayState,
+    route: &PathwayRoutePromptContext<'_>,
+) -> String {
+    let waypoint_context = pathway
+        .waypoints
+        .iter()
+        .enumerate()
+        .map(|(index, waypoint)| {
+            format!(
+                "{step}. segment index/count: {step}/{segments}; fallback name: {fallback}; {ecology}",
+                step = index + 1,
+                segments = pathway.distance.max(1),
+                fallback = waypoint.name,
+                ecology = pathway_ecosystem_context(&waypoint.meta),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Create {count} distinct hidden waypoint identities for successive segments of one cozy storybook route. They are generated together now but players encounter them one at a time through Scout.\nCanonical route ID: {route_id}\nCanonical route version: {route_version}\nRoute endpoints: origin {origin_name}; destination {destination_name}\nTravel direction: {direction}, from {origin_name} toward {destination_name}.\nNearby authored origin description: {origin_description}\nNearby authored origin persona: {origin_persona}\nOrigin ecology: {origin_ecology}\nNearby authored destination description: {destination_description}\nNearby authored destination persona: {destination_persona}\nDestination ecology: {destination_ecology}\n{waypoint_context}\nFor each waypoint return: name (evocative proper place name, 2-5 words); title (1-6 words); description (one concrete physical sentence); persona (one sentence describing how the place behaves, never dialogue); visual_detail (physical landscape details only). Preserve order. Ground every field in the supplied direction, endpoint descriptions, biome, terrain, climate, hydrology, vegetation, fauna, and ecosystem cues. You may name and describe a waypoint, but you must not choose or change topology, route identity, endpoints, directionality, ownership, route version, segment count, access, or rules. Do not introduce named people, items, quests, rewards, danger outcomes, magic powers, or unsupported ecological facts. Names must use only ASCII letters, spaces, hyphens, or apostrophes, and must not use numbers, Pathway, Segment, either route endpoint, or duplicates.",
+        count = pathway.waypoints.len(),
+        route_id = route.route_id,
+        route_version = route.route_version,
+        direction = route.direction,
+        origin_name = route.origin_name,
+        destination_name = route.destination_name,
+        origin_description = route.origin_meta.description,
+        origin_persona = route.origin_meta.persona,
+        origin_ecology = pathway_ecosystem_context(route.origin_meta),
+        destination_description = route.destination_meta.description,
+        destination_persona = route.destination_meta.persona,
+        destination_ecology = pathway_ecosystem_context(route.destination_meta),
+    )
+}
+
+pub(super) async fn pathway_content_generation_context(
+    state: &AppState,
+    pathway: &GeneratedPathwayState,
+) -> PathwayContentPromptContext {
+    let runtime = state.inner.lock().await;
+    let origin_name = runtime
+        .location_name(pathway.origin_location_id)
+        .unwrap_or_else(|| "one known place".to_string());
+    let destination_name = runtime
+        .location_name(pathway.destination_location_id)
+        .unwrap_or_else(|| "another known place".to_string());
+    let direction = runtime
+        .exit_direction(pathway.origin_location_id, pathway.destination_location_id)
+        .unwrap_or_else(|| "endpoint-to-endpoint".to_string());
+    let origin_meta = runtime.location_meta_for(pathway.origin_location_id);
+    let destination_meta = runtime.location_meta_for(pathway.destination_location_id);
+    let occupied_names = runtime
+        .generated_pathways
+        .values()
+        .filter(|existing| existing.id != pathway.id)
+        .flat_map(|existing| existing.waypoints.iter())
+        .map(|waypoint| waypoint.name.to_ascii_lowercase())
+        .chain(
+            runtime
+                .locations
+                .iter()
+                .filter(|(location_id, _)| {
+                    !pathway
+                        .waypoints
+                        .iter()
+                        .any(|waypoint| waypoint.id == **location_id)
+                })
+                .map(|(_, name)| name.to_ascii_lowercase()),
+        )
+        .collect();
+    let route_id = if pathway.source_route_id.is_empty() {
+        pathway.id.as_str()
+    } else {
+        pathway.source_route_id.as_str()
+    };
+    let route_version = pathway.source_route_version.max(1);
+    let prompt = generated_pathway_content_prompt(
+        pathway,
+        &PathwayRoutePromptContext {
+            route_id,
+            route_version,
+            origin_name: &origin_name,
+            destination_name: &destination_name,
+            direction: &direction,
+            origin_meta: &origin_meta,
+            destination_meta: &destination_meta,
+        },
+    );
+    PathwayContentPromptContext {
+        prompt,
+        origin_name,
+        destination_name,
+        occupied_names,
+    }
+}
+
+pub(super) fn sanitize_generated_pathway_name(value: &str) -> Option<String> {
+    let name = compact_whitespace(value.trim().trim_matches('"'));
+    let word_count = name.split_whitespace().count();
+    let char_count = name.chars().count();
+    let lower = name.to_ascii_lowercase();
+    if !(2..=5).contains(&word_count)
+        || !(4..=40).contains(&char_count)
+        || lower.contains("pathway")
+        || lower.contains("stretch")
+        || generated_label_contains_authority_language(&lower)
+        || !name
+            .chars()
+            .all(|character| character.is_ascii_alphabetic() || " -'".contains(character))
+    {
+        return None;
+    }
+    Some(name)
+}
+
+fn generated_label_contains_authority_language(value: &str) -> bool {
+    value
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .any(|token| {
+            matches!(
+                token,
+                "access"
+                    | "award"
+                    | "awards"
+                    | "clock"
+                    | "damage"
+                    | "health"
+                    | "inventory"
+                    | "item"
+                    | "items"
+                    | "orb"
+                    | "orbs"
+                    | "quest"
+                    | "quests"
+                    | "reward"
+                    | "rewards"
+                    | "unlock"
+                    | "unlocks"
+                    | "wallet"
+            )
+        })
+}
+
+fn sanitize_generated_content_text(
+    value: &str,
+    min_chars: usize,
+    max_chars: usize,
+) -> Option<String> {
+    let text = compact_whitespace(value.trim().trim_matches('"'));
+    let char_count = text.chars().count();
+    let lowered = format!(" {} ", text.to_ascii_lowercase());
+    if !(min_chars..=max_chars).contains(&char_count)
+        || text.chars().any(char::is_control)
+        || text.chars().any(|character| "{}<>\"".contains(character))
+        || [
+            " http://",
+            " https://",
+            " ignore previous",
+            " system prompt",
+            " developer message",
+            " assistant message",
+            " ai model",
+            " policy",
+            " wallet",
+            " orb ",
+            " orbs ",
+            " item ",
+            " items ",
+            " inventory ",
+            " reward",
+            " award",
+            " damage",
+            " health ",
+            " hit point",
+            " level up",
+            " grants ",
+            " gives you ",
+            " unlock",
+            " access gate",
+            " allows entry",
+            " opens access",
+            " locked until",
+            " quest",
+            " clock",
+        ]
+        .iter()
+        .any(|needle| lowered.contains(needle))
+    {
+        return None;
+    }
+    Some(text)
+}
+
+pub(super) fn sanitize_generated_pathway_title(value: &str) -> Option<String> {
+    let title = compact_whitespace(value.trim().trim_matches('"'));
+    let word_count = title.split_whitespace().count();
+    if !(1..=6).contains(&word_count)
+        || !(4..=48).contains(&title.chars().count())
+        || title.to_ascii_lowercase().contains("pathway to")
+        || generated_label_contains_authority_language(&title.to_ascii_lowercase())
+        || !title
+            .chars()
+            .all(|character| character.is_ascii_alphabetic() || " -'".contains(character))
+    {
+        return None;
+    }
+    Some(title)
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GeneratedWaypointContentProposal {
+    pub(super) name: String,
+    pub(super) title: String,
+    pub(super) description: String,
+    pub(super) persona: String,
+    pub(super) visual_detail: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GeneratedPathwayContentProposal {
+    waypoints: Vec<GeneratedWaypointContentProposal>,
+}
+
+pub(super) fn parse_generated_pathway_content(
+    text: &str,
+    expected: usize,
+) -> Option<Vec<GeneratedWaypointContentProposal>> {
+    let cleaned = text
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+    let json_text = if cleaned.starts_with('{') {
+        cleaned
+    } else {
+        let start = cleaned.find('{')?;
+        let end = cleaned.rfind('}')?;
+        cleaned.get(start..=end)?
+    };
+    let proposal: GeneratedPathwayContentProposal = serde_json::from_str(json_text).ok()?;
+    if proposal.waypoints.len() != expected {
+        return None;
+    }
+    let waypoints = proposal
+        .waypoints
+        .into_iter()
+        .map(|waypoint| {
+            Some(GeneratedWaypointContentProposal {
+                name: sanitize_generated_pathway_name(&waypoint.name)?,
+                title: sanitize_generated_pathway_title(&waypoint.title)?,
+                description: sanitize_generated_content_text(&waypoint.description, 24, 240)?,
+                persona: sanitize_generated_content_text(&waypoint.persona, 20, 180)?,
+                visual_detail: sanitize_generated_content_text(&waypoint.visual_detail, 12, 180)?,
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let unique = waypoints
+        .iter()
+        .map(|waypoint| waypoint.name.to_ascii_lowercase())
+        .collect::<BTreeSet<_>>();
+    (unique.len() == waypoints.len()).then_some(waypoints)
+}
+
+pub(super) fn generated_pathway_name_avoids_anchors(name: &str, anchors: &[&str]) -> bool {
+    let name = compact_whitespace(name).to_ascii_lowercase();
+    anchors.iter().all(|anchor| {
+        let anchor = compact_whitespace(anchor).to_ascii_lowercase();
+        anchor.is_empty() || !name.contains(&anchor)
+    })
+}
+
+pub(super) fn apply_generated_waypoint_content(
+    waypoint: &mut GeneratedWaypointState,
+    content: GeneratedWaypointContentProposal,
+) {
+    waypoint.name = content.name.clone();
+    waypoint.meta.title = content.title;
+    waypoint.meta.description = content.description;
+    waypoint.meta.persona = content.persona;
+    waypoint.meta.art_prompt = Some(format!(
+        "cozy storybook landscape, {detail}, {name}, {biome}, terrain of {terrain}, no people, no characters, no creatures, no text, no logo, no watermark",
+        detail = content.visual_detail,
+        name = content.name,
+        biome = waypoint.meta.biome,
+        terrain = waypoint.meta.terrain.join(", "),
+    ));
+}
+
+pub(super) fn set_pathway_generation_provenance(
+    pathway: &mut GeneratedPathwayState,
+    mode: GenerationMode,
+    config: Option<&AiConfig>,
+    source: &str,
+    attempts: u8,
+) {
+    pathway.generation = GenerationProvenance {
+        source: source.to_string(),
+        feature: PATHWAY_CONTENT_FEATURE.to_string(),
+        policy_mode: mode.as_str().to_string(),
+        prompt_version: PATHWAY_CONTENT_PROMPT_VERSION.to_string(),
+        provider: ai_provider_name(config).to_string(),
+        model: ai_model_name(config),
+        attempts,
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RuntimeWorld;
     use axum::{http::StatusCode, response::IntoResponse, routing::post, Json, Router};
     use base64::Engine;
     use std::sync::{
@@ -629,6 +1031,48 @@ mod tests {
         Arc,
     };
     use tokio::net::TcpListener;
+
+    #[test]
+    fn pathway_prompt_carries_route_direction_ecology_and_authored_context() {
+        let runtime = RuntimeWorld::seeded();
+        let pathway = runtime
+            .generated_pathway(5000, 700, 712, 2)
+            .expect("Bethlehem-to-Jerusalem route");
+        let origin_meta = runtime.location_meta_for(700);
+        let destination_meta = runtime.location_meta_for(712);
+        let prompt = generated_pathway_content_prompt(
+            &pathway,
+            &PathwayRoutePromptContext {
+                route_id: "route://cosyworld.the-holy-land/authored/bethlehem|jerusalem",
+                route_version: 3,
+                origin_name: "Bethlehem",
+                destination_name: "Jerusalem",
+                direction: "north",
+                origin_meta: &origin_meta,
+                destination_meta: &destination_meta,
+            },
+        );
+
+        assert!(prompt.contains("Canonical route ID: route://cosyworld.the-holy-land"));
+        assert!(prompt.contains("Canonical route version: 3"));
+        assert!(prompt.contains("Route endpoints: origin Bethlehem; destination Jerusalem"));
+        assert!(prompt.contains("Travel direction: north, from Bethlehem toward Jerusalem"));
+        assert!(prompt.contains(&origin_meta.description));
+        assert!(prompt.contains(&destination_meta.description));
+        assert!(prompt.contains("segment index/count: 1/2"));
+        for field in [
+            "biome:",
+            "terrain:",
+            "climate:",
+            "hydrology:",
+            "vegetation cues:",
+            "fauna cues:",
+            "ecosystem/resource cues:",
+        ] {
+            assert!(prompt.contains(field), "missing {field} from {prompt}");
+        }
+        assert!(prompt.contains("must not choose or change topology"));
+    }
 
     #[test]
     fn provider_names_follow_the_configured_endpoint() {

--- a/v2/orchestrator-rust/src/crafting.rs
+++ b/v2/orchestrator-rust/src/crafting.rs
@@ -770,6 +770,8 @@ mod tests {
             destination_location_id: location_id,
             distance: 1,
             created_by_actor_id: RATI_ACTOR_ID,
+            way_class: PathwayWayClass::Route,
+            traffic_count: 0,
             waypoints: vec![GeneratedWaypointState {
                 id: location_id,
                 canonical_id: String::new(),
@@ -1043,6 +1045,8 @@ mod tests {
             destination_location_id: location_id,
             distance: 1,
             created_by_actor_id: RATI_ACTOR_ID,
+            way_class: PathwayWayClass::Route,
+            traffic_count: 0,
             waypoints: vec![GeneratedWaypointState {
                 id: location_id,
                 canonical_id: String::new(),

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5567,10 +5567,11 @@
               : (searchingPathway ? "the first adjacent stretch of the chosen pathway is revealed" : "you arrive at the place you choose"),
             ...(onePath ? {} : {
               choices: groupedExits.map((exit) => ({
-                label: exit.destination_location_name,
+                label: exit.route_label || exit.destination_location_name,
                 detail: searchingPathway
-                  ? `${Number(exit.distance || 1)} stretches`
-                  : (exit.direction ? `${exit.direction} path` : "open path"),
+                  ? `${Number(exit.distance || 1)} stretches toward ${exit.destination_location_name}`
+                  : `${exit.destination_location_name}${exit.direction ? ` · ${exit.direction}` : ""}`,
+                previewAlt: exit.destination_location_name,
                 value: String(exit.destination_location_id),
                 card: cardForLocation(exit.destination_location_id),
               })),
@@ -10754,7 +10755,7 @@
       art?.classList.remove("avatar", "item", "location");
       art?.classList.add(shapeForCard(card));
       $("action-modal-image").src = actionImage(action);
-      $("action-modal-image").alt = choice?.label || card?.display_name || action?.detail || actionTitle(action);
+      $("action-modal-image").alt = choice?.previewAlt || choice?.label || card?.display_name || action?.detail || actionTitle(action);
     }
 
     function smallNumberWord(value) {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -590,7 +590,7 @@ struct LocationMeta {
 }
 
 const PATHWAY_CONTENT_FEATURE: &str = "pathway_content";
-const PATHWAY_CONTENT_PROMPT_VERSION: &str = "pathway-content-v1";
+const PATHWAY_CONTENT_PROMPT_VERSION: &str = "pathway-content-v2";
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 struct GenerationProvenance {
@@ -631,6 +631,10 @@ struct GeneratedPathwayState {
     destination_location_id: u64,
     distance: u8,
     created_by_actor_id: u64,
+    #[serde(default)]
+    way_class: PathwayWayClass,
+    #[serde(default)]
+    traffic_count: u64,
     waypoints: Vec<GeneratedWaypointState>,
     #[serde(default)]
     generation: GenerationProvenance,
@@ -10454,11 +10458,49 @@ impl RuntimeWorld {
                     {
                         continue;
                     }
-                    if let Some(current) = self.generated_pathways.get(&pathway.id) {
-                        refined
-                            .revealed_edges
-                            .extend(current.revealed_edges.clone());
-                        refined.familiar |= current.familiar;
+                    let Some(current) = self.generated_pathways.get(&pathway.id).cloned() else {
+                        continue;
+                    };
+                    refined
+                        .revealed_edges
+                        .extend(current.revealed_edges.clone());
+                    refined.familiar |= current.familiar;
+                    refined.traffic_count = current.traffic_count;
+                    refined.way_class = PathwayWayClass::for_traffic(refined.traffic_count);
+                    let current_waypoint_ids = current
+                        .waypoints
+                        .iter()
+                        .map(|waypoint| waypoint.id)
+                        .collect::<BTreeSet<_>>();
+                    let mut occupied_names = self
+                        .generated_pathways
+                        .values()
+                        .filter(|existing| existing.id != refined.id)
+                        .flat_map(|existing| existing.waypoints.iter())
+                        .map(|waypoint| waypoint.name.to_ascii_lowercase())
+                        .chain(
+                            self.locations
+                                .iter()
+                                .filter(|(location_id, _)| {
+                                    !current_waypoint_ids.contains(location_id)
+                                })
+                                .map(|(_, name)| name.to_ascii_lowercase()),
+                        )
+                        .collect::<BTreeSet<_>>();
+                    let pathway_canonical_id = refined.canonical_id.clone();
+                    for (index, (waypoint, fallback)) in refined
+                        .waypoints
+                        .iter_mut()
+                        .zip(&current.waypoints)
+                        .enumerate()
+                    {
+                        waypoint.name = reserve_unique_pathway_name(
+                            &mut occupied_names,
+                            &waypoint.name,
+                            &fallback.name,
+                            &pathway_canonical_id,
+                            index,
+                        );
                     }
                     for waypoint in &refined.waypoints {
                         self.locations.insert(waypoint.id, waypoint.name.clone());
@@ -10552,6 +10594,12 @@ impl RuntimeWorld {
                             *to_location_id,
                         );
                     }
+                    let traffic_delta =
+                        durable_pathway_traffic_evidence(&next_pathway, committed_events);
+                    next_pathway.traffic_count =
+                        next_pathway.traffic_count.saturating_add(traffic_delta);
+                    next_pathway.way_class =
+                        PathwayWayClass::for_traffic(next_pathway.traffic_count);
                     self.generated_pathways
                         .insert(next_pathway.id.clone(), next_pathway.clone());
                     if let Some(journey) = journey {
@@ -32598,219 +32646,6 @@ fn travel_narration_fallback(plan: &JourneyNarrationPlan) -> String {
     )
 }
 
-fn sanitize_generated_pathway_name(value: &str) -> Option<String> {
-    let name = compact_whitespace(value.trim().trim_matches('"'));
-    let word_count = name.split_whitespace().count();
-    let char_count = name.chars().count();
-    let lower = name.to_ascii_lowercase();
-    if !(2..=5).contains(&word_count)
-        || !(4..=40).contains(&char_count)
-        || lower.contains("pathway")
-        || lower.contains("stretch")
-        || generated_label_contains_authority_language(&lower)
-        || !name
-            .chars()
-            .all(|character| character.is_ascii_alphabetic() || " -'".contains(character))
-    {
-        return None;
-    }
-    Some(name)
-}
-
-fn generated_label_contains_authority_language(value: &str) -> bool {
-    value
-        .split(|character: char| !character.is_ascii_alphanumeric())
-        .any(|token| {
-            matches!(
-                token,
-                "access"
-                    | "award"
-                    | "awards"
-                    | "clock"
-                    | "damage"
-                    | "health"
-                    | "inventory"
-                    | "item"
-                    | "items"
-                    | "orb"
-                    | "orbs"
-                    | "quest"
-                    | "quests"
-                    | "reward"
-                    | "rewards"
-                    | "unlock"
-                    | "unlocks"
-                    | "wallet"
-            )
-        })
-}
-
-fn sanitize_generated_content_text(
-    value: &str,
-    min_chars: usize,
-    max_chars: usize,
-) -> Option<String> {
-    let text = compact_whitespace(value.trim().trim_matches('"'));
-    let char_count = text.chars().count();
-    let lowered = format!(" {} ", text.to_ascii_lowercase());
-    if !(min_chars..=max_chars).contains(&char_count)
-        || text.chars().any(char::is_control)
-        || text.chars().any(|character| "{}<>\"".contains(character))
-        || [
-            " http://",
-            " https://",
-            " ignore previous",
-            " system prompt",
-            " developer message",
-            " assistant message",
-            " ai model",
-            " policy",
-            " wallet",
-            " orb ",
-            " orbs ",
-            " item ",
-            " items ",
-            " inventory ",
-            " reward",
-            " award",
-            " damage",
-            " health ",
-            " hit point",
-            " level up",
-            " grants ",
-            " gives you ",
-            " unlock",
-            " access gate",
-            " allows entry",
-            " opens access",
-            " locked until",
-            " quest",
-            " clock",
-        ]
-        .iter()
-        .any(|needle| lowered.contains(needle))
-    {
-        return None;
-    }
-    Some(text)
-}
-
-fn sanitize_generated_pathway_title(value: &str) -> Option<String> {
-    let title = compact_whitespace(value.trim().trim_matches('"'));
-    let word_count = title.split_whitespace().count();
-    if !(1..=6).contains(&word_count)
-        || !(4..=48).contains(&title.chars().count())
-        || title.to_ascii_lowercase().contains("pathway to")
-        || generated_label_contains_authority_language(&title.to_ascii_lowercase())
-        || !title
-            .chars()
-            .all(|character| character.is_ascii_alphabetic() || " -'".contains(character))
-    {
-        return None;
-    }
-    Some(title)
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct GeneratedWaypointContentProposal {
-    name: String,
-    title: String,
-    description: String,
-    persona: String,
-    visual_detail: String,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct GeneratedPathwayContentProposal {
-    waypoints: Vec<GeneratedWaypointContentProposal>,
-}
-
-fn parse_generated_pathway_content(
-    text: &str,
-    expected: usize,
-) -> Option<Vec<GeneratedWaypointContentProposal>> {
-    let cleaned = text
-        .trim()
-        .trim_start_matches("```json")
-        .trim_start_matches("```")
-        .trim_end_matches("```")
-        .trim();
-    let json_text = if cleaned.starts_with('{') {
-        cleaned
-    } else {
-        let start = cleaned.find('{')?;
-        let end = cleaned.rfind('}')?;
-        cleaned.get(start..=end)?
-    };
-    let proposal: GeneratedPathwayContentProposal = serde_json::from_str(json_text).ok()?;
-    if proposal.waypoints.len() != expected {
-        return None;
-    }
-    let waypoints = proposal
-        .waypoints
-        .into_iter()
-        .map(|waypoint| {
-            Some(GeneratedWaypointContentProposal {
-                name: sanitize_generated_pathway_name(&waypoint.name)?,
-                title: sanitize_generated_pathway_title(&waypoint.title)?,
-                description: sanitize_generated_content_text(&waypoint.description, 24, 240)?,
-                persona: sanitize_generated_content_text(&waypoint.persona, 20, 180)?,
-                visual_detail: sanitize_generated_content_text(&waypoint.visual_detail, 12, 180)?,
-            })
-        })
-        .collect::<Option<Vec<_>>>()?;
-    let unique = waypoints
-        .iter()
-        .map(|waypoint| waypoint.name.to_ascii_lowercase())
-        .collect::<BTreeSet<_>>();
-    (unique.len() == waypoints.len()).then_some(waypoints)
-}
-
-fn generated_pathway_name_avoids_anchors(name: &str, anchors: &[&str]) -> bool {
-    let name = compact_whitespace(name).to_ascii_lowercase();
-    anchors.iter().all(|anchor| {
-        let anchor = compact_whitespace(anchor).to_ascii_lowercase();
-        anchor.is_empty() || !name.contains(&anchor)
-    })
-}
-
-fn apply_generated_waypoint_content(
-    waypoint: &mut GeneratedWaypointState,
-    content: GeneratedWaypointContentProposal,
-) {
-    waypoint.name = content.name.clone();
-    waypoint.meta.title = content.title;
-    waypoint.meta.description = content.description;
-    waypoint.meta.persona = content.persona;
-    waypoint.meta.art_prompt = Some(format!(
-        "cozy storybook landscape, {detail}, {name}, {biome}, terrain of {terrain}, no people, no characters, no creatures, no text, no logo, no watermark",
-        detail = content.visual_detail,
-        name = content.name,
-        biome = waypoint.meta.biome,
-        terrain = waypoint.meta.terrain.join(", "),
-    ));
-}
-
-fn set_pathway_generation_provenance(
-    pathway: &mut GeneratedPathwayState,
-    mode: GenerationMode,
-    config: Option<&AiConfig>,
-    source: &str,
-    attempts: u8,
-) {
-    pathway.generation = GenerationProvenance {
-        source: source.to_string(),
-        feature: PATHWAY_CONTENT_FEATURE.to_string(),
-        policy_mode: mode.as_str().to_string(),
-        prompt_version: PATHWAY_CONTENT_PROMPT_VERSION.to_string(),
-        provider: ai_provider_name(config).to_string(),
-        model: ai_model_name(config),
-        attempts,
-    };
-}
-
 async fn generate_hidden_pathway_content(
     state: &AppState,
     mutation: &mut ProjectionMutation,
@@ -32856,28 +32691,7 @@ async fn generate_hidden_pathway_content(
         );
         return;
     };
-    let waypoint_context = pathway
-        .waypoints
-        .iter()
-        .enumerate()
-        .map(|(index, waypoint)| {
-            format!(
-                "{}. fallback name: {}; biome: {}; terrain: {}",
-                index + 1,
-                waypoint.name,
-                waypoint.meta.biome,
-                waypoint.meta.terrain.join(", ")
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let prompt = format!(
-        "Create {count} distinct hidden waypoint identities for successive stretches of one cozy storybook route. They are generated together now but players encounter them one at a time through Explore. Route: {origin} toward {destination}.\n{context}\nFor each waypoint return: name (evocative proper place name, 2-5 words); title (1-6 words); description (one concrete physical sentence); persona (one sentence describing how the place behaves, never dialogue); visual_detail (physical landscape details only). Preserve order. Do not introduce people, creatures, items, quests, rewards, rules, danger outcomes, access, magic powers, or facts beyond the listed biome and terrain. Names must use only ASCII letters, spaces, hyphens, or apostrophes, and must not use numbers, Pathway, Stretch, the route destination, or duplicates.",
-        count = pathway.waypoints.len(),
-        origin = narration_plan.from_name,
-        destination = narration_plan.destination_name,
-        context = waypoint_context,
-    );
+    let prompt_context = pathway_content_generation_context(state, pathway).await;
     let response_format = serde_json::json!({
         "type": "json_schema",
         "json_schema": {
@@ -32914,7 +32728,7 @@ async fn generate_hidden_pathway_content(
         ChatCompletionRequest {
             feature: PATHWAY_CONTENT_FEATURE,
             system: "You create bounded hidden geography in CosyWorld. Return only JSON matching the supplied schema. World rules and rewards are outside your authority.",
-            user: &prompt,
+            user: &prompt_context.prompt,
             temperature: 0.8,
             max_tokens: 600,
             timeout: Duration::from_secs(12),
@@ -32954,8 +32768,13 @@ async fn generate_hidden_pathway_content(
             contents.iter().all(|content| {
                 generated_pathway_name_avoids_anchors(
                     &content.name,
-                    &[&narration_plan.from_name, &narration_plan.destination_name],
-                )
+                    &[
+                        &prompt_context.origin_name,
+                        &prompt_context.destination_name,
+                    ],
+                ) && !prompt_context
+                    .occupied_names
+                    .contains(&content.name.to_ascii_lowercase())
             })
         });
     let Some(contents) = contents else {
@@ -33169,11 +32988,11 @@ async fn move_actor(
         if let ProjectionMutation::JourneyTransition {
             narration: stored_narration,
             ..
-        } = &mut mutation
+        } = mutation.as_mut()
         {
             *stored_narration = narration;
         }
-        let content_generation = mutation.clone();
+        let content_generation = (*mutation).clone();
         let turn_action_kind = if action.kind == CW_ACTION_MOVE {
             CW_ACTION_MOVE
         } else {
@@ -33186,7 +33005,7 @@ async fn move_actor(
         let response = apply_journey_transition_with_hosted_access(
             state.clone(),
             action,
-            mutation,
+            *mutation,
             payload.actor_session.as_deref(),
             turn_action_kind,
             hosted_access_grant,
@@ -47557,6 +47376,14 @@ mod tests {
             .exits
             .iter()
             .any(|exit| exit.destination_location_id == first_waypoint_id));
+        assert_eq!(
+            after_first_search
+                .exits
+                .iter()
+                .find(|exit| exit.destination_location_id == first_waypoint_id)
+                .map(|exit| exit.route_label.as_str()),
+            Some("Route from Rain-Soft Garden to Moonlit Trail")
+        );
         assert!(!after_first_search
             .exits
             .iter()
@@ -47604,6 +47431,11 @@ mod tests {
             runtime.actor_by_id(5000).unwrap().location_id,
             first_waypoint_id
         );
+        let traveled_pathway = runtime
+            .pathway_for_anchors(RAIN_SOFT_GARDEN_LOCATION_ID, MOONLIT_TRAIL_LOCATION_ID)
+            .expect("travel updates the shared pathway");
+        assert_eq!(traveled_pathway.traffic_count, 1);
+        assert_eq!(traveled_pathway.way_class, PathwayWayClass::Track);
         let frontier_state = runtime.state_response(Some(5000), &AccessContext::default());
         assert_eq!(frontier_state.location.name, first_waypoint_name);
         assert_eq!(

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -1,16 +1,207 @@
 use super::*;
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum PathwayWayClass {
+    #[default]
+    Route,
+    Track,
+    Path,
+    Trail,
+    Road,
+    Avenue,
+    Highway,
+}
+
+impl PathwayWayClass {
+    pub(super) fn for_traffic(traffic_count: u64) -> Self {
+        match traffic_count {
+            0 => Self::Route,
+            1..=3 => Self::Track,
+            4..=7 => Self::Path,
+            8..=15 => Self::Trail,
+            16..=31 => Self::Road,
+            32..=63 => Self::Avenue,
+            _ => Self::Highway,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Route => "Route",
+            Self::Track => "Track",
+            Self::Path => "Path",
+            Self::Trail => "Trail",
+            Self::Road => "Road",
+            Self::Avenue => "Avenue",
+            Self::Highway => "Highway",
+        }
+    }
+}
+
+pub(super) fn pathway_anchor_name_token(name: &str) -> String {
+    name.split_whitespace()
+        .find_map(|word| {
+            let word = word
+                .chars()
+                .filter(|character| character.is_ascii_alphabetic() || *character == '-')
+                .collect::<String>();
+            (!word.is_empty() && !word.eq_ignore_ascii_case("the")).then_some(word)
+        })
+        .unwrap_or_else(|| "Known".to_string())
+}
+
+pub(super) fn deterministic_pathway_collision_name(
+    pathway_canonical_id: &str,
+    waypoint_index: usize,
+    fallback_name: &str,
+    collision_attempt: u64,
+) -> String {
+    let mut value = stable_pathway_hash(&format!("{pathway_canonical_id}:{waypoint_index}"));
+    let mut token = String::with_capacity(5);
+    for _ in 0..5 {
+        token.push(char::from(b'a' + (value % 26) as u8));
+        value /= 26;
+    }
+    if collision_attempt == 0 {
+        return format!("{fallback_name}-{token}");
+    }
+    let mut attempt = collision_attempt - 1;
+    let mut attempt_token = String::new();
+    loop {
+        attempt_token.push(char::from(b'a' + (attempt % 26) as u8));
+        if attempt < 26 {
+            break;
+        }
+        attempt = attempt / 26 - 1;
+    }
+    let attempt_token = attempt_token.chars().rev().collect::<String>();
+    format!("{fallback_name}-{token}-{attempt_token}")
+}
+
+pub(super) fn reserve_unique_pathway_name(
+    occupied_names: &mut BTreeSet<String>,
+    proposed_name: &str,
+    fallback_name: &str,
+    pathway_canonical_id: &str,
+    waypoint_index: usize,
+) -> String {
+    if occupied_names.insert(proposed_name.to_ascii_lowercase()) {
+        return proposed_name.to_string();
+    }
+    if occupied_names.insert(fallback_name.to_ascii_lowercase()) {
+        return fallback_name.to_string();
+    }
+    let mut collision_attempt = 0u64;
+    loop {
+        let candidate = deterministic_pathway_collision_name(
+            pathway_canonical_id,
+            waypoint_index,
+            fallback_name,
+            collision_attempt,
+        );
+        if occupied_names.insert(candidate.to_ascii_lowercase()) {
+            return candidate;
+        }
+        collision_attempt = collision_attempt
+            .checked_add(1)
+            .expect("pathway collision namespace exhausted");
+    }
+}
+
+fn generated_pathway_edge_direction(
+    pathway: &GeneratedPathwayState,
+    from_location_id: u64,
+    to_location_id: u64,
+) -> Option<bool> {
+    let path = std::iter::once(pathway.origin_location_id)
+        .chain(pathway.waypoints.iter().map(|waypoint| waypoint.id))
+        .chain(std::iter::once(pathway.destination_location_id))
+        .collect::<Vec<_>>();
+    path.windows(2).find_map(|edge| {
+        if edge == [from_location_id, to_location_id] {
+            Some(true)
+        } else if edge == [to_location_id, from_location_id] {
+            Some(false)
+        } else {
+            None
+        }
+    })
+}
+
+pub(super) fn durable_pathway_traffic_evidence(
+    pathway: &GeneratedPathwayState,
+    committed_events: &[EventView],
+) -> u64 {
+    committed_events
+        .iter()
+        .filter(|event| event.success && event.type_name == "actor.moved")
+        .filter_map(|event| Some((event.location_id?, event.destination_location_id?)))
+        .filter(|(from_location_id, to_location_id)| {
+            generated_pathway_edge_direction(pathway, *from_location_id, *to_location_id).is_some()
+        })
+        .count() as u64
+}
+
 #[derive(Clone, Debug)]
 pub(super) enum MovementPlan {
     Adjacent(CwAction),
     Journey {
         action: CwAction,
-        mutation: ProjectionMutation,
+        mutation: Box<ProjectionMutation>,
         narration: JourneyNarrationPlan,
     },
 }
 
 impl RuntimeWorld {
+    fn generated_pathway_for_edge(
+        &self,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) -> Option<(&GeneratedPathwayState, bool)> {
+        self.generated_pathways.values().find_map(|pathway| {
+            generated_pathway_edge_direction(pathway, from_location_id, to_location_id)
+                .map(|forward| (pathway, forward))
+        })
+    }
+
+    pub(super) fn route_label_for_edge(
+        &self,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) -> String {
+        let (way_class, origin_location_id, destination_location_id) =
+            if let Some((pathway, forward)) =
+                self.generated_pathway_for_edge(from_location_id, to_location_id)
+            {
+                if forward {
+                    (
+                        pathway.way_class,
+                        pathway.origin_location_id,
+                        pathway.destination_location_id,
+                    )
+                } else {
+                    (
+                        pathway.way_class,
+                        pathway.destination_location_id,
+                        pathway.origin_location_id,
+                    )
+                }
+            } else {
+                (PathwayWayClass::Route, from_location_id, to_location_id)
+            };
+        let origin_name = self
+            .location_name(origin_location_id)
+            .unwrap_or_else(|| format!("Location {origin_location_id}"));
+        let destination_name = self
+            .location_name(destination_location_id)
+            .unwrap_or_else(|| format!("Location {destination_location_id}"));
+        format!(
+            "{} from {origin_name} to {destination_name}",
+            way_class.label()
+        )
+    }
+
     pub(super) fn first_tale_destination_reached(&self, actor_id: u64) -> bool {
         self.rpg_claims
             .contains(&first_tale_destination_claim_key(actor_id))
@@ -134,7 +325,7 @@ impl RuntimeWorld {
         {
             return Ok(MovementPlan::Journey {
                 action,
-                mutation,
+                mutation: Box::new(mutation),
                 narration,
             });
         }
@@ -281,6 +472,142 @@ fn first_tale_destination_claim_key(actor_id: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn route_labels_are_directional_and_traffic_does_not_reallocate_identity() {
+        let mut runtime = RuntimeWorld::seeded();
+        let mut pathway = runtime
+            .generated_pathway(RATI_ACTOR_ID, 700, 712, 2)
+            .expect("Bethlehem-to-Jerusalem route");
+        let pathway_id = pathway.id.clone();
+        let waypoint_id = pathway.waypoints[0].id;
+        runtime.ensure_generated_pathway_route_records(&pathway);
+        runtime
+            .generated_pathways
+            .insert(pathway_id.clone(), pathway.clone());
+        let route_before = runtime
+            .routes
+            .values()
+            .find(|route| route.contains_edge(700, waypoint_id))
+            .expect("generated segment route")
+            .clone();
+        let journey = JourneyState {
+            actor_id: RATI_ACTOR_ID,
+            pathway_id: pathway_id.clone(),
+            origin_location_id: 700,
+            destination_location_id: 712,
+            destination_name: "Jerusalem".to_string(),
+            path: vec![700, waypoint_id, 712],
+            current_step: 0,
+            explorer: true,
+        };
+        runtime.journeys.insert(RATI_ACTOR_ID, journey.clone());
+        let identity_before = serde_json::to_vec(&(
+            pathway.id.clone(),
+            pathway.canonical_id.clone(),
+            pathway.source_route_id.clone(),
+            pathway.source_route_version,
+            pathway.owner_pack_id.clone(),
+            pathway.owner_pack_version.clone(),
+            pathway
+                .waypoints
+                .iter()
+                .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+                .collect::<Vec<_>>(),
+        ))
+        .expect("serialize route identity");
+        let journey_before = serde_json::to_vec(&journey).expect("serialize journey");
+
+        assert_eq!(
+            runtime.route_label_for_edge(700, waypoint_id),
+            "Route from Bethlehem to Jerusalem"
+        );
+        assert_eq!(
+            runtime.route_label_for_edge(712, waypoint_id),
+            "Route from Jerusalem to Bethlehem"
+        );
+
+        for (traffic_count, expected_class, expected_label) in [
+            (1, PathwayWayClass::Track, "Track"),
+            (4, PathwayWayClass::Path, "Path"),
+            (8, PathwayWayClass::Trail, "Trail"),
+            (16, PathwayWayClass::Road, "Road"),
+            (32, PathwayWayClass::Avenue, "Avenue"),
+            (64, PathwayWayClass::Highway, "Highway"),
+        ] {
+            pathway.traffic_count = traffic_count;
+            pathway.way_class = PathwayWayClass::for_traffic(traffic_count);
+            runtime
+                .generated_pathways
+                .insert(pathway_id.clone(), pathway.clone());
+            assert_eq!(
+                runtime.generated_pathways[&pathway_id].way_class,
+                expected_class
+            );
+            assert_eq!(
+                runtime.route_label_for_edge(700, waypoint_id),
+                format!("{expected_label} from Bethlehem to Jerusalem")
+            );
+        }
+        runtime
+            .generated_pathways
+            .get_mut(&pathway_id)
+            .expect("pathway remains allocated")
+            .waypoints[0]
+            .name = "Rain-Silver Crossing".to_string();
+
+        let evolved = &runtime.generated_pathways[&pathway_id];
+        let identity_after = serde_json::to_vec(&(
+            evolved.id.clone(),
+            evolved.canonical_id.clone(),
+            evolved.source_route_id.clone(),
+            evolved.source_route_version,
+            evolved.owner_pack_id.clone(),
+            evolved.owner_pack_version.clone(),
+            evolved
+                .waypoints
+                .iter()
+                .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+                .collect::<Vec<_>>(),
+        ))
+        .expect("serialize evolved identity");
+        assert_eq!(identity_after, identity_before);
+        assert_eq!(
+            serde_json::to_vec(&runtime.journeys[&RATI_ACTOR_ID]).expect("serialize journey"),
+            journey_before
+        );
+        assert_eq!(
+            runtime
+                .routes
+                .values()
+                .find(|route| route.contains_edge(700, waypoint_id))
+                .expect("segment remains allocated"),
+            &route_before
+        );
+        assert_eq!(
+            runtime.route_label_for_edge(712, waypoint_id),
+            "Highway from Jerusalem to Bethlehem"
+        );
+    }
+
+    #[test]
+    fn pathway_traffic_counts_only_committed_movement_on_its_exact_edges() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = runtime
+            .generated_pathway(RATI_ACTOR_ID, 700, 712, 2)
+            .expect("Bethlehem-to-Jerusalem route");
+        let waypoint_id = pathway.waypoints[0].id;
+        let forward = runtime.append_actor_moved_event(RATI_ACTOR_ID, 700, waypoint_id);
+        let reverse = runtime.append_actor_moved_event(RATI_ACTOR_ID, waypoint_id, 700);
+        let unrelated = runtime.append_actor_moved_event(RATI_ACTOR_ID, 1, 2);
+        let mut rejected = forward.clone();
+        rejected.success = false;
+
+        assert_eq!(
+            durable_pathway_traffic_evidence(&pathway, &[forward, reverse, unrelated, rejected],),
+            2
+        );
+    }
 
     fn discover_seed_exit_for_test(
         runtime: &mut RuntimeWorld,

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -489,6 +489,7 @@ impl RuntimeWorld {
         pathway: &mut GeneratedPathwayState,
         allow_legacy_backfill: bool,
     ) -> Result<(), String> {
+        pathway.way_class = PathwayWayClass::for_traffic(pathway.traffic_count);
         if pathway.origin_location_id == pathway.destination_location_id
             || !(2..=8).contains(&pathway.distance)
             || pathway.waypoints.len() != usize::from(pathway.distance.saturating_sub(1))
@@ -895,9 +896,17 @@ impl RuntimeWorld {
             "Quiet Rise",
             "Bramble Mile",
         ];
+        let route_name_prefix = format!(
+            "{}-{}",
+            pathway_anchor_name_token(&origin_name),
+            pathway_anchor_name_token(&destination_name),
+        );
         let waypoints = (0..waypoint_count)
             .map(|index| {
-                let landmark_name = names[(seed as usize + index) % names.len()].to_string();
+                let landmark_name = format!(
+                    "{route_name_prefix} {}",
+                    names[(seed as usize + index) % names.len()]
+                );
                 let canonical_id = generated_waypoint_canonical_id(&pathway_id, index);
                 let id = generated_pathway_location_id(&canonical_id);
                 let art_prompt = format!(
@@ -965,6 +974,8 @@ impl RuntimeWorld {
             destination_location_id,
             distance,
             created_by_actor_id: actor_id,
+            way_class: PathwayWayClass::Route,
+            traffic_count: 0,
             waypoints,
             generation: GenerationProvenance {
                 source: "deterministic_fallback".to_string(),
@@ -2218,6 +2229,139 @@ mod tests {
             .into_runtime()
             .expect("restart generated subgraph");
         assert_eq!(generated_subgraph_bytes(&restarted), committed_bytes);
+    }
+
+    #[test]
+    fn repeated_generated_names_fall_back_by_endpoint_and_replay_identically() {
+        let seed = RuntimeWorld::seeded();
+        let pathway_a = seed
+            .generated_pathway(RATI_ACTOR_ID, 700, 712, 2)
+            .expect("first generated route");
+        let pathway_b = seed
+            .generated_pathway(RATI_ACTOR_ID, 701, 703, 2)
+            .expect("second generated route");
+        let mut pathway_c = seed
+            .generated_pathway(RATI_ACTOR_ID, 703, 704, 2)
+            .expect("endpoint fallback fixture route");
+        let mut pathway_d = seed
+            .generated_pathway(RATI_ACTOR_ID, 704, 706, 2)
+            .expect("hashed fallback fixture route");
+        let fallback_b = pathway_b.waypoints[0].name.clone();
+        let repeated_name = "Rain-Silver Crossing";
+        let first_collision_name =
+            deterministic_pathway_collision_name(&pathway_b.canonical_id, 0, &fallback_b, 0);
+        pathway_c.waypoints[0].name = fallback_b.clone();
+        pathway_d.waypoints[0].name = first_collision_name.clone();
+        let discovery_record = |pathway: &GeneratedPathwayState, seed| JournalRecord {
+            projection_mutations: vec![ProjectionMutation::JourneyTransition {
+                pathway: pathway.clone(),
+                journey: None,
+                reveal_edges: vec![(pathway.origin_location_id, pathway.waypoints[0].id)],
+                narration: "A route becomes shared geography.".to_string(),
+                event_type: "pathway.discovered".to_string(),
+            }],
+            ..JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_NONE,
+                    actor_id: RATI_ACTOR_ID,
+                    ..CwAction::default()
+                },
+                seed,
+            )
+        };
+        let mut refined_a = pathway_a.clone();
+        let mut refined_b = pathway_b.clone();
+        refined_a.waypoints[0].name = repeated_name.to_string();
+        refined_b.waypoints[0].name = repeated_name.to_string();
+        let refine_record = |pathway: GeneratedPathwayState, seed| JournalRecord {
+            projection_mutations: vec![ProjectionMutation::RefinePathway { pathway }],
+            ..JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_NONE,
+                    actor_id: RATI_ACTOR_ID,
+                    ..CwAction::default()
+                },
+                seed,
+            )
+        };
+        let records = vec![
+            discovery_record(&pathway_a, 333_001),
+            discovery_record(&pathway_c, 333_002),
+            discovery_record(&pathway_d, 333_003),
+            discovery_record(&pathway_b, 333_004),
+            refine_record(refined_a, 333_005),
+            refine_record(refined_b, 333_006),
+        ];
+        let replay_records: Vec<JournalRecord> = serde_json::from_slice(
+            &serde_json::to_vec(&records).expect("serialize collision fixture"),
+        )
+        .expect("deserialize collision fixture");
+
+        let mut committed = RuntimeWorld::seeded();
+        let mut replayed = RuntimeWorld::seeded();
+        for record in &records {
+            assert_eq!(committed.apply_journal_record(record).0, CW_OK);
+        }
+        for record in &replay_records {
+            assert_eq!(replayed.apply_journal_record(record).0, CW_OK);
+        }
+
+        assert_eq!(
+            committed.generated_pathways[&pathway_a.id].waypoints[0].name,
+            repeated_name
+        );
+        assert_eq!(
+            committed.generated_pathways[&pathway_b.id].waypoints[0].name,
+            deterministic_pathway_collision_name(&pathway_b.canonical_id, 0, &fallback_b, 1)
+        );
+        assert_eq!(
+            committed.generated_pathways[&pathway_d.id].waypoints[0].name,
+            first_collision_name
+        );
+        let names = committed
+            .generated_pathways
+            .values()
+            .flat_map(|pathway| pathway.waypoints.iter())
+            .map(|waypoint| waypoint.name.to_ascii_lowercase())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names.iter().collect::<BTreeSet<_>>().len(),
+            names.len(),
+            "every simultaneously offered generated destination stays unique"
+        );
+        let endpoint_prefix = format!(
+            "{}-{}",
+            pathway_anchor_name_token(
+                &committed
+                    .location_name(pathway_b.origin_location_id)
+                    .expect("origin name"),
+            ),
+            pathway_anchor_name_token(
+                &committed
+                    .location_name(pathway_b.destination_location_id)
+                    .expect("destination name"),
+            ),
+        );
+        assert!(fallback_b.starts_with(&endpoint_prefix));
+
+        let stable_projection = |runtime: &RuntimeWorld| {
+            serde_json::to_vec(&(
+                runtime.generated_pathways.clone(),
+                runtime
+                    .routes
+                    .iter()
+                    .filter(|(_, route)| route.provenance.starts_with("generated_pathway:"))
+                    .map(|(id, route)| (id.clone(), route.clone()))
+                    .collect::<BTreeMap<_, _>>(),
+            ))
+            .expect("serialize collision projection")
+        };
+        let committed_bytes = stable_projection(&committed);
+        assert_eq!(stable_projection(&replayed), committed_bytes);
+        let restarted = RuntimeSnapshot::from_runtime(&committed)
+            .into_runtime()
+            .expect("restart collision fixture");
+        assert_eq!(stable_projection(&restarted), committed_bytes);
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -297,6 +297,7 @@ pub(super) struct ExitView {
     pub(super) route_version: u64,
     pub(super) destination_location_id: u64,
     pub(super) destination_location_name: String,
+    pub(super) route_label: String,
     pub(super) direction: Option<String>,
     pub(super) distance: u8,
     pub(super) locked: bool,
@@ -1697,6 +1698,8 @@ impl RuntimeWorld {
                     destination_location_name: self
                         .location_name(exit.to_location_id)
                         .unwrap_or_else(|| format!("Location {}", exit.to_location_id)),
+                    route_label: self
+                        .route_label_for_edge(exit.from_location_id, exit.to_location_id),
                     direction: self.exit_direction(exit.from_location_id, exit.to_location_id),
                     distance: self.pathway_distance(exit.from_location_id, exit.to_location_id),
                     locked: false,
@@ -2345,11 +2348,7 @@ impl RuntimeWorld {
 
                 let strategies = self.shared_question_strategy_views(job, actor_id);
                 let available = strategies.iter().any(|strategy| strategy.available);
-                let mut recent = progress
-                    .recent_contributions
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<_>>();
+                let mut recent = progress.recent_contributions.to_vec();
                 if let Some(danger) = danger {
                     recent.extend(danger.recent_contributions.iter().cloned());
                 }

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74533
+74365

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -2222,8 +2222,22 @@ async function main() {
         ],
         items: [],
         exits: [
-          { destination_location_id: 2, destination_location_name: "Rain-Soft Garden", direction: "east", accessible: true, locked: false },
-          { destination_location_id: 11, destination_location_name: "Homeroom", direction: "north", accessible: true, locked: false },
+          {
+            destination_location_id: 2,
+            destination_location_name: "Rain-Soft Garden",
+            route_label: "Route from The Cosy Cottage to Rain-Soft Garden",
+            direction: "east",
+            accessible: true,
+            locked: false,
+          },
+          {
+            destination_location_id: 11,
+            destination_location_name: "Homeroom",
+            route_label: "Route from The Cosy Cottage to Homeroom",
+            direction: "north",
+            accessible: true,
+            locked: false,
+          },
         ],
         room_features: [],
         cards: {
@@ -2331,8 +2345,11 @@ async function main() {
     assert(result.count === 1, `multiple open paths should collapse into one Travel card: ${JSON.stringify(result)}`);
     assert(result.detail === "choose a path" && result.command === "go", `grouped Travel should carry its destination choice: ${JSON.stringify(result)}`);
     assert(
-      ["Rain-Soft Garden", "Homeroom"].every((name) => result.choices.some((choice) => choice.label === name)),
-      `Travel should carry every open destination: ${JSON.stringify(result)}`,
+      [
+        "Route from The Cosy Cottage to Rain-Soft Garden",
+        "Route from The Cosy Cottage to Homeroom",
+      ].every((name) => result.choices.some((choice) => choice.label === name)),
+      `Travel should distinguish routes from their next location cards: ${JSON.stringify(result)}`,
     );
     assert(
       ["exit:2", "exit:11"].every((key) => result.focusKeys.includes(key)),


### PR DESCRIPTION
Closes #333

## Outcome
- separates stable canonical route identity from travel-direction labels, waypoint prose, and traffic-evolving way class
- presents directional endpoint labels such as `Route from Bethlehem to Jerusalem` and the reverse order, while durable traffic evolves Route → Track → Path → Trail → Road → Avenue → Highway without reallocating topology or journey state
- supplies the waypoint generator with route/version/direction/segment plus biome, terrain, climate, hydrology, vegetation, fauna, ecosystem, and nearby authored context; the model remains prose-only
- guarantees simultaneously offered generated destination names are unique, including when the endpoint fallback and first hashed suffix are both already occupied; replay and snapshot remain byte-identical

## Evidence
- full Rust run: 559/560 passed; the only failure was the known nondeterministic regional-chaos authority race, which immediately passed 1/1 in isolation
- five focused prompt/label/traffic/collision/journey tests passed, including a fixture that preoccupies two deterministic fallback names
- worldpack, kernel, AI-model, and WASM gates passed in the broader wrapper
- architecture: main.rs 74,365/74,365; Clippy 246/246
- formatting, diff, version, and syntax gates passed
- diff: 1,308 changed lines, under the 2,400 cap

## Browser evidence limitation
The isolated v0.0.209 server was healthy. Stock smoke was blocked before route visuals by an unrelated classless-avatar-purpose assertion; a focused harness then timed out awaiting Travel, and the in-app browser backend was unavailable. No screenshot is substituted. The changed browser route-label contract fixture is syntax-green and asserts distinct directional labels.