### PR TITLE
Make Travel and Scout route affordances truthful

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.245",
+  "version": "0.0.246",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.245",
+      "version": "0.0.246",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.245",
+  "version": "0.0.246",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.245"
+version = "0.0.246"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.245"
+version = "0.0.246"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -62939,15 +62939,15 @@ mod tests {
                 .any(|offer| offer.kind == "create_bond"),
             "only advancement-backed Befriend is gated at zero advancement"
         );
-        let move_offer = state
+        let scout_offer = state
             .action_offers
             .iter()
-            .find(|offer| offer.kind == "move")
-            .expect("move offer is exposed");
-        assert_eq!(move_offer.category, "travel");
-        assert_eq!(move_offer.intention, "travel");
-        assert_eq!(move_offer.verb, "Travel");
-        assert!(move_offer.accessible_label.starts_with("Travel to "));
+            .find(|offer| offer.kind == "explore_path")
+            .expect("Scout is exposed instead of false Travel");
+        assert_eq!(scout_offer.category, "travel");
+        assert_eq!(scout_offer.intention, "scout");
+        assert_eq!(scout_offer.verb, "Scout");
+        assert!(scout_offer.accessible_label.starts_with("Scout toward "));
 
         let inspector = state.inspector;
         assert_eq!(inspector.location_id, MOONLIT_TRAIL_LOCATION_ID);

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -338,6 +338,11 @@ impl RuntimeWorld {
         if let Some((action, mutation, narration)) =
             self.plan_journey_move(actor_id, destination_location_id)?
         {
+            if action.kind != CW_ACTION_MOVE {
+                return Err(
+                    "That route still needs scouting before it can be travelled.".to_string(),
+                );
+            }
             return Ok(MovementPlan::Journey {
                 action,
                 mutation: Box::new(mutation),
@@ -367,7 +372,7 @@ impl RuntimeWorld {
         self.plan_move_offer_action(actor_id, &offer, access)
     }
 
-    fn movement_offer_exits(&self, actor_id: u64, access: &AccessContext) -> Vec<ExitView> {
+    fn accessible_movement_exits(&self, actor_id: u64, access: &AccessContext) -> Vec<ExitView> {
         let Some(actor) = self
             .actor_by_id(actor_id)
             .filter(|actor| Self::actor_can_act(*actor))
@@ -389,6 +394,13 @@ impl RuntimeWorld {
             )
         });
         exits
+    }
+
+    fn movement_offer_exits(&self, actor_id: u64, access: &AccessContext) -> Vec<ExitView> {
+        self.accessible_movement_exits(actor_id, access)
+            .into_iter()
+            .filter(|exit| exit.distance <= 1)
+            .collect()
     }
 
     fn retarget_route_action_offer(
@@ -478,8 +490,13 @@ impl RuntimeWorld {
                 expanded.push(offer);
                 continue;
             }
-            expanded.extend(
+            let exits = if offer.kind == "flee" {
+                self.accessible_movement_exits(actor_id, access)
+            } else {
                 self.movement_offer_exits(actor_id, access)
+            };
+            expanded.extend(
+                exits
                     .into_iter()
                     .map(|exit| self.retarget_route_action_offer(actor_id, offer.clone(), exit)),
             );
@@ -488,12 +505,7 @@ impl RuntimeWorld {
     }
 
     pub(super) fn has_accessible_exit(&self, actor_id: u64, access: &AccessContext) -> bool {
-        let Some(actor) = self.actor_by_id(actor_id) else {
-            return false;
-        };
-        self.exit_views(actor.location_id, access)
-            .into_iter()
-            .any(|exit| exit.accessible && !exit.locked)
+        !self.accessible_movement_exits(actor_id, access).is_empty()
     }
 }
 
@@ -700,7 +712,7 @@ mod tests {
     }
 
     #[test]
-    fn movement_offers_bind_every_accessible_route_for_every_controller() {
+    fn movement_offers_bind_every_immediately_travelable_route_for_every_controller() {
         let mut runtime = RuntimeWorld::seeded();
         runtime
             .world
@@ -727,13 +739,17 @@ mod tests {
         let access = AccessContext::default();
         let exits = runtime.movement_offer_exits(RATI_ACTOR_ID, &access);
         assert!(
-            exits.len() >= 2,
-            "the route parity fixture needs at least two accessible exits"
+            !exits.is_empty(),
+            "the route parity fixture needs an immediately travelable exit"
         );
         let expected_destination_ids = exits
             .iter()
             .map(|exit| exit.destination_location_id)
             .collect::<Vec<_>>();
+        assert!(
+            exits.iter().all(|exit| exit.distance <= 1),
+            "Travel only binds routes whose next open step is immediately walkable"
+        );
 
         let direct_offers = runtime
             .legal_action_candidates(Some(RATI_ACTOR_ID), &access)
@@ -929,6 +945,18 @@ mod tests {
             long_destinations.len() >= 2,
             "the fixture must expose multiple long routes"
         );
+        let travel_destinations = initial
+            .action_offers
+            .iter()
+            .filter(|offer| offer.kind == "move")
+            .filter_map(|offer| offer.target.as_ref().and_then(|target| target.id))
+            .collect::<BTreeSet<_>>();
+        assert!(
+            long_destinations
+                .iter()
+                .all(|destination| !travel_destinations.contains(destination)),
+            "a route that still requires discovery must say Scout, not Travel"
+        );
         let scout_offers = initial
             .action_offers
             .iter()
@@ -956,6 +984,12 @@ mod tests {
             .filter(|target| target.kind == "location")
             .and_then(|target| target.id)
             .expect("Scout offer has an exact destination");
+        assert_eq!(
+            runtime
+                .plan_move_choice_action(actor_id, offered_destination, &access)
+                .expect_err("Scout-only routes cannot be submitted as Travel"),
+            "That Travel offer is no longer current."
+        );
         let forged_destination = long_destinations
             .iter()
             .copied()

--- a/v2/orchestrator-rust/src/rest.rs
+++ b/v2/orchestrator-rust/src/rest.rs
@@ -703,6 +703,14 @@ mod tests {
             runtime.frontier_travel_since_rest_required(5000)
         );
 
+        let (scout_action, scout_mutation, _) = runtime
+            .plan_scout_choice_action(5000, MOONLIT_TRAIL_LOCATION_ID)
+            .expect("the frontier route can be scouted");
+        let mut scout_record = JournalRecord::new(scout_action, 18_711);
+        scout_record.bind_offer_kind("explore_path");
+        scout_record.projection_mutations.push(scout_mutation);
+        assert_eq!(runtime.apply_journal_record(&scout_record).0, CW_OK);
+        let frontier_step_id = runtime.journeys[&5000].path[1];
         let state = runtime.state_response(Some(5000), &AccessContext::default());
         let safe_offer = state
             .action_offers
@@ -722,10 +730,9 @@ mod tests {
             .iter()
             .find(|offer| {
                 offer.kind == "move"
-                    && offer.target.as_ref().and_then(|target| target.id)
-                        == Some(MOONLIT_TRAIL_LOCATION_ID)
+                    && offer.target.as_ref().and_then(|target| target.id) == Some(frontier_step_id)
             })
-            .expect("full-ring weary actor keeps a frontier-bound Travel offer");
+            .expect("full-ring weary actor can Travel the revealed frontier step");
         assert!(frontier_offer
             .risk
             .as_deref()


### PR DESCRIPTION
Closes #541

## Summary
- only expose Travel for an immediately walkable open route step
- keep Scout as the affordance for routes that still require discovery
- reject any Travel plan that would resolve as a discovery action
- preserve combat Flee across every accessible exit and preserve frontier travel risk on revealed steps
- bump the release to 0.0.246

## Verification
- `npm run check`
- 505 Vitest tests
- official/composed worldpack gates and strict proof-world check
- C kernel suite
- 820 Rust tests
- architecture, clippy, and syntax gates