### PR TITLE
Bind generated descendants to worldpack policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.209",
+  "version": "0.0.210",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.209",
+      "version": "0.0.210",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.209",
+  "version": "0.0.210",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.209"
+version = "0.0.210"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.209"
+version = "0.0.210"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/cards.rs
+++ b/v2/orchestrator-rust/src/cards.rs
@@ -62,6 +62,8 @@ pub(super) struct CardView {
     pub(super) accessible: bool,
     pub(super) access_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) generation_policy: Option<GeneratedPolicyBinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) community_art: Option<CommunityArtView>,
 }
 
@@ -361,6 +363,17 @@ impl RuntimeWorld {
 }
 
 impl RuntimeWorld {
+    pub(super) fn decorate_generated_location_card(
+        &self,
+        mut card: CardView,
+        location_id: u64,
+    ) -> CardView {
+        card.generation_policy = self
+            .generated_pathway_for_location(location_id)
+            .map(|pathway| pathway.generation_policy.clone());
+        card
+    }
+
     pub(super) fn card_registry_for(
         &self,
         location: &LocationView,
@@ -374,10 +387,13 @@ impl RuntimeWorld {
             location.id,
             apply_location_access(
                 self.decorate_community_art_card(
-                    card_for_location(
+                    self.decorate_generated_location_card(
+                        card_for_location(
+                            location.id,
+                            location.name.as_str(),
+                            Some(&self.location_meta_for(location.id)),
+                        ),
                         location.id,
-                        location.name.as_str(),
-                        Some(&self.location_meta_for(location.id)),
                     ),
                     "location",
                     location.id,
@@ -391,10 +407,13 @@ impl RuntimeWorld {
                 exit.destination_location_id,
                 apply_location_access(
                     self.decorate_community_art_card(
-                        card_for_location(
+                        self.decorate_generated_location_card(
+                            card_for_location(
+                                exit.destination_location_id,
+                                exit.destination_location_name.as_str(),
+                                Some(&self.location_meta_for(exit.destination_location_id)),
+                            ),
                             exit.destination_location_id,
-                            exit.destination_location_name.as_str(),
-                            Some(&self.location_meta_for(exit.destination_location_id)),
                         ),
                         "location",
                         exit.destination_location_id,
@@ -1052,6 +1071,7 @@ pub(super) fn card_from_seed_content(card: &SeedCardContent) -> CardView {
         owned: false,
         accessible: true,
         access_reason: None,
+        generation_policy: None,
         community_art: None,
     }
 }
@@ -1147,6 +1167,7 @@ pub(super) fn external_card_view(spec: &ExternalCardSpec) -> CardView {
         owned: false,
         accessible: true,
         access_reason: None,
+        generation_policy: None,
         community_art: None,
     }
 }
@@ -1198,6 +1219,7 @@ pub(super) fn seed_card(spec: SeedCardSpec<'_>) -> CardView {
         owned: false,
         accessible: true,
         access_reason: None,
+        generation_policy: None,
         community_art: None,
     }
 }

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -18,8 +18,9 @@ use tracing::warn;
 
 use crate::{
     broadcast_events, commit_journal_record, is_safe_image_content_type, now_millis,
-    record_ai_usage_for_provider, request_image_policy_decision, request_replicate_art, AiConfig,
-    AppState, CwAction, EventView, ImagePolicyRequest, JournalRecord, ProjectionMutation,
+    record_ai_usage_for_provider, request_image_policy_decision, request_replicate_art,
+    resolve_generation_media_config, AiConfig, AppState, CwAction, EventView,
+    GeneratedPolicyBinding, ImagePolicyRequest, JournalRecord, ProjectionMutation,
     ReplicateAvatarArtConfig, RuntimeWorld, CW_ACTION_NONE, CW_OK,
 };
 
@@ -67,6 +68,8 @@ pub(super) struct CommunityArtGenerationState {
     pub(super) level: u8,
     #[serde(default = "legacy_community_art_generation_profile_version")]
     pub(super) generation_profile_version: u8,
+    #[serde(default)]
+    pub(super) generation_policy: GeneratedPolicyBinding,
     pub(super) required_orbs: i32,
     pub(super) funded_orbs: i32,
     #[serde(default)]
@@ -91,6 +94,7 @@ pub(super) struct CommunityArtPlan {
     pub(super) subject_id: u64,
     pub(super) level: u8,
     pub(super) generation_profile_version: u8,
+    pub(super) generation_policy: GeneratedPolicyBinding,
     pub(super) required_orbs: i32,
     pub(super) history_through_seq: u64,
     pub(super) prompt: String,
@@ -310,6 +314,7 @@ impl RuntimeWorld {
                 subject_id,
                 level,
                 generation_profile_version: community_art_generation_profile_version(subject_kind),
+                generation_policy: GeneratedPolicyBinding::default(),
                 required_orbs: required_orbs.max(1),
                 funded_orbs: 0,
                 contributions: BTreeMap::new(),
@@ -379,6 +384,7 @@ impl RuntimeWorld {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)] // Mirrors the durable begin-generation mutation.
     pub(super) fn apply_begin_community_art_generation_projection(
         &mut self,
         action_actor_id: u64,
@@ -387,9 +393,15 @@ impl RuntimeWorld {
         level: u8,
         provider_attempt: bool,
         generation_profile_version: u8,
+        generation_policy: &GeneratedPolicyBinding,
     ) -> Option<EventView> {
         let key = community_art_generation_key(subject_kind, subject_id, level);
         let generation = self.community_art_generations.get_mut(&key)?;
+        if generation.generation_policy.is_empty() {
+            generation.generation_policy = generation_policy.clone();
+        } else if &generation.generation_policy != generation_policy {
+            return None;
+        }
         if generation_profile_version > generation.generation_profile_version {
             generation.generation_profile_version = generation_profile_version;
             generation.provider_attempts = 0;
@@ -481,11 +493,25 @@ pub(super) async fn generate_and_store_community_art(
     generated_asset_dir: &Path,
     plan: &CommunityArtPlan,
 ) -> CommunityArtGenerationOutcome {
+    let config = match resolve_generation_media_config(
+        config,
+        plan.generation_policy.media.as_ref(),
+        plan.aspect_ratio,
+    ) {
+        Ok(config) => config,
+        Err(error) => {
+            return CommunityArtGenerationOutcome {
+                result: Err(CommunityArtGenerationError::Provider(error)),
+                prediction_id: None,
+                reused_candidate: false,
+            };
+        }
+    };
     let (image, reused_candidate) = match load_community_art_candidate(generated_asset_dir, plan) {
         Ok(Some(image)) => (image, true),
         Ok(None) => {
-            let prompt = community_art_generation_request(config, plan);
-            let image = match request_replicate_art(config, prompt, plan.aspect_ratio).await {
+            let prompt = community_art_generation_request(&config, plan);
+            let image = match request_replicate_art(&config, prompt, plan.aspect_ratio).await {
                 Ok(image) => image,
                 Err(error) => {
                     return CommunityArtGenerationOutcome {
@@ -560,8 +586,15 @@ pub(super) fn community_art_generation_request(
     plan: &CommunityArtPlan,
 ) -> String {
     let prompt_prefix = plan
-        .image_policy
-        .map(CommunityArtImagePolicy::generation_prompt_prefix)
+        .generation_policy
+        .media
+        .as_ref()
+        .map(|media| media.prompt_prefix.as_str())
+        .filter(|prefix| !prefix.trim().is_empty())
+        .or_else(|| {
+            plan.image_policy
+                .map(CommunityArtImagePolicy::generation_prompt_prefix)
+        })
         .unwrap_or(&config.prompt_prefix);
     crate::compact_whitespace(&format!("{prompt_prefix}, {}", plan.prompt))
 }
@@ -607,6 +640,7 @@ async fn begin_community_art_generation(
             level: plan.level,
             provider_attempt,
             generation_profile_version: plan.generation_profile_version,
+            generation_policy: plan.generation_policy.clone(),
         });
     let (commit_status, events) = commit_journal_record(state, &mut runtime, record).ok()?;
     drop(runtime);

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -172,6 +172,7 @@ fn location_generation_replaces_portrait_prompt_without_disabling_the_style_lora
         subject_id: 181_730,
         level: 1,
         generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
+        generation_policy: GeneratedPolicyBinding::default(),
         required_orbs: 1,
         history_through_seq: 99,
         prompt: build_community_art_prompt(
@@ -319,6 +320,7 @@ async fn location_policy_400_fails_before_orb_debit_or_replicate_schedule() {
             subject_id: waypoint_id,
             level: 1,
             generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
+            generation_policy: GeneratedPolicyBinding::default(),
             required_orbs: 1,
             history_through_seq: 0,
             prompt: String::new(),
@@ -383,6 +385,7 @@ async fn policy_retry_reuses_the_saved_candidate_without_calling_replicate() {
         subject_id: 181_728,
         level: 1,
         generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
+        generation_policy: GeneratedPolicyBinding::default(),
         required_orbs: 1,
         history_through_seq: 99,
         prompt: "A quiet rain-soft path with no figures.".to_string(),
@@ -504,6 +507,7 @@ fn provider_attempt_budget_is_journaled_and_survives_serialization() {
                 level: 1,
                 provider_attempt: true,
                 generation_profile_version: LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION,
+                generation_policy: GeneratedPolicyBinding::default(),
             });
         record
             .projection_mutations
@@ -596,6 +600,10 @@ fn newer_location_prompt_profile_reopens_a_paid_exhausted_job() {
                 level: 1,
                 provider_attempt: true,
                 generation_profile_version: LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION,
+                generation_policy: runtime
+                    .generated_pathway_for_location(subject_id)
+                    .map(|pathway| pathway.generation_policy.clone())
+                    .unwrap_or_default(),
             });
         record
             .projection_mutations
@@ -639,6 +647,10 @@ fn newer_location_prompt_profile_reopens_a_paid_exhausted_job() {
             level: 1,
             provider_attempt: true,
             generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
+            generation_policy: runtime
+                .generated_pathway_for_location(subject_id)
+                .map(|pathway| pathway.generation_policy.clone())
+                .unwrap_or_default(),
         });
     assert_eq!(runtime.apply_journal_record(&retry).0, CW_OK);
 

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -77,6 +77,8 @@ pub(super) struct SeedWorldpackManifest {
     #[serde(default)]
     pub(super) avatar_naming: Option<cosyworld_ai_model::AvatarNamingConfig>,
     #[serde(default)]
+    pub(super) generation_media_registry: serde_json::Value,
+    #[serde(default)]
     pub(super) packs: Vec<SeedWorldpackPack>,
     #[serde(default)]
     pub(super) registry: String,

--- a/v2/orchestrator-rust/src/crafting.rs
+++ b/v2/orchestrator-rust/src/crafting.rs
@@ -757,34 +757,20 @@ mod tests {
         runtime
     }
 
-    fn test_generated_pathway(runtime: &RuntimeWorld, location_id: u64) -> GeneratedPathwayState {
-        GeneratedPathwayState {
-            id: "replay-pathway".to_string(),
-            identity_version: 0,
-            canonical_id: String::new(),
-            source_route_id: String::new(),
-            source_route_version: 0,
-            owner_pack_id: "cosyworld.core".to_string(),
-            owner_pack_version: runtime.active_pack_version("cosyworld.core"),
-            origin_location_id: COSY_COTTAGE_LOCATION_ID,
-            destination_location_id: location_id,
-            distance: 1,
-            created_by_actor_id: RATI_ACTOR_ID,
-            waypoints: vec![GeneratedWaypointState {
-                id: location_id,
-                canonical_id: String::new(),
-                name: runtime.location_name(location_id).expect("location name"),
-                meta: runtime
-                    .location_meta
-                    .get(&location_id)
-                    .cloned()
-                    .expect("location metadata"),
-            }],
-            generation: GenerationProvenance::default(),
-            revealed_edges: BTreeSet::new(),
-            art_eligible: false,
-            familiar: false,
-        }
+    fn test_generated_pathway(runtime: &RuntimeWorld) -> GeneratedPathwayState {
+        let mut pathway = runtime
+            .generated_pathway(
+                RATI_ACTOR_ID,
+                COSY_COTTAGE_LOCATION_ID,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+                2,
+            )
+            .expect("canonical test pathway");
+        pathway.revealed_edges.insert(pathway_edge_key(
+            pathway.origin_location_id,
+            pathway.waypoints[0].id,
+        ));
+        pathway
     }
 
     #[test]
@@ -1031,38 +1017,26 @@ mod tests {
             .versioned_craft_plan(RATI_ACTOR_ID, 3103, Some("test-install"))
             .is_none());
 
-        let pathway = GeneratedPathwayState {
-            id: "test-pathway".to_string(),
-            identity_version: 0,
-            canonical_id: String::new(),
-            source_route_id: String::new(),
-            source_route_version: 0,
-            owner_pack_id: "cosyworld.core".to_string(),
-            owner_pack_version: runtime.active_pack_version("cosyworld.core"),
-            origin_location_id: COSY_COTTAGE_LOCATION_ID,
-            destination_location_id: location_id,
-            distance: 1,
-            created_by_actor_id: RATI_ACTOR_ID,
-            waypoints: vec![GeneratedWaypointState {
-                id: location_id,
-                canonical_id: String::new(),
-                name: runtime.location_name(location_id).expect("location name"),
-                meta: runtime
-                    .location_meta
-                    .get(&location_id)
-                    .cloned()
-                    .expect("location metadata"),
-            }],
-            generation: GenerationProvenance::default(),
-            revealed_edges: BTreeSet::new(),
-            art_eligible: false,
-            familiar: false,
-        };
+        let pathway = test_generated_pathway(&runtime);
+        let generated_location_id = pathway.waypoints[0].id;
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        runtime.ensure_generated_pathway_edge(
+            &pathway,
+            pathway.origin_location_id,
+            generated_location_id,
+        );
         runtime.ensure_generated_place_for_waypoint(
             &pathway,
-            location_id,
+            generated_location_id,
             COSY_COTTAGE_LOCATION_ID,
         );
+        runtime.world.actors[..runtime.world.actor_count]
+            .iter_mut()
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("Rati remains present")
+            .location_id = generated_location_id;
         let bracket_item_id = runtime
             .craft_receipts
             .get("test-anchor")
@@ -1079,7 +1053,7 @@ mod tests {
             .versioned_recipe_capability_source(
                 RATI_ACTOR_ID,
                 runtime.recipe_by_id(3103).expect("install recipe"),
-                location_id,
+                generated_location_id,
             )
             .is_some());
         let anchor_plan = runtime
@@ -1116,11 +1090,13 @@ mod tests {
         );
         assert!(runtime
             .tags
-            .get(&format!("generated-place:{location_id}:anchor-fixture"))
+            .get(&format!(
+                "generated-place:{generated_location_id}:anchor-fixture"
+            ))
             .is_some_and(|tag| tag.active));
         let generated = runtime
             .generated_places
-            .get(&location_id)
+            .get(&generated_location_id)
             .expect("generated place");
         assert!(runtime
             .clocks
@@ -1175,12 +1151,26 @@ mod tests {
         );
         assert_eq!(committed.apply_journal_record(&forge_record).0, CW_OK);
 
-        let pathway = test_generated_pathway(&committed, location_id);
+        let pathway = test_generated_pathway(&committed);
+        let generated_location_id = pathway.waypoints[0].id;
+        committed
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        committed.ensure_generated_pathway_edge(
+            &pathway,
+            pathway.origin_location_id,
+            generated_location_id,
+        );
         committed.ensure_generated_place_for_waypoint(
             &pathway,
-            location_id,
+            generated_location_id,
             COSY_COTTAGE_LOCATION_ID,
         );
+        committed.world.actors[..committed.world.actor_count]
+            .iter_mut()
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("Rati remains present")
+            .location_id = generated_location_id;
         let install_record = record_for_plan(
             &committed,
             committed
@@ -1209,12 +1199,25 @@ mod tests {
         let mut replayed = prepared_craft_runtime(location_id);
         assert_eq!(replayed.apply_journal_record(&durable_records[0]).0, CW_OK);
         assert_eq!(replayed.apply_journal_record(&durable_records[1]).0, CW_OK);
-        let replay_pathway = test_generated_pathway(&replayed, location_id);
+        let replay_pathway = test_generated_pathway(&replayed);
+        replayed
+            .generated_pathways
+            .insert(replay_pathway.id.clone(), replay_pathway.clone());
+        replayed.ensure_generated_pathway_edge(
+            &replay_pathway,
+            replay_pathway.origin_location_id,
+            generated_location_id,
+        );
         replayed.ensure_generated_place_for_waypoint(
             &replay_pathway,
-            location_id,
+            generated_location_id,
             COSY_COTTAGE_LOCATION_ID,
         );
+        replayed.world.actors[..replayed.world.actor_count]
+            .iter_mut()
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("Rati remains present")
+            .location_id = generated_location_id;
         assert_eq!(replayed.apply_journal_record(&durable_records[2]).0, CW_OK);
 
         assert_eq!(

--- a/v2/orchestrator-rust/src/generated_places.rs
+++ b/v2/orchestrator-rust/src/generated_places.rs
@@ -33,6 +33,8 @@ pub(super) struct GeneratedPlaceState {
     pub(super) source_generation: GenerationProvenance,
     pub(super) pack_id: String,
     pub(super) pack_version: String,
+    #[serde(default)]
+    pub(super) generation_policy: GeneratedPolicyBinding,
     pub(super) anchor_clock_id: String,
     pub(super) connection_clock_id: String,
     pub(super) settlement_clock_id: String,
@@ -53,6 +55,7 @@ pub(super) struct GeneratedPlaceView {
     pub(super) source_generation: GenerationProvenance,
     pub(super) pack_id: String,
     pub(super) pack_version: String,
+    pub(super) generation_policy: GeneratedPolicyBinding,
     pub(super) milestones: Vec<String>,
     pub(super) anchor_clock_id: String,
     pub(super) connection_clock_id: String,
@@ -229,6 +232,7 @@ impl RuntimeWorld {
                     source_generation: pathway.generation.clone(),
                     pack_id: pack_id.clone(),
                     pack_version: pack_version.clone(),
+                    generation_policy: pathway.generation_policy.clone(),
                     anchor_clock_id: generated_place_anchor_clock_id(location_id),
                     connection_clock_id: generated_place_connection_clock_id(location_id),
                     settlement_clock_id: generated_place_settlement_clock_id(location_id),
@@ -239,8 +243,9 @@ impl RuntimeWorld {
                 });
         state.schema_version = GENERATED_PLACE_SCHEMA_VERSION;
         state.canonical_id = waypoint.canonical_id.clone();
-        state.pack_id = pack_id;
-        state.pack_version = pack_version;
+        if state.generation_policy.is_empty() {
+            state.generation_policy = pathway.generation_policy.clone();
+        }
         let state = state.clone();
         self.ensure_generated_place_projection(&state, &waypoint);
     }
@@ -665,6 +670,7 @@ impl RuntimeWorld {
             source_generation: state.source_generation.clone(),
             pack_id: state.pack_id.clone(),
             pack_version: state.pack_version.clone(),
+            generation_policy: state.generation_policy.clone(),
             milestones: self.generated_place_milestones(location_id),
             anchor_clock_id: state.anchor_clock_id.clone(),
             connection_clock_id: state.connection_clock_id.clone(),

--- a/v2/orchestrator-rust/src/generation_policy.rs
+++ b/v2/orchestrator-rust/src/generation_policy.rs
@@ -1,0 +1,917 @@
+use super::*;
+
+pub(super) const PATHWAY_CONTENT_FEATURE: &str = "pathway_content";
+pub(super) const PATHWAY_CONTENT_PROMPT_VERSION: &str = "pathway-content-v1";
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(super) struct GenerationProvenance {
+    pub(super) source: String,
+    pub(super) feature: String,
+    pub(super) policy_mode: String,
+    pub(super) prompt_version: String,
+    pub(super) provider: String,
+    pub(super) model: String,
+    pub(super) attempts: u8,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct GeneratedWaypointState {
+    pub(super) id: u64,
+    #[serde(default)]
+    pub(super) canonical_id: String,
+    pub(super) name: String,
+    pub(super) meta: LocationMeta,
+    #[serde(default)]
+    pub(super) generation_policy: GeneratedPolicyBinding,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct GeneratedPathwayState {
+    pub(super) id: String,
+    #[serde(default)]
+    pub(super) identity_version: u8,
+    #[serde(default)]
+    pub(super) canonical_id: String,
+    #[serde(default)]
+    pub(super) source_route_id: String,
+    #[serde(default)]
+    pub(super) source_route_version: u64,
+    #[serde(default)]
+    pub(super) owner_pack_id: String,
+    #[serde(default)]
+    pub(super) owner_pack_version: String,
+    #[serde(default)]
+    pub(super) generation_policy: GeneratedPolicyBinding,
+    pub(super) origin_location_id: u64,
+    pub(super) destination_location_id: u64,
+    pub(super) distance: u8,
+    pub(super) created_by_actor_id: u64,
+    pub(super) waypoints: Vec<GeneratedWaypointState>,
+    #[serde(default)]
+    pub(super) generation: GenerationProvenance,
+    #[serde(default)]
+    pub(super) revealed_edges: BTreeSet<String>,
+    #[serde(default)]
+    pub(super) art_eligible: bool,
+    #[serde(default)]
+    pub(super) familiar: bool,
+}
+
+const GENERATION_EXTENSION: &str = "x-cosyworld-generation";
+pub(super) const LEGACY_GENERATION_POLICY_ID: &str = "cosyworld.compatibility.host-generation/1";
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct GeneratedMediaBinding {
+    pub(super) profile_id: String,
+    pub(super) recipe_id: String,
+    pub(super) provider: String,
+    pub(super) model: String,
+    pub(super) revision: String,
+    pub(super) prompt_version: String,
+    pub(super) prompt_prefix: String,
+    pub(super) aspect_ratios: Vec<String>,
+    pub(super) output_format: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct GeneratedPolicyBinding {
+    pub(super) schema_version: u8,
+    pub(super) policy_id: String,
+    pub(super) migration_version: u32,
+    pub(super) collision_namespace: String,
+    pub(super) owner_pack_id: String,
+    pub(super) owner_pack_version: String,
+    pub(super) composition_id: String,
+    pub(super) composition_bundle_hash: String,
+    pub(super) prose_profile_id: String,
+    pub(super) prose_prompt_version: String,
+    pub(super) ecology_transition: String,
+    pub(super) topology_profile_id: String,
+    pub(super) unmount_behavior: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) media: Option<GeneratedMediaBinding>,
+}
+
+impl GeneratedPolicyBinding {
+    pub(super) fn is_empty(&self) -> bool {
+        self.policy_id.is_empty()
+    }
+}
+
+pub(super) fn validate_generated_policy_binding(
+    binding: &GeneratedPolicyBinding,
+) -> Result<(), String> {
+    if binding.schema_version != 1
+        || binding.policy_id.is_empty()
+        || binding.owner_pack_id.is_empty()
+        || binding.owner_pack_version.is_empty()
+        || binding.composition_bundle_hash.is_empty()
+    {
+        return Err("generated policy binding is incomplete or unsupported".to_string());
+    }
+    if binding.policy_id == LEGACY_GENERATION_POLICY_ID {
+        if binding.media.is_some() {
+            return Err("legacy generation binding fabricates a media identity".to_string());
+        }
+        return Ok(());
+    }
+    if binding.collision_namespace.is_empty() || binding.composition_id.is_empty() {
+        return Err("reviewed generation policy binding is incomplete".to_string());
+    }
+    if binding.media.as_ref().is_some_and(|media| {
+        media.profile_id.is_empty()
+            || media.recipe_id.is_empty()
+            || media.provider.is_empty()
+            || media.model.is_empty()
+            || media.revision.is_empty()
+            || media.prompt_version.is_empty()
+            || media.aspect_ratios.is_empty()
+            || media.output_format.is_empty()
+    }) {
+        return Err("generated media binding is incomplete".to_string());
+    }
+    Ok(())
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyManifest {
+    policy_id: String,
+    migration_version: u32,
+    collision_namespace: String,
+    #[serde(default)]
+    prose: Option<PolicyProse>,
+    #[serde(default)]
+    media: Option<PolicyMedia>,
+    #[serde(default)]
+    topology: Option<PolicyTopology>,
+    #[serde(default)]
+    migrations: Vec<PolicyMigration>,
+    #[serde(default)]
+    cross_pack_routes: Vec<PolicyCrossRoute>,
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyProse {
+    profile_id: String,
+    prompt_versions: Vec<String>,
+    ecology: PolicyEcology,
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyEcology {
+    interpolation: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyMedia {
+    profile_id: String,
+    recipe_id: String,
+    #[serde(default)]
+    provider_preference: Option<PolicyProvider>,
+    prompt_version: String,
+    prompt_prefix: String,
+    output_formats: Vec<String>,
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyProvider {
+    provider: String,
+    model: String,
+    revision: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyTopology {
+    profile_id: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyMigration {
+    from_policy_id: String,
+    from_migration_version: u32,
+    from_pack_version: String,
+    mode: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyCrossRoute {
+    endpoints: Vec<PolicyEndpoint>,
+    generated_descendant_owner: String,
+    media_profile_id: String,
+    ecology_transition: String,
+    unmount: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct PolicyEndpoint {
+    pack_id: String,
+    location_id: u64,
+}
+
+#[derive(Deserialize)]
+struct MediaRegistry {
+    profiles: Vec<MediaProfile>,
+    recipes: Vec<MediaRecipe>,
+}
+
+#[derive(Deserialize)]
+struct MediaProfile {
+    id: String,
+    recipes: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct MediaRecipe {
+    id: String,
+    profile: String,
+    provider: String,
+    model: MediaModel,
+    state: String,
+    aspect_ratios: Vec<String>,
+    output_formats: Vec<String>,
+    prompt_versions: Vec<String>,
+    lora: bool,
+}
+
+#[derive(Deserialize)]
+struct MediaModel {
+    owner: String,
+    name: String,
+    revision: String,
+}
+
+fn policy_for_pack_in(
+    packs: &[SeedWorldpackPack],
+    pack_id: &str,
+) -> Result<Option<PolicyManifest>, String> {
+    let pack = packs
+        .iter()
+        .find(|pack| pack.id == pack_id)
+        .ok_or_else(|| format!("generated descendant owner pack {pack_id} is not mounted"))?;
+    let Some(value) = pack.extensions.get(GENERATION_EXTENSION) else {
+        return Ok(None);
+    };
+    serde_json::from_value(value.clone())
+        .map(Some)
+        .map_err(|error| format!("pack {pack_id} has an invalid generation policy: {error}"))
+}
+
+fn policy_for_pack(pack_id: &str) -> Result<Option<PolicyManifest>, String> {
+    policy_for_pack_in(&active_content().manifest.packs, pack_id)
+}
+
+fn media_registry() -> Result<MediaRegistry, String> {
+    serde_json::from_value(active_content().manifest.generation_media_registry.clone())
+        .map_err(|error| format!("generation media registry is unavailable: {error}"))
+}
+
+fn reviewed_media_binding(
+    profile_id: &str,
+    policy: Option<&PolicyMedia>,
+) -> Result<GeneratedMediaBinding, String> {
+    let registry = media_registry()?;
+    let profile = registry
+        .profiles
+        .iter()
+        .find(|candidate| candidate.id == profile_id)
+        .ok_or_else(|| format!("generation media profile {profile_id} is not published"))?;
+    let recipe_id = policy
+        .map(|media| media.recipe_id.as_str())
+        .or_else(|| (profile.recipes.len() == 1).then(|| profile.recipes[0].as_str()))
+        .ok_or_else(|| format!("generation media profile {profile_id} is ambiguous"))?;
+    let recipe = registry
+        .recipes
+        .iter()
+        .find(|candidate| candidate.id == recipe_id)
+        .ok_or_else(|| format!("generation media recipe {recipe_id} is not published"))?;
+    if recipe.state != "enabled"
+        || recipe.profile != profile.id
+        || !profile.recipes.contains(&recipe.id)
+    {
+        return Err(format!(
+            "generation media recipe {recipe_id} is not enabled"
+        ));
+    }
+    if let Some(media) = policy {
+        let model = format!("{}/{}", recipe.model.owner, recipe.model.name);
+        if media.profile_id != profile.id
+            || media
+                .provider_preference
+                .as_ref()
+                .is_some_and(|preference| {
+                    preference.provider != recipe.provider
+                        || preference.model != model
+                        || preference.revision != recipe.model.revision
+                })
+            || !recipe.prompt_versions.contains(&media.prompt_version)
+            || !media
+                .output_formats
+                .first()
+                .is_some_and(|format| recipe.output_formats.contains(format))
+        {
+            return Err(format!(
+                "generation media policy does not match recipe {recipe_id}"
+            ));
+        }
+    }
+    Ok(GeneratedMediaBinding {
+        profile_id: profile.id.clone(),
+        recipe_id: recipe.id.clone(),
+        provider: recipe.provider.clone(),
+        model: format!("{}/{}", recipe.model.owner, recipe.model.name),
+        revision: recipe.model.revision.clone(),
+        prompt_version: policy
+            .map(|media| media.prompt_version.clone())
+            .unwrap_or_else(|| recipe.prompt_versions[0].clone()),
+        prompt_prefix: policy
+            .map(|media| media.prompt_prefix.clone())
+            .unwrap_or_default(),
+        aspect_ratios: recipe.aspect_ratios.clone(),
+        output_format: policy
+            .and_then(|media| media.output_formats.first().cloned())
+            .unwrap_or_else(|| recipe.output_formats[0].clone()),
+    })
+}
+
+fn endpoint_pack(location_id: u64) -> Option<&'static str> {
+    active_content()
+        .locations
+        .iter()
+        .find(|location| location.id == location_id)
+        .map(|location| location.pack_id.as_str())
+}
+
+pub(super) fn generated_policy_binding(
+    route: &RouteRecordState,
+    origin_location_id: u64,
+    destination_location_id: u64,
+) -> Result<GeneratedPolicyBinding, String> {
+    let pack = active_content()
+        .manifest
+        .packs
+        .iter()
+        .find(|pack| pack.id == route.owner_pack_id)
+        .ok_or_else(|| "source route owner pack is not mounted".to_string())?;
+    let Some(policy) = policy_for_pack(&pack.id)? else {
+        return Ok(legacy_generated_policy_binding(
+            &pack.id,
+            &pack.version,
+            &active_content().manifest.id,
+            &active_content().manifest.bundle_hash,
+        ));
+    };
+    let endpoints = [
+        (endpoint_pack(origin_location_id), origin_location_id),
+        (
+            endpoint_pack(destination_location_id),
+            destination_location_id,
+        ),
+    ];
+    let cross_route = policy.cross_pack_routes.iter().find(|candidate| {
+        candidate.endpoints.len() == 2
+            && candidate.endpoints.iter().all(|endpoint| {
+                endpoints.contains(&(Some(endpoint.pack_id.as_str()), endpoint.location_id))
+            })
+    });
+    if endpoints[0].0 != endpoints[1].0 && cross_route.is_none() {
+        return Err("cross-pack source route has no matching bridge policy".to_string());
+    }
+    let media = if let Some(cross_route) = cross_route {
+        Some(reviewed_media_binding(&cross_route.media_profile_id, None)?)
+    } else {
+        policy
+            .media
+            .as_ref()
+            .map(|media| reviewed_media_binding(&media.profile_id, Some(media)))
+            .transpose()?
+    };
+    let owner_pack_id = cross_route
+        .map(|route| route.generated_descendant_owner.clone())
+        .unwrap_or_else(|| pack.id.clone());
+    if owner_pack_id != route.owner_pack_id {
+        return Err(
+            "generation policy descendant owner differs from source route owner".to_string(),
+        );
+    }
+    Ok(GeneratedPolicyBinding {
+        schema_version: 1,
+        policy_id: policy.policy_id,
+        migration_version: policy.migration_version,
+        collision_namespace: policy.collision_namespace,
+        owner_pack_id,
+        owner_pack_version: pack.version.clone(),
+        composition_id: active_content().manifest.id.clone(),
+        composition_bundle_hash: active_content().manifest.bundle_hash.clone(),
+        prose_profile_id: policy
+            .prose
+            .as_ref()
+            .map(|prose| prose.profile_id.clone())
+            .unwrap_or_default(),
+        prose_prompt_version: policy
+            .prose
+            .as_ref()
+            .and_then(|prose| prose.prompt_versions.first().cloned())
+            .unwrap_or_default(),
+        ecology_transition: cross_route
+            .map(|route| route.ecology_transition.clone())
+            .or_else(|| {
+                policy
+                    .prose
+                    .as_ref()
+                    .map(|prose| prose.ecology.interpolation.clone())
+            })
+            .unwrap_or_default(),
+        topology_profile_id: policy
+            .topology
+            .map(|topology| topology.profile_id)
+            .unwrap_or_else(|| "bridge_authority".to_string()),
+        unmount_behavior: cross_route
+            .map(|route| route.unmount.clone())
+            .unwrap_or_else(|| "freeze_with_owner".to_string()),
+        media,
+    })
+}
+
+pub(super) fn legacy_generated_policy_binding(
+    owner_pack_id: &str,
+    owner_pack_version: &str,
+    composition_id: &str,
+    bundle_hash: &str,
+) -> GeneratedPolicyBinding {
+    GeneratedPolicyBinding {
+        schema_version: 1,
+        policy_id: LEGACY_GENERATION_POLICY_ID.to_string(),
+        owner_pack_id: owner_pack_id.to_string(),
+        owner_pack_version: owner_pack_version.to_string(),
+        composition_id: composition_id.to_string(),
+        composition_bundle_hash: bundle_hash.to_string(),
+        unmount_behavior: "host_default".to_string(),
+        ..GeneratedPolicyBinding::default()
+    }
+}
+
+pub(super) fn generation_policy_allows_upgrade(
+    binding: &GeneratedPolicyBinding,
+    active_pack_version: &str,
+) -> Result<(), String> {
+    if binding.owner_pack_version == active_pack_version {
+        return Ok(());
+    }
+    let policy = policy_for_pack(&binding.owner_pack_id)?
+        .ok_or_else(|| "generation policy disappeared during pack upgrade".to_string())?;
+    policy
+        .migrations
+        .iter()
+        .any(|migration| {
+            migration.from_policy_id == binding.policy_id
+                && migration.from_migration_version == binding.migration_version
+                && migration.from_pack_version == binding.owner_pack_version
+                && migration.mode == "preserve_descendants"
+        })
+        .then_some(())
+        .ok_or_else(|| "pack upgrade has no exact generated-descendant migration".to_string())
+}
+
+pub(super) fn resolve_generation_media_config(
+    config: &ReplicateAvatarArtConfig,
+    binding: Option<&GeneratedMediaBinding>,
+    aspect_ratio: &str,
+) -> Result<ReplicateAvatarArtConfig, String> {
+    resolve_generation_media_config_from_registry(
+        config,
+        binding,
+        aspect_ratio,
+        active_content().manifest.generation_media_registry.clone(),
+    )
+}
+
+fn resolve_generation_media_config_from_registry(
+    config: &ReplicateAvatarArtConfig,
+    binding: Option<&GeneratedMediaBinding>,
+    aspect_ratio: &str,
+    registry_value: serde_json::Value,
+) -> Result<ReplicateAvatarArtConfig, String> {
+    let Some(binding) = binding else {
+        return Ok(config.clone());
+    };
+    let registry: MediaRegistry = serde_json::from_value(registry_value)
+        .map_err(|error| format!("generation media registry is unavailable: {error}"))?;
+    let profile = registry
+        .profiles
+        .iter()
+        .find(|profile| profile.id == binding.profile_id)
+        .ok_or_else(|| "generated media profile disappeared".to_string())?;
+    let recipe = registry
+        .recipes
+        .iter()
+        .find(|recipe| recipe.id == binding.recipe_id)
+        .ok_or_else(|| "generated media recipe disappeared".to_string())?;
+    let reviewed_model = format!("{}/{}", recipe.model.owner, recipe.model.name);
+    if recipe.state != "enabled"
+        || recipe.profile != binding.profile_id
+        || !profile.recipes.contains(&binding.recipe_id)
+        || recipe.provider != binding.provider
+        || reviewed_model != binding.model
+        || recipe.model.revision != binding.revision
+        || !recipe.prompt_versions.contains(&binding.prompt_version)
+        || !recipe.output_formats.contains(&binding.output_format)
+        || recipe.aspect_ratios != binding.aspect_ratios
+        || !binding
+            .aspect_ratios
+            .iter()
+            .any(|ratio| ratio == aspect_ratio)
+        || binding.provider != "replicate"
+    {
+        return Err("generated media binding is not an enabled reviewed recipe".to_string());
+    }
+    if recipe.lora && config.lora_url.is_none() {
+        return Err("generated media recipe requires configured LoRA weights".to_string());
+    }
+    let mut resolved = config.clone();
+    resolved.model = binding.model.clone();
+    resolved.version = Some(binding.revision.clone());
+    resolved.output_format = binding.output_format.clone();
+    resolved.prompt_prefix = binding.prompt_prefix.clone();
+    if !recipe.lora {
+        resolved.lora_url = None;
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn holy_land_pathway(runtime: &RuntimeWorld) -> GeneratedPathwayState {
+        runtime
+            .generated_pathway(RATI_ACTOR_ID, 700, 712, 2)
+            .expect("Holy Land authored route binds generation policy")
+    }
+
+    fn test_art_config() -> ReplicateAvatarArtConfig {
+        ReplicateAvatarArtConfig {
+            api_token: "test".to_string(),
+            model: "host/default".to_string(),
+            version: None,
+            lora_url: Some("host/lora".to_string()),
+            lora_input_key: "lora_weights".to_string(),
+            lora_scale_input_key: "lora_scale".to_string(),
+            lora_scale: 1.0,
+            prompt_prefix: "host prompt".to_string(),
+            output_format: "png".to_string(),
+        }
+    }
+
+    #[test]
+    fn pack_policy_lookup_is_mount_order_independent() {
+        let forward = active_content().manifest.packs.clone();
+        let mut reverse = forward.clone();
+        reverse.reverse();
+        let forward_policy = policy_for_pack_in(&forward, "cosyworld.the-holy-land")
+            .unwrap()
+            .unwrap();
+        let reverse_policy = policy_for_pack_in(&reverse, "cosyworld.the-holy-land")
+            .unwrap()
+            .unwrap();
+        assert_eq!(forward_policy.policy_id, reverse_policy.policy_id);
+        assert_eq!(
+            forward_policy.migration_version,
+            reverse_policy.migration_version
+        );
+    }
+
+    #[test]
+    fn legacy_binding_records_history_without_inventing_media_identity() {
+        let binding =
+            legacy_generated_policy_binding("pack.old", "1.0.0", "composition.old", "sha256:old");
+        assert_eq!(binding.policy_id, LEGACY_GENERATION_POLICY_ID);
+        assert_eq!(binding.composition_bundle_hash, "sha256:old");
+        assert!(binding.media.is_none());
+    }
+
+    #[test]
+    fn source_route_binding_is_captured_once_and_inherited_by_every_descendant() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = holy_land_pathway(&runtime);
+        let binding = pathway.generation_policy.clone();
+        let waypoint = pathway.waypoints[0].clone();
+        assert_eq!(binding.policy_id, "cosyworld.the-holy-land/generation/1");
+        assert_eq!(
+            binding.composition_bundle_hash,
+            active_content().manifest.bundle_hash
+        );
+        assert_eq!(waypoint.generation_policy, binding);
+
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        runtime.ensure_generated_pathway_route_records(&pathway);
+        runtime.ensure_generated_place_for_waypoint(
+            &pathway,
+            waypoint.id,
+            pathway.origin_location_id,
+        );
+        assert!(runtime
+            .routes
+            .values()
+            .filter(|route| route.provenance == format!("generated_pathway:{}", pathway.id))
+            .all(|route| route.generation_policy.as_ref() == Some(&binding)));
+        assert_eq!(
+            runtime.generated_places[&waypoint.id].generation_policy,
+            binding
+        );
+        assert_eq!(
+            runtime
+                .decorate_generated_location_card(
+                    card_for_location(waypoint.id, &waypoint.name, Some(&waypoint.meta)),
+                    waypoint.id,
+                )
+                .generation_policy,
+            Some(binding)
+        );
+    }
+
+    #[test]
+    fn restart_and_journal_replay_preserve_the_stored_binding_byte_for_byte() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = holy_land_pathway(&runtime);
+        let expected = serde_json::to_value(&pathway.generation_policy).unwrap();
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        runtime.ensure_generated_pathway_route_records(&pathway);
+        let restored = RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .expect("current snapshot restores");
+        assert_eq!(
+            serde_json::to_value(&restored.generated_pathways[&pathway.id].generation_policy)
+                .unwrap(),
+            expected
+        );
+
+        let mut replay = RuntimeWorld::seeded();
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: RATI_ACTOR_ID,
+                ..CwAction::default()
+            },
+            337_001,
+        );
+        record
+            .projection_mutations
+            .push(ProjectionMutation::RefinePathway {
+                pathway: pathway.clone(),
+            });
+        assert_eq!(replay.apply_journal_record(&record).0, CW_OK);
+        assert_eq!(
+            serde_json::to_value(&replay.generated_pathways[&pathway.id].generation_policy)
+                .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn legacy_snapshot_binds_to_its_historical_bundle_and_current_omission_fails() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = holy_land_pathway(&runtime);
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        runtime.ensure_generated_pathway_route_records(&pathway);
+        let historical_hash = active_content()
+            .manifest
+            .persistence_compatibility
+            .replay_compatible_bundle_hashes[0]
+            .clone();
+        let mut snapshot = RuntimeSnapshot::from_runtime(&runtime);
+        snapshot.version = 13;
+        snapshot.worldpack_bundle_hash = historical_hash.clone();
+        let persisted = snapshot
+            .generated_pathways
+            .get_mut(&pathway.id)
+            .expect("pathway is persisted");
+        persisted.generation_policy = GeneratedPolicyBinding::default();
+        for waypoint in &mut persisted.waypoints {
+            waypoint.generation_policy = GeneratedPolicyBinding::default();
+        }
+        for route in snapshot
+            .routes
+            .values_mut()
+            .filter(|route| route.provenance == format!("generated_pathway:{}", pathway.id))
+        {
+            route.generation_policy = None;
+        }
+        let mut forged_current: RuntimeSnapshot =
+            serde_json::from_slice(&serde_json::to_vec(&snapshot).unwrap()).unwrap();
+        forged_current.version = 14;
+        assert!(forged_current.into_runtime().is_err());
+
+        let restored = snapshot.into_runtime().expect("legacy snapshot migrates");
+        let binding = &restored.generated_pathways[&pathway.id].generation_policy;
+        assert_eq!(binding.policy_id, LEGACY_GENERATION_POLICY_ID);
+        assert_eq!(binding.composition_bundle_hash, historical_hash);
+        assert!(binding.media.is_none());
+        assert!(restored
+            .routes
+            .values()
+            .filter(|route| route.provenance == format!("generated_pathway:{}", pathway.id))
+            .all(|route| route.generation_policy.as_ref() == Some(binding)));
+    }
+
+    #[test]
+    fn upgrade_requires_the_exact_declared_migration_tuple() {
+        let declared = legacy_generated_policy_binding(
+            "cosyworld.the-holy-land",
+            "1.1.3",
+            "cosyworld.official",
+            "sha256:historical",
+        );
+        assert!(generation_policy_allows_upgrade(&declared, "1.1.4").is_ok());
+
+        let mut wrong_version = declared.clone();
+        wrong_version.owner_pack_version = "1.1.2".to_string();
+        assert!(generation_policy_allows_upgrade(&wrong_version, "1.1.4").is_err());
+        let mut wrong_policy = declared;
+        wrong_policy.policy_id = "cosyworld.other/generation/1".to_string();
+        assert!(generation_policy_allows_upgrade(&wrong_policy, "1.1.4").is_err());
+    }
+
+    #[test]
+    fn bridge_unmount_ownership_leaves_no_generated_descendant_orphan() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = runtime
+            .generated_pathway(RATI_ACTOR_ID, 1, 700, 2)
+            .expect("bridge route binds bridge generation policy");
+        let owner = "cosyworld.composition.core-holy-land";
+        assert_eq!(pathway.owner_pack_id, owner);
+        assert_eq!(pathway.generation_policy.owner_pack_id, owner);
+        assert!(pathway
+            .waypoints
+            .iter()
+            .all(|waypoint| waypoint.generation_policy.owner_pack_id == owner));
+        runtime.ensure_generated_pathway_route_records(&pathway);
+        let waypoint = &pathway.waypoints[0];
+        runtime.ensure_generated_place_for_waypoint(
+            &pathway,
+            waypoint.id,
+            pathway.origin_location_id,
+        );
+        assert_eq!(runtime.generated_places[&waypoint.id].pack_id, owner);
+        assert_eq!(
+            runtime.generated_places[&waypoint.id]
+                .generation_policy
+                .owner_pack_id,
+            owner
+        );
+        assert!(runtime
+            .routes
+            .values()
+            .filter(|route| route.provenance == format!("generated_pathway:{}", pathway.id))
+            .all(|route| route.owner_pack_id == owner));
+    }
+
+    #[test]
+    fn current_snapshot_rejects_generated_place_and_media_orphans() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = holy_land_pathway(&runtime);
+        let waypoint = pathway.waypoints[0].clone();
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        runtime.ensure_generated_place_for_waypoint(
+            &pathway,
+            waypoint.id,
+            pathway.origin_location_id,
+        );
+        runtime
+            .generated_places
+            .get_mut(&waypoint.id)
+            .expect("generated place exists")
+            .generation_policy = GeneratedPolicyBinding::default();
+        runtime.generated_pathways.remove(&pathway.id);
+        assert!(RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .is_err());
+
+        let mut runtime = RuntimeWorld::seeded();
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        let _ = runtime.apply_fund_community_art_projection(
+            "location",
+            waypoint.id,
+            1,
+            1,
+            RATI_ACTOR_ID,
+            "orphan-fixture",
+            1,
+            337_004,
+        );
+        runtime
+            .community_art_generations
+            .get_mut(&community_art_generation_key("location", waypoint.id, 1))
+            .expect("generated media state exists")
+            .generation_policy = pathway.generation_policy.clone();
+        runtime.generated_pathways.remove(&pathway.id);
+        assert!(RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .is_err());
+    }
+
+    #[test]
+    fn media_begin_record_persists_the_same_generated_binding_on_replay() {
+        let mut runtime = RuntimeWorld::seeded();
+        let pathway = holy_land_pathway(&runtime);
+        let subject_id = pathway.waypoints[0].id;
+        let binding = pathway.generation_policy.clone();
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway);
+        let _ = runtime.apply_fund_community_art_projection(
+            "location",
+            subject_id,
+            1,
+            1,
+            RATI_ACTOR_ID,
+            "binding-fixture",
+            1,
+            337_002,
+        );
+        let record = JournalRecord {
+            projection_mutations: vec![ProjectionMutation::BeginCommunityArtGeneration {
+                subject_kind: "location".to_string(),
+                subject_id,
+                level: 1,
+                provider_attempt: true,
+                generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
+                generation_policy: binding.clone(),
+            }],
+            ..JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_NONE,
+                    actor_id: RATI_ACTOR_ID,
+                    ..CwAction::default()
+                },
+                337_003,
+            )
+        };
+        let replayed: JournalRecord =
+            serde_json::from_slice(&serde_json::to_vec(&record).unwrap()).unwrap();
+        assert_eq!(runtime.apply_journal_record(&replayed).0, CW_OK);
+        assert_eq!(
+            runtime.community_art_generations
+                [&community_art_generation_key("location", subject_id, 1)]
+                .generation_policy,
+            binding
+        );
+    }
+
+    #[test]
+    fn absent_disabled_or_mismatched_recipe_fails_before_provider_submission() {
+        let runtime = RuntimeWorld::seeded();
+        let binding = holy_land_pathway(&runtime)
+            .generation_policy
+            .media
+            .expect("Holy Land policy has reviewed media");
+        let calls = Cell::new(0_u8);
+        let submit = |result: Result<ReplicateAvatarArtConfig, String>| {
+            result.map(|_| calls.set(calls.get() + 1))
+        };
+
+        let mut absent = binding.clone();
+        absent.recipe_id = "recipe.absent".to_string();
+        assert!(submit(resolve_generation_media_config(
+            &test_art_config(),
+            Some(&absent),
+            "16:9"
+        ))
+        .is_err());
+
+        let mut disabled_registry = active_content().manifest.generation_media_registry.clone();
+        disabled_registry["recipes"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|recipe| recipe["id"] == binding.recipe_id)
+            .unwrap()["state"] = serde_json::json!("disabled");
+        assert!(submit(resolve_generation_media_config_from_registry(
+            &test_art_config(),
+            Some(&binding),
+            "16:9",
+            disabled_registry,
+        ))
+        .is_err());
+
+        let mut mismatched = binding;
+        mismatched.revision = "sha256:not-reviewed".to_string();
+        assert!(submit(resolve_generation_media_config(
+            &test_art_config(),
+            Some(&mismatched),
+            "16:9"
+        ))
+        .is_err());
+        assert_eq!(calls.get(), 0, "provider submission must never be reached");
+    }
+}

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -21,6 +21,7 @@ mod content_registry;
 mod contributions;
 mod crafting;
 mod generated_places;
+mod generation_policy;
 mod hosted_access;
 mod jobs;
 mod journal_checkpoint;
@@ -83,6 +84,7 @@ use cosyworld_ai_model::ResidentReplyModelInput;
 use crafting::*;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use generated_places::*;
+use generation_policy::*;
 use hosted_access::*;
 use jobs::*;
 use kernel::*;
@@ -589,59 +591,6 @@ struct LocationMeta {
     art_prompt: Option<String>,
 }
 
-const PATHWAY_CONTENT_FEATURE: &str = "pathway_content";
-const PATHWAY_CONTENT_PROMPT_VERSION: &str = "pathway-content-v1";
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-struct GenerationProvenance {
-    source: String,
-    feature: String,
-    policy_mode: String,
-    prompt_version: String,
-    provider: String,
-    model: String,
-    attempts: u8,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct GeneratedWaypointState {
-    id: u64,
-    #[serde(default)]
-    canonical_id: String,
-    name: String,
-    meta: LocationMeta,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct GeneratedPathwayState {
-    id: String,
-    #[serde(default)]
-    identity_version: u8,
-    #[serde(default)]
-    canonical_id: String,
-    #[serde(default)]
-    source_route_id: String,
-    #[serde(default)]
-    source_route_version: u64,
-    #[serde(default)]
-    owner_pack_id: String,
-    #[serde(default)]
-    owner_pack_version: String,
-    origin_location_id: u64,
-    destination_location_id: u64,
-    distance: u8,
-    created_by_actor_id: u64,
-    waypoints: Vec<GeneratedWaypointState>,
-    #[serde(default)]
-    generation: GenerationProvenance,
-    #[serde(default)]
-    revealed_edges: BTreeSet<String>,
-    #[serde(default)]
-    art_eligible: bool,
-    #[serde(default)]
-    familiar: bool,
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct JourneyState {
     actor_id: u64,
@@ -980,6 +929,8 @@ enum ProjectionMutation {
         provider_attempt: bool,
         #[serde(default = "legacy_community_art_generation_profile_version")]
         generation_profile_version: u8,
+        #[serde(default)]
+        generation_policy: GeneratedPolicyBinding,
     },
     CompleteCommunityArtGeneration {
         subject_kind: String,
@@ -1938,7 +1889,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 12;
+const JOURNAL_RECORD_VERSION: u32 = 13;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -6157,7 +6108,7 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 13,
+            version: 14,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
@@ -6240,6 +6191,7 @@ impl RuntimeSnapshot {
 
     fn into_runtime(self) -> io::Result<RuntimeWorld> {
         let snapshot_version = self.version;
+        let compatibility_bundle_hash = self.worldpack_bundle_hash.clone();
         let compatibility =
             persisted_worldpack_replay_compatibility(&self.worldpack_bundle_hash, "snapshot")?;
         if compatibility == WorldpackReplayCompatibility::DeclaredMigration {
@@ -6452,7 +6404,10 @@ impl RuntimeSnapshot {
         .and_then(move |mut runtime| {
             runtime.ensure_authored_route_records();
             runtime
-                .migrate_generated_pathways_for_snapshot(snapshot_version)
+                .migrate_generated_pathways_for_snapshot(
+                    snapshot_version,
+                    &compatibility_bundle_hash,
+                )
                 .map_err(snapshot_error)?;
             runtime.backfill_recent_room_lines();
             runtime.ensure_seed_topology();
@@ -8314,7 +8269,7 @@ impl RuntimeWorld {
                 continue;
             };
             if self
-                .normalize_generated_pathway_identity(&mut pathway_snapshot, false)
+                .normalize_generated_pathway_identity(&mut pathway_snapshot, false, None)
                 .is_err()
             {
                 continue;
@@ -10141,6 +10096,7 @@ impl RuntimeWorld {
                 &record.projection_mutations,
                 enforce_active_contribution_contract,
                 record.version < JOURNAL_RECORD_VERSION,
+                &record.worldpack_bundle_hash,
             ));
             events.extend(self.apply_focused_job_record(record));
             self.refresh_craft_event_presentation(&mut events);
@@ -10263,6 +10219,7 @@ impl RuntimeWorld {
         mutations: &[ProjectionMutation],
         enforce_active_contribution_contract: bool,
         allow_legacy_generated_identity_backfill: bool,
+        historical_bundle_hash: &str,
     ) -> Vec<EventView> {
         let mut events = Vec::new();
         for mutation in mutations {
@@ -10412,7 +10369,27 @@ impl RuntimeWorld {
                     level,
                     provider_attempt,
                     generation_profile_version,
+                    generation_policy,
                 } => {
+                    let generation_policy = if generation_policy.is_empty()
+                        && subject_kind == "location"
+                    {
+                        if let Some(pathway) = self.generated_pathway_for_location(*subject_id) {
+                            if !allow_legacy_generated_identity_backfill {
+                                continue;
+                            }
+                            legacy_generated_policy_binding(
+                                &pathway.owner_pack_id,
+                                &pathway.owner_pack_version,
+                                &active_content().manifest.id,
+                                historical_bundle_hash,
+                            )
+                        } else {
+                            GeneratedPolicyBinding::default()
+                        }
+                    } else {
+                        generation_policy.clone()
+                    };
                     if let Some(event) = self.apply_begin_community_art_generation_projection(
                         action.actor_id,
                         subject_kind,
@@ -10420,6 +10397,7 @@ impl RuntimeWorld {
                         *level,
                         *provider_attempt,
                         *generation_profile_version,
+                        &generation_policy,
                     ) {
                         events.push(event);
                     }
@@ -10450,6 +10428,7 @@ impl RuntimeWorld {
                         .normalize_generated_pathway_identity(
                             &mut refined,
                             allow_legacy_generated_identity_backfill,
+                            Some(historical_bundle_hash),
                         )
                         .is_err()
                     {
@@ -10532,6 +10511,7 @@ impl RuntimeWorld {
                         .normalize_generated_pathway_identity(
                             &mut proposed_pathway,
                             allow_legacy_generated_identity_backfill,
+                            Some(historical_bundle_hash),
                         )
                         .is_err()
                     {
@@ -19400,6 +19380,9 @@ impl RuntimeWorld {
         subject_kind: &str,
         subject_id: u64,
     ) -> CardView {
+        if subject_kind == "location" {
+            card = self.decorate_generated_location_card(card, subject_id);
+        }
         let Some(level) = self.community_art_subject_level(subject_kind, subject_id) else {
             return card;
         };
@@ -19701,11 +19684,17 @@ impl RuntimeWorld {
             &history,
             image_policy,
         );
+        let generation_policy = (subject_kind == "location")
+            .then(|| self.generated_pathway_for_location(subject_id))
+            .flatten()
+            .map(|pathway| pathway.generation_policy.clone())
+            .unwrap_or_default();
         Ok(CommunityArtPlan {
             subject_kind: subject_kind.to_string(),
             subject_id,
             level,
             generation_profile_version: community_art_generation_profile_version(subject_kind),
+            generation_policy,
             required_orbs: i32::from(level.max(1)),
             history_through_seq,
             prompt,

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -47821,6 +47821,16 @@ mod tests {
 
     #[test]
     fn generated_place_lifecycle_is_typed_causal_bounded_and_replayable() {
+        std::thread::Builder::new()
+            .name("generated-place-lifecycle".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(generated_place_lifecycle_is_typed_causal_bounded_and_replayable_inner)
+            .expect("generated-place lifecycle test thread starts")
+            .join()
+            .expect("generated-place lifecycle test thread completes");
+    }
+
+    fn generated_place_lifecycle_is_typed_causal_bounded_and_replayable_inner() {
         fn apply_pair(
             first: &mut RuntimeWorld,
             replay: &mut RuntimeWorld,

--- a/v2/orchestrator-rust/src/settlement_buildings.rs
+++ b/v2/orchestrator-rust/src/settlement_buildings.rs
@@ -1800,7 +1800,22 @@ mod tests {
     #[test]
     fn fishery_completion_opens_a_reward_quest_and_empty_cache_without_cargo() {
         let mut runtime = RuntimeWorld::seeded();
-        let location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
+        let mut pathway = runtime
+            .generated_pathway(
+                RATI_ACTOR_ID,
+                COSY_COTTAGE_LOCATION_ID,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+                2,
+            )
+            .expect("canonical test pathway");
+        let location_id = pathway.waypoints[0].id;
+        pathway
+            .revealed_edges
+            .insert(pathway_edge_key(pathway.origin_location_id, location_id));
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway.clone());
+        runtime.ensure_generated_pathway_edge(&pathway, pathway.origin_location_id, location_id);
         let actor = runtime.world.actors[..runtime.world.actor_count]
             .iter_mut()
             .find(|actor| actor.id == RATI_ACTOR_ID)
@@ -1858,35 +1873,23 @@ mod tests {
             },
         );
         let decision_id = generated_building_governance_decision_id(location_id);
-        runtime.generated_places.insert(
+        runtime.ensure_generated_place_for_waypoint(
+            &pathway,
             location_id,
-            GeneratedPlaceState {
-                schema_version: GENERATED_PLACE_SCHEMA_VERSION,
-                location_id,
-                canonical_id: "test-generated-place".to_string(),
-                pathway_id: "test-pathway".to_string(),
-                connected_from_location_id: MOONLIT_TRAIL_LOCATION_ID,
-                discovered_by_actor_id: RATI_ACTOR_ID,
-                discovered_event_seq: Some(1),
-                source_generation: GenerationProvenance::default(),
-                pack_id: "cosyworld.core".to_string(),
-                pack_version: pack_version.clone(),
-                anchor_clock_id: "test-anchor".to_string(),
-                connection_clock_id: "test-connection".to_string(),
-                settlement_clock_id: "test-settlement".to_string(),
-                anchor_job_id: "test-anchor-job".to_string(),
-                connection_job_id: "test-connection-job".to_string(),
-                settlement_job_id: "test-settlement-job".to_string(),
-                building_proposal: Some(GeneratedBuildingProposalState {
-                    schema_version: GENERATED_PLACE_SCHEMA_VERSION,
-                    location_id,
-                    eligible_archetype_ids: vec!["fishery".to_string()],
-                    opened_event_seq: 2,
-                    governance_decision_id: decision_id.clone(),
-                    selected_archetype_id: None,
-                }),
-            },
+            pathway.origin_location_id,
         );
+        runtime
+            .generated_places
+            .get_mut(&location_id)
+            .expect("generated place exists")
+            .building_proposal = Some(GeneratedBuildingProposalState {
+            schema_version: GENERATED_PLACE_SCHEMA_VERSION,
+            location_id,
+            eligible_archetype_ids: vec!["fishery".to_string()],
+            opened_event_seq: 2,
+            governance_decision_id: decision_id.clone(),
+            selected_archetype_id: None,
+        });
         assert_eq!(
             runtime.sync_generated_place_governance(location_id, &["fishery".to_string()], 2,),
             GovernanceSyncOutcome::Opened

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -35,6 +35,8 @@ pub(super) struct RouteRecordState {
     pub(super) owner_pack_id: String,
     #[serde(default)]
     pub(super) owner_pack_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) generation_policy: Option<GeneratedPolicyBinding>,
     pub(super) provenance: String,
     pub(super) lifecycle: RouteLifecycle,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -121,6 +123,7 @@ impl RuntimeWorld {
     pub(super) fn migrate_generated_pathways_for_snapshot(
         &mut self,
         snapshot_version: u32,
+        historical_bundle_hash: &str,
     ) -> Result<(), String> {
         let pathway_ids = self.generated_pathways.keys().cloned().collect::<Vec<_>>();
         for pathway_id in pathway_ids {
@@ -129,7 +132,11 @@ impl RuntimeWorld {
                 .get(&pathway_id)
                 .cloned()
                 .ok_or_else(|| "generated pathway disappeared during load".to_string())?;
-            self.normalize_generated_pathway_identity(&mut pathway, snapshot_version < 13)?;
+            self.normalize_generated_pathway_identity(
+                &mut pathway,
+                snapshot_version < 14,
+                Some(historical_bundle_hash),
+            )?;
             self.generated_pathways.insert(pathway_id, pathway);
         }
         self.validate_generated_pathway_identity_claims()?;
@@ -150,6 +157,107 @@ impl RuntimeWorld {
             .any(|route_id| route_id.starts_with("route:generated:"))
         {
             return Err("current snapshot contains a legacy generated route identity".to_string());
+        }
+        let bindings = self
+            .generated_pathways
+            .iter()
+            .map(|(id, pathway)| (id.clone(), pathway.generation_policy.clone()))
+            .collect::<BTreeMap<_, _>>();
+        for route in self.routes.values_mut() {
+            let Some(pathway_id) = route.provenance.strip_prefix("generated_pathway:") else {
+                continue;
+            };
+            let binding = bindings
+                .get(pathway_id)
+                .ok_or_else(|| format!("generated route {} has no pathway owner", route.id))?;
+            if route.generation_policy.is_none() && snapshot_version < 14 {
+                route.generation_policy = Some(binding.clone());
+            }
+            if route.generation_policy.as_ref() != Some(binding) {
+                return Err(format!(
+                    "generated route {} policy binding differs from its pathway",
+                    route.id
+                ));
+            }
+            if route.owner_pack_id != binding.owner_pack_id
+                || route.owner_pack_version != binding.owner_pack_version
+            {
+                return Err(format!(
+                    "generated route {} ownership differs from its policy binding",
+                    route.id
+                ));
+            }
+        }
+        for place in self.generated_places.values_mut() {
+            let pathway = self
+                .generated_pathways
+                .get(&place.pathway_id)
+                .ok_or_else(|| {
+                    format!("generated place {} has no pathway owner", place.location_id)
+                })?;
+            if !pathway
+                .waypoints
+                .iter()
+                .any(|waypoint| waypoint.id == place.location_id)
+            {
+                return Err(format!(
+                    "generated place {} is not a waypoint of its pathway owner",
+                    place.location_id
+                ));
+            }
+            let binding = bindings
+                .get(&place.pathway_id)
+                .expect("validated pathway has a binding");
+            if place.generation_policy.is_empty() && snapshot_version < 14 {
+                place.generation_policy = binding.clone();
+            }
+            if &place.generation_policy != binding {
+                return Err(format!(
+                    "generated place {} policy binding differs from its pathway",
+                    place.location_id
+                ));
+            }
+            if snapshot_version < 14 && place.pack_id.is_empty() {
+                place.pack_id = binding.owner_pack_id.clone();
+                place.pack_version = binding.owner_pack_version.clone();
+            }
+            if place.pack_id != binding.owner_pack_id
+                || place.pack_version != binding.owner_pack_version
+            {
+                return Err(format!(
+                    "generated place {} ownership differs from its policy binding",
+                    place.location_id
+                ));
+            }
+        }
+        for generation in self.community_art_generations.values_mut() {
+            if generation.subject_kind != "location" {
+                continue;
+            }
+            let Some(binding) = self.generated_pathways.values().find_map(|pathway| {
+                pathway
+                    .waypoints
+                    .iter()
+                    .any(|waypoint| waypoint.id == generation.subject_id)
+                    .then_some(&pathway.generation_policy)
+            }) else {
+                if !generation.generation_policy.is_empty() {
+                    return Err(format!(
+                        "bound generated media {} has no pathway owner",
+                        generation.subject_id
+                    ));
+                }
+                continue;
+            };
+            if generation.generation_policy.is_empty() && snapshot_version < 14 {
+                generation.generation_policy = binding.clone();
+            }
+            if &generation.generation_policy != binding {
+                return Err(format!(
+                    "generated media {} policy binding differs from its pathway",
+                    generation.subject_id
+                ));
+            }
         }
         Ok(())
     }
@@ -183,6 +291,7 @@ impl RuntimeWorld {
         &self,
         pathway: &mut GeneratedPathwayState,
         allow_legacy_backfill: bool,
+        historical_bundle_hash: Option<&str>,
     ) -> Result<(), String> {
         if pathway.identity_version > 1 {
             return Err(format!(
@@ -199,6 +308,11 @@ impl RuntimeWorld {
                 .waypoints
                 .iter()
                 .any(|waypoint| waypoint.canonical_id.is_empty());
+        let policy_is_incomplete = pathway.generation_policy.is_empty()
+            || pathway
+                .waypoints
+                .iter()
+                .any(|waypoint| waypoint.generation_policy.is_empty());
         if pathway.identity_version == 0 {
             let is_unversioned_shape = pathway.canonical_id.is_empty()
                 && pathway.source_route_id.is_empty()
@@ -209,13 +323,15 @@ impl RuntimeWorld {
                     .waypoints
                     .iter()
                     .all(|waypoint| waypoint.canonical_id.is_empty());
-            if identity_is_incomplete && (!allow_legacy_backfill || !is_unversioned_shape) {
+            if (identity_is_incomplete && (!allow_legacy_backfill || !is_unversioned_shape))
+                || (policy_is_incomplete && !allow_legacy_backfill)
+            {
                 return Err(format!(
                     "generated pathway {} has incomplete current identity metadata",
                     pathway.id
                 ));
             }
-        } else if identity_is_incomplete {
+        } else if identity_is_incomplete || (policy_is_incomplete && !allow_legacy_backfill) {
             return Err(format!(
                 "generated pathway {} has incomplete current identity metadata",
                 pathway.id
@@ -272,11 +388,41 @@ impl RuntimeWorld {
         if pathway.owner_pack_version.is_empty() {
             pathway.owner_pack_version = source_route.owner_pack_version.clone();
         } else if pathway.owner_pack_version != source_route.owner_pack_version {
+            if pathway.generation_policy.is_empty() {
+                return Err(format!(
+                    "generated pathway {} has no policy binding for pack upgrade",
+                    pathway.id
+                ));
+            }
+            generation_policy_allows_upgrade(
+                &pathway.generation_policy,
+                &source_route.owner_pack_version,
+            )?;
+        }
+        if pathway.generation_policy.is_empty() {
+            if !allow_legacy_backfill {
+                return Err(format!(
+                    "generated pathway {} has no generation policy binding",
+                    pathway.id
+                ));
+            }
+            pathway.generation_policy = legacy_generated_policy_binding(
+                &pathway.owner_pack_id,
+                &pathway.owner_pack_version,
+                &active_content().manifest.id,
+                historical_bundle_hash
+                    .ok_or_else(|| "legacy pathway migration has no bundle identity".to_string())?,
+            );
+        }
+        if pathway.generation_policy.owner_pack_id != pathway.owner_pack_id
+            || pathway.generation_policy.owner_pack_version != pathway.owner_pack_version
+        {
             return Err(format!(
-                "generated pathway {} owner pack version changed",
+                "generated pathway {} policy binding ownership changed",
                 pathway.id
             ));
         }
+        validate_generated_policy_binding(&pathway.generation_policy)?;
         let expected_pathway_id = format!(
             "generated-pathway:{}@{}",
             pathway.source_route_id, pathway.source_route_version
@@ -305,6 +451,15 @@ impl RuntimeWorld {
             } else if waypoint.canonical_id != expected_canonical_id {
                 return Err(format!(
                     "generated waypoint {} canonical identity changed",
+                    waypoint.id
+                ));
+            }
+            if waypoint.generation_policy.is_empty() && allow_legacy_backfill {
+                waypoint.generation_policy = pathway.generation_policy.clone();
+            }
+            if waypoint.generation_policy != pathway.generation_policy {
+                return Err(format!(
+                    "generated waypoint {} policy binding differs from its pathway",
                     waypoint.id
                 ));
             }
@@ -473,6 +628,7 @@ impl RuntimeWorld {
             route.owner = format!("worldpack:{}", pathway.owner_pack_id);
             route.owner_pack_id = pathway.owner_pack_id.clone();
             route.owner_pack_version = pathway.owner_pack_version.clone();
+            route.generation_policy = Some(pathway.generation_policy.clone());
             self.routes.insert(canonical_route_id, route);
         }
         Ok(())
@@ -482,10 +638,15 @@ impl RuntimeWorld {
         &self,
         pathway: &GeneratedPathwayState,
         allow_legacy_backfill: bool,
+        historical_bundle_hash: Option<&str>,
     ) -> bool {
         let mut normalized = pathway.clone();
-        self.normalize_generated_pathway_identity(&mut normalized, allow_legacy_backfill)
-            .is_ok()
+        self.normalize_generated_pathway_identity(
+            &mut normalized,
+            allow_legacy_backfill,
+            historical_bundle_hash,
+        )
+        .is_ok()
     }
 
     pub(super) fn generated_pathway(
@@ -524,6 +685,8 @@ impl RuntimeWorld {
         let origin_meta = self.location_meta_for(origin_location_id);
         let destination_meta = self.location_meta_for(destination_location_id);
         let pathway_id = generated_pathway_canonical_id(source_route);
+        let generation_policy =
+            generated_policy_binding(source_route, origin_location_id, destination_location_id)?;
         let seed = stable_pathway_hash(&pathway_id);
         let waypoint_count = usize::from(distance.saturating_sub(1));
         let names = [
@@ -589,6 +752,7 @@ impl RuntimeWorld {
                         image_url: Some(format!("/assets/generated/pathways/{id}.svg")),
                         art_prompt: Some(art_prompt),
                     },
+                    generation_policy: generation_policy.clone(),
                 }
             })
             .collect();
@@ -600,6 +764,7 @@ impl RuntimeWorld {
             source_route_version: source_route.entity_version,
             owner_pack_id: source_route.owner_pack_id.clone(),
             owner_pack_version: source_route.owner_pack_version.clone(),
+            generation_policy,
             origin_location_id,
             destination_location_id,
             distance,
@@ -618,7 +783,7 @@ impl RuntimeWorld {
             art_eligible: distance >= 2,
             familiar: false,
         };
-        if !self.generated_pathway_identity_is_compatible(&pathway, false) {
+        if !self.generated_pathway_identity_is_compatible(&pathway, false, None) {
             return Err("generated pathway identity or numeric handle collides".to_string());
         }
         Ok(pathway)
@@ -642,6 +807,7 @@ impl RuntimeWorld {
             || current.owner != proposed.owner
             || current.owner_pack_id != proposed.owner_pack_id
             || current.owner_pack_version != proposed.owner_pack_version
+            || current.generation_policy != proposed.generation_policy
             || current.provenance != proposed.provenance;
         if structure_changed {
             current.edges = proposed.edges;
@@ -649,6 +815,7 @@ impl RuntimeWorld {
             current.owner = proposed.owner;
             current.owner_pack_id = proposed.owner_pack_id;
             current.owner_pack_version = proposed.owner_pack_version;
+            current.generation_policy = proposed.generation_policy;
             current.provenance = proposed.provenance;
             if !metadata_backfill {
                 current.entity_version = current.entity_version.saturating_add(1).max(1);
@@ -679,6 +846,7 @@ impl RuntimeWorld {
                     owner: format!("worldpack:{owner_pack_id}"),
                     owner_pack_id,
                     owner_pack_version,
+                    generation_policy: None,
                     provenance: "authored_exit".to_string(),
                     lifecycle: RouteLifecycle::Open,
                     discovery: None,
@@ -722,6 +890,7 @@ impl RuntimeWorld {
                 owner: format!("worldpack:{owner_pack_id}"),
                 owner_pack_id,
                 owner_pack_version,
+                generation_policy: None,
                 provenance: hidden.source.clone(),
                 lifecycle: RouteLifecycle::Latent,
                 discovery: None,
@@ -770,6 +939,7 @@ impl RuntimeWorld {
                 owner: format!("worldpack:{}", pathway.owner_pack_id),
                 owner_pack_id: pathway.owner_pack_id.clone(),
                 owner_pack_version: pathway.owner_pack_version.clone(),
+                generation_policy: Some(pathway.generation_policy.clone()),
                 provenance: format!("generated_pathway:{}", pathway.id),
                 lifecycle,
                 discovery: None,
@@ -1125,6 +1295,7 @@ impl RuntimeWorld {
                     .generated_pathway_identity_is_compatible(
                         pathway,
                         record.version < JOURNAL_RECORD_VERSION,
+                        Some(&record.worldpack_bundle_hash),
                     ),
                 _ => true,
             })
@@ -1243,11 +1414,13 @@ mod tests {
         pathway.source_route_version = 0;
         pathway.owner_pack_id.clear();
         pathway.owner_pack_version.clear();
+        pathway.generation_policy = GeneratedPolicyBinding::default();
         for (index, waypoint) in pathway.waypoints.iter_mut().enumerate() {
             waypoint.id = GENERATED_PATHWAY_LOCATION_ID_BASE
                 + (stable_pathway_hash(legacy_id) % 10_000) * 16
                 + index as u64;
             waypoint.canonical_id.clear();
+            waypoint.generation_policy = GeneratedPolicyBinding::default();
         }
         pathway.revealed_edges.clear();
         pathway
@@ -1864,6 +2037,7 @@ mod tests {
                 owner: "actor:1001".to_string(),
                 owner_pack_id: String::new(),
                 owner_pack_version: String::new(),
+                generation_policy: None,
                 provenance: "generated_pathway:orphan".to_string(),
                 lifecycle: RouteLifecycle::Latent,
                 discovery: None,

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -3119,7 +3119,10 @@ impl RuntimeWorld {
             location_cards.insert(
                 location.id,
                 apply_location_access(
-                    card_for_location(location.id, &name, Some(&meta)),
+                    self.decorate_generated_location_card(
+                        card_for_location(location.id, &name, Some(&meta)),
+                        location.id,
+                    ),
                     location.id,
                     access,
                 ),
@@ -3198,7 +3201,10 @@ impl RuntimeWorld {
                     .cloned()
                     .unwrap_or_else(|| {
                         apply_location_access(
-                            card_for_location(location.id, &name, Some(&meta)),
+                            self.decorate_generated_location_card(
+                                card_for_location(location.id, &name, Some(&meta)),
+                                location.id,
+                            ),
                             location.id,
                             access,
                         )

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74523
+74533

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74534
+74523


### PR DESCRIPTION
Part of #337.

This third stacked slice wires the compiled generation-policy contract into runtime-generated pathways, waypoints, routes, places, cards, community media, snapshots, and journals.

Key points:
- captures one immutable owner/composition/policy binding from the canonical authored route;
- preserves that binding byte-for-byte through replay and restart;
- requires exact declared migrations for pack upgrades;
- resolves media only through the reviewed host registry and fails closed before provider submission;
- rejects orphaned routes, places, non-member place claims, and bound media;
- preserves explicit legacy behavior with the historical bundle hash and no fabricated media identity.

Verification:
- Rust: 562/562 passed (full suite with loopback fixtures enabled)
- focused generation-policy matrix: 10/10 passed
- JS generated-subgraph freeze/remount: 1/1 passed
- full JS suite in push hook: 469/469 passed
- worldpack compiler + all compositions + strict proof: passed
- Clippy: 246/246 warning ceiling
- main.rs: 74,523/74,523 line ceiling (net shrink)
- diff: 1,522 changed lines, below the 2,250 cap

The isolated push hook stopped after its green JS suite because the external SRD checkout is not materialized in this worktree; the affected compiler/composition/proof checks were run directly and passed.