### PR TITLE
Split resident voice from bounded intent planning

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -193,15 +193,35 @@ For every successful scene-card commit:
 4. Build authoritative channel context from the triggering card/event, up to ten
    recent room-log entries, recent spoken lines, current cast and location,
    durable room memory, goals, economy facts, and resident continuity.
-5. Ask AI for one bounded resident proposal. The direct event is answered first;
-   newer log facts override older ones.
-6. Validate the resident's speech contract and commit the accepted `CW_ACTION_SAY`
-   through the journal and C kernel.
-7. Complete the heartbeat only after the reply attempt, so cards played while
+5. On a decision beat, freeze the exact current `resident-planner-offers-v1`
+   candidate IDs and state revision, then make at most one `intent_json` planner
+   call. That closed policy currently covers reachable move, pickup, drop, give,
+   trade, and use-item offers; unsupported legal kinds such as search remain in
+   deterministic hands and are not mislabeled as planner candidates. Pickups
+   requiring an inventory exchange are excluded until the candidate schema can
+   encode the exact outgoing item. Ordinary conversation and directly
+   controlled proxy reactions skip this step.
+6. Validate the planner's exact candidate echo. Invalid, unavailable, illegal,
+   or stale output becomes a rejected/absent planner brief and no pending action.
+7. Ask a `voice` model for public speech only. Its brief distinguishes proposed,
+   accepted, committed, superseded, rejected, and absent intent and forbids
+   claims that an uncommitted action, cost, or outcome already happened.
+8. Re-enumerate the authoritative candidates before persisting any pending
+   action, validate the speech contract, and commit `CW_ACTION_SAY` through the
+   journal and C kernel. Later deterministic hands still re-plan against current
+   offers and the kernel remains the only mutation authority.
+9. Complete the heartbeat only after the reply attempt, so cards played while
    inference is running still cannot stack another reply.
 
 The human operator is never impersonated by this path. Human dialogue is the
-moderated `say` action.
+moderated `say` action. Planner reason text exists only in the resident-planning
+trace, never in the projected pending action, a belief, or a world fact. The
+speech journal stores the planning status and accepted publication receipt;
+eventual action decision traces carry the same generation, candidate, revision,
+and causal event fields. Only the matching executed plan is cleared. A newer
+accepted generation durably supersedes an older one, while a rejected attempt
+leaves the older accepted plan intact. Replay consumes those records and never
+calls inference.
 
 ### Structured Decisions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.208",
+      "version": "0.0.209",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.208",
+  "version": "0.0.209",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/ai-capability-registry.md
+++ b/v2/docs/ai-capability-registry.md
@@ -132,9 +132,27 @@ candidates persist hashes, evidence, and decision metadata, never raw output
 bytes. The existing publication journal precondition remains the single writer
 for the final world-visible line.
 
-This live routing scope intentionally stops at avatar chat and its follow-up.
-Resident intent/voice composition remains on the `intent_json` path until that
-coupling is split in the follow-on work.
+Resident intelligence uses the same bounded Voice router for public prose.
+Decision beats make one separate `intent_json` request containing only the
+triggering public event, bounded continuity/goals, and the exact current
+planner-eligible candidate IDs plus their state revision. The declared
+`resident-planner-offers-v1` policy is closed over reachable move, pickup, drop,
+give, trade, and use-item offers. Other legal kinds, including search, stay in
+deterministic hands; pickups needing an inventory exchange are excluded until
+the schema can name the exact outgoing item. The strict response may echo only
+a candidate ID/revision, closed speech act, and proposal reason.
+Conversation-only beats and directly controlled proxy reactions skip the
+planner.
+
+Planner failure does not consume the Voice budget and degrades to rejected or
+absent intent with no action. Before a pending action is journaled, the server
+re-enumerates and compares the full authoritative candidate identity and fields.
+The C kernel remains the only mutation authority. Journaled planning,
+publication, causality, and eventual decision links replay without inference;
+raw planner reasoning remains only in the planning trace and is never copied
+into projected action state or promoted to world truth. Matching execution
+durably records committed or rejected disposition; a newer accepted generation
+supersedes the prior one, while a rejected new attempt does not mutate it.
 
 ## Privacy and attribution
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.208"
+version = "0.0.209"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.208"
+version = "0.0.209"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_resident_planning.rs
+++ b/v2/orchestrator-rust/src/ai_resident_planning.rs
@@ -1,0 +1,1100 @@
+use super::*;
+
+const RESIDENT_PLANNER_PROMPT_VERSION: &str = "resident-intent-v1";
+const RESIDENT_PLANNER_ELIGIBILITY_POLICY: &str = "resident-planner-offers-v1";
+const RESIDENT_PLANNER_ELIGIBLE_KINDS: &[&str] = &[
+    "move",
+    "pick_up",
+    "drop_item",
+    "give_item",
+    "trade_item",
+    "use_item",
+];
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(super) struct ResidentPlannerCandidate {
+    pub(super) candidate_id: String,
+    pub(super) composition_id: String,
+    pub(super) state_revision: u64,
+    pub(super) kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) target_actor_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) item_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) target_item_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) destination_location_id: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ResidentSpeechAct {
+    Inform,
+    Propose,
+    Commit,
+    Refuse,
+    React,
+}
+
+impl ResidentSpeechAct {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Inform => "inform",
+            Self::Propose => "propose",
+            Self::Commit => "commit",
+            Self::Refuse => "refuse",
+            Self::React => "react",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ResidentPlanningStatus {
+    Absent,
+    Requested,
+    Proposed,
+    Accepted,
+    Committed,
+    Rejected,
+    Superseded,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ResidentPlannerOutput {
+    candidate_id: String,
+    state_revision: u64,
+    speech_act: ResidentSpeechAct,
+    reason: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(super) struct ResidentPlanningTrace {
+    pub(super) schema_version: u32,
+    pub(super) generation_id: String,
+    pub(super) prompt_version: String,
+    pub(super) actor_id: u64,
+    pub(super) state_revision: u64,
+    pub(super) candidates: Vec<ResidentPlannerCandidate>,
+    #[serde(default)]
+    pub(super) eligibility_policy: String,
+    #[serde(default)]
+    pub(super) eligible_offer_kinds: Vec<String>,
+    pub(super) status: ResidentPlanningStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) candidate_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) speech_act: Option<ResidentSpeechAct>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) proposal_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) failure_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) model_attribution: Option<ModelAttribution>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) context_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) supersedes_generation_id: Option<String>,
+}
+
+impl ResidentPlanningTrace {
+    pub(super) fn absent(plan: &AvatarReplyPlan) -> Self {
+        Self {
+            schema_version: 1,
+            generation_id: resident_planning_generation_id(plan),
+            prompt_version: RESIDENT_PLANNER_PROMPT_VERSION.to_string(),
+            actor_id: plan.speaker_actor_id,
+            state_revision: plan
+                .planner_candidates
+                .first()
+                .map(|candidate| candidate.state_revision)
+                .unwrap_or_else(|| plan.observed_through_seq.unwrap_or(0)),
+            candidates: plan.planner_candidates.clone(),
+            eligibility_policy: RESIDENT_PLANNER_ELIGIBILITY_POLICY.to_string(),
+            eligible_offer_kinds: RESIDENT_PLANNER_ELIGIBLE_KINDS
+                .iter()
+                .map(|kind| (*kind).to_string())
+                .collect(),
+            status: ResidentPlanningStatus::Absent,
+            candidate_id: None,
+            speech_act: None,
+            proposal_reason: None,
+            failure_code: None,
+            model_attribution: None,
+            context_hash: None,
+            supersedes_generation_id: None,
+        }
+    }
+
+    pub(super) fn reject(&mut self, code: impl Into<String>) {
+        let has_valid_proposal = matches!(
+            self.status,
+            ResidentPlanningStatus::Proposed | ResidentPlanningStatus::Accepted
+        );
+        self.status = ResidentPlanningStatus::Rejected;
+        self.failure_code = Some(code.into());
+        if !has_valid_proposal {
+            self.candidate_id = None;
+            self.speech_act = None;
+            self.proposal_reason = None;
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct ResidentPlanningDisposition {
+    pub(super) trace: ResidentPlanningTrace,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) proposed_action: Option<AvatarProposedAction>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ResidentPlanningResult {
+    pub(super) proposed_action: Option<AvatarProposedAction>,
+    pub(super) trace: ResidentPlanningTrace,
+}
+
+pub(super) struct ResidentPlanningLifecycleSnapshot {
+    matched_pending_action: bool,
+    previous_pending_action: Option<AvatarProposedAction>,
+    previous_pending_planning: Option<ResidentPlanningTrace>,
+}
+
+impl RuntimeWorld {
+    pub(super) fn prepare_resident_planner_snapshot(
+        &self,
+        mut plan: AvatarReplyPlan,
+    ) -> AvatarReplyPlan {
+        let inference_controlled = self
+            .actor_by_id(plan.speaker_actor_id)
+            .is_some_and(|actor| self.actor_uses_inference(actor.id));
+        if !plan.planner_requested || !inference_controlled {
+            plan.planner_requested = false;
+            plan.planner_candidates.clear();
+            return plan;
+        }
+        plan.planner_candidates = self.resident_planner_candidates(plan.speaker_actor_id);
+        plan
+    }
+
+    fn resident_planner_candidates(&self, actor_id: u64) -> Vec<ResidentPlannerCandidate> {
+        let (_, offers) = self.legal_action_candidates(Some(actor_id), &AccessContext::default());
+        offers
+            .iter()
+            .filter(|offer| action_offer_is_reachable(offer))
+            .filter_map(|offer| self.resident_planner_candidate_from_offer(actor_id, offer))
+            .collect()
+    }
+
+    fn resident_planner_candidate_from_offer(
+        &self,
+        actor_id: u64,
+        offer: &RankedActionOffer,
+    ) -> Option<ResidentPlannerCandidate> {
+        if !resident_planner_offer_kind_is_eligible(&offer.kind) {
+            return None;
+        }
+        let parts = offer.id.split(':').collect::<Vec<_>>();
+        let mut candidate = ResidentPlannerCandidate {
+            candidate_id: offer.offer_id.clone(),
+            composition_id: offer.composition_id.clone(),
+            state_revision: offer.state_revision,
+            kind: String::new(),
+            target_actor_id: None,
+            item_id: None,
+            target_item_id: None,
+            destination_location_id: None,
+        };
+        match (offer.kind.as_str(), parts.as_slice()) {
+            ("move", ["move", destination]) => {
+                candidate.kind = "move".to_string();
+                candidate.destination_location_id = Some(destination.parse().ok()?);
+            }
+            ("pick_up", ["pick_up", item]) => {
+                let item_id = item.parse().ok()?;
+                self.plan_item_choice_action(actor_id, "pick_up", item_id, 0)
+                    .ok()?;
+                candidate.kind = "pick_up".to_string();
+                candidate.item_id = Some(item_id);
+            }
+            ("drop_item", ["drop_item", item]) => {
+                candidate.kind = "drop".to_string();
+                candidate.item_id = Some(item.parse().ok()?);
+            }
+            ("give_item", ["give_item", item, target]) => {
+                candidate.kind = "give".to_string();
+                candidate.item_id = Some(item.parse().ok()?);
+                candidate.target_actor_id = Some(target.parse().ok()?);
+            }
+            ("trade_item", ["trade_item", item, target, target_item]) => {
+                candidate.kind = "trade".to_string();
+                candidate.item_id = Some(item.parse().ok()?);
+                candidate.target_actor_id = Some(target.parse().ok()?);
+                candidate.target_item_id = Some(target_item.parse().ok()?);
+            }
+            ("use_item", ["use_item", item, target]) => {
+                candidate.kind = "use".to_string();
+                candidate.item_id = Some(item.parse().ok()?);
+                candidate.target_actor_id = Some(target.parse().ok()?);
+            }
+            _ => return None,
+        }
+        Some(candidate)
+    }
+
+    pub(super) fn resident_planner_proposal_is_current(
+        &self,
+        plan: &AvatarReplyPlan,
+        proposal: &AvatarProposedAction,
+    ) -> bool {
+        let (Some(candidate_id), Some(revision), Some(composition_id)) = (
+            proposal.candidate_id.as_deref(),
+            proposal.state_revision,
+            proposal.composition_id.as_deref(),
+        ) else {
+            return false;
+        };
+        let Some(frozen) = plan.planner_candidates.iter().find(|candidate| {
+            candidate.candidate_id == candidate_id
+                && candidate.composition_id == composition_id
+                && candidate.state_revision == revision
+        }) else {
+            return false;
+        };
+        if frozen.kind != proposal.kind
+            || frozen.target_actor_id != proposal.target_actor_id
+            || frozen.item_id != proposal.item_id
+            || frozen.target_item_id != proposal.target_item_id
+            || frozen.destination_location_id != proposal.destination_location_id
+        {
+            return false;
+        }
+        self.resident_planner_candidates(plan.speaker_actor_id)
+            .iter()
+            .any(|current| current == frozen)
+    }
+
+    pub(super) fn resident_planner_proposal_for_action(
+        &self,
+        actor: CwActor,
+        action: &CwAction,
+    ) -> Option<&AvatarProposedAction> {
+        let proposal = self
+            .resident_continuities
+            .get(&actor.id)
+            .and_then(|continuity| continuity.pending_action.as_ref())
+            .filter(|proposal| proposal.planning_generation_id.is_some())?;
+        let pending = self.resident_pending_proposed_action(actor)?;
+        (pending.kind == action.kind
+            && pending.actor_id == action.actor_id
+            && pending.target_actor_id == action.target_actor_id
+            && pending.item_id == action.item_id
+            && pending.target_item_id == action.target_item_id
+            && pending.destination_location_id == action.destination_location_id)
+            .then_some(proposal)
+    }
+
+    pub(super) fn resident_planning_lifecycle_snapshot(
+        &self,
+        action: &CwAction,
+    ) -> ResidentPlanningLifecycleSnapshot {
+        let matched_pending_action = action.kind != CW_ACTION_SAY
+            && self.actor_by_id(action.actor_id).is_some_and(|actor| {
+                self.resident_pending_proposed_action(actor)
+                    .is_some_and(|pending| {
+                        pending.kind == action.kind
+                            && pending.actor_id == action.actor_id
+                            && pending.target_actor_id == action.target_actor_id
+                            && pending.item_id == action.item_id
+                            && pending.target_item_id == action.target_item_id
+                            && pending.destination_location_id == action.destination_location_id
+                    })
+            });
+        let (previous_pending_action, previous_pending_planning) = self
+            .resident_continuities
+            .get(&action.actor_id)
+            .map(|continuity| {
+                (
+                    continuity.pending_action.clone(),
+                    continuity.pending_planning.clone(),
+                )
+            })
+            .unwrap_or_default();
+        ResidentPlanningLifecycleSnapshot {
+            matched_pending_action,
+            previous_pending_action,
+            previous_pending_planning,
+        }
+    }
+
+    pub(super) fn apply_resident_planning_lifecycle(
+        &mut self,
+        record: &JournalRecord,
+        status: u32,
+        before: ResidentPlanningLifecycleSnapshot,
+    ) {
+        let resident_id = record.action.actor_id;
+        let Some(continuity) = self.resident_continuities.get_mut(&resident_id) else {
+            return;
+        };
+        if record.action.kind != CW_ACTION_SAY && before.matched_pending_action {
+            continuity.pending_action = None;
+            continuity.pending_planning = None;
+            if let Some(mut trace) = before.previous_pending_planning {
+                trace.status = if status == CW_OK {
+                    ResidentPlanningStatus::Committed
+                } else {
+                    trace.failure_code = Some(format!("kernel_rejected:{status}"));
+                    ResidentPlanningStatus::Rejected
+                };
+                continuity.last_planning_disposition = Some(ResidentPlanningDisposition {
+                    trace,
+                    proposed_action: before.previous_pending_action,
+                });
+            }
+            return;
+        }
+        if status != CW_OK {
+            return;
+        }
+        let Some(incoming) = record.resident_planning.clone() else {
+            return;
+        };
+        match incoming.status {
+            ResidentPlanningStatus::Accepted => {
+                if before
+                    .previous_pending_planning
+                    .as_ref()
+                    .is_some_and(|previous| previous.generation_id != incoming.generation_id)
+                {
+                    let mut superseded = before
+                        .previous_pending_planning
+                        .expect("checked previous generation");
+                    superseded.status = ResidentPlanningStatus::Superseded;
+                    continuity.last_planning_disposition = Some(ResidentPlanningDisposition {
+                        trace: superseded,
+                        proposed_action: before.previous_pending_action,
+                    });
+                }
+                continuity.pending_planning = Some(incoming);
+            }
+            ResidentPlanningStatus::Rejected
+            | ResidentPlanningStatus::Superseded
+            | ResidentPlanningStatus::Committed => {
+                if continuity
+                    .last_planning_disposition
+                    .as_ref()
+                    .is_some_and(|disposition| {
+                        disposition.trace.generation_id == incoming.generation_id
+                    })
+                {
+                    continuity.last_planning_disposition = None;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn resident_planner_offer_kind_is_eligible(kind: &str) -> bool {
+    RESIDENT_PLANNER_ELIGIBLE_KINDS.contains(&kind)
+}
+
+pub(super) async fn request_resident_plan(
+    config: &AiConfig,
+    plan: &AvatarReplyPlan,
+) -> ResidentPlanningResult {
+    if !plan.planner_requested || plan.planner_candidates.is_empty() {
+        return ResidentPlanningResult {
+            proposed_action: None,
+            trace: ResidentPlanningTrace::absent(plan),
+        };
+    }
+    let mut trace = ResidentPlanningTrace::absent(plan);
+    trace.status = ResidentPlanningStatus::Requested;
+    let candidates =
+        serde_json::to_string(&plan.planner_candidates).unwrap_or_else(|_| "[]".to_string());
+    let system = "You are a bounded intent selector. Select exactly one candidate from the supplied authoritative planner-eligible list. Return one JSON object only. Echo candidate_id and state_revision exactly. speech_act must be inform, propose, commit, refuse, or react. reason is private proposal metadata, not a world fact. Never invent an action, target, item, destination, cost, outcome, reward, belief, candidate, or revision.";
+    let user = format!(
+        "Resident actor: {actor_id}\nTriggering public event: {event}\nBounded continuity and goals:\n{continuity}\n{goals}\nEligibility policy: {policy}; closed offer kinds: {eligible_kinds}\nExact current planner-eligible legal candidates:\n{candidates}\nReturn only {{\"candidate_id\":\"exact id\",\"state_revision\":0,\"speech_act\":\"inform|propose|commit|refuse|react\",\"reason\":\"brief selection rationale\"}}.",
+        actor_id = plan.speaker_actor_id,
+        event = plan.user_text,
+        continuity = format_resident_continuity(&plan.resident_continuity),
+        goals = format_goal_lines(&plan.goals),
+        policy = RESIDENT_PLANNER_ELIGIBILITY_POLICY,
+        eligible_kinds = RESIDENT_PLANNER_ELIGIBLE_KINDS.join(","),
+    );
+    let response_format = serde_json::json!({ "type": "json_object" });
+    let completion = request_chat_completion(
+        config,
+        ChatCompletionRequest {
+            feature: "resident_intent",
+            prompt_version: RESIDENT_PLANNER_PROMPT_VERSION,
+            capability: ModelCapability::IntentJson,
+            system,
+            user: &user,
+            temperature: 0.0,
+            max_tokens: 100,
+            timeout: Duration::from_secs(8),
+            max_attempts: 1,
+            referer: "http://127.0.0.1:3102",
+            response_format: Some(&response_format),
+        },
+    )
+    .await;
+    let text = match completion {
+        Ok(completion) => {
+            trace.model_attribution = completion.model_attribution;
+            trace.context_hash = Some(completion.context_hash);
+            completion.text
+        }
+        Err(error) => {
+            trace.reject(format!("planner_unavailable:{}", error.code()));
+            return ResidentPlanningResult {
+                proposed_action: None,
+                trace,
+            };
+        }
+    };
+    let proposed_action = validate_resident_planner_output(plan, &text, &mut trace);
+    ResidentPlanningResult {
+        proposed_action,
+        trace,
+    }
+}
+
+fn validate_resident_planner_output(
+    plan: &AvatarReplyPlan,
+    text: &str,
+    trace: &mut ResidentPlanningTrace,
+) -> Option<AvatarProposedAction> {
+    let output = match serde_json::from_str::<ResidentPlannerOutput>(text.trim()) {
+        Ok(output) => output,
+        Err(_) => {
+            trace.reject("planner_invalid_json");
+            return None;
+        }
+    };
+    let Some(candidate) = plan.planner_candidates.iter().find(|candidate| {
+        candidate.candidate_id == output.candidate_id
+            && candidate.state_revision == output.state_revision
+    }) else {
+        trace.reject("planner_candidate_mismatch");
+        return None;
+    };
+    let reason = sanitize_planner_reason(&output.reason);
+    if reason.is_none() {
+        trace.reject("planner_invalid_reason");
+        return None;
+    }
+    trace.status = ResidentPlanningStatus::Proposed;
+    trace.candidate_id = Some(candidate.candidate_id.clone());
+    trace.speech_act = Some(output.speech_act);
+    trace.proposal_reason = reason.clone();
+    Some(AvatarProposedAction {
+        kind: candidate.kind.clone(),
+        target_actor_id: candidate.target_actor_id,
+        item_id: candidate.item_id,
+        target_item_id: candidate.target_item_id,
+        destination_location_id: candidate.destination_location_id,
+        candidate_id: Some(candidate.candidate_id.clone()),
+        composition_id: Some(candidate.composition_id.clone()),
+        state_revision: Some(candidate.state_revision),
+        planning_generation_id: Some(trace.generation_id.clone()),
+        speech_act: Some(output.speech_act),
+        reason: None,
+    })
+}
+
+pub(super) fn resident_planning_generation_id(plan: &AvatarReplyPlan) -> String {
+    format!(
+        "resident-plan:{}:{}:{}",
+        plan.speaker_actor_id,
+        plan.publication_beat_id,
+        plan.planner_candidates
+            .first()
+            .map(|candidate| candidate.state_revision)
+            .unwrap_or_else(|| plan.observed_through_seq.unwrap_or(0))
+    )
+}
+
+fn sanitize_planner_reason(value: &str) -> Option<String> {
+    let value = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    let count = value.chars().count();
+    (count > 0 && count <= 180 && !value.chars().any(char::is_control)).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn planning_speech_record(
+        runtime: &RuntimeWorld,
+        mut trace: ResidentPlanningTrace,
+        proposed_action: Option<AvatarProposedAction>,
+        speech: &str,
+        seed: u64,
+    ) -> JournalRecord {
+        let content_id = runtime.next_content_id_value();
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_SAY,
+                actor_id: RATI_ACTOR_ID,
+                content_id,
+                ..CwAction::default()
+            },
+            seed,
+        );
+        record
+            .content_upserts
+            .insert(content_id, speech.to_string());
+        if proposed_action.is_some() {
+            trace.status = ResidentPlanningStatus::Accepted;
+        }
+        record.resident_planning = Some(trace);
+        record
+            .projection_mutations
+            .push(ProjectionMutation::UpdateResidentContinuity {
+                resident_id: RATI_ACTOR_ID,
+                proposal: AvatarIntentProposal {
+                    speech: speech.to_string(),
+                    intent: None,
+                    belief: None,
+                    desire: None,
+                    promise: None,
+                    refusal: None,
+                    proposed_action,
+                },
+                reason: "resident_intent".to_string(),
+            });
+        record
+    }
+
+    fn plan_with_candidate() -> AvatarReplyPlan {
+        let runtime = RuntimeWorld::seeded();
+        let mut plan = runtime
+            .resident_reply_plan_for_target(RATI_ACTOR_ID, SKULL_ACTOR_ID, "The kettle tipped.")
+            .expect("seeded residents share a room");
+        plan.planner_requested = true;
+        plan.planner_candidates = vec![ResidentPlannerCandidate {
+            candidate_id: "cosy:77:move:2".to_string(),
+            composition_id: "composition-move".to_string(),
+            state_revision: 77,
+            kind: "move".to_string(),
+            target_actor_id: None,
+            item_id: None,
+            target_item_id: None,
+            destination_location_id: Some(2),
+        }];
+        plan
+    }
+
+    #[test]
+    fn strict_planner_output_rejects_extra_and_invented_fields() {
+        assert!(serde_json::from_str::<ResidentPlannerOutput>(
+            r#"{"candidate_id":"cosy:77:move:2","state_revision":77,"speech_act":"propose","reason":"Step outside.","kind":"move"}"#
+        )
+        .is_err());
+        assert!(serde_json::from_str::<ResidentPlannerOutput>(
+            r#"{"candidate_id":"cosy:77:move:2","state_revision":77,"speech_act":"propose","reason":"Step outside.","success":true}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn absent_trace_is_deterministic_and_contains_no_hidden_reason() {
+        let plan = plan_with_candidate();
+        let trace = ResidentPlanningTrace::absent(&plan);
+        assert_eq!(trace.status, ResidentPlanningStatus::Absent);
+        assert_eq!(trace.state_revision, 77);
+        assert!(trace.proposal_reason.is_none());
+        assert!(trace.generation_id.contains("resident-plan:"));
+    }
+
+    #[test]
+    fn valid_output_can_only_select_the_exact_frozen_candidate() {
+        let plan = plan_with_candidate();
+        let mut trace = ResidentPlanningTrace::absent(&plan);
+        let action = validate_resident_planner_output(
+            &plan,
+            r#"{"candidate_id":"cosy:77:move:2","state_revision":77,"speech_act":"propose","reason":"The public event makes this route relevant."}"#,
+            &mut trace,
+        )
+        .expect("exact output selects the server candidate");
+        assert_eq!(action.kind, "move");
+        assert_eq!(action.destination_location_id, Some(2));
+        assert_eq!(action.state_revision, Some(77));
+        assert!(action.reason.is_none());
+        assert_eq!(
+            trace.proposal_reason.as_deref(),
+            Some("The public event makes this route relevant.")
+        );
+        assert_eq!(trace.status, ResidentPlanningStatus::Proposed);
+    }
+
+    #[test]
+    fn stale_and_unknown_candidates_fail_without_an_action() {
+        let plan = plan_with_candidate();
+        for (json, code) in [
+            (
+                r#"{"candidate_id":"cosy:77:move:2","state_revision":76,"speech_act":"propose","reason":"stale"}"#,
+                "planner_candidate_mismatch",
+            ),
+            (
+                r#"{"candidate_id":"invented","state_revision":77,"speech_act":"commit","reason":"illegal"}"#,
+                "planner_candidate_mismatch",
+            ),
+        ] {
+            let mut trace = ResidentPlanningTrace::absent(&plan);
+            assert!(validate_resident_planner_output(&plan, json, &mut trace).is_none());
+            assert_eq!(trace.status, ResidentPlanningStatus::Rejected);
+            assert_eq!(trace.failure_code.as_deref(), Some(code));
+        }
+    }
+
+    #[test]
+    fn commit_time_rejection_keeps_the_valid_proposal_link_trace_only() {
+        let plan = plan_with_candidate();
+        let mut trace = ResidentPlanningTrace::absent(&plan);
+        let action = validate_resident_planner_output(
+            &plan,
+            r#"{"candidate_id":"cosy:77:move:2","state_revision":77,"speech_act":"commit","reason":"private route ranking"}"#,
+            &mut trace,
+        )
+        .expect("valid proposal");
+        assert!(action.reason.is_none());
+
+        trace.reject("planner_stale_or_illegal");
+        assert_eq!(trace.status, ResidentPlanningStatus::Rejected);
+        assert_eq!(trace.candidate_id.as_deref(), Some("cosy:77:move:2"));
+        assert_eq!(trace.speech_act, Some(ResidentSpeechAct::Commit));
+        assert_eq!(
+            trace.proposal_reason.as_deref(),
+            Some("private route ranking")
+        );
+        assert_eq!(
+            trace.failure_code.as_deref(),
+            Some("planner_stale_or_illegal")
+        );
+    }
+
+    #[tokio::test]
+    async fn unavailable_planner_degrades_to_rejected_trace_without_an_action() {
+        let config = AiConfig {
+            api_key: "offline-test".to_string(),
+            base_url: "http://127.0.0.1:9".to_string(),
+            model: "offline-model".to_string(),
+            vision_model: "offline-vision".to_string(),
+            ..AiConfig::default()
+        };
+        let result = request_resident_plan(&config, &plan_with_candidate()).await;
+        assert!(result.proposed_action.is_none());
+        assert_eq!(result.trace.status, ResidentPlanningStatus::Rejected);
+        assert!(result
+            .trace
+            .failure_code
+            .as_deref()
+            .is_some_and(|code| code.starts_with("planner_unavailable:")));
+    }
+
+    #[test]
+    fn direct_controller_snapshot_and_ordinary_talk_skip_planning() {
+        let runtime = RuntimeWorld::seeded();
+        let mut direct = plan_with_candidate();
+        direct.speaker_actor_id = 5000;
+        direct.planner_requested = true;
+        let direct = runtime.prepare_resident_planner_snapshot(direct);
+        assert!(!direct.planner_requested);
+        assert!(direct.planner_candidates.is_empty());
+
+        let mut ordinary = plan_with_candidate();
+        ordinary.planner_requested = false;
+        let ordinary = runtime.prepare_resident_planner_snapshot(ordinary);
+        assert!(!ordinary.planner_requested);
+        assert!(ordinary.planner_candidates.is_empty());
+    }
+
+    #[test]
+    fn current_snapshot_rejects_forged_fields_and_newer_revision() {
+        let mut runtime = RuntimeWorld::seeded();
+        let plan = runtime
+            .resident_reply_plan_for_target(
+                SKULL_ACTOR_ID,
+                RATI_ACTOR_ID,
+                "Choose what to do next.",
+            )
+            .expect("Rati can react")
+            .requesting_planner();
+        let plan = runtime.prepare_resident_planner_snapshot(plan);
+        let candidate = plan
+            .planner_candidates
+            .first()
+            .expect("seeded Rati has a legal planner candidate")
+            .clone();
+        let proposal = AvatarProposedAction {
+            kind: candidate.kind.clone(),
+            target_actor_id: candidate.target_actor_id,
+            item_id: candidate.item_id,
+            target_item_id: candidate.target_item_id,
+            destination_location_id: candidate.destination_location_id,
+            candidate_id: Some(candidate.candidate_id.clone()),
+            composition_id: Some(candidate.composition_id.clone()),
+            state_revision: Some(candidate.state_revision),
+            planning_generation_id: Some("resident-plan:eventual-action".to_string()),
+            speech_act: Some(ResidentSpeechAct::Propose),
+            reason: Some("private selector rationale".to_string()),
+        };
+        assert!(runtime.resident_planner_proposal_is_current(&plan, &proposal));
+        runtime.apply_resident_intent_projection(
+            RATI_ACTOR_ID,
+            &AvatarIntentProposal {
+                speech: "I can try the exact offered action.".to_string(),
+                intent: None,
+                belief: None,
+                desire: None,
+                promise: None,
+                refusal: None,
+                proposed_action: Some(proposal.clone()),
+            },
+            "resident_intent",
+        );
+        let continuity = runtime
+            .resident_continuities
+            .get(&RATI_ACTOR_ID)
+            .expect("accepted proposal is durable");
+        assert!(!format_resident_continuity(continuity).contains("private selector rationale"));
+        assert!(!continuity
+            .desires
+            .iter()
+            .any(|note| note.text.contains("private selector rationale")));
+        let actor = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
+        let action = runtime
+            .resident_pending_proposed_action(actor)
+            .expect("accepted candidate reaches deterministic hands");
+        let decision = runtime.resident_decision_trace(&ResidentAutonomyCandidate {
+            actor_id: RATI_ACTOR_ID,
+            rank: 0,
+            score: 0,
+            record: JournalRecord::new(action, 392),
+        });
+        assert_eq!(
+            decision.planning_generation_id.as_deref(),
+            Some("resident-plan:eventual-action")
+        );
+        assert_eq!(
+            decision.planner_candidate_id.as_deref(),
+            Some(candidate.candidate_id.as_str())
+        );
+        assert_eq!(
+            decision.planner_state_revision,
+            Some(candidate.state_revision)
+        );
+        let mut forged = proposal.clone();
+        forged.kind = "invented".to_string();
+        assert!(!runtime.resident_planner_proposal_is_current(&plan, &forged));
+        runtime.world.next_event_seq = runtime.world.next_event_seq.saturating_add(1);
+        assert!(!runtime.resident_planner_proposal_is_current(&plan, &proposal));
+    }
+
+    #[test]
+    fn planner_candidates_are_complete_for_the_declared_closed_policy() {
+        let runtime = RuntimeWorld::seeded();
+        let (_, offers) =
+            runtime.legal_action_candidates(Some(RATI_ACTOR_ID), &AccessContext::default());
+        let expected = offers
+            .iter()
+            .filter(|offer| action_offer_is_reachable(offer))
+            .filter_map(|offer| runtime.resident_planner_candidate_from_offer(RATI_ACTOR_ID, offer))
+            .collect::<Vec<_>>();
+        assert_eq!(runtime.resident_planner_candidates(RATI_ACTOR_ID), expected);
+        assert!(!resident_planner_offer_kind_is_eligible("search"));
+        assert!(RESIDENT_PLANNER_ELIGIBLE_KINDS
+            .iter()
+            .all(|kind| resident_planner_offer_kind_is_eligible(kind)));
+
+        let mut plan = plan_with_candidate();
+        plan.planner_candidates = expected;
+        let trace = ResidentPlanningTrace::absent(&plan);
+        assert_eq!(
+            trace.eligibility_policy,
+            RESIDENT_PLANNER_ELIGIBILITY_POLICY
+        );
+        assert_eq!(
+            trace.eligible_offer_kinds,
+            RESIDENT_PLANNER_ELIGIBLE_KINDS
+                .iter()
+                .map(|kind| (*kind).to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn pickup_that_requires_an_exchange_is_excluded_from_planner_candidates() {
+        let mut runtime = RuntimeWorld::seeded();
+        for item in &mut runtime.world.items[..runtime.world.item_count] {
+            match item.id {
+                DEWBRIGHT_BUTTON_ITEM_ID => {
+                    item.location_id = 0;
+                    item.holder_actor_id = RATI_ACTOR_ID;
+                    item.held_since_tick = 20;
+                    item.weight_tenths = 150;
+                }
+                2004 => {
+                    item.location_id = COSY_COTTAGE_LOCATION_ID;
+                    item.holder_actor_id = 0;
+                    item.held_since_tick = 0;
+                }
+                2001 | 2003 | STORY_BUTTON_ITEM_ID => {
+                    item.location_id = 0;
+                    item.holder_actor_id = 0;
+                    item.held_since_tick = 0;
+                }
+                _ => {}
+            }
+        }
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .expect("Rati exists")
+            .stats
+            .strength = 1;
+        assert!(runtime.actor_inventory_full(RATI_ACTOR_ID));
+        let (_, offers) =
+            runtime.legal_action_candidates(Some(RATI_ACTOR_ID), &AccessContext::default());
+        assert!(offers
+            .iter()
+            .any(|offer| offer.kind == "pick_up" && offer.id == "pick_up:2004"));
+        assert!(runtime
+            .plan_item_choice_action(RATI_ACTOR_ID, "pick_up", 2004, 0)
+            .is_err());
+        assert!(!runtime
+            .resident_planner_candidates(RATI_ACTOR_ID)
+            .iter()
+            .any(|candidate| candidate.kind == "pick_up" && candidate.item_id == Some(2004)));
+    }
+
+    #[test]
+    fn accepted_rejected_committed_lifecycle_replays_without_a_gateway() {
+        let mut runtime = RuntimeWorld::seeded();
+        let plan = runtime
+            .resident_reply_plan_for_target(
+                SKULL_ACTOR_ID,
+                RATI_ACTOR_ID,
+                "Choose what to do next.",
+            )
+            .expect("Rati can react")
+            .requesting_planner();
+        let plan = runtime.prepare_resident_planner_snapshot(plan);
+        let candidate = plan
+            .planner_candidates
+            .first()
+            .expect("seeded Rati has an executable planner candidate")
+            .clone();
+        let mut accepted_trace = ResidentPlanningTrace::absent(&plan);
+        let output = serde_json::json!({
+            "candidate_id": candidate.candidate_id,
+            "state_revision": candidate.state_revision,
+            "speech_act": "commit",
+            "reason": "private route ranking",
+        })
+        .to_string();
+        let accepted_action = validate_resident_planner_output(&plan, &output, &mut accepted_trace)
+            .expect("exact candidate validates");
+        assert!(accepted_action.reason.is_none());
+
+        let accepted_record = planning_speech_record(
+            &runtime,
+            accepted_trace.clone(),
+            Some(accepted_action.clone()),
+            "I will take the offered path.",
+            392_001,
+        );
+        let accepted_json =
+            serde_json::to_string(&accepted_record).expect("accepted record serializes");
+        assert_eq!(accepted_json.matches("private route ranking").count(), 1);
+        assert_eq!(runtime.apply_journal_record(&accepted_record).0, CW_OK);
+
+        let mut records = vec![accepted_record];
+        let mut noop = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: RATI_ACTOR_ID,
+                ..CwAction::default()
+            },
+            392_002,
+        );
+        noop.projection_mutations
+            .push(ProjectionMutation::UpdateResidentContinuity {
+                resident_id: RATI_ACTOR_ID,
+                proposal: AvatarIntentProposal {
+                    speech: String::new(),
+                    intent: None,
+                    belief: None,
+                    desire: None,
+                    promise: None,
+                    refusal: None,
+                    proposed_action: None,
+                },
+                reason: "resident_autonomy_intent".to_string(),
+            });
+        assert_eq!(runtime.apply_journal_record(&noop).0, CW_OK);
+        records.push(noop);
+        assert_eq!(
+            runtime
+                .resident_continuities
+                .get(&RATI_ACTOR_ID)
+                .and_then(|continuity| continuity.pending_planning.as_ref())
+                .map(|trace| trace.generation_id.as_str()),
+            Some(accepted_trace.generation_id.as_str())
+        );
+
+        let mut rejected_trace = ResidentPlanningTrace::absent(&plan);
+        rejected_trace.generation_id = "resident-plan:rejected-newer".to_string();
+        rejected_trace.reject("planner_invalid_json");
+        let rejected_record = planning_speech_record(
+            &runtime,
+            rejected_trace,
+            None,
+            "I will not replace the earlier plan.",
+            392_003,
+        );
+        assert_eq!(runtime.apply_journal_record(&rejected_record).0, CW_OK);
+        records.push(rejected_record);
+        let continuity = runtime
+            .resident_continuities
+            .get(&RATI_ACTOR_ID)
+            .expect("continuity persists");
+        assert_eq!(
+            continuity
+                .pending_planning
+                .as_ref()
+                .map(|trace| trace.generation_id.as_str()),
+            Some(accepted_trace.generation_id.as_str())
+        );
+        assert_eq!(
+            continuity
+                .pending_action
+                .as_ref()
+                .and_then(|action| action.planning_generation_id.as_deref()),
+            Some(accepted_trace.generation_id.as_str())
+        );
+
+        let actor = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
+        let committed_action = runtime
+            .resident_pending_proposed_action(actor)
+            .expect("accepted action remains executable");
+        let action_record = JournalRecord::new(committed_action, 392_004);
+        assert_eq!(runtime.apply_journal_record(&action_record).0, CW_OK);
+        records.push(action_record);
+        let outcome_plan = runtime
+            .resident_economy_action_reply_plan(&committed_action)
+            .expect("committed action has a Voice reply plan");
+        let disposition = outcome_plan
+            .resident_continuity
+            .last_planning_disposition
+            .clone()
+            .expect("committed disposition reaches Voice");
+        assert_eq!(disposition.trace.status, ResidentPlanningStatus::Committed);
+        assert!(resident_voice_planning_brief(&ResidentPlanningResult {
+            proposed_action: disposition.proposed_action.clone(),
+            trace: disposition.trace.clone(),
+        })
+        .contains("status=committed"));
+
+        let outcome_record = planning_speech_record(
+            &runtime,
+            disposition.trace,
+            None,
+            "That path is now behind me.",
+            392_005,
+        );
+        assert_eq!(runtime.apply_journal_record(&outcome_record).0, CW_OK);
+        records.push(outcome_record);
+        let continuity = runtime
+            .resident_continuities
+            .get(&RATI_ACTOR_ID)
+            .expect("continuity persists");
+        assert!(continuity.pending_action.is_none());
+        assert!(continuity.pending_planning.is_none());
+        assert!(continuity.last_planning_disposition.is_none());
+
+        let expected = serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
+            .expect("final runtime serializes");
+        let encoded = serde_json::to_string(&records).expect("records serialize");
+        let replay_records: Vec<JournalRecord> =
+            serde_json::from_str(&encoded).expect("records deserialize");
+        let mut replayed = RuntimeWorld::seeded();
+        for record in &replay_records {
+            assert_eq!(replayed.apply_journal_record(record).0, CW_OK);
+        }
+        assert_eq!(
+            serde_json::to_value(RuntimeSnapshot::from_runtime(&replayed))
+                .expect("replayed runtime serializes"),
+            expected
+        );
+    }
+
+    #[test]
+    fn accepted_generation_supersedes_only_the_previous_generation() {
+        let mut runtime = RuntimeWorld::seeded();
+        let mut trace_a = ResidentPlanningTrace::absent(&plan_with_candidate());
+        trace_a.generation_id = "resident-plan:a".to_string();
+        let action_a = AvatarProposedAction {
+            kind: "move".to_string(),
+            destination_location_id: Some(MOONLIT_TRAIL_LOCATION_ID),
+            planning_generation_id: Some(trace_a.generation_id.clone()),
+            ..AvatarProposedAction::default()
+        };
+        let record_a = planning_speech_record(
+            &runtime,
+            trace_a.clone(),
+            Some(action_a),
+            "Plan A.",
+            392_101,
+        );
+        assert_eq!(runtime.apply_journal_record(&record_a).0, CW_OK);
+
+        let mut trace_b = trace_a.clone();
+        trace_b.generation_id = "resident-plan:b".to_string();
+        trace_b.supersedes_generation_id = Some(trace_a.generation_id.clone());
+        let action_b = AvatarProposedAction {
+            kind: "move".to_string(),
+            destination_location_id: Some(MOONLIT_TRAIL_LOCATION_ID),
+            planning_generation_id: Some(trace_b.generation_id.clone()),
+            ..AvatarProposedAction::default()
+        };
+        let record_b = planning_speech_record(
+            &runtime,
+            trace_b.clone(),
+            Some(action_b),
+            "Plan B.",
+            392_102,
+        );
+        assert_eq!(runtime.apply_journal_record(&record_b).0, CW_OK);
+        let continuity = runtime
+            .resident_continuities
+            .get(&RATI_ACTOR_ID)
+            .expect("continuity persists");
+        assert_eq!(
+            continuity
+                .pending_planning
+                .as_ref()
+                .map(|trace| trace.generation_id.as_str()),
+            Some("resident-plan:b")
+        );
+        assert_eq!(
+            continuity
+                .last_planning_disposition
+                .as_ref()
+                .map(|disposition| (
+                    disposition.trace.generation_id.as_str(),
+                    disposition.trace.status,
+                )),
+            Some(("resident-plan:a", ResidentPlanningStatus::Superseded))
+        );
+    }
+}

--- a/v2/orchestrator-rust/src/ai_resident_planning.rs
+++ b/v2/orchestrator-rust/src/ai_resident_planning.rs
@@ -806,7 +806,12 @@ mod tests {
         let expected = offers
             .iter()
             .filter(|offer| action_offer_is_reachable(offer))
-            .filter_map(|offer| runtime.resident_planner_candidate_from_offer(RATI_ACTOR_ID, offer))
+            .filter(|offer| resident_planner_offer_kind_is_eligible(&offer.kind))
+            .map(|offer| {
+                runtime
+                    .resident_planner_candidate_from_offer(RATI_ACTOR_ID, offer)
+                    .expect("every seeded reachable offer in the closed policy is executable")
+            })
             .collect::<Vec<_>>();
         assert_eq!(runtime.resident_planner_candidates(RATI_ACTOR_ID), expected);
         assert!(!resident_planner_offer_kind_is_eligible("search"));

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -5,6 +5,7 @@ mod actor_presence;
 mod actor_rules_facets;
 mod ai_gateway;
 mod ai_publication;
+mod ai_resident_planning;
 mod ai_voice_routing;
 mod avatar_identity;
 mod canonical_journal;
@@ -60,6 +61,7 @@ use actor_practice::*;
 use actor_rules_facets::*;
 use ai_gateway::*;
 use ai_publication::*;
+use ai_resident_planning::*;
 use avatar_identity::*;
 use axum::{
     extract::{ConnectInfo, Path as AxumPath, Query, State},
@@ -82,7 +84,6 @@ use content_packs::*;
 use content_policy::*;
 use content_registry::*;
 use contributions::*;
-use cosyworld_ai_model::ResidentReplyModelInput;
 use crafting::*;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use generated_places::*;
@@ -1316,6 +1317,10 @@ struct ResidentContinuityState {
     refusals: Vec<ResidentContinuityNote>,
     #[serde(default)]
     pending_action: Option<AvatarProposedAction>,
+    #[serde(default)]
+    pending_planning: Option<ResidentPlanningTrace>,
+    #[serde(default)]
+    last_planning_disposition: Option<ResidentPlanningDisposition>,
     open_obligations: Vec<String>,
     current_intent: Option<String>,
     last_observed_event_seq: u64,
@@ -1351,6 +1356,8 @@ impl ResidentContinuityState {
             promises: Vec::new(),
             refusals: Vec::new(),
             pending_action: None,
+            pending_planning: None,
+            last_planning_disposition: None,
             open_obligations: Vec::new(),
             current_intent: None,
             last_observed_event_seq: 0,
@@ -1485,7 +1492,7 @@ struct ActorAutonomyState {
     attention_credits: u8,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct AvatarProposedAction {
     kind: String,
@@ -1494,7 +1501,19 @@ struct AvatarProposedAction {
     #[serde(default)]
     item_id: Option<u64>,
     #[serde(default)]
+    target_item_id: Option<u64>,
+    #[serde(default)]
     destination_location_id: Option<u64>,
+    #[serde(default)]
+    candidate_id: Option<String>,
+    #[serde(default)]
+    composition_id: Option<String>,
+    #[serde(default)]
+    state_revision: Option<u64>,
+    #[serde(default)]
+    planning_generation_id: Option<String>,
+    #[serde(default)]
+    speech_act: Option<ResidentSpeechAct>,
     #[serde(default)]
     reason: Option<String>,
 }
@@ -1842,6 +1861,12 @@ struct ResidentDecisionTrace {
     choice: ResidentDecisionChoiceTrace,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     outcome: Option<ResidentDecisionOutcomeTrace>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    planning_generation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    planner_candidate_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    planner_state_revision: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1875,6 +1900,8 @@ struct JournalRecord {
     source_location_id: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     resident_decision: Option<ResidentDecisionTrace>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    resident_planning: Option<ResidentPlanningTrace>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     ai_publication: Option<AiPublicationReceipt>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1919,7 +1946,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 11;
+const JOURNAL_RECORD_VERSION: u32 = 12;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -1956,6 +1983,7 @@ impl JournalRecord {
             observed_through_seq: None,
             source_location_id: None,
             resident_decision: None,
+            resident_planning: None,
             ai_publication: None,
             focused_encounter,
             offer_kind: None,
@@ -9982,6 +10010,7 @@ impl RuntimeWorld {
 
         self.next_seed = record.seed;
         let action = self.action_with_skill_bonus(record.action);
+        let resident_planning_lifecycle = self.resident_planning_lifecycle_snapshot(&action);
         let advances_world_tick = record.advances_world_tick();
         let authoritative_contribution_clock_ids = record
             .projection_mutations
@@ -10132,9 +10161,6 @@ impl RuntimeWorld {
             for delta in &record.orb_deltas {
                 self.apply_orb_delta(delta.actor_id, delta.delta);
             }
-            if action.kind != CW_ACTION_SAY {
-                self.clear_resident_pending_action(action.actor_id);
-            }
             self.reconcile_card_zones();
             let delivery_evidence = self.update_item_provenance(&events);
             let logistics_events = self.apply_actor_causal_logistics(delivery_evidence);
@@ -10183,6 +10209,7 @@ impl RuntimeWorld {
                 }
             }
         }
+        self.apply_resident_planning_lifecycle(record, status, resident_planning_lifecycle);
         self.ensure_canonical_identities(record.seed);
         if status == CW_OK {
             self.ensure_active_actor_rules_facets();
@@ -16471,6 +16498,8 @@ impl RuntimeWorld {
             observed_through_seq: None,
             source_location_id: None,
             publication_beat_id: String::new(),
+            planner_requested: false,
+            planner_candidates: Vec::new(),
         })
     }
 
@@ -16863,20 +16892,6 @@ impl RuntimeWorld {
                 190,
             );
         }
-        if let Some(text) = proposal
-            .proposed_action
-            .as_ref()
-            .and_then(|action| action.reason.as_deref())
-            .and_then(|reason| sanitize_continuity_note_text(Some(reason)))
-        {
-            push_resident_continuity_note(
-                &mut continuity.desires,
-                text,
-                reason,
-                source_event_seq,
-                150,
-            );
-        }
         if let Some(text) = sanitize_continuity_note_text(proposal.promise.as_deref()) {
             push_resident_continuity_note(
                 &mut continuity.promises,
@@ -16895,18 +16910,12 @@ impl RuntimeWorld {
                 220,
             );
         }
-        if reason != "resident_autonomy_intent" {
+        if reason != "resident_autonomy_intent" && proposal.proposed_action.is_some() {
             continuity.pending_action = proposal.proposed_action.clone();
         }
         if let Some(source_event_seq) = source_event_seq {
             continuity.last_observed_event_seq =
                 continuity.last_observed_event_seq.max(source_event_seq);
-        }
-    }
-
-    fn clear_resident_pending_action(&mut self, resident_id: u64) {
-        if let Some(continuity) = self.resident_continuities.get_mut(&resident_id) {
-            continuity.pending_action = None;
         }
     }
 
@@ -21433,6 +21442,8 @@ impl RuntimeWorld {
             observed_through_seq: None,
             source_location_id: None,
             publication_beat_id: String::new(),
+            planner_requested: false,
+            planner_candidates: Vec::new(),
         })
     }
 
@@ -21577,6 +21588,8 @@ impl RuntimeWorld {
             observed_through_seq: None,
             source_location_id: None,
             publication_beat_id: String::new(),
+            planner_requested: false,
+            planner_candidates: Vec::new(),
         })
     }
 
@@ -22084,6 +22097,19 @@ impl RuntimeWorld {
                     None
                 }
             }
+            "trade" => {
+                let target_actor_id = proposal.target_actor_id?;
+                let item_id = proposal.item_id?;
+                let target_item_id = proposal.target_item_id?;
+                Some(CwAction {
+                    kind: CW_ACTION_TRADE_ITEM,
+                    actor_id: actor.id,
+                    target_actor_id,
+                    item_id,
+                    target_item_id,
+                    ..CwAction::default()
+                })
+            }
             "use" => {
                 let item_id = proposal.item_id?;
                 if !self
@@ -22421,10 +22447,7 @@ impl RuntimeWorld {
             .unwrap_or_else(|| format!("Resident {}", actor.id));
         let mut proposed_action = AvatarProposedAction {
             kind: "wait".to_string(),
-            target_actor_id: None,
-            item_id: None,
-            destination_location_id: None,
-            reason: None,
+            ..AvatarProposedAction::default()
         };
         let intent = match action.kind {
             CW_ACTION_COMBAT_ATTACK | CW_ACTION_COMBAT_FINESSE_ATTACK => {
@@ -22901,6 +22924,7 @@ impl RuntimeWorld {
                 }
             })
             .collect();
+        let planner = self.resident_planner_proposal_for_action(actor, &candidate.record.action);
         ResidentDecisionTrace {
             schema_version: 1,
             actor_id: candidate.actor_id,
@@ -22927,6 +22951,10 @@ impl RuntimeWorld {
                 action: candidate.record.action,
             },
             outcome: None,
+            planning_generation_id: planner
+                .and_then(|proposal| proposal.planning_generation_id.clone()),
+            planner_candidate_id: planner.and_then(|proposal| proposal.candidate_id.clone()),
+            planner_state_revision: planner.and_then(|proposal| proposal.state_revision),
         }
     }
 
@@ -30173,7 +30201,11 @@ async fn command_inner(
 }
 
 async fn complete_avatar_reply(state: &AppState, plan: AvatarReplyPlan) -> Result<(), String> {
-    let proposal = match avatar_reply_intent(state.ai_config.as_ref().as_ref(), &plan).await {
+    let plan = {
+        let runtime = state.inner.lock().await;
+        runtime.prepare_resident_planner_snapshot(plan)
+    };
+    let proposal = match avatar_reply_intent(state, &plan).await {
         Ok(proposal) => proposal,
         Err(error) => {
             warn!("AI resident inference failed; skipping dialogue: {}", error);
@@ -30196,18 +30228,17 @@ async fn complete_orb_chat_exchange(
     target_actor_id: u64,
     first_reply_plan: AvatarReplyPlan,
 ) {
-    let first_proposal =
-        match avatar_reply_intent(state.ai_config.as_ref().as_ref(), &first_reply_plan).await {
-            Ok(proposal) => proposal,
-            Err(error) => {
-                warn!(
-                    "AI resident inference failed; ending chat exchange: {}",
-                    error
-                );
-                record_rejected_ai_publication(state, &error);
-                return;
-            }
-        };
+    let first_proposal = match avatar_reply_intent(state, &first_reply_plan).await {
+        Ok(proposal) => proposal,
+        Err(error) => {
+            warn!(
+                "AI resident inference failed; ending chat exchange: {}",
+                error
+            );
+            record_rejected_ai_publication(state, &error);
+            return;
+        }
+    };
     let first_reply_events = {
         let mut runtime = state.inner.lock().await;
         commit_resident_reply_record(state, &mut runtime, &first_reply_plan, first_proposal)
@@ -30311,18 +30342,17 @@ async fn complete_orb_chat_exchange(
     let Some(closing_plan) = closing_plan else {
         return;
     };
-    let closing_proposal =
-        match avatar_reply_intent(state.ai_config.as_ref().as_ref(), &closing_plan).await {
-            Ok(proposal) => proposal,
-            Err(error) => {
-                warn!(
-                    "AI resident closing inference failed; ending chat exchange: {}",
-                    error
-                );
-                record_rejected_ai_publication(state, &error);
-                return;
-            }
-        };
+    let closing_proposal = match avatar_reply_intent(state, &closing_plan).await {
+        Ok(proposal) => proposal,
+        Err(error) => {
+            warn!(
+                "AI resident closing inference failed; ending chat exchange: {}",
+                error
+            );
+            record_rejected_ai_publication(state, &error);
+            return;
+        }
+    };
     let closing_events = {
         let mut runtime = state.inner.lock().await;
         commit_resident_reply_record(state, &mut runtime, &closing_plan, closing_proposal)
@@ -30341,6 +30371,7 @@ fn commit_resident_reply_record(
     let CertifiedAvatarIntent {
         mut proposal,
         speech,
+        mut planning,
     } = certified;
     let (_, publication_receipt) = into_recorded_speech_parts(state, speech);
     let speaker = runtime.actor_by_id(plan.speaker_actor_id)?;
@@ -30349,6 +30380,22 @@ fn commit_resident_reply_record(
     }
     if runtime.actor_uses_inference(speaker.id) {
         proposal = runtime.collision_safe_resident_proposal(plan, proposal)?;
+        if proposal
+            .proposed_action
+            .as_ref()
+            .is_some_and(|action| !runtime.resident_planner_proposal_is_current(plan, action))
+        {
+            proposal.proposed_action = None;
+            planning.reject("planner_stale_or_illegal");
+        } else if proposal.proposed_action.is_some() {
+            planning.status = ResidentPlanningStatus::Accepted;
+            planning.supersedes_generation_id = runtime
+                .resident_continuities
+                .get(&speaker.id)
+                .and_then(|continuity| continuity.pending_planning.as_ref())
+                .filter(|pending| pending.generation_id != planning.generation_id)
+                .map(|pending| pending.generation_id.clone());
+        }
     } else {
         proposal.speech =
             runtime.collision_safe_avatar_followup(plan.speaker_actor_id, &proposal.speech)?;
@@ -30369,6 +30416,7 @@ fn commit_resident_reply_record(
         .content_upserts
         .insert(content_id, proposal.speech.clone());
     record.ai_publication = Some(publication_receipt);
+    record.resident_planning = Some(planning);
     if runtime.actor_uses_inference(speaker.id) {
         record
             .projection_mutations
@@ -30494,7 +30542,7 @@ async fn complete_player_tick_observation(
                     &observation.source_events,
                     Some(&active_direct_actor_ids),
                 )
-                .map(|plan| plan.with_observation(&observation))
+                .map(|plan| plan.with_observation(&observation).requesting_planner())
         } else {
             runtime.direct_observation_reply_plan(&observation)
         }
@@ -30950,7 +30998,7 @@ async fn maybe_emit_ambient_event(state: AppState) {
     };
     drop(runtime);
 
-    let proposal = match request_ai_avatar_intent(&config, &plan).await {
+    let proposal = match request_ai_avatar_intent(&config, None, &plan).await {
         Ok(proposal) => proposal,
         Err(error) => {
             warn!(
@@ -32511,59 +32559,13 @@ fn resident_proposed_action_intent(action: &AvatarProposedAction) -> Option<Stri
     if let Some(destination_location_id) = action.destination_location_id {
         parts.push(format!("destination {destination_location_id}"));
     }
-    if let Some(reason) = sanitize_continuity_note_text(action.reason.as_deref()) {
-        parts.push(reason);
-    }
     Some(trim_to_chars(&parts.join("; "), 180))
 }
 
-fn parse_resident_intent_json(text: &str, plan: &AvatarReplyPlan) -> Option<AvatarIntentProposal> {
-    let raw: AvatarIntentProposal = serde_json::from_str(text.trim()).ok()?;
-    let speech = sanitize_resident_reply(plan, &raw.speech)?;
-    let proposed_action = raw
-        .proposed_action
-        .and_then(sanitize_resident_proposed_action);
-    Some(AvatarIntentProposal {
-        speech,
-        intent: sanitize_continuity_note_text(raw.intent.as_deref()),
-        belief: sanitize_continuity_note_text(raw.belief.as_deref()),
-        desire: sanitize_continuity_note_text(raw.desire.as_deref()),
-        promise: sanitize_continuity_note_text(raw.promise.as_deref()),
-        refusal: sanitize_continuity_note_text(raw.refusal.as_deref()),
-        proposed_action,
-    })
-}
-
-fn sanitize_resident_proposed_action(raw: AvatarProposedAction) -> Option<AvatarProposedAction> {
-    let kind = sanitize_continuity_note_text(Some(&raw.kind))?;
-    let kind = kind.to_ascii_lowercase().replace([' ', '-'], "_");
-    if !matches!(
-        kind.as_str(),
-        "wait"
-            | "speak"
-            | "move"
-            | "pick_up"
-            | "drop"
-            | "give"
-            | "trade"
-            | "use"
-            | "search"
-            | "refuse"
-    ) {
-        return None;
-    }
-    Some(AvatarProposedAction {
-        kind,
-        target_actor_id: raw.target_actor_id,
-        item_id: raw.item_id,
-        destination_location_id: raw.destination_location_id,
-        reason: sanitize_continuity_note_text(raw.reason.as_deref()),
-    })
-}
-
+#[cfg(test)]
 fn sanitize_resident_reply(plan: &AvatarReplyPlan, text: &str) -> Option<String> {
     cosyworld_ai_model::sanitize_resident_reply(
-        &ResidentReplyModelInput {
+        &cosyworld_ai_model::ResidentReplyModelInput {
             npc_actor_id: plan.speaker_actor_id,
             npc_name: plan.speaker_name.clone(),
             speech_mode: plan.speech_mode.clone(),
@@ -66851,10 +66853,9 @@ mod tests {
                 refusal: None,
                 proposed_action: Some(AvatarProposedAction {
                     kind: "move".to_string(),
-                    target_actor_id: None,
-                    item_id: None,
                     destination_location_id: Some(offered_destination),
                     reason: Some("the offered path is the next reachable room".to_string()),
+                    ..AvatarProposedAction::default()
                 }),
             },
             "resident_intent",
@@ -66920,10 +66921,9 @@ mod tests {
                 refusal: None,
                 proposed_action: Some(AvatarProposedAction {
                     kind: "move".to_string(),
-                    target_actor_id: None,
-                    item_id: None,
                     destination_location_id: Some(proposed_destination),
                     reason: Some("model-selected alternative".to_string()),
+                    ..AvatarProposedAction::default()
                 }),
             },
             "resident_intent",
@@ -67115,10 +67115,8 @@ mod tests {
             .expect("the exact drop offer plans");
         let exact_proposal = AvatarProposedAction {
             kind: "drop".to_string(),
-            target_actor_id: None,
             item_id: Some(STORY_BUTTON_ITEM_ID),
-            destination_location_id: None,
-            reason: None,
+            ..AvatarProposedAction::default()
         };
         assert!(runtime.resident_proposed_action_matches_legal_offer(
             5000,
@@ -70776,6 +70774,8 @@ mod tests {
             observed_through_seq: None,
             source_location_id: None,
             publication_beat_id: String::new(),
+            planner_requested: false,
+            planner_candidates: Vec::new(),
         }
     }
 
@@ -70849,68 +70849,6 @@ mod tests {
         assert_eq!(resident.user_text, "What changed here?");
     }
     #[test]
-    fn resident_intent_json_parses_speech_and_taxonomy() {
-        let plan = resident_reply_test_plan(RATI_ACTOR_ID, "Rati", "prose");
-        let proposal = parse_resident_intent_json(
-            r#"{
-              "speech": "\"I will keep one stitch open for the room.\"",
-              "intent": "listen for the next room need",
-              "belief": "the cottage is waiting on a small kindness",
-              "desire": "find who needs Moonwool Thread",
-              "promise": "keep one stitch open",
-              "refusal": "do not pretend the button has already moved",
-              "proposed_action": {
-                "kind": "search",
-                "target_actor_id": null,
-                "item_id": 2002,
-                "destination_location_id": null,
-                "reason": "the scarf basket still has an unanswered clue"
-              }
-            }"#,
-            &plan,
-        )
-        .expect("structured resident intent parses");
-
-        assert_eq!(proposal.speech, "I will keep one stitch open for the room.");
-        assert_eq!(
-            proposal.intent.as_deref(),
-            Some("listen for the next room need")
-        );
-        assert_eq!(
-            proposal.belief.as_deref(),
-            Some("the cottage is waiting on a small kindness")
-        );
-        assert_eq!(
-            proposal.desire.as_deref(),
-            Some("find who needs Moonwool Thread")
-        );
-        assert_eq!(proposal.promise.as_deref(), Some("keep one stitch open"));
-        assert_eq!(
-            proposal.refusal.as_deref(),
-            Some("do not pretend the button has already moved")
-        );
-        let action = proposal
-            .proposed_action
-            .as_ref()
-            .expect("proposed action retained");
-        assert_eq!(action.kind, "search");
-        assert_eq!(action.item_id, Some(2002));
-    }
-
-    #[test]
-    fn resident_intent_json_rejects_wrappers_and_unknown_fields() {
-        let plan = resident_reply_test_plan(RATI_ACTOR_ID, "Rati", "prose");
-        let valid = r#"{"speech":"The teapot is wobbling.","intent":null,"belief":null,"desire":null,"promise":null,"refusal":null,"proposed_action":null}"#;
-        assert!(parse_resident_intent_json(valid, &plan).is_some());
-        assert!(parse_resident_intent_json(&format!("```json\n{valid}\n```"), &plan).is_none());
-        assert!(parse_resident_intent_json(
-            r#"{"speech":"The teapot is wobbling.","intent":null,"belief":null,"desire":null,"promise":null,"refusal":null,"proposed_action":null,"debug":"private"}"#,
-            &plan,
-        )
-        .is_none());
-    }
-
-    #[test]
     fn resident_intent_projection_records_typed_continuity_notes() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.resident_continuities.clear();
@@ -70924,10 +70862,9 @@ mod tests {
             refusal: Some("do not pretend the button has already moved".to_string()),
             proposed_action: Some(AvatarProposedAction {
                 kind: "search".to_string(),
-                target_actor_id: None,
                 item_id: Some(DEWBRIGHT_BUTTON_ITEM_ID),
-                destination_location_id: None,
                 reason: Some("the scarf basket still has an unanswered clue".to_string()),
+                ..AvatarProposedAction::default()
             }),
         };
         let content_id = runtime.next_content_id_value();

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -47846,6 +47846,16 @@ mod tests {
 
     #[test]
     fn generated_place_lifecycle_is_typed_causal_bounded_and_replayable() {
+        std::thread::Builder::new()
+            .name("generated-place-lifecycle".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(generated_place_lifecycle_is_typed_causal_bounded_and_replayable_inner)
+            .expect("generated-place lifecycle test thread starts")
+            .join()
+            .expect("generated-place lifecycle test thread completes");
+    }
+
+    fn generated_place_lifecycle_is_typed_causal_bounded_and_replayable_inner() {
         fn apply_pair(
             first: &mut RuntimeWorld,
             replay: &mut RuntimeWorld,

--- a/v2/orchestrator-rust/src/prompts.rs
+++ b/v2/orchestrator-rust/src/prompts.rs
@@ -69,6 +69,7 @@ impl From<VoiceRoutingError> for GeneratedSpeechError {
 pub(super) struct CertifiedAvatarIntent {
     pub(super) proposal: AvatarIntentProposal,
     pub(super) speech: CertifiedSpeech,
+    pub(super) planning: ResidentPlanningTrace,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -99,6 +100,10 @@ pub(super) struct AvatarReplyPlan {
     pub(super) source_location_id: Option<u64>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub(super) publication_beat_id: String,
+    #[serde(default)]
+    pub(super) planner_requested: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(super) planner_candidates: Vec<ResidentPlannerCandidate>,
 }
 
 impl AvatarReplyPlan {
@@ -110,6 +115,11 @@ impl AvatarReplyPlan {
             Some(observation.observed_through_seq),
             observation.source_location_id,
         );
+        self
+    }
+
+    pub(super) fn requesting_planner(mut self) -> Self {
+        self.planner_requested = true;
         self
     }
 
@@ -201,11 +211,23 @@ impl AvatarChatPlan {
 }
 
 pub(super) async fn avatar_reply_intent(
-    config: Option<&AiConfig>,
+    state: &AppState,
     plan: &AvatarReplyPlan,
 ) -> Result<CertifiedAvatarIntent, GeneratedSpeechError> {
-    let config = config.ok_or_else(|| AiGatewayError::unconfigured("avatar dialogue"))?;
-    request_ai_avatar_intent(config, plan).await
+    let config = state
+        .ai_config
+        .as_ref()
+        .as_ref()
+        .ok_or_else(|| AiGatewayError::unconfigured("avatar dialogue"))?;
+    request_ai_avatar_intent(
+        config,
+        state
+            .event_store_path
+            .as_deref()
+            .map(std::path::PathBuf::as_path),
+        plan,
+    )
+    .await
 }
 
 pub(super) async fn avatar_chat_text(
@@ -338,8 +360,16 @@ async fn request_ai_avatar_chat(
 
 pub(super) async fn request_ai_avatar_intent(
     config: &AiConfig,
+    store_path: Option<&Path>,
     plan: &AvatarReplyPlan,
 ) -> Result<CertifiedAvatarIntent, GeneratedSpeechError> {
+    let (planning, voice_action) = if !plan.planner_requested {
+        resident_disposition_for_voice(plan)
+    } else {
+        let planning = request_resident_plan(config, plan).await;
+        let voice_action = planning.proposed_action.clone();
+        (planning, voice_action)
+    };
     let system = resident_system_prompt(plan);
     let recent = if plan.recent_lines.is_empty() {
         "No recent room dialogue.".to_string()
@@ -354,8 +384,12 @@ pub(super) async fn request_ai_avatar_intent(
     let location_memory = format_location_memory(&plan.location_memory);
     let goals = format_goal_lines(&plan.goals);
     let resident_continuity = format_resident_continuity(&plan.resident_continuity);
+    let planning_brief = resident_voice_planning_brief(&ResidentPlanningResult {
+        proposed_action: voice_action,
+        trace: planning.trace.clone(),
+    });
     let user = format!(
-        "Location: {location} / {location_title}\nLocation description: {location_description}\nLocation persona: {location_persona}\nLocation memory:\n{location_memory}\nCurrent goals:\n{goals}\nSpeaker continuity:\n{resident_continuity}\nActor economy:\n{economy_note}\nCast present: {cast}\nRecent played cards and room log, oldest to newest:\n{recent_activity}\nRecent room lines:\n{recent}\nCard or direct event to respond to:\n{line}\nReply contract: react to what actually happened in this channel. Treat the room log and played cards as facts, with newer entries superseding older state. Answer the direct event first, then use at most one concrete detail from the recent context as a hook. If it names a concrete item or place, repeat that name so the conversation cannot silently change subjects.\nReturn valid JSON only with this shape:\n{{\"speech\":\"one visible reply from {name}\",\"intent\":\"what {name} is trying next, or null\",\"belief\":\"what {name} now believes, or null\",\"desire\":\"what {name} wants, or null\",\"promise\":\"what {name} commits to, or null\",\"refusal\":\"what {name} refuses, or null\",\"proposed_action\":{{\"kind\":\"wait|speak|move|pick_up|drop|give|trade|use|search|refuse\",\"target_actor_id\":null,\"item_id\":null,\"destination_location_id\":null,\"reason\":\"why this action follows\"}}}}\nUse null for unknown optional fields. The kernel has not accepted proposed_action yet, so do not claim it already happened.",
+        "Location: {location} / {location_title}\nLocation description: {location_description}\nLocation persona: {location_persona}\nLocation memory:\n{location_memory}\nCurrent goals:\n{goals}\nSpeaker continuity:\n{resident_continuity}\nActor economy:\n{economy_note}\nCast present: {cast}\nRecent played cards and room log, oldest to newest:\n{recent_activity}\nRecent room lines:\n{recent}\nCard or direct event to respond to:\n{line}\nPlanner brief: {planning_brief}\nReply contract: react to what actually happened in this channel. Treat the room log and played cards as facts, with newer entries superseding older state. Answer the direct event first, then use at most one concrete detail from the recent context as a hook. If it names a concrete item or place, repeat that name so the conversation cannot silently change subjects. Write only {name}'s visible spoken line. A proposed action is not committed; never claim its cost, success, outcome, or reward.",
         location = plan.location_name,
         location_title = plan.location_title,
         location_description = plan.location_description,
@@ -371,58 +405,114 @@ pub(super) async fn request_ai_avatar_intent(
         name = plan.speaker_name
     );
 
-    let response_format = serde_json::json!({ "type": "json_object" });
-    let mut rejections = Vec::new();
-    for candidate_round in 1..=2 {
-        let completion = match request_chat_completion(
-            config,
-            ChatCompletionRequest {
-                feature: "dialogue_resident",
-                prompt_version: "dialogue-resident-v1",
-                capability: ModelCapability::IntentJson,
-                system: &system,
-                user: &user,
-                temperature: 0.75,
-                max_tokens: 160,
-                timeout: Duration::from_secs(8),
-                max_attempts: 2,
-                referer: "http://127.0.0.1:3102",
-                response_format: Some(&response_format),
+    let speech = route_certified_voice(
+        config,
+        store_path,
+        VoiceAttemptRequest {
+            feature: "dialogue_resident",
+            prompt_version: "dialogue-resident-voice-v1",
+            system,
+            user,
+            temperature: 0.75,
+            max_tokens: 120,
+            referer: "http://127.0.0.1:3102",
+        },
+        resident_gate_context(plan, planning.proposed_action.is_some()),
+    )
+    .await?;
+    let proposal = AvatarIntentProposal {
+        speech: speech.text().to_string(),
+        intent: None,
+        belief: None,
+        desire: None,
+        promise: None,
+        refusal: None,
+        proposed_action: planning.proposed_action,
+    };
+    Ok(CertifiedAvatarIntent {
+        proposal,
+        speech,
+        planning: planning.trace,
+    })
+}
+
+fn resident_disposition_for_voice(
+    plan: &AvatarReplyPlan,
+) -> (ResidentPlanningResult, Option<AvatarProposedAction>) {
+    let disposition = plan
+        .resident_continuity
+        .last_planning_disposition
+        .clone()
+        .filter(|disposition| {
+            matches!(
+                disposition.trace.status,
+                ResidentPlanningStatus::Committed
+                    | ResidentPlanningStatus::Rejected
+                    | ResidentPlanningStatus::Superseded
+            )
+        });
+    match disposition {
+        Some(disposition) => (
+            ResidentPlanningResult {
+                proposed_action: None,
+                trace: disposition.trace,
             },
-        )
-        .await
-        {
-            Ok(completion) => completion,
-            Err(error) if rejections.is_empty() => return Err(error.into()),
-            Err(_) => return Err(GeneratedSpeechError::Rejected(rejections)),
-        };
-        let mut proposal = match parse_resident_intent_json(&completion.text, plan) {
-            Some(proposal) => proposal,
-            None => {
-                let mut context = resident_gate_context(plan, false);
-                context.envelope_valid = false;
-                context.candidate_round = candidate_round;
-                match certify_speech(Some(config), completion, "", context) {
-                    Err(rejection) => {
-                        rejections.push(*rejection);
-                        continue;
-                    }
-                    Ok(_) => unreachable!("an invalid envelope cannot certify"),
-                }
-            }
-        };
-        let mut context = resident_gate_context(plan, proposal.proposed_action.is_some());
-        context.candidate_round = candidate_round;
-        match certify_speech(Some(config), completion, &proposal.speech, context) {
-            Ok(speech) => {
-                let speech = speech.with_prior_rejections(rejections);
-                proposal.speech = speech.text().to_string();
-                return Ok(CertifiedAvatarIntent { proposal, speech });
-            }
-            Err(rejection) => rejections.push(*rejection),
-        }
+            disposition.proposed_action,
+        ),
+        None => (
+            ResidentPlanningResult {
+                proposed_action: None,
+                trace: ResidentPlanningTrace::absent(plan),
+            },
+            None,
+        ),
     }
-    Err(GeneratedSpeechError::Rejected(rejections))
+}
+
+pub(super) fn resident_voice_planning_brief(planning: &ResidentPlanningResult) -> String {
+    match (planning.trace.status, planning.proposed_action.as_ref()) {
+        (ResidentPlanningStatus::Proposed, Some(action)) => format!(
+            "status=proposed; {}; speech_act={}. This is not committed.",
+            resident_voice_action_brief(action),
+            action
+                .speech_act
+                .map(ResidentSpeechAct::as_str)
+                .unwrap_or("inform")
+        ),
+        (ResidentPlanningStatus::Rejected, _) => {
+            "status=rejected. No action was accepted; speak or wait safely.".to_string()
+        }
+        (ResidentPlanningStatus::Superseded, _) => {
+            "status=superseded. A newer decision replaced this plan; do not claim it happened."
+                .to_string()
+        }
+        (ResidentPlanningStatus::Accepted, Some(action)) => format!(
+            "status=accepted; {}. The kernel has not committed an outcome.",
+            resident_voice_action_brief(action)
+        ),
+        (ResidentPlanningStatus::Committed, Some(action)) => format!(
+            "status=committed; {}. Mention only the recorded public outcome.",
+            resident_voice_action_brief(action)
+        ),
+        _ => "status=absent. No action was proposed; this is speech only.".to_string(),
+    }
+}
+
+fn resident_voice_action_brief(action: &AvatarProposedAction) -> String {
+    let mut fields = vec![format!("kind={}", action.kind)];
+    if let Some(target_actor_id) = action.target_actor_id {
+        fields.push(format!("target_actor_id={target_actor_id}"));
+    }
+    if let Some(item_id) = action.item_id {
+        fields.push(format!("item_id={item_id}"));
+    }
+    if let Some(target_item_id) = action.target_item_id {
+        fields.push(format!("target_item_id={target_item_id}"));
+    }
+    if let Some(destination_location_id) = action.destination_location_id {
+        fields.push(format!("destination_location_id={destination_location_id}"));
+    }
+    fields.join("; ")
 }
 
 fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGateContext {
@@ -523,7 +613,7 @@ fn format_location_memory(memory: &[String]) -> String {
         .join("\n")
 }
 
-fn format_goal_lines(goals: &[String]) -> String {
+pub(super) fn format_goal_lines(goals: &[String]) -> String {
     if goals.is_empty() {
         return "No active player-facing goal is currently highlighted.".to_string();
     }
@@ -616,7 +706,7 @@ pub(super) fn format_resident_continuity(continuity: &ResidentContinuityState) -
 }
 
 pub(super) fn resident_system_prompt(plan: &AvatarReplyPlan) -> String {
-    let base = "Return valid JSON only. Never mention AI, models, prompts, policies, tools, or system instructions. Do not speak for other avatars. Treat speaker continuity as this avatar's durable perspective, while the room/kernel facts remain authoritative. The speech field is the only visible room line. Typed intent fields update continuity only after the kernel accepts the speech event. Comedy rules: ground every line in one physical action, prop, or bodily complaint from the room. Punchlines over poetry. Cheeky teasing and light flirting are welcome; keep it playful, never cruel or explicit. Never use the words whisper, eternal, void, abyss, veil, hush, sacred, vow, moonlit, or objects that remember things. If in doubt, be funnier and more specific.";
+    let base = "Write only the visible spoken line, never JSON or metadata. Never mention AI, models, prompts, policies, tools, or system instructions. Do not speak for other avatars. Treat speaker continuity as this avatar's durable perspective, while the room/kernel facts remain authoritative. A planner brief describes only proposal status: never change its action or claim an uncommitted cost, success, outcome, or reward. Comedy rules: ground every line in one physical action, prop, or bodily complaint from the room. Punchlines over poetry. Cheeky teasing and light flirting are welcome; keep it playful, never cruel or explicit. Never use the words whisper, eternal, void, abyss, veil, hush, sacred, vow, moonlit, or objects that remember things. If in doubt, be funnier and more specific.";
     if plan.economy_note == DIRECTLY_CONTROLLED_SELF_REACTION_CONTEXT {
         return format!(
             "You are {}, the acting avatar in CosyWorld. Speak briefly on behalf of its direct controller in first person, reacting to the concrete outcome of the action just chosen. Do not narrate rules, claim private controller thoughts, or invent another action. Keep it under 34 words. {base}",
@@ -631,37 +721,37 @@ pub(super) fn resident_system_prompt(plan: &AvatarReplyPlan) -> String {
     }
     match plan.speaker_actor_id {
         1001 => format!(
-            "You are Rati, the cottage's brisk landlady mouse. The speech field must be first person: bossy, mothering, armed with knitting needles and opinions about boots. One concrete room prop per line. Under 40 words. {base}"
+            "You are Rati, the cottage's brisk landlady mouse. Speak in first person: bossy, mothering, armed with knitting needles and opinions about boots. One concrete room prop per line. Under 40 words. {base}"
         ),
         1002 => format!(
-            "You are Gust, a weather gremlin. The speech field must contain only 3 to 6 emoji used as a punchline or heckle reacting to what just happened: no letters, no words, no markdown, no explanation. {base}"
+            "You are Gust, a weather gremlin. Return only 3 to 6 emoji used as a punchline or heckle reacting to what just happened: no letters, no words, no markdown, no explanation. {base}"
         ),
         1003 => format!(
-            "You are Skull, the deadpan wolf and the room's straight man. The speech field must be exactly one third-person emote wrapped in asterisks: minimal reaction to maximum chaos, no quoted speech, no inner monologue, no gore. {base}"
+            "You are Skull, the deadpan wolf and the room's straight man. Return exactly one third-person emote wrapped in asterisks: minimal reaction to maximum chaos, no quoted speech, no inner monologue, no gore. {base}"
         ),
         1005 => format!(
-            "You are Oak, the Old Oak Tree in the Lonely Forest. The speech field answers through four short voices that bicker like a family radio show: Root is stubborn, Ring cites ancient precedent, Leaf is distractible, Hollow repeats secrets it should not. Keep speech under 60 words. {base}"
+            "You are Oak, the Old Oak Tree in the Lonely Forest. Answer through four short voices that bicker like a family radio show: Root is stubborn, Ring cites ancient precedent, Leaf is distractible, Hollow repeats secrets it should not. Keep speech under 60 words. {base}"
         ),
         1051 => format!(
-            "You are Euphemie, a mansion ghost mostly annoyed that nobody dusts. The speech field should be brief and practical; her warnings are about stairs and drafts, not fate. Short authentic Haitian Creole fragments welcome; never invent parody dialect or fake broken Creole. Under 40 words. {base}"
+            "You are Euphemie, a mansion ghost mostly annoyed that nobody dusts. Be brief and practical; her warnings are about stairs and drafts, not fate. Short authentic Haitian Creole fragments welcome; never invent parody dialect or fake broken Creole. Under 40 words. {base}"
         ),
         1056 => format!(
-            "You are Chamuel, Lord Samael's fussy, immaculate page. The speech field must be first person: precise, accidentally flirty, correcting people mid-crisis and defending your filing system with your life. Under 45 words. {base}"
+            "You are Chamuel, Lord Samael's fussy, immaculate page. Speak in first person: precise, accidentally flirty, correcting people mid-crisis and defending your filing system with your life. Under 45 words. {base}"
         ),
         1066 => format!(
-            "You are Azazoth, a many-tentacled deep-sea god who hosts a feast nobody attends and takes the leftovers personally. The speech field must be first person: grand appetites, wounded pride, at least one tentacle doing something undignified. Under 45 words. {base}"
+            "You are Azazoth, a many-tentacled deep-sea god who hosts a feast nobody attends and takes the leftovers personally. Speak in first person: grand appetites, wounded pride, at least one tentacle doing something undignified. Under 45 words. {base}"
         ),
         1067 => format!(
-            "You are Zadkiel, a dark angel of tremendous formality forging dramatic pronouncements nobody asked for. The speech field must be first person: formal delivery constantly undercut by anvil logistics and whether anyone was watching. Under 45 words. {base}"
+            "You are Zadkiel, a dark angel of tremendous formality forging dramatic pronouncements nobody asked for. Speak in first person: formal delivery constantly undercut by anvil logistics and whether anyone was watching. Under 45 words. {base}"
         ),
         1068 => format!(
-            "You are Badger, grumpy landlord of the lower burrow. The speech field must be first person: gruff, economical, complaining about the immediate physical mess, helping anyway and furious about it. Under 40 words. {base}"
+            "You are Badger, grumpy landlord of the lower burrow. Speak in first person: gruff, economical, complaining about the immediate physical mess, helping anyway and furious about it. Under 40 words. {base}"
         ),
         1069 => format!(
-            "You are Toad, a reckless stunt toad with zero completed jumps. The speech field must be first person: breathless, already mid-jump, announcing stunts nobody asked for and treating applause as medical care. Under 40 words. {base}"
+            "You are Toad, a reckless stunt toad with zero completed jumps. Speak in first person: breathless, already mid-jump, announcing stunts nobody asked for and treating applause as medical care. Under 40 words. {base}"
         ),
         _ => format!(
-            "You are {} in CosyWorld, a grounded physical-comedy village. Keep the speech field concise, concrete, and cheeky. {base}",
+            "You are {} in CosyWorld, a grounded physical-comedy village. Keep the line concise, concrete, and cheeky. {base}",
             plan.speaker_name
         ),
     }
@@ -715,12 +805,68 @@ mod publication_tests {
         assert_eq!(inference.generation_key, "resident-event-73");
     }
 
-    #[tokio::test]
-    async fn unavailable_provider_yields_no_certified_character_speech() {
+    #[test]
+    fn direct_proxy_and_conversation_only_reply_skip_the_planner() {
+        let (_, mut reply) = seeded_plans();
+        reply.economy_note = DIRECTLY_CONTROLLED_REACTION_CONTEXT.to_string();
+        let absent = ResidentPlanningResult {
+            proposed_action: None,
+            trace: ResidentPlanningTrace::absent(&reply),
+        };
+        assert_eq!(
+            resident_voice_planning_brief(&absent),
+            "status=absent. No action was proposed; this is speech only."
+        );
+        assert!(!reply.planner_requested);
+        assert!(reply.planner_candidates.is_empty());
+    }
+
+    #[test]
+    fn voice_brief_distinguishes_proposed_from_committed_action() {
         let (_, reply) = seeded_plans();
-        assert!(matches!(
-            avatar_reply_intent(None, &reply).await,
-            Err(GeneratedSpeechError::Gateway(_))
-        ));
+        let action = AvatarProposedAction {
+            kind: "move".to_string(),
+            ..AvatarProposedAction::default()
+        };
+        let mut planning = ResidentPlanningResult {
+            proposed_action: Some(action),
+            trace: ResidentPlanningTrace::absent(&reply),
+        };
+        planning.trace.status = ResidentPlanningStatus::Proposed;
+        let proposed = resident_voice_planning_brief(&planning);
+        assert!(proposed.contains("status=proposed"));
+        assert!(proposed.contains("not committed"));
+
+        planning.trace.status = ResidentPlanningStatus::Committed;
+        let committed = resident_voice_planning_brief(&planning);
+        assert!(committed.contains("status=committed"));
+        assert!(committed.contains("recorded public outcome"));
+    }
+
+    #[test]
+    fn committed_disposition_is_voice_context_not_a_new_proposal() {
+        let (_, mut reply) = seeded_plans();
+        let action = AvatarProposedAction {
+            kind: "move".to_string(),
+            destination_location_id: Some(MOONLIT_TRAIL_LOCATION_ID),
+            planning_generation_id: Some("resident-plan:committed".to_string()),
+            ..AvatarProposedAction::default()
+        };
+        let mut trace = ResidentPlanningTrace::absent(&reply);
+        trace.generation_id = "resident-plan:committed".to_string();
+        trace.status = ResidentPlanningStatus::Committed;
+        reply.resident_continuity.last_planning_disposition = Some(ResidentPlanningDisposition {
+            trace,
+            proposed_action: Some(action),
+        });
+
+        let (planning, voice_action) = resident_disposition_for_voice(&reply);
+        assert_eq!(planning.trace.status, ResidentPlanningStatus::Committed);
+        assert!(planning.proposed_action.is_none());
+        assert!(resident_voice_planning_brief(&ResidentPlanningResult {
+            proposed_action: voice_action,
+            trace: planning.trace,
+        })
+        .contains("status=committed"));
     }
 }

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74553
+74490

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,3 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-74490
+74500


### PR DESCRIPTION
## Summary
- split resident public voice realization from one-shot bounded intent planning
- validate exact frozen candidates and preserve durable accepted/committed/rejected/superseded lifecycle links
- keep private planner rationale trace-only while the kernel remains the sole mutation authority
- exclude exchange-required pickups and explicitly declare the current closed planner eligibility policy
- isolate the inherited oversized generated-place replay test on a named 16 MiB thread for Linux CI

## Validation
- `RUST_MIN_STACK=33554432 npm run v2:rust:test` — 608 passed
- `cargo test ai_resident_planning -- --nocapture` — 12 passed
- `cargo test generated_place_lifecycle_is_typed_causal_bounded_and_replayable` — 1 passed on default stack
- `cargo test prompts::publication_tests -- --nocapture` — 5 passed
- `npm run v2:architecture` — main.rs 74500/74500, clippy 246/246
- `npm run v2:syntax`
- `npm run check:version`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #392