### PR TITLE
Add bounded Fly volume headroom controls

### DIFF
--- a/.github/workflows/volume-headroom.yml
+++ b/.github/workflows/volume-headroom.yml
@@ -1,0 +1,46 @@
+name: Volume headroom
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: volume-headroom-${{ github.repository }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  primary:
+    name: Primary volume below 70%
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Check primary volume headroom
+        run: scripts/check-fly-volume-space.sh cosyworld /data 70
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  lonely-forest:
+    name: Lonely Forest volume below 70%
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Check Lonely Forest volume headroom
+        run: scripts/check-fly-volume-space.sh cosyworld-lonelyforest /data 70
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}

--- a/docs/deployment/07-deployment.md
+++ b/docs/deployment/07-deployment.md
@@ -146,6 +146,10 @@ NODE_OPTIONS="--max-old-space-size=4096"
 - V2 health endpoints: `/health`, `/meta`
 - Node companion runtime discovery: `/api/runtime`
 - Logs: platform logs or `/logs/` for legacy Node deployments
+- Fly volume headroom: the scheduled `Volume headroom` GitHub Actions workflow
+  checks both production `/data` mounts every 15 minutes and fails at 70% used.
+  The mounts auto-extend at 80% in 1 GB increments, capped at 5 GB; the deploy
+  gate remains a separate fail-closed check at 85%.
 
 ---
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,6 +14,19 @@ immutable registry digest, then deploys the same digest with
 `fly.lonelyforest.toml`. The two apps run identical code with independent
 volumes and WebAuthn relying-party domains.
 
+## Volume headroom
+
+Both Fly data volumes extend automatically at 80% usage in 1 GB increments,
+up to a 5 GB ceiling. The deploy workflow still refuses to deploy at 85% so a
+failed or exhausted auto-extension cannot be hidden by a release.
+
+`.github/workflows/volume-headroom.yml` checks both volumes every 15 minutes
+and fails its app-specific job at 70% usage. Operators should subscribe to
+GitHub Actions failure notifications for the `Volume headroom` workflow. A
+failure at 70% is an alert to inspect SQLite and generated-asset growth before
+the 80% automatic extension is needed; reaching the 5 GB limit requires a
+retention or capacity decision rather than another automatic increase.
+
 ## Lonely Forest infrastructure
 
 Application releases no longer build ECR images or update ECS. AWS remains the

--- a/fly.lonelyforest.toml
+++ b/fly.lonelyforest.toml
@@ -44,6 +44,11 @@ primary_region = "sjc"
 [[mounts]]
   source = "lonelyforest_data"
   destination = "/data"
+  # Keep the installation writable through a growth spike without allowing
+  # unbounded storage spend.
+  auto_extend_size_threshold = 80
+  auto_extend_size_increment = "1GB"
+  auto_extend_size_limit = "5GB"
 
 # Deploy strategy stays `rolling`: bluegreen/canary would boot a second
 # machine beside this one, and the /data volume is single-writer — two

--- a/fly.toml
+++ b/fly.toml
@@ -39,6 +39,12 @@ primary_region = "sjc"
 [[mounts]]
   source = "cosyworld_data"
   destination = "/data"
+  # Extend before the 85% deploy guard can become the only warning. The 5 GB
+  # ceiling bounds spend while leaving several recovery windows after the
+  # 2026-07-28 full-disk outage.
+  auto_extend_size_threshold = 80
+  auto_extend_size_increment = "1GB"
+  auto_extend_size_limit = "5GB"
 
 [[vm]]
   cpu_kind = "shared"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.244",
+  "version": "0.0.245",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.244",
+      "version": "0.0.245",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.244",
+  "version": "0.0.245",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -5,6 +5,10 @@ const workflow = readFileSync(
   new URL('../../.github/workflows/deploy.yml', import.meta.url),
   'utf8'
 );
+const volumeHeadroomWorkflow = readFileSync(
+  new URL('../../.github/workflows/volume-headroom.yml', import.meta.url),
+  'utf8'
+);
 const primaryFlyConfig = readFileSync(
   new URL('../../fly.toml', import.meta.url),
   'utf8'
@@ -48,6 +52,37 @@ describe('deploy workflow', () => {
     expect(fly).not.toContain('--image');
     expect(workflow).not.toContain('\n  aws:');
     expect(job('github-release')).toContain('needs: [fly]');
+  });
+
+  it('auto-extends both data volumes before the deploy guard, with bounded spend', () => {
+    for (const config of [primaryFlyConfig, lonelyForestFlyConfig]) {
+      expect(config).toContain('auto_extend_size_threshold = 80');
+      expect(config).toContain('auto_extend_size_increment = "1GB"');
+      expect(config).toContain('auto_extend_size_limit = "5GB"');
+    }
+
+    const fly = job('fly', 'github-release');
+    expect(fly).toContain('check-fly-volume-space.sh cosyworld /data 85');
+    expect(fly).toContain(
+      'check-fly-volume-space.sh cosyworld-lonelyforest /data 85'
+    );
+    expect(80).toBeLessThan(85);
+  });
+
+  it('checks production volume headroom every fifteen minutes', () => {
+    expect(volumeHeadroomWorkflow).toContain('cron: "*/15 * * * *"');
+    expect(volumeHeadroomWorkflow).toContain(
+      'check-fly-volume-space.sh cosyworld /data 70'
+    );
+    expect(volumeHeadroomWorkflow).toContain(
+      'check-fly-volume-space.sh cosyworld-lonelyforest /data 70'
+    );
+    expect(volumeHeadroomWorkflow).toContain(
+      'FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}'
+    );
+    expect(volumeHeadroomWorkflow).toContain(
+      'FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}'
+    );
   });
 
   it('keeps the image workshop configured on both Fly tenants', () => {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.244"
+version = "0.0.245"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.244"
+version = "0.0.245"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- auto-extend both production Fly data volumes at 80% usage
- grow in bounded 1 GB increments with a 5 GB ceiling
- check both app volumes every 15 minutes and fail app-specific monitor jobs at 70%
- retain the independent fail-closed 85% pre-deploy guard
- document the operator thresholds and notification path

## Validation

- `flyctl config validate --config fly.toml`
- `flyctl config validate --config fly.lonelyforest.toml`
- `npm run check` (505 JavaScript tests, worldpack/proof/kernel checks, 820 Rust tests, architecture and syntax gates)

This does not delete or mutate the primary volume's legacy MongoDB or reset-backup payload. That retention decision remains explicit.

Refs #500
