### PR TITLE
Close focused encounters after bounded recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.243",
+  "version": "0.0.244",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.243",
+      "version": "0.0.244",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.243",
+  "version": "0.0.244",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/core-c/include/cosy_kernel.h
+++ b/v2/core-c/include/cosy_kernel.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /* Version 9 is reserved by #411 for project-push ABI state. */
-#define CW_KERNEL_VERSION 10u
+#define CW_KERNEL_VERSION 11u
 
 #define CW_MAX_ACTORS 512u
 #define CW_MAX_ITEMS 1024u
@@ -204,7 +204,12 @@ typedef enum {
      their projection-owned meaning. */
   CW_ACTION_PROJECT_PUSH = 31,
   /* Action 31 is reserved by #411 for CW_ACTION_PROJECT_PUSH. */
-  CW_ACTION_REST = 32
+  CW_ACTION_REST = 32,
+  /* Terminal closure for an encounter that can never advance again. The
+     orchestrator commits this only after bounded recovery attempts fail
+     deterministically; it resolves the encounter with no winning side so a
+     stuck scene releases its participants instead of retrying forever. */
+  CW_ACTION_COMBAT_ABANDON = 33
 } cw_action_kind;
 
 typedef enum {

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -2253,6 +2253,36 @@ static cw_status apply_combat_pass(cw_world *world, const cw_action *action, cw_
   return CW_OK;
 }
 
+/* Close an encounter that can never advance again. Unlike every other combat
+   action this does not require the caller to hold the current turn: a stuck
+   encounter is precisely one whose current turn can never be completed. It
+   resolves with no winning side (total 0) and releases the participants. */
+static cw_status apply_combat_abandon(cw_world *world, const cw_action *action, cw_event_buffer *out_events) {
+  if (!action->content_id) return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
+  cw_combat_encounter *encounter = find_combat_encounter(world, action->content_id);
+  if (!encounter || encounter->status != CW_COMBAT_ENCOUNTER_ACTIVE) {
+    return reject(world, out_events, action, CW_REASON_ENCOUNTER_NOT_FOUND);
+  }
+  if (!find_combat_participant_const(encounter, action->actor_id)) {
+    return reject(world, out_events, action, CW_REASON_NOT_PARTICIPANT);
+  }
+  for (size_t i = 0; i < encounter->participant_count; ++i) {
+    cw_actor *participant = find_actor(world, encounter->participants[i].actor_id);
+    if (participant) participant->conditions &= ~CW_CONDITION_DODGING;
+  }
+  encounter->status = CW_COMBAT_ENCOUNTER_RESOLVED;
+  append_event(world, out_events, CW_EVENT_COMBAT_ENCOUNTER_RESOLVED);
+  if (out_events && out_events->count > 0) {
+    cw_event *event = &out_events->events[out_events->count - 1];
+    event->success = 1;
+    event->actor_id = action->actor_id;
+    event->location_id = encounter->location_id;
+    event->content_id = encounter->id;
+    event->total = 0;
+  }
+  return CW_OK;
+}
+
 static cw_status apply_combat_need_time(cw_world *world, const cw_action *action, cw_event_buffer *out_events) {
   cw_combat_encounter *encounter = 0;
   cw_actor *actor = 0;
@@ -2313,6 +2343,7 @@ cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uin
       && action->kind != CW_ACTION_COMBAT_DODGE
       && action->kind != CW_ACTION_COMBAT_ESCAPE
       && action->kind != CW_ACTION_COMBAT_PASS
+      && action->kind != CW_ACTION_COMBAT_ABANDON
       && action->kind != CW_ACTION_COMBAT_NEED_TIME) {
     cw_status status = reject(world, out_events, action, CW_REASON_COMBAT_ACTION_REQUIRED);
     if (out_events && out_events->count > 0) {
@@ -2412,6 +2443,9 @@ cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uin
       break;
     case CW_ACTION_COMBAT_NEED_TIME:
       status = apply_combat_need_time(world, action, out_events);
+      break;
+    case CW_ACTION_COMBAT_ABANDON:
+      status = apply_combat_abandon(world, action, out_events);
       break;
     case CW_ACTION_UNLOCK_EXIT:
       status = apply_unlock_exit(world, action, out_events);

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -397,6 +397,88 @@ static void test_rules_utilize_item_records_project_use_without_consuming(void) 
   assert(item->charges == 3);
 }
 
+static void test_combat_abandon_closes_a_stuck_encounter(void) {
+  cw_world world;
+  cw_event_buffer events;
+  cw_world_init(&world);
+  assert(cw_seed_cosy_cottage(&world, &events) == CW_OK);
+
+  cw_action create = {0};
+  create.kind = CW_ACTION_CREATE_ACTOR;
+  create.actor_id = 5101;
+  create.location_id = 3;
+  assert(cw_world_apply(&world, &create, 401, &events) == CW_OK);
+
+  cw_actor *human = &world.actors[5];
+  cw_actor *echo = &world.actors[3];
+  human->stats.hp_base = 100;
+  echo->stats.hp_base = 100;
+
+  cw_action start = {0};
+  start.kind = CW_ACTION_COMBAT_START;
+  start.actor_id = human->id;
+  start.target_actor_id = echo->id;
+  start.content_id = 9101;
+  assert(cw_world_apply(&world, &start, 501, &events) == CW_OK);
+  cw_combat_encounter *encounter = &world.combat_encounters[0];
+  assert(encounter->status == CW_COMBAT_ENCOUNTER_ACTIVE);
+
+  /* An unknown encounter is rejected rather than closing anything. */
+  cw_action missing = {0};
+  missing.kind = CW_ACTION_COMBAT_ABANDON;
+  missing.actor_id = human->id;
+  missing.content_id = encounter->id + 7777;
+  assert(cw_world_apply(&world, &missing, 502, &events) == CW_ERR_RULE);
+  assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
+  assert(encounter->status == CW_COMBAT_ENCOUNTER_ACTIVE);
+
+  /* An abandon without an encounter id is an invalid action. */
+  cw_action untargeted = {0};
+  untargeted.kind = CW_ACTION_COMBAT_ABANDON;
+  untargeted.actor_id = human->id;
+  assert(cw_world_apply(&world, &untargeted, 503, &events) == CW_ERR_RULE);
+  assert(encounter->status == CW_COMBAT_ENCOUNTER_ACTIVE);
+
+  /* An unrelated actor cannot use the system recovery action to close
+     somebody else's encounter. */
+  cw_action unrelated = {0};
+  unrelated.kind = CW_ACTION_COMBAT_ABANDON;
+  unrelated.actor_id = world.actors[0].id;
+  unrelated.content_id = encounter->id;
+  assert(cw_world_apply(&world, &unrelated, 504, &events) == CW_ERR_RULE);
+  assert(events.events[0].reason == CW_REASON_NOT_PARTICIPANT);
+  assert(encounter->status == CW_COMBAT_ENCOUNTER_ACTIVE);
+
+  /* Abandon closes the encounter with no winning side, from any participant
+     and regardless of whose turn it currently is. */
+  cw_id waiting_id = encounter->participants[encounter->current_index].actor_id == human->id
+      ? echo->id
+      : human->id;
+  cw_action abandon = {0};
+  abandon.kind = CW_ACTION_COMBAT_ABANDON;
+  abandon.actor_id = waiting_id;
+  abandon.content_id = encounter->id;
+  assert(cw_world_apply(&world, &abandon, 505, &events) == CW_OK);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_COMBAT_ENCOUNTER_RESOLVED);
+  assert(events.events[0].success == 1);
+  assert(events.events[0].content_id == encounter->id);
+  assert(events.events[0].total == 0);
+  assert(encounter->status == CW_COMBAT_ENCOUNTER_RESOLVED);
+
+  /* Participants are released: ordinary play is legal again for both. */
+  cw_action move = {0};
+  move.kind = CW_ACTION_MOVE;
+  move.actor_id = human->id;
+  move.destination_location_id = 2;
+  assert(cw_world_apply(&world, &move, 506, &events) == CW_OK);
+
+  /* Abandoning an already-resolved encounter is rejected, so a repeated
+     closure can never double-resolve on replay. */
+  assert(cw_world_apply(&world, &abandon, 507, &events) == CW_ERR_RULE);
+  assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
+}
+
 static void test_combat_v2_encounter_turns_dodge_targeting_and_escape(void) {
   cw_world world;
   cw_event_buffer events;
@@ -1791,6 +1873,7 @@ int main(void) {
   test_items_and_combat_gate();
   test_rules_utilize_item_records_project_use_without_consuming();
   test_combat_v2_encounter_turns_dodge_targeting_and_escape();
+  test_combat_abandon_closes_a_stuck_encounter();
   test_combat_v4_weapon_profile_and_legacy_replay();
   test_card_zones_spell_exhaustion_and_theft_atomicity();
   test_rest_grade_refresh_matrix_and_atomic_validation();

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.243"
+version = "0.0.244"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.243"
+version = "0.0.244"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -715,37 +715,174 @@ fn focused_combat_turn_needs_recovery(
         })
 }
 
-async fn recover_available_combat_turns(state: &AppState) -> io::Result<Vec<EventView>> {
+/// Consecutive deterministic recovery failures a focused encounter may take
+/// before the scheduler closes it. A deterministic kernel status means the
+/// encounter cannot advance from the state it is in, so retrying the same sweep
+/// cannot help; the small cap only absorbs a legitimate state change racing
+/// with the attempt.
+const FOCUSED_RECOVERY_DETERMINISTIC_FAILURE_LIMIT: u32 = 3;
+
+/// Consecutive transient recovery failures before the same terminal closure.
+/// Higher than the deterministic cap because I/O and inference failures do
+/// genuinely clear on their own, but still bounded so nothing retries forever.
+const FOCUSED_RECOVERY_TRANSIENT_FAILURE_LIMIT: u32 = 20;
+
+/// How long to leave a deterministically stuck encounter alone before trying
+/// again. Each attempt holds the runtime lock for its whole duration, so
+/// retrying a known-stuck encounter every second is what starved `/world` and
+/// `/meta` during the 2026-07-28 incident.
+const FOCUSED_RECOVERY_DETERMINISTIC_BACKOFF: Duration = Duration::from_secs(30);
+
+/// A kernel status that will not change while the encounter stays as it is.
+/// `CW_ERR_FULL` is excluded: a full event buffer clears once the pending
+/// events drain.
+fn focused_recovery_status_is_deterministic(status: u32) -> bool {
+    matches!(status, CW_ERR_RULE | CW_ERR_INVALID | CW_ERR_NOT_FOUND)
+}
+
+#[derive(Default)]
+struct FocusedRecoveryFailures {
+    consecutive: u32,
+    retry_after: Option<Instant>,
+}
+
+/// Per-encounter recovery failure history for one scheduler task. This is
+/// deliberately task-local rather than world state: it is a retry budget, not a
+/// world fact, so it must not enter snapshots or the journal. A restart simply
+/// grants a stuck encounter a fresh budget before closing it again.
+#[derive(Default)]
+struct FocusedRecoveryTracker {
+    encounters: BTreeMap<u64, FocusedRecoveryFailures>,
+}
+
+impl FocusedRecoveryTracker {
+    fn is_backing_off(&self, encounter_id: u64, now: Instant) -> bool {
+        self.encounters
+            .get(&encounter_id)
+            .and_then(|failures| failures.retry_after)
+            .is_some_and(|retry_after| now < retry_after)
+    }
+
+    fn clear(&mut self, encounter_id: u64) {
+        self.encounters.remove(&encounter_id);
+    }
+
+    /// Record a failed attempt and report whether the encounter has exhausted
+    /// its budget and must now be closed.
+    fn record_failure(&mut self, encounter_id: u64, deterministic: bool, now: Instant) -> bool {
+        let failures = self.encounters.entry(encounter_id).or_default();
+        failures.consecutive = failures.consecutive.saturating_add(1);
+        failures.retry_after = deterministic.then(|| now + FOCUSED_RECOVERY_DETERMINISTIC_BACKOFF);
+        let limit = if deterministic {
+            FOCUSED_RECOVERY_DETERMINISTIC_FAILURE_LIMIT
+        } else {
+            FOCUSED_RECOVERY_TRANSIENT_FAILURE_LIMIT
+        };
+        failures.consecutive >= limit
+    }
+}
+
+/// Terminally resolve an encounter that has exhausted its recovery budget. The
+/// closure goes through the journal so replay reproduces it, and resolves with
+/// no winning side so the room simply settles.
+fn abandon_stuck_encounter(
+    state: &AppState,
+    runtime: &mut RuntimeWorld,
+    encounter_id: u64,
+    events: &mut Vec<EventView>,
+) -> io::Result<u32> {
+    let actor_id = runtime
+        .combat_current_actor_id(encounter_id)
+        .or_else(|| {
+            let encounter = runtime.combat_encounter(encounter_id)?;
+            encounter.participants[..encounter.participant_count]
+                .first()
+                .map(|participant| participant.actor_id)
+        })
+        .unwrap_or_default();
+    let record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_COMBAT_ABANDON,
+            actor_id,
+            content_id: encounter_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    )
+    .into_system();
+    let (status, abandon_events) = commit_journal_record(state, runtime, record)?;
+    events.extend(abandon_events);
+    Ok(status)
+}
+
+async fn recover_available_combat_turns(
+    state: &AppState,
+    tracker: &mut FocusedRecoveryTracker,
+) -> Vec<EventView> {
+    let now = Instant::now();
     let mut runtime = state.inner.lock().await;
     let encounter_ids = runtime.world.combat_encounters[..runtime.world.combat_encounter_count]
         .iter()
         .map(|encounter| encounter.id)
         .filter(|encounter_id| runtime.active_combat_encounter(*encounter_id).is_some())
         .collect::<Vec<_>>();
+    tracker
+        .encounters
+        .retain(|encounter_id, _| encounter_ids.contains(encounter_id));
     let mut events = Vec::new();
     for encounter_id in encounter_ids {
-        if !focused_combat_turn_needs_recovery(state, &runtime, encounter_id) {
+        if tracker.is_backing_off(encounter_id, now) {
             continue;
         }
-        let status =
-            drive_available_combat_turns(state, &mut runtime, encounter_id, 0, &mut events)?;
-        if status != CW_OK {
-            return Err(io::Error::other(format!(
-                "focused encounter {encounter_id} recovery failed with status {status}"
-            )));
+        if !focused_combat_turn_needs_recovery(state, &runtime, encounter_id) {
+            tracker.clear(encounter_id);
+            continue;
+        }
+        // One encounter's failure must not abandon the sweep: the rest of the
+        // world still needs its turns driven.
+        let outcome =
+            drive_available_combat_turns(state, &mut runtime, encounter_id, 0, &mut events);
+        let (deterministic, detail) = match outcome {
+            Ok(CW_OK) => {
+                tracker.clear(encounter_id);
+                continue;
+            }
+            Ok(status) => (
+                focused_recovery_status_is_deterministic(status),
+                format!("status {status}"),
+            ),
+            Err(error) => (false, format!("error {error}")),
+        };
+        if !tracker.record_failure(encounter_id, deterministic, now) {
+            warn!("focused encounter {encounter_id} recovery failed with {detail}; will retry");
+            continue;
+        }
+        match abandon_stuck_encounter(state, &mut runtime, encounter_id, &mut events) {
+            Ok(CW_OK) => {
+                warn!(
+                    "focused encounter {encounter_id} could not recover ({detail}); closed it and released its participants"
+                );
+                tracker.clear(encounter_id);
+            }
+            Ok(status) => warn!(
+                "focused encounter {encounter_id} could not recover ({detail}) and closing it was rejected with status {status}"
+            ),
+            Err(error) => warn!(
+                "focused encounter {encounter_id} could not recover ({detail}) and closing it failed: {error}"
+            ),
         }
     }
-    Ok(events)
+    events
 }
 
 pub(super) fn start_focused_encounter_scheduler(state: AppState) {
     tokio::spawn(async move {
+        let mut tracker = FocusedRecoveryTracker::default();
         loop {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            match recover_available_combat_turns(&state).await {
-                Ok(events) if !events.is_empty() => broadcast_events(&state, &events),
-                Ok(_) => {}
-                Err(error) => warn!("focused encounter recovery failed: {error}"),
+            let events = recover_available_combat_turns(&state, &mut tracker).await;
+            if !events.is_empty() {
+                broadcast_events(&state, &events);
             }
             match recover_available_focused_job_turns(&state).await {
                 Ok(events) if !events.is_empty() => broadcast_events(&state, &events),
@@ -1254,10 +1391,10 @@ mod tests {
         ));
         let _ = fs::remove_file(&path);
         let state = test_app_state(runtime, Some(path.clone()));
+        let mut tracker = FocusedRecoveryTracker::default();
         assert!(
-            recover_available_combat_turns(&state)
+            recover_available_combat_turns(&state, &mut tracker)
                 .await
-                .expect("idle recovery succeeds")
                 .is_empty(),
             "a scene with nobody available must not churn Pass records"
         );
@@ -1267,9 +1404,7 @@ mod tests {
             actor_for_session(&state.actor_sessions, &session),
             Some(5000)
         );
-        let events = recover_available_combat_turns(&state)
-            .await
-            .expect("focused scheduler recovery succeeds");
+        let events = recover_available_combat_turns(&state, &mut tracker).await;
         assert!(events
             .iter()
             .any(|event| { event.type_name == "combat.pass" && event.actor_id == Some(5001) }));
@@ -1291,6 +1426,171 @@ mod tests {
             assert_eq!(replayed.apply_journal_record(record).0, CW_OK);
         }
         assert_eq!(replayed.combat_current_actor_id(encounter_id), Some(5000));
+        let _ = fs::remove_file(path);
+    }
+
+    /// Production ran this loop for seven hours on 2026-07-28: an encounter
+    /// whose current participant can never complete a turn fails recovery with
+    /// the same deterministic status every sweep. The scheduler must give up
+    /// and close the scene instead of holding the runtime lock forever.
+    #[tokio::test]
+    async fn a_stuck_focused_encounter_is_closed_after_bounded_recovery_failures() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Held Witness",
+        );
+        create_test_human(&mut runtime, 5001, MOONLIT_TRAIL_LOCATION_ID, "Stuck Rival");
+        for (actor_id, dexterity) in [(5000, 50), (5001, 100)] {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == actor_id)
+                .expect("stuck encounter participant");
+            actor.stats.dexterity = dexterity;
+            actor.stats.hp_base = 100;
+            runtime
+                .actor_autonomy
+                .entry(actor_id)
+                .or_default()
+                .control_mode = ActorControlMode::DirectInput;
+        }
+        let encounter_id = combat_encounter_id(MOONLIT_JOB_ID);
+        let start = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_COMBAT_START,
+                actor_id: 5001,
+                target_actor_id: 5000,
+                content_id: encounter_id,
+                ..CwAction::default()
+            },
+            72_310,
+        )
+        .into_system();
+        assert_eq!(runtime.apply_journal_record(&start).0, CW_OK);
+        assert_eq!(runtime.combat_current_actor_id(encounter_id), Some(5001));
+
+        // Strand the scene the way production was stranded: the participant
+        // holding the turn can no longer act, so no Pass will ever be accepted
+        // for them and the encounter can never advance on its own.
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|actor| actor.id == 5001)
+            .expect("stuck current participant")
+            .status = CW_ACTOR_KNOCKED_OUT;
+
+        let replay_base = RuntimeSnapshot::from_runtime(&runtime);
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-stuck-encounter-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        let state = test_app_state(runtime, Some(path.clone()));
+        let (session, _) = issue_actor_session(&state, 5000);
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &session),
+            Some(5000)
+        );
+
+        let mut tracker = FocusedRecoveryTracker::default();
+        for attempt in 1..FOCUSED_RECOVERY_DETERMINISTIC_FAILURE_LIMIT {
+            let events = recover_available_combat_turns(&state, &mut tracker).await;
+            assert!(
+                !events
+                    .iter()
+                    .any(|event| event.type_name == "combat.encounter.resolved"),
+                "the scene must not close before its recovery budget is spent"
+            );
+            let failures = tracker
+                .encounters
+                .get_mut(&encounter_id)
+                .expect("a failed recovery is tracked");
+            assert_eq!(failures.consecutive, attempt);
+            assert!(
+                failures.retry_after.is_some(),
+                "a deterministic failure must back off instead of retrying every second"
+            );
+            // Serve the backoff instantly so the test spends the budget without
+            // sleeping; the assertion above is what pins the backoff itself.
+            failures.retry_after = None;
+        }
+
+        let events = recover_available_combat_turns(&state, &mut tracker).await;
+        let resolved = events
+            .iter()
+            .find(|event| event.type_name == "combat.encounter.resolved")
+            .expect("the exhausted scene closes");
+        assert!(resolved.success);
+        assert_eq!(resolved.content_id, Some(encounter_id));
+        // The kernel resolves an abandoned scene with winning side 0, which the
+        // projection carries as absent. Both clients already read that as "the
+        // scuffle is over for now" rather than announcing a victor.
+        assert_eq!(
+            resolved.total, None,
+            "an abandoned scene has no winning side"
+        );
+
+        let runtime = state.inner.lock().await;
+        assert!(
+            runtime.active_combat_encounter(encounter_id).is_none(),
+            "the encounter is closed"
+        );
+        // Participants are released back to ordinary presence.
+        for actor_id in [5000, 5001] {
+            assert!(
+                runtime
+                    .active_combat_encounter_for_actor(actor_id)
+                    .is_none(),
+                "actor {actor_id} is released from the closed scene"
+            );
+        }
+        let offered = runtime
+            .state_response(Some(5000), &AccessContext::default())
+            .primary_action
+            .options
+            .iter()
+            .map(|option| option.kind.clone())
+            .collect::<Vec<_>>();
+        for ordinary in ["work", "search"] {
+            assert!(
+                offered.iter().any(|kind| kind == ordinary),
+                "ordinary play offers {ordinary} again once the scene closes; got {offered:?}"
+            );
+        }
+        drop(runtime);
+
+        let journal = read_action_journal(&path).expect("stuck encounter journal");
+        assert!(
+            journal.iter().any(|record| {
+                record.action.kind == CW_ACTION_COMBAT_ABANDON
+                    && record.action.content_id == encounter_id
+                    && record.origin == JournalOrigin::System
+            }),
+            "the closure is journaled so it is not invented at read time"
+        );
+
+        let mut replayed = replay_base
+            .into_runtime()
+            .expect("stuck encounter checkpoint restores");
+        assert!(
+            replayed.active_combat_encounter(encounter_id).is_some(),
+            "the restored checkpoint still holds the stuck scene open"
+        );
+        for record in &journal {
+            replayed.apply_journal_record(record);
+        }
+        assert!(
+            replayed.active_combat_encounter(encounter_id).is_none(),
+            "replay reproduces the closure"
+        );
         let _ = fs::remove_file(path);
     }
 

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -21,9 +21,12 @@ pub const CW_MAX_COMBAT_PARTICIPANTS: usize = 16;
 pub const CW_ITEM_DEFAULT_WEIGHT_TENTHS: u16 = 10;
 
 // Kernel version 9 is reserved by #411 for project-push ABI state.
-pub const CW_KERNEL_VERSION: u32 = 10;
+pub const CW_KERNEL_VERSION: u32 = 11;
 
 pub const CW_OK: u32 = 0;
+pub const CW_ERR_INVALID: u32 = 1;
+pub const CW_ERR_FULL: u32 = 2;
+pub const CW_ERR_NOT_FOUND: u32 = 3;
 pub const CW_ERR_RULE: u32 = 4;
 
 pub const CW_ACTOR_HUMAN: u8 = 1;
@@ -129,6 +132,10 @@ pub const CW_ACTION_RULES_UTILIZE_ITEM: u8 = 30;
 pub const CW_ACTION_PROJECT_PUSH: u8 = 31;
 // Action 31 is reserved by #411 for CW_ACTION_PROJECT_PUSH.
 pub const CW_ACTION_REST: u8 = 32;
+// Terminal closure for an encounter that can never advance again. Committed
+// only by the focused-encounter scheduler after bounded deterministic recovery
+// failures; see `combat::start_focused_encounter_scheduler`.
+pub const CW_ACTION_COMBAT_ABANDON: u8 = 33;
 
 pub const CW_EVENT_ACTOR_CREATED: u8 = 2;
 pub const CW_EVENT_ITEM_PICKED_UP: u8 = 7;

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -295,6 +295,7 @@ pub(super) fn focused_encounter_context_for_action(
         | CW_ACTION_COMBAT_FINESSE_ATTACK
         | CW_ACTION_COMBAT_DODGE
         | CW_ACTION_COMBAT_ESCAPE
+        | CW_ACTION_COMBAT_ABANDON
         | CW_ACTION_COMBAT_PASS => FocusedActivationStep::Commit,
         _ => return None,
     };
@@ -460,6 +461,7 @@ pub(super) fn action_concurrency_policy(kind: u8) -> ConcurrencyPolicy {
         | CW_ACTION_COMBAT_DODGE
         | CW_ACTION_COMBAT_ESCAPE
         | CW_ACTION_COMBAT_PASS
+        | CW_ACTION_COMBAT_ABANDON
         | CW_ACTION_COMBAT_NEED_TIME => ConcurrencyPolicy::SceneTurn,
         CW_ACTION_PICK_UP_ITEM
         | CW_ACTION_DROP_ITEM

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -7802,7 +7802,13 @@ async function main() {
       await page.waitForFunction(() => !(state?.tags || []).some((tag) => tag.label === "tired"));
       if ((await currentLocation()) !== "Moonlit Trail") await travelTo("Moonlit Trail");
     }
-    let firstListenCommitted = false;
+    let firstListenCommitted = startingState.economy?.listen_attempted_here === true;
+    if (firstListenCommitted) {
+      steps.push({
+        label: "frontier notice already attempted",
+        location: await currentLocation(),
+      });
+    }
     for (let attempt = 1; attempt <= 3 && !firstListenCommitted; attempt += 1) {
       const firstListen = await drawPrimaryMatching("first frontier notice", ["notice", "for a clue"]);
       steps.push({ label: "first frontier notice", primary: firstListen, location: await currentLocation(), attempt });
@@ -11039,20 +11045,51 @@ async function main() {
         ["take", "swap"].includes(String(action.label || "").toLowerCase())
           && String(action.detail || action.command || "").toLowerCase().includes("wolfprint charm")
       )));
+      let primerCommitted = false;
+      progressPrimer = wolfprintAvailable ? "feature use" : "safe help";
       if (wolfprintAvailable) {
         await takeItem("Wolfprint Charm");
         const projectCluePrimary = await primaryText();
         steps.push({ label: "project clue default", primary: projectCluePrimary });
-        if (projectCluePrimary.toLowerCase().includes("search")) {
-          await clickPrimary("search project clue");
+        const projectClueNeedles = await page.evaluate(() => {
+          const visibleActions = actions.map((action) => [
+            action.label,
+            action.detail,
+            action.command,
+          ].filter(Boolean).join(" ").toLowerCase());
+          if (visibleActions.some((text) => text.includes("investigate this place"))) {
+            return ["investigate this place"];
+          }
+          if (visibleActions.some((text) => (
+            text.includes("search") && text.includes("moonlit trail")
+          ))) {
+            return ["search", "moonlit trail"];
+          }
+          return null;
+        });
+        if (projectClueNeedles) {
+          await drawPrimaryMatching("investigate project clue", projectClueNeedles);
+          await clickPrimary("investigate project clue");
           await page.waitForFunction(
             () => !document.querySelector("#primary")?.disabled,
           );
+          const projectAfterClue = await fetchCurrentState();
+          const projectProgressAfterClue = (projectAfterClue.clocks || []).find(
+            (clock) => clock.id === "moonlit-trail.progress",
+          );
+          primerCommitted = Number(projectProgressAfterClue?.filled || 0)
+            > Number(projectProgressBeforePrimer?.filled || 0);
+          if (primerCommitted) {
+            progressPrimer = "investigate project clue";
+            steps.push({
+              label: "investigation primed project",
+              progress: Number(projectProgressAfterClue?.filled || 0),
+            });
+          }
         }
       }
-      progressPrimer = wolfprintAvailable ? "feature use" : "safe help";
-      let featureUseCommitted = false;
-      if (wolfprintAvailable) {
+      let featureUseCommitted = primerCommitted;
+      if (wolfprintAvailable && !featureUseCommitted) {
         try {
           const projectUsePrimary = await drawPrimaryMatching(
             "project feature use",
@@ -11082,15 +11119,39 @@ async function main() {
           await clickPrimary("rest before helping project");
           progressPrimer = "rest then safe help";
         }
-        const projectHelpPrimary = await drawPrimaryMatching(
-          "project safe help",
-          ["steady the trail together", "coach"],
-        );
-        assert(
-          projectHelpPrimary.toLowerCase().includes("quiet the echo"),
-          "fallback project help should retain the authored project card",
-        );
-        await clickPrimary("help project safely");
+        const legacyProjectHelpAvailable = await page.evaluate(() => (
+          actions.some((action) => {
+            const text = [
+              action.label,
+              action.detail,
+              action.command,
+              ...(action.choices || []).flatMap((choice) => [choice.label, choice.detail]),
+            ].filter(Boolean).join(" ").toLowerCase();
+            return text.includes("steady the trail together") && text.includes("coach");
+          })
+        ));
+        if (legacyProjectHelpAvailable) {
+          const projectHelpPrimary = await drawPrimaryMatching(
+            "project safe help",
+            ["steady the trail together", "coach"],
+          );
+          assert(
+            projectHelpPrimary.toLowerCase().includes("quiet the echo"),
+            "fallback project help should retain the authored project card",
+          );
+          await clickPrimary("help project safely");
+        } else {
+          const projectInvestigatePrimary = await drawPrimaryMatching(
+            "project safe investigation",
+            ["investigate this place", "moonlit trail"],
+          );
+          assert(
+            projectInvestigatePrimary.toLowerCase().includes("choose an approach"),
+            "fallback project investigation should retain its authored approaches",
+          );
+          await clickPrimary("investigate project safely");
+          progressPrimer = "safe investigation";
+        }
       }
     }
     await page.waitForFunction(() => {


### PR DESCRIPTION
Closes #543.

## What changed

- classify focused-encounter recovery failures as deterministic or transient
- back deterministic failures off for 30 seconds instead of retrying every scheduler tick
- cap recovery at 3 deterministic or 20 transient failures per encounter
- journal a terminal sideless encounter closure after the cap so replay reproduces it and participants return to ordinary play
- add kernel ABI action 33 for that orchestrator-only closure and reject unrelated actors
- update the fresh-seed browser gate for the current `investigate` project-clue affordance
- release as `0.0.244`

## Validation

- exact stuck-encounter closure/replay regression
- kernel suite
- `npm run check`
  - 503 JavaScript tests
  - worldpack, proof-world, and kernel checks
  - 820 Rust tests
  - architecture and clippy ceilings
  - syntax checks
- `npm run v2:browser:check`
