### PR TITLE
Keep Journal events out of chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.213",
+  "version": "0.0.214",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.213",
+      "version": "0.0.214",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.213",
+  "version": "0.0.214",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.213"
+version = "0.0.214"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.213"
+version = "0.0.214"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -3177,6 +3177,9 @@
     .terminal {
       grid-template-rows: auto minmax(0, 1fr);
     }
+    .log {
+      grid-row: 2;
+    }
     .room-title-main {
       flex: 1 1 auto;
       max-width: none;
@@ -3301,26 +3304,25 @@
       grid-template-rows: auto minmax(0, 1fr);
       border-top: 1px solid var(--line);
       background: #11100d;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
     .journal-view[hidden] {
       display: none;
     }
     .journal-heading {
       min-width: 0;
-      padding: 10px 16px 8px;
+      padding: 6px 10px;
       display: flex;
       align-items: baseline;
       justify-content: space-between;
-      gap: 12px;
-      border-bottom: 1px solid rgba(239, 201, 107, 0.14);
+      gap: 10px;
+      border-bottom: 1px solid var(--line);
       color: var(--dim);
     }
     .journal-heading h2 {
       margin: 0;
-      color: var(--amber);
-      font: 800 11px/1 ui-sans-serif, system-ui, sans-serif;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
+      color: var(--green);
+      font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
     .journal-heading span {
       min-width: 0;
@@ -3337,7 +3339,7 @@
       overscroll-behavior: contain;
       scrollbar-width: thin;
       scrollbar-color: rgba(239, 201, 107, 0.38) rgba(5, 12, 7, 0.2);
-      padding: 4px 16px 18px;
+      padding: 0 10px 10px;
     }
     .journal-stream > [hidden] {
       display: none;
@@ -3376,11 +3378,11 @@
     .journal-row > summary {
       box-sizing: border-box;
       min-width: 0;
-      min-height: 34px;
-      padding: 8px 0;
+      min-height: 30px;
+      padding: 5px 0;
       display: grid;
-      grid-template-columns: minmax(6ch, auto) minmax(0, 1fr) auto auto;
-      gap: 8px;
+      grid-template-columns: minmax(10ch, 16ch) minmax(0, 1fr) auto auto;
+      gap: 6px;
       align-items: center;
       list-style: none;
       cursor: pointer;
@@ -3389,15 +3391,18 @@
       display: none;
     }
     .journal-row-label {
-      max-width: 15ch;
+      max-width: 16ch;
       overflow: hidden;
-      color: var(--amber);
+      color: var(--green);
       font-size: 10px;
-      font-weight: 850;
-      letter-spacing: 0.025em;
+      font-weight: 700;
       text-overflow: ellipsis;
-      text-transform: uppercase;
+      text-transform: lowercase;
       white-space: nowrap;
+    }
+    .journal-row-label::before {
+      content: "> ";
+      color: var(--faint);
     }
     .journal-row-summary {
       min-width: 0;
@@ -3426,9 +3431,10 @@
       content: "+";
     }
     .journal-row-detail {
-      margin: -1px 0 9px;
-      padding: 0 24px 0 min(14ch, 112px);
+      margin: -1px 0 7px;
+      padding: 0 20px 0 min(14ch, 104px);
       display: flex;
+      flex-wrap: wrap;
       align-items: baseline;
       gap: 10px;
       color: var(--text);
@@ -3443,6 +3449,25 @@
       line-height: 1.4;
       overflow-wrap: anywhere;
     }
+    .journal-row-lines {
+      flex: 1 1 100%;
+      min-width: 0;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 3px;
+      list-style: none;
+      color: var(--dim);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+    .journal-row-lines li {
+      overflow-wrap: anywhere;
+    }
+    .journal-row-lines li::before {
+      content: "$ ";
+      color: var(--faint);
+    }
     .journal-row-inspector {
       flex-basis: 100%;
       margin: 2px 0 0;
@@ -3451,9 +3476,6 @@
       list-style: none;
       color: var(--dim);
       font-size: 10px;
-    }
-    .journal-row.story .journal-row-detail {
-      flex-wrap: wrap;
     }
     .journal-row-inspector li {
       display: grid;
@@ -3467,7 +3489,8 @@
       border-bottom: 1px solid var(--line-strong);
       background: transparent;
       color: var(--dim);
-      padding: 1px 0;
+      min-height: 28px;
+      padding: 4px 0;
       font: inherit;
       font-size: 10px;
       cursor: pointer;
@@ -3479,15 +3502,24 @@
       outline: 0;
     }
     .terminal.journal-open {
+      grid-template-columns: minmax(0, 1fr) minmax(300px, 38%);
       grid-template-rows: auto minmax(0, 1fr);
     }
     .terminal.journal-open .room {
+      grid-column: 1;
+      grid-row: 1;
       padding-bottom: 10px;
     }
-    .terminal.journal-open .room-hero,
-    .terminal.journal-open .room-copy,
     .terminal.journal-open .log {
-      display: none;
+      grid-column: 1;
+      grid-row: 2;
+      display: flex;
+    }
+    .terminal.journal-open .journal-view {
+      grid-column: 2;
+      grid-row: 1 / span 2;
+      border-top: 0;
+      border-left: 1px solid var(--line);
     }
     .terminal.panel-open .journal-view {
       display: none;
@@ -3520,8 +3552,31 @@
         padding-left: 12px;
         padding-right: 12px;
       }
+      .terminal.journal-open {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: auto minmax(140px, 1fr) minmax(150px, 42%);
+      }
+      .terminal.journal-open .room {
+        grid-column: 1;
+        grid-row: 1;
+      }
+      .terminal.journal-open .room-hero,
+      .terminal.journal-open .room-copy {
+        display: none;
+      }
+      .terminal.journal-open .log {
+        grid-column: 1;
+        grid-row: 2;
+      }
+      .terminal.journal-open .journal-view {
+        grid-column: 1;
+        grid-row: 3;
+        border-top: 1px solid var(--line);
+        border-left: 0;
+      }
       .journal-row > summary {
-        grid-template-columns: minmax(5.5ch, auto) minmax(0, 1fr) auto auto;
+        min-height: 36px;
+        grid-template-columns: minmax(8ch, 11ch) minmax(0, 1fr) auto auto;
         gap: 6px;
       }
       .journal-row-detail {
@@ -3856,18 +3911,17 @@
         </div>
         <button class="room-log-latest" id="room-log-latest" type="button" aria-controls="journal-view" hidden><span class="room-log-latest-track" id="room-log-latest-track"></span></button>
         <div class="room-copy" id="location-copy"></div>
-        <section class="shared-questions" id="promoted-question" aria-live="polite" aria-label="Current story and shared question" hidden></section>
       </section>
       <section class="journal-view" id="journal-view" aria-label="Journal" hidden>
         <header class="journal-heading">
-          <h2>Journal</h2>
+          <h2>journal://</h2>
           <span id="journal-location"></span>
         </header>
         <div class="journal-stream">
-          <section class="shared-questions" id="shared-questions" aria-label="Shared questions in this place" hidden></section>
+          <section class="shared-questions" id="shared-questions" aria-label="Current story and shared questions in this place" hidden></section>
           <section class="updates" id="updates" aria-live="polite" aria-label="First tale" hidden></section>
           <div class="room-memory" id="room-memory" hidden></div>
-          <section class="journal-log" id="journal-log" role="log" aria-label="Room history"></section>
+          <section class="journal-log" id="journal-log" role="region" aria-label="Room history"></section>
         </div>
       </section>
       <section class="log" id="log" role="log" aria-live="polite" aria-relevant="additions text" aria-label="Shared room chat"></section>
@@ -7618,7 +7672,7 @@
     function acknowledgeVisibleClockPresentations() {
       if (!actorId || !actorSession || document.visibilityState !== "visible" || activeModal()) return;
       if (libraryPanelPinned || accountPanelPinned) return;
-      const panels = [$("promoted-question"), $("shared-questions")]
+      const panels = [$("shared-questions")]
         .filter((panel) => panel && !panel.hidden && panel.getClientRects().length > 0);
       for (const panel of panels) {
         for (const row of panel.querySelectorAll("[data-clock-presentation][data-clock-id]")) {
@@ -7925,7 +7979,6 @@
         document.querySelector(".room")?.classList.add("collapsed");
       }
       renderRoomCopy(location.id);
-      renderPromotedQuestion();
       renderSharedQuestions();
       renderTimelines();
       renderCommands();
@@ -8107,6 +8160,7 @@
       attrs = "",
       action = "",
       inspector = [],
+      detailLines = [],
     } = {}) {
       const compactSummary = journalSummary(summary || detail || "Something changed");
       const sentence = journalSentence(detail || summary || "Something changed");
@@ -8117,8 +8171,15 @@
       const inspectorHtml = inspector.length
         ? `<ul class="journal-row-inspector" aria-label="Raw events">${inspector.map((entry) => `<li><code>#${Number(entry.seq || 0)} ${escapeHtml(entry.type || "event")}</code><span>${escapeHtml(cleanStatusText(eventText(entry)))}</span></li>`).join("")}</ul>`
         : "";
-      const detailHtml = sentence || inspectorHtml
-        ? `<div class="journal-row-detail">${sentence ? `<p>${escapeHtml(sentence)}</p>` : ""}${inspectorHtml}${action}</div>`
+      const lines = (Array.isArray(detailLines) ? detailLines : [])
+        .map(cleanStatusText)
+        .filter(Boolean)
+        .slice(0, 12);
+      const detailLinesHtml = lines.length
+        ? `<ul class="journal-row-lines">${lines.map((line) => `<li>${escapeHtml(line)}</li>`).join("")}</ul>`
+        : "";
+      const detailHtml = sentence || detailLinesHtml || inspectorHtml || action
+        ? `<div class="journal-row-detail">${sentence ? `<p>${escapeHtml(sentence)}</p>` : ""}${detailLinesHtml}${inspectorHtml}${action}</div>`
         : "";
       const aria = [label, compactSummary, progress].filter(Boolean).join(". ");
       return `<details class="journal-row ${escapeAttr(kind)}"${attrs} aria-label="${escapeAttr(aria)}"><summary><span class="journal-row-label">${escapeHtml(label)}</span><span class="journal-row-summary">${escapeHtml(compactSummary)}</span>${progressHtml}<span class="journal-row-marker" aria-hidden="true"></span></summary>${detailHtml}</details>`;
@@ -8139,7 +8200,7 @@
       latestControl.setAttribute("aria-expanded", open ? "true" : "false");
       latestControl.setAttribute("aria-label", open ? "Close Journal, latest entry" : `Open Journal, latest: ${latest}`);
       toggle.querySelector(".room-log-kicker")?.replaceChildren(document.createTextNode(open ? "Close Journal" : "Journal"));
-      document.querySelector(".prompt").hidden = Boolean(panelMode || open);
+      document.querySelector(".prompt").hidden = Boolean(panelMode);
       if (open) {
         scheduleVisibleWorldBeatReceipts();
         scheduleVisibleClockPresentationReceipts();
@@ -8379,32 +8440,27 @@
       return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
     }
 
-    function promotedFrontHtml(front, index = 0) {
+    function sharedFrontHtml(front) {
       const stateName = String(front.presentation_state || "active");
-      const idBase = `story-front-${String(front.id || index).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
-      const titleId = `${idBase}-title`;
       const stakes = (front.stakes_questions || []).filter(Boolean);
-      const stakeIds = stakes.map((_, stakeIndex) => `${idBase}-stake-${stakeIndex + 1}`);
       const names = narrativeNames(front.participant_names);
-      const referenceId = names ? `${idBase}-reference` : "";
       const outcome = String(front.outcome_statement || "").trim();
-      const outcomeId = outcome ? `${idBase}-outcome` : "";
-      const describedBy = [...stakeIds, referenceId, outcomeId].filter(Boolean).join(" ");
-      const kicker = {
-        persisted: "the larger trouble persists",
-        resolved: "the larger trouble is resolved",
-        escalated: "the larger trouble has escalated",
-      }[stateName] || "larger trouble";
-      const stakeHtml = stakes.length
-        ? `<div class="story-front-stakes">${stakes.map((stake, stakeIndex) => `<p class="story-front-question" id="${stakeIds[stakeIndex]}">${escapeHtml(stake)}</p>`).join("")}</div>`
-        : "";
-      const referenceHtml = names
-        ? `<p class="story-front-reference" id="${referenceId}">${escapeHtml(`The answer still matters to ${names}.`)}</p>`
-        : "";
-      const outcomeHtml = outcome
-        ? `<p class="story-front-outcome" id="${outcomeId}">${escapeHtml(outcome)}</p>`
-        : "";
-      return `<article class="shared-question story-front ${escapeAttr(stateName)}" role="region" aria-labelledby="${titleId}"${describedBy ? ` aria-describedby="${describedBy}"` : ""}><span class="shared-question-kicker">${escapeHtml(kicker)}</span><h2 id="${titleId}">${escapeHtml(front.premise)}</h2>${stakeHtml}${referenceHtml}${outcomeHtml}</article>`;
+      const label = {
+        persisted: "front:persisted",
+        resolved: "front:resolved",
+        escalated: "front:escalated",
+      }[stateName] || "front:active";
+      const detailLines = [
+        ...stakes.map(journalClause),
+        names ? `the answer still matters to ${names}` : "",
+        outcome,
+      ].filter(Boolean);
+      return journalRowHtml({
+        label,
+        summary: front.premise,
+        detailLines,
+        kind: `story-front ${stateName}`,
+      });
     }
 
     function sharedQuestionHtml(question) {
@@ -8427,36 +8483,45 @@
         const hands = recent
           .map((entry) => `${entry.actor_name || "a traveler"} ${lowerInitial(entry.strategy_label || "helped")}`)
           .join(" and ");
-        const detail = [
+        const detailLines = [
           journalClause(question.completion_memory || question.situation),
           hands ? `${hands} helped change it` : "",
           participants.length ? `${participants.join(", ")} were involved` : "",
-        ].filter(Boolean).join("; ");
+        ].filter(Boolean);
         return journalRowHtml({
           label: "changed",
           summary: question.completion_memory || question.situation,
-          detail,
-          progress,
+          detailLines,
           kind: "completed-memory",
           attrs,
           action,
         });
       }
-      const detail = [
+      const suggestions = (question.suggested_actions || []).slice(0, 2);
+      const suggestionLines = suggestions.map((suggestion, index) => {
+        const risk = journalClause(suggestion.risk || "no special risk is expected");
+        return [
+          `choice ${index + 1}/${suggestions.length}: ${journalClause(suggestion.label)}`,
+          suggestion.target_label ? `target ${journalClause(suggestion.target_label)}` : "",
+          suggestion.source ? `source ${journalClause(suggestion.source)}` : "",
+          suggestion.likely_effect ? `likely ${lowerInitial(journalClause(suggestion.likely_effect))}` : "",
+          risk ? `risk ${lowerInitial(risk)}` : "",
+        ].filter(Boolean).join(" · ");
+      });
+      const detailLines = [
         journalClause(question.situation),
         `progress is ${progress}`,
         question.danger_segments ? `danger is ${Number(question.danger_filled || 0)}/${Number(question.danger_segments || 0)}` : "",
         question.danger_situation ? `danger now: ${journalClause(question.danger_situation)}` : "",
         question.danger_consequence ? `if danger fills: ${lowerInitial(journalClause(question.danger_consequence))}` : "",
         question.outcome ? `finishing could ${lowerInitial(journalClause(question.outcome))}` : "",
-        (question.suggested_actions || []).length
-          ? `suggested now: ${question.suggested_actions.map((suggestion) => journalClause(suggestion.label)).join(", ")}`
-          : (helpers.length ? `help by ${helpers.join(", ")}` : ""),
-      ].filter(Boolean).join("; ");
+        ...suggestionLines,
+        suggestions.length === 0 && helpers.length ? `help by ${helpers.join(", ")}` : "",
+      ].filter(Boolean);
       return journalRowHtml({
-        label: `${rhythm} question`,
+        label: `question:${rhythm}`,
         summary: question.question,
-        detail,
+        detailLines,
         progress,
         kind: "active-question",
         attrs,
@@ -8464,59 +8529,15 @@
       });
     }
 
-    function sharedQuestionMeterHtml(label, filled, segments, kind = "") {
-      const total = Math.max(0, Number(segments || 0));
-      const current = Math.min(total, Math.max(0, Number(filled || 0)));
-      const percent = total ? Math.round((current / total) * 100) : 0;
-      return `<div class="shared-question-meter ${escapeAttr(kind)}" role="progressbar" aria-label="${escapeAttr(label)}" aria-valuemin="0" aria-valuemax="${total}" aria-valuenow="${current}" aria-valuetext="${current} of ${total}"><strong>${escapeHtml(label)}</strong><span>${current}/${total}</span><span class="shared-question-meter-track" aria-hidden="true"><span style="--meter-fill:${percent}%"></span></span></div>`;
-    }
-
-    function promotedQuestionHtml(question) {
-      const completed = question.presentation_state === "completed_memory";
-      const attrs = ` data-clock-presentation data-clock-id="${escapeAttr(question.progress_clock_id || "")}" data-question-state="${completed ? "completed_memory" : "active"}"`;
-      const contributors = (question.participant_names || []).filter(Boolean);
-      if (completed) {
-        const result = String(question.completion_memory || question.situation || "The shared question is settled.");
-        const contributorCopy = contributors.length ? `Contributors: ${contributors.join(", ")}.` : "";
-        return `<article class="shared-question completed-memory"${attrs} role="note" aria-label="${escapeAttr([result, contributorCopy].filter(Boolean).join(" "))}"><span class="shared-question-kicker">${question.resolution === "failed" ? "the road changed" : "the beacon changed"}</span><h2>${escapeHtml(result)}</h2>${contributorCopy ? `<p class="shared-question-situation">${escapeHtml(contributorCopy)}</p>` : ""}</article>`;
-      }
-      const suggestions = (question.suggested_actions || []).slice(0, 2);
-      const suggestionHtml = suggestions.length
-        ? `<ol class="shared-question-suggestions" aria-label="${suggestions.length} suggested ${suggestions.length === 1 ? "action" : "actions"}">${suggestions.map((suggestion, index) => {
-          const ordinal = `Suggestion ${index + 1} of ${suggestions.length}`;
-          const risk = suggestion.risk || "No special risk is expected.";
-          const rationale = `${ordinal}. ${suggestion.label}. Target: ${suggestion.target_label}. Source: ${suggestion.source}. Likely effect: ${suggestion.likely_effect}. Risk: ${risk}`;
-          return `<li aria-label="${escapeAttr(rationale)}"><strong>${escapeHtml(`${ordinal}: ${suggestion.label}`)}</strong><br />Target: ${escapeHtml(suggestion.target_label)} · Source: ${escapeHtml(suggestion.source)} · Likely: ${escapeHtml(suggestion.likely_effect)} · Risk: ${escapeHtml(risk)}</li>`;
-        }).join("")}</ol>`
-        : "";
-      const aria = [
-        question.question,
-        question.situation,
-        `Progress ${Number(question.filled || 0)} of ${Number(question.segments || 0)}`,
-        `Danger ${Number(question.danger_filled || 0)} of ${Number(question.danger_segments || 0)}`,
-        `Completion changes: ${question.outcome}`,
-        `Danger consequence: ${question.danger_consequence}`,
-      ].filter(Boolean).join(". ");
-      return `<article class="shared-question active-question"${attrs} role="region" aria-label="${escapeAttr(aria)}"><div class="shared-question-heading"><span><span class="shared-question-kicker">current question</span><h2>${escapeHtml(question.question)}</h2></span><span class="shared-question-progress">${Number(question.filled || 0)}/${Number(question.segments || 0)}</span></div><p class="shared-question-situation">${escapeHtml(question.situation)}</p><div class="shared-question-meters">${sharedQuestionMeterHtml("Progress", question.filled, question.segments)}${sharedQuestionMeterHtml("Danger", question.danger_filled, question.danger_segments, "danger")}</div><div class="shared-question-detail"><span><strong>Completion changes</strong><br />${escapeHtml(question.outcome || "")}</span><span><strong>Danger now</strong><br />${escapeHtml(question.danger_situation || "")}</span><span><strong>If danger fills</strong><br />${escapeHtml(question.danger_consequence || "")}</span></div>${suggestionHtml}</article>`;
-    }
-
-    function renderPromotedQuestion() {
-      const panel = $("promoted-question");
+    function renderSharedQuestions() {
+      const panel = $("shared-questions");
       const fronts = frontsForPresentation();
       const questions = sharedQuestionsForPresentation();
       panel.hidden = fronts.length === 0 && questions.length === 0;
       panel.innerHTML = [
-        ...fronts.slice(0, 1).map(promotedFrontHtml),
-        ...questions.slice(0, 1).map(promotedQuestionHtml),
+        ...fronts.slice(0, 1).map(sharedFrontHtml),
+        ...questions.map(sharedQuestionHtml),
       ].join("");
-      if (questions.length) scheduleVisibleClockPresentationReceipts();
-    }
-
-    function renderSharedQuestions() {
-      const panel = $("shared-questions");
-      const questions = sharedQuestionsForPresentation();
-      panel.hidden = questions.length === 0;
-      panel.innerHTML = questions.map(sharedQuestionHtml).join("");
       if (questions.length && journalOpen) scheduleVisibleClockPresentationReceipts();
     }
 
@@ -8526,15 +8547,12 @@
         (event.location_id || event.destination_location_id)
         && !eventMatchesCurrentLocation(event)
       ) return false;
-      if (event.type === "message.created") return true;
+      if (event.type === "message.created") return false;
       const meta = statusUpdateMeta(event);
       return Boolean(meta?.text || sceneCardEventText(event));
     }
 
     function journalEventSummary(event) {
-      if (event.type === "message.created") {
-        return journalSummary(`${event.actor_name || "CosyWorld"} — ${eventText(event)}`);
-      }
       if (isRollEvent(event)) {
         const roll = rollMeta(event);
         return journalSummary(`${roll.title} · ${roll.result}`);
@@ -8553,15 +8571,6 @@
           detail: storyReceipt.text,
           kind: "story",
           inspector: logEvents.filter((candidate) => covered.has(Number(candidate?.seq || 0))),
-        });
-      }
-      if (event.type === "message.created") {
-        const text = eventText(event);
-        return journalRowHtml({
-          label: "chat",
-          summary: journalEventSummary(event),
-          detail: text,
-          kind: event.actor_id === actorId ? "you" : "chat",
         });
       }
       if (isRollEvent(event)) {
@@ -8602,7 +8611,7 @@
         : journalRowHtml({
             label: "room",
             summary: "Nothing has been written here yet",
-            detail: "Chat with someone or explore the room to leave the first trace",
+            detail: "Explore the room or change the world to leave the first trace",
             kind: "empty",
           });
       if (stream) {
@@ -9118,7 +9127,7 @@
       log.classList.toggle("quiet-mode", !libraryPanel && !accountPanel && inferredOnly);
       const panelMode = libraryPanel ? "library" : (accountPanel ? "account" : "");
       document.querySelector(".terminal")?.classList.toggle("panel-open", Boolean(panelMode));
-      document.querySelector(".prompt").hidden = Boolean(panelMode || journalOpen);
+      document.querySelector(".prompt").hidden = Boolean(panelMode);
       if (panelMode) {
         log.setAttribute("role", "region");
         log.setAttribute("aria-label", panelMode === "library" ? "World Library" : "Your avatar and collection");

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -48061,7 +48061,7 @@ mod tests {
         assert!(INDEX_HTML.contains("/actions/set-charm-equipped"));
         assert!(INDEX_HTML.contains("data-export-journal"));
         assert!(INDEX_HTML
-            .contains("id=\"shared-questions\" aria-label=\"Shared questions in this place\""));
+            .contains("id=\"shared-questions\" aria-label=\"Current story and shared questions in this place\""));
         assert!(INDEX_HTML.contains("function renderSharedQuestions"));
         assert!(INDEX_HTML.contains("role=\"progressbar\""));
         assert!(INDEX_HTML.contains("question.strategies"));

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -5420,8 +5420,8 @@ async function main() {
     );
     assert(
       result.roomLatest === result.latestJournalRow
-        && result.roomLatest === "Thimble Guest — Anyone want to follow the newly opened path?",
-      `the room ticker should mirror the newest Journal row: ${JSON.stringify(result)}`,
+        && result.roomLatest === "Thimble Guest looks closely around The Cosy Cottage.",
+      `the room ticker should mirror the newest Journal event without duplicating chat: ${JSON.stringify(result)}`,
     );
     assert(result.preferredPlayerBeat === "Thimble Guest listened; the room answered", `the collapsed log should keep the player's card beat above derived memories and resident ripples: ${JSON.stringify(result)}`);
     assert(result.preferredReportBeat === "Report submitted for Gust.", `direct safety confirmations should still become the collapsed room headline: ${JSON.stringify(result)}`);
@@ -5663,6 +5663,7 @@ async function main() {
     const screenshotPath = resolve(visualSnapshotDir, "lantern-question-two-suggestions.png");
     const metadataPath = resolve(visualSnapshotDir, "lantern-question-two-suggestions.json");
     await mkdir(visualSnapshotDir, { recursive: true });
+    await page.setViewportSize({ width: 1100, height: 900 });
     const evidence = await page.evaluate(() => {
       window.__cosyLanternQuestionEvidence = {
         state,
@@ -5783,13 +5784,15 @@ async function main() {
       focusedKey = "";
       playerPromotedHandKey = "";
       render();
-      const front = document.querySelector("#promoted-question .story-front");
-      const question = document.querySelector("#promoted-question .active-question");
+      setJournalOpen(true);
+      const front = document.querySelector("#shared-questions .story-front");
+      const question = document.querySelector("#shared-questions .active-question");
+      front.open = true;
+      question.open = true;
       const meters = [...question.querySelectorAll('[role="progressbar"]')].map((meter) => ({
         label: meter.getAttribute("aria-label"),
         now: meter.getAttribute("aria-valuenow"),
         max: meter.getAttribute("aria-valuemax"),
-        text: meter.getAttribute("aria-valuetext"),
       }));
       const buttons = ["primary", "secondary"].map((id) => {
         const button = document.getElementById(id);
@@ -5800,47 +5803,72 @@ async function main() {
           visible: Boolean(button && button.getClientRects().length),
         };
       });
+      const rect = (selector) => {
+        const node = document.querySelector(selector);
+        const box = node?.getBoundingClientRect();
+        return box ? {
+          top: box.top,
+          right: box.right,
+          bottom: box.bottom,
+          left: box.left,
+          width: box.width,
+          height: box.height,
+        } : null;
+      };
       return {
         frontText: front?.textContent || "",
-        frontLabelledBy: front?.getAttribute("aria-labelledby") || "",
-        frontDescribedBy: front?.getAttribute("aria-describedby") || "",
-        frontDescription: (front?.getAttribute("aria-describedby") || "")
-          .split(/\s+/)
-          .filter(Boolean)
-          .map((id) => document.getElementById(id)?.textContent || "")
+        frontSummary: front?.querySelector(".journal-row-summary")?.textContent || "",
+        frontDescription: [...(front?.querySelectorAll(".journal-row-lines li") || [])]
+          .map((line) => line.textContent || "")
           .join(" "),
-        frontRosterLists: front?.querySelectorAll("ul, ol").length || 0,
+        frontInspectorLists: front?.querySelectorAll(".journal-row-inspector").length || 0,
         questionText: question?.textContent || "",
-        questionAria: question?.getAttribute("aria-label") || "",
+        questionDescription: [...(question?.querySelectorAll(".journal-row-lines li") || [])]
+          .map((line) => line.textContent || "")
+          .join(" "),
         meters,
         buttons,
-        suggestionLabels: [...question.querySelectorAll(".shared-question-suggestions li")]
-          .map((item) => item.getAttribute("aria-label") || ""),
+        roomStoryCount: document.querySelectorAll(".room .story-front, .room .active-question, #promoted-question").length,
+        journalVisible: Boolean(document.querySelector("#journal-view")?.getClientRects().length),
+        chatVisible: Boolean(document.querySelector("#log")?.getClientRects().length),
+        promptVisible: Boolean(document.querySelector(".prompt")?.getClientRects().length),
+        journalRect: rect("#journal-view"),
+        chatRect: rect("#log"),
       };
     });
     assert(
-      evidence.frontText.includes("beacon's shadow has learned Rowan's shape")
-        && evidence.frontText.includes("Can Rowan be separated from the shadow")
-        && evidence.frontText.includes("Will the party restore a guiding light")
-        && evidence.frontText.includes("The answer still matters to Pip Thistle, Moth-Eaten Knight, and Rowan Vale.")
+      evidence.frontSummary.includes("beacon's shadow has learned Rowan's shape")
         && evidence.frontDescription.includes("Can Rowan be separated from the shadow")
-        && evidence.frontRosterLists === 0,
-      `ordinary scene should present the front as accessible narrative, not a roster: ${JSON.stringify(evidence)}`,
+        && evidence.frontDescription.includes("Will the party restore a guiding light")
+        && evidence.frontDescription.includes("the answer still matters to Pip Thistle, Moth-Eaten Knight, and Rowan Vale")
+        && evidence.frontInspectorLists === 0,
+      `the Journal should present the front as compact accessible narrative, not a roster: ${JSON.stringify(evidence)}`,
     );
-    assert(evidence.questionText.includes("Progress2/6") && evidence.questionText.includes("Danger1/6"), `ordinary scene should show both exact clocks: ${JSON.stringify(evidence)}`);
-    assert(evidence.questionText.includes("Completion changes") && evidence.questionText.includes("If danger fills"), `ordinary scene should explain both outcomes: ${JSON.stringify(evidence)}`);
+    assert(
+      evidence.questionText.includes("Can the Mothwood beacon be relit")
+        && evidence.questionDescription.includes("progress is 2/6")
+        && evidence.questionDescription.includes("danger is 1/6")
+        && evidence.questionDescription.includes("if danger fills")
+        && evidence.questionDescription.includes("finishing could")
+        && evidence.questionDescription.includes("choice 1/2")
+        && evidence.questionDescription.includes("choice 2/2")
+        && evidence.questionDescription.includes("target the brass beacon shutters")
+        && evidence.questionDescription.includes("risk trouble may draw nearer while you rest"),
+      `the compact Journal question should preserve clocks, outcomes, and both rationales: ${JSON.stringify(evidence)}`,
+    );
     assert(
       JSON.stringify(evidence.meters) === JSON.stringify([
-        { label: "Progress", now: "2", max: "6", text: "2 of 6" },
-        { label: "Danger", now: "1", max: "6", text: "1 of 6" },
+        { label: "Progress", now: "2", max: "6" },
       ]),
-      `progress and danger meters should expose exact accessible values: ${JSON.stringify(evidence)}`,
+      `the collapsed Journal row should expose exact progress without dashboard meter chrome: ${JSON.stringify(evidence)}`,
     );
     assert(
-      evidence.suggestionLabels.length === 2
-        && evidence.suggestionLabels[0].startsWith("Suggestion 1 of 2")
-        && evidence.suggestionLabels[1].startsWith("Suggestion 2 of 2"),
-      `the rationale list should describe exactly two suggestions: ${JSON.stringify(evidence)}`,
+      evidence.roomStoryCount === 0
+        && evidence.journalVisible
+        && evidence.chatVisible
+        && evidence.promptVisible
+        && evidence.chatRect.right <= evidence.journalRect.left + 0.5,
+      `Journal should be the sole story surface and must not replace or overlap chat: ${JSON.stringify(evidence)}`,
     );
     assert(
       evidence.buttons.every((button) => button.visible)
@@ -5849,7 +5877,6 @@ async function main() {
         && evidence.buttons.every((button) => !/action \d+ of \d+/i.test(button.aria)),
       `the two playable cards should use suggestion ordinals and no legal-superset count: ${JSON.stringify(evidence)}`,
     );
-    await page.setViewportSize({ width: 1100, height: 900 });
     await page.screenshot({ path: screenshotPath, fullPage: false });
     evidence.frontOutcomes = await page.evaluate(() => {
       const cases = [
@@ -5872,15 +5899,13 @@ async function main() {
           fronts: [{ ...state.fronts[0], ...frontCase }],
         };
         render();
-        const front = document.querySelector("#promoted-question .story-front");
-        const describedBy = front?.getAttribute("aria-describedby") || "";
+        const front = document.querySelector("#shared-questions .story-front");
+        front.open = true;
         return {
           presentationState: frontCase.presentation_state,
           text: front?.textContent || "",
-          describedText: describedBy
-            .split(/\s+/)
-            .filter(Boolean)
-            .map((id) => document.getElementById(id)?.textContent || "")
+          describedText: [...(front?.querySelectorAll(".journal-row-lines li") || [])]
+            .map((line) => line.textContent || "")
             .join(" "),
         };
       });
@@ -5916,8 +5941,10 @@ async function main() {
         }],
       };
       render();
-      const front = document.querySelector("#promoted-question .story-front");
-      const memory = document.querySelector("#promoted-question .completed-memory");
+      const front = document.querySelector("#shared-questions .story-front");
+      const memory = document.querySelector("#shared-questions .completed-memory");
+      front.open = true;
+      memory.open = true;
       return {
         frontText: front?.textContent || "",
         text: memory?.textContent || "",
@@ -5928,7 +5955,7 @@ async function main() {
     assert(
       evidence.terminal.frontText.includes("the larger trouble remains unresolved")
         && evidence.terminal.text.includes("road went fully dark")
-        && evidence.terminal.text.includes("Contributors: Mara Wick, Road Reader")
+        && evidence.terminal.text.includes("Mara Wick, Road Reader were involved")
         && evidence.terminal.progressbars === 0
         && evidence.terminal.suggestions === 0,
       `terminal question should retire task bars to contributor memory: ${JSON.stringify(evidence)}`,
@@ -5946,6 +5973,7 @@ async function main() {
       focusedKey = previous.focusedKey;
       playerPromotedHandKey = previous.playerPromotedHandKey;
       delete window.__cosyLanternQuestionEvidence;
+      setJournalOpen(false);
       render();
     });
     if (previousViewport) await page.setViewportSize(previousViewport);
@@ -8774,9 +8802,11 @@ async function main() {
       );
       const rows = [...document.querySelectorAll("#journal-view .journal-row")];
       const summaries = rows.map((row) => row.querySelector(".journal-row-summary")).filter(Boolean);
-      const detailNodes = rows.map((row) => row.querySelector(".journal-row-detail p")).filter(Boolean);
+      const detailNodes = rows.map((row) => row.querySelector(".journal-row-detail")).filter(Boolean);
       const terminalRect = document.querySelector(".terminal")?.getBoundingClientRect();
       const journalRect = document.querySelector("#journal-view")?.getBoundingClientRect();
+      const chatRect = document.querySelector("#log")?.getBoundingClientRect();
+      const journalStyle = getComputedStyle(document.querySelector("#journal-view"));
       return {
         expanded: document.querySelector("#room-log-toggle")?.getAttribute("aria-expanded") || "",
         journalVisible: visible(document.querySelector("#journal-view")),
@@ -8784,6 +8814,8 @@ async function main() {
         transcriptVisible: visible(document.querySelector("#log")),
         promptVisible: visible(document.querySelector("footer.prompt")),
         role: document.querySelector("#journal-log")?.getAttribute("role") || "",
+        heading: document.querySelector(".journal-heading h2")?.textContent || "",
+        fontFamily: journalStyle.fontFamily,
         rowCount: rows.length,
         allCollapsed: rows.every((row) => !row.open),
         rowsCompact: rows.every((row) => row.getBoundingClientRect().height <= 42),
@@ -8795,6 +8827,16 @@ async function main() {
         }),
         detailsHidden: detailNodes.every((node) => !visible(node)),
         noDashboardCopy: !/why this matters|what we know/i.test(document.querySelector("#journal-view")?.textContent || ""),
+        noCardChrome: document.querySelectorAll("#journal-view article, #journal-view img, #journal-view .shared-question-meter, #journal-view .shared-question-suggestions").length === 0,
+        panesDoNotOverlap: Boolean(
+          journalRect
+          && chatRect
+          && (
+            window.innerWidth <= 900
+              ? chatRect.bottom <= journalRect.top + 0.5
+              : chatRect.right <= journalRect.left + 0.5
+          )
+        ),
         insideTerminal: Boolean(
           terminalRect
           && journalRect
@@ -8809,26 +8851,41 @@ async function main() {
       };
     }, room.stateSignature);
     assert(journal.expanded === "true" && journal.journalVisible, `${label}: Journal should open from beside the location name: ${JSON.stringify(journal)}`);
-    assert(!journal.heroVisible && !journal.transcriptVisible && !journal.promptVisible, `${label}: Journal should take over the location/chat/action region: ${JSON.stringify(journal)}`);
-    assert(journal.role === "log" && journal.rowCount >= 2, `${label}: Journal should expose current context and chronological history: ${JSON.stringify(journal)}`);
+    assert(journal.transcriptVisible && journal.promptVisible && journal.panesDoNotOverlap, `${label}: Journal must remain separate from visible chat and actions: ${JSON.stringify(journal)}`);
+    assert(journal.role === "region" && journal.rowCount >= 2, `${label}: Journal should expose current context and chronological history without replaying it as a live log: ${JSON.stringify(journal)}`);
     assert(journal.allCollapsed && journal.rowsCompact && journal.summariesOneLine && journal.detailsHidden, `${label}: Journal rows should begin as true one-line summaries: ${JSON.stringify(journal)}`);
-    assert(journal.noDashboardCopy && journal.insideTerminal && journal.stateUnchanged, `${label}: Journal should stay minimalist without changing inference-facing state: ${JSON.stringify(journal)}`);
+    assert(
+      journal.heading === "journal://"
+        && /mono|menlo|consolas/i.test(journal.fontFamily)
+        && journal.noCardChrome
+        && journal.noDashboardCopy
+        && journal.insideTerminal
+        && journal.stateUnchanged,
+      `${label}: Journal should stay a minimalist console without changing inference-facing state: ${JSON.stringify(journal)}`,
+    );
 
     const rowCount = await page.locator("#journal-view .journal-row > summary").count();
     assert(rowCount >= 1, `${label}: Journal should have an expandable row`);
     await page.locator("#journal-view .journal-row > summary").first().click();
     const expandedRow = await page.evaluate(() => {
       const open = document.querySelector("#journal-view .journal-row[open]");
-      const detail = open?.querySelector(".journal-row-detail p")?.textContent?.trim() || "";
-      const endings = detail.match(/[.!?…]+(?:["')\]]+)?(?:\s|$)/g) || [];
-      const sentenceCount = detail ? Math.max(1, endings.length) : 0;
+      const detail = open?.querySelector(".journal-row-detail")?.textContent?.trim() || "";
       return {
         detail,
-        sentenceCount,
+        lineCount: open?.querySelectorAll(".journal-row-lines li").length || 0,
+        paragraphCount: open?.querySelectorAll(".journal-row-detail > p").length || 0,
+        chromeCount: open?.querySelectorAll("h1, h2, h3, article, img").length || 0,
         openCount: document.querySelectorAll("#journal-view .journal-row[open]").length,
       };
     });
-    assert(expandedRow.openCount === 1 && expandedRow.detail && expandedRow.sentenceCount === 1, `${label}: expanding a row should reveal exactly one sentence: ${JSON.stringify(expandedRow)}`);
+    assert(
+      expandedRow.openCount === 1
+        && expandedRow.detail
+        && expandedRow.lineCount <= 12
+        && expandedRow.paragraphCount <= 1
+        && expandedRow.chromeCount === 0,
+      `${label}: expanding a row should reveal bounded console detail without card chrome: ${JSON.stringify(expandedRow)}`,
+    );
 
     await page.locator("#room-log-toggle").click();
     await page.waitForFunction(() => (


### PR DESCRIPTION
## What changed

- Moves the active story front and shared questions out of the room scene and into the Journal.
- Keeps chat and the action prompt visible whenever the Journal is open.
- Gives the Journal a compact `journal://` console treatment with one-line summaries and expandable `$` detail lines.
- Uses a desktop side-by-side split and a bounded mobile stack so Journal content never overlaps chat.
- Stops duplicating `message.created` chat messages into Journal history.
- Adds browser regression coverage for populated story/question content, exact clock and rationale details, pane geometry, compact rows, and desktop/mobile visibility.
- Bumps the release version to 0.0.214.

## Why

The Journal-open grid declared only two rows while chat was still assigned to grid row 3. CSS created an implicit row, which left chat clipped beneath large promoted story cards rendered directly in the room. Journal opening also explicitly hid chat and the action prompt, and speech was duplicated into Journal history.

## Impact

Story state now has one dedicated home in the Journal, speech stays in chat, and players retain visible chat/actions while reviewing world events. The expanded Journal preserves the full stakes, clock state, consequences, contributors, and two suggested-action rationales without dashboard-style card chrome.

## Validation

- Repository pre-push `npm run check` passed:
  - 481 JavaScript tests
  - official and composition worldpack checks
  - strict proof-world check
  - C kernel tests
  - 739 Rust tests
  - main.rs architecture ceiling
  - clippy warning ceiling
  - JavaScript/Python syntax checks
- Deterministic Playwright browser smoke passed, including the populated Lantern Keeper story/question state.
- Live in-app browser geometry checks at 1280×900 and 390×844 confirmed zero Journal/chat overlap, visible chat, visible actions, no horizontal overflow, and no promoted story DOM in the room.