### PR TITLE
Expose generated media migration tuple

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.231",
+  "version": "0.0.232",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.231",
+      "version": "0.0.232",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.231",
+  "version": "0.0.232",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.231"
+version = "0.0.232"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.231"
+version = "0.0.232"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -429,8 +429,24 @@ impl RuntimeWorld {
                     generation.generation_policy = binding.clone();
                 } else {
                     return Err(format!(
-                        "generated media {} policy binding differs from its pathway",
-                        generation.subject_id
+                        "generated media {} policy binding differs from its pathway: \
+                         media={{schema:{}, policy:{}, migration:{}, owner:{}@{}, composition:{}, bundle:{}}}; \
+                         pathway={{schema:{}, policy:{}, migration:{}, owner:{}@{}, composition:{}, bundle:{}}}",
+                        generation.subject_id,
+                        generation.generation_policy.schema_version,
+                        generation.generation_policy.policy_id,
+                        generation.generation_policy.migration_version,
+                        generation.generation_policy.owner_pack_id,
+                        generation.generation_policy.owner_pack_version,
+                        generation.generation_policy.composition_id,
+                        generation.generation_policy.composition_bundle_hash,
+                        binding.schema_version,
+                        binding.policy_id,
+                        binding.migration_version,
+                        binding.owner_pack_id,
+                        binding.owner_pack_version,
+                        binding.composition_id,
+                        binding.composition_bundle_hash,
                     ));
                 }
             }


### PR DESCRIPTION
## Summary
- include both generated-media and owning-pathway policy tuples in fail-closed startup errors
- keep the compatibility gate unchanged
- bump the release to 0.0.232 so production can reveal the exact historical tuple required by #319

## Verification
- `npm run check` (483 JS tests, worldpack/kernel checks, 793 Rust tests, architecture/lint/syntax)
- targeted generated-media divergence regression

Refs #319