### PR TITLE
Make Prepare strictly improve project Push

### DIFF
--- a/docs/systems/09-cosyworld-rpg-system.md
+++ b/docs/systems/09-cosyworld-rpg-system.md
@@ -365,11 +365,23 @@ the browser, terminal, inspector, and submission endpoint; see
 | Attack | kernel Attack | Rare frontier conflict, resolved as a risk toward an objective. |
 | Defend | kernel Defend | Short defensive condition. |
 | Flee | kernel Flee | A valid success path out of danger. |
-| Prepare | projection action now; kernel later only if needed | Create advantage, lower next risk, add a temporary tag. |
+| Prepare | projection setup backed by the Push resolver | Add a temporary prepared tag only when it strictly improves the next Push after the remaining-clock cap. |
 | Rest | projection action now; kernel later only if needed | Reset fatigue/skill step-downs; in the frontier, costs a danger/season tick. |
-| Contribute | projection clock action | Advance one named job or covenant clock through job-specific Push and, when available, Help strategies. |
+| Contribute | kernel Push action plus projection clock application | Advance one named job or covenant clock through job-specific Push and, when available, Help strategies. |
 
 Generated long-distance pathways use these same verbs and UI rules. Scout reveals one adjacent stretch as shared geography without moving, but it never replaces the rest of the hand or locks future movement. When an Explorer first opens a route, bounded structured generation may create every hidden waypoint's narrative identity from its deterministic biome and terrain; each identity remains concealed until its Scout edge is revealed. Invalid or disabled generation keeps the deterministic identity, and neither form may change topology or rules. Generated waypoint rooms begin risky and frontier-zoned. Every generated route receives one shared familiarity job and progress clock across its waypoint rooms; Push and Help are strategies on one contribution card and advance that same clock. Filling the clock settles the route into sanctuary rules and unlocks generated landscape art, while the deterministic SVG remains available throughout discovery and as the inference fallback.
+
+Project Push resolution is append-only at kernel action `31`. Its recorded input
+contains the direct progress, authored preparation bonus, prepared flag,
+evidence count, project location count, and remaining clock segments. The
+kernel rejects malformed or over-claimed evidence and clamps only to the
+recorded remaining segments. Preparation always adds at least one segment;
+evidence from any project location adds one prepared segment immediately, and
+complete evidence across a multi-location project adds two. Prepare and Push
+previews call that same resolver with the same input snapshot shown in the
+journaled action. Kernel event `project.push.resolved` owns the committed delta.
+Historical action-0 project journals keep their original projection-owned
+calculation and replay meaning.
 
 ### Primary Action Priority
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.205",
+      "version": "0.0.206",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/core-c/include/cosy_kernel.h
+++ b/v2/core-c/include/cosy_kernel.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#define CW_KERNEL_VERSION 8u
+#define CW_KERNEL_VERSION 9u
 
 #define CW_MAX_ACTORS 512u
 #define CW_MAX_ITEMS 1024u
@@ -158,7 +158,10 @@ typedef enum {
   CW_ACTION_REVEAL_ITEM = 29,
   /* Project use records an authored item contribution without inheriting the
      healing-and-consumption semantics of legacy USE_ITEM journals. */
-  CW_ACTION_RULES_UTILIZE_ITEM = 30
+  CW_ACTION_RULES_UTILIZE_ITEM = 30,
+  /* Append-only project resolution. Legacy action-0 project journals retain
+     their projection-owned meaning. */
+  CW_ACTION_PROJECT_PUSH = 31
 } cw_action_kind;
 
 typedef enum {
@@ -202,7 +205,8 @@ typedef enum {
   CW_EVENT_ITEM_EXHAUSTED = 37,
   CW_EVENT_ITEM_TRANSFORMED = 38,
   CW_EVENT_EXIT_UNLOCKED = 39,
-  CW_EVENT_ITEM_REVEALED = 40
+  CW_EVENT_ITEM_REVEALED = 40,
+  CW_EVENT_PROJECT_PUSH_RESOLVED = 41
 } cw_event_type;
 
 typedef enum {
@@ -291,6 +295,15 @@ typedef struct {
 } cw_item;
 
 typedef struct {
+  uint8_t base_progress;
+  uint8_t prepared_bonus_progress;
+  uint8_t prepared;
+  uint8_t evidence_count;
+  uint8_t location_count;
+  uint8_t remaining_progress;
+} cw_project_push_input;
+
+typedef struct {
   uint8_t kind;
   uint8_t ability;
   uint16_t dc;
@@ -316,6 +329,7 @@ typedef struct {
   uint8_t output_item_size_class;
   uint8_t output_item_role;
   uint16_t reserved2;
+  cw_project_push_input project_push;
 } cw_action;
 
 typedef struct {
@@ -407,6 +421,7 @@ cw_status cw_world_set_evolution_track(cw_world *world, cw_id actor_id, const cw
 cw_status cw_world_apply(cw_world *world, const cw_action *action, uint64_t seed, cw_event_buffer *out_events);
 cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uint64_t seed, uint8_t advance_tick, cw_event_buffer *out_events);
 cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_offers *out_offers);
+cw_status cw_resolve_project_push(const cw_project_push_input *input, uint8_t *out_progress);
 const char *cw_event_type_name(uint8_t type);
 int16_t cw_actor_current_hp(const cw_actor *actor);
 int cw_actor_is_bloodied(const cw_actor *actor);

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -626,6 +626,63 @@ static cw_status require_active_actor(cw_world *world, const cw_action *action, 
   return CW_OK;
 }
 
+cw_status cw_resolve_project_push(const cw_project_push_input *input, uint8_t *out_progress) {
+  if (!input || !out_progress) return CW_ERR_INVALID;
+  if (!input->base_progress
+      || !input->location_count
+      || !input->remaining_progress
+      || input->prepared > 1
+      || input->evidence_count > input->location_count) {
+    return CW_ERR_RULE;
+  }
+
+  uint16_t progress = input->base_progress;
+  if (input->prepared) {
+    progress += input->prepared_bonus_progress
+      ? input->prepared_bonus_progress
+      : 1u;
+    if (input->evidence_count) {
+      progress += input->location_count > 1
+          && input->evidence_count == input->location_count
+        ? 2u
+        : 1u;
+    }
+  }
+  if (progress > input->remaining_progress) progress = input->remaining_progress;
+  *out_progress = (uint8_t)progress;
+  return CW_OK;
+}
+
+static cw_status apply_project_push(
+    cw_world *world,
+    const cw_action *action,
+    cw_event_buffer *out_events) {
+  cw_actor *actor = 0;
+  cw_status status = require_active_actor(world, action, out_events, &actor);
+  if (status != CW_OK) return status;
+
+  uint8_t progress = 0;
+  status = cw_resolve_project_push(&action->project_push, &progress);
+  if (status != CW_OK) {
+    return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
+  }
+
+  append_event(world, out_events, CW_EVENT_PROJECT_PUSH_RESOLVED);
+  if (out_events && out_events->count > 0) {
+    cw_event *event = &out_events->events[out_events->count - 1];
+    event->success = 1;
+    event->actor_id = actor->id;
+    event->location_id = actor->location_id;
+    event->content_id = action->content_id;
+    event->raw_roll = action->project_push.evidence_count;
+    event->modifier = action->project_push.prepared_bonus_progress;
+    event->total = progress;
+    event->dc = action->project_push.location_count;
+    event->damage = action->project_push.base_progress;
+  }
+  return CW_OK;
+}
+
 static cw_status apply_say(cw_world *world, const cw_action *action, cw_event_buffer *out_events) {
   cw_actor *actor = 0;
   cw_status status = require_active_actor(world, action, out_events, &actor);
@@ -2175,6 +2232,9 @@ cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uin
     case CW_ACTION_RULES_UTILIZE_ITEM:
       status = apply_rules_utilize_item(world, action, out_events);
       break;
+    case CW_ACTION_PROJECT_PUSH:
+      status = apply_project_push(world, action, out_events);
+      break;
     case CW_ACTION_ATTACK:
       status = apply_attack(world, action, seed, out_events);
       break;
@@ -2396,6 +2456,7 @@ const char *cw_event_type_name(uint8_t type) {
     case CW_EVENT_ITEM_TRANSFORMED: return "item.transformed";
     case CW_EVENT_EXIT_UNLOCKED: return "exit.unlocked";
     case CW_EVENT_ITEM_REVEALED: return "item.revealed";
+    case CW_EVENT_PROJECT_PUSH_RESOLVED: return "project.push.resolved";
     default: return "unknown";
   }
 }

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -1434,6 +1434,85 @@ static void test_combat_join_preserves_legacy_sides_and_accepts_explicit_sides(v
   assert(test_combat_side(encounter, explicit_npc->id) == 1);
 }
 
+static void test_project_push_resolution_matrix_and_action_event(void) {
+  const struct {
+    uint8_t prepared;
+    uint8_t evidence_count;
+    uint8_t location_count;
+    uint8_t expected;
+  } cases[] = {
+    {0, 0, 1, 2},
+    {1, 0, 1, 3},
+    {1, 1, 1, 4},
+    {0, 1, 3, 2},
+    {1, 1, 3, 4},
+    {1, 3, 3, 5},
+  };
+  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+    cw_project_push_input input = {
+      .base_progress = 2,
+      .prepared_bonus_progress = 1,
+      .prepared = cases[i].prepared,
+      .evidence_count = cases[i].evidence_count,
+      .location_count = cases[i].location_count,
+      .remaining_progress = 6,
+    };
+    uint8_t progress = 0;
+    assert(cw_resolve_project_push(&input, &progress) == CW_OK);
+    assert(progress == cases[i].expected);
+  }
+
+  cw_project_push_input near_complete = {
+    .base_progress = 2,
+    .prepared_bonus_progress = 1,
+    .prepared = 1,
+    .evidence_count = 3,
+    .location_count = 3,
+    .remaining_progress = 1,
+  };
+  uint8_t progress = 0;
+  assert(cw_resolve_project_push(&near_complete, &progress) == CW_OK);
+  assert(progress == 1);
+
+  cw_project_push_input malformed = near_complete;
+  malformed.evidence_count = 4;
+  assert(cw_resolve_project_push(&malformed, &progress) == CW_ERR_RULE);
+  malformed = near_complete;
+  malformed.prepared = 2;
+  assert(cw_resolve_project_push(&malformed, &progress) == CW_ERR_RULE);
+  malformed = near_complete;
+  malformed.remaining_progress = 0;
+  assert(cw_resolve_project_push(&malformed, &progress) == CW_ERR_RULE);
+
+  cw_world world;
+  cw_event_buffer events;
+  cw_world_init(&world);
+  assert(cw_seed_cosy_cottage(&world, &events) == CW_OK);
+  cw_action push = {0};
+  push.kind = CW_ACTION_PROJECT_PUSH;
+  push.actor_id = 1001;
+  push.content_id = 411;
+  push.project_push = (cw_project_push_input) {
+    .base_progress = 2,
+    .prepared_bonus_progress = 1,
+    .prepared = 1,
+    .evidence_count = 1,
+    .location_count = 3,
+    .remaining_progress = 6,
+  };
+  assert(cw_world_apply(&world, &push, 411, &events) == CW_OK);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_PROJECT_PUSH_RESOLVED);
+  assert(events.events[0].actor_id == 1001);
+  assert(events.events[0].total == 4);
+  assert(strcmp(cw_event_type_name(events.events[0].type), "project.push.resolved") == 0);
+
+  push.project_push.evidence_count = 4;
+  assert(cw_world_apply(&world, &push, 412, &events) == CW_ERR_RULE);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
+}
+
 static void apply_replay_sequence(cw_world *world, cw_event *events, size_t *event_count) {
   cw_event_buffer buffer;
   *event_count = 0;
@@ -1511,6 +1590,7 @@ int main(void) {
   test_search_and_craft_create_without_consuming_inputs();
   test_authoritative_world_effect_actions();
   test_combat_join_preserves_legacy_sides_and_accepts_explicit_sides();
+  test_project_push_resolution_matrix_and_action_event();
   test_deterministic_replay();
   puts("cosy kernel tests passed");
   return 0;

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -1472,24 +1472,10 @@ impl RuntimeWorld {
                         self.contribution_progress_amount(actor_id, &intent),
                     ));
                 }
-                let amount = self.prepared_project_progress_amount(actor_id, actor.location_id);
-                let setup_effect = "makes the next try count";
-                let multi_room_partial = self
-                    .active_job_for_location(actor.location_id)
-                    .is_some_and(|job| {
-                        job.location_ids.len() > 1
-                            && self.project_location_evidence_count(actor_id, job)
-                                < job.location_ids.len()
-                    });
-                if amount > 2 {
-                    Some(format!(
-                        "brings together every clue you found; {setup_effect}"
-                    ))
-                } else if multi_room_partial {
-                    Some(format!("uses the clues you found here; {setup_effect}"))
-                } else {
-                    Some(setup_effect.to_string())
-                }
+                self.job_contribution_intent(actor_id, "work", None, None, None)
+                    .and_then(|intent| {
+                        self.project_push_effect_text(actor_id, &intent, true, true)
+                    })
             }
             "defend" if self.prepare_available(actor_id) => {
                 Some("guards carefully and makes the next try count".to_string())
@@ -1498,10 +1484,9 @@ impl RuntimeWorld {
             "work" => self
                 .job_contribution_intent(actor_id, "work", None, None, None)
                 .map(|intent| {
-                    self.project_headway_text(
-                        &intent.strategy.clock_id,
-                        self.contribution_progress_amount(actor_id, &intent),
-                    )
+                    let prepared = self.prepared_tag_active(actor_id, actor.location_id);
+                    self.project_push_effect_text(actor_id, &intent, prepared, false)
+                        .unwrap_or_else(|| "Push inputs are no longer valid.".to_string())
                 }),
             "help" => self
                 .job_contribution_intent(actor_id, "help", None, None, None)

--- a/v2/orchestrator-rust/src/contributions.rs
+++ b/v2/orchestrator-rust/src/contributions.rs
@@ -307,6 +307,12 @@ impl RuntimeWorld {
             })
             .all(|intent| {
                 self.job_contribution_intent_preconditions_hold(record.action.actor_id, intent)
+                    && (record.action.kind != CW_ACTION_PROJECT_PUSH
+                        || self.project_push_input(
+                            record.action.actor_id,
+                            intent,
+                            record.action.project_push.prepared == 1,
+                        ) == Some(record.action.project_push))
             })
     }
 
@@ -468,6 +474,12 @@ impl RuntimeWorld {
         let prepared = self
             .actor_by_id(actor_id)
             .is_some_and(|actor| self.prepared_tag_active(actor_id, actor.location_id));
+        if intent.strategy.action_kind == "work" {
+            return self
+                .project_push_input(actor_id, intent, prepared)
+                .and_then(Self::resolve_project_push)
+                .unwrap_or(0);
+        }
         intent
             .strategy
             .baseline_progress
@@ -477,6 +489,143 @@ impl RuntimeWorld {
             } else {
                 0
             })
+    }
+
+    pub(super) fn project_push_input(
+        &self,
+        actor_id: u64,
+        intent: &JobContributionIntent,
+        prepared: bool,
+    ) -> Option<CwProjectPushInput> {
+        if intent.strategy.action_kind != "work"
+            || !matches!(
+                intent.strategy.resolution,
+                ContributionResolutionPolicy::Certain
+            )
+        {
+            return None;
+        }
+        let job = self.jobs.get(&intent.job_id)?;
+        let clock = self.clocks.get(&intent.strategy.clock_id)?;
+        let remaining_progress = clock.segments.checked_sub(clock.filled)?;
+        let location_count = u8::try_from(job.location_ids.len()).ok()?;
+        let evidence_count =
+            u8::try_from(self.project_location_evidence_count(actor_id, job)).ok()?;
+        let base_progress = intent
+            .strategy
+            .baseline_progress
+            .checked_add(intent.strategy.success_progress)?;
+        let input = CwProjectPushInput {
+            base_progress,
+            prepared_bonus_progress: intent.strategy.prepared_bonus_progress,
+            prepared: u8::from(prepared),
+            evidence_count,
+            location_count,
+            remaining_progress,
+        };
+        Self::resolve_project_push(input).map(|_| input)
+    }
+
+    pub(super) fn resolve_project_push(input: CwProjectPushInput) -> Option<u8> {
+        let mut progress = 0;
+        let status = unsafe { cw_resolve_project_push(&input, &mut progress) };
+        (status == CW_OK).then_some(progress)
+    }
+
+    pub(super) fn project_push_progress(
+        &self,
+        actor_id: u64,
+        intent: &JobContributionIntent,
+        prepared: bool,
+    ) -> Option<u8> {
+        self.project_push_input(actor_id, intent, prepared)
+            .and_then(Self::resolve_project_push)
+    }
+
+    fn project_push_evidence_effect(input: CwProjectPushInput) -> u8 {
+        if input.evidence_count == 0 {
+            0
+        } else if input.location_count > 1 && input.evidence_count == input.location_count {
+            2
+        } else {
+            1
+        }
+    }
+
+    fn project_push_evidence_text(input: CwProjectPushInput) -> String {
+        let evidence_effect = Self::project_push_evidence_effect(input);
+        if input.location_count == 1 {
+            if input.evidence_count == 1 {
+                "Evidence complete: 1/1 location (+1 prepared segment).".to_string()
+            } else {
+                "Evidence: 0/1 location; finding it adds 1 prepared segment.".to_string()
+            }
+        } else if input.evidence_count == input.location_count {
+            format!(
+                "Evidence complete: {}/{} locations (+{evidence_effect} prepared segments).",
+                input.evidence_count, input.location_count
+            )
+        } else if input.evidence_count > 0 {
+            format!(
+                "Partial evidence: {}/{} locations (+{evidence_effect} prepared segment now); complete evidence adds 2.",
+                input.evidence_count, input.location_count
+            )
+        } else {
+            format!(
+                "Evidence: 0/{} locations; any evidence adds 1 prepared segment, complete evidence adds 2.",
+                input.location_count
+            )
+        }
+    }
+
+    pub(super) fn project_push_effect_text(
+        &self,
+        actor_id: u64,
+        intent: &JobContributionIntent,
+        prepared: bool,
+        prepare_preview: bool,
+    ) -> Option<String> {
+        let input = self.project_push_input(actor_id, intent, prepared)?;
+        let amount = Self::resolve_project_push(input)?;
+        let evidence_text = Self::project_push_evidence_text(input);
+        if prepare_preview {
+            let direct_input = self.project_push_input(actor_id, intent, false)?;
+            let direct = Self::resolve_project_push(direct_input)?;
+            return Some(format!(
+                "Next Push advances {amount} {}; Push now advances {direct}. {evidence_text}",
+                if amount == 1 { "segment" } else { "segments" }
+            ));
+        }
+
+        let gross = u16::from(input.base_progress)
+            + if prepared {
+                u16::from(input.prepared_bonus_progress.max(1))
+                    + u16::from(Self::project_push_evidence_effect(input))
+            } else {
+                0
+            };
+        let breakdown = if prepared {
+            format!(
+                "{} base + {} preparation + {} evidence",
+                input.base_progress,
+                input.prepared_bonus_progress.max(1),
+                Self::project_push_evidence_effect(input)
+            )
+        } else {
+            format!("{} base", input.base_progress)
+        };
+        let cap = if u16::from(amount) < gross {
+            format!(
+                " Only {} remain, so {amount} of {gross} gross segments apply.",
+                input.remaining_progress
+            )
+        } else {
+            String::new()
+        };
+        Some(format!(
+            "Advances {amount} {} now ({breakdown}).{cap} {evidence_text}",
+            if amount == 1 { "segment" } else { "segments" }
+        ))
     }
 
     fn contribution_project_view(

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -17,7 +17,7 @@ pub const CW_MAX_COMBAT_ENCOUNTERS: usize = 32;
 pub const CW_MAX_COMBAT_PARTICIPANTS: usize = 16;
 pub const CW_ITEM_DEFAULT_WEIGHT_TENTHS: u16 = 10;
 
-pub const CW_KERNEL_VERSION: u32 = 8;
+pub const CW_KERNEL_VERSION: u32 = 9;
 
 pub const CW_OK: u32 = 0;
 pub const CW_ERR_RULE: u32 = 4;
@@ -107,6 +107,7 @@ pub const CW_ACTION_COMBAT_NEED_TIME: u8 = 27;
 pub const CW_ACTION_UNLOCK_EXIT: u8 = 28;
 pub const CW_ACTION_REVEAL_ITEM: u8 = 29;
 pub const CW_ACTION_RULES_UTILIZE_ITEM: u8 = 30;
+pub const CW_ACTION_PROJECT_PUSH: u8 = 31;
 
 pub const CW_EVENT_ACTOR_CREATED: u8 = 2;
 pub const CW_EVENT_ITEM_PICKED_UP: u8 = 7;
@@ -138,6 +139,7 @@ pub const CW_EVENT_ITEM_EXHAUSTED: u8 = 37;
 pub const CW_EVENT_ITEM_TRANSFORMED: u8 = 38;
 pub const CW_EVENT_EXIT_UNLOCKED: u8 = 39;
 pub const CW_EVENT_ITEM_REVEALED: u8 = 40;
+pub const CW_EVENT_PROJECT_PUSH_RESOLVED: u8 = 41;
 
 pub const CW_CRAFT_INPUT_PERSISTS: u8 = 0;
 pub const CW_CRAFT_INPUT_CONSUMED: u8 = 1;
@@ -235,6 +237,23 @@ fn default_item_size_class() -> u8 {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwProjectPushInput {
+    pub base_progress: u8,
+    pub prepared_bonus_progress: u8,
+    pub prepared: u8,
+    pub evidence_count: u8,
+    pub location_count: u8,
+    pub remaining_progress: u8,
+}
+
+impl CwProjectPushInput {
+    fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub struct CwAction {
     pub kind: u8,
@@ -278,6 +297,8 @@ pub struct CwAction {
     pub output_item_role: u8,
     #[serde(default)]
     pub reserved2: u16,
+    #[serde(default, skip_serializing_if = "CwProjectPushInput::is_empty")]
+    pub project_push: CwProjectPushInput,
 }
 
 #[repr(C)]
@@ -448,7 +469,70 @@ extern "C" {
         actor_id: u64,
         out_offers: *mut CwActionOffers,
     ) -> u32;
+    pub fn cw_resolve_project_push(input: *const CwProjectPushInput, out_progress: *mut u8) -> u32;
     pub fn cw_event_type_name(type_: u8) -> *const c_char;
     pub fn cw_actor_current_hp(actor: *const CwActor) -> i16;
     pub fn cw_actor_is_bloodied(actor: *const CwActor) -> i32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_push_ffi_matches_single_and_multi_location_matrix() {
+        for (prepared, evidence_count, location_count, expected) in [
+            (0, 0, 1, 2),
+            (1, 0, 1, 3),
+            (1, 1, 1, 4),
+            (0, 1, 3, 2),
+            (1, 1, 3, 4),
+            (1, 3, 3, 5),
+        ] {
+            let input = CwProjectPushInput {
+                base_progress: 2,
+                prepared_bonus_progress: 1,
+                prepared,
+                evidence_count,
+                location_count,
+                remaining_progress: 6,
+            };
+            let mut progress = 0;
+            assert_eq!(
+                unsafe { cw_resolve_project_push(&input, &mut progress) },
+                CW_OK
+            );
+            assert_eq!(progress, expected);
+        }
+    }
+
+    #[test]
+    fn project_push_ffi_clamps_only_remaining_and_rejects_over_claims() {
+        let mut input = CwProjectPushInput {
+            base_progress: 2,
+            prepared_bonus_progress: 1,
+            prepared: 1,
+            evidence_count: 3,
+            location_count: 3,
+            remaining_progress: 1,
+        };
+        let mut progress = 0;
+        assert_eq!(
+            unsafe { cw_resolve_project_push(&input, &mut progress) },
+            CW_OK
+        );
+        assert_eq!(progress, 1);
+
+        input.evidence_count = 4;
+        assert_eq!(
+            unsafe { cw_resolve_project_push(&input, &mut progress) },
+            CW_ERR_RULE
+        );
+        input.evidence_count = 3;
+        input.prepared = 2;
+        assert_eq!(
+            unsafe { cw_resolve_project_push(&input, &mut progress) },
+            CW_ERR_RULE
+        );
+    }
 }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -33,6 +33,8 @@ mod movement;
 mod mud;
 mod natural_affordances;
 mod ownership;
+#[cfg(test)]
+mod project_push_tests;
 mod prompts;
 mod quest_loot;
 mod rate_limit;
@@ -786,6 +788,12 @@ struct JobContributionTrace {
     baseline_progress: u8,
     success_progress: u8,
     prepared_bonus_progress: u8,
+    #[serde(default)]
+    project_push_prepared: bool,
+    #[serde(default)]
+    project_evidence_count: u8,
+    #[serde(default)]
+    project_location_count: u8,
     total_progress: u8,
     clock_id: String,
     claim_key: Option<String>,
@@ -1923,7 +1931,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 11;
+const JOURNAL_RECORD_VERSION: u32 = 12;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -6064,6 +6072,7 @@ fn journal_binding_for_kernel_action(kind: u8) -> Option<ResolvedActionBinding> 
         CW_ACTION_GIVE_ITEM => "give_item",
         CW_ACTION_TRADE_ITEM => "trade_item",
         CW_ACTION_USE_ITEM | CW_ACTION_RULES_UTILIZE_ITEM => "use_item",
+        CW_ACTION_PROJECT_PUSH => "work",
         CW_ACTION_CRAFT => "craft",
         CW_ACTION_THEFT => "theft",
         CW_ACTION_SAY => "chat",
@@ -12310,6 +12319,22 @@ impl RuntimeWorld {
             };
         let mut source_event_seqs = requirement_source_event_seqs.clone();
         source_event_seqs.extend(resolution_source_event_seqs);
+        let project_push_event = if action.kind == CW_ACTION_PROJECT_PUSH {
+            let expected_progress = Self::resolve_project_push(action.project_push);
+            committed_events.iter().find(|event| {
+                event.type_name == "project.push.resolved"
+                    && event.actor_id == Some(action.actor_id)
+                    && event.total.and_then(|total| u8::try_from(total).ok()) == expected_progress
+            })
+        } else {
+            None
+        };
+        if action.kind == CW_ACTION_PROJECT_PUSH && project_push_event.is_none() {
+            return Vec::new();
+        }
+        if let Some(event) = project_push_event {
+            source_event_seqs.push(event.seq);
+        }
         source_event_seqs.sort_unstable();
         source_event_seqs.dedup();
 
@@ -12318,7 +12343,15 @@ impl RuntimeWorld {
                 return Vec::new();
             }
         }
-        let prepared_bonus_progress = if self
+        let project_push_prepared =
+            action.kind == CW_ACTION_PROJECT_PUSH && action.project_push.prepared == 1;
+        let prepared_bonus_progress = if action.kind == CW_ACTION_PROJECT_PUSH {
+            if project_push_prepared {
+                action.project_push.prepared_bonus_progress
+            } else {
+                0
+            }
+        } else if self
             .actor_by_id(action.actor_id)
             .is_some_and(|actor| self.prepared_tag_active(action.actor_id, actor.location_id))
         {
@@ -12331,11 +12364,18 @@ impl RuntimeWorld {
         } else {
             0
         };
-        let total_progress = intent
-            .strategy
-            .baseline_progress
-            .saturating_add(success_progress)
-            .saturating_add(prepared_bonus_progress);
+        let total_progress = if let Some(event) = project_push_event {
+            event
+                .total
+                .and_then(|total| u8::try_from(total).ok())
+                .expect("validated project Push event total")
+        } else {
+            intent
+                .strategy
+                .baseline_progress
+                .saturating_add(success_progress)
+                .saturating_add(prepared_bonus_progress)
+        };
         if total_progress > 0 {
             if let Some(job) = self.jobs.get_mut(&intent.job_id) {
                 job.participant_ids.push(action.actor_id);
@@ -12358,6 +12398,17 @@ impl RuntimeWorld {
             baseline_progress: intent.strategy.baseline_progress,
             success_progress,
             prepared_bonus_progress,
+            project_push_prepared,
+            project_evidence_count: action
+                .project_push
+                .evidence_count
+                .checked_mul(u8::from(action.kind == CW_ACTION_PROJECT_PUSH))
+                .unwrap_or(0),
+            project_location_count: action
+                .project_push
+                .location_count
+                .checked_mul(u8::from(action.kind == CW_ACTION_PROJECT_PUSH))
+                .unwrap_or(0),
             total_progress,
             clock_id: intent.strategy.clock_id.clone(),
             claim_key: claim_key.clone(),
@@ -16776,7 +16827,7 @@ impl RuntimeWorld {
             CW_ACTION_RULES_MAGIC => CW_OFFER_USE_ITEM,
             CW_ACTION_PICK_UP_ITEM => CW_OFFER_PICK_UP,
             CW_ACTION_USE_ITEM => CW_OFFER_USE_ITEM,
-            CW_ACTION_RULES_UTILIZE_ITEM => return true,
+            CW_ACTION_RULES_UTILIZE_ITEM | CW_ACTION_PROJECT_PUSH => return true,
             CW_ACTION_ATTACK => CW_OFFER_ATTACK,
             CW_ACTION_DEFEND => CW_OFFER_DEFEND,
             CW_ACTION_GIVE_ITEM => CW_OFFER_GIVE_ITEM,
@@ -18123,26 +18174,34 @@ impl RuntimeWorld {
         {
             return true;
         }
-        let clock_id = if let Some(job) = self.active_job_for_location(actor.location_id) {
-            if !focused_job_action_available(self, actor_id, &job.id, "prepare") {
-                return false;
-            }
-            if !job
-                .contribution_strategies
-                .iter()
-                .any(|strategy| strategy.prepared_bonus_progress > 0)
-            {
-                return false;
-            }
-            job.progress_clock_id.clone()
-        } else {
-            let Some(clock_id) = self.active_progress_clock_id_for_location(actor.location_id)
-            else {
-                return false;
+        let (clock_id, work_intent) =
+            if let Some(job) = self.active_job_for_location(actor.location_id) {
+                if !focused_job_action_available(self, actor_id, &job.id, "prepare") {
+                    return false;
+                }
+                let Some(intent) =
+                    self.job_contribution_intent(actor_id, "work", Some(&job.id), None, None)
+                else {
+                    return false;
+                };
+                (job.progress_clock_id.clone(), intent)
+            } else {
+                let Some(clock_id) = self.active_progress_clock_id_for_location(actor.location_id)
+                else {
+                    return false;
+                };
+                let Some(intent) = self.job_contribution_intent(actor_id, "work", None, None, None)
+                else {
+                    return false;
+                };
+                (clock_id, intent)
             };
-            clock_id
-        };
+        let preparation_improves_push = self
+            .project_push_progress(actor_id, &work_intent, false)
+            .zip(self.project_push_progress(actor_id, &work_intent, true))
+            .is_some_and(|(unprepared, prepared)| prepared > unprepared);
         actor.status == CW_ACTOR_ACTIVE
+            && preparation_improves_push
             && !self.prepared_tag_active(actor_id, actor.location_id)
             && !self.project_preparation_spent_for_clock(actor_id, actor.location_id, &clock_id)
             && !self.tired_tag_active(actor_id)
@@ -19135,22 +19194,13 @@ impl RuntimeWorld {
     }
 
     fn prepared_project_progress_amount(&self, actor_id: u64, location_id: u64) -> u8 {
-        let Some(job) = self.active_job_for_location(location_id) else {
-            return 2;
-        };
-        if job.location_ids.len() > 1 {
-            let needed = job.location_ids.len();
-            let found = self.project_location_evidence_count(actor_id, job);
-            if found >= needed {
-                3
-            } else {
-                2
-            }
-        } else if self.searched_room_feature_count(actor_id, location_id) > 0 {
-            3
-        } else {
-            2
-        }
+        self.job_contribution_intent(actor_id, "work", None, None, None)
+            .filter(|_| {
+                self.actor_by_id(actor_id)
+                    .is_some_and(|actor| actor.location_id == location_id)
+            })
+            .and_then(|intent| self.project_push_progress(actor_id, &intent, true))
+            .unwrap_or(0)
     }
 
     #[cfg(test)]
@@ -22189,7 +22239,17 @@ impl RuntimeWorld {
                     ..CwAction::default()
                 }
             }
-            ("prepare" | "work" | "help", _) => CwAction {
+            ("work", ContributionResolutionPolicy::Certain) => CwAction {
+                kind: CW_ACTION_PROJECT_PUSH,
+                actor_id: actor.id,
+                project_push: self.project_push_input(
+                    actor.id,
+                    &intent,
+                    self.prepared_tag_active(actor.id, actor.location_id),
+                )?,
+                ..CwAction::default()
+            },
+            ("prepare" | "help", _) => CwAction {
                 kind: CW_ACTION_NONE,
                 actor_id: actor.id,
                 ..CwAction::default()
@@ -34644,7 +34704,15 @@ async fn work(
     };
     let clock_id = intent.strategy.clock_id.clone();
     let prepared = runtime.prepared_tag_active(payload.actor_id, location_id);
-    let progress_amount = runtime.contribution_progress_amount(payload.actor_id, &intent);
+    let Some(project_push) = runtime.project_push_input(payload.actor_id, &intent, prepared) else {
+        return Json(ActionResponse {
+            ok: false,
+            status: 409,
+            events: Vec::new(),
+        });
+    };
+    let progress_amount =
+        RuntimeWorld::resolve_project_push(project_push).expect("validated project Push input");
     let progress_reason = if prepared && progress_amount > 2 {
         "informed_work"
     } else if prepared {
@@ -34655,8 +34723,9 @@ async fn work(
     let pathway_upgrade_id = runtime.generated_pathway_id_for_progress_clock(&clock_id);
     let mut record = JournalRecord::new(
         CwAction {
-            kind: CW_ACTION_NONE,
+            kind: CW_ACTION_PROJECT_PUSH,
             actor_id: payload.actor_id,
+            project_push,
             ..CwAction::default()
         },
         runtime.next_seed_value(),
@@ -56884,9 +56953,18 @@ mod tests {
                 reason: "prepare".to_string(),
             });
         assert_eq!(runtime.apply_journal_record(&prepare_record).0, CW_OK);
+        let work_intent = runtime
+            .job_contribution_intent(5000, "work", Some(MOONLIT_JOB_ID), None, None)
+            .expect("searched Moonlit project offers Push");
+        let prepared_input = runtime
+            .project_push_input(5000, &work_intent, true)
+            .expect("searched prepared Push snapshot");
+        assert_eq!(prepared_input.evidence_count, 1);
+        assert_eq!(prepared_input.location_count, 1);
+        assert_eq!(RuntimeWorld::resolve_project_push(prepared_input), Some(4));
         assert_eq!(
             runtime.project_progress_amount(5000, MOONLIT_TRAIL_LOCATION_ID),
-            3
+            4
         );
         discover_all_seed_exits_for_test(&mut runtime);
         let ready_features = runtime.room_feature_views(MOONLIT_TRAIL_LOCATION_ID, Some(5000));
@@ -56916,10 +56994,14 @@ mod tests {
 
         assert!(response.ok);
         assert_eq!(response.status, CW_OK);
+        assert!(response
+            .events
+            .iter()
+            .any(|event| { event.type_name == "project.push.resolved" && event.total == Some(4) }));
         assert!(response.events.iter().any(|event| {
             event.type_name == "clock.updated"
                 && event.clock_id.as_deref() == Some(MOONLIT_PROGRESS_CLOCK_ID)
-                && event.clock_delta == Some(3)
+                && event.clock_delta == Some(4)
                 && event.content.as_deref()
                     == Some("job_contribution:moonlit-trail:quiet-the-echo:steady-trail")
         }));
@@ -56950,12 +57032,12 @@ mod tests {
                 .clocks
                 .get(MOONLIT_PROGRESS_CLOCK_ID)
                 .map(|clock| clock.filled),
-            Some(3)
+            Some(4)
         );
         assert!(!runtime.prepared_tag_active(5000, MOONLIT_TRAIL_LOCATION_ID));
-        assert!(runtime.project_preparation_spent_for_actor(5000));
+        assert!(!runtime.project_preparation_spent_for_actor(5000));
         assert!(!runtime.prepare_available(5000));
-        assert!(runtime.work_available(5000));
+        assert!(!runtime.work_available(5000));
         let post_work_state = runtime.state_response(Some(5000), &AccessContext::default());
         assert!(!post_work_state
             .primary_action
@@ -56963,34 +57045,10 @@ mod tests {
             .iter()
             .any(|option| option.kind == "prepare"));
         assert_eq!(post_work_state.primary_action.kind, "pick_up");
-        assert!(post_work_state.primary_action.options.iter().any(|option| {
-            option.kind == "work" && option.label == "Finish" && option.command == "work"
-        }));
-        let finish_offer = post_work_state
+        assert!(!post_work_state
             .action_offers
             .iter()
-            .find(|offer| offer.kind == "work")
-            .expect("finish-ready work offer is exposed");
-        assert_eq!(finish_offer.label, "Push Quiet the echo");
-        assert_eq!(finish_offer.intention, "contribute");
-        assert_eq!(finish_offer.command, "contribute steady-trail");
-        assert_eq!(finish_offer.rank, 36);
-        assert!(finish_offer
-            .effect
-            .as_deref()
-            .is_some_and(|effect| effect.contains("finishes the shared work")));
-        assert!(finish_offer.progress.is_some_and(|amount| amount > 0));
-        let finish_help_offer = post_work_state
-            .action_offers
-            .iter()
-            .find(|offer| offer.kind == "help")
-            .expect("finish-ready help offer is exposed");
-        assert!(finish_help_offer
-            .effect
-            .as_deref()
-            .is_some_and(|effect| effect.contains("finishes the shared work")
-                && effect.contains("first help brings you closer")));
-        assert!(finish_help_offer.progress.is_some_and(|amount| amount > 0));
+            .any(|offer| matches!(offer.kind.as_str(), "prepare" | "work" | "help")));
     }
 
     #[test]
@@ -58108,116 +58166,6 @@ mod tests {
     }
 
     #[test]
-    fn multi_room_project_needs_evidence_from_each_room_for_best_prepared_progress() {
-        let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = 36;
-        let mut create_record = JournalRecord::new(create, 7143);
-        create_record.actor_meta_upserts.insert(
-            5000,
-            ActorMeta {
-                name: "Two-Sided Listener".to_string(),
-                speech_mode: "prose".to_string(),
-                title: "Bell Mediator".to_string(),
-                description: "A test avatar checking multi-room project evidence.".to_string(),
-            },
-        );
-        assert_eq!(runtime.apply_journal_record(&create_record).0, CW_OK);
-        assert_eq!(runtime.prepared_project_progress_amount(5000, 36), 2);
-
-        let mut solar_search_record = JournalRecord::new(
-            CwAction {
-                kind: CW_ACTION_NONE,
-                actor_id: 5000,
-                ..CwAction::default()
-            },
-            7144,
-        );
-        solar_search_record
-            .projection_mutations
-            .push(ProjectionMutation::SearchFeature {
-                location_id: 36,
-                feature_key: "sun_bell".to_string(),
-                feature_name: "Missing Sun Bell".to_string(),
-                content: "The empty bracket hums downward.".to_string(),
-                reason: "search_feature".to_string(),
-            });
-        assert_eq!(runtime.apply_journal_record(&solar_search_record).0, CW_OK);
-        assert_eq!(
-            runtime.project_location_evidence_count(
-                5000,
-                runtime
-                    .active_job_for_location(36)
-                    .expect("solar job remains active")
-            ),
-            1
-        );
-        assert_eq!(runtime.prepared_project_progress_amount(5000, 36), 2);
-        let partial_state = runtime.state_response(Some(5000), &AccessContext::default());
-        let partial_prepare = partial_state
-            .action_offers
-            .iter()
-            .find(|offer| offer.kind == "prepare")
-            .and_then(|offer| offer.effect.as_deref())
-            .expect("partial prepare effect is exposed");
-        assert!(partial_prepare.contains("clues you found here"));
-        assert!(partial_prepare.contains("makes the next try count"));
-        assert_eq!(
-            partial_state
-                .action_offers
-                .iter()
-                .find(|offer| offer.kind == "prepare")
-                .and_then(|offer| offer.progress),
-            Some(2)
-        );
-
-        runtime
-            .listen_attempt_claims
-            .insert(listen_attempt_claim_key(5000, DARKEST_OCEAN_LOCATION_ID));
-        assert_eq!(
-            runtime.project_location_evidence_count(
-                5000,
-                runtime
-                    .active_job_for_location(36)
-                    .expect("solar job remains active")
-            ),
-            2
-        );
-        assert_eq!(runtime.prepared_project_progress_amount(5000, 36), 2);
-        runtime
-            .listen_attempt_claims
-            .insert(listen_attempt_claim_key(5000, DARK_ABYSS_LOCATION_ID));
-        assert_eq!(
-            runtime.project_location_evidence_count(
-                5000,
-                runtime
-                    .active_job_for_location(36)
-                    .expect("solar job remains active")
-            ),
-            3
-        );
-        assert_eq!(runtime.prepared_project_progress_amount(5000, 36), 3);
-        let complete_state = runtime.state_response(Some(5000), &AccessContext::default());
-        let complete_prepare = complete_state
-            .action_offers
-            .iter()
-            .find(|offer| offer.kind == "prepare")
-            .and_then(|offer| offer.effect.as_deref())
-            .expect("complete prepare effect is exposed");
-        assert!(complete_prepare.contains("every clue you found"));
-        assert_eq!(
-            complete_state
-                .action_offers
-                .iter()
-                .find(|offer| offer.kind == "prepare")
-                .and_then(|offer| offer.progress),
-            Some(3)
-        );
-    }
-
-    #[test]
     fn project_feature_use_advances_moonlit_clock_once() {
         let mut runtime = RuntimeWorld::seeded();
         let mut create = CwAction::default();
@@ -58803,6 +58751,10 @@ mod tests {
         .await
         .0;
         assert!(first_work.ok);
+        assert!(first_work
+            .events
+            .iter()
+            .any(|event| { event.type_name == "project.push.resolved" && event.total == Some(2) }));
         assert!(first_work.events.iter().any(|event| {
             event.type_name == "clock.updated"
                 && event.clock_id.as_deref() == Some("solar-abyss.drowned-bell")
@@ -58847,6 +58799,10 @@ mod tests {
         .await
         .0;
         assert!(finishing_work.ok);
+        assert!(finishing_work
+            .events
+            .iter()
+            .any(|event| { event.type_name == "project.push.resolved" && event.total == Some(2) }));
         assert!(finishing_work.events.iter().any(|event| {
             event.type_name == "clock.updated"
                 && event.clock_id.as_deref() == Some("solar-abyss.drowned-bell")
@@ -58978,94 +58934,6 @@ mod tests {
                 .map(|clock| clock.filled),
             Some(0)
         );
-    }
-
-    #[test]
-    fn defend_sets_up_active_room_project() {
-        let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = MOONLIT_TRAIL_LOCATION_ID;
-        let mut create_record = JournalRecord::new(create, 7160);
-        create_record.actor_meta_upserts.insert(
-            5000,
-            ActorMeta {
-                name: "Guard Worker".to_string(),
-                speech_mode: "prose".to_string(),
-                title: "Shielded Helper".to_string(),
-                description: "A test avatar turning defense into project preparation.".to_string(),
-            },
-        );
-        assert_eq!(runtime.apply_journal_record(&create_record).0, CW_OK);
-
-        let initial = runtime.state_response(Some(5000), &AccessContext::default());
-        let defend_offer = initial
-            .action_offers
-            .iter()
-            .find(|offer| offer.kind == "defend")
-            .expect("defend offer is exposed in combat project room");
-        assert_eq!(defend_offer.progress, Some(2));
-        assert_eq!(
-            defend_offer.effect.as_deref(),
-            Some("guards carefully and makes the next try count")
-        );
-        for offer in &initial.action_offers {
-            let player_copy = format!(
-                "{} {}",
-                offer.effect.as_deref().unwrap_or_default(),
-                offer.risk.as_deref().unwrap_or_default()
-            )
-            .to_ascii_lowercase();
-            for forbidden in ["progress", "clock", "ledger", "tag", "projection", "kernel"] {
-                assert!(
-                    !player_copy.contains(forbidden),
-                    "{} offer leaked {forbidden}: {player_copy}",
-                    offer.kind
-                );
-            }
-            assert!(
-                !player_copy.contains(" +"),
-                "{} offer leaked arithmetic: {player_copy}",
-                offer.kind
-            );
-        }
-        assert_eq!(
-            runtime.project_progress_amount(5000, MOONLIT_TRAIL_LOCATION_ID),
-            1
-        );
-
-        let mut defend_action = CwAction::default();
-        defend_action.kind = CW_ACTION_DEFEND;
-        defend_action.actor_id = 5000;
-        let (status, events) =
-            runtime.apply_journal_record(&JournalRecord::new(defend_action, 7161));
-        assert_eq!(status, CW_OK);
-        assert!(events.iter().any(|event| {
-            event.type_name == "combat.defend"
-                && event.actor_id == Some(5000)
-                && event.location_id == Some(MOONLIT_TRAIL_LOCATION_ID)
-        }));
-        assert!(events.iter().any(|event| {
-            event.type_name == "tag.applied"
-                && event.tag_id.as_deref()
-                    == Some(prepared_tag_id(5000, MOONLIT_TRAIL_LOCATION_ID).as_str())
-                && event.tag_label.as_deref() == Some("prepared")
-                && event.content.as_deref() == Some("defend_prepare")
-        }));
-        assert!(runtime.prepared_tag_active(5000, MOONLIT_TRAIL_LOCATION_ID));
-        assert_eq!(
-            runtime.project_progress_amount(5000, MOONLIT_TRAIL_LOCATION_ID),
-            2
-        );
-
-        let prepared = runtime.state_response(Some(5000), &AccessContext::default());
-        assert!(prepared
-            .action_offers
-            .iter()
-            .find(|offer| offer.kind == "defend")
-            .and_then(|offer| offer.effect.as_deref())
-            .is_some_and(|effect| effect.contains("careful guard")));
     }
 
     #[test]
@@ -62974,7 +62842,10 @@ mod tests {
         assert_eq!(work_offer.intention, "contribute");
         assert_eq!(work_offer.verb, "Push");
         assert_eq!(work_offer.accessible_label, "Push Quiet the echo");
-        assert_eq!(work_offer.effect.as_deref(), Some("makes good headway"));
+        assert!(work_offer.effect.as_deref().is_some_and(|effect| {
+            effect.contains("Advances 2 segments now (2 base)")
+                && effect.contains("Evidence: 0/1 location")
+        }));
         assert_eq!(work_offer.progress, Some(2));
         assert!(work_offer
             .risk
@@ -63011,8 +62882,10 @@ mod tests {
         assert!(!suggested.disabled);
         assert!(state.action_offers.iter().any(|offer| {
             offer.kind == "prepare"
-                && offer.progress == Some(2)
-                && offer.effect.as_deref() == Some("makes the next try count")
+                && offer.progress == Some(3)
+                && offer.effect.as_deref().is_some_and(|effect| {
+                    effect.contains("Next Push advances 3 segments; Push now advances 2")
+                })
         }));
         assert!(inspector
             .fronts

--- a/v2/orchestrator-rust/src/project_push_tests.rs
+++ b/v2/orchestrator-rust/src/project_push_tests.rs
@@ -1,0 +1,424 @@
+use super::*;
+
+#[test]
+fn defend_sets_up_active_room_project() {
+    let mut runtime = RuntimeWorld::seeded();
+    let mut create = CwAction::default();
+    create.kind = CW_ACTION_CREATE_ACTOR;
+    create.actor_id = 5000;
+    create.location_id = MOONLIT_TRAIL_LOCATION_ID;
+    let mut create_record = JournalRecord::new(create, 7160);
+    create_record.actor_meta_upserts.insert(
+        5000,
+        ActorMeta {
+            name: "Guard Worker".to_string(),
+            speech_mode: "prose".to_string(),
+            title: "Shielded Helper".to_string(),
+            description: "A test avatar turning defense into project preparation.".to_string(),
+        },
+    );
+    assert_eq!(runtime.apply_journal_record(&create_record).0, CW_OK);
+
+    let initial = runtime.state_response(Some(5000), &AccessContext::default());
+    let defend_offer = initial
+        .action_offers
+        .iter()
+        .find(|offer| offer.kind == "defend")
+        .expect("defend offer is exposed in combat project room");
+    assert_eq!(defend_offer.progress, Some(3));
+    assert_eq!(
+        defend_offer.effect.as_deref(),
+        Some("guards carefully and makes the next try count")
+    );
+    for offer in &initial.action_offers {
+        let player_copy = format!(
+            "{} {}",
+            offer.effect.as_deref().unwrap_or_default(),
+            offer.risk.as_deref().unwrap_or_default()
+        )
+        .to_ascii_lowercase();
+        for forbidden in ["progress", "clock", "ledger", "tag", "projection", "kernel"] {
+            assert!(
+                !player_copy.contains(forbidden),
+                "{} offer leaked {forbidden}: {player_copy}",
+                offer.kind
+            );
+        }
+        assert!(
+            !player_copy.contains(" +"),
+            "{} offer leaked arithmetic: {player_copy}",
+            offer.kind
+        );
+    }
+    assert_eq!(
+        runtime.project_progress_amount(5000, MOONLIT_TRAIL_LOCATION_ID),
+        1
+    );
+
+    let mut defend_action = CwAction::default();
+    defend_action.kind = CW_ACTION_DEFEND;
+    defend_action.actor_id = 5000;
+    let (status, events) = runtime.apply_journal_record(&JournalRecord::new(defend_action, 7161));
+    assert_eq!(status, CW_OK);
+    assert!(events.iter().any(|event| {
+        event.type_name == "combat.defend"
+            && event.actor_id == Some(5000)
+            && event.location_id == Some(MOONLIT_TRAIL_LOCATION_ID)
+    }));
+    assert!(events.iter().any(|event| {
+        event.type_name == "tag.applied"
+            && event.tag_id.as_deref()
+                == Some(prepared_tag_id(5000, MOONLIT_TRAIL_LOCATION_ID).as_str())
+            && event.tag_label.as_deref() == Some("prepared")
+            && event.content.as_deref() == Some("defend_prepare")
+    }));
+    assert!(runtime.prepared_tag_active(5000, MOONLIT_TRAIL_LOCATION_ID));
+    let work_intent = runtime
+        .job_contribution_intent(5000, "work", Some(MOONLIT_JOB_ID), None, None)
+        .expect("Defend leaves a valid prepared Push");
+    let prepared_input = runtime
+        .project_push_input(5000, &work_intent, true)
+        .expect("prepared Push snapshot");
+    assert_eq!(
+        prepared_input,
+        CwProjectPushInput {
+            base_progress: 2,
+            prepared_bonus_progress: 1,
+            prepared: 1,
+            evidence_count: 0,
+            location_count: 1,
+            remaining_progress: 4,
+        }
+    );
+    assert_eq!(RuntimeWorld::resolve_project_push(prepared_input), Some(3));
+    assert_eq!(
+        runtime.project_progress_amount(5000, MOONLIT_TRAIL_LOCATION_ID),
+        3
+    );
+
+    let prepared = runtime.state_response(Some(5000), &AccessContext::default());
+    assert!(prepared
+        .action_offers
+        .iter()
+        .find(|offer| offer.kind == "defend")
+        .and_then(|offer| offer.effect.as_deref())
+        .is_some_and(|effect| effect.contains("careful guard")));
+}
+
+#[test]
+fn multi_room_project_makes_partial_evidence_useful_and_complete_evidence_best() {
+    let mut runtime = RuntimeWorld::seeded();
+    runtime
+        .clocks
+        .get_mut("solar-abyss.drowned-bell")
+        .expect("solar project clock")
+        .segments = 6;
+    let mut create = CwAction::default();
+    create.kind = CW_ACTION_CREATE_ACTOR;
+    create.actor_id = 5000;
+    create.location_id = 36;
+    let mut create_record = JournalRecord::new(create, 7143);
+    create_record.actor_meta_upserts.insert(
+        5000,
+        ActorMeta {
+            name: "Two-Sided Listener".to_string(),
+            speech_mode: "prose".to_string(),
+            title: "Bell Mediator".to_string(),
+            description: "A test avatar checking multi-room project evidence.".to_string(),
+        },
+    );
+    assert_eq!(runtime.apply_journal_record(&create_record).0, CW_OK);
+    assert_eq!(runtime.prepared_project_progress_amount(5000, 36), 3);
+
+    let mut solar_search_record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            ..CwAction::default()
+        },
+        7144,
+    );
+    solar_search_record
+        .projection_mutations
+        .push(ProjectionMutation::SearchFeature {
+            location_id: 36,
+            feature_key: "sun_bell".to_string(),
+            feature_name: "Missing Sun Bell".to_string(),
+            content: "The empty bracket hums downward.".to_string(),
+            reason: "search_feature".to_string(),
+        });
+    assert_eq!(runtime.apply_journal_record(&solar_search_record).0, CW_OK);
+    assert_eq!(
+        runtime.project_location_evidence_count(
+            5000,
+            runtime
+                .active_job_for_location(36)
+                .expect("solar job remains active")
+        ),
+        1
+    );
+    assert_eq!(runtime.prepared_project_progress_amount(5000, 36), 4);
+    let partial_state = runtime.state_response(Some(5000), &AccessContext::default());
+    let partial_prepare = partial_state
+        .action_offers
+        .iter()
+        .find(|offer| offer.kind == "prepare")
+        .and_then(|offer| offer.effect.as_deref())
+        .expect("partial prepare effect is exposed");
+    assert!(partial_prepare.contains("Next Push advances 4 segments; Push now advances 2"));
+    assert!(partial_prepare.contains("Partial evidence: 1/3 locations"));
+    assert!(partial_prepare.contains("complete evidence adds 2"));
+    assert_eq!(
+        partial_state
+            .action_offers
+            .iter()
+            .find(|offer| offer.kind == "prepare")
+            .and_then(|offer| offer.progress),
+        Some(4)
+    );
+
+    runtime
+        .listen_attempt_claims
+        .insert(listen_attempt_claim_key(5000, DARKEST_OCEAN_LOCATION_ID));
+    assert_eq!(
+        runtime.project_location_evidence_count(
+            5000,
+            runtime
+                .active_job_for_location(36)
+                .expect("solar job remains active")
+        ),
+        2
+    );
+    assert_eq!(runtime.prepared_project_progress_amount(5000, 36), 4);
+    runtime
+        .listen_attempt_claims
+        .insert(listen_attempt_claim_key(5000, DARK_ABYSS_LOCATION_ID));
+    assert_eq!(
+        runtime.project_location_evidence_count(
+            5000,
+            runtime
+                .active_job_for_location(36)
+                .expect("solar job remains active")
+        ),
+        3
+    );
+    assert_eq!(runtime.prepared_project_progress_amount(5000, 36), 5);
+    let complete_state = runtime.state_response(Some(5000), &AccessContext::default());
+    let complete_prepare = complete_state
+        .action_offers
+        .iter()
+        .find(|offer| offer.kind == "prepare")
+        .and_then(|offer| offer.effect.as_deref())
+        .expect("complete prepare effect is exposed");
+    assert!(complete_prepare.contains("Next Push advances 5 segments; Push now advances 2"));
+    assert!(complete_prepare.contains("Evidence complete: 3/3 locations"));
+    assert!(complete_prepare.contains("+2 prepared segments"));
+    assert_eq!(
+        complete_state
+            .action_offers
+            .iter()
+            .find(|offer| offer.kind == "prepare")
+            .and_then(|offer| offer.progress),
+        Some(5)
+    );
+}
+
+#[test]
+fn single_location_prepare_is_strictly_better_and_suppressed_at_clock_cap() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        MOONLIT_TRAIL_LOCATION_ID,
+        "Single-Room Planner",
+    );
+    let intent = runtime
+        .job_contribution_intent(5000, "work", Some(MOONLIT_JOB_ID), None, None)
+        .expect("Moonlit project offers Push");
+    assert_eq!(runtime.project_push_progress(5000, &intent, false), Some(2));
+    assert_eq!(runtime.project_push_progress(5000, &intent, true), Some(3));
+    assert!(runtime.prepare_available(5000));
+
+    let initial = runtime.state_response(Some(5000), &AccessContext::default());
+    let prepare = initial
+        .action_offers
+        .iter()
+        .find(|offer| offer.kind == "prepare")
+        .expect("strictly better Prepare is offered");
+    assert_eq!(prepare.progress, Some(3));
+    assert!(prepare.effect.as_deref().is_some_and(|effect| {
+        effect.contains("Next Push advances 3 segments; Push now advances 2")
+            && effect.contains("Evidence: 0/1 location")
+    }));
+    let push = initial
+        .action_offers
+        .iter()
+        .find(|offer| offer.kind == "work")
+        .expect("Push is offered");
+    assert_eq!(push.progress, Some(2));
+    assert!(push
+        .effect
+        .as_deref()
+        .is_some_and(|effect| effect.contains("Advances 2 segments now (2 base)")));
+
+    runtime
+        .listen_attempt_claims
+        .insert(listen_attempt_claim_key(5000, MOONLIT_TRAIL_LOCATION_ID));
+    assert_eq!(runtime.project_push_progress(5000, &intent, true), Some(4));
+    let evidenced = runtime.state_response(Some(5000), &AccessContext::default());
+    assert!(evidenced.action_offers.iter().any(|offer| {
+        offer.kind == "prepare"
+            && offer.progress == Some(4)
+            && offer.effect.as_deref().is_some_and(|effect| {
+                effect.contains("Evidence complete: 1/1 location")
+                    && effect.contains("+1 prepared segment")
+            })
+    }));
+
+    let clock = runtime
+        .clocks
+        .get_mut(MOONLIT_PROGRESS_CLOCK_ID)
+        .expect("Moonlit project clock");
+    clock.filled = clock.segments - 1;
+    assert_eq!(runtime.project_push_progress(5000, &intent, false), Some(1));
+    assert_eq!(runtime.project_push_progress(5000, &intent, true), Some(1));
+    assert!(!runtime.prepare_available(5000));
+    let near_complete = runtime.state_response(Some(5000), &AccessContext::default());
+    assert!(!near_complete
+        .action_offers
+        .iter()
+        .any(|offer| offer.kind == "prepare"));
+    assert!(near_complete.action_offers.iter().any(|offer| {
+        offer.kind == "work"
+            && offer.progress == Some(1)
+            && offer.effect.as_deref().is_some_and(|effect| {
+                effect.contains("Advances 1 segment now")
+                    && effect.contains("1 of 2 gross segments apply")
+                    && effect.contains("Only 1 remain")
+            })
+    }));
+}
+
+#[test]
+fn legacy_action_zero_project_journal_is_byte_stable_and_new_push_replays_kernel_delta() {
+    fn project_runtime() -> RuntimeWorld {
+        let mut runtime = RuntimeWorld::seeded();
+        runtime
+            .clocks
+            .get_mut("solar-abyss.drowned-bell")
+            .expect("solar project clock")
+            .segments = 6;
+        create_test_human(&mut runtime, 5000, 36, "Replay Planner");
+        runtime.tags.insert(
+            prepared_tag_id(5000, 36),
+            RpgTagState {
+                id: prepared_tag_id(5000, 36),
+                scope: "actor".to_string(),
+                scope_id: 5000,
+                label: "prepared".to_string(),
+                kind: "aspect".to_string(),
+                active: true,
+                source_event_seq: None,
+                expires: Some("after_work".to_string()),
+            },
+        );
+        runtime
+            .listen_attempt_claims
+            .insert(listen_attempt_claim_key(5000, 36));
+        runtime
+    }
+
+    let mut legacy_runtime = project_runtime();
+    let intent = legacy_runtime
+        .job_contribution_intent(5000, "work", None, None, None)
+        .expect("solar project offers Push");
+    let mut legacy_record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            ..CwAction::default()
+        },
+        411_001,
+    )
+    .into_player_card();
+    legacy_record.version = 11;
+    legacy_record
+        .projection_mutations
+        .push(ProjectionMutation::ResolveJobContribution {
+            intent: intent.clone(),
+        });
+    let legacy_bytes = serde_json::to_vec(&legacy_record).expect("serialize v11 record");
+    assert!(!String::from_utf8_lossy(&legacy_bytes).contains("project_push"));
+    let legacy_round_trip: JournalRecord =
+        serde_json::from_slice(&legacy_bytes).expect("deserialize v11 record");
+    assert_eq!(
+        serde_json::to_vec(&legacy_round_trip).expect("reserialize v11 record"),
+        legacy_bytes
+    );
+    let (legacy_status, legacy_events) = legacy_runtime.apply_journal_record(&legacy_round_trip);
+    assert_eq!(legacy_status, CW_OK);
+    assert!(legacy_events.iter().any(|event| {
+        event.type_name == "clock.updated"
+            && event.clock_id.as_deref() == Some("solar-abyss.drowned-bell")
+            && event.clock_delta == Some(3)
+    }));
+    assert!(!legacy_events
+        .iter()
+        .any(|event| event.type_name == "project.push.resolved"));
+    drop(legacy_runtime);
+
+    let new_record = {
+        let runtime = project_runtime();
+        let project_push = runtime
+            .project_push_input(5000, &intent, true)
+            .expect("valid partial-evidence Push input");
+        assert_eq!(RuntimeWorld::resolve_project_push(project_push), Some(4));
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_PROJECT_PUSH,
+                actor_id: 5000,
+                project_push,
+                ..CwAction::default()
+            },
+            411_002,
+        )
+        .into_player_card();
+        record
+            .projection_mutations
+            .push(ProjectionMutation::ResolveJobContribution {
+                intent: intent.clone(),
+            });
+        record
+    };
+    let new_bytes = serde_json::to_vec(&new_record).expect("serialize v12 Push record");
+    assert!(String::from_utf8_lossy(&new_bytes).contains("\"project_push\""));
+
+    for _ in 0..2 {
+        let mut runtime = project_runtime();
+        let preview_state = runtime.state_response(Some(5000), &AccessContext::default());
+        let preview = preview_state
+            .action_offers
+            .iter()
+            .find(|offer| offer.kind == "work")
+            .expect("prepared partial-evidence Push preview");
+        assert_eq!(preview.progress, Some(4));
+        assert!(preview.effect.as_deref().is_some_and(|effect| {
+            effect.contains("Advances 4 segments now (2 base + 1 preparation + 1 evidence)")
+                && effect.contains("Partial evidence: 1/3 locations")
+        }));
+        let replay_record: JournalRecord =
+            serde_json::from_slice(&new_bytes).expect("deserialize v12 Push record");
+        let (status, events) = runtime.apply_journal_record(&replay_record);
+        assert_eq!(status, CW_OK);
+        let resolved = events
+            .iter()
+            .find(|event| event.type_name == "project.push.resolved")
+            .expect("kernel Push event");
+        assert_eq!(resolved.total, preview.progress.map(i16::from));
+        assert!(events.iter().any(|event| {
+            event.type_name == "clock.updated"
+                && event.clock_id.as_deref() == Some("solar-abyss.drowned-bell")
+                && event.clock_delta == resolved.total
+        }));
+    }
+}

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -465,6 +465,7 @@ pub(super) fn action_concurrency_policy(kind: u8) -> ConcurrencyPolicy {
         | CW_ACTION_DROP_ITEM
         | CW_ACTION_USE_ITEM
         | CW_ACTION_RULES_UTILIZE_ITEM
+        | CW_ACTION_PROJECT_PUSH
         | CW_ACTION_GIVE_ITEM
         | CW_ACTION_TRADE_ITEM
         | CW_ACTION_CRAFT
@@ -1138,6 +1139,7 @@ pub(super) fn actor_action_turn_rejection(
         CW_ACTION_RULES_SEARCH | CW_ACTION_ABILITY_CHECK => "check",
         CW_ACTION_RULES_STUDY => "study",
         CW_ACTION_RULES_UTILIZE_ITEM => "use_item",
+        CW_ACTION_PROJECT_PUSH => "work",
         _ => "",
     };
     if action.kind == CW_ACTION_SAY

--- a/v2/orchestrator-rust/tests/fixtures/srd-action-replay-golden-v2.json
+++ b/v2/orchestrator-rust/tests/fixtures/srd-action-replay-golden-v2.json
@@ -51,7 +51,7 @@
   ],
   "expected": {
     "rules_profile": "cosyworld.srd5/1",
-    "kernel_version": 8,
+    "kernel_version": 9,
     "world_tick": 8,
     "next_event_seq": 17,
     "actor": {"id":5000,"location_id":3,"status":1,"damage":0},

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74555
+74428


### PR DESCRIPTION
Closes #411

## Outcome

- adds append-only kernel action 31 and event 41 for authoritative project Push resolution
- makes prepared single-location work strictly better than direct Push and gives partial/complete multi-location evidence immediate, visible value
- hides Prepare when the remaining-clock cap makes it no better than direct Push
- uses the same C/FFI resolver and exact input snapshot for previews, commits, and replay
- preserves byte-identical version-11 action-0 records and their legacy delta

## Resolution matrix

With base progress 2 and six segments remaining:

| State | Direct | Prepared |
|---|---:|---:|
| Single, no evidence | 2 | 3 |
| Single, complete | 2 | 4 |
| Multi, no evidence | 2 | 3 |
| Multi, partial | 2 | 4 |
| Multi, complete | 2 | 5 |

At one segment remaining, both clamp to one and Prepare is absent.

## Evidence

- full Rust suite: 551/551 passed
- parent focused project Push tests: 6/6 passed
- C kernel suite passed with warnings as errors
- preview 4 = `project.push.resolved.total` 4 = `clock.updated.delta` 4
- architecture, clippy ceiling, formatting, version, and diff checks passed
- main.rs reduced to 74,428 lines with the ceiling lowered to match
- diff: 16 files, 1,309 changed lines, below the 2,400-line slice limit
