### PR TITLE
Make Chat run a bounded avatar conversation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.236",
+  "version": "0.0.237",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.236",
+      "version": "0.0.237",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.236",
+  "version": "0.0.237",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -151,7 +151,7 @@ The Rust orchestrator currently owns:
   or combat targets without durable consent, blocks fail closed, and private
   economy details are visible only to the controlling avatar.
 - Generated human avatar flavor: name, title, description, and runtime avatar card.
-- Advancement-backed `Chat` for beginning a friendship, plus moderated human-authored `say` lines for shared room speech.
+- Bounded avatar-to-resident `Chat` exchanges, advancement-backed `Befriend`, and moderated human-authored `say` lines for shared room speech.
 - OpenAI-compatible contextual resident replies with no deterministic dialogue substitute when inference is unavailable.
 - Event projection.
 - Snapshot persistence.
@@ -289,7 +289,7 @@ http://127.0.0.1:3102/?reset=1
 
 The avatar gate begins with an immediate character question and carries that answer through the visible game as the avatar's purpose. A quiet transcript frames `a new tale is waiting`; the completed Begin lands as a visible arrival beat and arms the first resident heartbeat. The new avatar sheet describes moments and people still ahead, calls a local session a `local tale`, and reports the carried deck by physical weight rather than a fixed card count.
 
-The browser frames onboarding as `Your first tale`: Notice a clue, watch the Journal settle the earned growth in that same action, then keep exploring or use advancement through a relevant character surface. Chat spends one advancement point to begin a friendship and opens a resident picker when several eligible new friends are nearby. Advancement never creates a charm, skill, spell, or weapon card. Remember handles mature friendships separately.
+The browser frames onboarding as `Your first tale`: Notice a clue, watch the Journal settle the earned growth in that same action, then keep exploring or use advancement through a relevant character surface. Chat starts a short system-funded exchange with an eligible nearby resident; Befriend spends one advancement point to begin a friendship and opens a resident picker when several eligible new friends are nearby. Advancement never creates a charm, skill, spell, or weapon card. Remember handles mature friendships separately.
 
 Multi-target verbs stay compact: Take, Use, Give, Trade, Attack, and Chat put legal targets inside one card instead of duplicating hand slots. Long connections remain ordinary segmented geography—Search reveals one adjacent pathway and Travel enters it. Player-facing copy describes story outcomes rather than exposing raw d20, damage, HP, or clock arithmetic. The collapsed room `LOG` names who did what and what changed; the expanded history preserves the audited sequence. That log is also supplied to resident inference, so a delayed reply can refer to cards played and changes that happened in the channel instead of inventing an isolated conversation.
 
@@ -334,7 +334,7 @@ runs both the deterministic visual/accessibility pass and the longer
 living-world journey. Together they verify runtime metadata, signed wallet
 challenge/session access and avatar recovery, avatar creation, actor-session
 continuity, walletless `connect wallet`, one-button normal play, zero-Orb
-earning-action priority, no-typing `listen`, advancement-backed Chat,
+earning-action priority, no-typing `listen`, bounded Chat, advancement-backed Befriend,
 contextual resident heartbeats, moderated room speech and `/me` emotes, moderation/report flows, two-browser
 fanout and presence leave, compass/typed command behavior, weighted-deck item
 take/drop/retake behavior, multiple loose cards at one location, reload
@@ -705,13 +705,14 @@ This is the adapter seam for replacing the dev snapshot with Ruby High wallet/se
 
 The world remains shared: `location-science-lab`, `location-homeroom`, `location-library`, `location-cafeteria`, `location-greenhouse`, and `location-courtyard` unlock travel to their one global rooms. They do not create per-wallet rooms or teacher DMs.
 
-Chat is advancement-backed friendship, not a human text box or branch picker:
+Chat is a bounded avatar-to-resident exchange, not a human text box, branch picker, or friendship purchase:
 
-- When a banked advancement point and an eligible nearby resident make `create_bond` legal, the browser labels that offer `Chat`.
-- The server validates the actor session, target resident, shared location, room turn, rate limit, available advancement, and absence of an existing Bond.
-- Success spends one advancement point, creates the Bond, passes the room turn, and arms the room's normal delayed reply heartbeat.
-- Chat never spends an Orb. The resident reply is system-funded and, if inference is unavailable or invalid, the friendship remains committed without canned dialogue.
-- The legacy `/actions/chat` route delegates to the same advancement-backed contract for older clients.
+- When an inference-controlled, unblocked, unmuted resident is actively nearby, the browser offers `Chat`; a resident picker appears when several targets qualify.
+- The server validates the actor session, target resident, shared location, rate limit, and current presence before queuing one durable exchange.
+- A successful exchange emits exactly four authoritative `message.created` events—two lines from the player's avatar and two from the resident—through the normal journal and SSE feed.
+- Chat spends neither an Orb nor advancement and does not create a Bond. A rapid retry reuses the active durable job instead of starting a duplicate exchange.
+- The separate `Befriend` action spends one advancement point and creates a Bond when `create_bond` is legal.
+- If inference, context, or commit fails, the server emits a visible `chat.failed` status instead of silently doing nothing or substituting canned dialogue.
 - `say <message>`, `/me <action>`, and `POST /actions/say` commit moderated human-authored room text as normal `message.created` events; unsafe or overlong text is rejected before it reaches the journal.
 - Legacy branch records in old snapshots are ignored by `/state` and do not change the primary action.
 
@@ -942,7 +943,7 @@ Public mutation endpoints also pass through lightweight in-memory rate limits be
 
 - Avatar creation: 12 attempts per client IP per 10 minutes.
 - Wallet challenge/session: 30 attempts per client IP per minute.
-- Chat/friendship and player room-message actions: 45 attempts per actor per minute, with a broader shared IP mutation cap.
+- Chat, friendship, and player room-message actions: 45 attempts per actor per minute, with a broader shared IP mutation cap.
 - Player reports: 12 attempts per actor per 10 minutes, with the broader shared IP mutation cap.
 - Movement, item, check, and combat actions: 180 attempts per actor per minute, with the same shared IP mutation cap.
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.236"
+version = "0.0.237"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.236"
+version = "0.0.237"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/chat_action.rs
+++ b/v2/orchestrator-rust/src/chat_action.rs
@@ -1,0 +1,559 @@
+use super::*;
+
+static CHAT_ACTION_LOCKS: OnceLock<StdMutex<BTreeMap<String, Weak<Mutex<()>>>>> = OnceLock::new();
+
+pub(super) async fn chat(
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    Json(payload): Json<ChatRequest>,
+) -> Json<ActionResponse> {
+    if !allow_actor_mutation(
+        &state,
+        client_addr,
+        payload.actor_id,
+        "chat-actor",
+        CHAT_ACTION_LIMIT,
+    ) {
+        return action_rate_limited_response();
+    }
+
+    let chat_lock = chat_action_lock(&state, payload.actor_id, payload.target_actor_id);
+    let _chat_guard = chat_lock.lock().await;
+    {
+        let runtime = state.inner.lock().await;
+        if !client_actor_authorized_for_state(
+            &runtime,
+            &state,
+            payload.actor_id,
+            payload.actor_session.as_deref(),
+        ) {
+            return client_actor_rejected_response();
+        }
+    }
+    if let Some(path) = state.event_store_path.as_deref() {
+        match active_orb_chat_job(path, payload.actor_id, payload.target_actor_id) {
+            Ok(true) => {
+                return Json(ActionResponse {
+                    ok: true,
+                    status: CW_OK,
+                    events: Vec::new(),
+                });
+            }
+            Ok(false) => {}
+            Err(error) => {
+                warn!("could not inspect the durable Chat queue: {error}");
+                return Json(ActionResponse {
+                    ok: false,
+                    status: 503,
+                    events: vec![EventView {
+                        type_name: "chat.failed".to_string(),
+                        actor_id: Some(payload.actor_id),
+                        target_actor_id: Some(payload.target_actor_id),
+                        content: Some(
+                            "The conversation could not start safely; try again.".to_string(),
+                        ),
+                        ..EventView::default()
+                    }],
+                });
+            }
+        }
+    }
+
+    let mut runtime = state.inner.lock().await;
+    let target_is_available = runtime.actor_uses_inference(payload.target_actor_id)
+        && !runtime.actors_blocked(payload.actor_id, payload.target_actor_id)
+        && !runtime.actor_muted(payload.actor_id, payload.target_actor_id);
+    let Some(plan) = target_is_available
+        .then(|| runtime.avatar_chat_plan_for(payload.actor_id, payload.target_actor_id))
+        .flatten()
+    else {
+        return Json(ActionResponse {
+            ok: false,
+            status: 409,
+            events: vec![EventView {
+                type_name: "chat.failed".to_string(),
+                actor_id: Some(payload.actor_id),
+                target_actor_id: Some(payload.target_actor_id),
+                content: Some("That conversation is no longer within reach.".to_string()),
+                ..EventView::default()
+            }],
+        });
+    };
+
+    let source_world_tick = runtime.world.tick;
+    let observed_through_seq = runtime.world.next_event_seq.saturating_sub(1);
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: payload.actor_id,
+            target_actor_id: payload.target_actor_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    );
+    record.offer_kind = Some("chat".to_string());
+    record
+        .projection_mutations
+        .push(ProjectionMutation::ChatStatus {
+            target_actor_id: payload.target_actor_id,
+            status: "queued".to_string(),
+            reason: "the conversation is unfolding".to_string(),
+        });
+    record.queued_actor_job = Some(ActorJobPayload::OrbChat(OrbChatJob {
+        actor_id: payload.actor_id,
+        target_actor_id: payload.target_actor_id,
+        plan: plan.clone(),
+        queue_event_id: None,
+        source_world_tick: None,
+        observed_through_seq: None,
+    }));
+    let Ok((status, events)) = commit_journal_record(&state, &mut runtime, record) else {
+        return Json(ActionResponse {
+            ok: false,
+            status: 500,
+            events: vec![EventView {
+                type_name: "chat.failed".to_string(),
+                actor_id: Some(payload.actor_id),
+                target_actor_id: Some(payload.target_actor_id),
+                content: Some("The conversation could not be saved; try again.".to_string()),
+                ..EventView::default()
+            }],
+        });
+    };
+    drop(runtime);
+
+    broadcast_events(&state, &events);
+    if status == CW_OK {
+        let queue_event_id = events
+            .iter()
+            .find(|event| event.type_name == "chat.queued" && event.success)
+            .map(|event| event.seq);
+        if state.event_store_path.is_some() {
+            state.actor_job_notify.notify_waiters();
+        } else {
+            let chat_state = state.clone();
+            tokio::spawn(async move {
+                complete_queued_orb_chat(
+                    &chat_state,
+                    payload.actor_id,
+                    payload.target_actor_id,
+                    plan,
+                    queue_event_id,
+                    Some(source_world_tick),
+                    Some(observed_through_seq),
+                )
+                .await;
+            });
+        }
+    }
+    Json(ActionResponse {
+        ok: status == CW_OK,
+        status,
+        events,
+    })
+}
+
+fn chat_action_lock(state: &AppState, actor_id: u64, target_actor_id: u64) -> Arc<Mutex<()>> {
+    let key = format!(
+        "{:p}:{actor_id}:{target_actor_id}",
+        Arc::as_ptr(&state.inner)
+    );
+    let mut locks = CHAT_ACTION_LOCKS
+        .get_or_init(|| StdMutex::new(BTreeMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+        return lock;
+    }
+    let lock = Arc::new(Mutex::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    lock
+}
+
+fn active_orb_chat_job(path: &Path, actor_id: u64, target_actor_id: u64) -> io::Result<bool> {
+    let conn = open_event_store(path)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT context_json FROM actor_jobs
+             WHERE kind = ?1 AND actor_id = ?2 AND status IN ('pending', 'running')",
+        )
+        .map_err(sqlite_error)?;
+    let rows = stmt
+        .query_map(params![ACTOR_JOB_KIND_ORB_CHAT, actor_id as i64], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(sqlite_error)?;
+    for row in rows {
+        let payload = row.map_err(sqlite_error)?;
+        let Ok(ActorJobPayload::OrbChat(job)) = serde_json::from_str::<ActorJobPayload>(&payload)
+        else {
+            continue;
+        };
+        if job.target_actor_id == target_actor_id {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{routing::post, Router};
+
+    #[tokio::test]
+    async fn chat_endpoint_queues_a_bounded_exchange_without_spending_advancement() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-chat-action-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        let state = test_app_state(RuntimeWorld::seeded(), Some(path.clone()));
+        {
+            let mut runtime = state.inner.lock().await;
+            create_test_human(
+                &mut runtime,
+                5000,
+                COSY_COTTAGE_LOCATION_ID,
+                "Inference Tester",
+            );
+        }
+        let (actor_session, _) = issue_actor_session(&state, 5000);
+
+        let response = chat(
+            ConnectInfo("127.0.0.1:44001".parse().expect("client address")),
+            State(state.clone()),
+            Json(ChatRequest {
+                actor_id: 5000,
+                actor_session: Some(actor_session.clone()),
+                target_actor_id: RATI_ACTOR_ID,
+            }),
+        )
+        .await
+        .0;
+
+        assert!(response.ok);
+        assert_eq!(response.status, CW_OK);
+        assert!(response.events.iter().any(|event| {
+            event.type_name == "chat.queued"
+                && event.actor_id == Some(5000)
+                && event.target_actor_id == Some(RATI_ACTOR_ID)
+        }));
+        assert!(!response
+            .events
+            .iter()
+            .any(|event| event.type_name == "advancement.spent"));
+        let unauthorized_retry = chat(
+            ConnectInfo("127.0.0.1:44002".parse().expect("client address")),
+            State(state.clone()),
+            Json(ChatRequest {
+                actor_id: 5000,
+                actor_session: Some("not-the-actor-session".to_string()),
+                target_actor_id: RATI_ACTOR_ID,
+            }),
+        )
+        .await
+        .0;
+        assert!(
+            !unauthorized_retry.ok,
+            "an active Chat job must not bypass actor authorization"
+        );
+        let retry = chat(
+            ConnectInfo("127.0.0.1:44001".parse().expect("client address")),
+            State(state.clone()),
+            Json(ChatRequest {
+                actor_id: 5000,
+                actor_session: Some(actor_session),
+                target_actor_id: RATI_ACTOR_ID,
+            }),
+        )
+        .await
+        .0;
+        assert!(retry.ok);
+        assert!(
+            retry.events.is_empty(),
+            "retrying an active Chat must reuse the durable exchange"
+        );
+        let queued = claim_next_actor_job_of_kind(&path, ACTOR_JOB_KIND_ORB_CHAT)
+            .expect("inspect Chat outbox")
+            .expect("Chat queued one durable job");
+        let ActorJobPayload::OrbChat(job) = queued.payload else {
+            panic!("Chat queued the wrong actor job");
+        };
+        assert_eq!(job.actor_id, 5000);
+        assert_eq!(job.target_actor_id, RATI_ACTOR_ID);
+        complete_actor_job(&path, queued.id).expect("complete inspected Chat job");
+        assert!(
+            claim_next_actor_job_of_kind(&path, ACTOR_JOB_KIND_ORB_CHAT)
+                .expect("inspect deduplicated Chat outbox")
+                .is_none(),
+            "a rapid Chat retry must not queue a second exchange"
+        );
+        let runtime = state.inner.lock().await;
+        assert_eq!(runtime.orb_balance(5000), STARTING_ORBS);
+        assert_eq!(runtime.advancement_points_available(5000), 0);
+        assert!(runtime.active_bond(5000, RATI_ACTOR_ID).is_none());
+        assert!(!runtime
+            .event_log
+            .iter()
+            .any(|event| { event.type_name == "message.created" && event.actor_id == Some(5000) }));
+        drop(runtime);
+        let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn co_present_chat_is_free_and_not_owned_by_a_room_turn() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-concurrent-chat-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Current Player",
+        );
+        create_test_human(
+            &mut runtime,
+            5001,
+            COSY_COTTAGE_LOCATION_ID,
+            "Waiting Chatter",
+        );
+        let state = test_app_state(runtime, Some(path.clone()));
+        let (session_5000, _) = issue_actor_session(&state, 5000);
+        let (session_5001, _) = issue_actor_session(&state, 5001);
+        assert_eq!(
+            ping_actor_session_for_actor(&state.actor_sessions, 5000, &session_5000),
+            Some(false)
+        );
+        assert_eq!(
+            ping_actor_session_for_actor(&state.actor_sessions, 5001, &session_5001),
+            Some(false)
+        );
+
+        let before_tick = {
+            let runtime = state.inner.lock().await;
+            let active_direct_actors = active_actor_ids_for_state(&state);
+            let turn = room_turn_view_for_runtime(
+                &state,
+                &runtime,
+                COSY_COTTAGE_LOCATION_ID,
+                Some(5000),
+                &active_direct_actors,
+            );
+            assert!(!turn.enabled);
+            assert_eq!(turn.policy, "concurrent");
+            runtime.world.tick
+        };
+
+        for (actor_id, actor_session, port) in
+            [(5001, session_5001, 44002), (5000, session_5000, 44003)]
+        {
+            let response = chat(
+                ConnectInfo(format!("127.0.0.1:{port}").parse().expect("client address")),
+                State(state.clone()),
+                Json(ChatRequest {
+                    actor_id,
+                    actor_session: Some(actor_session),
+                    target_actor_id: RATI_ACTOR_ID,
+                }),
+            )
+            .await
+            .0;
+            assert!(
+                response.ok,
+                "each co-present avatar can chat without owning a room turn"
+            );
+            assert!(response
+                .events
+                .iter()
+                .any(|event| event.type_name == "chat.queued"));
+            assert!(!response.events.iter().any(|event| {
+                matches!(
+                    event.type_name.as_str(),
+                    "bond.created" | "advancement.spent"
+                )
+            }));
+        }
+
+        let runtime = state.inner.lock().await;
+        let active_direct_actors = active_actor_ids_for_state(&state);
+        let turn = room_turn_view_for_runtime(
+            &state,
+            &runtime,
+            COSY_COTTAGE_LOCATION_ID,
+            Some(5000),
+            &active_direct_actors,
+        );
+        assert_eq!(
+            runtime.world.tick, before_tick,
+            "queued conversation is asynchronous system work, not a player-card tick"
+        );
+        for actor_id in [5000, 5001] {
+            assert_eq!(runtime.advancement_points_available(actor_id), 0);
+            assert!(runtime.active_bond(actor_id, RATI_ACTOR_ID).is_none());
+        }
+        assert!(!turn.enabled);
+        assert_eq!(turn.policy, "concurrent");
+        assert_eq!(turn.current_actor_id, None);
+        assert!(!turn.is_current_actor);
+        drop(runtime);
+        let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn unavailable_inference_commits_a_visible_chat_failure() {
+        let state = test_app_state(RuntimeWorld::seeded(), None);
+        let plan = {
+            let mut runtime = state.inner.lock().await;
+            create_test_human(
+                &mut runtime,
+                5000,
+                COSY_COTTAGE_LOCATION_ID,
+                "Inference Tester",
+            );
+            runtime
+                .avatar_chat_plan_for(5000, RATI_ACTOR_ID)
+                .expect("co-present inference resident is a Chat target")
+        };
+
+        complete_queued_orb_chat(
+            &state,
+            5000,
+            RATI_ACTOR_ID,
+            plan,
+            Some(41),
+            Some(7),
+            Some(40),
+        )
+        .await;
+
+        let runtime = state.inner.lock().await;
+        assert!(runtime.event_log.iter().any(|event| {
+            event.type_name == "chat.failed"
+                && event.actor_id == Some(5000)
+                && event.target_actor_id == Some(RATI_ACTOR_ID)
+                && event
+                    .content
+                    .as_deref()
+                    .is_some_and(|content| content.contains("try talking again"))
+        }));
+        assert!(!runtime
+            .event_log
+            .iter()
+            .any(|event| event.type_name == "message.created"));
+    }
+
+    #[tokio::test]
+    async fn completed_chat_commits_exactly_two_lines_from_each_participant() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let app = Router::new().route(
+            "/chat/completions",
+            post({
+                let calls = calls.clone();
+                move || {
+                    let index = calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    async move {
+                        let content = [
+                            "I found a quiet minute. How is the cottage treating you?",
+                            "Kindly enough, though the kettle has opinions about punctuality.",
+                            "Then I will keep one ear on the kettle and one on your story.",
+                            "A sensible arrangement. Come back before it starts whistling secrets.",
+                        ]
+                        .get(index)
+                        .copied()
+                        .unwrap_or("The conversation has already settled.");
+                        Json(serde_json::json!({
+                            "model": "test-chat-model",
+                            "choices": [{
+                                "finish_reason": "stop",
+                                "message": { "content": content }
+                            }]
+                        }))
+                    }
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind bounded Chat inference server");
+        let address = listener
+            .local_addr()
+            .expect("Chat inference server address");
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let mut state = test_app_state(RuntimeWorld::seeded(), None);
+        state.ai_config = Arc::new(Some(AiConfig {
+            api_key: "test".to_string(),
+            base_url: format!("http://{address}"),
+            model: "test-chat-model".to_string(),
+            ..AiConfig::default()
+        }));
+        let plan = {
+            let mut runtime = state.inner.lock().await;
+            create_test_human(
+                &mut runtime,
+                5000,
+                COSY_COTTAGE_LOCATION_ID,
+                "Inference Tester",
+            );
+            runtime
+                .avatar_chat_plan_for(5000, RATI_ACTOR_ID)
+                .expect("co-present inference resident is a Chat target")
+        };
+
+        complete_queued_orb_chat(
+            &state,
+            5000,
+            RATI_ACTOR_ID,
+            plan,
+            Some(51),
+            Some(8),
+            Some(50),
+        )
+        .await;
+
+        let runtime = state.inner.lock().await;
+        let speakers = runtime
+            .event_log
+            .iter()
+            .filter(|event| event.type_name == "message.created")
+            .filter_map(|event| event.actor_id)
+            .collect::<Vec<_>>();
+        let event_diagnostic = runtime
+            .event_log
+            .iter()
+            .map(|event| {
+                (
+                    event.type_name.clone(),
+                    event.actor_id,
+                    event.content.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            speakers,
+            vec![5000, RATI_ACTOR_ID, 5000, RATI_ACTOR_ID],
+            "Chat must stay bounded to two authoritative lines per participant; calls={}, events={event_diagnostic:?}",
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+        );
+        assert!(runtime.event_log.iter().any(|event| {
+            event.type_name == "chat.completed"
+                && event.actor_id == Some(5000)
+                && event.target_actor_id == Some(RATI_ACTOR_ID)
+        }));
+        assert!(!runtime
+            .event_log
+            .iter()
+            .any(|event| event.type_name == "chat.failed"));
+        drop(runtime);
+        server.abort();
+    }
+}

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -421,7 +421,7 @@ impl RuntimeWorld {
                     target
                         .as_ref()
                         .and_then(|target| target.label.as_deref())
-                        .map(|label| format!("chat {label}"))
+                        .map(|label| format!("bond {label}"))
                         .unwrap_or_else(|| option.command.clone())
                 } else {
                     option.command.clone()
@@ -1369,14 +1369,20 @@ impl RuntimeWorld {
                 id: Some(actor.location_id),
                 label: self.location_name(actor.location_id),
             }),
-            "chat" | "influence" => {
-                self.default_chat_target(actor_id)
-                    .map(|target| ActionTargetView {
-                        kind: "actor".to_string(),
-                        id: Some(target.id),
-                        label: self.actor_name(target.id),
-                    })
-            }
+            "chat" => self
+                .default_inference_chat_target(actor_id)
+                .map(|target| ActionTargetView {
+                    kind: "actor".to_string(),
+                    id: Some(target.id),
+                    label: self.actor_name(target.id),
+                }),
+            "influence" => self
+                .default_chat_target(actor_id)
+                .map(|target| ActionTargetView {
+                    kind: "actor".to_string(),
+                    id: Some(target.id),
+                    label: self.actor_name(target.id),
+                }),
 
             "attack" | "defend" => self
                 .active_combat_encounter_for_actor(actor_id)

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5126,6 +5126,69 @@
         accessibleLabel: String(accessibleLabel || offer?.accessible_label || "").trim(),
       });
       const buildChatAction = () => {
+        if (!options.has("chat")) return null;
+        const chatOffer = offerFor("chat");
+        const offeredTargetId = Number(chatOffer?.target?.id || 0);
+        const chatCandidates = actorTargets
+          .filter((actor) => (
+            actor.control_mode !== "direct_input"
+            && !actor.blocked_by_you
+            && !actor.muted_by_you
+          ))
+          .sort((left, right) => (
+            Number(right.id === offeredTargetId) - Number(left.id === offeredTargetId)
+            || actorLabel(left).localeCompare(actorLabel(right))
+          ));
+        if (!chatCandidates.length) return null;
+        const firstChat = chatCandidates[0];
+        const oneChat = chatCandidates.length === 1;
+        const firstTargetName = firstChat.name || actorLabel(firstChat);
+        const chatAction = {
+          ...semanticAction(chatOffer, "chat"),
+          kind: "orb-chat",
+          label: "chat",
+          detail: oneChat ? `with ${actorLabel(firstChat)} · a short exchange` : "choose someone nearby",
+          command: oneChat ? (chatOffer?.command || `chat ${firstTargetName}`) : "chat",
+          focusKey: oneChat
+            ? `talk:${firstChat.id}`
+            : `talk:${chatCandidates.map((actor) => actor.id).join("|")}`,
+          focusKeys: chatCandidates.map((actor) => `actor:${actor.id}`),
+          card: cardForActor(firstChat.id),
+          shape: "avatar",
+          priority: Number(chatOffer?.rank || 70),
+          targetName: oneChat ? firstTargetName : "",
+          targetActorId: firstChat.id,
+          modalTitle: oneChat ? `chat with ${firstTargetName}` : "choose someone to chat with",
+          modalSummary: oneChat
+            ? `Your avatar and ${firstTargetName} will trade a few short lines.`
+            : "Choose someone nearby for a short back-and-forth conversation.",
+          effect: oneChat
+            ? `a short conversation with ${firstTargetName} unfolds`
+            : "a short conversation unfolds",
+          busyLabel: "chatting",
+          busyDetail: "finding the thread…",
+          ...(oneChat ? {} : {
+            choices: chatCandidates.map((actor) => ({
+              label: actorLabel(actor),
+              detail: actor.title || "share a short exchange",
+              value: String(actor.id),
+              card: cardForActor(actor.id),
+            })),
+            selectedChoice: String(firstChat.id),
+          }),
+        };
+        chatAction.selectedTarget = () => chatCandidates.find((actor) => (
+          String(actor.id) === String(chatAction.selectedChoice || firstChat.id)
+        )) || firstChat;
+        chatAction.pendingTargetActorId = () => Number(chatAction.selectedTarget().id);
+        chatAction.selectedPayload = () => ({
+          actor_id: actorId,
+          target_actor_id: Number(chatAction.selectedTarget().id),
+        });
+        chatAction.run = () => action("/actions/chat", chatAction.selectedPayload());
+        return chatAction;
+      };
+      const buildBondAction = () => {
         if (!options.has("create_bond") || Number(ledger.advancement_points || 0) <= 0) return null;
         const chatOffer = offerFor("create_bond");
         const offeredTargetId = Number(chatOffer?.target?.id || 0);
@@ -5142,13 +5205,13 @@
         const firstRelationship = firstChat.relationship || null;
         const authoredRelationship = firstRelationship?.initial_status === "forming";
         const chatAction = {
-          ...semanticAction(chatOffer, "chat"),
-          kind: "advancement-chat",
-          label: "chat",
+          ...semanticAction(chatOffer, "befriend"),
+          kind: "advancement-bond",
+          label: "befriend",
           detail: oneChat
             ? `with ${actorLabel(firstChat)} · use what you learned`
             : "choose someone · use what you learned",
-          command: oneChat ? (chatOffer?.command || `chat ${firstTargetName}`) : "chat",
+          command: oneChat ? (chatOffer?.command || `bond ${firstTargetName}`) : "bond",
           focusKey: oneChat
             ? `bond:${firstChat.id}`
             : `bond:${chatCandidates.map((actor) => actor.id).join("|")}`,
@@ -5157,12 +5220,12 @@
           shape: "avatar",
           priority: Number(chatOffer?.rank || 77),
           targetName: oneChat ? firstTargetName : "",
-          modalTitle: oneChat ? `chat with ${firstTargetName}` : "choose someone to chat with",
+          modalTitle: oneChat ? `befriend ${firstTargetName}` : "choose someone to befriend",
           modalSummary: oneChat
             ? (authoredRelationship
               ? `Use one advancement point to begin this forming relationship: “${firstRelationship.statement}”`
               : `Use one advancement point to begin a friendship with ${firstTargetName}.`)
-            : "Choose someone nearby. Chat uses one advancement point and begins a friendship.",
+            : "Choose someone nearby. Befriending uses one advancement point.",
           effect: oneChat
             ? (authoredRelationship
               ? firstRelationship.deterministic_consequence
@@ -5608,6 +5671,8 @@
       }
       const chatAction = buildChatAction();
       if (chatAction) built.push(chatAction);
+      const bondAction = buildBondAction();
+      if (bondAction) built.push(bondAction);
       if (options.has("pick_up")) {
         const roomItems = (view.items || []).filter((item) => (
           Number(item.location_id || 0) === currentLocationId
@@ -6973,7 +7038,7 @@
 
     function offerKindsForPath(path, actionCard = pendingAction) {
       const byPath = {
-        "/actions/chat": ["create_bond"],
+        "/actions/chat": ["chat"],
         "/actions/move": ["move"],
         "/actions/explore-path": ["explore_path"],
         "/actions/flee": ["flee"],
@@ -9461,7 +9526,7 @@
       const deck = state?.deck || {};
       const largeText = localStorage.getItem("cosyworld.ui.largeText") === "true";
       const reduceMotion = localStorage.getItem("cosyworld.ui.reduceMotion") === "true";
-      return `<div class="account-title"><h2 id="account-panel-title">orbs & settings</h2><span class="account-wallet">${escapeHtml(String(economy.orbs || 0))} Orbs</span></div><div class="setting-list"><label class="setting-row"><span class="setting-copy"><strong>Larger text</strong><small>Increase interface and story text throughout the game.</small></span><input type="checkbox" data-ui-setting="largeText"${largeText ? " checked" : ""} /></label><label class="setting-row"><span class="setting-copy"><strong>Reduce motion</strong><small>Minimize dealing, pulsing, and transition animation.</small></span><input type="checkbox" data-ui-setting="reduceMotion"${reduceMotion ? " checked" : ""} /></label></div><div class="account-section"><div class="account-section-title">About Orbs</div><div class="keepsake-note">Orbs fund community images only. They do not buy stronger actions.</div>${accountRow("Chat", "appears when advancement can begin a friendship")}${accountRow("room voices", "one contextual reply per armed card heartbeat")}${accountRow("AI", economy.openrouter_connected ? "connected" : "world default")}${accountRow("carried deck", `${deckWeightLabel(deck.carried_weight_tenths)} / ${deckWeightLabel(deck.carrying_capacity_tenths)}`)}</div>`;
+      return `<div class="account-title"><h2 id="account-panel-title">orbs & settings</h2><span class="account-wallet">${escapeHtml(String(economy.orbs || 0))} Orbs</span></div><div class="setting-list"><label class="setting-row"><span class="setting-copy"><strong>Larger text</strong><small>Increase interface and story text throughout the game.</small></span><input type="checkbox" data-ui-setting="largeText"${largeText ? " checked" : ""} /></label><label class="setting-row"><span class="setting-copy"><strong>Reduce motion</strong><small>Minimize dealing, pulsing, and transition animation.</small></span><input type="checkbox" data-ui-setting="reduceMotion"${reduceMotion ? " checked" : ""} /></label></div><div class="account-section"><div class="account-section-title">About Orbs</div><div class="keepsake-note">Orbs fund community images only. They do not buy stronger actions.</div>${accountRow("Chat", "a short avatar and resident exchange")}${accountRow("Befriend", "uses advancement to begin a friendship")}${accountRow("room voices", "one contextual reply per armed card heartbeat")}${accountRow("AI", economy.openrouter_connected ? "connected" : "world default")}${accountRow("carried deck", `${deckWeightLabel(deck.carried_weight_tenths)} / ${deckWeightLabel(deck.carrying_capacity_tenths)}`)}</div>`;
     }
 
     function libraryPanelHtml() {
@@ -10029,7 +10094,7 @@
         return `The way opens, and ${actor} steps into ${event.destination_location_name || "somewhere new"}.`;
       }
       if (type === "chat.failed") {
-        return "The conversation slipped away before it could begin. Your Orb came back.";
+        return "The conversation slipped away before it could begin. Try talking again.";
       }
       if (type === "dialogue.unavailable") {
         return "Dialogue unavailable: Mara's promised reply could not run. The authored relationship beat still stands, and no substitute speech was created.";
@@ -11632,6 +11697,11 @@
         const targetName = action?.targetName || String(action.detail).split(/[·,]/)[0].trim();
         return `chat with ${targetName}`;
       }
+      if (label === "befriend" && action?.choices?.length) return "choose someone to befriend";
+      if (label === "befriend" && action?.detail) {
+        const targetName = action?.targetName || String(action.detail).split(/[·,]/)[0].trim();
+        return `befriend ${targetName}`;
+      }
       if (label === "take" && action?.choices?.length) return "choose what to take";
       if (label === "swap" && action?.choices?.length) return "choose what to swap";
       if (label === "give" && action?.choices?.length) return "choose who receives it";
@@ -11746,7 +11816,19 @@
           ["Watch for", friendlyActionText(action?.risk)],
         ].filter((row) => String(row[1] || "").trim());
       }
-      if (String(action?.label || "").toLowerCase() === "chat") {
+      if (String(action?.kind || "") === "orb-chat") {
+        if (action?.choices?.length) {
+          return [
+            ["Choose", "who you want to talk with"],
+            ["Then", "your avatar and theirs trade two short lines each"],
+          ];
+        }
+        return [
+          ["With", action?.targetName || String(action?.detail || "").split(/[·,]/)[0].trim()],
+          ["Then", "your avatar and theirs trade two short lines each"],
+        ];
+      }
+      if (String(action?.label || "").toLowerCase() === "befriend") {
         const selectedRelationship = action?.selectedTarget?.()?.relationship || action?.relationship;
         if (selectedRelationship?.initial_status === "forming") {
           return [
@@ -11859,10 +11941,9 @@
     }
 
     function renderActionModalRows(action) {
-      const selectedRelationship = action?.selectedTarget?.()?.relationship || action?.relationship;
-      const authoredRelationship = String(action?.label || "").toLowerCase() === "chat"
-        && selectedRelationship?.initial_status === "forming";
-      const rows = (authoredRelationship ? actionModalRows(action) : [])
+      const showConversationDetails = ["orb-chat", "advancement-bond"]
+        .includes(String(action?.kind || ""));
+      const rows = (showConversationDetails ? actionModalRows(action) : [])
         .filter((row) => String(row?.[0] || "").trim() && String(row?.[1] || "").trim());
       const meta = $("action-modal-meta");
       meta.innerHTML = rows.map(([key, value]) => {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -15,6 +15,7 @@ mod beliefs_tests;
 mod canonical_journal;
 mod canonical_world;
 mod cards;
+mod chat_action;
 mod combat;
 mod communal_governance;
 mod community_art;
@@ -91,6 +92,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use canonical_journal::*;
 use canonical_world::*;
 use cards::*;
+use chat_action::*;
 use combat::*;
 use communal_governance::*;
 use community_art::*;
@@ -19384,6 +19386,7 @@ impl RuntimeWorld {
         let can_use_item_contribution = self
             .job_contribution_intent(actor_id, "use_item", None, None, None)
             .is_some();
+        let can_chat = self.default_inference_chat_target(actor_id).is_some();
         let can_create_bond = self.default_bondable_resident(actor_id).is_some();
         let can_resolve_bond = self.default_resolvable_bond(actor_id).is_some();
         let can_cast_spell = self.default_spell_card(actor_id).is_some();
@@ -19570,13 +19573,24 @@ impl RuntimeWorld {
                 command: "cast steady light".to_string(),
             });
         }
+        if can_chat {
+            let command = self
+                .default_inference_chat_target(actor_id)
+                .map(|target| format!("chat {}", self.actor_view(target).name))
+                .unwrap_or_else(|| "chat".to_string());
+            options.push(ActionOption {
+                kind: "chat".to_string(),
+                label: "Chat".to_string(),
+                command,
+            });
+        }
         if can_create_bond {
             let command = self
                 .default_bond_command(actor_id)
                 .unwrap_or_else(|| "bond".to_string());
             options.push(ActionOption {
                 kind: "create_bond".to_string(),
-                label: "Chat".to_string(),
+                label: "Befriend".to_string(),
                 command,
             });
         }
@@ -19624,7 +19638,7 @@ impl RuntimeWorld {
                 "work" if self.work_finishes_active_progress(actor_id) => "Finish",
                 "work" => "Work",
                 "help" => "Help",
-                "create_bond" => "Chat",
+                "create_bond" => "Befriend",
                 "resolve_bond" => "Remember",
                 _ => "Act",
             }
@@ -19653,6 +19667,16 @@ impl RuntimeWorld {
 
     fn default_chat_target(&self, actor_id: u64) -> Option<CwActor> {
         self.active_chat_targets(actor_id).into_iter().next()
+    }
+
+    fn default_inference_chat_target(&self, actor_id: u64) -> Option<CwActor> {
+        self.active_chat_targets(actor_id)
+            .into_iter()
+            .find(|target| {
+                self.actor_uses_inference(target.id)
+                    && !self.actors_blocked(actor_id, target.id)
+                    && !self.actor_muted(actor_id, target.id)
+            })
     }
 
     fn has_active_chat_target(&self, actor_id: u64) -> bool {
@@ -25780,7 +25804,7 @@ fn action_offer_rejected(reason: impl Into<String>) -> Json<ActionResponse> {
 
 fn action_path_accepts_kind(path: &str, kind: &str) -> bool {
     match path {
-        "/actions/chat" => kind == "create_bond",
+        "/actions/chat" => kind == "chat",
         "/actions/move" => kind == "move",
         "/actions/explore-path" => kind == "explore_path",
         "/actions/flee" => kind == "flee",
@@ -26092,30 +26116,6 @@ async fn submit_action_offer(
         }
         _ => action_offer_rejected("unsupported offer submission path"),
     }
-}
-
-async fn chat(
-    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
-    State(state): State<AppState>,
-    Json(payload): Json<ChatRequest>,
-) -> Json<ActionResponse> {
-    let target_name = {
-        let runtime = state.inner.lock().await;
-        runtime
-            .actor_name(payload.target_actor_id)
-            .unwrap_or_else(|| format!("Actor {}", payload.target_actor_id))
-    };
-    create_bond(
-        ConnectInfo(client_addr),
-        State(state),
-        Json(ReviseBondRequest {
-            actor_id: payload.actor_id,
-            actor_session: payload.actor_session,
-            target_actor_id: payload.target_actor_id,
-            statement: default_bond_statement(&target_name),
-        }),
-    )
-    .await
 }
 
 static COMMUNITY_ART_FUNDING_LOCKS: OnceLock<StdMutex<BTreeMap<String, Weak<Mutex<()>>>>> =
@@ -26708,8 +26708,27 @@ async fn complete_queued_orb_chat(
         None,
         started_at.elapsed(),
     );
-    if let Some(reply_plan) = reply_plan {
-        complete_orb_chat_exchange(state, actor_id, target_actor_id, reply_plan).await;
+    let exchange_result = match reply_plan {
+        Some(reply_plan) => {
+            complete_orb_chat_exchange(state, actor_id, target_actor_id, reply_plan).await
+        }
+        None => Err("the target could not answer the opening line".to_string()),
+    };
+    if let Err(error) = exchange_result {
+        warn!("bounded avatar chat ended early: {}", error);
+        commit_chat_status(
+            state,
+            actor_id,
+            target_actor_id,
+            "failed",
+            "the conversation ended early; try talking again",
+            queue_event_id,
+            source_world_tick,
+            observed_through_seq,
+            Some(plan.location_id),
+        )
+        .await;
+        return;
     }
     commit_chat_status(
         state,
@@ -29066,6 +29085,19 @@ async fn command_inner(
             .await;
             command_action_response_with_events(resolved, response, presence_events)
         }
+        CommandDispatch::Chat { target_actor_id } => {
+            let Json(response) = chat(
+                ConnectInfo(client_addr),
+                State(state),
+                Json(ChatRequest {
+                    actor_id: payload.actor_id,
+                    actor_session: payload.actor_session,
+                    target_actor_id,
+                }),
+            )
+            .await;
+            command_action_response_with_events(resolved, response, presence_events)
+        }
         CommandDispatch::Influence { target_actor_id } => {
             let Json(response) = influence(
                 ConnectInfo(client_addr),
@@ -29875,7 +29907,7 @@ async fn complete_orb_chat_exchange(
     actor_id: u64,
     target_actor_id: u64,
     first_reply_plan: AvatarReplyPlan,
-) {
+) -> Result<(), String> {
     let first_proposal = match avatar_reply_intent(state, &first_reply_plan).await {
         Ok(proposal) => proposal,
         Err(error) => {
@@ -29884,7 +29916,7 @@ async fn complete_orb_chat_exchange(
                 error
             );
             record_rejected_ai_publication(state, &error);
-            return;
+            return Err(error.to_string());
         }
     };
     let first_reply_events = {
@@ -29892,7 +29924,7 @@ async fn complete_orb_chat_exchange(
         commit_resident_reply_record(state, &mut runtime, &first_reply_plan, first_proposal, None)
     };
     let Some(first_reply_events) = first_reply_events else {
-        return;
+        return Err("the target reply no longer fit the current room".to_string());
     };
     broadcast_events(state, &first_reply_events);
     tokio::time::sleep(Duration::from_millis(260)).await;
@@ -29908,7 +29940,7 @@ async fn complete_orb_chat_exchange(
         plan.map(|plan| plan.with_reply_beat("avatar-chat-followup", &first_reply_plan))
     };
     let Some(followup_plan) = followup_plan else {
-        return;
+        return Err("the participants moved apart before the follow-up".to_string());
     };
     let certified_followup = match avatar_chat_followup_text(state, &followup_plan).await {
         Ok(followup) => followup,
@@ -29918,7 +29950,7 @@ async fn complete_orb_chat_exchange(
                 error
             );
             record_rejected_ai_publication(state, &error);
-            return;
+            return Err(error.to_string());
         }
     };
     let (proposed_followup, followup_receipt) =
@@ -29929,12 +29961,12 @@ async fn complete_orb_chat_exchange(
             .avatar_chat_plan_for(actor_id, target_actor_id)
             .is_none()
         {
-            return;
+            return Err("the participants moved apart before the follow-up".to_string());
         }
         let Some(followup) = runtime.collision_safe_avatar_followup(actor_id, &proposed_followup)
         else {
             warn!("AI avatar follow-up repeated recent dialogue; ending chat exchange");
-            return;
+            return Err("the avatar follow-up repeated recent dialogue".to_string());
         };
         let content_id = runtime.next_content_id_value();
         let mut record = JournalRecord::new(
@@ -29966,10 +29998,10 @@ async fn complete_orb_chat_exchange(
                 reason: format!("chat:{actor_id}:{target_actor_id}"),
             });
         let Ok((status, events)) = commit_journal_record(state, &mut runtime, record) else {
-            return;
+            return Err("the avatar follow-up could not be committed".to_string());
         };
         if status != CW_OK || events.is_empty() {
-            return;
+            return Err("the avatar follow-up was no longer valid".to_string());
         }
         let plan = runtime
             .resident_reply_plan_for_target(actor_id, target_actor_id, &followup)
@@ -29988,7 +30020,7 @@ async fn complete_orb_chat_exchange(
     tokio::time::sleep(Duration::from_millis(260)).await;
 
     let Some(closing_plan) = closing_plan else {
-        return;
+        return Err("the target could not answer the follow-up".to_string());
     };
     let closing_proposal = match avatar_reply_intent(state, &closing_plan).await {
         Ok(proposal) => proposal,
@@ -29998,16 +30030,18 @@ async fn complete_orb_chat_exchange(
                 error
             );
             record_rejected_ai_publication(state, &error);
-            return;
+            return Err(error.to_string());
         }
     };
     let closing_events = {
         let mut runtime = state.inner.lock().await;
         commit_resident_reply_record(state, &mut runtime, &closing_plan, closing_proposal, None)
     };
-    if let Some(events) = closing_events {
-        broadcast_events(state, &events);
-    }
+    let Some(events) = closing_events else {
+        return Err("the closing reply no longer fit the current room".to_string());
+    };
+    broadcast_events(state, &events);
+    Ok(())
 }
 
 fn commit_resident_reply_record(
@@ -49109,7 +49143,8 @@ mod tests {
         assert!(!INDEX_HTML.contains("scroll-behavior: smooth;"));
         assert!(INDEX_HTML.contains("pendingAction?.kind === \"orb-chat\""));
         assert!(INDEX_HTML.contains("Use one advancement point to begin a friendship with"));
-        assert!(INDEX_HTML.contains("kind: \"advancement-chat\""));
+        assert!(INDEX_HTML.contains("kind: \"orb-chat\""));
+        assert!(INDEX_HTML.contains("kind: \"advancement-bond\""));
         assert!(!INDEX_HTML.contains("label: \"grow closer\""));
         assert!(!INDEX_HTML.contains("cmd-progress"));
         assert!(INDEX_HTML.contains("if (!result.ok) void queueRefresh();"));
@@ -49268,7 +49303,7 @@ mod tests {
         assert!(INDEX_HTML.contains("function orbChangeText"));
         assert!(!INDEX_HTML.contains("flashEconomy(`+${delta}`"));
         assert!(!INDEX_HTML.contains("flashEconomy(`-${spent}`"));
-        assert!(INDEX_HTML.contains("Chat uses one advancement point and begins a friendship."));
+        assert!(INDEX_HTML.contains("Befriending uses one advancement point."));
         assert!(!INDEX_HTML.contains("one Orb for the whole exchange"));
         assert!(INDEX_HTML.contains("/actions/fund-image"));
         assert!(INDEX_HTML.contains("fund community images only"));
@@ -49329,7 +49364,9 @@ mod tests {
         assert!(!INDEX_HTML.contains("action.evolveModes?.includes(\"practice\")"));
         assert!(INDEX_HTML.contains("/actions/create-bond"));
         assert!(INDEX_HTML.contains("label: \"chat\""));
+        assert!(INDEX_HTML.contains("label: \"befriend\""));
         assert!(INDEX_HTML.contains("choose someone to chat with"));
+        assert!(INDEX_HTML.contains("choose someone to befriend"));
         assert!(INDEX_HTML.contains("Choose whose story to carry forward."));
         assert!(INDEX_HTML.contains("Use one advancement point to begin a friendship with"));
         assert!(INDEX_HTML.contains("your friendship with ${firstTargetName} begins"));
@@ -54153,7 +54190,7 @@ mod tests {
         assert_eq!(state.economy.listen_cost_orbs, 0);
         assert!(state.economy.listen_reward_claimable);
         assert!(!state.economy.openrouter_connected);
-        assert_eq!(state.economy.chat_payer, "advancement");
+        assert_eq!(state.economy.chat_payer, "cosyworld_system");
     }
 
     #[test]
@@ -56373,10 +56410,10 @@ mod tests {
             });
         assert_eq!(runtime.apply_journal_record(&bank_record).0, CW_OK);
         let banked_state = runtime.state_response(Some(5000), &AccessContext::default());
-        let default_command = "chat Rati";
+        let default_command = "bond Rati";
         assert!(banked_state.primary_action.options.iter().any(|option| {
             option.kind == "create_bond"
-                && option.label == "Chat"
+                && option.label == "Befriend"
                 && option.command == default_command
         }));
         let bond_offer = banked_state
@@ -61186,158 +61223,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_chat_endpoint_uses_advancement_to_begin_a_friendship() {
-        let state = test_app_state(RuntimeWorld::seeded(), None);
-        {
-            let mut runtime = state.inner.lock().await;
-            create_test_human(
-                &mut runtime,
-                5000,
-                COSY_COTTAGE_LOCATION_ID,
-                "Inference Tester",
-            );
-            grant_test_advancement(&mut runtime, 5000, "test:chat-growth");
-        }
-        let (actor_session, _) = issue_actor_session(&state, 5000);
-
-        let response = chat(
-            ConnectInfo("127.0.0.1:44001".parse().expect("client address")),
-            State(state.clone()),
-            Json(ChatRequest {
-                actor_id: 5000,
-                actor_session: Some(actor_session),
-                target_actor_id: RATI_ACTOR_ID,
-            }),
-        )
-        .await
-        .0;
-
-        assert!(response.ok);
-        assert_eq!(response.status, CW_OK);
-        assert!(response.events.iter().any(|event| {
-            event.type_name == "bond.created"
-                && event.actor_id == Some(5000)
-                && event.target_actor_id == Some(RATI_ACTOR_ID)
-        }));
-        assert!(response
-            .events
-            .iter()
-            .any(|event| event.type_name == "advancement.spent"));
-        assert!(!response
-            .events
-            .iter()
-            .any(|event| event.type_name == "chat.queued"));
-        let runtime = state.inner.lock().await;
-        assert_eq!(runtime.orb_balance(5000), STARTING_ORBS);
-        assert_eq!(runtime.advancement_points_available(5000), 0);
-        assert!(runtime.active_bond(5000, RATI_ACTOR_ID).is_some());
-        assert!(!runtime
-            .event_log
-            .iter()
-            .any(|event| { event.type_name == "message.created" && event.actor_id == Some(5000) }));
-    }
-
-    #[tokio::test]
-    async fn co_present_advancement_chat_is_not_owned_by_a_room_turn() {
-        let mut runtime = RuntimeWorld::seeded();
-        create_test_human(
-            &mut runtime,
-            5000,
-            COSY_COTTAGE_LOCATION_ID,
-            "Current Player",
-        );
-        create_test_human(
-            &mut runtime,
-            5001,
-            COSY_COTTAGE_LOCATION_ID,
-            "Waiting Chatter",
-        );
-        grant_test_advancement(&mut runtime, 5000, "test:chat-turn:5000");
-        grant_test_advancement(&mut runtime, 5001, "test:chat-turn:5001");
-        let state = test_app_state(runtime, None);
-        let (session_5000, _) = issue_actor_session(&state, 5000);
-        let (session_5001, _) = issue_actor_session(&state, 5001);
-        assert_eq!(
-            ping_actor_session_for_actor(&state.actor_sessions, 5000, &session_5000),
-            Some(false)
-        );
-        assert_eq!(
-            ping_actor_session_for_actor(&state.actor_sessions, 5001, &session_5001),
-            Some(false)
-        );
-
-        let before_tick = {
-            let runtime = state.inner.lock().await;
-            let active_direct_actors = active_actor_ids_for_state(&state);
-            let turn = room_turn_view_for_runtime(
-                &state,
-                &runtime,
-                COSY_COTTAGE_LOCATION_ID,
-                Some(5000),
-                &active_direct_actors,
-            );
-            assert!(!turn.enabled);
-            assert_eq!(turn.policy, "concurrent");
-            runtime.world.tick
-        };
-
-        let first = chat(
-            ConnectInfo("127.0.0.1:44002".parse().expect("client address")),
-            State(state.clone()),
-            Json(ChatRequest {
-                actor_id: 5001,
-                actor_session: Some(session_5001),
-                target_actor_id: RATI_ACTOR_ID,
-            }),
-        )
-        .await
-        .0;
-        assert!(
-            first.ok,
-            "a co-present avatar can chat without owning a room turn"
-        );
-        assert!(first
-            .events
-            .iter()
-            .any(|event| event.type_name == "bond.created"));
-
-        let second = chat(
-            ConnectInfo("127.0.0.1:44003".parse().expect("client address")),
-            State(state.clone()),
-            Json(ChatRequest {
-                actor_id: 5000,
-                actor_session: Some(session_5000),
-                target_actor_id: RATI_ACTOR_ID,
-            }),
-        )
-        .await
-        .0;
-        assert!(
-            second.ok,
-            "a second co-present avatar can commit the compatible chat independently"
-        );
-        assert!(second
-            .events
-            .iter()
-            .any(|event| event.type_name == "bond.created"));
-
-        let runtime = state.inner.lock().await;
-        let active_direct_actors = active_actor_ids_for_state(&state);
-        let turn = room_turn_view_for_runtime(
-            &state,
-            &runtime,
-            COSY_COTTAGE_LOCATION_ID,
-            Some(5000),
-            &active_direct_actors,
-        );
-        assert_eq!(runtime.world.tick, before_tick + 2);
-        assert!(!turn.enabled);
-        assert_eq!(turn.policy, "concurrent");
-        assert_eq!(turn.current_actor_id, None);
-        assert!(!turn.is_current_actor);
-    }
-
-    #[tokio::test]
     async fn ordered_combat_pass_and_need_time_share_one_replayable_kernel_path() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
@@ -63105,11 +62990,15 @@ mod tests {
             .as_deref()
             .is_some_and(|risk| risk.contains("rushing in may tire you")));
         assert!(
+            state.action_offers.iter().any(|offer| offer.kind == "chat"),
+            "free Chat remains an ordinary room offer without advancement"
+        );
+        assert!(
             !state
                 .action_offers
                 .iter()
-                .any(|offer| matches!(offer.kind.as_str(), "chat" | "create_bond")),
-            "Chat is not an ordinary room offer without available advancement"
+                .any(|offer| offer.kind == "create_bond"),
+            "only advancement-backed Befriend is gated at zero advancement"
         );
         let move_offer = state
             .action_offers
@@ -66335,11 +66224,10 @@ mod tests {
             .resolve_command(&command_request(5000, "talk rati"), &access)
             .expect("chat resolves");
         match chat.dispatch {
-            CommandDispatch::Disabled { status, output } => {
-                assert_eq!(status, 409);
-                assert!(output.contains("already share a friendship"));
+            CommandDispatch::Chat { target_actor_id } => {
+                assert_eq!(target_actor_id, RATI_ACTOR_ID);
             }
-            other => panic!("Chat should not create a duplicate friendship, got {other:?}"),
+            other => panic!("Chat should remain available within a friendship, got {other:?}"),
         }
 
         let report = runtime
@@ -66553,11 +66441,16 @@ mod tests {
         assert_eq!(state.primary_action.kind, "pick_up");
         assert_eq!(state.primary_action.label, "Take");
         assert_eq!(state.primary_action.command, "take Hearth Tonic");
+        assert!(state
+            .primary_action
+            .options
+            .iter()
+            .any(|option| option.kind == "chat"));
         assert!(!state
             .primary_action
             .options
             .iter()
-            .any(|option| matches!(option.kind.as_str(), "chat" | "create_bond")));
+            .any(|option| option.kind == "create_bond"));
         assert!(state
             .primary_action
             .options
@@ -71179,11 +71072,16 @@ mod tests {
         assert!(state.branch.is_none());
         assert_eq!(state.primary_action.kind, "pick_up");
         assert_eq!(state.primary_action.label, "Take");
+        assert!(state
+            .primary_action
+            .options
+            .iter()
+            .any(|option| option.kind == "chat"));
         assert!(!state
             .primary_action
             .options
             .iter()
-            .any(|option| matches!(option.kind.as_str(), "chat" | "create_bond")));
+            .any(|option| option.kind == "create_bond"));
     }
 
     #[test]
@@ -71258,11 +71156,16 @@ mod tests {
         assert!(state.branch.is_none());
         assert_eq!(state.primary_action.kind, "pick_up");
         assert_eq!(state.primary_action.label, "Take");
+        assert!(state
+            .primary_action
+            .options
+            .iter()
+            .any(|option| option.kind == "chat"));
         assert!(!state
             .primary_action
             .options
             .iter()
-            .any(|option| matches!(option.kind.as_str(), "chat" | "create_bond")));
+            .any(|option| option.kind == "create_bond"));
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -81,6 +81,9 @@ pub(crate) enum CommandDispatch {
     },
     Check,
     Study,
+    Chat {
+        target_actor_id: u64,
+    },
     Influence {
         target_actor_id: u64,
     },
@@ -603,6 +606,7 @@ pub(crate) fn command_action_failure_output(resolved: &ResolvedCommand, status: 
             "Those container contents changed while you were choosing. Check your deck."
         }
         CommandDispatch::ReviseCalling { .. } => "That purpose cannot change just now.",
+        CommandDispatch::Chat { .. } => "That conversation is no longer within reach.",
         CommandDispatch::CreateBond { .. } => "There is not a friendship ready to grow just now.",
         CommandDispatch::ReviseBond { .. } => "That friendship cannot change right now.",
         CommandDispatch::TrainSkill { .. } => {
@@ -2368,39 +2372,28 @@ impl RuntimeWorld {
                     .map_err(|output| command_error(&command, "chat", 404, output))?;
                 let target_name = self.actor_view(target).name;
                 let chat_command = format!("chat {target_name}");
-                if self.active_bond(actor.id, target.id).is_some() {
+                if !self.actor_uses_inference(target.id)
+                    || self.actors_blocked(actor.id, target.id)
+                    || self.actor_muted(actor.id, target.id)
+                {
                     return Ok(ResolvedCommand {
                         command: chat_command.clone(),
                         verb,
-                        action: Some(command_action("create_bond", "Chat", &chat_command)),
+                        action: Some(command_action("chat", "Chat", &chat_command)),
                         dispatch: CommandDispatch::Disabled {
                             status: 409,
                             output: format!(
-                                "You already share a friendship with {target_name}; play another card and let the room answer."
+                                "A shared conversation with {target_name} is not available."
                             ),
-                        },
-                    });
-                }
-                if self.advancement_points_available(actor.id) < usize::from(BOND_SLOT_COST) {
-                    return Ok(ResolvedCommand {
-                        command: chat_command.clone(),
-                        verb,
-                        action: Some(command_action("create_bond", "Chat", &chat_command)),
-                        dispatch: CommandDispatch::Disabled {
-                            status: 409,
-                            output: advancement_gate_output(&format!(
-                                "Chat with {target_name}"
-                            )),
                         },
                     });
                 }
                 Ok(ResolvedCommand {
                     command: chat_command.clone(),
                     verb,
-                    action: Some(command_action("create_bond", "Chat", &chat_command)),
-                    dispatch: CommandDispatch::CreateBond {
+                    action: Some(command_action("chat", "Chat", &chat_command)),
+                    dispatch: CommandDispatch::Chat {
                         target_actor_id: target.id,
-                        statement: default_bond_statement(&target_name),
                     },
                 })
             }
@@ -3865,8 +3858,20 @@ mod tests {
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "New Friend");
         assert_eq!(runtime.advancement_points_available(5000), 0);
 
+        let chat = runtime
+            .resolve_command(&command_request("chat Rati"), &AccessContext::default())
+            .expect("free Chat should resolve without advancement");
+        assert!(
+            matches!(
+                chat.dispatch,
+                CommandDispatch::Chat {
+                    target_actor_id: RATI_ACTOR_ID
+                }
+            ),
+            "Chat is conversation, not an advancement-spending friendship action"
+        );
+
         for command in [
-            "chat Rati",
             "purpose I listen for odd jobs.",
             "friendship Rati: I bring small kindnesses to Rati.",
         ] {

--- a/v2/orchestrator-rust/src/offer_commands.rs
+++ b/v2/orchestrator-rust/src/offer_commands.rs
@@ -258,7 +258,10 @@ fn dispatch_for_offer(
         "work" => Ok(CommandDispatch::Work),
         "help" => Ok(CommandDispatch::Help),
         "rest" => Ok(CommandDispatch::Rest),
-        "chat" | "create_bond" => {
+        "chat" => Ok(CommandDispatch::Chat {
+            target_actor_id: required_target_id(offer, "actor")?,
+        }),
+        "create_bond" => {
             let target_actor_id = required_target_id(offer, "actor")?;
             let target_name = runtime
                 .actor_name(target_actor_id)

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -496,6 +496,7 @@ pub(super) fn command_concurrency_policy(dispatch: &CommandDispatch) -> Concurre
         | CommandDispatch::Craft { .. }
         | CommandDispatch::Work
         | CommandDispatch::Help
+        | CommandDispatch::Chat { .. }
         | CommandDispatch::CreateBond { .. }
         | CommandDispatch::ReviseBond { .. }
         | CommandDispatch::ResolveBond { .. }

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -1976,7 +1976,7 @@ impl RuntimeWorld {
                 listen_reward_claimable,
                 listen_attempted_here,
                 openrouter_connected: false,
-                chat_payer: "advancement".to_string(),
+                chat_payer: "cosyworld_system".to_string(),
                 wooden_boxes: access.owned_box_ids.len(),
                 unopened_packs: access.unopened_pack_ids.len(),
             },

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -49,4 +49,6 @@
 # integration, not further feature growth in main.rs.
 # 74609 -> 74531: move ReplicateAvatarArtConfig and its environment loader
 # into the existing media-recipes seam.
-74531
+# 74516 -> 74434: extract the free bounded Chat endpoint and its concurrent-room
+# coverage into chat_action.rs.
+74434

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -1129,12 +1129,12 @@ async function main() {
   async function assertFreeActionsIgnoreOrbBalance() {
     const claimableActions = await zeroOrbActionLabels(true);
     const claimableLabels = claimableActions.map((action) => action.label);
-    assert(claimableLabels[0] === "notice", `the first Notice should remain available with no Orbs: ${JSON.stringify(claimableActions)}`);
+    assert(claimableLabels.includes("notice"), `the first Notice should remain available with no Orbs: ${JSON.stringify(claimableActions)}`);
     assert(!claimableLabels.includes("connect ai"), `free actions should not offer Connect AI as a command: ${JSON.stringify(claimableActions)}`);
     const exhaustedActions = await zeroOrbActionLabels(false);
     const exhaustedLabels = exhaustedActions.map((action) => action.label);
     assert(!exhaustedLabels.includes("notice"), `a claimed first clue should become repeat Notice: ${JSON.stringify(exhaustedActions)}`);
-    assert(exhaustedActions[0]?.label === "notice again" && exhaustedActions[0]?.detail === "free", `repeat Notice should ignore a stale legacy cost and remain free at zero Orbs: ${JSON.stringify(exhaustedActions)}`);
+    assert(exhaustedActions.some((action) => action.label === "notice again" && action.detail === "free"), `repeat Notice should ignore a stale legacy cost and remain free at zero Orbs: ${JSON.stringify(exhaustedActions)}`);
     const travelActions = await page.evaluate(() => {
       const previousState = state;
       const previousActorId = actorId;
@@ -1423,7 +1423,7 @@ async function main() {
     });
     assert(result.fresh[0]?.label === "notice", `fresh room clue should still lead the first action: ${JSON.stringify(result)}`);
     assert(result.repeat[0]?.label !== "notice again", `repeat Notice should not stay the default action: ${JSON.stringify(result)}`);
-    assert(!result.repeat.some((action) => action.label === "chat"), `Chat should stay absent when no advancement-backed friendship is offered: ${JSON.stringify(result)}`);
+    assert(result.repeat.some((action) => action.label === "chat"), `free Chat should remain available beside repeat Notice when the server exposes an eligible resident: ${JSON.stringify(result)}`);
     const repeatIndex = result.repeat.findIndex((action) => action.label === "notice again");
     assert(repeatIndex > 0 && result.repeat[repeatIndex]?.detail === "free", `free repeat Notice should remain available without hijacking the primary action: ${JSON.stringify(result)}`);
     const stalePaidRepeat = result.stalePaidRepeat.find((action) => action.label === "notice again");
@@ -1488,7 +1488,7 @@ async function main() {
     const chatIndex = result.findIndex((action) => action.label === "chat");
     const notice = result.find((action) => action.intention === "notice");
     assert(result[0]?.label === "notice", `fresh Notice can still lead calm-room discovery: ${JSON.stringify(result)}`);
-    assert(chatIndex === -1, `calm-room fixtures without advancement should not invent Chat: ${JSON.stringify(result)}`);
+    assert(chatIndex >= 0, `calm-room fixtures with an eligible resident should retain free Chat: ${JSON.stringify(result)}`);
     assert(searchIndex === -1 || searchIndex > travelIndex, `calm-room feature search should stay behind travel unless focused: ${JSON.stringify(result)}`);
     assert(locationSearch?.title === "inspect the cosy cottage", `room Inspect should name where the player is looking: ${JSON.stringify(result)}`);
     assert(locationSearch?.summary === "Inspect The Cosy Cottage for one hidden thing.", `room Inspect should promise one meaningful discovery in story language: ${JSON.stringify(result)}`);
@@ -1612,7 +1612,7 @@ async function main() {
     const listenAgainIndex = result.findIndex((action) => action.label === "notice again");
     const travelIndex = result.findIndex((action) => action.label === "travel");
     const chatIndex = result.findIndex((action) => action.label === "chat");
-    assert(chatIndex === -1, `optional feature fixtures without advancement should not invent Chat: ${JSON.stringify(result)}`);
+    assert(chatIndex >= 0, `optional feature fixtures with an eligible resident should retain free Chat: ${JSON.stringify(result)}`);
     assert(listenAgainIndex > travelIndex && result[listenAgainIndex]?.detail === "free", `repeat Notice should remain available without outranking concrete travel: ${JSON.stringify(result)}`);
     assert(useIndex === -1 || useIndex > travelIndex, `optional feature use should stay behind travel unless focused: ${JSON.stringify(result)}`);
     if (useIndex >= 0) {
@@ -1927,15 +1927,23 @@ async function main() {
       const baseState = {
         location: { id: 1, name: "The Cosy Cottage" },
         primary_action: {
-          kind: "create_bond",
-          options: [{ kind: "create_bond" }],
+          kind: "chat",
+          options: [{ kind: "chat" }, { kind: "create_bond" }],
         },
-        action_offers: [{
-          kind: "create_bond",
-          command: "chat Skull",
-          target: { kind: "actor", id: 1003, label: "Skull" },
-          effect: "a friendship with Skull begins",
-        }],
+        action_offers: [
+          {
+            kind: "chat",
+            command: "chat Skull",
+            target: { kind: "actor", id: 1003, label: "Skull" },
+            effect: "opens a small exchange with Skull",
+          },
+          {
+            kind: "create_bond",
+            command: "bond Skull: I bring small kindnesses to Skull.",
+            target: { kind: "actor", id: 1003, label: "Skull" },
+            effect: "a friendship with Skull begins",
+          },
+        ],
         economy: { orbs: 0, chat_cost_orbs: 0, can_chat_with_orbs: false, openrouter_connected: false },
         ledger: { advancement_points: 1 },
         bonds: [],
@@ -2000,13 +2008,24 @@ async function main() {
         const chatActions = chatActionsFor(patch);
         return (command ? chatActions.find((entry) => entry.command === command) : chatActions[0]) || null;
       };
+      const bondActionFor = (patch) => {
+        const fakeState = { ...baseState, ...patch };
+        state = fakeState;
+        actorId = 5000;
+        const entry = buildActions(fakeState).find((action) => action.label === "befriend");
+        return entry ? {
+          summary: actionSummary(entry),
+          rows: actionModalRows(entry),
+          payload: entry.selectedPayload?.() || null,
+        } : null;
+      };
       const orderedActionsFor = (patch) => {
         const fakeState = {
           ...baseState,
           ...patch,
           primary_action: {
-            kind: "create_bond",
-            options: [{ kind: "create_bond" }, { kind: "move" }],
+            kind: "chat",
+            options: [{ kind: "chat" }, { kind: "create_bond" }, { kind: "move" }],
           },
           exits: [{
             destination_location_id: 2,
@@ -2028,9 +2047,9 @@ async function main() {
         const fakeState = {
           ...baseState,
           action_offers: [{
-            ...baseState.action_offers[0],
+            ...baseState.action_offers[1],
             target: { kind: "actor", id: 1001, label: "Rati" },
-            command: "chat Rati",
+            command: "bond Rati: I bring small kindnesses to Rati.",
           }],
           actors: [
             baseState.actors[0],
@@ -2053,7 +2072,7 @@ async function main() {
         };
         state = fakeState;
         actorId = 5000;
-        const action = buildActions(fakeState).find((entry) => entry.label === "chat");
+        const action = buildActions(fakeState).find((entry) => entry.label === "befriend");
         openActionModal(action);
         const before = [...document.querySelectorAll("#action-modal-meta .action-row")]
           .map((node) => node.textContent.trim().replace(/\s+/g, " "));
@@ -2103,11 +2122,11 @@ async function main() {
               },
             },
           }),
-          mara: chatActionFor({
+          mara: bondActionFor({
             action_offers: [{
-              ...baseState.action_offers[0],
+              ...baseState.action_offers[1],
               target: { kind: "actor", id: 8301, label: "Mara Wick" },
-              command: "chat Mara Wick",
+              command: "bond Mara Wick: I keep watch with Mara Wick.",
             }],
             actors: [
               baseState.actors[0],
@@ -2134,33 +2153,33 @@ async function main() {
         actorId = previousActorId;
       }
     });
-    assert(result.serverPaid?.detail === "with Skull · use what you learned", `Chat should show the resident and advancement source: ${JSON.stringify(result)}`);
-    assert(result.staleConnectedHint?.detail === "with Skull · use what you learned", `stale OpenRouter hints must not affect advancement-backed Chat: ${JSON.stringify(result)}`);
-    assert(result.claimed === null, `Chat should disappear once that friendship already exists: ${JSON.stringify(result)}`);
+    assert(result.serverPaid?.detail === "with Skull · a short exchange", `Chat should show the resident and bounded exchange: ${JSON.stringify(result)}`);
+    assert(result.staleConnectedHint?.detail === "with Skull · a short exchange", `stale OpenRouter hints must not affect Chat: ${JSON.stringify(result)}`);
+    assert(result.claimed?.detail === "with Skull · a short exchange", `Chat should remain available after friendship begins: ${JSON.stringify(result)}`);
     assert(result.freshOrder?.some((action) => action.label === "chat"), `eligible Chat should stay available beside travel: ${JSON.stringify(result)}`);
-    assert(result.claimedOrder?.[0]?.label === "travel" && !result.claimedOrder.some((action) => action.label === "chat"), `an existing friendship should remove Chat: ${JSON.stringify(result)}`);
+    assert(result.claimedOrder?.some((action) => action.label === "chat"), `an existing friendship should not remove Chat: ${JSON.stringify(result)}`);
     assert(result.multiResident?.length === 1, `nearby residents should share one choice-bearing Chat card: ${JSON.stringify(result)}`);
-    assert(result.multiResident[0]?.detail === "choose someone · use what you learned", `multi-resident Chat should advertise its in-card choice and advancement source: ${JSON.stringify(result)}`);
+    assert(result.multiResident[0]?.detail === "choose someone nearby", `multi-resident Chat should advertise its in-card target choice: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.title === "choose someone to chat with", `multi-resident Chat should open a clear target picker: ${JSON.stringify(result)}`);
-    assert(result.multiResident[0]?.summary === "Choose someone nearby. Chat uses one advancement point and begins a friendship.", `multi-resident Chat should explain its advancement and friendship result: ${JSON.stringify(result)}`);
+    assert(result.multiResident[0]?.summary === "Choose someone nearby for a short back-and-forth conversation.", `multi-resident Chat should explain its bounded conversation: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.choices?.map((choice) => choice.label).join(",") === "Rati,Skull", `the Chat card should carry every eligible resident choice: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.alternateTargetId === 1003, `confirming an alternate Chat choice should address that resident: ${JSON.stringify(result)}`);
     assert(result.multiResident[0]?.focusKeys?.includes("actor:1001") && result.multiResident[0]?.focusKeys?.includes("actor:1003"), `one Chat card should retain affinity for every resident it can reach: ${JSON.stringify(result)}`);
     assert(result.serverPaid?.title === "chat with Skull", `Chat confirmation should name the resident: ${JSON.stringify(result)}`);
-    assert(result.serverPaid?.summary === "Use one advancement point to begin a friendship with Skull.", `Chat confirmation should explain its advancement cost: ${JSON.stringify(result)}`);
+    assert(result.serverPaid?.summary === "Your avatar and Skull will trade a few short lines.", `Chat confirmation should explain its bounded exchange: ${JSON.stringify(result)}`);
     assert(!result.serverPaid?.rows?.some((row) => row[0] === "Costs"), `chat confirmation should never display an Orb cost: ${JSON.stringify(result)}`);
-    assert(result.serverPaid?.rows?.some((row) => row[0] === "Spend" && row[1] === "one advancement point"), `Chat confirmation should name the advancement spend: ${JSON.stringify(result)}`);
-    assert(result.serverPaid?.rows?.some((row) => row[0] === "Then" && row[1].includes("room heartbeat")), `Chat confirmation should explain the delayed room reply: ${JSON.stringify(result)}`);
+    assert(!result.serverPaid?.rows?.some((row) => row[0] === "Spend"), `Chat confirmation should not spend advancement: ${JSON.stringify(result)}`);
+    assert(result.serverPaid?.rows?.some((row) => row[0] === "Then" && row[1].includes("two short lines each")), `Chat confirmation should explain the bounded exchange: ${JSON.stringify(result)}`);
     assert(!/reply hook|authors a line|-[0-9]+ Orb/i.test(JSON.stringify(result.serverPaid)), `chat confirmation should hide implementation and subtraction jargon: ${JSON.stringify(result)}`);
     assert(!String(result.serverPaid?.detail || "").includes("lv"), `chat cards should let the evolved art and title carry character growth: ${JSON.stringify(result)}`);
     assert(!String(result.serverPaid?.detail || "").includes("/"), `chat detail should not include card title chrome: ${JSON.stringify(result)}`);
     assert(!String(result.staleConnectedHint?.detail || "").includes("/"), `stale OpenRouter chat detail should not include card title chrome: ${JSON.stringify(result)}`);
-    assert(result.mara?.summary.includes("forming relationship") && result.mara?.summary.includes("Mara is watching"), `Mara Chat should preview the forming relationship statement: ${JSON.stringify(result)}`);
-    assert(result.mara?.rows?.some((row) => row[0] === "Status" && row[1].includes("does not claim friendship")), `Mara Chat must not present an established friendship: ${JSON.stringify(result)}`);
-    assert(result.mara?.rows?.some((row) => row[0] === "Campaign beat" && row[1].includes("empty key hook")), `Mara Chat should preview its deterministic campaign beat: ${JSON.stringify(result)}`);
-    assert(result.mara?.rows?.some((row) => row[0] === "Dialogue" && row[1].includes("explicit unavailable result")), `Mara Chat should distinguish optional dialogue from the relationship mutation: ${JSON.stringify(result)}`);
-    assert(result.mara?.payload?.statement === "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key.", `Mara Chat must submit the confirmed authored statement: ${JSON.stringify(result)}`);
-    assert(result.renderedMara?.before?.length === 0, `an ordinary Chat target should keep the existing compact modal: ${JSON.stringify(result.renderedMara)}`);
+    assert(result.mara?.summary.includes("forming relationship") && result.mara?.summary.includes("Mara is watching"), `Mara Befriend should preview the forming relationship statement: ${JSON.stringify(result)}`);
+    assert(result.mara?.rows?.some((row) => row[0] === "Status" && row[1].includes("does not claim friendship")), `Mara Befriend must not present an established friendship: ${JSON.stringify(result)}`);
+    assert(result.mara?.rows?.some((row) => row[0] === "Campaign beat" && row[1].includes("empty key hook")), `Mara Befriend should preview its deterministic campaign beat: ${JSON.stringify(result)}`);
+    assert(result.mara?.rows?.some((row) => row[0] === "Dialogue" && row[1].includes("explicit unavailable result")), `Mara Befriend should distinguish optional dialogue from the relationship mutation: ${JSON.stringify(result)}`);
+    assert(result.mara?.payload?.statement === "Mara is watching whether I follow the failed lamps and return Rowan's Keeper Brass Key.", `Mara Befriend must submit the confirmed authored statement: ${JSON.stringify(result)}`);
+    assert(result.renderedMara?.before?.some((row) => row.includes("one advancement point")), `an ordinary Befriend target should show the relationship spend: ${JSON.stringify(result.renderedMara)}`);
     assert(
       result.renderedMara?.selected?.map((row) => row.label).join(",")
         === "Relationship,Status,Campaign beat,Spend,Dialogue",
@@ -3565,21 +3584,21 @@ async function main() {
     const actions = result.single;
     const bondIndex = actions.findIndex((action) => action.focusKey === "bond:1001");
     const travelIndex = actions.findIndex((action) => action.label === "travel");
-    assert(bondIndex >= 0, `Chat should surface when a resident can become a friend: ${JSON.stringify(result)}`);
-    assert(bondIndex < travelIndex, `Chat should appear before leaving with spendable advancement: ${JSON.stringify(result)}`);
-    assert(actions[bondIndex]?.label === "chat", `relationship action should use the unified Chat verb: ${JSON.stringify(result)}`);
-    assert(actions[bondIndex]?.detail === "with Rati · use what you learned", `Chat should preview its person and cost simply: ${JSON.stringify(result)}`);
-    assert(actions[bondIndex]?.title === "chat with Rati", `Chat confirmation should name the resident: ${JSON.stringify(result)}`);
-    assert(actions[bondIndex]?.summary === "Use one advancement point to begin a friendship with Rati.", `Chat confirmation should explain its advancement cost: ${JSON.stringify(result)}`);
-    assert(actions[bondIndex]?.rows?.some((row) => row[1] === "a friendship begins and their response arrives on the room heartbeat"), `Chat confirmation should describe its friendship and heartbeat outcome: ${JSON.stringify(result)}`);
-    assert(actions[bondIndex]?.confirm === "chat", `relationship confirmation should keep the Chat verb: ${JSON.stringify(result)}`);
+    assert(bondIndex >= 0, `Befriend should surface when a resident can become a friend: ${JSON.stringify(result)}`);
+    assert(bondIndex < travelIndex, `Befriend should appear before leaving with spendable advancement: ${JSON.stringify(result)}`);
+    assert(actions[bondIndex]?.label === "befriend", `relationship action should use the distinct Befriend verb: ${JSON.stringify(result)}`);
+    assert(actions[bondIndex]?.detail === "with Rati · use what you learned", `Befriend should preview its person and cost simply: ${JSON.stringify(result)}`);
+    assert(actions[bondIndex]?.title === "befriend Rati", `Befriend confirmation should name the resident: ${JSON.stringify(result)}`);
+    assert(actions[bondIndex]?.summary === "Use one advancement point to begin a friendship with Rati.", `Befriend confirmation should explain its advancement cost: ${JSON.stringify(result)}`);
+    assert(actions[bondIndex]?.rows?.some((row) => row[1] === "a friendship begins and their response arrives on the room heartbeat"), `Befriend confirmation should describe its friendship and heartbeat outcome: ${JSON.stringify(result)}`);
+    assert(actions[bondIndex]?.confirm === "befriend", `relationship confirmation should keep the Befriend verb: ${JSON.stringify(result)}`);
     assert(actions[bondIndex]?.command === "bond Rati: I bring small kindnesses to Rati.", `relationship action should keep the underlying command intact: ${JSON.stringify(result)}`);
-    const multipleBonds = result.multiple.filter((action) => action.label === "chat");
-    assert(multipleBonds.length === 1 && multipleBonds[0]?.detail === "choose someone · use what you learned", `several possible friends should share one Chat card: ${JSON.stringify(result)}`);
-    assert(multipleBonds[0]?.title === "choose someone to chat with" && multipleBonds[0]?.summary === "Choose someone nearby. Chat uses one advancement point and begins a friendship.", `Chat should make the promised friendship choice explicit: ${JSON.stringify(result)}`);
-    assert(multipleBonds[0]?.choices.join(",") === "Rati,Gust" && multipleBonds[0]?.alternatePayload?.target_actor_id === 1002, `Chat should submit the resident selected inside the card: ${JSON.stringify(result)}`);
+    const multipleBonds = result.multiple.filter((action) => action.label === "befriend");
+    assert(multipleBonds.length === 1 && multipleBonds[0]?.detail === "choose someone · use what you learned", `several possible friends should share one Befriend card: ${JSON.stringify(result)}`);
+    assert(multipleBonds[0]?.title === "choose someone to befriend" && multipleBonds[0]?.summary === "Choose someone nearby. Befriending uses one advancement point.", `Befriend should make the promised friendship choice explicit: ${JSON.stringify(result)}`);
+    assert(multipleBonds[0]?.choices.join(",") === "Rati,Gust" && multipleBonds[0]?.alternatePayload?.target_actor_id === 1002, `Befriend should submit the resident selected inside the card: ${JSON.stringify(result)}`);
     assert(multipleBonds[0]?.alternatePayload?.statement === "I bring small kindnesses to Gust.", `each friendship choice should carry its own warm statement: ${JSON.stringify(result)}`);
-    assert(multipleBonds[0]?.focusKeys.includes("actor:1001") && multipleBonds[0]?.focusKeys.includes("actor:1002"), `one Chat card should retain affinity for every eligible friend: ${JSON.stringify(result)}`);
+    assert(multipleBonds[0]?.focusKeys.includes("actor:1001") && multipleBonds[0]?.focusKeys.includes("actor:1002"), `one Befriend card should retain affinity for every eligible friend: ${JSON.stringify(result)}`);
     const visibleRelationshipCopy = {
       label: actions[bondIndex]?.label,
       detail: actions[bondIndex]?.detail,
@@ -4652,6 +4671,7 @@ async function main() {
           content: "that offer expired; refresh the scene",
         }),
       },
+      asyncChatFailure: sceneCardEventText({ type: "chat.failed" }),
     }));
     assert(result.action.chatCost === "That choice did not land. Here are the choices you have now.", `a stale Chat payment error should not imply that Chat costs Orbs: ${JSON.stringify(result)}`);
     assert(result.action.orbCost === "That choice did not land. Here are the choices you have now.", `non-image payment errors should not advertise another Orb sink: ${JSON.stringify(result)}`);
@@ -4660,6 +4680,10 @@ async function main() {
     assert(result.command.changed === "That choice changed while you were deciding. Nothing else happened; look again.", `stale typed commands should explain the atomic outcome naturally: ${JSON.stringify(result)}`);
     assert(result.action.hurry === "The room needs a breath. Try again in a moment.", `rate limits should sound like the room, not infrastructure: ${JSON.stringify(result)}`);
     assert(result.command.serverGuidance === "There is no need to fight here now.", `typed commands should preserve contextual server guidance: ${JSON.stringify(result)}`);
+    assert(
+      result.asyncChatFailure === "The conversation slipped away before it could begin. Try talking again.",
+      `asynchronous Chat failure should be visible without implying a refund for a free action: ${JSON.stringify(result)}`,
+    );
     assert(
       result.rejectedOffer.lowSignal && !result.rejectedOffer.journaled,
       `offer rejection telemetry should stay out of the player Journal: ${JSON.stringify(result.rejectedOffer)}`,
@@ -7341,21 +7365,22 @@ async function main() {
   }
 
   async function clickPrimaryAndAssertPending(label) {
-    await page.locator("#primary").click();
+    if (useFocusedActionOnNextClick) {
+      await page.evaluate(() => openActionModal(focusedAction()));
+      useFocusedActionOnNextClick = false;
+    } else {
+      await page.locator("#primary").click();
+    }
     await confirmActionModalIfOpen();
     await page.waitForFunction(() => {
-      const primary = document.querySelector("#primary");
-      return primary
-        && !primary.disabled
-        && primary.getAttribute("aria-busy") !== "true"
-        && Boolean(document.querySelector("#log .line.chat.pending[role='status']"));
+      return Boolean(document.querySelector("#log .line.chat.pending[role='status']"));
     });
     const pendingCopy = await page.locator("#log .line.chat.pending").getAttribute("aria-label");
     assert(
-      /is finding the thread\. Your next actions are ready while the conversation unfolds\./.test(pendingCopy || ""),
-      `queued Chat should announce that play can continue: ${pendingCopy}`,
+      /is finding the thread\.(?: Your conversation is unfolding| Your next actions are ready while the conversation unfolds)\./.test(pendingCopy || ""),
+      `queued Chat should announce that the conversation is unfolding: ${pendingCopy}`,
     );
-    steps.push({ label, pending: "queued", cards: "ready" });
+    steps.push({ label, pending: "queued" });
   }
 
   async function beginAvatarAndAssertArrival() {
@@ -8051,13 +8076,6 @@ async function main() {
               || (action.choices || []).some((choice) => String(choice.label || "").toLowerCase().includes(residentName.toLowerCase()))
             )
         )),
-        chat: actions.some((action) => (
-          String(action.label || "").toLowerCase() === "chat"
-            && (
-              String(action.detail || "").toLowerCase().includes(residentName.toLowerCase())
-              || (action.choices || []).some((choice) => String(choice.label || "").toLowerCase().includes(residentName.toLowerCase()))
-            )
-        )),
         use: actions.some((action) => (
           String(action.label || "").toLowerCase() === "use"
             && [
@@ -8071,9 +8089,7 @@ async function main() {
       lastAvailability = availability;
       if (!availability.nearby) continue;
       if (!availability.give) {
-        if (availability.chat) {
-          await clickActionMatching(`learn what ${name} wants`, ["chat", name.toLowerCase()]);
-        } else if (availability.use) {
+        if (availability.use) {
           await clickActionMatching(`use ${itemName} for ${name}`, ["use", itemName.toLowerCase()]);
           return lastJourney;
         } else {
@@ -9751,7 +9767,7 @@ async function main() {
         roomLineCount: document.querySelectorAll("#log .line.event.room").length,
         sceneLineCount: document.querySelectorAll("#log .line.event.scene-card").length,
         chatFailureSceneCount: [...document.querySelectorAll("#log .line.event.scene-card")]
-          .filter((node) => /conversation slipped away.*Orb came back/i.test(node.textContent || "")).length,
+          .filter((node) => /conversation slipped away.*try talking again/i.test(node.textContent || "")).length,
         rollLineCount: document.querySelectorAll("#log .roll-line").length,
         roomFallbackStacked: !roomRow || Boolean(roomLabelRect && roomTextRect && roomLabelRect.bottom <= roomTextRect.top + 1),
         roomFallbackClipped: Boolean(roomText && roomText.scrollHeight > roomText.clientHeight + 1),
@@ -10444,7 +10460,15 @@ async function main() {
 
   async function focusedChatTargetId() {
     const focusedTargetId = await page.evaluate(() => {
-      const focused = actionForButton("primary") || focusedAction();
+      const focused = focusedAction() || actionForButton("primary");
+      const selected = focused?.selectedTarget?.();
+      const selectedId = Number(
+        selected?.id
+          || focused?.targetActorId
+          || focused?.pendingTargetActorId?.()
+          || 0,
+      );
+      if (selectedId) return selectedId;
       const match = String(focused?.focusKey || "").match(/^(?:actor|talk):(\d+)$/);
       return Number(match?.[1] || 0);
     });
@@ -10488,8 +10512,10 @@ async function main() {
         });
         return response.json();
       }, targetActorId);
-      assert(duplicate.ok === false && duplicate.status === 409, `overlapping chat should be rejected: ${JSON.stringify(duplicate)}`);
-      assert((duplicate.events || []).length === 0, "overlapping chat should not emit events");
+      assert(
+        duplicate.ok === true && (duplicate.events || []).length === 0,
+        `overlapping Chat should idempotently reuse the active exchange: ${JSON.stringify(duplicate)}`,
+      );
       await assertNoVisibleOverflow();
       chatPendingChecked = true;
     } else {
@@ -10524,7 +10550,7 @@ async function main() {
       return;
     }
     let exchange = [];
-    for (let attempt = 0; attempt < 100 && exchange.length === 0; attempt += 1) {
+    for (let attempt = 0; attempt < 750 && exchange.length < 4; attempt += 1) {
       exchange = await page.evaluate(async ({ actorId, targetActorId, afterSeq }) => {
         const actorSession = localStorage.getItem("cosyworld.actorSession") || "";
         const params = new URLSearchParams({
@@ -10549,25 +10575,22 @@ async function main() {
         }
         return exchange;
       }, { actorId: before.actorId, targetActorId, afterSeq: before.latestMessageSeq });
-      if (exchange.length === 0) await page.waitForTimeout(100);
+      if (exchange.length < 4) await page.waitForTimeout(100);
     }
     assert(
-      exchange.length >= 1
-        && exchange.length <= 4
+      exchange.length === 4
         && exchange[0]?.actorId === before.actorId
         && exchange.every((line, index) => line.actorId === (index % 2 === 0 ? before.actorId : targetActorId)),
-      `Chat should commit an inferred avatar line and any available alternating continuation beats: ${JSON.stringify(exchange)}`,
+      `Chat should commit exactly two alternating lines from each participant: ${JSON.stringify(exchange)}`,
     );
     assert(
       exchange.every((line) => String(line.content || "").trim().length >= 2),
       `every inferred Chat beat should contain a visible line: ${JSON.stringify(exchange)}`,
     );
-    if (exchange.length === 4) {
-      assert(
-        !/\?\s*$/.test(exchange[3]?.content || ""),
-        `the fourth beat should gently close the exchange instead of opening another question: ${JSON.stringify(exchange)}`,
-      );
-    }
+    assert(
+      !/\?\s*$/.test(exchange[3]?.content || ""),
+      `the fourth beat should gently close the exchange instead of opening another question: ${JSON.stringify(exchange)}`,
+    );
     await page.waitForFunction(
       () => !document.querySelector("#primary")?.disabled,
       null,
@@ -10906,11 +10929,15 @@ async function main() {
   assert(
     residentChatDiagnostic.advancement > 0
       && residentChatDiagnostic.offers.includes("create_bond")
-      && residentChatDiagnostic.actions.includes("chat"),
-    `Chat should remain available while another advancement-backed friendship can begin: ${JSON.stringify(residentChatDiagnostic)}`,
+      && residentChatDiagnostic.offers.includes("chat")
+      && residentChatDiagnostic.actions.includes("chat")
+      && residentChatDiagnostic.actions.includes("befriend"),
+    `Chat and Befriend should remain distinct while a friendship can begin: ${JSON.stringify(residentChatDiagnostic)}`,
   );
-  await focusPrimaryMatching("spend one advancement on Chat", (text) => text.startsWith("chat"), 32);
-  await clickPrimary("spend one advancement on Chat");
+  await focusPrimaryMatching("focus Chat with a nearby resident", (text) => text.startsWith("chat"), 32);
+  await chatWithFocusedResident("Chat button starts a bounded exchange");
+  await focusPrimaryMatching("spend one advancement on Befriend", (text) => text.startsWith("befriend"), 32);
+  await clickPrimary("spend one advancement on Befriend");
   await page.waitForFunction(
     (before) => Number(state?.ledger?.advancement_points || 0) < before,
     residentChatDiagnostic.advancement,
@@ -10925,13 +10952,13 @@ async function main() {
   });
   assert(
     spentChatDiagnostic.advancement === residentChatDiagnostic.advancement - 1,
-    `Chat should spend exactly one advancement point: ${JSON.stringify({ before: residentChatDiagnostic, after: spentChatDiagnostic })}`,
+    `Befriend should spend exactly one advancement point: ${JSON.stringify({ before: residentChatDiagnostic, after: spentChatDiagnostic })}`,
   );
   if (spentChatDiagnostic.advancement === 0) {
     assert(
       !spentChatDiagnostic.offers.includes("create_bond")
-        && !spentChatDiagnostic.actions.includes("chat"),
-      `Chat should disappear once no advancement-backed friendship remains: ${JSON.stringify(spentChatDiagnostic)}`,
+        && !spentChatDiagnostic.actions.includes("befriend"),
+      `Befriend should disappear once no advancement-backed friendship remains: ${JSON.stringify(spentChatDiagnostic)}`,
     );
   }
   steps.push({ label: "spent one advancement on friendship", location: residentChatDiagnostic.location });


### PR DESCRIPTION
## Summary

Fixes the Chat button’s silent no-op by making it a real, durable, bounded conversation action.

- adds authenticated `POST /actions/chat` queueing with per actor/target serialization;
- runs exactly four authoritative beats: avatar → target → avatar → target;
- publishes every accepted beat through `message.created` and the normal SSE/replay path;
- keeps rapid duplicate presses idempotent while one exchange is active;
- emits a visible `chat.failed` event when inference is unavailable instead of inventing dialogue or doing nothing;
- keeps free Chat distinct from advancement-backed Befriend across offers, UI, and MUD commands;
- shows an accessible pending conversation row immediately after confirmation;
- moves the Chat endpoint and concurrency coverage into `chat_action.rs`, shrinking `main.rs` by 82 lines and lowering its enforced ceiling.

## Validation

- `npm run check` (pre-push): 483 JS tests, all worldpack/composition/proof checks, kernel, 797 Rust tests, architecture/clippy ceilings, syntax — pass.
- isolated browser smoke — pass.
- living-world browser stress — pass.
- browser contract invokes the actual Chat card, observes pending UI, checks idempotent double press, verifies visible AI-disabled failure, no invented messages/no Orb change, and distinct Befriend behavior.

Tracks #531. Keep #531 open until the merged release is deployed and the production interaction is verified.