### PR TITLE
Choose deterministic redeal for the action hand

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,6 +1,6 @@
 # CosyWorld Product Requirements
 
-Last major revision: 2026-07-19. This document replaces the CosyWorld 2.0 PRD, which was written for the original one-room, Chat-only MVP and survived as a stack of amendments. The world it described has shipped and grown past it; this document sets direction from where the product actually is — including the turn system, resident autonomy, and the card-composed world.
+Last major revision: 2026-07-27. This document replaces the CosyWorld 2.0 PRD, which was written for the original one-room, Chat-only MVP and survived as a stack of amendments. The world it described has shipped and grown past it; this document sets direction from where the product actually is — including the turn system, resident autonomy, and the card-composed world.
 
 Companion documents:
 
@@ -24,7 +24,7 @@ CosyWorld V2 is a playable, production-deployable game, live-tested with simulta
 
 - CosyWorld Core (free) and the Ruby High: First Bell expansion (card-gated), with compiled cards and complete room sheets validated by the content gate. Release counts are generated from the compiled worldpack rather than maintained in this prose.
 - The full verb surface: advancement-backed Chat (begin a friendship), moderated typed `say` and `/me`, Listen, Travel, Take, Drop, Give, Use, Trade, Prepare, Rest, Work, Help, Attack, Defend, Flee, plus Calling/Bond/skill/growth actions.
-- The card-hand control surface: dealt action cards with art and labels, a detail/confirm surface, and shuffle — play feels like turns, not clicking.
+- The card-hand control surface: two dealt action cards with art and labels, a detail/confirm surface, and a free deterministic redeal — play feels like turns, not clicking.
 - Room turn-taking for co-present humans, with ping/pong pacing: waiting players can ping the current player; unresponsive players are skipped, not waited on.
 - Resident autonomy on played time: residents wander, remember, and hunt the items they desire — a resident reclaiming her own lost keepsake is now an observed, emergent story beat.
 - The RPG retention layer: Callings, first-class Bonds, sanctuary/frontier zoning, progress and danger clocks, seeded Jobs and Fronts, factions, the Visit Ledger with growth banking into skill steps and bond slots — all rendered in the shared transcript (arrivals, callings, clues, dice, growth).
@@ -42,7 +42,7 @@ Every feature must serve at least one of these; a feature that serves none does 
 2. **Cozy by guarantee, stakes by consent.** The home and sanctuary rooms never decay, never see combat, and never advance while nobody is playing. Danger, player-powered clocks, and loss exist only on the frontier — where the player chose to walk.
 3. **The world runs on played time.** World time advances only through committed player turns — never on a wall clock. A quiet world is still, not rotting; a busy world is alive because people are in it. "The world moved while you were away" is always true in a populated shard, and it always means other players moved it.
 4. **Identity through play.** A player should be able to say "I am the kind soul who ___, my home is ___, and I am slowly ___" after ten minutes. Callings, Bonds, and the Journal make that sentence mechanical and publicly remembered.
-5. **One meaningful action hand.** The resting UI is a dealt hand of at most three labeled action cards plus shuffle — one surface, server-derived from the player's cards, location cards, visible world state, and base rules. Each card shows its target, cost, and risk before commit. Playing a card is a turn. Speech (`say`, `/me`) is always available and never consumes a turn. The small action hand is a focus mechanism, not an inventory limit.
+5. **One meaningful action hand.** The resting UI is two labeled action cards plus a free redeal — one surface, server-derived from the player's cards, location cards, visible world state, and base rules. Redeal deterministically pages through the remaining legal offers before cycling; it never changes legality, rank, cost, or outcome. Each card shows its target, cost, and risk before commit. Playing a card is a turn; redealing and speech (`say`, `/me`) are turn-exempt. The small action hand is a focus mechanism, not an inventory limit, and there is no parallel **More Actions** list.
 6. **AI is a world actor, not the product.** AI proposes narration, resident speech, and media; the kernel decides truth. Core world actions remain playable without inference. Dialogue is never fabricated from canned text: an explicit dialogue action fails visibly and without charge when inference is unavailable, while incidental resident speech is skipped.
 7. **Progression is earned, never bought.** Orbs buy only shared images — never Chat, power, access, success, or growth. Every ordinary world verb has a zero-Orb path.
 8. **Ownership without a token.** The target ownership layer is CosyWorld's own signed provenance log (Ed25519, content-addressed, append-only) — gifting free and first-class, trading world-bound and lineage-preserving, secret poems as commit-reveal claim tickets. External NFTs remain an optional bridge that gates official expansions, never the base game.
@@ -67,7 +67,7 @@ Two rules follow.
 
 Everything else is *fiction, not vocabulary*: a clock is "the trail feels safer lately," a job is "someone needs help," a front is weather and trouble, a faction is who a character stands with. System names (clock, front, claim key, projection, sanctuary/frontier) never appear in the player UI. A new feature must fit an existing noun or replace one — the budget does not grow by default.
 
-**Rule 2 — the action hand is the controller.** The shipped control surface is a dealt hand of action cards: at most three labeled cards plus shuffle, each opening a card-art detail surface that names target, cost, and risk before commit. It is a projection of a deeper card composition, not the ownership ledger or the player's physical inventory. This won over both the bare one-button rail and the unlabeled-emoji experiment because it makes each turn a readable, deliberate choice. The same contract projects onto every future transport: cards become Discord reactions, terminal keys, or voice intents without new server concepts — the v1 emoji grammar remains the prior art for the Discord revival. Three laws hold regardless of transport: every card carries a visible label (never a bare glyph), browsing the hand is free, and every legal core action remains reachable even when it is not among the three suggestions.
+**Rule 2 — the action hand is the controller.** The shipped control surface is a dealt hand of two labeled action cards plus a free redeal, each card opening a detail surface that names target, cost, and risk before commit. Redeal replaces the visible pair with the next pair from the finite, authoritative offer order, excluding already shown offers until that pool is exhausted and then cycling. It is browsing, not a random draw: it cannot change legality or silently re-rank the opening hand. This one surface won over the bare one-button rail, the unlabeled-emoji experiment, and a parallel grouped **More Actions** list because it keeps the controls small while making each turn readable and deliberate. The same contract projects onto every future transport: cards become Discord reactions, terminal keys, or voice intents without new server concepts — the v1 emoji grammar remains the prior art for the Discord revival. Three laws hold regardless of transport: every card carries a visible label (never a bare glyph), browsing/redeal is free, and every legal core action is reachable through finite deterministic redeals even when it is not in the opening pair.
 
 ## The Card-Composed World
 
@@ -125,7 +125,7 @@ The loop exists and multiplayer works; the priority is making the world worth re
 ### P0 — product law (held today; regressions are release blockers)
 
 - A human must create an avatar before acting; returning players recover their avatar (local session or signed wallet) instead of duplicating people.
-- The resting UI is one dealt hand: at most three labeled action cards plus shuffle, server-derived; no permanent composer, send button, or navigation sidebar. Browsing is free; playing spends a turn.
+- The resting UI is one dealt hand: two labeled action cards plus a free deterministic redeal, server-derived; no permanent composer, **More Actions** list, send button, or navigation sidebar. Redealing is free; playing spends a turn.
 - All world mutation resolves through the C kernel; AI and clients never decide outcomes, rewards, access, or affordability.
 - World time advances only through committed player turns; nothing mutates on a wall clock.
 - Every player-visible AI output is a shared room event; there are no private resident conversations.
@@ -195,7 +195,7 @@ Economy health:
 ## Risks
 
 - **Card-zone ambiguity creates duplicate authority.** Collection ownership, world possession, carried cards, equipped cards, spell preparation, and the action hand must never collapse into one field or be inferred from the browser. Migrate each legacy field through a versioned boundary and reject ambiguous state rather than guessing.
-- **Scene composition can become illegible.** The underlying merge may be deep while the resting surface stays small. Keep the three-card action hand, make precedence inspectable, and test that a legal core action remains reachable even when it is not suggested.
+- **Scene composition can become illegible.** The underlying merge may be deep while the resting surface stays small. Keep the two-card action hand, make precedence inspectable, and test that every legal core action is reachable through the deterministic redeal cycle even when it is not initially suggested.
 - **Retention layer under-delivers.** If Journal marks feel like chores, the whole Now bet fails. Keep marks tied to genuinely novel events (truths, bonds, frontier returns, witnessed moments), never grind.
 - **Crafting opens a generative moderation surface.** AI-decorated names/blurbs on player-triggered mints must pass the same sanitizer as speech, with authored fallbacks — and recipe outputs must never be kernel-arbitrary.
 - **Moderation debt blocks launch.** One shared world with open traffic and thin filtering is an incident, not a risk. Public-traffic moderation is a P1 gate.

--- a/docs/backlog/action-verbs-and-economy.md
+++ b/docs/backlog/action-verbs-and-economy.md
@@ -1,0 +1,642 @@
+# Action Verbs And Economy — Backlog
+
+**Epic**: Make every playable choice concrete, correctly costed, reachable,
+and semantically identical across the browser, terminal, API, replay, and
+inference-controlled avatars.
+
+**Status**: Groomed, not estimated (2026-07-26). This is follow-on product work
+after the implemented `cosyworld.srd5/1` action-card foundation. It does not
+authorize or imply full SRD 5.2.1 compatibility.
+
+**Related architecture**:
+
+- [SRD-Backed Action and Collectible System](../systems/04-action-system.md)
+- [CosyWorld RPG System Bible](../systems/09-cosyworld-rpg-system.md)
+- Generated-place lifecycle contract (dedicated document pending)
+- [ADR-001: SRD 5.2.1 Action-Card Profile](../decisions/001-srd-action-card-profile.md)
+- [ADR 0002: the action hand is authoritative state](../decisions/0002-action-hand-is-authoritative-state.md)
+
+The current rules substrate is sounder than its vocabulary. Stable rule
+bindings, targets, resolvers, traces, and stale-offer rejection exist, but
+several player-facing choices still describe lifecycle state or implementation
+requirements instead of a thing the avatar can intentionally do. User-observed
+copy such as **“anchor a lasting fixture”** belongs to the same family as the
+runtime's “install a durable anchor,” “answer the place's current need,” and
+“mature this discovered place.” These phrases are mechanically meaningful to
+the engine and vague to a player.
+
+This backlog also resolves the action-economy ambiguity around the ordinary
+two-card hand, world turns, combat Tempo, progression spends, and actions that
+are legal but not currently dealt.
+
+---
+
+## Product Decisions Proposed By This Backlog
+
+Except for item 1, these are recommendations until AVE-0 records the final
+decision. #354 and ADR 0002 settle item 1 now:
+
+1. The ordinary two-card hand is a **spotlight over the legal action set**, not
+   the sole source of legality. Free deterministic redeal pages every other
+   currently legal choice without currency, command knowledge, or draw luck.
+   The proposed grouped **More Actions** surface is explicitly closed.
+2. Every offer declares its action economy explicitly. Labels and action kinds
+   never imply whether something consumes a world turn, Tempo, advancement, or
+   an item use.
+3. Ordinary state-changing world actions consume one world turn. Read-only
+   inspection is free. Personal loadout and progression maintenance is free in
+   sanctuary and either unavailable or explicitly Tempo-costed during danger.
+4. Combat uses a small two-Tempo economy. Movement and setup may leave one
+   Tempo; Attack, Dodge, Ready, Dash, and Flee commit all remaining Tempo.
+5. A player-facing title follows **concrete verb + concrete target**. Internal
+   lifecycle words such as Anchored, Connected, claim, trace, typed output, or
+   resolver never serve as the only explanation.
+6. Dash, Disengage, and Hide land only with the movement, engagement,
+   visibility, and replay state that makes them real. Adding names to the
+   registry or browser is not implementation.
+
+---
+
+## Acceptance Principles
+
+Every ticket in this epic must preserve these constraints:
+
+1. The same canonical action or operation has the same meaning in every
+   transport. Friendly pack vocabulary may reskin it without changing the
+   target, cost, effect, timing, or resolver.
+2. Every state-changing action exposes:
+   - a concrete verb;
+   - a concrete target or object;
+   - structured requirements;
+   - world-turn, Tempo, progression, and item-use costs;
+   - immediate effect;
+   - important follow-on unlock or consequence; and
+   - a useful disabled reason when unavailable.
+3. A scene card is never an invitation to satisfy hidden validation logic.
+   If the engine requires a particular item, recipe, origin, destination,
+   second participant, or action class, the player can see that requirement.
+4. Informational needs and executable actions are different UI objects. When
+   there is no eligible recipe, item, target, or strategy, show a need—not an
+   active generic button.
+5. AI may decorate an approved noun or sentence shape. It never decides what
+   qualifies, what an action costs, or what state transition occurs.
+6. The C kernel or a narrowly validated journaled reducer remains
+   authoritative. Copy improvements never move resolution into the client.
+7. Old action and event meanings remain replay-readable. A changed economy or
+   tactical contract receives a new versioned identity.
+8. Orbs never buy an ordinary verb, turn, Tempo, success, progression, or
+   better outcome.
+
+---
+
+## Current Confusion Inventory
+
+| Current or observed copy | Hidden mechanical meaning | Why it is confusing | Target direction |
+| --- | --- | --- | --- |
+| Anchor a lasting fixture | Craft a typed durable item at this generated location | No item, recipe, location, cost, or immediate result | **Build a mossglass waymarker at Alder Hollow** |
+| Install a durable anchor | Produce `place.anchor.created` and advance Discovered to Anchored | “Anchor” is both a verb and lifecycle noun; “durable” is an invisible predicate | **Install the Mothglass Lantern here** |
+| Answer the place's current need | Select any contribution that may qualify for the current maturity stage | It names neither the need nor an executable approach | Stage-specific Build, Deliver, or Welcome action |
+| Mature this discovered place | Advance the aggregate place maturity clock | Describes system state rather than player intent | **Make Alder Hollow a safe stopping place** |
+| Unanswered local needs | Generated-place danger clock | No threatened fiction or fill consequence | **The path is washing away** plus the consequence |
+| Physically deliver the declared needed supplies | Prove actor-causal pickup, continuous carrying, and delivery | “Physically” and “declared” expose validation language; the item and route are absent | **Carry bridge rope from Rain-Soft Garden to Alder Hollow** |
+| Build familiarity through distinct visits, contributions, and traces | Meet settlement claim diversity and participant thresholds | “Distinct,” “contribution,” and “trace” are audit vocabulary | **Help more travelers use and care for this place**, with visible progress |
+| Contribute / Push / Pitch in / Take point | Advance a project through Study, Utilize, Help, or another strategy | The approach, object, and likely result are hidden | **Repair the bell frame** / **Help Rowan fit the lens** |
+| Chat | Spend advancement to create a new Bond | Players expect ordinary conversation, not a progression purchase | **Begin a friendship with Rati** |
+| Remember | Resolve an active Bond | It does not disclose that the active Bond ends | **Close this chapter with Rati**, with an explicit consequence |
+| Make room for Watch Bell | Spend advancement to unlock a bracelet slot | It may sound like equipping or granting the charm | **Add a bracelet slot for Watch Bell** |
+| Prepare | Create a scoped, consumable project setup | It does not name what is prepared or what consumes it | **Lay out the repair tools** / **Brace the lantern frame** |
+| Inspect | Study in product copy; Look in the terminal alias table | The same word invokes different domains | Reserve Inspect for analytical Study; use Look for read-only examination |
+| Help | SRD Help in product copy; command help in the terminal | The same word is both gameplay and interface | Gameplay keeps Help; terminal documentation becomes Commands or `?` |
+| Defend / Dodge | One current combat action under two primary names | Players cannot form a stable combat vocabulary | Dodge is canonical; Defend remains an input-only compatibility alias |
+
+---
+
+## AVE-0 — Establish A Green, Truthful Baseline
+
+**Priority**: P0 (blocks action-economy and vocabulary changes)
+**Scope**: Decision records, runtime/docs alignment, action-focused tests
+**Depends on**: nothing
+
+### What to do
+
+- Record the current runtime contract before changing it: two ordinary hand
+  entries, up to five current combat choices, a complete server-side legal
+  offer set, and structured non-browser access.
+- Consume ADR 0002's settled spotlight + deterministic redeal model. Do not
+  reopen the rejected **More Actions** list or leave “hard two-card gate” and
+  “all legal actions remain reachable” simultaneously normative.
+- Resolve current three-versus-five combat-hand documentation drift.
+- Keep Say and shuffle/redeal as supported turn-exempt inputs, then update tests
+  and help copy to match.
+- Align package and Rust crate versions.
+- Triage the existing Rust failures into:
+  - restricted-environment listener tests;
+  - obsolete expectations after an accepted product change; and
+  - real action, clock, inventory, evolution, or combat regressions.
+- Keep unrelated failing infrastructure tests visible, but define a green,
+  action-focused gate that this epic cannot regress.
+
+### Acceptance
+
+- The ADRs, RPG Bible, action-system document, browser copy, and runtime agree
+  on ordinary and combat hand capacity and browser reachability.
+- Tests continue to require supported Say and shuffle/redeal. No test expects a
+  retired Defend, Grow, or legacy skill action unless it is explicitly a
+  compatibility test.
+- `npm run v2:worldpack:inspect` and `npm run v2:kernel` pass.
+- The action-offer, Search/Study, Influence, project Help/Prepare/Work, bounded
+  Magic, item Utilize, combat action-hand, and golden SRD replay tests pass.
+- Restricted listener tests are reported separately from semantic failures;
+  they do not conceal a red action baseline.
+
+---
+
+## AVE-1 — Canonicalize The Player Verb Lexicon
+
+**Priority**: P0
+**Scope**: Rules registry, operation bindings, pack vocabulary, browser, terminal
+**Depends on**: AVE-0
+
+### What to do
+
+- Adopt one canonical player meaning for each core word:
+  - Notice → perceptual Search;
+  - Inspect → analytical Study;
+  - Use → Utilize;
+  - Cast → Magic;
+  - Help → the Help action;
+  - Dodge → the current avoidance action;
+  - Prepare → current scoped project setup;
+  - Ready → future explicit trigger and response;
+  - Flee → current Escape operation;
+  - Disengage → future avoidance of engagement consequences;
+  - Chat/Befriend → decide whether the player-facing promise is conversation
+    or creating a Bond, and name it truthfully.
+- Move terminal documentation from `help` to `commands` and/or `?`, leaving
+  Help available as a gameplay verb.
+- Make Look the read-only examination verb and Inspect the Study-bound action.
+- Retain old words as input-only compatibility aliases where replay or muscle
+  memory warrants it. Do not render two primary names for one mechanic.
+- Generate aliases and help output from the same registry consumed by action
+  offers instead of maintaining a parallel semantic switch.
+- Require every pack reskin to preserve a visible or inspectable canonical
+  action identity.
+
+### Acceptance
+
+- Typing and clicking the same word resolve to the same action domain.
+- `inspect <target>` never silently performs free Look while an Inspect card
+  resolves Study.
+- `help <target/project>` performs gameplay Help; `commands` or `?` opens help.
+- New combat offers say Dodge. Historical Defend commands and journals remain
+  compatible without rendering Defend as a second action.
+- A vocabulary parity test covers browser label, accessible label, terminal
+  command, API binding, and inspector identity for every supported action.
+
+---
+
+## AVE-2 — Make Action Economy Explicit In Every Offer
+
+**Priority**: P0
+**Scope**: Action-offer schema, submission receipts, turns, inspector, clients
+**Depends on**: AVE-0, AVE-1
+
+### What to do
+
+- Replace action-kind inference with an explicit economy block, versioned with
+  the offer contract. At minimum it declares:
+  - `world_turn`: `consume` or `exempt`;
+  - `tempo`: integer combat cost or absent outside combat;
+  - `ends_turn`;
+  - advancement cost;
+  - item instance and use/charge cost; and
+  - any other allowed non-Orb resource cost.
+- Record the resolved economy in the committed receipt so replay does not
+  depend on today's kind table.
+- Adopt and test the default taxonomy:
+
+| Activity | Default economy |
+| --- | --- |
+| Look, UI inspection, inventory, accessibility, report | World-turn exempt |
+| Calling/Bond wording, bracelet/loadout maintenance | Exempt in sanctuary; unavailable or explicitly Tempo-costed during danger |
+| Travel, Search, Study, Influence, relationship-forming Chat | One world turn |
+| Take, Drop, Give, Trade, Steal, Use, Craft | One world turn |
+| Prepare, project Work, Help, Rest | One world turn |
+| Combat | Explicit Tempo under the active combat protocol |
+
+- Make disabled reasons distinguish “not legal,” “legal but unaffordable,”
+  “wrong phase/turn,” and “stale; refresh.”
+- Continue to expose `risk` and `effect`; neither substitutes for cost.
+
+### Acceptance
+
+- A reviewer can determine whether an offer consumes time or resources without
+  reading its kind or resolver implementation.
+- Browser, terminal, API, and inferred submissions commit identical costs.
+- A stale or tampered economy block causes no partial mutation.
+- Turn-exempt actions cannot accidentally advance clocks, fronts, encounter
+  order, resident heartbeats, or world simulation.
+- No ordinary action economy field permits an Orb cost.
+- Golden replay preserves the economy version and committed turn effect.
+
+---
+
+## AVE-3 — Make The Two-Card Hand And Redeal Complete
+
+**Priority**: P0 product decision resolved by #354; P1 implementation
+**Scope**: Browser action surface, action-hand ADR, accessibility, analytics
+**Depends on**: AVE-0, AVE-2
+
+### What to do
+
+- Keep two authoritative spotlight actions in ordinary scenes.
+- Keep one compact free **redeal** affordance that replaces the visible pair
+  with the next pair in the finite server-authored legal-offer order.
+- Exclude already shown offers until the current pool is exhausted, allow a
+  final one-card page, then cycle back to the authoritative opening pair.
+- Keep `hand.shuffled` as the journal record and preserve `shuffle` plus `more`
+  as input aliases for the same turn-exempt redeal.
+- Do not add the rejected grouped **More Actions** list, a command field, random
+  draw, or client-authored reconstruction. “More” means “next two,” not “show
+  all.”
+- Preserve provider reasoning—Calling, friendship, held item, job, location—
+  as “why this is suggested,” not “why all other legal actions disappeared.”
+- During the active actor's combat turn, show every legal combat action family
+  up to the protocol cap; combat does not use ordinary redeal.
+- Instrument spotlight selection, redeal, disabled-action inspection,
+  abandonment, and stale refresh without recording private text.
+
+### Acceptance
+
+- Every legal ordinary action appears after a finite number of deterministic
+  redeals without luck, currency, or command knowledge.
+- The first two cards remain deterministic and retain their provider reasons.
+- Redeal cannot create, re-rank, retarget, or enable an offer and consumes no
+  world turn.
+- Keyboard and screen-reader users can advance the redeal cycle and enumerate
+  the complete legal set, including cost, risk, effect, target, and disabled
+  reason.
+- Two clients with the same authoritative state receive the same spotlight and
+  legal set and produce the same redeal order.
+- Combat continues to present its complete bounded choice set directly.
+- Browser contract tests continue to require the shuffle control, glyph, and
+  compact “more” label recorded by ADR 0002.
+
+---
+
+## AVE-4 — Introduce A Concrete Action-Copy Contract
+
+**Priority**: P0
+**Scope**: Action envelope, pack schema, authoring guide, browser and terminal
+**Depends on**: AVE-1, AVE-2
+
+### What to do
+
+- Give every action offer structured presentation fields rather than one
+  overloaded label:
+  - canonical verb;
+  - concrete title;
+  - target;
+  - requirements;
+  - cost summary;
+  - immediate effect preview;
+  - important unlock/consequence preview; and
+  - disabled reason/remedy.
+- Require the title to follow **concrete verb + concrete object/target** unless
+  the verb is self-contained and universally understood, such as Rest or
+  Dodge.
+- Prefer names already grounded in world state:
+  “Use Dawn Oil on the Beacon,” not “Answer the need.”
+- Keep rule binding, lifecycle stage, claim keys, resolver, and exact
+  provenance in the inspector. They may supplement but never replace the
+  player explanation.
+- Separate a non-executable need panel from an executable action card. A place
+  may say “A permanent landmark is still needed” before the player possesses a
+  qualifying recipe or item.
+- Require pack reskins and contextual offers to satisfy the same clarity
+  fields as Core.
+
+### Acceptance
+
+- For every card, a player can answer: what will I do, to what, what do I need,
+  what will it cost, and what changes next?
+- No active state-changing card is titled only Work, Contribute, Push, Current
+  Need, Mature, Anchor, or another lifecycle/umbrella term.
+- If a required item or target is unavailable, the UI names it and does not
+  present a generic action that is guaranteed to fail.
+- Browser confirmation and terminal preview use the same structured copy.
+- Copy changes cannot modify mechanics, and mechanical changes cannot ship
+  without refreshed effect/cost previews.
+
+### Reference presentation
+
+```text
+Build a mossglass waymarker
+At Alder Hollow · Stone + Moonwool Thread · 1 turn · Safe
+Creates a permanent landmark here.
+Afterward, travelers can begin supply deliveries.
+
+Inspector: Craft → place.anchor.created → Discovered to Anchored
+```
+
+---
+
+## AVE-5 — Replace Generated-Place Lifecycle Jargon With Stage-Specific Play
+
+**Priority**: P0 (current generated-place loop is mechanically legible but
+player-copy opaque)
+**Scope**: Generated-place jobs, biome templates, requirements, clocks, UI
+**Depends on**: AVE-4 and the generated-place lifecycle contract
+
+### What to do
+
+- Preserve the authoritative lifecycle:
+  `Unfound → Discovered → Anchored → Connected → Settled`.
+- Replace its generic job premise and action copy with deterministic,
+  stage-specific needs:
+
+| Stage | Need panel | Executable offer examples |
+| --- | --- | --- |
+| Unfound | The route has not been explored | **Scout toward Alder Hollow** |
+| Discovered | This place needs a permanent landmark | **Build a mossglass waymarker here** / **Install the Mothglass Lantern here** |
+| Anchored | The landmark is ready, but supplies have not arrived | **Carry bridge rope from Rain-Soft Garden to Alder Hollow** |
+| Connected | People can reach this place; it needs shared use and care | **Welcome Rowan to Alder Hollow** / **Repair the waymarker** / **Leave a trail account** |
+| Settled | Alder Hollow is now a safe stopping place | No maturity action; show completion and resulting sanctuary |
+
+- Author a closed, validated vocabulary of possible landmark/fixture nouns by
+  biome and qualifying recipe: waymarker, lantern post, shelter frame, bridge
+  marker, garden bed, bell frame, or another pack-authored noun.
+- Never ask AI to decide whether an object qualifies. Decorative generation
+  may name an already selected noun within content hygiene rules.
+- Expose the exact item, recipe, origin, destination, and delivery method
+  needed for the current stage.
+- Translate settlement evidence into visible human progress without exposing
+  claim-key jargon:
+
+```text
+Landmark built                 ✓
+Supplies delivered             ✓
+Travelers who helped           1 of 2
+Different helpful acts         3 of 5
+```
+
+- Give every generated danger clock concrete authored stakes and a visible
+  fill consequence. Replace “Unanswered local needs” with a biome- and
+  stage-appropriate threat such as “The path is washing away.”
+- Rewrite job reward and consequence copy as observable world outcomes, not
+  “advances one represented maturity stage.”
+
+### Acceptance
+
+- The phrases “anchor a lasting fixture,” “typed durable anchor,” “answer the
+  current need,” “declared needed supplies,” and “distinct contributions and
+  traces” do not appear as primary player instructions.
+- A qualifying craft offer names the actual output and location before
+  confirmation.
+- A delivery offer names the item, origin, destination, and accepted completion
+  interaction.
+- Players can see settlement participation/diversity progress without seeing
+  claim keys, event IDs, controller kinds, or anti-farming internals.
+- Repeated generic Work still cannot skip any stage.
+- Generated names or unavailable AI never change requirements, lifecycle
+  outcome, or deterministic fallback copy.
+
+---
+
+## AVE-6 — Replace Generic Project Buttons With Concrete Approaches
+
+**Priority**: P1
+**Scope**: Jobs, project offer composition, Study/Utilize/Help/Prepare bindings
+**Depends on**: AVE-1, AVE-4
+
+### What to do
+
+- Treat Contribute as an internal grouping/result, not the default action title.
+- Let each active job publish one or more concrete strategies:
+  - Study to understand or plan;
+  - Utilize to act with a named tool or feature;
+  - Help a named actor performing a named task;
+  - Prepare a named setup with duration and consumption rules;
+  - Give or deliver a named physical item;
+  - Attack, Dodge, Influence, or another action only when authored stakes make
+    that approach meaningful.
+- Replace Work/Push labels with the strategy's concrete fiction.
+- Show differing risk, effect, requirements, and consequences between
+  strategies before selection.
+- Record both the stable action and project contribution in the receipt so the
+  same outcome cannot be farmed through vocabulary changes.
+
+### Acceptance
+
+- The Moonlit job and every generated-place stage expose at least two
+  mechanically distinct concrete approaches when the state actually supports
+  them.
+- A Help offer names both the recipient and task.
+- A Utilize offer names its item/feature and cannot execute after that source
+  is transferred or exhausted.
+- A Prepare offer names what is set up, what consumes it, and when it expires.
+- No project relies on generic Work as an undocumented resolver.
+
+---
+
+## AVE-7 — Version A Two-Tempo Tactical Economy
+
+**Priority**: P1
+**Scope**: `cosyworld.combat/6`, positions, combat offers, AI policy, replay
+**Depends on**: AVE-2, AVE-3, AVE-6
+
+### What to do
+
+- Keep existing combat protocols replay-readable; introduce a new protocol for
+  the economy change.
+- Give the active participant two Tempo at turn start.
+- Start with this bounded cost table:
+
+| Action family | Proposed cost |
+| --- | --- |
+| Step between authored positions | 1 Tempo |
+| Use, Help, Hide, Disengage | 1 Tempo |
+| Attack | Commit all remaining Tempo |
+| Dodge | Commit all remaining Tempo |
+| Ready | Commit all remaining Tempo |
+| Dash | Commit remaining Tempo for additional legal movement |
+| Flee | Commit remaining Tempo and exit when legal |
+
+- Model three to five authored positions and validated relations—adjacency,
+  cover, sight, hazard, and exit—without grids or client geometry.
+- Recompose the complete combat hand after a non-ending first action.
+- Prevent repeated Attack and accidental free movement by making end-turn
+  behavior explicit in the economy block.
+- Give inference-controlled avatars the identical legal set, costs, previews,
+  and deterministic selection trace.
+
+### Acceptance
+
+- Move-then-act is possible; attack-twice is not.
+- The client cannot invent positions, movement allowance, cover, Tempo, or
+  end-turn behavior.
+- Every legal combat family is visible without ordinary-scene redeal.
+- Hit, harm, finish, objective effect, and movement previews match the actual
+  resolver.
+- Snapshot, reconnect, stale submission, and legacy replay tests cover both
+  Tempo and position state.
+
+---
+
+## AVE-8 — Implement Dash, Disengage, And Hide As Real Actions
+
+**Priority**: P1 after the tactical foundation; otherwise unsupported
+**Scope**: Rules profile successor, combat/movement/visibility state, tests
+**Depends on**: AVE-7
+
+### What to do
+
+- Introduce a versioned successor profile or explicit compatible extension;
+  do not silently change `cosyworld.srd5/1`.
+- Implement Dash only when additional movement has a defined value and legal
+  path.
+- Implement engagement and its ordinary movement consequences before
+  Disengage. Keep Flee/Escape a distinct operation.
+- Implement Hide only with:
+  - scene-provided concealment eligibility;
+  - authoritative hidden/concealed state;
+  - detection and reveal rules;
+  - targeting consequences;
+  - Search interaction;
+  - duration and invalidation triggers; and
+  - replay/snapshot identity.
+- Keep each action absent when its preconditions or meaningful effect do not
+  exist.
+
+### Acceptance
+
+- Dash, Disengage, and Hide each have a resolver, legal targets, safe/risky
+  behavior, event outputs, stale rejection, and replay fixture.
+- Travel is never mislabeled Dash, and Flee is never mislabeled Disengage.
+- Hide cannot be activated in an exposed scene or retained after an
+  invalidating action.
+- Search and visibility tests prove who can target or reveal a hidden actor.
+- The profile conformance report moves an action from unsupported only after
+  its full deterministic contract passes.
+
+---
+
+## AVE-9 — Broaden Ready And Magic Only Through Authored Content
+
+**Priority**: P2
+**Scope**: Trigger contracts, bounded spell effects, pack authoring
+**Depends on**: AVE-2, AVE-4; Ready also depends on AVE-7
+
+### What to do
+
+- Continue calling the current one-use project setup Prepare.
+- Add Ready only when an offer names:
+  - a perceivable trigger;
+  - one bounded response;
+  - duration;
+  - reserved/committed Tempo;
+  - invalidation conditions; and
+  - deterministic trigger ordering without reaction chains.
+- Broaden Magic by adding complete effect descriptors and authored cards, not
+  by enabling prose or importing a spell list wholesale.
+- Every spell declares target, range/position predicate, uses/exhaustion,
+  duration, stacking, recovery, effect budget, and replay behavior.
+
+### Acceptance
+
+- Prepare and Ready never appear as interchangeable primary labels.
+- A Ready card can be understood without consulting prose or guessing its
+  trigger.
+- An unsupported or unprepared spell produces no executable Magic offer.
+- Adding one spell cannot change ordinary action access or bypass the free/core
+  power ceiling.
+- Triggered responses and spell effects are deterministic, journaled, and
+  snapshot-safe.
+
+---
+
+## AVE-10 — Add Action-Clarity Gates And Comprehension Evidence
+
+**Priority**: P1, introduced with AVE-1 and expanded as tickets land
+**Scope**: Compiler/checker, browser smoke, terminal parity, playtest script
+**Depends on**: AVE-1 through AVE-6 for the first complete gate
+
+### What to do
+
+- Add a worldpack/action-copy checker that flags high-risk abstract primary
+  labels such as:
+  - current need;
+  - mature;
+  - typed;
+  - declared;
+  - trace;
+  - contribute;
+  - lasting fixture; and
+  - bare Work, Push, Prepare, or Anchor without a concrete target.
+- Use an allowlist with reviewed rationale rather than banning ordinary words
+  globally; “anchor” may remain a lore noun or inspector term.
+- Validate that every state-changing offer has structured target,
+  requirements, cost, effect preview, and remedy when disabled.
+- Add cross-surface golden fixtures for representative Search, Study,
+  Influence, Magic, Prepare, Help, Utilize, inventory, progression,
+  generated-place, and combat offers.
+- Run a short comprehension study using five questions:
+  1. What will your avatar do?
+  2. What or whom will they act on?
+  3. What do you need and what will it cost?
+  4. What changes immediately?
+  5. What becomes possible or risky afterward?
+- Track repeated confirmation cancellation, disabled-action selection, stale
+  refresh, and redeal use as usability signals, not success metrics by
+  themselves.
+
+### Acceptance
+
+- Core and mounted expansion packs pass the action-copy checker.
+- Browser and terminal previews answer all five comprehension questions from
+  the same server fields.
+- Tests fail when concrete nouns are replaced with generic lifecycle copy.
+- At least one generated-place playthrough reaches Settled without the tester
+  asking what “anchor,” “current need,” “declared supplies,” or “trace” means.
+- Accessibility review confirms that screen-reader labels contain verb,
+  target, cost, and important consequence without reading inspector jargon.
+
+---
+
+## Dependency Order
+
+```text
+AVE-0 truthful baseline
+  ├── AVE-1 canonical vocabulary
+  │     ├── AVE-4 concrete copy contract
+  │     │     ├── AVE-5 generated-place copy and offers
+  │     │     └── AVE-6 concrete project approaches
+  │     └── AVE-2 explicit action economy
+  │             └── AVE-3 spotlight + deterministic redeal reachability
+  │                     └── AVE-7 combat/6 two-Tempo economy
+  │                             └── AVE-8 Dash, Disengage, Hide
+  └── AVE-10 clarity gates grow alongside AVE-1 through AVE-6
+
+AVE-9 Ready/Magic breadth depends on AVE-2 and AVE-4;
+Ready additionally depends on AVE-7.
+```
+
+AVE-1, AVE-2, and the schema portion of AVE-4 may proceed together after
+AVE-0. AVE-5 should land before scaling generated pathways because every new
+generated place otherwise multiplies opaque copy. AVE-7 and AVE-8 are a
+separate versioned tactical slice and must not block ordinary-scene clarity.
+
+---
+
+## Out Of Scope
+
+- Full Dungeons & Dragons or full SRD 5.2.1 compatibility.
+- Importing complete class, spell, monster, equipment, rest, or death systems.
+- Randomly drawn ordinary-action legality.
+- Client-authored actions, costs, targets, or effects.
+- AI-generated mechanics or AI deciding whether an item satisfies a lifecycle
+  requirement.
+- Grid pathfinding, measured range, facing, ammunition simulation, reaction
+  chains, or a large tactical hotbar.
+- Rewriting internal lifecycle, claim, provenance, or replay vocabulary when
+  it is already correct and confined to developer/inspector surfaces.

--- a/docs/backlog/rest-travel-and-weariness.md
+++ b/docs/backlog/rest-travel-and-weariness.md
@@ -1,0 +1,367 @@
+# Rest, Travel, and Weariness — Backlog
+
+**Epic**: Make rest the recovery verb the card layer already promises — graded
+by place and carried gear, refreshing exhausted cards through the kernel, with
+expedition depth visible as an unlabeled ring rather than a stamina number.
+
+**Status**: Groomed and filed (2026-07-26); delivery is in progress. The linked
+issues are the source of truth for each slice's implementation state.
+
+**Execution backlog**: epic [#356](https://github.com/cenetex/cosyworld/issues/356).
+
+| Ticket | Issue | Priority |
+| --- | --- | --- |
+| RT-0 — decisions | [#348](https://github.com/cenetex/cosyworld/issues/348) | P0 |
+| RT-1 — `CW_ACTION_REST` with card refresh | [#349](https://github.com/cenetex/cosyworld/issues/349) | P1 |
+| RT-2 — grade from place and gear | [#350](https://github.com/cenetex/cosyworld/issues/350) | P1 |
+| RT-3 — lodging feature and a Core inn | [#351](https://github.com/cenetex/cosyworld/issues/351) | P1 |
+| RT-4 — flip rest availability | [#352](https://github.com/cenetex/cosyworld/issues/352) | P1 |
+| RT-5 — the expedition ring | [#353](https://github.com/cenetex/cosyworld/issues/353) | P1 |
+| RT-6 — redeal wins; close More Actions | [#354](https://github.com/cenetex/cosyworld/issues/354) | P0 decision, resolved |
+| RT-7 — lodging pays in fiction | [#355](https://github.com/cenetex/cosyworld/issues/355) | P2 |
+
+**Related architecture**:
+
+- [SRD-Backed Action and Collectible System](../systems/04-action-system.md)
+- [CosyWorld RPG System Bible](../systems/09-cosyworld-rpg-system.md)
+- [ADR 0002: the action hand is authoritative state](../decisions/0002-action-hand-is-authoritative-state.md)
+
+**Related backlog**: [Action Verbs And Economy](action-verbs-and-economy.md).
+AVE owns the verb lexicon, per-offer cost/risk presentation, and complete legal
+reachability. This backlog owns what rest *does* and where it is legal. Where
+they touch — the cost surface a rest offer renders into, and the Recover
+intention group — AVE is authoritative and RT consumes it.
+
+## Why now
+
+Three facts make this a coherent slice rather than a feature request.
+
+1. **Nothing ever un-exhausts a card.** `charges` is set at creation
+   (`v2/core-c/src/cosy_kernel.c:252`, `:269`) and only ever decremented into
+   `CW_CARD_ZONE_EXHAUSTED` (`:830`, `:866`). The deck UI already tells players
+   otherwise — "Used spells stay exhausted until refreshed"
+   (`v2/orchestrator-rust/src/index.html:8564`). Exhaustion is a one-way door
+   with a promise painted on it.
+2. **Rest has no upside.** The projection route
+   (`v2/orchestrator-rust/src/main.rs:35921`) only clears tags. It removes
+   debuffs and grants nothing, which is why it reads as a chore.
+3. **A two-axis weariness model already exists and already replays** — the
+   `tired` condition plus one `frontier_travel_since_rest:<seq>` tag per
+   frontier move (`main.rs:10474`), required count scaling with level
+   (`main.rs:16529`). It is invisible and its availability rule is inverted.
+
+The card-zone and capacity work in PRD P1 is the right moment: camping gear
+that costs carry slots which could hold loot is the trade-off that makes this
+an expedition system instead of bookkeeping.
+
+## Current behavior (baseline to preserve or migrate)
+
+| Concern | Today | Location |
+| --- | --- | --- |
+| Rest action | Projection only; clears `tired`, `trained_since_rest`, all `frontier_travel_since_rest:*` | `main.rs:35921` |
+| Frontier rest cost | Advances the room's frontier danger clock by 1 | `main.rs:36006` |
+| Gear exemption | Hardcoded to Moonlit Trail + Hearth Tonic warmth tag | `main.rs:16596` |
+| Rest availability | Requires `tired` **and** travel count ≥ `level.clamp(1,4)` | `main.rs:16523` |
+| `tired` sources | Work, repeated unprepared Help, repeat frontier Listen, knack practice | `main.rs:10766`, `:11512`, `:23081`, `:35697`, `:35880` |
+| Hand promotion | Rest ranks 84 outside the frontier; provider `rules:recovery` when tired | `main.rs:19846`, `:19961` |
+| Redeal | `hand.shuffled` event and free `shuffle`/`more` command exist; browser presents the compact “more” redeal control | `main.rs`, `index.html` |
+| Lodging | `Wayside Lantern Inn` exists only in `v2/content/the-lantern-keeper/` | — |
+| Core zoning | 6 sanctuary / 16 frontier room sheets, no lodging rung | `v2/content/core/room_sheets.json` |
+
+---
+
+## Principles (acceptance gate for every ticket)
+
+1. Rest is graded by **place and carried gear**, never by a currency and never
+   by a continuous meter.
+2. Refreshing charges and card zones is authoritative state, so it crosses the
+   C kernel. Tag clearing may stay projection.
+3. Weariness never removes a legal option. A full ring raises risk; it never
+   blocks Travel, or a player strands with an empty hand.
+4. Sanctuary rest is always free, always complete, and never interruptible —
+   `PRD.md` pillar 2 holds without exception.
+5. Lodging is paid in fiction (access, bond, job, room resource), never in
+   Orbs. The only negative Orb reason stays `community_image_generation`.
+6. The ring is a projection served typed from `views.rs`, computed from state
+   that already replays. The client never derives it from tags.
+7. No new player-facing noun. "Stamina" and "weariness" are system words and do
+   not appear in player copy (`PRD.md:56`).
+8. Old journaled rest records keep their tag-clearing meaning. A new grade
+   semantic needs a new action code, never a reinterpretation.
+
+---
+
+## RT-0 — Record the rest-grade and ring decisions
+
+**Priority**: P0 (blocks every ticket below; resolves a product-law conflict)
+**Scope**: ADR + PRD amendment
+**Depends on**: nothing
+
+### What to do
+
+- Record the three-rung rest ladder — Hearth (sanctuary), Lodged (a room with
+  the lodging feature), Camp (frontier with equipped shelter) — and the fourth
+  case where frontier rest without gear is simply not offered.
+- Record what each rung refreshes, so the grade ladder is a contract rather
+  than tuning: Camp clears `tired` and one spell; Lodged clears `tired` and
+  `trained_since_rest` and the whole spell hand; Hearth clears everything
+  including the expedition counter, charms, and relics.
+- Record that lodging is never Orb-priced, and name the permitted gates:
+  access, an existing bond, a completed job, or an authored room resource.
+- Record the ring as **expedition depth**, filling as the player travels out,
+  discrete pips equal to `frontier_travel_since_rest_required`. Record that it
+  is unlabeled, single (not concentric with HP), and animates only on commit.
+- Consume the redeal decision from ADR 0002 and RT-6. Rest and recovery offers
+  use the same ordinary hand and deterministic redeal as every other offer; no
+  rest ticket owns or changes that surface.
+- State whether the ring supersedes or coexists with any future HP surfacing.
+  Recommended answer: one ring, weariness only; wounds get portrait treatment.
+
+### Acceptance
+
+- The ADR names the four rest grades, their refresh contracts, the lodging
+  gates, and the ring's semantics.
+- `PRD.md`, ADR 0002, and the RPG bible agree that free deterministic redeal is
+  the two-card hand's only complete-offer reachability surface.
+- The RPG bible's Rest row (`docs/systems/09-cosyworld-rpg-system.md:417`)
+  reflects the kernel decision rather than "projection action now."
+- No document describes rest as both currency-priced and zero-Orb.
+
+---
+
+## RT-1 — Add `CW_ACTION_REST` with card refresh
+
+**Priority**: P1 (load-bearing; closes the exhaustion dead end)
+**Scope**: C kernel + ABI + Rust FFI + replay mapping
+**Depends on**: RT-0
+
+### What to do
+
+- Add `CW_ACTION_REST = 26` after `CW_ACTION_THEFT`
+  (`v2/core-c/include/cosy_kernel.h:152`). Do not overload an existing code.
+- Give the action a rest-grade argument supplied by the orchestrator. The
+  kernel validates and applies; it does not infer the grade from geography.
+- Implement charge restoration and `CW_CARD_ZONE_EXHAUSTED` → prior-zone
+  transitions per grade, respecting the profile-declared `exhaustion` recovery
+  string (`v2/orchestrator-rust/src/content_load.rs:749`) rather than a
+  hardcoded rule.
+- Emit one authoritative event per refreshed card so the transcript can render
+  recovery as a public beat.
+- Reject a grade the caller is not entitled to rather than silently downgrading
+  it.
+- Add the Rust FFI wrapper, replay mapping, and C tests in the same change,
+  per the kernel-rule checklist in `CLAUDE.md`.
+- Leave the existing projection rest route intact and journaled as-is; old
+  records keep their meaning.
+
+### Acceptance
+
+- A spell used to exhaustion, then rested at Hearth grade, is castable again,
+  and the transition is journaled and replayable.
+- Replaying a journal containing pre-RT-1 rest records reproduces the old
+  tag-only outcome exactly; the golden replay fixture is extended, not edited.
+- Kernel tests cover each grade's refresh scope, an over-claimed grade, and a
+  rest with nothing to refresh.
+- The deck UI's refresh promise (`index.html:8564`) is true.
+
+---
+
+## RT-2 — Derive rest grade from place and carried gear
+
+**Priority**: P1
+**Scope**: Rust projection + item capability schema
+**Depends on**: RT-1
+
+### What to do
+
+- Introduce a declared `camp_shelter` item capability. Keep it a capability on
+  the existing `tool` role rather than a ninth role — the role vocabulary
+  (`consumable`, `container`, `generic`, `relic`, `skill_charm`, `spell`,
+  `tool`, `weapon`) stays closed.
+- Require the shelter to be validly equipped, not merely owned, matching the
+  container capacity rule.
+- Replace `hearth_tonic_warmth_guards_rest` (`main.rs:16596`) and its
+  `MOONLIT_TRAIL_LOCATION_ID` constant with the capability check. Preserve the
+  Hearth Tonic's existing warmth behavior by giving the item the capability.
+- Derive the grade in one place: sanctuary → Hearth, lodging feature → Lodged,
+  frontier with equipped shelter → Camp, otherwise not offered.
+- Keep the frontier danger-clock tick on Camp grade only.
+- When rest is not offered on the frontier, give the hand an honest reason
+  naming the missing gear, in register per `v2/docs/writing-style.md`.
+
+### Acceptance
+
+- Resting on the frontier with an equipped shelter does not advance the danger
+  clock; without one, rest is absent from the legal set entirely.
+- The Moonlit Trail behavior covered by
+  `hearth_tonic_warmth_spends_to_block_frontier_rest_danger`
+  (`main.rs:55991`) holds with no location ID in the code path.
+- Grade derivation has one call site and is covered for all four cases.
+- A shelter that is carried but unequipped does not confer Camp grade.
+
+---
+
+## RT-3 — Add the lodging room feature and a Core inn
+
+**Priority**: P1 (the free world currently has no middle rung)
+**Scope**: Worldpack content + compiler validation
+**Depends on**: RT-2
+
+### What to do
+
+- Add a `lodging` room feature to the room-feature schema with its own
+  validation, so lodging is authored data rather than a location allowlist.
+- Author at least one lodging room in `v2/content/core/` reachable from the
+  Cottage hub, so the ladder exists without any expansion pack.
+- Give `Wayside Lantern Inn` (`v2/content/the-lantern-keeper/`) the feature.
+  Per `CLAUDE.md`, cross-pack topology belongs in composition data, not in
+  either reusable pack.
+- Run the worldpack lock and compile, and commit the generated bundle with the
+  lock, per the content workflow.
+
+### Acceptance
+
+- A zero-Orb player with no expansion cards can reach a lodging room from The
+  Cosy Cottage and rest there at Lodged grade.
+- The content gate rejects a lodging feature that omits its required fields.
+- No runtime code names an inn by location ID.
+
+---
+
+## RT-4 — Flip rest availability from grind gate to place gate
+
+**Priority**: P1
+**Scope**: Rust projection + journal compatibility
+**Depends on**: RT-1
+
+### What to do
+
+- Replace `rest_available` (`main.rs:16523`). Today it requires `tired` **and**
+  travel count ≥ required, which withholds rest until the player has gone far
+  enough. Rest should be offered wherever the grade is legal.
+- Keep the anti-grind property by cost and effect, not by absence: a rest with
+  nothing to refresh and no tags to clear stays out of the ranked hand while
+  remaining reachable as a legal action.
+- Preserve `frontier_travel_since_rest_required` as the ring's pip count and
+  the Hearth-grade reset target; it stops being an availability predicate.
+- Confirm the existing rank promotion (`main.rs:19846`) and `rules:recovery`
+  provider (`main.rs:19961`) still surface rest at the right moment.
+
+### Acceptance
+
+- A player who has never left sanctuary can rest at home.
+- `tired_actor_must_rest_before_more_project_exertion` (`main.rs:55729`) still
+  passes or is replaced by an equivalent assertion on the new semantics.
+- No journaled action changes meaning; the flip lives in offer projection only.
+
+---
+
+## RT-5 — Serve and render the expedition ring
+
+**Priority**: P1
+**Scope**: `views.rs` projection + browser client
+**Depends on**: RT-4
+
+### What to do
+
+- Add a typed actor-view field carrying filled count, pip total, and a
+  needs-rest flag. The client must not read tags or infer the ring.
+- Render an unlabeled segmented ring around the avatar portrait, 1–4 pips,
+  filling outward as the player travels into frontier rooms.
+- Give the tired state a soft, dimmed treatment rather than an alarm colour;
+  cozy register, no red.
+- Animate only on commit. Nothing about the ring may move on a wall clock.
+- Do not add a second concentric arc for HP. If wounds need visibility, treat
+  the portrait itself.
+- Add the ring to the visual baseline set.
+
+### Acceptance
+
+- The ring's filled count equals `frontier_travel_since_rest_count` after any
+  sequence of moves, verified across a snapshot round trip and a replay.
+- No player-visible string contains "stamina," "weariness," or "tired" as a
+  gauge label.
+- The ring does not re-render or animate on a timer with no committed turn.
+- Mobile viewport keeps the ring legible at portrait size.
+
+---
+
+## RT-6 — Redeal is normative; More Actions is closed
+
+**Priority**: P0 decision, no implementation of its own
+**Scope**: Decision only; recorded in ADR 0002 and consumed by AVE-3
+**Depends on**: RT-0
+
+The originating design conversation asked for a binary choice with an escape
+hatch — *don't like these two? here are two others*. That is a **redeal**.
+[AVE-3](action-verbs-and-economy.md) proposed a grouped **More Actions** list
+for the same problem. #354 resolves the conflict in favor of **redeal**.
+
+### Resolution
+
+- The ordinary surface remains two cards plus one compact free redeal control.
+  Redeal pages the finite authoritative legal-offer order without repeats until
+  the pool is exhausted, then cycles.
+- `hand.shuffled` is the journal record. Redeal consumes no turn, currency,
+  item use, or progression and cannot change legality, rank, target, cost,
+  risk, effect, or resolver.
+- The grouped **More Actions** list loses and is explicitly closed. It must not
+  ship beside redeal or return under another label. The browser label “more”
+  means “draw the next two actions,” not “open all actions.”
+- Rest and recovery offers require no special surface. They enter the same
+  legal set and can appear in the opening pair or a later redeal.
+- ADR 0002 deliberately upholds the browser assertions requiring the shuffle
+  control, glyph, and compact “more” label. The earlier no-shuffle assertion
+  cited by #354 is superseded, not silently deleted.
+
+### Acceptance
+
+- Exactly one reachability surface—redeal—is normative in `PRD.md`, the action
+  hand ADR, and both backlogs; **More Actions** is explicitly closed in each
+  decision-bearing contract.
+- The current positive browser shuffle assertions are upheld by the recorded
+  decision and the earlier negative expectation is explicitly superseded.
+- No RT ticket depends on the outcome; the rest ladder is surface-agnostic.
+
+---
+
+## RT-7 — Give lodging a fiction price
+
+**Priority**: P2
+**Scope**: Jobs + bonds + worldpack content
+**Depends on**: RT-3
+
+### What to do
+
+- Make the first stay free and subsequent stays ask for something the world
+  already models: a delivery, firewood, a message carried, or a bond with the
+  keeper.
+- Seed the ask through the existing job system so the inn becomes a content
+  faucet — an expedition converts into work — rather than a currency sink.
+- Grant a Lodged-grade boon that is mechanically distinct from Hearth: a hot
+  meal as a next-risk reduction, i.e. a free Prepare, so the middle rung has
+  its own identity instead of being a weaker home.
+- Verify no path debits Orbs.
+
+### Acceptance
+
+- A player with zero Orbs and no wallet can lodge indefinitely by doing the
+  inn's work.
+- The Orb ledger records no lodging-related debit under any reason.
+- Lodging an nth time without satisfying the ask fails visibly, with a reason,
+  and without charging anything.
+
+---
+
+## Open questions
+
+- **Ring direction.** Fills (depth travelled) or drains (supplies left)?
+  Recommended: fills, matching the existing tag accumulation and reading
+  cozier. Drains is the more orthodox OSR framing and is the alternative if
+  playtesting shows depth reads as progress rather than cost.
+- **Closed — redeal or More Actions.** RT-6 selected deterministic redeal.
+  More Actions is rejected and must not reopen as a third surface.
+- **`tired` from Work.** Work is currently the main `tired` source. Once rest
+  is graded and gear-gated, tiring a player inside sanctuary may strand nothing
+  but still feel punitive. Confirm during RT-4 whether Work should tire only on
+  the frontier.

--- a/docs/decisions/0002-action-hand-is-authoritative-state.md
+++ b/docs/decisions/0002-action-hand-is-authoritative-state.md
@@ -2,8 +2,9 @@
 
 - Status: Accepted
 - Date: 2026-07-17
+- Amended: 2026-07-27 by #354
 - Decision owners: CosyWorld maintainers
-- Related: #20, #48, #94
+- Related: #20, #48, #94, #354
 
 ## Context
 
@@ -28,7 +29,7 @@ deterministic `action_hand`:
 {
   "action_hand": {
     "schema_version": 1,
-    "capacity": 3,
+    "capacity": 2,
     "entries": [
       {
         "offer_id": "check:listen",
@@ -66,17 +67,47 @@ An offer is eligible only when it is enabled and every required target or
 project reference is present. `work` and `help` for the same progress clock are
 one hand group; `use_item` and `use_feature` are one Use group. Candidates sort
 by provider priority, then existing action rank, then stable offer id. The
-composer initially takes no more than two entries from one provider, fills any
-remaining slots in the same stable order, and ensures that at least one
+composer fills the two ordinary hand slots in the same stable order, taking no
+more than two entries from one provider, and ensures that at least one
 generally useful action (Notice, Inspect, Travel, Chat, Rest, or Grow) is
 present when one is reachable.
 
 Clients use `action_hand.entries` for initial card order and use
 `provider.reason` on the card, accessible name, hover copy, and confirmation
-dialog. A client may merge equivalent offers into one choice-bearing card and
-may let the player page through the remaining complete offer list, but it must
-not hash, randomize, or silently re-rank the authoritative opening hand. A
-change to the projected offer/provider ids is the signal to recompose it.
+dialog. A client may merge equivalent offers into one choice-bearing card, but
+it must not hash, randomize, or silently re-rank the authoritative opening
+hand. A change to the projected offer/provider ids is the signal to recompose
+it.
+
+### Complete-offer reachability: redeal
+
+The free deterministic **redeal** is the only ordinary-scene escape hatch from
+the opening pair. Each redeal replaces both visible cards with the next pair in
+the authoritative legal-offer order, excluding offers already shown in that
+cycle. After every currently legal offer has appeared, the next redeal begins
+the same cycle again. A final one-card page is allowed when the remaining pool
+is odd.
+
+Redeal is browsing, not a world action or a random draw. It consumes no world
+turn, currency, item use, or progression; it cannot change the legal set,
+provider rank, target, cost, risk, effect, or resolver. The `hand.shuffled`
+event is its journal record. The browser-local page cursor is disposable
+presentation state: refresh may return to the authoritative opening pair, while
+the durable event still records that the player asked for another page.
+
+A grouped **More Actions** list is explicitly rejected and closed by #354. It
+would be a second ordinary action surface with different reachability and
+spotlight behavior, not another rendering of redeal. The browser's compact
+“more” control means “draw the next two actions”; it must never open or imply a
+complete pick-list. Future transports may render the same redeal as a reaction,
+terminal command, or voice intent, but may not introduce the rejected list
+under another name.
+
+This amendment deliberately upholds the browser's shuffle/redeal contract. The
+regression assertions requiring `id="shuffle"`, `class="shuffle-glyph"`, and
+the compact “more” label remain normative. They supersede the earlier
+no-shuffle browser expectation cited by #354 and must not be quietly removed or
+inverted.
 
 Wallet keepsakes may supply matching art and an explicit cosmetic annotation.
 Equipping, removing, or owning one does not change action eligibility, order,
@@ -92,8 +123,8 @@ client to recognize a deliberately changed composition contract.
 
 Property-style fixtures cover stable repeated responses, reachable targets,
 the generally useful fallback, Calling/Journal/friendship/held-item changes,
-and snapshot round trips. Browser smoke covers the visible three-card
-explanation and verifies that kept-close cards remain cosmetic.
+and snapshot round trips. Browser smoke covers the visible two-card hand, its
+required redeal control, and verifies that kept-close cards remain cosmetic.
 
 ## Consequences
 
@@ -102,3 +133,8 @@ the action resolver. Pack authors can change vocabulary and world resources,
 but cannot inject client-local priority. Debugging an unexpected hand starts
 from three inspectable values—offer, provider, tie-break—instead of browser
 storage or a deal nonce.
+
+The cost of closing **More Actions** is that reaching a specific low-ranked
+offer can take several redeals. The benefit is one small learnable control
+surface, no duplicate grouping taxonomy, and behavior that already matches the
+browser, terminal alias, PRD, `hand.shuffled` event, and no-turn redeal tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.206",
+  "version": "0.0.207",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.206",
+      "version": "0.0.207",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.206",
+  "version": "0.0.207",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.206"
+version = "0.0.207"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.206"
+version = "0.0.207"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Decision
- make free deterministic redeal the two-card hand's sole complete-offer reachability surface
- explicitly close the grouped More Actions proposal
- align PRD, ADR 0002, and both groomed backlog contracts with the shipped finite redeal cycle
- uphold the existing positive shuffle/glyph/“more” browser assertions and journaled `hand.shuffled` contract

## Evidence
The browser already exposes `id="shuffle"` as “Draw two more actions”; its finite page cursor excludes shown offers before cycling, `shuffle` and `more` are turn-exempt aliases, and `hand.shuffled` is durable. More Actions had no implementation and would introduce a second ordinary action surface.

## Validation
- `cargo test browser_index_contract_stays_chat_mud_shell` — 1 passed
- `cargo test shuffle_command_is_free_hand_redeal_hint` — 1 passed
- `cargo test action_hand_is_deterministic_reachable_identity_driven_and_replayable` — 1 passed
- `npm run v2:syntax`
- `npm run check:version` — 0.0.207
- `cargo fmt --all -- --check`
- relative Markdown link validation for all four documents
- redeal/More Actions semantic consistency validation
- `git diff --check`

Closes #354