### PR TITLE
Give the combat turn banner its own footer row above the card hand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.222",
+  "version": "0.0.223",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.222",
+      "version": "0.0.223",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.222",
+  "version": "0.0.223",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.222"
+version = "0.0.223"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.222"
+version = "0.0.223"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1663,6 +1663,10 @@
 
     .turn-banner {
       grid-column: 1 / -1;
+      /* The narrow layout turns .prompt into a flex row; grid-column is
+         meaningless there, so the banner must also claim a full flex line or
+         it squeezes in beside the combat cards (issue #490). */
+      flex: 1 1 100%;
       display: flex;
       align-items: stretch;
       gap: 8px;
@@ -2893,6 +2897,7 @@
       }
       .prompt {
         display: flex;
+        flex-wrap: wrap;
         gap: 5px;
         width: 100%;
         max-width: 100%;

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -3391,6 +3391,17 @@ async function main() {
           target_actor_id: 5000,
           target_actor_name: "Lantern Stitch",
         });
+        const knockoutHtml = defeatTransitionHtml();
+        clearDefeatTransition();
+        const deathCaptured = captureDefeatTransition({
+          seq: 100,
+          type: "combat.death",
+          actor_id: 1004,
+          actor_name: "Moonlit Echo",
+          target_actor_id: 5000,
+          target_actor_name: "Lantern Stitch",
+        });
+        const deathHtml = defeatTransitionHtml();
         state = {
           ...state,
           primary_action: { kind: "create_avatar", options: [] },
@@ -3399,7 +3410,9 @@ async function main() {
         const restart = buildActions(state)[0];
         return {
           captured,
-          html: defeatTransitionHtml(),
+          deathCaptured,
+          knockoutHtml,
+          deathHtml,
           restartLabel: restart?.label || "",
           restartDetail: restart?.detail || "",
           restartTitle: restart?.modalTitle || "",
@@ -3414,9 +3427,69 @@ async function main() {
       }
     });
     assert(result.captured, `the player's knockout should capture an explicit defeat transition: ${JSON.stringify(result)}`);
-    assert(/this tale has ended/i.test(result.html) && /Lantern Stitch was defeated by Moonlit Echo/i.test(result.html), `the defeat scene should name the outcome and both combatants: ${JSON.stringify(result)}`);
-    assert(/This avatar is gone/i.test(result.html) && /linked account and keepsakes are still here/i.test(result.html), `the defeat scene should explain what was lost and what remains: ${JSON.stringify(result)}`);
+    assert(/Lantern Stitch was knocked out by Moonlit Echo/i.test(result.knockoutHtml), `the knockout scene should name the outcome and both combatants without declaring the tale ended: ${JSON.stringify(result)}`);
+    assert(!/this tale has ended/i.test(result.knockoutHtml) && /body is still where it fell/i.test(result.knockoutHtml), `a knockout is recoverable; the scene must not claim permanent loss: ${JSON.stringify(result)}`);
+    assert(result.deathCaptured, `the player's death should capture an explicit defeat transition: ${JSON.stringify(result)}`);
+    assert(/this tale has ended/i.test(result.deathHtml) && /This avatar is gone/i.test(result.deathHtml), `the death scene keeps the ended-tale copy: ${JSON.stringify(result)}`);
     assert(result.restartLabel === "begin again" && result.restartDetail === "make a new avatar" && result.restartTitle === "begin another tale" && result.restartConfirm === "begin again", `the post-defeat action should be a deliberate restart rather than a silent reset: ${JSON.stringify(result)}`);
+  }
+
+  async function assertCombatTurnBannerOwnsFullRowAboveCardHand() {
+    // Issue #490: the narrow layout turns the footer into a flex row, where
+    // grid-column is meaningless; the banner must still claim its own row
+    // above the widest (three-entry combat) hand instead of crushing the
+    // cards into slivers beside it.
+    const previousViewport = page.viewportSize();
+    await page.setViewportSize({ width: 360, height: 860 });
+    await page.waitForTimeout(50);
+    const result = await page.evaluate(() => {
+      const prompt = document.querySelector(".prompt");
+      const banner = $("turn-banner");
+      const pill = $("turn-ping-pill");
+      const controls = $("turn-banner-controls");
+      const shuffle = $("shuffle");
+      const previousHidden = banner.hidden;
+      const previousPill = pill.innerHTML;
+      const previousControls = controls.innerHTML;
+      const previousShuffleDisplay = shuffle.style.display;
+      const previousHasDraw = prompt.classList.contains("has-draw");
+      try {
+        pill.innerHTML = '<span class="turn-ping-copy">ordered combat — your turn</span><span class="turn-ping-time">45s</span>';
+        controls.innerHTML = [
+          '<button type="button" class="turn-banner-control">pass</button>',
+          '<button type="button" class="turn-banner-control">need time</button>',
+        ].join("");
+        banner.hidden = false;
+        // The widest hand ADR 0002 allows: three footer cards (combat capacity
+        // three, or two cards plus the draw).
+        prompt.classList.add("has-draw");
+        shuffle.style.display = "flex";
+        const promptRect = prompt.getBoundingClientRect();
+        const bannerRect = banner.getBoundingClientRect();
+        const cards = [...prompt.querySelectorAll(".cmd")]
+          .filter((card) => card.offsetParent !== null)
+          .map((card) => card.getBoundingClientRect());
+        return {
+          cardCount: cards.length,
+          promptWidth: promptRect.width,
+          bannerWidth: bannerRect.width,
+          bannerBottom: bannerRect.bottom,
+          highestCardTop: Math.min(...cards.map((rect) => rect.top)),
+          narrowestCard: Math.min(...cards.map((rect) => rect.width)),
+        };
+      } finally {
+        banner.hidden = previousHidden;
+        pill.innerHTML = previousPill;
+        controls.innerHTML = previousControls;
+        shuffle.style.display = previousShuffleDisplay;
+        prompt.classList.toggle("has-draw", previousHasDraw);
+      }
+    });
+    if (previousViewport) await page.setViewportSize(previousViewport);
+    assert(result.cardCount >= 3, `the combat hand should present at least three footer cards for this fixture: ${JSON.stringify(result)}`);
+    assert(result.bannerWidth >= result.promptWidth * 0.9, `the banner must span the footer, not sit beside the cards: ${JSON.stringify(result)}`);
+    assert(result.bannerBottom <= result.highestCardTop + 1, `the banner must occupy its own row above the card grid: ${JSON.stringify(result)}`);
+    assert(result.narrowestCard >= 60, `every combat card must stay at usable size beneath the banner: ${JSON.stringify(result)}`);
   }
 
   async function assertBondSurfacesAsCompactRelationshipAction() {
@@ -10078,6 +10151,8 @@ async function main() {
   await assertMultiRoomPrepareCopyUsesServerProgress();
   await assertSpentPreparationSurfacesProjectPush();
   await assertCombatPotionDoesNotDefaultToEnemyHealing();
+  await assertPlayerDefeatTransitionIsExplicit();
+  await assertCombatTurnBannerOwnsFullRowAboveCardHand();
   await assertCombatProjectActionsUseCompactTradeoffCopy();
   await assertCompactMetaCopyAvoidsSlashes();
   await assertServerEligibleRestPriorityFollowsRoomDanger();


### PR DESCRIPTION
## Root cause

`.prompt` is a grid at wide widths and the banner's `grid-column: 1 / -1` works there — but the `@media (max-width: 900px)` rule turns `.prompt` into `display: flex`, where `grid-column` is meaningless. The banner became an ordinary flex item beside the combat cards, and with the widest hand (ADR 0002 combat capacity 3, plus the draw) the cards were compressed to unusable slivers — the opposite of #461's contract. 900px is not just phones: plenty of desktop windows hit the broken path.

## Fix

- `.turn-banner` gains `flex: 1 1 100%` (a no-op in the grid layout, a full flex line in the narrow layout) and the media-query `.prompt` gains `flex-wrap: wrap`, so the banner always owns a full row above the card grid.
- Pass and Need time stay on the banner and out of ranked card slots (unchanged; the existing smoke assertions for the banner controls still hold).

## Verification

- New `assertCombatTurnBannerOwnsFullRowAboveCardHand` browser smoke: a three-footer-card fixture at 360px asserts the banner spans ≥90% of the footer, sits entirely above the cards, and the narrowest card stays ≥60px. I ran the equivalent probe against a live server **with and without the fix**: without it the banner takes ~53% of the footer width beside the cards and the narrowest card drops below usable size (the reported slivers); with it all assertions pass at both 360px and 430px.
- The previously defined-but-never-called `assertPlayerDefeatTransitionIsExplicit` is now wired in and updated for the #494 knockout copy (knockout says the body remains; death keeps "this tale has ended").

### Pre-existing smoke staleness (not caused by this change)

While running the full browser smoke against a fresh-seeded world I hit two failures that reproduce identically with the unmodified script from `main`:

1. `assertWorldProjectionAvailable` expects exactly `["Homeroom","Mossbell Inn","Rain-Soft Garden"]` as cottage map exits, but the current composition includes the authored Holy Land bridge (`1 → 700 Bethlehem`, added in #257).
2. An earlier buttons assertion (`chat with Skull · use what you learned…`) mismatches on a fresh seed.

I'll file a follow-up issue for the stale smoke fixtures.

Full pre-push gate passes: 755 Rust tests, Vitest, worldpack, kernel, clippy/architecture, syntax (main.rs untouched, ceiling unchanged).

Closes #490
