### PR TITLE
Ordered-combat timing banner, and make the voice attempt budget reachable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.214",
+  "version": "0.0.215",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.214",
+      "version": "0.0.215",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.214",
+  "version": "0.0.215",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.214"
+version = "0.0.215"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.214"
+version = "0.0.215"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -173,6 +173,15 @@ pub(crate) struct VoiceSelectionDecision {
     pub(crate) weighted_key: f64,
     pub(crate) estimated_cost_microdollars: u64,
     pub(crate) selected: bool,
+    /// True when this attempt reuses an already-planned model to fill the
+    /// attempt budget, because the registry pinned fewer distinct candidates
+    /// than the budget allows. Recorded so telemetry can tell a genuinely
+    /// diverse cast apart from a thin pool being resampled.
+    ///
+    /// Defaulted so `decision_json` rows written before this field existed
+    /// still deserialize.
+    #[serde(default)]
+    pub(crate) resampled: bool,
     pub(crate) excluded_reason: Option<String>,
 }
 
@@ -593,6 +602,7 @@ fn build_voice_plan(
                     weighted_key,
                     estimated_cost_microdollars,
                     selected: false,
+                    resampled: false,
                     excluded_reason,
                 },
             ))
@@ -628,6 +638,37 @@ fn build_voice_plan(
         }
         all.push(decision);
     }
+
+    // A thin candidate pool must not silence a resident. Every publication gate
+    // gets its verdict from one sampled completion, so a single rejection is a
+    // property of that sample rather than of the model. When the registry pins
+    // fewer distinct models than the attempt budget allows, resample the best
+    // planned candidate to fill the remaining attempts. The gates still judge
+    // every sample independently and no rejected bytes become observable; this
+    // only stops one unlucky sample from being terminal. Still bounded by the
+    // spend ceiling, so the cost envelope is unchanged.
+    if !planned.is_empty() && planned.len() < config.max_attempts as usize {
+        let mut ordinal = planned.len() as u8;
+        while planned.len() < config.max_attempts as usize {
+            let source = planned[0].clone();
+            let cost = source.decision.estimated_cost_microdollars;
+            if spent.saturating_add(cost) > config.spend_ceiling_microdollars {
+                break;
+            }
+            spent = spent.saturating_add(cost);
+            ordinal += 1;
+            let mut decision = source.decision.clone();
+            decision.selected = true;
+            decision.ordinal = ordinal;
+            decision.resampled = true;
+            planned.push(PlannedCandidate {
+                selection: source.selection.clone(),
+                decision: decision.clone(),
+            });
+            all.push(decision);
+        }
+    }
+
     Ok((planned, all))
 }
 
@@ -1408,6 +1449,90 @@ mod tests {
             std::process::id(),
             crate::now_seed()
         ))
+    }
+
+    fn single_candidate(routing: VoiceRoutingConfig) -> AiConfig {
+        config(
+            vec![candidate(
+                "provider/tiny-a",
+                "provider-a",
+                "tiny/a",
+                "tiny-a",
+                "r1",
+                true,
+            )],
+            routing,
+        )
+    }
+
+    #[test]
+    fn a_thin_candidate_pool_still_fills_the_attempt_budget_by_resampling() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 3,
+            ..VoiceRoutingConfig::default()
+        });
+        let candidates = config.pin_models(ModelCapability::Voice).unwrap();
+        assert_eq!(candidates.len(), 1, "the pool pins exactly one model");
+
+        let (planned, _) = build_voice_plan(
+            None,
+            "generation-thin",
+            5_000,
+            "prose",
+            &request("dialogue_avatar"),
+            &config.voice_routing,
+            candidates,
+        )
+        .unwrap();
+
+        // One pinned model previously produced one attempt, so any single
+        // publication rejection was terminal and the resident fell silent.
+        assert_eq!(planned.len(), 3, "the attempt budget is reachable");
+        assert!(
+            planned
+                .iter()
+                .all(|entry| entry.decision.requested_model_id == "provider/tiny-a"),
+            "a thin pool resamples the same model rather than inventing one",
+        );
+        let ordinals = planned
+            .iter()
+            .map(|entry| entry.decision.ordinal)
+            .collect::<Vec<_>>();
+        assert_eq!(ordinals, vec![1, 2, 3], "ordinals stay unique and ordered");
+        assert_eq!(
+            planned
+                .iter()
+                .filter(|entry| entry.decision.resampled)
+                .count(),
+            2,
+            "only the filler attempts are marked as resampled",
+        );
+    }
+
+    #[test]
+    fn resampling_never_exceeds_the_spend_ceiling() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 4,
+            spend_ceiling_microdollars: 1,
+            unknown_cost_microdollars: 1,
+            ..VoiceRoutingConfig::default()
+        });
+        let candidates = config.pin_models(ModelCapability::Voice).unwrap();
+        let (planned, _) = build_voice_plan(
+            None,
+            "generation-thin-budget",
+            5_000,
+            "prose",
+            &request("dialogue_avatar"),
+            &config.voice_routing,
+            candidates,
+        )
+        .unwrap();
+        assert_eq!(
+            planned.len(),
+            1,
+            "the spend ceiling still bounds the attempt budget",
+        );
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1635,8 +1635,38 @@
       border-top: 1px solid var(--line);
       background: rgba(5, 8, 6, 0.98);
     }
-    .turn-ping-pill {
+    .turn-banner {
       grid-column: 1 / -1;
+      display: flex;
+      align-items: stretch;
+      gap: 8px;
+      min-width: 0;
+      flex-wrap: wrap;
+    }
+    .turn-banner[hidden] { display: none; }
+    .turn-banner-controls {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex: 0 0 auto;
+    }
+    .turn-banner-controls:empty { display: none; }
+    .turn-banner-control {
+      min-height: 34px;
+      padding: 0 12px;
+      border-radius: 4px;
+      border: 1px solid rgba(255, 141, 141, 0.58);
+      background: rgba(255, 141, 141, 0.14);
+      color: var(--red);
+      font: inherit;
+      font-size: 12px;
+      font-weight: 900;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .turn-banner-control:disabled { opacity: 0.55; cursor: default; }
+    .turn-ping-pill {
+      flex: 1 1 220px;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -3928,7 +3958,10 @@
     </main>
     <div class="status" id="error" role="status" aria-live="polite" aria-atomic="true"></div>
     <footer class="prompt">
-      <div class="turn-ping-pill" id="turn-ping-pill" role="status" aria-live="polite" aria-atomic="true" hidden></div>
+      <div class="turn-banner" id="turn-banner" hidden>
+        <div class="turn-ping-pill" id="turn-ping-pill" role="status" aria-live="polite" aria-atomic="true"></div>
+        <div class="turn-banner-controls" id="turn-banner-controls"></div>
+      </div>
       <button class="cmd primary" id="primary" data-player-concept="action" data-analytics-event="action.select"></button>
       <button class="cmd secondary" id="secondary" data-player-concept="action" data-analytics-event="action.select"></button>
       <button class="cmd shuffle type-shuffle" id="shuffle" data-player-concept="draw" data-analytics-event="action.draw" aria-label="Draw two more actions">
@@ -4122,6 +4155,7 @@
     let economyFlashTimer = null;
     let presenceHeartbeatTimer = null;
     let announcedTurnHandoffKey = "";
+    let turnBannerControlRuns = new Map();
     let walletQrPollTimer = null;
     let walletQrResolve = null;
     let firstTaleActorIdSeen = 0;
@@ -5142,75 +5176,16 @@
             run: () => action("/actions/timeout", { actor_id: actorId }),
           });
         }
-        const waitingAction = {
-          handProvider: {
-            kind: "rules",
-            id: "rules:ordered-scene",
-            label: "Ordered scene",
-            reason: "This scene explicitly uses turns",
-            priority: 0,
-          },
-          label: "ordered combat",
-          detail: `${currentName} acts now`,
-          command: "look",
-          focusKey: "ordered-scene",
-          card: cardForActor(turn.current_actor_id) || cardForLocation(view.location?.id),
-          shape: "avatar",
-          priority: 5,
-          modalTitle: "combat uses an ordered floor",
-          modalSummary: turn.explanation || `${currentName} acts now. Chat and inspection stay available.`,
-          effect: "shows the current combat order without taking an action",
-          run: () => runCommandText("look"),
-        };
-        waitingActions.push(waitingAction);
+        // Ordered-combat status belongs in the turn banner, not the card hand.
+        // A waiting player receives no dealt card here, so nothing can bypass
+        // or crowd the combat floor. See issue #461.
         return waitingActions.map(decorateActionHand);
       }
 
+      // Pass and Need time are timing controls, not ranked combat actions.
+      // They render in the turn banner so the card row stays reserved for
+      // legal combat choices. See issue #461 and turnBannerControlSpecs.
       const built = [];
-      if (turn.enabled && turn.is_current_actor && turn.policy === "scene-turn") {
-        if (turn.can_pass) {
-          built.push({
-            handProvider: {
-              kind: "rules",
-              id: "rules:ordered-scene-pass",
-              label: "Ordered scene",
-              reason: "Pass the authored combat floor",
-              priority: 0,
-            },
-            label: "pass",
-            detail: "yield this combat turn",
-            command: "pass",
-            focusKey: "scene-pass",
-            card: cardForActor(actorId),
-            shape: "avatar",
-            modalTitle: "pass this combat turn",
-            modalSummary: "The next combat participant acts. Passing does not make you dodge.",
-            effect: "advances the ordered scene once",
-            run: () => action("/actions/pass", { actor_id: actorId }),
-          });
-        }
-        if (turn.can_need_time) {
-          built.push({
-            handProvider: {
-              kind: "rules",
-              id: "rules:ordered-scene-need-time",
-              label: "Ordered scene",
-              reason: "Ask for a nonpunitive pause",
-              priority: 0,
-            },
-            label: "need time",
-            detail: "pause without losing your turn",
-            command: "need time",
-            focusKey: "scene-need-time",
-            card: cardForActor(actorId),
-            shape: "avatar",
-            modalTitle: "take more time",
-            modalSummary: `Keep the combat floor and add ${Math.round(Number(turn.need_time_extension_ms || 60000) / 1000)} seconds of authored grace.`,
-            effect: "records the pause without advancing world time or skipping anyone",
-            run: () => action("/actions/need-time", { actor_id: actorId }),
-          });
-        }
-      }
       const journey = view.journey || null;
       if (journey) {
         const nextLocationId = Number(journey.next_location_id || 0);
@@ -6465,20 +6440,67 @@
     }
 
     function turnPingPillHtml(turn = state?.turn) {
-      if (!turn?.enabled || turn?.policy !== "scene-turn") return "";
+      if (!turn?.enabled) return "";
       const currentName = turn.current_actor_name || "the current player";
-      const copy = turn.is_current_actor
-        ? "ordered combat — your turn"
-        : `ordered combat — ${currentName} acts now`;
+      // Combat keeps its own wording; other ordered policies still need the
+      // same status now that no card carries it. See issue #461.
+      const copy = turn.policy === "scene-turn"
+        ? (turn.is_current_actor ? "ordered combat — your turn" : `ordered combat — ${currentName} acts now`)
+        : (turn.is_current_actor ? "ordered scene — your turn" : `ordered scene — ${currentName} acts now`);
       const grace = Math.round(Number(turn.grace_period_ms || 0) / 1000);
-      return `<span class="turn-ping-copy">${escapeHtml(copy)}</span>${grace > 0 ? `<span class="turn-ping-time" aria-hidden="true">${escapeHtml(`${grace}s grace`)}</span>` : ""}`;
+      // Urgency carries a glyph and distinct wording, never colour alone.
+      const mark = turn.is_current_actor
+        ? `<span class="turn-ping-mark" aria-hidden="true">&#9654;</span>`
+        : "";
+      return `${mark}<span class="turn-ping-copy">${escapeHtml(copy)}</span>${grace > 0 ? `<span class="turn-ping-time" aria-hidden="true">${escapeHtml(`${grace}s grace`)}</span>` : ""}`;
+    }
+
+    // Ordered-combat timing is scene status, not a dealt action. Pass and Need
+    // time live here as bounded controls so the card row stays reserved for
+    // legal combat actions. See issue #461.
+    function turnBannerControlSpecs(turn = state?.turn) {
+      if (!turn?.enabled || turn?.policy !== "scene-turn" || !turn?.is_current_actor) return [];
+      const specs = [];
+      if (turn.can_pass) {
+        specs.push({
+          key: "pass",
+          label: "pass",
+          title: "Yield this combat turn. The next participant acts; passing does not make you dodge.",
+          run: () => action("/actions/pass", { actor_id: actorId }),
+        });
+      }
+      if (turn.can_need_time) {
+        const seconds = Math.round(Number(turn.need_time_extension_ms || 60000) / 1000);
+        specs.push({
+          key: "need-time",
+          label: "need time",
+          title: `Keep the combat floor and add ${seconds} seconds of authored grace.`,
+          run: () => action("/actions/need-time", { actor_id: actorId }),
+        });
+      }
+      return specs;
+    }
+
+    function renderTurnBannerControls() {
+      const host = $("turn-banner-controls");
+      if (!host) return;
+      const specs = turnBannerControlSpecs();
+      turnBannerControlRuns = new Map(specs.map((spec) => [spec.key, spec.run]));
+      const html = specs
+        .map((spec) => (
+          `<button type="button" class="turn-banner-control" data-turn-control="${escapeAttr(spec.key)}" title="${escapeAttr(spec.title)}">${escapeHtml(spec.label)}</button>`
+        ))
+        .join("");
+      if (host.innerHTML !== html) host.innerHTML = html;
     }
 
     function renderTurnPingPill() {
       const pill = $("turn-ping-pill");
       if (!pill) return;
       const html = turnPingPillHtml();
-      pill.hidden = !html;
+      const banner = $("turn-banner");
+      if (banner) banner.hidden = !html;
+      renderTurnBannerControls();
       pill.classList.toggle("urgent", Boolean(state?.turn?.enabled && state?.turn?.is_current_actor));
       const handoffKey = html ? String(state?.turn?.handoff_key || "") : "";
       if (!html) {
@@ -12517,6 +12539,17 @@
         .replaceAll("<", "&lt;")
         .replaceAll(">", "&gt;");
     }
+
+    document.addEventListener("click", (event) => {
+      const control = event.target.closest("[data-turn-control]");
+      if (!control) return;
+      const run = turnBannerControlRuns.get(control.getAttribute("data-turn-control") || "");
+      if (!run) return;
+      event.preventDefault();
+      event.stopPropagation();
+      control.disabled = true;
+      Promise.resolve(run()).finally(() => { control.disabled = false; });
+    }, true);
 
     document.addEventListener("click", (event) => {
       const target = event.target.closest("[data-card-key]");

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -48220,6 +48220,14 @@ mod tests {
         assert!(!INDEX_HTML.contains("const buildUnlockCharmSlotAction"));
         assert!(INDEX_HTML.contains("id=\"turn-ping-pill\""));
         assert!(INDEX_HTML.contains("ordered combat — your turn"));
+        // Issue #461: ordered-combat timing is a banner above the card row, and
+        // Pass/Need time are banner controls rather than dealt combat cards.
+        assert!(INDEX_HTML.contains("id=\"turn-banner\""));
+        assert!(INDEX_HTML.contains("id=\"turn-banner-controls\""));
+        assert!(INDEX_HTML.contains("data-turn-control"));
+        assert!(!INDEX_HTML.contains("rules:ordered-scene-pass"));
+        assert!(!INDEX_HTML.contains("rules:ordered-scene-need-time"));
+        assert!(!INDEX_HTML.contains("shows the current combat order without taking an action"));
         assert!(INDEX_HTML.contains("Receive one ambient lead from the room."));
         assert!(!INDEX_HTML.contains("temporary Dex priority boost"));
         assert!(INDEX_HTML.contains("class=\"roll-symbol\""));

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -1,3 +1,7 @@
 # Total physical lines in main.rs, including inline tests. Tests spend the same
 # budget as production code so extracted systems take their tests with them.
-73214
+#
+# 73214 -> 73222: eight INDEX_HTML contract assertions for issue #461, pinning
+# the ordered-combat banner markup and the removal of the dealt timing cards.
+# Test-only, no new system; the behaviour itself lives in index.html.
+73222

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -7254,7 +7254,13 @@ async function main() {
     await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
     const scene = await page.evaluate(() => {
       const rows = [...document.querySelectorAll("#log > *")];
-      const reply = rows.findLast((node) => node.classList.contains("chat") && node.classList.contains("npc"));
+      // Chat rows are classified you/avatar/world; there is no longer an "npc"
+      // class. A resident reply is any avatar row that is not the player's.
+      const reply = rows.findLast((node) => (
+        node.classList.contains("chat")
+        && node.classList.contains("avatar")
+        && !node.classList.contains("you")
+      ));
       return {
         residentReply: reply?.textContent?.trim().replace(/\s+/g, " ") || "",
         roomLatest: document.querySelector("#room-log-latest")?.textContent?.trim().replace(/\s+/g, " ") || "",

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -732,6 +732,37 @@ async function main() {
             ping_active: false,
           },
         }).map((action) => ({ label: action.label, detail: action.detail, summary: action.modalSummary, effect: action.effect })),
+        orderedTurnBanner: (() => {
+          const turn = {
+            enabled: true,
+            policy: "scene-turn",
+            is_current_actor: false,
+            current_actor_id: 5001,
+            current_actor_name: "Mabel Crumblethorn",
+          };
+          const host = document.createElement("div");
+          host.innerHTML = turnPingPillHtml(turn);
+          return {
+            copy: host.querySelector(".turn-ping-copy")?.textContent || "",
+            controls: turnBannerControlSpecs(turn).map((spec) => spec.label),
+          };
+        })(),
+        currentTurnBanner: (() => {
+          const turn = {
+            enabled: true,
+            policy: "scene-turn",
+            is_current_actor: true,
+            can_pass: true,
+            can_need_time: true,
+            need_time_extension_ms: 60000,
+          };
+          const host = document.createElement("div");
+          host.innerHTML = turnPingPillHtml(turn);
+          return {
+            copy: host.querySelector(".turn-ping-copy")?.textContent || "",
+            controls: turnBannerControlSpecs(turn).map((spec) => spec.label),
+          };
+        })(),
         welcomingListenWithoutOption: buildActions({
           location: { id: 1, name: "The Cosy Cottage" },
           primary_action: { options: [{ kind: "search" }] },
@@ -983,21 +1014,31 @@ async function main() {
         && guide.roomThreadHand.buttonCue === "",
       `a client-only room guide must not override the authoritative projected hand: ${JSON.stringify(guide.roomThreadHand)}`,
     );
-    assert(guide.arrivalActions.length === 1 && guide.arrivalActions[0]?.label === "ordered combat", `an explicitly ordered scene should remain authoritative while the newcomer's first-tale Notice waits: ${JSON.stringify(guide)}`);
+    // Issue #461: ordered-scene timing is banner status, never a dealt card.
+    // The floor is preserved by dealing a waiting player no bypass action at
+    // all, which is stricter than the previous single observational card.
+    assert(guide.arrivalActions.length === 0, `an explicitly ordered scene should remain authoritative while the newcomer's first-tale Notice waits, dealing no bypass card: ${JSON.stringify(guide)}`);
     assert(guide.welcomingListenWithoutOption.some((action) => action.label === "notice" && action.focusKey === "check"), `the welcoming Notice should remain playable when ordinary room options rotate: ${JSON.stringify(guide)}`);
-    assert(guide.waitingWelcomeWithoutOption.length === 1 && guide.waitingWelcomeWithoutOption[0]?.label === "ordered combat", `another player's explicit combat turn should not be bypassed by first-tale guidance: ${JSON.stringify(guide)}`);
-    assert(/acts now/i.test(guide.arrivalActions[0]?.detail || "") && /chat and inspection stay available/i.test(guide.arrivalActions[0]?.summary || ""), `the ordered-scene wait should explain whose turn it is without hiding free interaction: ${JSON.stringify(guide)}`);
-    assert(guide.arrivalActions[0]?.effect === "shows the current combat order without taking an action", `the ordered-scene action should remain observational: ${JSON.stringify(guide)}`);
-    assert(guide.waitingActions.length === 1 && guide.waitingActions[0]?.label === "ordered combat", `ordinary ordered-scene waiting should preserve the combat floor: ${JSON.stringify(guide)}`);
+    assert(guide.waitingWelcomeWithoutOption.length === 0, `another player's explicit combat turn should not be bypassed by first-tale guidance: ${JSON.stringify(guide)}`);
+    assert(guide.waitingActions.length === 0, `ordinary ordered-scene waiting should preserve the combat floor without a timer card: ${JSON.stringify(guide)}`);
     assert(
-      guide.nudgeActions.length === 2
+      guide.nudgeActions.length === 1
         && guide.nudgeActions[0]?.label === "nudge"
         && guide.nudgeActions[0]?.focusKey === "scene-timeout"
-        && /play or pass/i.test(guide.nudgeActions[0]?.detail || "")
-        && guide.nudgeActions[1]?.label === "ordered combat",
-      `an eligible waiting participant should receive the nudge beside the observational ordered-scene card: ${JSON.stringify(guide.nudgeActions)}`,
+        && /play or pass/i.test(guide.nudgeActions[0]?.detail || ""),
+      `an eligible waiting participant should receive the nudge and nothing else: ${JSON.stringify(guide.nudgeActions)}`,
     );
-    assert(guide.gatheringActions.length === 1 && guide.gatheringActions[0]?.label === "ordered combat", `a pending ordered-scene handoff should preserve the combat floor: ${JSON.stringify(guide)}`);
+    assert(guide.gatheringActions.length === 0, `a pending ordered-scene handoff should preserve the combat floor: ${JSON.stringify(guide)}`);
+    assert(
+      guide.orderedTurnBanner?.copy === "ordered combat — Mabel Crumblethorn acts now"
+        && guide.orderedTurnBanner?.controls?.length === 0,
+      `a waiting combat participant should read the ordered status from the banner: ${JSON.stringify(guide.orderedTurnBanner)}`,
+    );
+    assert(
+      guide.currentTurnBanner?.copy === "ordered combat — your turn"
+        && guide.currentTurnBanner?.controls?.join(",") === "pass,need time",
+      `the acting combat participant should reach pass and need time from the banner, not the card row: ${JSON.stringify(guide.currentTurnBanner)}`,
+    );
   }
 
   async function waitForChatText(needle) {


### PR DESCRIPTION
Closes #461
Refs #391, #390, #474

## What this changes

### Ordered-combat timing moves out of the card hand (#461)

Timing chrome was dealt as three entries in the card row: an observational `ordered combat` card whose command was literally `look`, plus Pass and Need time. In combat that competed for ranked slots with Attack, Defend, Dodge, movement, and items.

Timing is scene status, not a dealt action. The existing turn pill becomes a banner spanning the row above the cards, with Pass and Need time as bounded controls beside it, and a waiting player is dealt no card at all.

Two things worth review attention:

- The controls sit **outside** the `aria-live` subtree. `renderTurnPingPill` rewrites `innerHTML` on handoff, so buttons inside that region would lose focus and re-announce on every turn change — contradicting the ticket's own "one handoff announcement" requirement.
- The banner now renders for **every** enabled turn policy, not just `scene-turn`. The card it replaces was not gated on policy, so `target-serialized` and `governed-choice` waiting would otherwise have lost its status entirely.

### The voice attempt budget was structurally unreachable (#391)

The planner built one attempt per *distinct pinned model*. With the legacy-config registry pinning a single model, `max_attempts=2` could never be reached: one sample was taken and any publication rejection was terminal, so the resident fell silent.

Every gate judges one sampled completion, so a rejection is a property of that sample rather than of the model. When the registry pins fewer distinct candidates than the budget allows, the best planned candidate is resampled to fill the remaining attempts. Gates still judge every sample independently, no rejected bytes become observable, and resampling stays inside the existing spend ceiling.

Verified on a live local runtime: `dialogue_resident` now issues two inferences per generation instead of one.

## Smoke contract changes

The browser smoke asserted a waiting player receives exactly one card labelled `ordered combat`. That encoded the old contract; the invariant it protects is that nothing may bypass the combat floor. Those assertions now require **zero** dealt cards plus banner status, which is stricter.

It also looked for a `.chat.npc` row. The client classifies chat rows `you`/`avatar`/`world` and emits no `npc` class anywhere, so that selector could never match.

## Known limitation

This does **not** fully clear `voice_candidates_exhausted`. The remaining failures are `voice_anchor_missing`, which is deterministic — the anchor gate requires an exact normalized-word match against location and user-text tokens, so resampling cannot rescue a line that phrases the room differently. Filed as #474 with a reproduction.

The browser smoke therefore still fails on `main` for that reason, independently of this branch. Verified by running the identical smoke on clean `main`.

## Checks

`npm run check` green locally: 481 JS tests, 741 Rust tests, worldpack, kernel, architecture, syntax. `npm run lint` and `npm run check:version` clean.

`v2/scripts/main-rs-line-ceiling.txt` raised 73214 -> 73222 for eight test-only `INDEX_HTML` contract assertions, documented in the file as the check requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)