### PR TITLE
Expose generated pathway migration tuples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.229",
+  "version": "0.0.230",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.229",
+      "version": "0.0.230",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.229",
+  "version": "0.0.230",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.229"
+version = "0.0.230"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.229"
+version = "0.0.230"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/generation_policy.rs
+++ b/v2/orchestrator-rust/src/generation_policy.rs
@@ -510,7 +510,16 @@ pub(super) fn generation_policy_allows_upgrade(
         .ok_or_else(|| "generation policy disappeared during pack upgrade".to_string())?;
     policy_declares_preserved_binding(&policy, binding)
         .then_some(())
-        .ok_or_else(|| "pack upgrade has no exact generated-descendant migration".to_string())
+        .ok_or_else(|| {
+            format!(
+                "pack upgrade from {}@{} policy {} migration {} to {} has no exact generated-descendant migration",
+                binding.owner_pack_id,
+                binding.owner_pack_version,
+                binding.policy_id,
+                binding.migration_version,
+                active_pack_version,
+            )
+        })
 }
 
 pub(super) fn resolve_generation_media_config(
@@ -793,7 +802,12 @@ mod tests {
 
         let mut wrong_version = declared.clone();
         wrong_version.owner_pack_version = "1.1.2".to_string();
-        assert!(generation_policy_allows_upgrade(&wrong_version, "1.1.5").is_err());
+        let error = generation_policy_allows_upgrade(&wrong_version, "1.1.5")
+            .expect_err("an undeclared historical tuple must fail closed");
+        assert_eq!(
+            error,
+            "pack upgrade from cosyworld.the-holy-land@1.1.2 policy cosyworld.the-holy-land/generation/1 migration 1 to 1.1.5 has no exact generated-descendant migration"
+        );
         let mut wrong_policy = declared;
         wrong_policy.policy_id = "cosyworld.other/generation/1".to_string();
         assert!(generation_policy_allows_upgrade(&wrong_policy, "1.1.5").is_err());

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -767,7 +767,8 @@ impl RuntimeWorld {
             generation_policy_allows_upgrade(
                 &pathway.generation_policy,
                 &source_route.owner_pack_version,
-            )?;
+            )
+            .map_err(|error| format!("generated pathway {}: {error}", pathway.id))?;
         }
         if pathway.generation_policy.is_empty() {
             if !allow_legacy_backfill {


### PR DESCRIPTION
## What changed

- Include the generated pathway ID and the complete persisted generation-policy tuple in pack-upgrade failures.
- Keep exact migration matching and fail-closed behavior unchanged.
- Bump the runtime to 0.0.230.

## Why

Production recovery issue #319 has reached a historical generated-pathway binding that is absent from the active policy migration table. The current error hides the owner pack, version, policy, and migration version, forcing unsafe guesses. This makes the next production boot identify the exact tuple so the migration can be declared narrowly.

## Validation

- `npm run check` (483 JavaScript tests, worldpack/kernel checks, 792 Rust tests, architecture/lint/syntax)
- pre-push `npm run check` repeated successfully