### PR TITLE
Accept authoritative action offer IDs

### DIFF
--- a/docs/decisions/0002-action-hand-is-authoritative-state.md
+++ b/docs/decisions/0002-action-hand-is-authoritative-state.md
@@ -78,6 +78,21 @@ may let the player page through the remaining complete offer list, but it must
 not hash, randomize, or silently re-rank the authoritative opening hand. A
 change to the projected offer/provider ids is the signal to recompose it.
 
+## Command submission
+
+`POST /commands` accepts an `offer_id` from the current `action_offers`
+projection as its authoritative action input. The server resolves that exact
+identifier under the same world-state lock that checks its embedded
+`state_revision`; it does not reparse the offer's display command. Malformed,
+stale, unknown, and disabled identifiers fail before presence, journal, event,
+seed, or world state can change and return distinct typed failure codes.
+
+The optional prose `command` field remains temporarily available for older
+clients and the command palette. It is a legacy convenience resolver, not the
+authoritative join between an offer and an action. When both fields are sent,
+`offer_id` wins. Retirement or stricter hand enforcement remains a separate
+decision alongside #354.
+
 Wallet keepsakes may supply matching art and an explicit cosmetic annotation.
 Equipping, removing, or owning one does not change action eligibility, order,
 rank, effects, costs, odds, or hand power.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.205",
+      "version": "0.0.206",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -766,14 +766,14 @@ Dialogue prompts keep the latest 16 spoken lines per room in a bounded, snapshot
 - `POST /commands`
 
 `POST /commands` is the canonical mutation gateway. New callers send the
-authenticated numeric actor handle plus the stable envelope advertised by
-`/state`:
+authenticated numeric actor handle, an `offer_id` from the current `/state`
+projection, and the stable envelope:
 
 ```json
 {
   "actor_id": 5000,
   "actor_session": "...",
-  "command": "go east",
+  "offer_id": "cosyworld.srd5/1:92811:move:202",
   "envelope": {
     "world_id": "world://cosyworld/official",
     "intent_id": "client:018f...",
@@ -783,6 +783,14 @@ authenticated numeric actor handle plus the stable envelope advertised by
   }
 }
 ```
+
+The identifier's embedded state revision is checked while resolving the exact
+projected offer. Failures expose `error_kind` as `invalid_offer_id`,
+`stale_offer`, `unknown_offer`, or `disabled_offer` and commit no presence or
+world mutation. The prose `command` field is retained as a legacy convenience
+for the palette and older clients; its failures use `parse_failure`. It is not
+the authoritative offer submission contract, and `offer_id` takes precedence
+when both fields are present.
 
 The response includes a durable `receipt` with the same world/intent/actor,
 the committed `world_epoch` and `world_seq`, affected canonical entity

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -57,6 +57,7 @@ mod tests {
             actor_id,
             actor_session: None,
             command: command.to_string(),
+            offer_id: None,
             wallet_address: None,
             wallet: None,
             wallet_session: None,

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -1028,6 +1028,7 @@ mod tests {
             actor_id,
             actor_session: None,
             command: command.to_string(),
+            offer_id: None,
             wallet_address: None,
             wallet: None,
             wallet_session: None,

--- a/v2/orchestrator-rust/src/communal_governance.rs
+++ b/v2/orchestrator-rust/src/communal_governance.rs
@@ -1343,6 +1343,7 @@ mod tests {
             actor_id,
             actor_session: None,
             command: command.to_string(),
+            offer_id: None,
             wallet_address: None,
             wallet: None,
             wallet_session: None,

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -52,6 +52,10 @@ fn offer_composition_matches_at_submitted_revision(
 }
 
 impl RuntimeWorld {
+    pub(super) fn current_state_revision(&self) -> u64 {
+        self.world.next_event_seq.saturating_sub(1)
+    }
+
     pub(super) fn validate_action_offer_submission(
         &self,
         actor_id: u64,
@@ -293,7 +297,7 @@ impl RuntimeWorld {
                     target.as_ref(),
                     project.as_ref(),
                 );
-                let state_revision = self.world.next_event_seq.saturating_sub(1);
+                let state_revision = self.current_state_revision();
                 let source_collectible =
                     self.action_offer_source_collectible(&option.kind, actor_id);
                 let mut source_card_instances =
@@ -393,7 +397,7 @@ impl RuntimeWorld {
                 target.label.as_deref().unwrap_or("the journey destination")
             );
             let provider = self.action_offer_provider(kind, actor_id, Some(&target), None);
-            let state_revision = self.world.next_event_seq.saturating_sub(1);
+            let state_revision = self.current_state_revision();
             let source_collectible = self.location_source_collectible(actor_id);
             let source_card_instances = source_collectible.clone().into_iter().collect();
             let legacy_id = format!("explore_path:{}", target.id.clone().unwrap_or_default());
@@ -525,7 +529,7 @@ impl RuntimeWorld {
     ) -> RankedActionOffer {
         let binding = resolved_action_binding(kind)
             .unwrap_or_else(|| panic!("validated action offer kind has no rules binding: {kind}"));
-        let state_revision = self.world.next_event_seq.saturating_sub(1);
+        let state_revision = self.current_state_revision();
         let legacy_id = format!("{kind}:{}", normalize_command_text(command));
         let offer_id = format!(
             "{}:{}:{}",
@@ -1725,6 +1729,7 @@ mod tests {
             actor_id,
             actor_session: None,
             command: command.to_string(),
+            offer_id: None,
             wallet_address: None,
             wallet: None,
             wallet_session: None,

--- a/v2/orchestrator-rust/src/contributions.rs
+++ b/v2/orchestrator-rust/src/contributions.rs
@@ -1105,6 +1105,7 @@ mod tests {
                         actor_id: 5000,
                         actor_session: None,
                         command: offer.command.clone(),
+                        offer_id: None,
                         wallet_address: None,
                         wallet: None,
                         wallet_session: None,

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -32,6 +32,7 @@ mod moderation;
 mod movement;
 mod mud;
 mod natural_affordances;
+mod offer_commands;
 mod ownership;
 mod prompts;
 mod quest_loot;
@@ -91,6 +92,7 @@ use moderation::*;
 use movement::*;
 use mud::*;
 use natural_affordances::*;
+use offer_commands::*;
 use ownership::*;
 use prompts::*;
 use qrcode::{render::svg, QrCode};
@@ -27114,6 +27116,7 @@ fn narrative_move_rejected_response(
         command: command.into(),
         verb: String::new(),
         output: Some(output.into()),
+        error_kind: None,
         action: None,
         receipt: None,
         events: Vec::new(),
@@ -27279,6 +27282,7 @@ async fn submit_narrative_move(
             actor_id: payload.character_id,
             actor_session: Some(actor_session),
             command: command_text,
+            offer_id: None,
             wallet_address: Some(wallet_address),
             wallet: None,
             wallet_session: Some(session_id),
@@ -28036,6 +28040,7 @@ fn canonical_command_error(
         command: normalize_command_text(command),
         verb: String::new(),
         output: Some(output.into()),
+        error_kind: None,
         action: None,
         receipt: None,
         events: Vec::new(),
@@ -28267,7 +28272,7 @@ async fn command_with_forwarding(
 
     let request_hash = command_request_hash(
         &envelope.actor_ref,
-        &normalize_command_text(&payload.command),
+        &command_submission_identity(&payload),
         &envelope.observed,
         envelope.last_world_seq,
     );
@@ -28441,7 +28446,7 @@ async fn command_with_forwarding(
     let command_context = Arc::new(CanonicalCommandCommitContext {
         envelope: envelope.clone(),
         request_hash: request_hash.clone(),
-        normalized_command: normalize_command_text(&payload.command),
+        normalized_command: command_submission_identity(&payload),
         compatibility_envelope,
         leases,
         phase: AtomicU8::new(0),
@@ -28456,6 +28461,10 @@ async fn command_with_forwarding(
             ),
         )
         .await;
+
+    if payload.offer_id.is_some() && response.error_kind.is_some() {
+        return Json(response);
+    }
 
     if !command_context.committed() {
         if let Some(path) = state.event_store_path.as_deref() {
@@ -29094,10 +29103,12 @@ async fn command_inner(
         })
         .unwrap_or(false);
     let normalized_command = normalize_command_text(&payload.command);
-    if matches!(
-        normalized_command.as_str(),
-        "pass" | "need time" | "need-time"
-    ) {
+    if payload.offer_id.is_none()
+        && matches!(
+            normalized_command.as_str(),
+            "pass" | "need time" | "need-time"
+        )
+    {
         let request = ActorRequest {
             actor_id: payload.actor_id,
             actor_session: payload.actor_session,
@@ -29134,58 +29145,17 @@ async fn command_inner(
                 "need".to_string()
             },
             output: Some(output.to_string()),
+            error_kind: None,
             action: None,
             receipt: None,
             events: response.events,
         });
     }
-    let resolved = {
-        let runtime = state.inner.lock().await;
-        if !client_actor_authorized_for_state(
-            &runtime,
-            &state,
-            payload.actor_id,
-            payload.actor_session.as_deref(),
-        ) {
-            return Json(CommandResponse {
-                ok: false,
-                status: 403,
-                command: normalize_command_text(&payload.command),
-                verb: String::new(),
-                output: Some(
-                    "Your avatar slipped out of reach. Begin again or reconnect your account."
-                        .to_string(),
-                ),
-                action: None,
-                receipt: None,
-                events: Vec::new(),
-            });
-        }
-        let active_direct_actors = active_actor_ids_for_state(&state);
-        runtime.resolve_command_with_presence(&payload, &access, Some(&active_direct_actors))
-    };
-
-    let presence_events = if was_active {
-        Vec::new()
-    } else {
-        commit_presence_event(&state, payload.actor_id, true).await
-    };
-
-    let resolved = match resolved {
-        Ok(resolved) => resolved,
-        Err(error) => {
-            return Json(CommandResponse {
-                ok: false,
-                status: error.status,
-                command: error.command,
-                verb: error.verb,
-                output: Some(error.output),
-                action: None,
-                receipt: None,
-                events: presence_events,
-            });
-        }
-    };
+    let (resolved, presence_events) =
+        match resolve_command_submission_at_boundary(&state, &payload, &access, was_active).await {
+            Ok(resolved) => resolved,
+            Err(response) => return response,
+        };
 
     if command_dispatch_consumes_room_turn(&resolved.dispatch) {
         let runtime = state.inner.lock().await;
@@ -29211,6 +29181,7 @@ async fn command_inner(
             command: resolved.command,
             verb: resolved.verb,
             output: Some(output),
+            error_kind: None,
             action: resolved.action,
             receipt: None,
             events: presence_events,
@@ -29221,6 +29192,7 @@ async fn command_inner(
             command: resolved.command,
             verb: resolved.verb,
             output: Some(output),
+            error_kind: None,
             action: resolved.action,
             receipt: None,
             events: presence_events,
@@ -29418,6 +29390,7 @@ async fn command_inner(
                         "Your avatar slipped out of reach. Begin again or reconnect your account."
                             .to_string(),
                     ),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -29433,6 +29406,7 @@ async fn command_inner(
                     command: resolved.command,
                     verb: resolved.verb,
                     output: Some("You are no longer in that room.".to_string()),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -29458,6 +29432,7 @@ async fn command_inner(
                     command: resolved.command,
                     verb: resolved.verb,
                     output: Some(output.to_string()),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -29484,6 +29459,7 @@ async fn command_inner(
                         "That choice got lost before the room could answer. Try once more."
                             .to_string(),
                     ),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -29545,6 +29521,7 @@ async fn command_inner(
                         "Your avatar slipped out of reach. Begin again or reconnect your account."
                             .to_string(),
                     ),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -29564,6 +29541,7 @@ async fn command_inner(
                         command: resolved.command,
                         verb: resolved.verb,
                         output: Some(reason),
+                        error_kind: None,
                         action: resolved.action,
                         receipt: None,
                         events: presence_events,
@@ -29602,6 +29580,7 @@ async fn command_inner(
                         "That choice got lost before the room could answer. Try once more."
                             .to_string(),
                     ),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -29873,6 +29852,7 @@ async fn command_inner(
                         "Your avatar slipped out of reach. Begin again or reconnect your account."
                             .to_string(),
                     ),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -29885,6 +29865,7 @@ async fn command_inner(
                     command: resolved.command,
                     verb: resolved.verb,
                     output: Some(output),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -29918,6 +29899,7 @@ async fn command_inner(
                         "That choice got lost before the room could answer. Try once more."
                             .to_string(),
                     ),
+                    error_kind: None,
                     action: resolved.action,
                     receipt: None,
                     events: presence_events,
@@ -30148,6 +30130,7 @@ async fn command_inner(
                 command: resolved.command,
                 verb: resolved.verb,
                 output,
+                error_kind: None,
                 action: resolved.action,
                 receipt: None,
                 events: presence_events,
@@ -39079,6 +39062,7 @@ fn canonical_fallback_command_response(
             "The command committed before its full response was delivered. Refresh to continue."
                 .to_string(),
         ),
+        error_kind: None,
         action: None,
         receipt: Some(CanonicalCommandReceipt {
             world_id: OFFICIAL_WORLD_ID.to_string(),
@@ -42017,6 +42001,7 @@ mod tests {
             actor_id,
             actor_session: None,
             command: command.to_string(),
+            offer_id: None,
             wallet_address: None,
             wallet: None,
             wallet_session: None,
@@ -43549,6 +43534,7 @@ mod tests {
             actor_id,
             actor_session: Some(actor_session.to_string()),
             command: command.to_string(),
+            offer_id: None,
             wallet_address: None,
             wallet: None,
             wallet_session: None,

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -11,6 +11,8 @@ pub(crate) struct CommandResponse {
     pub(crate) command: String,
     pub(crate) verb: String,
     pub(crate) output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) error_kind: Option<CommandErrorKind>,
     pub(crate) action: Option<CommandActionView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) receipt: Option<CanonicalCommandReceipt>,
@@ -21,7 +23,10 @@ pub(crate) struct CommandResponse {
 pub(crate) struct CommandRequest {
     pub(crate) actor_id: u64,
     pub(crate) actor_session: Option<String>,
+    #[serde(default)]
     pub(crate) command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) offer_id: Option<String>,
     pub(crate) wallet_address: Option<String>,
     pub(crate) wallet: Option<String>,
     pub(crate) wallet_session: Option<String>,
@@ -29,6 +34,16 @@ pub(crate) struct CommandRequest {
     pub(crate) cards: Option<String>,
     #[serde(default)]
     pub(crate) envelope: Option<CanonicalCommandEnvelope>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CommandErrorKind {
+    ParseFailure,
+    InvalidOfferId,
+    StaleOffer,
+    UnknownOffer,
+    DisabledOffer,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -190,6 +205,7 @@ pub(crate) struct CommandError {
     pub(crate) verb: String,
     pub(crate) status: u32,
     pub(crate) output: String,
+    pub(crate) kind: CommandErrorKind,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -205,6 +221,15 @@ pub(crate) fn normalize_command_text(input: &str) -> String {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+pub(crate) fn command_submission_identity(payload: &CommandRequest) -> String {
+    payload
+        .offer_id
+        .as_deref()
+        .map(str::trim)
+        .map(|offer_id| format!("offer_id:{offer_id}"))
+        .unwrap_or_else(|| normalize_command_text(&payload.command))
 }
 
 fn normalize_emote_message(input: &str) -> Option<String> {
@@ -392,6 +417,22 @@ pub(crate) fn command_error(
         verb: verb.to_string(),
         status,
         output: output.into(),
+        kind: CommandErrorKind::ParseFailure,
+    }
+}
+
+pub(crate) fn offer_command_error(
+    _offer_id: &str,
+    kind: CommandErrorKind,
+    status: u32,
+    output: impl Into<String>,
+) -> CommandError {
+    CommandError {
+        command: String::new(),
+        verb: String::new(),
+        status,
+        output: output.into(),
+        kind,
     }
 }
 
@@ -438,6 +479,7 @@ pub(crate) async fn commit_shuffle_hand_command(
             output: Some(
                 "That choice got lost before the room could answer. Try once more.".to_string(),
             ),
+            error_kind: None,
             action: resolved.action,
             receipt: None,
             events: leading_events,
@@ -479,6 +521,7 @@ pub(crate) fn command_action_response_with_prefix_and_events(
         command: resolved.command,
         verb: resolved.verb,
         output,
+        error_kind: None,
         action: resolved.action,
         receipt: None,
         events: response.events,
@@ -580,6 +623,7 @@ pub(crate) fn command_rate_limited_response_with_events(
         command: resolved.command,
         verb: resolved.verb,
         output: Some("The room needs a breath. Try again in a moment.".to_string()),
+        error_kind: None,
         action: resolved.action,
         receipt: None,
         events,

--- a/v2/orchestrator-rust/src/offer_commands.rs
+++ b/v2/orchestrator-rust/src/offer_commands.rs
@@ -1,0 +1,826 @@
+use super::*;
+
+const MAX_OFFER_ID_CHARS: usize = 2_048;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ParsedOfferId<'a> {
+    rules_profile: &'a str,
+    state_revision: u64,
+    local_id: &'a str,
+}
+
+fn parse_offer_id(value: &str) -> Option<ParsedOfferId<'_>> {
+    let value = value.trim();
+    if value.is_empty() || value.chars().count() > MAX_OFFER_ID_CHARS {
+        return None;
+    }
+    let mut parts = value.splitn(3, ':');
+    let rules_profile = parts.next()?.trim();
+    let state_revision = parts.next()?.parse().ok()?;
+    let local_id = parts.next()?.trim();
+    if rules_profile.is_empty() || local_id.is_empty() {
+        return None;
+    }
+    Some(ParsedOfferId {
+        rules_profile,
+        state_revision,
+        local_id,
+    })
+}
+
+fn offer_error(
+    offer_id: &str,
+    kind: CommandErrorKind,
+    status: u32,
+    output: impl Into<String>,
+) -> CommandError {
+    offer_command_error(offer_id, kind, status, output)
+}
+
+fn select_current_offer(
+    runtime: &RuntimeWorld,
+    actor_id: u64,
+    access: &AccessContext,
+    offer_id: &str,
+) -> Result<RankedActionOffer, CommandError> {
+    let Some(parsed) = parse_offer_id(offer_id) else {
+        return Err(offer_error(
+            offer_id,
+            CommandErrorKind::InvalidOfferId,
+            400,
+            "That offer_id is malformed. Refresh the scene and submit an identifier from action_offers.",
+        ));
+    };
+    let current_revision = runtime.current_state_revision();
+    if parsed.state_revision != current_revision {
+        return Err(offer_error(
+            offer_id,
+            CommandErrorKind::StaleOffer,
+            409,
+            format!(
+                "That offer expired at state revision {}; the current revision is {current_revision}. Refresh the scene and choose again.",
+                parsed.state_revision
+            ),
+        ));
+    }
+    let (_, offers) = runtime.legal_action_candidates(Some(actor_id), access);
+    let exact = offers.into_iter().find(|offer| offer.offer_id == offer_id);
+    if let Some(offer) = exact.as_ref().filter(|offer| offer.disabled) {
+        return Err(offer_error(
+            offer_id,
+            CommandErrorKind::DisabledOffer,
+            409,
+            offer.disabled_reason.clone().unwrap_or_else(|| {
+                "That projected action is currently disabled. Refresh the scene and choose an enabled offer."
+                    .to_string()
+            }),
+        ));
+    }
+    if let Some(offer) = exact {
+        return Ok(offer);
+    }
+    Err(offer_error(
+        offer_id,
+        CommandErrorKind::UnknownOffer,
+        404,
+        format!(
+            "That offer_id is not in the current action_offers for rules profile {}. Refresh the scene and choose a published offer.",
+            parsed.rules_profile
+        ),
+    ))
+}
+
+fn required_target_id(offer: &RankedActionOffer, kind: &str) -> Result<u64, CommandError> {
+    offer
+        .target
+        .as_ref()
+        .filter(|target| target.kind == kind)
+        .and_then(|target| target.id)
+        .ok_or_else(|| {
+            offer_error(
+                &offer.offer_id,
+                CommandErrorKind::UnknownOffer,
+                409,
+                "That published offer no longer has its authoritative target. Refresh the scene.",
+            )
+        })
+}
+
+fn stable_parts<'a>(offer: &'a RankedActionOffer, prefix: &str) -> Option<Vec<&'a str>> {
+    offer
+        .id
+        .strip_prefix(prefix)
+        .map(|rest| rest.split(':').collect())
+}
+
+fn dispatch_for_offer(
+    runtime: &RuntimeWorld,
+    actor_id: u64,
+    offer: &RankedActionOffer,
+) -> Result<CommandDispatch, CommandError> {
+    if let Some(project) = offer.project.as_ref() {
+        if let Some(strategy_id) = project.strategy_id.as_ref() {
+            return Ok(CommandDispatch::Contribute {
+                job_id: project.id.clone(),
+                strategy_id: strategy_id.clone(),
+                action_kind: offer.kind.clone(),
+            });
+        }
+    }
+    let invalid = || {
+        offer_error(
+            &offer.offer_id,
+            CommandErrorKind::UnknownOffer,
+            409,
+            "That published offer no longer has an actionable structured binding. Refresh the scene.",
+        )
+    };
+    match offer.kind.as_str() {
+        "move" => Ok(CommandDispatch::Move {
+            destination_location_id: required_target_id(offer, "location")?,
+        }),
+        "explore_path" => Ok(CommandDispatch::Scout),
+        "flee" => Ok(CommandDispatch::Flee {
+            destination_location_id: required_target_id(offer, "location")?,
+        }),
+        "check" => Ok(CommandDispatch::Check),
+        "study" => Ok(CommandDispatch::Study),
+        "influence" => Ok(CommandDispatch::Influence {
+            target_actor_id: required_target_id(offer, "actor")?,
+        }),
+        "cast_spell" => {
+            let item = runtime.default_spell_card(actor_id).ok_or_else(invalid)?;
+            Ok(CommandDispatch::CastSpell {
+                item_id: item.id,
+                target_actor_id: actor_id,
+            })
+        }
+        "pick_up" => Ok(CommandDispatch::PickUp {
+            item_id: required_target_id(offer, "item")?,
+        }),
+        "drop_item" => Ok(CommandDispatch::Drop {
+            item_id: required_target_id(offer, "item")?,
+        }),
+        "use_item" => {
+            let parts = stable_parts(offer, "use_item:").ok_or_else(invalid)?;
+            let [item_id, target_actor_id] = parts.as_slice() else {
+                return Err(invalid());
+            };
+            Ok(CommandDispatch::UseItem {
+                item_id: item_id.parse().map_err(|_| invalid())?,
+                target_actor_id: target_actor_id.parse().map_err(|_| invalid())?,
+            })
+        }
+        "search" => {
+            let target = runtime
+                .default_search_target(actor_id)
+                .ok_or_else(invalid)?;
+            if offer.target.as_ref().is_none_or(|published| {
+                published.kind != "feature" || published.id != Some(target.location_id)
+            }) {
+                return Err(invalid());
+            }
+            Ok(CommandDispatch::SearchFeature {
+                location_id: target.location_id,
+                feature_key: target.key,
+                feature_name: target.name,
+                output: target.output,
+            })
+        }
+        "use_feature" => {
+            let rest = offer.id.strip_prefix("use_feature:").ok_or_else(invalid)?;
+            let mut parts = rest.splitn(3, ':');
+            let item_id = parts
+                .next()
+                .and_then(|part| part.parse().ok())
+                .ok_or_else(invalid)?;
+            let location_id = parts
+                .next()
+                .and_then(|part| part.parse().ok())
+                .ok_or_else(invalid)?;
+            let feature_key = parts
+                .next()
+                .filter(|part| !part.is_empty())
+                .ok_or_else(invalid)?;
+            let candidate = runtime
+                .plan_feature_use_choice(actor_id, item_id, location_id, feature_key)
+                .map_err(|_| invalid())?;
+            Ok(CommandDispatch::UseFeature {
+                item_id,
+                location_id,
+                feature_key: feature_key.to_string(),
+                output: candidate.content,
+            })
+        }
+        "give_item" => {
+            let parts = stable_parts(offer, "give_item:").ok_or_else(invalid)?;
+            let [item_id, target_actor_id] = parts.as_slice() else {
+                return Err(invalid());
+            };
+            Ok(CommandDispatch::GiveItem {
+                item_id: item_id.parse().map_err(|_| invalid())?,
+                target_actor_id: target_actor_id.parse().map_err(|_| invalid())?,
+            })
+        }
+        "trade_item" => {
+            let parts = stable_parts(offer, "trade_item:").ok_or_else(invalid)?;
+            let [item_id, target_actor_id, target_item_id] = parts.as_slice() else {
+                return Err(invalid());
+            };
+            Ok(CommandDispatch::TradeItem {
+                item_id: item_id.parse().map_err(|_| invalid())?,
+                target_actor_id: target_actor_id.parse().map_err(|_| invalid())?,
+                target_item_id: target_item_id.parse().map_err(|_| invalid())?,
+            })
+        }
+        "theft" => {
+            let (target, item) = runtime
+                .default_theft_candidate(actor_id)
+                .ok_or_else(invalid)?;
+            if required_target_id(offer, "item")? != item.id {
+                return Err(invalid());
+            }
+            Ok(CommandDispatch::Theft {
+                item_id: item.id,
+                target_actor_id: target.id,
+            })
+        }
+        "craft" => Ok(CommandDispatch::Craft {
+            recipe_id: required_target_id(offer, "recipe")?,
+        }),
+        "attack" => Ok(CommandDispatch::Attack {
+            target_actor_id: required_target_id(offer, "actor")?,
+        }),
+        "defend" => Ok(CommandDispatch::Defend),
+        "prepare" => Ok(CommandDispatch::Prepare),
+        "work" => Ok(CommandDispatch::Work),
+        "help" => Ok(CommandDispatch::Help),
+        "rest" => Ok(CommandDispatch::Rest),
+        "chat" | "create_bond" => {
+            let target_actor_id = required_target_id(offer, "actor")?;
+            let target_name = runtime
+                .actor_name(target_actor_id)
+                .unwrap_or_else(|| format!("Avatar {target_actor_id}"));
+            Ok(CommandDispatch::CreateBond {
+                target_actor_id,
+                statement: default_bond_statement(&target_name),
+            })
+        }
+        "resolve_bond" => Ok(CommandDispatch::ResolveBond {
+            target_actor_id: required_target_id(offer, "actor")?,
+        }),
+        _ => Err(invalid()),
+    }
+}
+
+impl RuntimeWorld {
+    pub(crate) fn resolve_command_submission(
+        &self,
+        payload: &CommandRequest,
+        access: &AccessContext,
+        active_direct_actor_ids: Option<&BTreeSet<u64>>,
+    ) -> Result<ResolvedCommand, CommandError> {
+        let Some(offer_id) = payload.offer_id.as_deref() else {
+            return self.resolve_command_with_presence(payload, access, active_direct_actor_ids);
+        };
+        let offer = select_current_offer(self, payload.actor_id, access, offer_id)?;
+        let dispatch = dispatch_for_offer(self, payload.actor_id, &offer)?;
+        Ok(ResolvedCommand {
+            command: offer.command.clone(),
+            verb: offer.kind.clone(),
+            action: Some(command_action(&offer.kind, &offer.label, &offer.command)),
+            dispatch,
+        })
+    }
+}
+
+pub(crate) async fn resolve_command_submission_at_boundary(
+    state: &AppState,
+    payload: &CommandRequest,
+    access: &AccessContext,
+    was_active: bool,
+) -> Result<(ResolvedCommand, Vec<EventView>), Json<CommandResponse>> {
+    let resolved = {
+        let runtime = state.inner.lock().await;
+        if !client_actor_authorized_for_state(
+            &runtime,
+            state,
+            payload.actor_id,
+            payload.actor_session.as_deref(),
+        ) {
+            return Err(Json(CommandResponse {
+                ok: false,
+                status: 403,
+                command: normalize_command_text(&payload.command),
+                verb: String::new(),
+                output: Some(
+                    "Your avatar slipped out of reach. Begin again or reconnect your account."
+                        .to_string(),
+                ),
+                error_kind: None,
+                action: None,
+                receipt: None,
+                events: Vec::new(),
+            }));
+        }
+        let active_direct_actors = active_actor_ids_for_state(state);
+        runtime.resolve_command_submission(payload, access, Some(&active_direct_actors))
+    };
+
+    match resolved {
+        Ok(resolved) => {
+            let presence_events = if was_active {
+                Vec::new()
+            } else {
+                commit_presence_event(state, payload.actor_id, true).await
+            };
+            Ok((resolved, presence_events))
+        }
+        Err(error) => {
+            let presence_events = if was_active || payload.offer_id.is_some() {
+                Vec::new()
+            } else {
+                commit_presence_event(state, payload.actor_id, true).await
+            };
+            Err(Json(CommandResponse {
+                ok: false,
+                status: error.status,
+                command: error.command,
+                verb: error.verb,
+                output: Some(error.output),
+                error_kind: Some(error.kind),
+                action: None,
+                receipt: None,
+                events: presence_events,
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(actor_id: u64, session: &str, offer_id: &str) -> CommandRequest {
+        CommandRequest {
+            actor_id,
+            actor_session: Some(session.to_string()),
+            command: "this prose must never be parsed".to_string(),
+            offer_id: Some(offer_id.to_string()),
+            wallet_address: None,
+            wallet: None,
+            wallet_session: None,
+            owned_card_ids: None,
+            cards: None,
+            envelope: None,
+        }
+    }
+
+    fn snapshot_bytes(runtime: &RuntimeWorld) -> Vec<u8> {
+        serde_json::to_vec(&RuntimeSnapshot::from_runtime(runtime)).expect("runtime snapshot")
+    }
+
+    fn runtime_from_bytes(bytes: &[u8]) -> RuntimeWorld {
+        serde_json::from_slice::<RuntimeSnapshot>(bytes)
+            .expect("snapshot parses")
+            .into_runtime()
+            .expect("snapshot reconnects")
+    }
+
+    #[test]
+    fn offer_id_parser_preserves_colons_and_spaces_in_the_local_identity() {
+        assert_eq!(
+            parse_offer_id("cosyworld.srd5/1:42:contribution:work:job id:strategy"),
+            Some(ParsedOfferId {
+                rules_profile: "cosyworld.srd5/1",
+                state_revision: 42,
+                local_id: "contribution:work:job id:strategy",
+            })
+        );
+    }
+
+    #[test]
+    fn offer_id_wins_over_legacy_prose_and_hashing_is_deterministic() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5_000, COSY_COTTAGE_LOCATION_ID, "ID Winner");
+        let offer = runtime
+            .legal_action_candidates(Some(5_000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| !offer.disabled)
+            .expect("seeded actor has an enabled offer");
+        let left = request(5_000, "session", &offer.offer_id);
+        let mut right = left.clone();
+        right.command = "different legacy prose".to_string();
+        let resolved = runtime
+            .resolve_command_submission(&left, &AccessContext::default(), None)
+            .expect("offer identity resolves before prose");
+        assert_eq!(
+            resolved.action.as_ref().map(|action| action.kind.as_str()),
+            Some(offer.kind.as_str())
+        );
+        assert_eq!(
+            command_submission_identity(&left),
+            command_submission_identity(&right)
+        );
+        assert_eq!(
+            command_request_hash(
+                "actor:test",
+                &command_submission_identity(&left),
+                &CanonicalObservedVersions::default(),
+                runtime.current_state_revision(),
+            ),
+            command_request_hash(
+                "actor:test",
+                &command_submission_identity(&right),
+                &CanonicalObservedVersions::default(),
+                runtime.current_state_revision(),
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_change_prose_payload_remains_compatible_and_parse_failures_are_typed() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Legacy Speaker",
+        );
+        let legacy: CommandRequest = serde_json::from_value(serde_json::json!({
+            "actor_id": 5_000,
+            "command": "look"
+        }))
+        .expect("pre-offer_id command payload still deserializes");
+        assert_eq!(legacy.offer_id, None);
+        assert_eq!(command_submission_identity(&legacy), "look");
+        assert!(matches!(
+            runtime
+                .resolve_command_submission(&legacy, &AccessContext::default(), None)
+                .expect("legacy prose still resolves")
+                .dispatch,
+            CommandDispatch::Read { .. }
+        ));
+
+        let state = test_app_state(runtime, None);
+        let (session, _) = issue_actor_session(&state, 5_000);
+        let mut invalid = legacy;
+        invalid.actor_session = Some(session);
+        invalid.command = "verb-that-does-not-exist".to_string();
+        let response = command_inner(
+            ConnectInfo("127.0.0.1:44089".parse().expect("client address")),
+            State(state),
+            Json(invalid),
+        )
+        .await
+        .0;
+        assert!(!response.ok);
+        assert_eq!(response.error_kind, Some(CommandErrorKind::ParseFailure));
+        assert!(response.events.iter().any(|event| {
+            event.type_name == "actor.presence" && event.content.as_deref() == Some("active")
+        }));
+    }
+
+    #[tokio::test]
+    async fn every_enabled_seeded_offer_crosses_the_real_command_boundary_by_id() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Offer Property",
+        );
+        let access = AccessContext::default();
+        let offers = runtime
+            .legal_action_candidates(Some(5_000), &access)
+            .1
+            .into_iter()
+            .filter(|offer| !offer.disabled)
+            .collect::<Vec<_>>();
+        assert!(!offers.is_empty());
+        let initial = snapshot_bytes(&runtime);
+
+        for offer in offers {
+            let state = test_app_state(runtime_from_bytes(&initial), None);
+            let (session, _) = issue_actor_session(&state, 5_000);
+            let response = command_inner(
+                ConnectInfo("127.0.0.1:44090".parse().expect("client address")),
+                State(state),
+                Json(request(5_000, &session, &offer.offer_id)),
+            )
+            .await
+            .0;
+            assert!(
+                response.error_kind.is_none(),
+                "{} hit submission routing instead of action execution: {:?}",
+                offer.offer_id,
+                response
+            );
+            assert_eq!(
+                response.action.as_ref().map(|action| action.kind.as_str()),
+                Some(offer.kind.as_str()),
+                "{} crossed the command boundary as its projected action",
+                offer.offer_id
+            );
+            assert_ne!(response.status, 404, "{} was not routed", offer.offer_id);
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_offer_reactivates_inactive_actor_and_still_executes() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Returning Offer",
+        );
+        let offer = runtime
+            .legal_action_candidates(Some(5_000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| !offer.disabled && offer.kind == "influence")
+            .expect("seeded Cottage projects an executable influence offer");
+        let state = test_app_state(runtime, None);
+        let (session, _) = issue_actor_session(&state, 5_000);
+        assert!(!active_actor_ids(&state.actor_sessions).contains(&5_000));
+
+        let response = command(
+            ConnectInfo("127.0.0.1:44096".parse().expect("client address")),
+            State(state.clone()),
+            Json(request(5_000, &session, &offer.offer_id)),
+        )
+        .await
+        .0;
+
+        assert!(response.error_kind.is_none());
+        assert_eq!(
+            response.action.as_ref().map(|action| action.kind.as_str()),
+            Some("influence")
+        );
+        assert!(response.events.iter().any(|event| {
+            event.type_name == "actor.presence" && event.content.as_deref() == Some("active")
+        }));
+        assert!(response
+            .events
+            .iter()
+            .any(|event| event.type_name == "influence.committed"));
+        assert!(active_actor_ids(&state.actor_sessions).contains(&5_000));
+        assert_eq!(
+            state.inner.lock().await.latest_actor_presence_state(5_000),
+            Some(true)
+        );
+    }
+
+    async fn assert_atomic_offer_rejection(
+        state: &AppState,
+        actor_id: u64,
+        session: &str,
+        offer_id: &str,
+        expected: CommandErrorKind,
+    ) {
+        let before = {
+            let runtime = state.inner.lock().await;
+            snapshot_bytes(&runtime)
+        };
+        let response = command(
+            ConnectInfo("127.0.0.1:44091".parse().expect("client address")),
+            State(state.clone()),
+            Json(request(actor_id, session, offer_id)),
+        )
+        .await
+        .0;
+        assert!(!response.ok);
+        assert_eq!(response.error_kind, Some(expected));
+        assert!(
+            response.events.is_empty(),
+            "offer rejection emits no presence event"
+        );
+        let runtime = state.inner.lock().await;
+        assert_eq!(
+            snapshot_bytes(&runtime),
+            before,
+            "offer rejection is byte-atomic"
+        );
+        let restored = runtime_from_bytes(&before);
+        assert_eq!(
+            serde_json::to_vec(&runtime.event_log).expect("current event log"),
+            serde_json::to_vec(&restored.event_log).expect("restored event log")
+        );
+        assert_eq!(runtime.world.next_event_seq, restored.world.next_event_seq);
+        assert_eq!(runtime.presence_states, restored.presence_states);
+    }
+
+    #[tokio::test]
+    async fn malformed_stale_and_unknown_offer_ids_reject_without_any_mutation() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Atomic Rejector",
+        );
+        let current_revision = runtime.current_state_revision();
+        let rules_profile = active_content().manifest.rules_profile.clone();
+        let state = test_app_state(runtime, None);
+        let (session, _) = issue_actor_session(&state, 5_000);
+
+        assert_atomic_offer_rejection(
+            &state,
+            5_000,
+            &session,
+            "not-an-offer-id",
+            CommandErrorKind::InvalidOfferId,
+        )
+        .await;
+        assert_atomic_offer_rejection(
+            &state,
+            5_000,
+            &session,
+            &format!("{rules_profile}:{}:missing:offer", current_revision - 1),
+            CommandErrorKind::StaleOffer,
+        )
+        .await;
+        assert_atomic_offer_rejection(
+            &state,
+            5_000,
+            &session,
+            &format!("{rules_profile}:{current_revision}:missing:offer"),
+            CommandErrorKind::UnknownOffer,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn disabled_offer_rejects_atomically_and_staleness_takes_precedence() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Current Fighter",
+        );
+        create_test_human(
+            &mut runtime,
+            5_001,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Waiting Fighter",
+        );
+        let encounter_id = combat_encounter_id(MOONLIT_JOB_ID);
+        assert_eq!(
+            runtime
+                .apply_journal_record(&JournalRecord::new(
+                    CwAction {
+                        kind: CW_ACTION_COMBAT_START,
+                        actor_id: 5_000,
+                        target_actor_id: 1_004,
+                        content_id: encounter_id,
+                        ..CwAction::default()
+                    },
+                    88_001,
+                ))
+                .0,
+            CW_OK
+        );
+        assert_eq!(
+            runtime
+                .apply_journal_record(&JournalRecord::new(
+                    combat_join_action(5_001, encounter_id),
+                    88_002,
+                ))
+                .0,
+            CW_OK
+        );
+        let disabled = runtime
+            .legal_action_candidates(Some(5_001), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| offer.disabled)
+            .expect("off-turn fighter projects a disabled wait offer");
+        let parsed = parse_offer_id(&disabled.offer_id).expect("disabled offer id parses");
+        let stale_disabled = format!(
+            "{}:{}:{}",
+            parsed.rules_profile,
+            parsed.state_revision - 1,
+            parsed.local_id
+        );
+        let state = test_app_state(runtime, None);
+        let (session, _) = issue_actor_session(&state, 5_001);
+        assert_atomic_offer_rejection(
+            &state,
+            5_001,
+            &session,
+            &stale_disabled,
+            CommandErrorKind::StaleOffer,
+        )
+        .await;
+        assert_atomic_offer_rejection(
+            &state,
+            5_001,
+            &session,
+            &disabled.offer_id,
+            CommandErrorKind::DisabledOffer,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn issue_306_contextual_influence_executes_by_id_through_commands_api() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Context Caller",
+        );
+        let offer = runtime
+            .legal_action_candidates(Some(5_000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| {
+                offer.kind == "influence"
+                    && offer
+                        .composition_trace
+                        .contextual_offers
+                        .iter()
+                        .any(|id| id == "cosyworld.core:cottage-ask-local-lead")
+            })
+            .expect("#306 contextual influence offer");
+        let state = test_app_state(runtime, None);
+        let (session, _) = issue_actor_session(&state, 5_000);
+        let payload: CommandRequest = serde_json::from_value(serde_json::json!({
+            "actor_id": 5_000,
+            "actor_session": session,
+            "offer_id": offer.offer_id,
+            "command": "ask for a local lead"
+        }))
+        .expect("additive /commands offer_id JSON contract");
+        let response = command(
+            ConnectInfo("127.0.0.1:44092".parse().expect("client address")),
+            State(state),
+            Json(payload),
+        )
+        .await
+        .0;
+        assert!(response.ok, "{response:?}");
+        assert_eq!(response.error_kind, None);
+        assert_eq!(
+            response.action.as_ref().map(|action| action.kind.as_str()),
+            Some("influence")
+        );
+        assert!(
+            !response.events.is_empty(),
+            "#306 reaches a real action outcome"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_370_feature_use_executes_by_id_without_a_command_string() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Feature User",
+        );
+        for item in &mut runtime.world.items[..runtime.world.item_count] {
+            if item.id == STORY_BUTTON_ITEM_ID {
+                item.location_id = 0;
+                item.holder_actor_id = 5_000;
+                item.held_since_tick = runtime.world.tick;
+            }
+        }
+        let offer = runtime
+            .legal_action_candidates(Some(5_000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| offer.kind == "use_feature")
+            .expect("#370 structured feature-use offer");
+        let state = test_app_state(runtime, None);
+        let (session, _) = issue_actor_session(&state, 5_000);
+        let payload: CommandRequest = serde_json::from_value(serde_json::json!({
+            "actor_id": 5_000,
+            "actor_session": session,
+            "offer_id": offer.offer_id
+        }))
+        .expect("offer-only /commands request");
+        let response = command(
+            ConnectInfo("127.0.0.1:44093".parse().expect("client address")),
+            State(state),
+            Json(payload),
+        )
+        .await
+        .0;
+        assert!(response.ok, "{response:?}");
+        assert_eq!(response.error_kind, None);
+        assert_eq!(
+            response.action.as_ref().map(|action| action.kind.as_str()),
+            Some("use_feature")
+        );
+        assert!(response
+            .events
+            .iter()
+            .any(|event| event.type_name == "item.used"));
+    }
+}

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -1239,6 +1239,7 @@ pub(super) fn command_turn_rejected_response(
         command: resolved.command,
         verb: resolved.verb,
         output: view.explanation,
+        error_kind: None,
         action: resolved.action,
         receipt: None,
         events,

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74555
+74541


### PR DESCRIPTION
Closes #409.

## Summary

- accept an optional authoritative `offer_id` on `POST /commands`
- resolve the exact current projected offer into a structured dispatch without reparsing display prose
- return typed malformed, stale, unknown, disabled, and legacy parse failures
- preserve legacy prose callers while making `offer_id` win when both are present
- keep offer failures atomic, including presence state, while retaining canonical presence activation on successful submissions

## Evidence

- full Rust suite — 555/555 pass
- authoritative offer suite — 9/9 pass
- every enabled seeded Cottage offer crosses the real command boundary independently
- #306 influence and #370 feature-use offers execute by ID
- live HTTP matrix — `400 invalid_offer_id`, `409 stale_offer`, `404 unknown_offer`, `409 disabled_offer`
- replay golden, historical tick replay, and legacy prose resolution — pass
- architecture/clippy/version/syntax/diff gates — pass
- `main.rs` ceiling reduced 74,555 → 74,541

## Atomicity

Malformed, stale, unknown, and genuinely projected disabled offers preserve the complete runtime snapshot, journal/event position, and presence state byte-for-byte. A valid offer submitted by an inactive actor still records canonical active presence and executes its action.
