### PR TITLE
Preserve refused turn nudges and explain why

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.205",
+      "version": "0.0.206",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -835,7 +835,9 @@ Public action endpoints accept active human actors only when the matching `actor
 
 `POST /actions/report` accepts JSON `{ "actor_id": 5000, "actor_session": "...", "target_actor_id": 1001, "reason": "..." }`. The reporter and target must both be in the same room, and human targets must be visible in active room presence. Success returns `200` plus a durable report id for moderator review; reports do not broadcast into the room timeline.
 
-`POST /actions/timeout` accepts JSON `{ "actor_id": 5000, "actor_session": "..." }`. It is only useful for an active human waiting on another active human's room turn. The first request gently nudges the current player and starts an eight-second wait; later requests tell the room that those players are still here. If the current player remains away, the next choice passes to an eligible responder. The durable event names remain `turn.ping_started`, `turn.pong`, and `turn.ping_skipped` for compatibility, but the browser presents only the warmer Nudge / I'm here language.
+`POST /actions/timeout` accepts JSON `{ "actor_id": 5000, "actor_session": "..." }`. It is available to an active participant waiting on another active participant in an explicitly ordered combat or cooperative-work scene. A successful nudge journals a system Pass for the current holder and advances to the next eligible participant. Refusals return actionable events with stable types: `turn.timeout_refused.requester_holds_turn`, `turn.timeout_refused.participants_below_two`, `turn.timeout_refused.requester_not_eligible`, `turn.timeout_refused.no_focused_scene`, or `turn.timeout_refused.cooldown`. Refusal checks happen before any world mutation.
+
+`POST /actions/need-time` uses the same actor payload for the current ordered-scene holder's one nonpunitive grace extension. It does not pass the turn or advance world time.
 
 Public mutation endpoints also pass through lightweight in-memory rate limits before they touch the world reducer:
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -540,7 +540,7 @@ fn drive_combat_inference_turns(
     Ok(CW_OK)
 }
 
-fn drive_available_combat_turns(
+pub(super) fn drive_available_combat_turns(
     state: &AppState,
     runtime: &mut RuntimeWorld,
     encounter_id: u64,

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -4887,6 +4887,29 @@
       };
       if (turn.enabled && !turn.is_current_actor) {
         const currentName = turn.current_actor_name || "another avatar";
+        const waitingActions = [];
+        if (turn.can_request_timeout) {
+          waitingActions.push({
+            handProvider: {
+              kind: "rules",
+              id: "rules:ordered-scene-timeout",
+              label: "Ordered scene",
+              reason: "Ask the current participant to play or pass",
+              priority: 0,
+            },
+            label: "nudge",
+            detail: `ask ${currentName} to play or pass`,
+            command: "nudge",
+            focusKey: "scene-timeout",
+            card: cardForActor(turn.current_actor_id) || cardForLocation(view.location?.id),
+            shape: "avatar",
+            priority: 0,
+            modalTitle: `gently nudge ${currentName}`,
+            modalSummary: `Ask ${currentName} to play or pass so this ordered scene can continue.`,
+            effect: "passes the ordered floor to the next eligible participant",
+            run: () => action("/actions/timeout", { actor_id: actorId }),
+          });
+        }
         const waitingAction = {
           handProvider: {
             kind: "rules",
@@ -4907,7 +4930,8 @@
           effect: "shows the current combat order without taking an action",
           run: () => runCommandText("look"),
         };
-        return [waitingAction].map(decorateActionHand);
+        waitingActions.push(waitingAction);
+        return waitingActions.map(decorateActionHand);
       }
 
       const built = [];
@@ -6715,7 +6739,7 @@
       pushEvents(result.events || []);
       if (!result.ok) {
         setError(actionFailureMessage(path, result));
-      } else if (["/actions/move", "/actions/flee", "/actions/explore-path"].includes(path)) {
+      } else if (["/actions/move", "/actions/flee", "/actions/explore-path", "/actions/timeout"].includes(path)) {
         await refresh();
       }
       if (result.ok && clearFirstTaleAfterAction) firstTaleCelebration = false;
@@ -6731,6 +6755,12 @@
       const status = Number(result.status || 0);
       const conflict = (result.events || []).find((event) => event?.type === "action.conflict");
       if (conflict?.content) return String(conflict.content);
+      const timeoutRefusal = (result.events || []).find((event) => (
+        String(event?.type || "").startsWith("turn.timeout_refused.")
+      ));
+      if (path === "/actions/timeout" && timeoutRefusal?.content) {
+        return String(timeoutRefusal.content);
+      }
       if (status === 402 && path.includes("fund-image")) {
         return "You need one Orb to add to this community image.";
       }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -29105,7 +29105,7 @@ async fn command_inner(
         let Json(response) = if normalized_command == "pass" {
             pass_ordered_scene_turn(ConnectInfo(client_addr), State(state), Json(request)).await
         } else {
-            request_turn_timeout(ConnectInfo(client_addr), State(state), Json(request)).await
+            request_turn_need_time(ConnectInfo(client_addr), State(state), Json(request)).await
         };
         let output = if response.ok {
             if response
@@ -48816,7 +48816,6 @@ mod tests {
         assert!(INDEX_HTML.contains("Use one advancement point to begin a friendship with"));
         assert!(INDEX_HTML.contains("kind: \"advancement-chat\""));
         assert!(!INDEX_HTML.contains("label: \"grow closer\""));
-        assert!(INDEX_HTML.contains("return [waitingAction].map(decorateActionHand);"));
         assert!(!INDEX_HTML.contains("cmd-progress"));
         assert!(INDEX_HTML.contains("if (!result.ok) void queueRefresh();"));
         assert!(INDEX_HTML.contains("event?.type !== \"action.receipt\""));

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -139,7 +139,7 @@ pub(super) fn app_router(state: AppState) -> Router {
         .route("/presence/leave", post(leave_presence))
         .route("/actions/submit", post(submit_action_offer))
         .route("/actions/timeout", post(request_turn_timeout))
-        .route("/actions/need-time", post(request_turn_timeout))
+        .route("/actions/need-time", post(request_turn_need_time))
         .route("/actions/pass", post(pass_ordered_scene_turn))
         .route("/actions/narrative-move", post(submit_narrative_move))
         .route("/actions/chat", post(chat))

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -995,6 +995,104 @@ pub(super) fn combat_turn_view(
     actor_id: u64,
     room_id: u64,
 ) -> Option<RoomTurnView> {
+    focused_turn_view(runtime, actor_id, room_id, None)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TurnTimeoutRefusal {
+    NoFocusedScene,
+    RequesterHoldsTurn,
+    ParticipantsBelowTwo,
+    RequesterNotEligible,
+    Cooldown,
+}
+
+impl TurnTimeoutRefusal {
+    fn event_type(self) -> &'static str {
+        match self {
+            Self::NoFocusedScene => "turn.timeout_refused.no_focused_scene",
+            Self::RequesterHoldsTurn => "turn.timeout_refused.requester_holds_turn",
+            Self::ParticipantsBelowTwo => "turn.timeout_refused.participants_below_two",
+            Self::RequesterNotEligible => "turn.timeout_refused.requester_not_eligible",
+            Self::Cooldown => "turn.timeout_refused.cooldown",
+        }
+    }
+
+    fn status(self) -> u32 {
+        match self {
+            Self::Cooldown => 429,
+            Self::RequesterNotEligible => 403,
+            Self::NoFocusedScene | Self::RequesterHoldsTurn | Self::ParticipantsBelowTwo => 409,
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::NoFocusedScene => {
+                "There is no ordered scene to nudge. Check what is here and choose an available action."
+            }
+            Self::RequesterHoldsTurn => {
+                "You already hold this turn. Play an action, pass, or ask for more time."
+            }
+            Self::ParticipantsBelowTwo => {
+                "Fewer than two eligible participants remain, so nobody can be nudged. The ordered scene will recover when another participant returns."
+            }
+            Self::RequesterNotEligible => {
+                "You are no longer an eligible participant in this ordered scene. Rejoin the scene before nudging its current player."
+            }
+            Self::Cooldown => {
+                "That player was nudged too recently. Give the scene a moment, then try again if the turn is still waiting."
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FocusedTimeoutEligibility {
+    focused: FocusedEncounterView,
+    eligible_participant_ids: Vec<u64>,
+}
+
+fn focused_timeout_eligibility(
+    runtime: &RuntimeWorld,
+    requester_actor_id: u64,
+    active_direct_actor_ids: &BTreeSet<u64>,
+) -> Result<FocusedTimeoutEligibility, TurnTimeoutRefusal> {
+    let focused = focused_encounter_for_actor(runtime, requester_actor_id)
+        .ok_or(TurnTimeoutRefusal::NoFocusedScene)?;
+    if focused.current_actor_id == requester_actor_id {
+        return Err(TurnTimeoutRefusal::RequesterHoldsTurn);
+    }
+    let eligible_participant_ids = focused
+        .participant_order
+        .iter()
+        .copied()
+        .filter(|participant_id| {
+            runtime
+                .actor_by_id(*participant_id)
+                .is_some_and(RuntimeWorld::actor_can_act)
+                && (runtime.actor_uses_inference(*participant_id)
+                    || active_direct_actor_ids.contains(participant_id))
+        })
+        .collect::<Vec<_>>();
+    if eligible_participant_ids.len() < FOCUSED_ENCOUNTER_MIN_PARTICIPANTS {
+        return Err(TurnTimeoutRefusal::ParticipantsBelowTwo);
+    }
+    if !eligible_participant_ids.contains(&requester_actor_id) {
+        return Err(TurnTimeoutRefusal::RequesterNotEligible);
+    }
+    Ok(FocusedTimeoutEligibility {
+        focused,
+        eligible_participant_ids,
+    })
+}
+
+fn focused_turn_view(
+    runtime: &RuntimeWorld,
+    actor_id: u64,
+    room_id: u64,
+    active_direct_actor_ids: Option<&BTreeSet<u64>>,
+) -> Option<RoomTurnView> {
     let focused = focused_encounter_for_actor(runtime, actor_id)?;
     let current_actor_id = focused.current_actor_id;
     let current_actor_name = runtime.actor_name(current_actor_id);
@@ -1005,7 +1103,20 @@ pub(super) fn combat_turn_view(
     } else {
         focused_job_need_time_used(runtime, focused.encounter_id, current_actor_id)
     };
-    let waiting_actor_ids = focused.waiting_actor_ids();
+    let timeout_eligibility = active_direct_actor_ids
+        .map(|active_actor_ids| focused_timeout_eligibility(runtime, actor_id, active_actor_ids));
+    let waiting_actor_ids = timeout_eligibility
+        .as_ref()
+        .and_then(|eligibility| eligibility.as_ref().ok())
+        .map(|eligibility| {
+            eligibility
+                .eligible_participant_ids
+                .iter()
+                .copied()
+                .filter(|participant_id| *participant_id != current_actor_id)
+                .collect()
+        })
+        .unwrap_or_else(|| focused.waiting_actor_ids());
     let explanation = Some(format!(
         "{} {} acts now; chat and inspection stay available.",
         if is_combat {
@@ -1036,7 +1147,7 @@ pub(super) fn combat_turn_view(
         }),
         need_time_extension_ms: ORDERED_SCENE_NEED_TIME_MS,
         handoff_key: Some(focused.handoff_key()),
-        can_request_timeout: false,
+        can_request_timeout: timeout_eligibility.is_some_and(|eligibility| eligibility.is_ok()),
         timeout_requests: Vec::new(),
         waiting_actor_ids,
         ping_active: false,
@@ -1053,10 +1164,12 @@ pub(super) fn room_turn_view_for_runtime(
     runtime: &RuntimeWorld,
     location_id: u64,
     viewer_actor_id: Option<u64>,
-    _active_actor_ids: &BTreeSet<u64>,
+    active_actor_ids: &BTreeSet<u64>,
 ) -> RoomTurnView {
     viewer_actor_id
-        .and_then(|actor_id| combat_turn_view(runtime, actor_id, location_id))
+        .and_then(|actor_id| {
+            focused_turn_view(runtime, actor_id, location_id, Some(active_actor_ids))
+        })
         .unwrap_or_else(|| RoomTurnView::idle(location_id))
 }
 
@@ -1408,7 +1521,7 @@ pub(super) async fn recover_available_focused_job_turns(
     Ok(events)
 }
 
-pub(super) async fn request_turn_timeout(
+pub(super) async fn request_turn_need_time(
     ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
     Json(payload): Json<ActorRequest>,
@@ -1429,6 +1542,153 @@ pub(super) async fn request_turn_timeout(
         payload.actor_session.as_deref(),
     )
     .await
+}
+
+fn turn_timeout_refusal_response(
+    runtime: Option<&RuntimeWorld>,
+    actor_id: u64,
+    refusal: TurnTimeoutRefusal,
+) -> Json<ActionResponse> {
+    let focused = runtime.and_then(|runtime| focused_encounter_for_actor(runtime, actor_id));
+    Json(ActionResponse {
+        ok: false,
+        status: refusal.status(),
+        events: vec![EventView {
+            type_name: refusal.event_type().to_string(),
+            success: false,
+            actor_id: Some(actor_id),
+            actor_name: runtime.and_then(|runtime| runtime.actor_name(actor_id)),
+            target_actor_id: focused.as_ref().map(|focused| focused.current_actor_id),
+            target_actor_name: focused.as_ref().and_then(|focused| {
+                runtime.and_then(|runtime| runtime.actor_name(focused.current_actor_id))
+            }),
+            location_id: focused.as_ref().map(|focused| focused.location_id),
+            content_id: focused.as_ref().map(|focused| focused.encounter_id),
+            content: Some(refusal.message().to_string()),
+            ..EventView::default()
+        }],
+    })
+}
+
+pub(super) async fn request_turn_timeout(
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    Json(payload): Json<ActorRequest>,
+) -> Json<ActionResponse> {
+    if !allow_actor_mutation(
+        &state,
+        client_addr,
+        payload.actor_id,
+        "turn-timeout",
+        GENERAL_ACTION_LIMIT,
+    ) {
+        return turn_timeout_refusal_response(None, payload.actor_id, TurnTimeoutRefusal::Cooldown);
+    }
+
+    let was_active = payload
+        .actor_session
+        .as_deref()
+        .and_then(|token| {
+            actor_session_active_for_actor(&state.actor_sessions, payload.actor_id, token)
+        })
+        .unwrap_or(false);
+    let mut runtime = state.inner.lock().await;
+    if !client_actor_authorized_for_state(
+        &runtime,
+        &state,
+        payload.actor_id,
+        payload.actor_session.as_deref(),
+    ) {
+        return client_actor_rejected_response();
+    }
+    let active_direct_actor_ids = active_actor_ids_for_state(&state);
+    let eligibility =
+        match focused_timeout_eligibility(&runtime, payload.actor_id, &active_direct_actor_ids) {
+            Ok(eligibility) => eligibility,
+            Err(refusal) => {
+                return turn_timeout_refusal_response(Some(&runtime), payload.actor_id, refusal);
+            }
+        };
+    let focused = eligibility.focused;
+    let current_actor_id = focused.current_actor_id;
+    let turn_location_id = Some(focused.location_id);
+    let timeout_requested = EventView {
+        type_name: "turn.timeout_requested".to_string(),
+        success: true,
+        actor_id: Some(payload.actor_id),
+        actor_name: runtime.actor_name(payload.actor_id),
+        target_actor_id: Some(current_actor_id),
+        target_actor_name: runtime.actor_name(current_actor_id),
+        location_id: turn_location_id,
+        content_id: Some(focused.encounter_id),
+        content: Some(
+            "The waiting participant asked the current player to play or pass.".to_string(),
+        ),
+        ..EventView::default()
+    };
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: if focused.profile_id == FOCUSED_COMBAT_PROFILE_ID {
+                CW_ACTION_COMBAT_PASS
+            } else {
+                CW_ACTION_NONE
+            },
+            actor_id: current_actor_id,
+            content_id: focused.encounter_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    )
+    .into_system();
+    if focused.profile_id != FOCUSED_COMBAT_PROFILE_ID {
+        record.bind_offer_kind("pass");
+        record
+            .projection_mutations
+            .push(ProjectionMutation::FocusedControl {
+                control: "pass".to_string(),
+            });
+        bind_focused_encounter_context(&runtime, &mut record);
+    }
+    let Ok((mut status, mut events)) = commit_journal_record(&state, &mut runtime, record) else {
+        return Json(ActionResponse {
+            ok: false,
+            status: 500,
+            events: Vec::new(),
+        });
+    };
+    if status == CW_OK && focused.profile_id == FOCUSED_COMBAT_PROFILE_ID {
+        status = drive_available_combat_turns(
+            &state,
+            &mut runtime,
+            focused.encounter_id,
+            current_actor_id,
+            &mut events,
+        )
+        .unwrap_or(500);
+    }
+    let observation = advance_turn_and_capture_player_tick_observation(
+        &state,
+        &mut runtime,
+        turn_location_id,
+        payload.actor_id,
+        status,
+        &mut events,
+    );
+    events.insert(0, timeout_requested);
+    drop(runtime);
+
+    broadcast_events(&state, &events);
+    if let Some(observation) = observation {
+        schedule_player_tick_observation(&state, observation);
+    }
+    if !was_active {
+        events.extend(commit_presence_event(&state, payload.actor_id, true).await);
+    }
+    Json(ActionResponse {
+        ok: status == CW_OK,
+        status,
+        events,
+    })
 }
 
 pub(super) async fn pass_ordered_scene_turn(
@@ -1643,6 +1903,68 @@ mod tests {
         record
     }
 
+    fn focused_timeout_fixture() -> RuntimeWorld {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Current Worker",
+        );
+        create_test_human(
+            &mut runtime,
+            5001,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Waiting Worker",
+        );
+        for actor_id in [5000, 5001] {
+            runtime
+                .actor_autonomy
+                .entry(actor_id)
+                .or_default()
+                .control_mode = ActorControlMode::DirectInput;
+        }
+        {
+            let job = runtime
+                .jobs
+                .get_mut(FIRST_TALE_JOB_ID)
+                .expect("focused timeout fixture job");
+            job.status = "active".to_string();
+            job.focused_profile = Some(FOCUSED_WORK_PROFILE.to_string());
+            job.focused_encounter = None;
+        }
+        for clock_id in [
+            FIRST_TALE_PROGRESS_CLOCK_ID,
+            "rain-soft-garden.path-washes-out",
+        ] {
+            let clock = runtime
+                .clocks
+                .get_mut(clock_id)
+                .expect("focused timeout fixture clock");
+            clock.segments = 12;
+            clock.filled = 0;
+            clock.status = "active".to_string();
+            clock.recent_contributions.clear();
+            clock.completion = None;
+        }
+        let first = focused_work_record(&runtime, 5000, 83_100);
+        assert_eq!(runtime.apply_journal_record(&first).0, CW_OK);
+        let second = focused_work_record(&runtime, 5001, 83_101);
+        assert_eq!(runtime.apply_journal_record(&second).0, CW_OK);
+        assert_eq!(
+            focused_job_encounter(&runtime, 5000)
+                .expect("focused timeout fixture starts")
+                .current_actor_id,
+            5000
+        );
+        runtime
+    }
+
+    fn runtime_snapshot_bytes(runtime: &RuntimeWorld) -> Vec<u8> {
+        serde_json::to_vec(&RuntimeSnapshot::from_runtime(runtime))
+            .expect("runtime snapshot serializes")
+    }
+
     #[test]
     fn ordinary_operations_have_explicit_concurrency_policies() {
         assert_eq!(
@@ -1698,6 +2020,238 @@ mod tests {
         );
         assert!(!view.ping_active);
         assert_eq!(view.grace_period_ms, 0);
+    }
+
+    #[test]
+    fn timeout_refusal_contract_has_distinct_machine_stable_types() {
+        let refusals = [
+            TurnTimeoutRefusal::NoFocusedScene,
+            TurnTimeoutRefusal::RequesterHoldsTurn,
+            TurnTimeoutRefusal::ParticipantsBelowTwo,
+            TurnTimeoutRefusal::RequesterNotEligible,
+            TurnTimeoutRefusal::Cooldown,
+        ];
+        let event_types = refusals
+            .iter()
+            .map(|refusal| refusal.event_type())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(event_types.len(), refusals.len());
+        assert!(event_types
+            .iter()
+            .all(|event_type| event_type.starts_with("turn.timeout_refused.")));
+        assert!(refusals
+            .iter()
+            .all(|refusal| !refusal.message().trim().is_empty()));
+    }
+
+    #[tokio::test]
+    async fn current_holder_timeout_refusal_is_actionable_and_byte_unchanged() {
+        let state = test_app_state(focused_timeout_fixture(), None);
+        let (current_session, _) = issue_actor_session(&state, 5000);
+        let (waiting_session, _) = issue_actor_session(&state, 5001);
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &current_session),
+            Some(5000)
+        );
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &waiting_session),
+            Some(5001)
+        );
+        let before = {
+            let runtime = state.inner.lock().await;
+            runtime_snapshot_bytes(&runtime)
+        };
+
+        let response = request_turn_timeout(
+            ConnectInfo("127.0.0.1:45170".parse().unwrap()),
+            State(state.clone()),
+            Json(ActorRequest {
+                actor_id: 5000,
+                actor_session: Some(current_session),
+            }),
+        )
+        .await
+        .0;
+
+        assert!(!response.ok);
+        assert_eq!(response.status, 409);
+        assert_eq!(response.events.len(), 1);
+        assert_eq!(
+            response.events[0].type_name,
+            "turn.timeout_refused.requester_holds_turn"
+        );
+        assert_eq!(
+            response.events[0].content.as_deref(),
+            Some("You already hold this turn. Play an action, pass, or ask for more time.")
+        );
+        let after = {
+            let runtime = state.inner.lock().await;
+            runtime_snapshot_bytes(&runtime)
+        };
+        assert_eq!(after, before, "a holder refusal cannot mutate turn state");
+    }
+
+    #[tokio::test]
+    async fn participants_below_two_timeout_refusal_is_actionable_and_byte_unchanged() {
+        let state = test_app_state(focused_timeout_fixture(), None);
+        let (current_session, _) = issue_actor_session(&state, 5000);
+        let (waiting_session, _) = issue_actor_session(&state, 5001);
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &current_session),
+            Some(5000)
+        );
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &waiting_session),
+            Some(5001)
+        );
+        assert!(mark_actor_session_inactive(
+            &state.actor_sessions,
+            5000,
+            &current_session
+        ));
+        let active_actor_ids = active_actor_ids_for_state(&state);
+        let before = {
+            let runtime = state.inner.lock().await;
+            let turn = actor_room_turn_view(&state, &runtime, 5001, &active_actor_ids)
+                .expect("waiting actor projects a turn");
+            assert!(!turn.can_request_timeout);
+            runtime_snapshot_bytes(&runtime)
+        };
+
+        let response = request_turn_timeout(
+            ConnectInfo("127.0.0.1:45171".parse().unwrap()),
+            State(state.clone()),
+            Json(ActorRequest {
+                actor_id: 5001,
+                actor_session: Some(waiting_session),
+            }),
+        )
+        .await
+        .0;
+
+        assert!(!response.ok);
+        assert_eq!(response.status, 409);
+        assert_eq!(response.events.len(), 1);
+        assert_eq!(
+            response.events[0].type_name,
+            "turn.timeout_refused.participants_below_two"
+        );
+        assert_eq!(
+            response.events[0].content.as_deref(),
+            Some(
+                "Fewer than two eligible participants remain, so nobody can be nudged. The ordered scene will recover when another participant returns."
+            )
+        );
+        let after = {
+            let runtime = state.inner.lock().await;
+            runtime_snapshot_bytes(&runtime)
+        };
+        assert_eq!(
+            after, before,
+            "a participant-count refusal cannot mutate turn state"
+        );
+    }
+
+    #[tokio::test]
+    async fn projected_timeout_eligibility_matches_replayable_nudge_advancement() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-focused-timeout-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        let runtime = RuntimeSnapshot::from_runtime(&focused_timeout_fixture())
+            .into_runtime()
+            .expect("timeout fixture reconnects before the replay test");
+        let state = test_app_state(runtime, Some(path.clone()));
+        let (current_session, _) = issue_actor_session(&state, 5000);
+        let (waiting_session, _) = issue_actor_session(&state, 5001);
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &current_session),
+            Some(5000)
+        );
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &waiting_session),
+            Some(5001)
+        );
+        let active_actor_ids = active_actor_ids_for_state(&state);
+        let replay_base = {
+            let runtime = state.inner.lock().await;
+            let eligibility = focused_timeout_eligibility(&runtime, 5001, &active_actor_ids)
+                .expect("waiting actor is eligible");
+            assert_eq!(eligibility.eligible_participant_ids, vec![5000, 5001]);
+            let turn = actor_room_turn_view(&state, &runtime, 5001, &active_actor_ids)
+                .expect("waiting actor projects a turn");
+            assert!(turn.can_request_timeout);
+            assert_eq!(turn.waiting_actor_ids, vec![5001]);
+            RuntimeSnapshot::from_runtime(&runtime)
+        };
+
+        let response = request_turn_timeout(
+            ConnectInfo("127.0.0.1:45172".parse().unwrap()),
+            State(state.clone()),
+            Json(ActorRequest {
+                actor_id: 5001,
+                actor_session: Some(waiting_session),
+            }),
+        )
+        .await
+        .0;
+
+        assert!(response.ok);
+        assert_eq!(response.status, CW_OK);
+        assert!(response
+            .events
+            .iter()
+            .any(|event| event.type_name == "turn.timeout_requested"
+                && event.actor_id == Some(5001)
+                && event.target_actor_id == Some(5000)));
+        assert!(response
+            .events
+            .iter()
+            .any(|event| event.type_name == "focused.pass" && event.actor_id == Some(5000)));
+        let (expected, committed_journal_seq) = {
+            let runtime = state.inner.lock().await;
+            assert_eq!(
+                focused_job_encounter(&runtime, 5001)
+                    .expect("nudge keeps the focus active")
+                    .current_actor_id,
+                5001
+            );
+            (runtime_snapshot_bytes(&runtime), runtime.action_journal_seq)
+        };
+
+        let journal = read_action_journal(&path).expect("timeout journal");
+        assert_eq!(journal.len(), 1);
+        assert_eq!(journal[0].origin, JournalOrigin::System);
+        assert_eq!(journal[0].action.actor_id, 5000);
+        assert_eq!(journal[0].offer_kind.as_deref(), Some("pass"));
+        let mut replayed = replay_base
+            .into_runtime()
+            .expect("timeout replay base restores");
+        assert_eq!(replayed.apply_journal_record(&journal[0]).0, CW_OK);
+        // The reducer replays world state; the durable store supplies its row
+        // sequence separately when continuity restoration completes.
+        replayed.action_journal_seq = committed_journal_seq;
+        let replayed_bytes = runtime_snapshot_bytes(&replayed);
+        if replayed_bytes != expected {
+            let expected_value: serde_json::Value =
+                serde_json::from_slice(&expected).expect("expected snapshot parses");
+            let replayed_value: serde_json::Value =
+                serde_json::from_slice(&replayed_bytes).expect("replayed snapshot parses");
+            let differing_keys = expected_value
+                .as_object()
+                .expect("expected snapshot object")
+                .iter()
+                .filter_map(|(key, expected)| {
+                    (replayed_value.get(key) != Some(expected)).then_some(key.as_str())
+                })
+                .collect::<Vec<_>>();
+            panic!(
+                "the successful nudge must replay to the identical focused state; differing top-level keys: {differing_keys:?}"
+            );
+        }
+        let _ = fs::remove_file(path);
     }
 
     #[test]

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74555
+74554

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -764,6 +764,24 @@ async function main() {
             ping_active: false,
           },
         }).map((action) => ({ label: action.label, detail: action.detail, effect: action.effect })),
+        nudgeActions: buildActions({
+          location: { id: 1, name: "The Cosy Cottage" },
+          primary_action: { options: [{ kind: "check" }] },
+          economy: { listen_attempted_here: true },
+          turn: {
+            enabled: true,
+            policy: "scene-turn",
+            is_current_actor: false,
+            can_request_timeout: true,
+            current_actor_id: 5001,
+            current_actor_name: "Mabel Crumblethorn",
+          },
+        }).map((action) => ({
+          label: action.label,
+          detail: action.detail,
+          effect: action.effect,
+          focusKey: action.focusKey,
+        })),
         gatheringActions: buildActions({
           location: { id: 1, name: "The Cosy Cottage" },
           primary_action: { options: [{ kind: "check" }] },
@@ -971,6 +989,14 @@ async function main() {
     assert(/acts now/i.test(guide.arrivalActions[0]?.detail || "") && /chat and inspection stay available/i.test(guide.arrivalActions[0]?.summary || ""), `the ordered-scene wait should explain whose turn it is without hiding free interaction: ${JSON.stringify(guide)}`);
     assert(guide.arrivalActions[0]?.effect === "shows the current combat order without taking an action", `the ordered-scene action should remain observational: ${JSON.stringify(guide)}`);
     assert(guide.waitingActions.length === 1 && guide.waitingActions[0]?.label === "ordered combat", `ordinary ordered-scene waiting should preserve the combat floor: ${JSON.stringify(guide)}`);
+    assert(
+      guide.nudgeActions.length === 2
+        && guide.nudgeActions[0]?.label === "nudge"
+        && guide.nudgeActions[0]?.focusKey === "scene-timeout"
+        && /play or pass/i.test(guide.nudgeActions[0]?.detail || "")
+        && guide.nudgeActions[1]?.label === "ordered combat",
+      `an eligible waiting participant should receive the nudge beside the observational ordered-scene card: ${JSON.stringify(guide.nudgeActions)}`,
+    );
     assert(guide.gatheringActions.length === 1 && guide.gatheringActions[0]?.label === "ordered combat", `a pending ordered-scene handoff should preserve the combat floor: ${JSON.stringify(guide)}`);
   }
 


### PR DESCRIPTION
Closes #417

## Outcome
- keeps `/actions/need-time` as the current-holder grace action and restores `/actions/timeout` as a waiting-participant nudge
- drives both projected `can_request_timeout` and endpoint acceptance from one pure eligible-participant calculation
- returns stable actionable refusal events for no focused scene, current holder, fewer than two eligible participants, ineligible requester, and cooldown before any runtime mutation
- journals a successful nudge as the current holder’s existing system Pass, advancing combat/work through the established reducers and replaying byte-identically
- exposes the nudge only when eligible and renders exact refusal content instead of a generic 409

## Evidence
- all turn-module tests: 12/12 passed
- current-holder and below-two rejection fixtures preserve the full serialized RuntimeSnapshot byte-for-byte
- successful fixture proves projected participant set matches acceptance, advances 5000 → 5001, records system Pass, and replays identically
- full Rust: 550/551; only the pre-existing regional-chaos race failed and passed on isolated retry
- cargo check/build/fmt, JavaScript/Python syntax, version, diff, and targeted ordered-combat gates passed
- architecture: main.rs 74,554/74,554; Clippy 246/246
- diff: 647 changed lines, under the 2,400 cap

## Screenshot limitation
The ordinary player UI is changed, but the connected browser backend reported no available browser (`[]`). Per the browser contract no standalone/synthetic screenshot was substituted. The browser smoke contract and syntax gate cover nudge visibility and exact refusal rendering.