### PR TITLE
Fix Scout after route discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.205",
+  "version": "0.0.206",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.205"
+version = "0.0.206"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -948,9 +948,9 @@ impl RuntimeWorld {
         let exits = self.exit_views(actor.location_id, access);
         if let Some(journey) = self.journey_view(actor_id) {
             let next_is_revealed = journey.next_location_id.is_some_and(|next_id| {
-                exits.iter().any(|exit| {
-                    exit.destination_location_id == next_id && exit.accessible && !exit.locked
-                })
+                exits
+                    .iter()
+                    .any(|exit| exit.destination_location_id == next_id)
             });
             if journey.next_location_id.is_some() && !next_is_revealed {
                 return Some(ActionTargetView {
@@ -1803,5 +1803,60 @@ mod tests {
             CommandDispatch::Scout
         ));
         assert!(destination_location_id > 0);
+    }
+
+    #[test]
+    fn revealed_but_inaccessible_journey_segment_does_not_offer_scout_again() {
+        const ALPINE_FOREST_LOCATION_ID: u64 = 50;
+        const LIBRARY_LOCATION_ID: u64 = 12;
+
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, ALPINE_FOREST_LOCATION_ID, "Map Reader");
+        let mut pathway =
+            runtime.generated_pathway(5000, ALPINE_FOREST_LOCATION_ID, LIBRARY_LOCATION_ID, 3);
+        let path = runtime.pathway_path(&pathway, ALPINE_FOREST_LOCATION_ID, LIBRARY_LOCATION_ID);
+        for edge in path.windows(2) {
+            pathway
+                .revealed_edges
+                .insert(pathway_edge_key(edge[0], edge[1]));
+            runtime.ensure_generated_pathway_edge(&pathway, edge[0], edge[1]);
+        }
+        let current_step = path.len() - 2;
+        let current_location_id = path[current_step];
+        let pathway_id = pathway.id.clone();
+        runtime
+            .generated_pathways
+            .insert(pathway_id.clone(), pathway);
+        runtime.journeys.insert(
+            5000,
+            JourneyState {
+                actor_id: 5000,
+                pathway_id,
+                origin_location_id: ALPINE_FOREST_LOCATION_ID,
+                destination_location_id: LIBRARY_LOCATION_ID,
+                destination_name: "Library".to_string(),
+                path,
+                current_step,
+                explorer: true,
+            },
+        );
+        let actor_count = runtime.world.actor_count;
+        runtime.world.actors[..actor_count]
+            .iter_mut()
+            .find(|actor| actor.id == 5000)
+            .expect("test traveller exists")
+            .location_id = current_location_id;
+
+        let state = runtime.state_response(Some(5000), &AccessContext::default());
+        let library_exit = state
+            .exits
+            .iter()
+            .find(|exit| exit.destination_location_id == LIBRARY_LOCATION_ID)
+            .expect("the revealed Library edge stays projected");
+        assert!(!library_exit.accessible);
+        assert!(!state
+            .action_offers
+            .iter()
+            .any(|offer| offer.kind == "explore_path"));
     }
 }

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -4959,12 +4959,11 @@
       if (journey) {
         const nextLocationId = Number(journey.next_location_id || 0);
         const nextIsDestination = nextLocationId === Number(journey.destination_location_id || 0);
+        const scoutOffer = offerFor("explore_path");
         const nextStretchRevealed = (view.exits || []).some((exit) => (
           Number(exit.destination_location_id || 0) === nextLocationId
-          && !exitUnavailable(exit, view)
         ));
-        if (!nextStretchRevealed) {
-          const scoutOffer = offerFor("explore_path");
+        if (scoutOffer && !nextStretchRevealed) {
           const scoutVerb = offerVerb(scoutOffer, "Scout");
           const scoutLabel = targetBearingLabel("scout", scoutVerb, journey.destination_name);
           built.push({

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -47698,7 +47698,6 @@ mod tests {
             .exits
             .iter()
             .any(|exit| exit.destination_location_id == second_waypoint_id));
-
         let (second_travel, mut second_travel_mutation, second_travel_narration) = runtime
             .plan_journey_move(5000, second_waypoint_id)
             .expect("second segment travel planning succeeds")
@@ -47736,7 +47735,6 @@ mod tests {
             runtime.actor_by_id(5000).unwrap().location_id,
             second_waypoint_id
         );
-
         let (final_travel, mut final_travel_mutation, final_travel_narration) = runtime
             .plan_journey_move(5000, MOONLIT_TRAIL_LOCATION_ID)
             .expect("final segment travel planning succeeds")
@@ -48886,7 +48884,7 @@ mod tests {
         assert!(INDEX_HTML
             .contains("the hidden next stretch toward ${journey.destination_name} is revealed"));
         assert!(INDEX_HTML.contains("const built = [];"));
-        assert!(INDEX_HTML.contains("if (!nextStretchRevealed)"));
+        assert!(INDEX_HTML.contains("scoutOffer && !nextStretchRevealed"));
         assert!(!INDEX_HTML.contains("function mergeDuplicateSearchCards"));
         assert!(!INDEX_HTML.contains("Follow the revealed path into ${nextName}."));
         assert!(INDEX_HTML.contains("Reveal the first adjacent stretch toward"));

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -5211,6 +5211,19 @@ async function main() {
         primary_action: { kind: "act", options: [{ kind: "move" }, { kind: "check" }] },
         search_available: false,
       };
+      const nonScoutOffers = (base.action_offers || [])
+        .filter((offer) => offer.kind !== "explore_path");
+      const scoutOffer = {
+        kind: "explore_path",
+        intention: "scout",
+        verb: "Scout",
+        rank: 55,
+        target: {
+          kind: "location",
+          id: 3,
+          label: "Moonlit Trail",
+        },
+      };
       const initial = buildActions({
         ...base,
         journey: null,
@@ -5227,6 +5240,7 @@ async function main() {
       }).find((action) => action.command === "search pathway to Moonlit Trail");
       const searchingActions = buildActions({
         ...base,
+        action_offers: [...nonScoutOffers, scoutOffer],
         exits: [],
         journey: {
           destination_location_id: 3,
@@ -5264,6 +5278,7 @@ async function main() {
       const travelling = travellingActions.find((action) => action.focusKey === "exit:100001");
       const finalSearchActions = buildActions({
         ...base,
+        action_offers: [...nonScoutOffers, scoutOffer],
         exits: [],
         journey: {
           destination_location_id: 3,
@@ -5299,9 +5314,52 @@ async function main() {
         },
       });
       const finalTravel = finalTravelActions.find((action) => action.focusKey === "exit:3");
+      const foundButUnavailableActions = buildActions({
+        ...base,
+        action_offers: [...nonScoutOffers, scoutOffer],
+        exits: [{
+          destination_location_id: 100001,
+          destination_location_name: "Foxglove Turn",
+          direction: "east",
+          distance: 1,
+          accessible: false,
+          locked: false,
+        }],
+        journey: {
+          destination_location_id: 3,
+          destination_name: "Moonlit Trail",
+          current_step: 1,
+          total_steps: 3,
+          steps_remaining: 2,
+          explorer: true,
+          next_location_id: 100001,
+          next_location_name: "Foxglove Turn",
+        },
+      });
+      const missingWithoutScoutOfferActions = buildActions({
+        ...base,
+        action_offers: nonScoutOffers,
+        exits: [],
+        journey: {
+          destination_location_id: 3,
+          destination_name: "Moonlit Trail",
+          current_step: 1,
+          total_steps: 3,
+          steps_remaining: 2,
+          explorer: true,
+          next_location_id: 100001,
+          next_location_name: "Foxglove Turn",
+        },
+      });
       return {
         searchingActionCount: searchingActions.length,
         travellingActionCount: travellingActions.length,
+        scoutAfterFound: foundButUnavailableActions.some((action) => (
+          String(action.intention || "").toLowerCase() === "scout"
+        )),
+        scoutWithoutOffer: missingWithoutScoutOfferActions.some((action) => (
+          String(action.intention || "").toLowerCase() === "scout"
+        )),
         initial: {
           label: initial?.label,
           detail: initial?.detail,
@@ -5352,6 +5410,14 @@ async function main() {
         && result.travelling.command === "go Foxglove Turn"
         && result.travellingActionCount > 1,
       `a revealed adjacent segment should offer ordinary Travel without replacing the hand: ${JSON.stringify(result)}`,
+    );
+    assert(
+      result.scoutAfterFound === false,
+      `a found segment must not recreate Scout merely because Travel is unavailable: ${JSON.stringify(result)}`,
+    );
+    assert(
+      result.scoutWithoutOffer === false,
+      `a missing exit must not recreate Scout after the authoritative Scout offer disappears: ${JSON.stringify(result)}`,
     );
     assert(
       result.finalSearch.label === "scout"


### PR DESCRIPTION
## What changed

- Treat a projected journey exit as discovered even when travel through it is currently inaccessible or locked.
- Require an authoritative `explore_path` offer before the browser renders Scout instead of synthesizing it from journey state.
- Add server and browser smoke regressions for found-but-inaccessible segments and missing Scout offers.
- Bump the package and orchestrator version to `0.0.206` as required by the repository hook.

## Root cause

Route discovery and route accessibility were conflated in both the server offer projection and the browser fallback. A revealed next segment could therefore look undiscovered when travel was unavailable, causing Scout to reappear.

## Result

Once the next path segment is found, Scout disappears. Travel can remain unavailable for its own access reason without turning the segment back into an exploration target.

## Verification

- Full pre-push `npm run check`
- 43 Vitest files / 453 tests
- 548 Rust tests
- Worldpack compositions and strict proof-world gate
- C kernel tests
- Rust architecture and clippy ceilings
- JavaScript and Python syntax checks
