### PR TITLE
Include media registries in the release image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@
 !v2/core-c/**
 !v2/content/
 !v2/content/**
+!v2/media/
+!v2/media/**
 !v2/orchestrator-rust/
 !v2/orchestrator-rust/Cargo.toml
 !v2/orchestrator-rust/Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN cargo chef cook --release --recipe-path /app/recipe.json
 
 COPY v2/core-c /app/v2/core-c
 COPY v2/content /app/v2/content
+COPY v2/media /app/v2/media
 COPY v2/ai-model-rust /app/v2/ai-model-rust
 COPY v2/orchestrator-rust /app/v2/orchestrator-rust
 COPY src/services/web/public/images/cosy-cottage.png /app/src/services/web/public/images/cosy-cottage.png

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.212",
+  "version": "0.0.213",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.212",
+      "version": "0.0.213",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.212",
+  "version": "0.0.213",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -13,6 +13,11 @@ const lonelyForestFlyConfig = readFileSync(
   new URL('../../fly.lonelyforest.toml', import.meta.url),
   'utf8'
 );
+const dockerfile = readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
+const dockerignore = readFileSync(
+  new URL('../../.dockerignore', import.meta.url),
+  'utf8'
+);
 
 const job = (name, nextName) => {
   const start = workflow.indexOf(`\n  ${name}:`);
@@ -66,5 +71,21 @@ describe('deploy workflow', () => {
       expect(config).toContain(visionModel);
       expect(config).toContain(visionReasoning);
     }
+  });
+
+  it('copies compile-time media registries into the release image build', () => {
+    const dependencyBuild = 'RUN cargo chef cook --release --recipe-path /app/recipe.json';
+    const mediaCopy = 'COPY v2/media /app/v2/media';
+    const releaseBuild = 'RUN cargo build --release';
+
+    expect(dockerignore).toContain('!v2/media/');
+    expect(dockerignore).toContain('!v2/media/**');
+    expect(dockerfile).toContain(mediaCopy);
+    expect(dockerfile.indexOf(dependencyBuild)).toBeLessThan(
+      dockerfile.indexOf(mediaCopy)
+    );
+    expect(dockerfile.indexOf(mediaCopy)).toBeLessThan(
+      dockerfile.indexOf(releaseBuild)
+    );
   });
 });

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.212"
+version = "0.0.213"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.212"
+version = "0.0.213"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What changed

- include `v2/media/**` in the Docker build context
- copy `v2/media` into the release build stage before `cargo build --release`
- add a deploy-workflow regression test that verifies the ignore exceptions and copy ordering
- bump package and orchestrator versions to `0.0.213`

## Why

The merge-train deployment built the dependency layer successfully, then failed compiling the application because `media_evolution.rs` and `media_recipes.rs` use `include_str!` for:

- `v2/media/evolution-canary.json`
- `v2/media/recipes.json`

Those files existed in the repository but were excluded by `.dockerignore` and never copied by the Dockerfile. Normal Rust and CI builds had the files, so only the remote release image exposed the packaging gap.

## Impact

The Fly release image can compile the integrated media evolution and recipe registries. The runtime image remains unchanged in shape: the registries are embedded in the binary at compile time.

## Validation

- focused deploy packaging test: 4/4 passed
- JavaScript: 44 files, 481/481 tests passed
- full enforced pre-push `npm run check` passed
- Rust: 739/739 tests passed
- worldpack schemas, five compositions, and strict proof passed
- kernel, architecture (`main.rs` 73,214/73,214; clippy 275/275), syntax, version, and diff checks passed

A local image build was unavailable because the Docker/Podman daemon is not running; hosted CI and the Fly remote builder provide the final image-build verification.