### PR TITLE
Offer a new beginning when an avatar dies instead of ordinary actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.217",
+  "version": "0.0.218",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.217",
+      "version": "0.0.218",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.217",
+  "version": "0.0.218",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.217"
+version = "0.0.218"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.217"
+version = "0.0.218"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -152,6 +152,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_dead_avatar_is_offered_a_new_beginning_rather_than_ordinary_actions() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Ended Tale");
+
+        // Alive, the avatar receives ordinary play.
+        let alive = runtime.state_response_with_presence(
+            Some(5000),
+            &AccessContext::default(),
+            Some(&BTreeSet::from([5000])),
+            false,
+        );
+        assert_ne!(alive.primary_action.kind, "create_avatar");
+
+        let actor = runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|actor| actor.id == 5000)
+            .expect("the avatar exists");
+        actor.status = CW_ACTOR_DEAD;
+
+        // Dead, the avatar still resolves through actor_by_id, so it used to
+        // fall through to ordinary actions: the client showed "this tale has
+        // ended" while the hand dealt Notice, and taking it failed as a stale
+        // offer with no way forward.
+        let ended = runtime.state_response_with_presence(
+            Some(5000),
+            &AccessContext::default(),
+            Some(&BTreeSet::from([5000])),
+            false,
+        );
+        assert_eq!(
+            ended.primary_action.kind, "create_avatar",
+            "a dead avatar must be offered a new beginning",
+        );
+        assert!(
+            !ended.primary_action.disabled,
+            "the new beginning must be reachable",
+        );
+    }
+
+    #[tokio::test]
     async fn knocked_out_avatar_remains_present_targetable_and_observable() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -19163,7 +19163,17 @@ impl RuntimeWorld {
             };
         };
 
-        if self.actor_by_id(actor_id).is_none() {
+        // A defeated avatar still resolves through `actor_by_id`, so matching
+        // only on a missing actor left a dead player being offered ordinary
+        // actions they can never submit. The client showed "this tale has
+        // ended, choose begin again below" while the hand still dealt Notice,
+        // and taking it failed as a stale offer. Death must project the same
+        // beginning as having no avatar at all.
+        let departed = match self.actor_by_id(actor_id) {
+            None => true,
+            Some(actor) => actor.status == CW_ACTOR_DEAD,
+        };
+        if departed {
             return PrimaryAction {
                 kind: "create_avatar".to_string(),
                 label: "Create Avatar".to_string(),

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -8,4 +8,8 @@
 # 73222 -> 73227: five INDEX_HTML contract assertions for issue #476, pinning
 # the image error fallback so generated art can never regress to the browser's
 # broken-image icon. Test-only; the behaviour lives in index.html.
-73227
+#
+# 73227 -> 73237: ten lines in primary_action so a dead avatar is offered a new
+# beginning instead of ordinary actions it can never submit. Existing function,
+# no new system.
+73237


### PR DESCRIPTION
Refs #380

## Reported from live play

An avatar was defeated on the Moonlit Trail. The scene rendered correctly:

> **THIS TALE HAS ENDED** — Elsa Willowmere was defeated by Coach.
> This avatar is gone. Any linked account and keepsakes are still here. Choose begin again below when you are ready.

But the card hand still dealt **Notice**, and taking it failed with *"That choice changed while you were deciding. Nothing else happened."* There was no begin-again control anywhere. The player was stuck on a dead avatar with no path forward.

## Cause

`primary_action` projected `create_avatar` only when the actor was absent:

```rust
if self.actor_by_id(actor_id).is_none() { /* create_avatar */ }
```

A defeated avatar still resolves through `actor_by_id` — its **status** changes, the record stays — so a dead player fell through to ordinary action projection and was dealt actions they could never submit, since `client_actor_can_submit` requires `actor_can_act`.

The client only renders the begin-again card when the server projects `create_avatar` (`buildActions` checks `view.primary_action?.kind` first), so the instruction on screen could never be followed. The stale-offer error was the correct new behaviour from #409 doing its job on top of a hand that should never have been dealt.

## Change

Treat a dead avatar as departed and project the same beginning as having no avatar at all.

Knocked out is deliberately **excluded**: it is recoverable and must keep its ordinary presence, which `knocked_out_avatar_remains_present_targetable_and_observable` continues to assert.

## Test

`a_dead_avatar_is_offered_a_new_beginning_rather_than_ordinary_actions` asserts the same avatar projects ordinary play while alive and `create_avatar` once dead, so it fails without the fix rather than passing vacuously.

## Checks

`npm run check` green: 44 JS test files, 744 Rust tests, worldpack, kernel, architecture, syntax.

Ceiling raised 73227 -> 73237, documented in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)