### PR TITLE
Offer a knocked-out avatar the release path instead of an unplayable hand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.221",
+  "version": "0.0.222",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.221",
+      "version": "0.0.222",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.221",
+  "version": "0.0.222",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.221"
+version = "0.0.222"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.221"
+version = "0.0.222"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -195,6 +195,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn knocked_out_avatar_is_offered_a_new_beginning_and_no_unplayable_hand() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Downed Traveler",
+        );
+        let actor = runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|actor| actor.id == 5000)
+            .expect("the avatar exists");
+        actor.status = CW_ACTOR_KNOCKED_OUT;
+
+        // The body stays in the world (see the presence contract below), but
+        // the player holding it has no legal move: every ordinary offer fails
+        // `actor_can_act` at submission. Until rescue or recovery exists, the
+        // projection must deal the one honest exit — the release path that
+        // lets the player begin again while the body persists.
+        let downed = runtime.state_response_with_presence(
+            Some(5000),
+            &AccessContext::default(),
+            Some(&BTreeSet::from([5000])),
+            false,
+        );
+        assert_eq!(
+            downed.primary_action.kind, "create_avatar",
+            "a knocked-out avatar must be offered a new beginning, not ordinary play",
+        );
+        assert!(
+            !downed.primary_action.disabled,
+            "the new beginning must be reachable",
+        );
+        assert!(
+            downed
+                .action_offers
+                .iter()
+                .all(|offer| offer.kind == "create_avatar"),
+            "a knocked-out avatar must not be dealt offers it cannot submit: {:?}",
+            downed
+                .action_offers
+                .iter()
+                .map(|offer| offer.kind.clone())
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    #[tokio::test]
     async fn knocked_out_avatar_remains_present_targetable_and_observable() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
@@ -269,7 +320,10 @@ mod tests {
             .items
             .iter()
             .any(|item| item.id == STORY_BUTTON_ITEM_ID && item.holder_actor_id == Some(5001)));
-        assert!(observer_view.primary_action.disabled);
+        // The fallen avatar's own projection deals the release path, not an
+        // unplayable hand: present and observable does not mean playable.
+        assert_eq!(observer_view.primary_action.kind, "create_avatar");
+        assert!(!observer_view.primary_action.disabled);
 
         let who = runtime
             .resolve_command_with_presence(

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -345,6 +345,29 @@ impl RuntimeWorld {
                 "no_active_avatar",
             )];
         };
+        // A present avatar that cannot act (knocked out) has no legal move, so
+        // the hand deals only the release path. Dealing rest, exploration, or
+        // room offers alongside it would hand the player cards that every
+        // submission rejects.
+        if self
+            .actor_by_id(actor_id)
+            .is_some_and(|actor| !Self::actor_can_act(actor))
+        {
+            return vec![self.ranked_offer_from_parts(
+                "create_avatar",
+                "Create Avatar",
+                "create avatar",
+                0,
+                false,
+                None,
+                None,
+                None,
+                None,
+                Some("Creates a new avatar at the cottage threshold.".to_string()),
+                None,
+                "no_active_avatar",
+            )];
+        }
         let actor_location_id = self.actor_by_id(actor_id).map(|actor| actor.location_id);
         let zone = actor_location_id
             .map(|location_id| {

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -4254,6 +4254,7 @@
       defeatTransition = {
         actorName: event.target_actor_name || defeated?.name || "Your avatar",
         opponentName: event.actor_name || "the danger",
+        kind: String(event.type || ""),
         eventSeq: Number(event.seq || 0),
       };
       saveDefeatTransition();
@@ -9505,9 +9506,14 @@
       if (!defeatTransition) return "";
       const actor = defeatTransition.actorName || "Your avatar";
       const opponent = defeatTransition.opponentName || "the danger";
-      const kicker = "this tale has ended";
-      const text = `${actor} was defeated by ${opponent}.`;
-      const cue = "This avatar is gone. Any linked account and keepsakes are still here. Choose begin again below when you are ready.";
+      const knockedOut = defeatTransition.kind === "combat.knockout";
+      const kicker = knockedOut ? "knocked out" : "this tale has ended";
+      const text = knockedOut
+        ? `${actor} was knocked out by ${opponent}.`
+        : `${actor} was defeated by ${opponent}.`;
+      const cue = knockedOut
+        ? "Their body is still where it fell, and the world keeps it. Choose begin again below when you are ready."
+        : "This avatar is gone. Any linked account and keepsakes are still here. Choose begin again below when you are ready.";
       const aria = `${kicker}. ${text} ${cue}`;
       return `<div class="room-scene defeat-scene" role="alert" aria-label="${escapeAttr(aria)}"><span class="room-scene-kicker">${escapeHtml(kicker)}</span><span class="room-scene-text">${escapeHtml(text)}</span><span class="room-scene-cue">${escapeHtml(cue)}</span></div>`;
     }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -19207,14 +19207,18 @@ impl RuntimeWorld {
         };
 
         // A defeated avatar still resolves through `actor_by_id`, so matching
-        // only on a missing actor left a dead player being offered ordinary
-        // actions they can never submit. The client showed "this tale has
-        // ended, choose begin again below" while the hand still dealt Notice,
-        // and taking it failed as a stale offer. Death must project the same
-        // beginning as having no avatar at all.
+        // only on a missing actor left a defeated player being offered
+        // ordinary actions they can never submit: every offer fails
+        // `actor_can_act` as a stale offer, and the defeat copy instructs a
+        // beginning the projection never dealt. A knocked-out avatar keeps its
+        // presence in the world — the body stays visible and targetable — but
+        // the player holding it has no legal move until rescue or recovery
+        // exists, so any avatar that cannot act projects the same beginning as
+        // having no avatar at all. The client releases its binding and shows
+        // creation, while the body persists.
         let departed = match self.actor_by_id(actor_id) {
             None => true,
-            Some(actor) => actor.status == CW_ACTOR_DEAD,
+            Some(actor) => !Self::actor_can_act(actor),
         };
         if departed {
             return PrimaryAction {
@@ -48602,6 +48606,10 @@ mod tests {
         ));
         assert!(INDEX_HTML.contains("function captureDefeatTransition"));
         assert!(INDEX_HTML.contains("this tale has ended"));
+        // A knockout is not an ended tale: the scene must say the body remains
+        // and still point at the one real exit.
+        assert!(INDEX_HTML.contains("was knocked out by"));
+        assert!(INDEX_HTML.contains("Their body is still where it fell"));
         assert!(INDEX_HTML.contains("Choose begin again below when you are ready."));
         assert!(INDEX_HTML.contains("label: beginningAgain ? \"begin again\" : \"begin\""));
         assert!(INDEX_HTML.contains("character_creation_id"));

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -27,4 +27,10 @@
 # gains the AppState fields, /meta.persistence reporting, and the boot-duration
 # log; the reconciliation itself lives in topology.rs and generation_policy.rs,
 # and the rejection record in journal_checkpoint.rs. Existing persistence seam.
-73589
+#
+# 73589 -> 73597: issue #494 wires the defeated-avatar release projection in
+# primary_action (comment plus a one-line condition) and pins the knockout
+# scene copy in the INDEX_HTML contract test. The offer suppression lives in
+# composition.rs, the regression tests in actor_presence.rs. Existing
+# projection seam, no new system.
+73597


### PR DESCRIPTION
## Root cause

A knocked-out avatar keeps ordinary presence by design (`actor_is_present` includes `CW_ACTOR_KNOCKED_OUT`), so the projection dealt it ordinary offers — but `actor_can_act` requires `CW_ACTOR_ACTIVE`, so every submission failed as a stale offer. Meanwhile the defeat scene declared "this tale has ended" and pointed at a begin-again control the projection never produced: `primary_action` only offered `create_avatar` for `CW_ACTOR_DEAD`, which the combat path never sets. Net effect (#494): a soft-locked session recoverable only by clearing localStorage. Net effect (#489): a permanent-loss screen over a recoverable state, with the client and server each internally consistent and mutually contradictory.

## Resolution

Per #494's direction: until rescue/recovery land (#383, #492, #493), a KO avatar gets an honest projection — no unplayable hand, and the one real exit.

- **Server**: `primary_action` projects `create_avatar` for any avatar that cannot act, and `ranked_action_offers` deals only that release offer (suppressing rest/explore/room offers). The client already releases its binding and shows avatar creation when a bound actor receives `create_avatar`, so begin-again works and survives reload while the body persists — visible and targetable per the existing presence contract. This also wires the #480 defeated-avatar branch to the real defeat path (#489's last criterion).
- **Client**: the defeat scene distinguishes `combat.knockout` from `combat.death`. A knockout says "{actor} was knocked out by {opponent}. Their body is still where it fell, and the world keeps it." instead of declaring the tale ended.

## Tests

- New `knocked_out_avatar_is_offered_a_new_beginning_and_no_unplayable_hand`: KO projection offers `create_avatar` (enabled) and no other offers.
- Updated `knocked_out_avatar_remains_present_targetable_and_observable`: the body-stays-present assertions are unchanged; the old `primary_action.disabled` assertion (which encoded the dead-end) now asserts the release path.
- INDEX_HTML contract assertions pin the knockout copy.
- Full gate via pre-push hook: 755 Rust tests, Vitest, worldpack, kernel, clippy/architecture ceilings, syntax.

Closes #494
Closes #489