### PR TITLE
Match anchors on a shared stem so grounded resident speech is not rejected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.215",
+  "version": "0.0.216",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.215",
+      "version": "0.0.216",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.215",
+  "version": "0.0.216",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.215"
+version = "0.0.216"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.215"
+version = "0.0.216"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -690,7 +690,39 @@ fn has_deterministic_anchor(value: &str, anchors: &[String], mode: SpeechMode) -
     }
     let candidate = normalized_words(value).into_iter().collect::<BTreeSet<_>>();
     let anchors = anchor_tokens(anchors);
-    !anchors.is_empty() && !candidate.is_disjoint(&anchors)
+    // An empty anchor set rejects. A scene that offers nothing to be grounded
+    // to cannot certify that a line is grounded, and silently accepting here
+    // would remove the gate exactly where the scene is least described. This
+    // is deliberate: see the empty-anchor test below.
+    !anchors.is_empty()
+        && candidate.iter().any(|word| {
+            anchors
+                .iter()
+                .any(|anchor| anchor_words_match(word, anchor))
+        })
+}
+
+/// Anchors are drawn from location names, titles, and remembered activity, so a
+/// grounded line often shares a stem rather than a whole word: "rain on the
+/// sill" against an anchor of `rainlit`, or "hearths" against `hearth`. Exact
+/// set matching rejected those, which silenced residents deterministically —
+/// resampling could not help because the mismatch is a property of the scene
+/// vocabulary rather than of the sample.
+///
+/// Match when the words are equal, or when the shorter is a prefix of the
+/// longer and is itself long enough to carry meaning. The floor keeps short
+/// fragments from matching unrelated words.
+fn anchor_words_match(candidate: &str, anchor: &str) -> bool {
+    const MIN_SHARED_PREFIX: usize = 4;
+    if candidate == anchor {
+        return true;
+    }
+    let (shorter, longer) = if candidate.len() <= anchor.len() {
+        (candidate, anchor)
+    } else {
+        (anchor, candidate)
+    };
+    shorter.len() >= MIN_SHARED_PREFIX && longer.starts_with(shorter)
 }
 
 fn near_duplicate(left: &str, right: &str) -> bool {
@@ -817,6 +849,57 @@ mod tests {
                 .map(|check| check.passed),
             Some(false)
         );
+    }
+
+    #[test]
+    fn anchor_accepts_a_shared_stem_and_still_rejects_ungrounded_speech() {
+        // The Cosy Cottage is titled "Rainlit Hearth", so these are the real
+        // anchor tokens a resident is judged against.
+        let anchors = vec!["The Cosy Cottage".to_string(), "Rainlit Hearth".to_string()];
+
+        // Near miss on a shared stem: exact matching rejected this
+        // deterministically, so the resident never spoke.
+        assert!(has_deterministic_anchor(
+            "Rain on the sill again.",
+            &anchors,
+            SpeechMode::Prose,
+        ));
+        // Plural of an anchor word.
+        assert!(has_deterministic_anchor(
+            "Both hearths are lit.",
+            &anchors,
+            SpeechMode::Prose,
+        ));
+        // Whole-word match keeps working.
+        assert!(has_deterministic_anchor(
+            "The cottage is warm.",
+            &anchors,
+            SpeechMode::Prose,
+        ));
+        // Ungrounded output is still rejected.
+        assert!(!has_deterministic_anchor(
+            "I have opinions about quarterly logistics.",
+            &anchors,
+            SpeechMode::Prose,
+        ));
+        // A short fragment must not match an unrelated longer word.
+        assert!(!has_deterministic_anchor(
+            "Cot.",
+            &anchors,
+            SpeechMode::Prose,
+        ));
+    }
+
+    #[test]
+    fn an_empty_anchor_set_rejects_every_line() {
+        // Deliberate: a scene describing nothing cannot certify that a line is
+        // grounded in it. Documented so this is never mistaken for a bug and
+        // silently relaxed into an open gate.
+        assert!(!has_deterministic_anchor(
+            "Anything at all.",
+            &[],
+            SpeechMode::Prose,
+        ));
     }
 
     #[test]

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -7252,6 +7252,19 @@ async function main() {
     await drawPrimaryMatching("current room Notice", ["notice"]);
     await clickPrimary("notice");
     await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
+    if (!runLivingWorldStress && runtimeMeta.features?.ai_enabled) {
+      // A resident reply is asynchronous: intent inference, then dialogue
+      // inference, then the authored chat delay. Re-enabling the primary button
+      // does not mean the line has landed, so wait for it rather than sampling
+      // the log the instant the action completes.
+      await page
+        .waitForFunction(() => [...document.querySelectorAll("#log > *")].some((node) => (
+          node.classList.contains("chat")
+          && node.classList.contains("avatar")
+          && !node.classList.contains("you")
+        )), { timeout: 45000 })
+        .catch(() => {});
+    }
     const scene = await page.evaluate(() => {
       const rows = [...document.querySelectorAll("#log > *")];
       // Chat rows are classified you/avatar/world; there is no longer an "npc"


### PR DESCRIPTION
Closes #474
Refs #390, #391

## Problem

The anchor gate required an **exact** normalized-word match between the generated line and the anchor set:

```rust
!anchors.is_empty() && !candidate.is_disjoint(&anchors)
```

Anchors come from location names, titles, and remembered activity, so a line that refers to the scene in natural language usually shares a *stem* rather than a whole word. In The Cosy Cottage ("Rainlit Hearth") the tokens are `cosy`, `cottage`, `rainlit`, `hearth`, so "rain on the sill" was rejected because `rain` != `rainlit`.

The rejection is a property of the scene vocabulary, not of the sample, so it is deterministic: every resample failed identically, the generation terminated `voice_candidates_exhausted`, and the resident fell silent.

## Change

Match when the words are equal, or when the shorter is a prefix of the longer and is at least four characters. The floor stops short fragments matching unrelated words — "Cot." still does not satisfy `cottage`.

The empty-anchor case is now documented and tested rather than incidental. It continues to **reject** every line: a scene describing nothing cannot certify that a line is grounded in it, and quietly accepting there would remove the gate exactly where the scene is least described. That is a deliberate choice, recorded so it is not later mistaken for a bug and relaxed into an open gate.

## Verification

On a live local runtime, after clearing the cached `unavailable` jobs:

- `voice_candidates_exhausted`: **7 -> 0** across 45 voice jobs.
- Residents publish prose again, e.g. "The hearth hears a tiny hello."

Existing `voice_anchor_missing_check_is_deterministic` still passes, so the gate still rejects what it should.

## Also here

The browser smoke waited only for the primary button to re-enable before sampling the chat log. A resident reply is asynchronous — intent inference, then dialogue inference, then the authored chat delay — so it now waits for the reply with a bounded timeout.

## Known remaining failure

This does **not** turn the browser smoke green. Its "group chat should retain the resident's spoken reply" assertion still fails, and I confirmed it is a different cause: with a 45s wait the `#log` contains only the `chat-empty` placeholder, so no chat row of any kind is produced in that scenario, while residents demonstrably publish `message.created` elsewhere in the same world. That assertion is skipped in CI because no AI key is configured. Filed separately rather than papered over.

## Checks

`npm run check` green: 44 JS test files, 743 Rust tests, worldpack, kernel, architecture, syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)