### PR TITLE
Migrate legacy generated media ownership

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.233",
+  "version": "0.0.234",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.233",
+      "version": "0.0.234",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.233",
+  "version": "0.0.234",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/official/assets.json
+++ b/v2/content/official/assets.json
@@ -28,7 +28,7 @@
   {
     "pack_id": "cosyworld.the-holy-land",
     "pack_version": "1.2.1",
-    "pack_integrity": "sha256:bda90d20b1c30024bab64cd1529035b4397d1b0ab8eda3378d0176413bec8fda",
+    "pack_integrity": "sha256:d54565c7516b305da3ecd7acecdaf2fc28fb2dd3491da1ad139fd83fdb6b2d3a",
     "provider": "cosyworld.the-holy-land/assets",
     "mount": "cards",
     "root": "the-holy-land",

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -771,7 +771,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:936fb16d280df4e073056c41c6c81034162b4407012ae2dbc9302813d31948df",
+    "bundle_hash": "sha256:fea970b0cdbb1266e4fd20bbec60ed2ff48bb8feb36a799ebd558700a7f83028",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -2424,6 +2424,12 @@
               {
                 "from_policy_id": "cosyworld.compatibility.host-generation/1",
                 "from_migration_version": 0,
+                "from_pack_version": "1.1.4",
+                "mode": "preserve_descendants"
+              },
+              {
+                "from_policy_id": "cosyworld.compatibility.host-generation/1",
+                "from_migration_version": 0,
                 "from_pack_version": "1.1.3",
                 "mode": "preserve_descendants"
               }
@@ -2436,7 +2442,7 @@
           "type": "workspace",
           "path": "../../content/the-holy-land"
         },
-        "integrity": "sha256:bda90d20b1c30024bab64cd1529035b4397d1b0ab8eda3378d0176413bec8fda"
+        "integrity": "sha256:d54565c7516b305da3ecd7acecdaf2fc28fb2dd3491da1ad139fd83fdb6b2d3a"
       },
       {
         "id": "cosyworld.composition.core-holy-land",
@@ -14575,7 +14581,7 @@
     {
       "pack_id": "cosyworld.the-holy-land",
       "pack_version": "1.2.1",
-      "pack_integrity": "sha256:bda90d20b1c30024bab64cd1529035b4397d1b0ab8eda3378d0176413bec8fda",
+      "pack_integrity": "sha256:d54565c7516b305da3ecd7acecdaf2fc28fb2dd3491da1ad139fd83fdb6b2d3a",
       "provider": "cosyworld.the-holy-land/assets",
       "mount": "cards",
       "root": "the-holy-land",

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -769,7 +769,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:936fb16d280df4e073056c41c6c81034162b4407012ae2dbc9302813d31948df",
+  "bundle_hash": "sha256:fea970b0cdbb1266e4fd20bbec60ed2ff48bb8feb36a799ebd558700a7f83028",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -2422,6 +2422,12 @@
             {
               "from_policy_id": "cosyworld.compatibility.host-generation/1",
               "from_migration_version": 0,
+              "from_pack_version": "1.1.4",
+              "mode": "preserve_descendants"
+            },
+            {
+              "from_policy_id": "cosyworld.compatibility.host-generation/1",
+              "from_migration_version": 0,
               "from_pack_version": "1.1.3",
               "mode": "preserve_descendants"
             }
@@ -2434,7 +2440,7 @@
         "type": "workspace",
         "path": "../../content/the-holy-land"
       },
-      "integrity": "sha256:bda90d20b1c30024bab64cd1529035b4397d1b0ab8eda3378d0176413bec8fda"
+      "integrity": "sha256:d54565c7516b305da3ecd7acecdaf2fc28fb2dd3491da1ad139fd83fdb6b2d3a"
     },
     {
       "id": "cosyworld.composition.core-holy-land",

--- a/v2/content/the-holy-land/pack.json
+++ b/v2/content/the-holy-land/pack.json
@@ -184,6 +184,12 @@
         {
           "from_policy_id": "cosyworld.compatibility.host-generation/1",
           "from_migration_version": 0,
+          "from_pack_version": "1.1.4",
+          "mode": "preserve_descendants"
+        },
+        {
+          "from_policy_id": "cosyworld.compatibility.host-generation/1",
+          "from_migration_version": 0,
           "from_pack_version": "1.1.3",
           "mode": "preserve_descendants"
         }

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.233"
+version = "0.0.234"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.233"
+version = "0.0.234"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/generation_policy.rs
+++ b/v2/orchestrator-rust/src/generation_policy.rs
@@ -485,8 +485,10 @@ pub(super) fn generated_policy_drift_is_declared_preserving_upgrade(
     let pathway_is_current = pathway.policy_id == policy.policy_id
         && pathway.migration_version == policy.migration_version
         && pathway.owner_pack_version == pack.version;
-    let pathway_is_preserved_history = pathway.policy_id == policy.policy_id
-        && policy_declares_preserved_binding(&policy, pathway);
+    // A pathway can itself still carry an explicitly preserved compatibility
+    // policy. Requiring its policy id to equal the active policy id would
+    // ignore the exact cross-policy tuple named by the migration manifest.
+    let pathway_is_preserved_history = policy_declares_preserved_binding(&policy, pathway);
     let record_is_preserved_history = policy_declares_preserved_binding(&policy, record);
     let transition_is_monotonic = pathway_is_current
         || (pathway_is_preserved_history
@@ -1098,6 +1100,96 @@ mod tests {
         assert_eq!(
             restored.community_art_generations[&key].generation_policy,
             pathway_binding
+        );
+    }
+
+    #[test]
+    fn production_legacy_media_owner_upgrade_adopts_the_pathway_binding() {
+        // Production checkpoint subject 157216 was generated under Holy Land
+        // 1.1.4's host compatibility policy. Its pathway was then migrated to
+        // 1.1.6 with every other identity field unchanged. The active policy
+        // declares this exact historical tuple as descendant-preserving.
+        let mut runtime = RuntimeWorld::seeded();
+        let mut pathway = holy_land_pathway(&runtime);
+        // Use the fixture pathway's canonical waypoint id; subject 157216 is
+        // the production instance carrying the same policy tuple.
+        let subject_id = pathway.waypoints[0].id;
+        let shared_bundle =
+            "sha256:9e91a900766633f5f52b8fe58e8f409f020233553e3fe5bf24ff519553e972ac";
+        let pathway_binding = legacy_generated_policy_binding(
+            "cosyworld.the-holy-land",
+            "1.1.6",
+            "cosyworld.official",
+            shared_bundle,
+        );
+        pathway.owner_pack_version = pathway_binding.owner_pack_version.clone();
+        pathway.generation_policy = pathway_binding.clone();
+        for waypoint in &mut pathway.waypoints {
+            waypoint.generation_policy = pathway_binding.clone();
+        }
+        runtime
+            .generated_pathways
+            .insert(pathway.id.clone(), pathway);
+        let _ = runtime.apply_fund_community_art_projection(
+            "location",
+            subject_id,
+            1,
+            1,
+            RATI_ACTOR_ID,
+            "production-media-157216",
+            1,
+            337_009,
+            None,
+        );
+        let media_binding = legacy_generated_policy_binding(
+            "cosyworld.the-holy-land",
+            "1.1.4",
+            "cosyworld.official",
+            shared_bundle,
+        );
+        let policy = policy_for_pack("cosyworld.the-holy-land")
+            .expect("active Holy Land policy resolves")
+            .expect("Holy Land owns a generation policy");
+        assert!(
+            policy_declares_preserved_binding(&policy, &media_binding),
+            "the active policy must name the exact legacy media tuple"
+        );
+        assert!(
+            policy_declares_preserved_binding(&policy, &pathway_binding),
+            "the active policy must name the exact legacy pathway tuple"
+        );
+        let key = community_art_generation_key("location", subject_id, 1);
+        runtime
+            .community_art_generations
+            .get_mut(&key)
+            .expect("production-shaped generated media exists")
+            .generation_policy = media_binding.clone();
+
+        assert!(
+            generated_policy_drift_is_declared_preserving_upgrade(
+                &media_binding,
+                &pathway_binding,
+            )
+            .expect("reviewed policy lookup succeeds"),
+            "the exact production owner upgrade must be declared"
+        );
+        let restored = RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .expect("the production-shaped legacy media checkpoint must load");
+        assert_eq!(
+            restored.community_art_generations[&key].generation_policy,
+            pathway_binding
+        );
+
+        let mut undeclared = media_binding;
+        undeclared.owner_pack_version = "1.1.2".to_string();
+        assert!(
+            !generated_policy_drift_is_declared_preserving_upgrade(
+                &undeclared,
+                &restored.community_art_generations[&key].generation_policy,
+            )
+            .expect("reviewed policy lookup succeeds"),
+            "nearby but undeclared legacy history must remain rejected"
         );
     }
 

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -220,7 +220,7 @@
         "type": "workspace",
         "path": "../../content/the-holy-land"
       },
-      "integrity": "sha256:bda90d20b1c30024bab64cd1529035b4397d1b0ab8eda3378d0176413bec8fda",
+      "integrity": "sha256:d54565c7516b305da3ecd7acecdaf2fc28fb2dd3491da1ad139fd83fdb6b2d3a",
       "dependencies": [
         {
           "id": "cosyworld.core",


### PR DESCRIPTION
## Summary
- declare the exact Holy Land `1.1.4` host-compatibility media tuple as descendant-preserving
- allow an explicitly declared legacy pathway tuple to participate in the existing fail-closed migration path
- add a production-shaped checkpoint regression for media subject 157216 and reject adjacent undeclared history
- release `0.0.233`

## Production evidence
The `0.0.232` diagnostic exposed this otherwise-identical tuple:
- media owner: `cosyworld.the-holy-land@1.1.4`
- pathway owner: `cosyworld.the-holy-land@1.1.6`
- schema/policy/migration/composition/bundle: identical

## Validation
- `npm run check`
- 483 JS tests
- worldpack/kernel validation
- 794 Rust tests
- architecture, lint, and syntax checks

Recovery follow-up for #319.