### PR TITLE
Fix return travel through generated routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.239",
+  "version": "0.0.240",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.239",
+      "version": "0.0.240",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.239",
+  "version": "0.0.240",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.239"
+version = "0.0.240"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.239"
+version = "0.0.240"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -7488,6 +7488,18 @@ async function main() {
   }
 
   async function travelTo(name) {
+    const current = await fetchCurrentState();
+    const destinationIsDirect = (current.exits || []).some((exit) => (
+      exit.destination_location_name === name
+    ));
+    const journeyTargetsDestination = current.journey?.destination_name === name;
+    if (!destinationIsDirect && !journeyTargetsDestination) {
+      // A completed long-route journey leaves its generated waypoints in the
+      // world. Later trips must follow those adjacent exits instead of looking
+      // for a card that still names the authored endpoint.
+      await travelPathTo(name);
+      return;
+    }
     const focusedRoute = await focusRoute(name);
     steps.push({ label: `focus ${name}`, primary: focusedRoute });
     const route = focusedRoute.toLowerCase();


### PR DESCRIPTION
## Summary

- make the browser smoke traverse an already-materialized generated pathway when the authored destination is no longer adjacent
- prevent the Moonlit Trail recovery flow from searching for a stale direct `Rain-Soft Garden` action
- release the fix as `0.0.240`

## Root cause

After a long route had been revealed, later return travel exposed only the next generated waypoint. The smoke helper still matched actions by the final authored endpoint name, so it rejected the valid waypoint travel action.

## Validation

- `npm run check:version`
- `git diff --check`
- `npm run v2:check`
  - 816 Rust tests passed
  - normal browser smoke passed
  - living-world stress smoke passed, including Moonlit Trail → generated waypoints → Rain-Soft Garden
- pre-push `npm run check`
  - 483 Node tests passed
  - worldpack, kernel, Rust, architecture, and syntax checks passed

## Review checklist

- [x] Change is isolated from unrelated local work
- [x] Version metadata is consistent across Node and Rust
- [x] No generated artifacts or runtime data are included
- [x] Full browser and release gates pass
