### PR TITLE
Gate deploys on live worldpack compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      - name: Guard primary worldpack bundle compatibility
+        run: node v2/scripts/check-deploy-worldpack.mjs https://cosyworld.fly.dev
+
       - name: Deploy primary Fly app
         run: flyctl deploy --remote-only --config fly.toml
         env:
@@ -39,6 +42,9 @@ jobs:
         run: scripts/check-fly-volume-space.sh cosyworld-lonelyforest /data 85
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
+
+      - name: Guard Lonely Forest worldpack bundle compatibility
+        run: node v2/scripts/check-deploy-worldpack.mjs https://lonelyforest.com
 
       - name: Build and deploy Lonely Forest
         run: flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.241",
+  "version": "0.0.242",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.241",
+      "version": "0.0.242",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.241",
+  "version": "0.0.242",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,
@@ -50,7 +50,7 @@
     "v2:media:evolution": "node v2/scripts/report-media-evolution.mjs",
     "v2:proof-world": "node v2/scripts/check-proof-world.mjs",
     "v2:spike:deck-gated": "node v2/scripts/spike-deck-gated-actions.mjs",
-    "v2:syntax": "node --check v2/scripts/smoke-browser.mjs && node --check v2/scripts/smoke-production-profile.mjs && node --check v2/scripts/smoke-deployed-ruby-high.mjs && node --check v2/scripts/smoke-standalone-compositions.mjs && node --check v2/scripts/smoke-core-ruby-composition.mjs && node --check v2/scripts/inspect-action-journal.mjs && node --check v2/scripts/report-media-evolution.mjs && python3 -m py_compile v2/cli/cosy_cli.py",
+    "v2:syntax": "node --check v2/scripts/smoke-browser.mjs && node --check v2/scripts/smoke-production-profile.mjs && node --check v2/scripts/smoke-deployed-ruby-high.mjs && node --check v2/scripts/smoke-standalone-compositions.mjs && node --check v2/scripts/smoke-core-ruby-composition.mjs && node --check v2/scripts/inspect-action-journal.mjs && node --check v2/scripts/check-deploy-worldpack.mjs && node --check v2/scripts/report-media-evolution.mjs && python3 -m py_compile v2/cli/cosy_cli.py",
     "reset-setup": "node scripts/reset-setup.mjs",
     "build": "npm run clean && npm run build:js && npm run docs",
     "clean": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\"",

--- a/test/v2/worldpack-bundle-gate.test.mjs
+++ b/test/v2/worldpack-bundle-gate.test.mjs
@@ -1,0 +1,268 @@
+import crypto from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  candidateFromRegistry,
+  evaluateWorldpackGate,
+  resolveBaseUrl,
+} from "../../v2/scripts/check-deploy-worldpack.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const gatePath = path.join(repoRoot, "v2/scripts/check-deploy-worldpack.mjs");
+const compiledRegistryPath = path.join(
+  repoRoot,
+  "v2/content/official/registry.json",
+);
+
+function digest(value) {
+  return `sha256:${crypto.createHash("sha256").update(value).digest("hex")}`;
+}
+
+const LIVE_HASH = digest("live-journal-bundle");
+const CANDIDATE_HASH = digest("candidate-bundle");
+const OLDER_HASH = digest("older-declared-bundle");
+
+function registry(overrides = {}) {
+  return {
+    manifest: {
+      bundle_hash: CANDIDATE_HASH,
+      persistence_compatibility: {
+        schema_version: 1,
+        replay_compatible_bundle_hashes: [OLDER_HASH],
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe("worldpack deploy gate evaluation", () => {
+  it("passes when the candidate matches the live journal bundle", () => {
+    const decision = evaluateWorldpackGate({
+      candidateHash: LIVE_HASH,
+      candidateReplayCompatible: [],
+      liveHash: LIVE_HASH,
+    });
+    expect(decision).toMatchObject({ ok: true, status: "exact" });
+  });
+
+  it("passes when the candidate declares the live bundle replay-compatible", () => {
+    const decision = evaluateWorldpackGate({
+      candidateHash: CANDIDATE_HASH,
+      candidateReplayCompatible: [OLDER_HASH, LIVE_HASH],
+      liveHash: LIVE_HASH,
+    });
+    expect(decision).toMatchObject({ ok: true, status: "declared_migration" });
+  });
+
+  it("fails closed on an undeclared mismatch and names both hashes", () => {
+    const decision = evaluateWorldpackGate({
+      candidateHash: CANDIDATE_HASH,
+      candidateReplayCompatible: [OLDER_HASH],
+      liveHash: LIVE_HASH,
+    });
+    expect(decision.ok).toBe(false);
+    expect(decision.status).toBe("incompatible");
+    expect(decision.reason).toContain(CANDIDATE_HASH);
+    expect(decision.reason).toContain(LIVE_HASH);
+  });
+
+  it("blocks a rollback across a migration boundary", () => {
+    // The older bundle was authored before the live hash existed, so it
+    // cannot declare it — the gate stops the rollback that would crash-loop.
+    const decision = evaluateWorldpackGate({
+      candidateHash: OLDER_HASH,
+      candidateReplayCompatible: [],
+      liveHash: LIVE_HASH,
+    });
+    expect(decision).toMatchObject({ ok: false, status: "incompatible" });
+  });
+
+  it("fails closed when the live app reports no usable bundle hash", () => {
+    for (const liveHash of ["", "not-a-digest", undefined]) {
+      const decision = evaluateWorldpackGate({
+        candidateHash: CANDIDATE_HASH,
+        candidateReplayCompatible: [LIVE_HASH],
+        liveHash,
+      });
+      expect(decision).toMatchObject({ ok: false, status: "unverifiable" });
+    }
+  });
+});
+
+describe("candidate registry validation", () => {
+  it("reads the bundle hash and declared compatibility list", () => {
+    expect(candidateFromRegistry(registry())).toEqual({
+      bundleHash: CANDIDATE_HASH,
+      replayCompatible: [OLDER_HASH],
+    });
+  });
+
+  it("accepts a manifest without declared compatibility", () => {
+    const candidate = candidateFromRegistry({
+      manifest: { bundle_hash: CANDIDATE_HASH },
+    });
+    expect(candidate.replayCompatible).toEqual([]);
+  });
+
+  it("rejects a manifest without a valid bundle hash", () => {
+    expect(() => candidateFromRegistry({ manifest: {} })).toThrow(/bundle hash/);
+    expect(() =>
+      candidateFromRegistry({ manifest: { bundle_hash: "deadbeef" } }),
+    ).toThrow(/bundle hash/);
+  });
+
+  it("rejects malformed declared hashes", () => {
+    expect(() =>
+      candidateFromRegistry(
+        registry({
+          persistence_compatibility: {
+            replay_compatible_bundle_hashes: ["sha256:zzz"],
+          },
+        }),
+      ),
+    ).toThrow(/sha256 digest/);
+  });
+});
+
+describe("target resolution", () => {
+  it("maps fly app names to their fly.dev origin", () => {
+    expect(resolveBaseUrl("cosyworld")).toBe("https://cosyworld.fly.dev");
+    expect(resolveBaseUrl("cosyworld-lonelyforest")).toBe(
+      "https://cosyworld-lonelyforest.fly.dev",
+    );
+  });
+
+  it("keeps explicit base URLs and strips trailing slashes", () => {
+    expect(resolveBaseUrl("https://lonelyforest.com/")).toBe(
+      "https://lonelyforest.com",
+    );
+  });
+
+  it("rejects missing or unsafe targets", () => {
+    expect(() => resolveBaseUrl(undefined)).toThrow(/required/);
+    expect(() => resolveBaseUrl("app;rm -rf")).toThrow(/base URL/);
+  });
+});
+
+describe("worldpack deploy gate CLI", () => {
+  let tempRoot;
+  let registryPath;
+  let metaPath;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(tmpdir(), "cosyworld-deploy-gate-"));
+    registryPath = path.join(tempRoot, "registry.json");
+    metaPath = path.join(tempRoot, "meta.json");
+    await writeFile(registryPath, JSON.stringify(registry()));
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  function runGate(extraArgs) {
+    const result = spawnSync(
+      process.execPath,
+      [gatePath, "cosyworld", "--registry", registryPath, "--meta-file", metaPath, ...extraArgs],
+      { encoding: "utf8" },
+    );
+    return {
+      status: result.status,
+      output: `${result.stdout}\n${result.stderr}`,
+    };
+  }
+
+  async function writeMeta(bundleHash) {
+    await writeFile(metaPath, JSON.stringify({ worldpack: { bundle_hash: bundleHash } }));
+  }
+
+  it("exits 0 when the candidate matches the live bundle", async () => {
+    await writeMeta(CANDIDATE_HASH);
+    const result = runGate([]);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("status=exact");
+  });
+
+  it("exits 0 with a notice for a declared migration", async () => {
+    await writeMeta(OLDER_HASH);
+    const result = runGate([]);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("status=declared_migration");
+    expect(result.output).toContain("::notice::");
+  });
+
+  it("exits 1 on an undeclared mismatch and names both hashes and the remedy", async () => {
+    await writeMeta(LIVE_HASH);
+    const result = runGate([]);
+    expect(result.status).toBe(1);
+    expect(result.output).toContain(LIVE_HASH);
+    expect(result.output).toContain(CANDIDATE_HASH);
+    expect(result.output).toContain("v2/docs/worldpacks.md");
+    expect(result.output).toContain("fresh-seed");
+  });
+
+  it("exits 1 when the live app reports no bundle hash", async () => {
+    await writeMeta("");
+    const result = runGate([]);
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("refusing to deploy blind");
+  });
+
+  it("exits 2 when the candidate registry is missing", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        gatePath,
+        "cosyworld",
+        "--registry",
+        path.join(tempRoot, "missing.json"),
+        "--meta-file",
+        metaPath,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(2);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("cannot read candidate registry");
+  });
+
+  it("exits 2 when the meta file cannot be read", () => {
+    const result = runGate([]);
+    expect(result.status).toBe(2);
+    expect(result.output).toContain("--meta-file");
+  });
+
+  it("exits 2 without a target", () => {
+    const result = spawnSync(
+      process.execPath,
+      [gatePath, "--registry", registryPath, "--meta-file", metaPath],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(2);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("usage:");
+  });
+
+  it("loads the committed official registry against its own declared history", () => {
+    // The compiled bundle must always be able to state its own identity;
+    // this catches a registry shape drift that would break the deploy gate.
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        `import("node:fs").then(async (fs) => {
+          const { candidateFromRegistry } = await import(${JSON.stringify(gatePath)});
+          const registry = JSON.parse(fs.readFileSync(${JSON.stringify(compiledRegistryPath)}, "utf8"));
+          const candidate = candidateFromRegistry(registry);
+          console.log(candidate.bundleHash, candidate.replayCompatible.length);
+        })`,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^sha256:[0-9a-f]{64} \d+$/);
+  });
+});

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -328,6 +328,21 @@ composition authoritative; it never seeds a fresh public history under the same
 world id or runs mixed-composition writers. See
 [`canonical-world.md`](canonical-world.md) for the migration and failover gate.
 
+### Pre-deploy bundle gate
+
+`v2/scripts/check-deploy-worldpack.mjs` runs in the deploy workflow before any
+image is swapped. It reads the candidate bundle hash and declared
+`replay_compatible_bundle_hashes` from the committed compiled registry, fetches
+the live app's bundle hash from its public `/meta` (the hash the live journal
+was written under), and refuses the deploy unless the two match exactly or the
+candidate declares the live hash replay-compatible. An unreadable or
+unverifiable live identity fails closed: the deploy stops instead of
+discovering the mismatch as a crash-loop after the old machine is gone. A
+rollback across a migration boundary is blocked by construction, because the
+older bundle cannot declare a newer hash. The gate never mutates the journal,
+the snapshot, or the recorded hashes; the remedy for a blocked deploy is the
+declared migration path above, never a hand-edited hash.
+
 Pack content has a canonical, version-independent identity of the form
 `pack://<pack-id>/<kind>/<local-id>`. For example,
 `pack://five-e-commons/creature/goblin-warrior` and

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.241"
+version = "0.0.242"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.241"
+version = "0.0.242"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/check-deploy-worldpack.mjs
+++ b/v2/scripts/check-deploy-worldpack.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Pre-deploy worldpack bundle compatibility gate.
+ *
+ * The runtime fails closed when the persisted journal/snapshot bundle hash
+ * does not match the active bundle and is not declared replay-compatible.
+ * That is correct — but discovering the mismatch only after the new machine
+ * boots turns every stale-checkout, wrong-branch, or cross-migration deploy
+ * into an outage (2026-07-29: both production worlds crash-looped to the
+ * restart limit and recovered by rollback).
+ *
+ * This script performs the same comparison before the image is swapped:
+ *
+ *   candidate bundle hash (the checkout about to deploy)
+ *     == live bundle hash (the bundle the target app's journal was written
+ *        under, read from the running app's public /meta)
+ *   OR the candidate bundle declares the live hash in
+ *      persistence_compatibility.replay_compatible_bundle_hashes
+ *
+ * Anything else — mismatch, unreachable /meta, unverifiable identity — exits
+ * non-zero so the deploy stops before the old machine is replaced. A rollback
+ * across a migration boundary fails this gate by construction: the older
+ * bundle cannot declare a newer hash.
+ *
+ * Usage:
+ *   node v2/scripts/check-deploy-worldpack.mjs <fly-app | https://base-url>
+ *     [--registry v2/content/official/registry.json]
+ *     [--meta-file captured-meta.json]   # read /meta from disk instead of HTTP
+ *     [--timeout-ms 15000]
+ *
+ * Exit codes: 0 compatible; 1 incompatible or live identity unreadable
+ * (fail closed); 2 usage or local registry error.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(scriptPath), "../..");
+const DEFAULT_REGISTRY_PATH = path.join(
+  repoRoot,
+  "v2/content/official/registry.json",
+);
+const DEFAULT_TIMEOUT_MS = 15_000;
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const REMEDIATION =
+  "Either deploy the bundle the live journal was written under, or author an "
+  + "explicit migration that declares the live hash replay-compatible "
+  + "(v2/worlds/official/world.json persistence_compatibility, then "
+  + "npm run v2:worldpack:lock && npm run v2:worldpack), or follow the "
+  + "documented fresh-seed path in v2/docs/worldpacks.md "
+  + "('Identity and persistence') — a fresh seed is only allowed for "
+  + "isolated installs, never the official world. Never blank a recorded "
+  + "bundle hash to force a load.";
+
+class UsageError extends Error {}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  return index < 0 ? undefined : args[index + 1];
+}
+
+export function resolveBaseUrl(target) {
+  if (!target) {
+    throw new UsageError("a fly app name or https:// base URL is required");
+  }
+  if (target.startsWith("https://") || target.startsWith("http://")) {
+    return target.replace(/\/+$/, "");
+  }
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(target)) {
+    throw new UsageError(
+      `target must be a fly app name or https:// base URL, got '${target}'`,
+    );
+  }
+  return `https://${target}.fly.dev`;
+}
+
+export function candidateFromRegistry(registry) {
+  const bundleHash = registry?.manifest?.bundle_hash;
+  if (typeof bundleHash !== "string" || !SHA256_PATTERN.test(bundleHash)) {
+    throw new UsageError(
+      "candidate registry manifest has no valid bundle hash — run "
+      + "npm run v2:worldpack and commit the compiled bundle",
+    );
+  }
+  const declared = registry.manifest.persistence_compatibility
+    ?.replay_compatible_bundle_hashes ?? [];
+  if (!Array.isArray(declared)) {
+    throw new UsageError(
+      "registry persistence_compatibility.replay_compatible_bundle_hashes "
+      + "must be an array",
+    );
+  }
+  for (const hash of declared) {
+    if (typeof hash !== "string" || !SHA256_PATTERN.test(hash)) {
+      throw new UsageError(
+        `declared replay-compatible hash is not a sha256 digest: ${hash}`,
+      );
+    }
+  }
+  return { bundleHash, replayCompatible: declared };
+}
+
+export function evaluateWorldpackGate({ candidateHash, candidateReplayCompatible, liveHash }) {
+  if (typeof liveHash !== "string" || !SHA256_PATTERN.test(liveHash)) {
+    return {
+      ok: false,
+      status: "unverifiable",
+      reason:
+        "the live app did not report a verifiable worldpack bundle hash — "
+        + "refusing to deploy blind",
+    };
+  }
+  if (liveHash === candidateHash) {
+    return {
+      ok: true,
+      status: "exact",
+      reason: "candidate bundle matches the bundle the live journal was written under",
+    };
+  }
+  if (candidateReplayCompatible.includes(liveHash)) {
+    return {
+      ok: true,
+      status: "declared_migration",
+      reason:
+        "candidate bundle declares the live journal's bundle hash "
+        + "replay-compatible",
+    };
+  }
+  return {
+    ok: false,
+    status: "incompatible",
+    reason:
+      `candidate worldpack ${candidateHash} does not match the live journal's `
+      + `worldpack ${liveHash} and does not declare it replay-compatible`,
+  };
+}
+
+export async function fetchLiveWorldpackHash({ baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = fetch }) {
+  const url = `${baseUrl}/meta`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    });
+  } catch (error) {
+    throw new Error(
+      `could not read live worldpack identity from ${url}: ${error.message}`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (!response.ok) {
+    throw new Error(
+      `could not read live worldpack identity from ${url}: HTTP ${response.status}`,
+    );
+  }
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new Error(
+      `could not read live worldpack identity from ${url}: ${error.message}`,
+    );
+  }
+  const liveHash = body?.worldpack?.bundle_hash;
+  return typeof liveHash === "string" ? liveHash : "";
+}
+
+function currentCommit() {
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA;
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return result.status === 0 ? result.stdout.trim() : "unknown";
+}
+
+const VALUE_OPTIONS = new Set(["--registry", "--meta-file", "--timeout-ms"]);
+
+function positionalTarget(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (VALUE_OPTIONS.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (!arg.startsWith("--")) return arg;
+  }
+  return undefined;
+}
+
+async function main(args) {
+  const target = positionalTarget(args);
+  const registryPath = option(args, "--registry") ?? DEFAULT_REGISTRY_PATH;
+  const metaFile = option(args, "--meta-file");
+  const timeoutOption = option(args, "--timeout-ms");
+  const timeoutMs = timeoutOption === undefined
+    ? DEFAULT_TIMEOUT_MS
+    : Number(timeoutOption);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 120_000) {
+    throw new UsageError("--timeout-ms must be an integer from 1000 through 120000");
+  }
+
+  const baseUrl = resolveBaseUrl(target);
+  let registry;
+  try {
+    registry = JSON.parse(fs.readFileSync(path.resolve(registryPath), "utf8"));
+  } catch (error) {
+    throw new UsageError(
+      `cannot read candidate registry at ${registryPath}: ${error.message}`,
+    );
+  }
+  const candidate = candidateFromRegistry(registry);
+
+  let liveHash;
+  if (metaFile) {
+    try {
+      const body = JSON.parse(fs.readFileSync(path.resolve(metaFile), "utf8"));
+      const reported = body?.worldpack?.bundle_hash;
+      liveHash = typeof reported === "string" ? reported : "";
+    } catch (error) {
+      throw new UsageError(`cannot read --meta-file ${metaFile}: ${error.message}`);
+    }
+  } else {
+    liveHash = await fetchLiveWorldpackHash({ baseUrl, timeoutMs });
+  }
+
+  const decision = evaluateWorldpackGate({
+    candidateHash: candidate.bundleHash,
+    candidateReplayCompatible: candidate.replayCompatible,
+    liveHash,
+  });
+
+  console.log(
+    `worldpack deploy gate: target=${baseUrl} status=${decision.status}\n`
+    + `  live journal worldpack: ${liveHash || "(none reported)"}\n`
+    + `  candidate worldpack:    ${candidate.bundleHash}\n`
+    + `  candidate commit:       ${currentCommit()}`,
+  );
+  if (!decision.ok) {
+    console.error(
+      `::error::${decision.reason}. The new machine would fail its `
+      + "production continuity check and crash-loop after the old one is "
+      + `gone. ${REMEDIATION}`,
+    );
+    return 1;
+  }
+  if (decision.status === "declared_migration") {
+    console.log(
+      "::notice::deploy crosses a declared worldpack migration: "
+      + `${liveHash} -> ${candidate.bundleHash}`,
+    );
+  }
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(scriptPath)) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      const prefix = error instanceof UsageError ? "usage error" : "worldpack deploy gate failed";
+      console.error(`::error::${prefix}: ${error.message}`);
+      if (error instanceof UsageError) {
+        console.error(
+          "usage: check-deploy-worldpack.mjs <fly-app | https://base-url> "
+          + "[--registry registry.json] [--meta-file meta.json] [--timeout-ms N]",
+        );
+        process.exit(2);
+      }
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## What changed

- add a fail-closed pre-deploy worldpack compatibility gate
- compare the candidate bundle and declared replay-compatible hashes with each live journal's bundle
- run the gate before both Fly image swaps
- document rollback and migration behavior
- release as 0.0.242

## Why

A stale or cross-migration checkout can pass build validation but crash-loop only after replacing the serving machine. This gate stops incompatible or unverifiable deployments before the swap and names both hashes plus the supported remedy.

## Validation

- 503 JavaScript tests
- official and composed worldpack checks
- proof-world and kernel checks
- 818 Rust tests
- architecture and syntax checks
- exact live bundle match against `cosyworld.fly.dev`
- exact live bundle match against `lonelyforest.com`

Closes #551
