### PR TITLE
Guard deploys against full Fly data volumes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,20 @@ jobs:
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Guard primary volume free space
+        run: scripts/check-fly-volume-space.sh cosyworld /data 85
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
       - name: Deploy primary Fly app
         run: flyctl deploy --remote-only --config fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Guard Lonely Forest volume free space
+        run: scripts/check-fly-volume-space.sh cosyworld-lonelyforest /data 85
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
 
       - name: Build and deploy Lonely Forest
         run: flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false

--- a/fly.lonelyforest.toml
+++ b/fly.lonelyforest.toml
@@ -45,6 +45,10 @@ primary_region = "sjc"
   source = "lonelyforest_data"
   destination = "/data"
 
+# Deploy strategy stays `rolling`: bluegreen/canary would boot a second
+# machine beside this one, and the /data volume is single-writer — two
+# machines on one SQLite volume corrupts the journal. The deploy workflow
+# therefore guards volume free space before swapping (issue #546).
 [http_service]
   internal_port = 3000
   force_https = true

--- a/fly.toml
+++ b/fly.toml
@@ -46,6 +46,10 @@ primary_region = "sjc"
   memory = "2gb"
   processes = ["app"]
 
+# Deploy strategy stays `rolling`: bluegreen/canary would boot a second
+# machine beside this one, and the /data volume is single-writer — two
+# machines on one SQLite volume corrupts the journal. The deploy workflow
+# therefore guards volume free space before swapping (issue #546).
 [http_service]
   internal_port = 3000
   force_https = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.238",
+  "version": "0.0.239",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.238",
+      "version": "0.0.239",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.238",
+  "version": "0.0.239",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/scripts/check-fly-volume-space.sh
+++ b/scripts/check-fly-volume-space.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Pre-deploy guard: refuse to swap a machine onto a nearly full data volume.
+#
+# A boot that cannot write (journal append, snapshot, migration) crash-loops
+# the release, and with a single machine that is an outage by construction.
+# The 2026-07-28 production outage was exactly this: the volume hit 100%, a
+# deploy swapped configs, and the app could not boot until the volume was
+# extended by hand.
+#
+# Usage: check-fly-volume-space.sh <fly-app> [mount-point] [threshold-percent]
+# Requires: flyctl authenticated (FLY_API_TOKEN) and ssh-agent access to the app.
+set -euo pipefail
+
+APP="${1:?fly app name required}"
+MOUNT="${2:-/data}"
+THRESHOLD="${3:-85}"
+
+if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || [ "$THRESHOLD" -lt 1 ] || [ "$THRESHOLD" -gt 100 ]; then
+  echo "::error::threshold must be an integer 1-100, got '$THRESHOLD'" >&2
+  exit 2
+fi
+
+df_line="$(flyctl ssh console -a "$APP" -C "df -P $MOUNT" 2>/dev/null | awk 'NR==2 {print}')"
+if [ -z "$df_line" ]; then
+  echo "::error::could not read df for $MOUNT on app $APP — refusing to deploy blind" >&2
+  exit 1
+fi
+
+used_percent="$(echo "$df_line" | awk '{gsub(/%/, "", $5); print $5}')"
+available="$(echo "$df_line" | awk '{print $4}')"
+if ! [[ "$used_percent" =~ ^[0-9]+$ ]]; then
+  echo "::error::could not parse df output for $MOUNT on app $APP: $df_line" >&2
+  exit 1
+fi
+
+echo "$APP $MOUNT is ${used_percent}% used (${available} blocks available; threshold ${THRESHOLD}%)"
+if [ "$used_percent" -ge "$THRESHOLD" ]; then
+  echo "::error::$APP $MOUNT at ${used_percent}% >= ${THRESHOLD}% — extend the volume (flyctl volumes extend <id> --size <gb> -a $APP) or free space before deploying. Deploying onto a full volume crash-loops the release." >&2
+  exit 1
+fi

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.238"
+version = "0.0.239"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.238"
+version = "0.0.239"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What happened on 2026-07-28

08:47 UTC: the deploy workflow swapped the single production machine onto a new config while `/data` was at 100%. Every boot died on `database or disk is full`, the workflow timed out, and production crash-looped until the volume was extended by hand. The failure was knowable **before** the swap — nothing checked.

## Changes

- **`scripts/check-fly-volume-space.sh`** — pre-deploy guard: reads `df -P /data` from the app's machine via `flyctl ssh console`, and refuses the deploy at ≥85% used with an actionable error (names the `flyctl volumes extend` command). Fails closed when the df read is unavailable rather than deploying blind.
- **`deploy.yml`** — the guard runs before each app's deploy step, with the app's own token.
- **`fly.toml` / `fly.lonelyforest.toml`** — documents why the strategy stays `rolling`: bluegreen/canary boots a second machine, and the `/data` volume is single-writer — two machines on one SQLite volume corrupts the journal. The guard carries the safety instead.

## Verification

Ran the guard live against both production apps (read-only):

```
pass: cosyworld /data is 50% used (threshold 85%) → exit 0
fail: cosyworld /data at 50% >= 1%  → exit 1 with the extend-volume guidance
pass: cosyworld-lonelyforest /data is 23% used (threshold 85%) → exit 0
```

Full pre-push gate (vitest, worldpack, kernel, Rust, architecture, syntax) passes.

Refs #546 — the bluegreen portion is resolved as "documented rejection" per the single-writer volume constraint; the guard is the workable half of the issue.
