### PR TITLE
Fall back to authored art instead of the browser's broken-image icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.216",
+  "version": "0.0.217",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.216",
+      "version": "0.0.217",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.216",
+  "version": "0.0.217",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.216"
+version = "0.0.217"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.216"
+version = "0.0.217"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1635,6 +1635,32 @@
       border-top: 1px solid var(--line);
       background: rgba(5, 8, 6, 0.98);
     }
+    /* Art that has not been generated yet. The image itself already falls back
+       to the authored placeholder; this marks it as pending rather than final
+       so it never reads as finished art. See issue #476. */
+    img[data-art-missing="true"] {
+      opacity: 0.72;
+      filter: saturate(0.7);
+    }
+    .card-art:has(img[data-art-missing="true"])::after,
+    .action-art:has(img[data-art-missing="true"])::after {
+      content: "no art generated yet";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      padding: 4px 8px;
+      background: rgba(5, 12, 7, 0.82);
+      color: var(--amber);
+      font: 700 10px/1.3 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.04em;
+      text-align: center;
+    }
+    .card-art,
+    .action-art {
+      position: relative;
+    }
+
     .turn-banner {
       grid-column: 1 / -1;
       display: flex;
@@ -12539,6 +12565,26 @@
         .replaceAll("<", "&lt;")
         .replaceAll(">", "&gt;");
     }
+
+    // Art that never generated used to reach the DOM as a live URL and render
+    // as the browser's broken-image icon: the `cardImage(x) || fallbackCardImage(x)`
+    // guard at each call site only catches an empty URL, not one that 404s.
+    // `error` does not bubble, but it does fire during capture, so one listener
+    // here covers every image including those built through innerHTML.
+    // See issue #476.
+    document.addEventListener("error", (event) => {
+      const image = event.target;
+      if (!(image instanceof HTMLImageElement)) return;
+      if (image.dataset.artFallback === "applied") return;
+      image.dataset.artFallback = "applied";
+      // Marks the element as awaiting generated art so it can be styled and,
+      // later, carry the funding affordance.
+      image.dataset.artMissing = "true";
+      const role = image.dataset.artRole
+        || (image.closest("[data-card-key]")?.getAttribute("data-card-key") || "").split(":")[0]
+        || "card";
+      image.src = fallbackCardImage({ role, display_name: image.alt || "CosyWorld art" });
+    }, true);
 
     document.addEventListener("click", (event) => {
       const control = event.target.closest("[data-turn-control]");

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -48222,6 +48222,11 @@ mod tests {
         assert!(INDEX_HTML.contains("ordered combat — your turn"));
         // Issue #461: ordered-combat timing is a banner above the card row, and
         // Pass/Need time are banner controls rather than dealt combat cards.
+        // Issue #476: art that fails to load must fall back to the authored
+        // placeholder instead of the browser's broken-image icon.
+        assert!(INDEX_HTML.contains("addEventListener(\"error\""));
+        assert!(INDEX_HTML.contains("data-art-missing"));
+        assert!(INDEX_HTML.contains("no art generated yet"));
         assert!(INDEX_HTML.contains("id=\"turn-banner\""));
         assert!(INDEX_HTML.contains("id=\"turn-banner-controls\""));
         assert!(INDEX_HTML.contains("data-turn-control"));

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -4,4 +4,8 @@
 # 73214 -> 73222: eight INDEX_HTML contract assertions for issue #461, pinning
 # the ordered-combat banner markup and the removal of the dealt timing cards.
 # Test-only, no new system; the behaviour itself lives in index.html.
-73222
+#
+# 73222 -> 73227: five INDEX_HTML contract assertions for issue #476, pinning
+# the image error fallback so generated art can never regress to the browser's
+# broken-image icon. Test-only; the behaviour lives in index.html.
+73227


### PR DESCRIPTION
Refs #476

## Problem

Reported from live play: cards, avatars, and room art whose image never generated render as the browser's broken-image icon.

Every call site guards with `cardImage(card) || fallbackCardImage(card)`, but `cardImage` returns `card?.image_url || ""`, so the guard only catches an **empty** URL. A URL that is present but cannot resolve — art never generated, a pending or failed generation, a 404 asset — passes straight through to the DOM.

Nothing recovered from the failure: `index.html` contained exactly one `onerror` handler and it belonged to the SSE stream. None of `#location-image`, `#room-hero-image`, `#card-modal-image`, `#action-modal-image`, or the templated avatar/box/pack images had one.

## Change

One capture-phase `error` listener on `document`. `error` does not bubble, but it does fire during capture, so a single hook covers every image — including those built through `innerHTML`, which cannot easily carry an inline handler — rather than threading a handler through eight-plus elements and every future one.

A rescued image is marked `data-art-missing` and styled as pending, so it reads as art that has not been generated yet rather than as finished art.

## Verification

Driven in a real browser against a URL that cannot resolve:

```json
{
  "artMissing": "true",
  "fallbackApplied": "applied",
  "srcIsAuthoredPlaceholder": true,
  "renderedWidth": 320
}
```

The element ends up on the authored SVG placeholder with the marker applied, instead of a broken icon.

## Deliberately not included

The "pay orb to generate" call to action. #476 asks it to distinguish *not yet funded*, *funded and pending*, and *generation failed*, and showing a funding prompt to a player who has already funded that art would be worse than the placeholder alone. That needs the funding state wired to the placeholder, so the issue stays open for it; this PR removes the broken-image icon, which is the player-visible breakage.

## Checks

`npm run check` green: 44 JS test files, 743 Rust tests, worldpack, kernel, architecture, syntax.

`main-rs-line-ceiling.txt` raised 73222 -> 73227 for five test-only `INDEX_HTML` contract assertions, documented in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)