### PR TITLE
Stabilize post-project browser recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.226",
+  "version": "0.0.227",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.226",
+      "version": "0.0.227",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.226",
+  "version": "0.0.227",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/mvp.sh
+++ b/v2/mvp.sh
@@ -305,7 +305,18 @@ run_browser_check() {
     local runtime_path="${COSYWORLD_BROWSER_CHECK_RUNTIME:-}"
     stop_server
     case "$runtime_path" in
-      */cosyworld-browser-check.*) rm -rf -- "$runtime_path" ;;
+      */cosyworld-browser-check.*)
+        for _ in 1 2 3; do
+          if rm -rf -- "$runtime_path"; then
+            break
+          fi
+          sleep 0.1
+        done
+        if [ -e "$runtime_path" ]; then
+          echo "browser-check runtime cleanup did not settle: $runtime_path" >&2
+          return 1
+        fi
+        ;;
     esac
     COSYWORLD_BROWSER_CHECK_RUNTIME=""
   }

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.226"
+version = "0.0.227"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.226"
+version = "0.0.227"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -11226,7 +11226,6 @@ async function main() {
       )));
       if (!restAlreadyAvailable) {
         await leaveTrailTo("Rain-Soft Garden");
-        await travelTo("Moonlit Trail");
         steps.push({ label: "post-project recovery walk", location: await currentLocation() });
       }
       const recoveryCard = await drawPrimaryMatching("rest after extra project work", ["rest", "feel fresh"]);


### PR DESCRIPTION
## Summary

- keep the fresh-seed browser smoke in Rain-Soft Garden for the required post-project rest instead of entering a frontier encounter first
- retain the later resident-join travel coverage, including seasonal frontier reset behavior
- make browser-check temporary-directory cleanup resilient to short-lived writer races and fail clearly if cleanup still cannot complete
- bump the app/orchestrator version to 0.0.227

## Why

The merge of #515 passed its PR gate but the subsequent `main` CI run failed because the smoke test traveled back into Moonlit Trail, entered the Coach frontier encounter, and then asserted that `rest` was drawable while combat actions correctly had focus.

## Validation

- `npm run v2:browser:check` — passed normal and stress suites, CLI smoke, health, and cleanup
- mandatory pre-push `npm run check` — passed 483 JavaScript tests, worldpack/proof checks, kernel checks, 787 Rust tests, architecture/lint ceilings, and syntax checks

This is a test-flow and test-harness robustness fix; production gameplay behavior is unchanged.