### PR TITLE
Reject repeated resident catchphrases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.249",
+  "version": "0.0.250",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.249",
+      "version": "0.0.250",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.249",
+  "version": "0.0.250",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.249"
+version = "0.0.250"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.249"
+version = "0.0.250"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -8,6 +8,8 @@ use sha2::{Digest, Sha256};
 use std::{collections::BTreeSet, io, path::Path};
 
 pub(crate) const AI_PUBLICATION_RECEIPT_VERSION: u32 = 1;
+pub(crate) const VOICE_SIGNATURE_SHINGLE_WIDTH: usize = 4;
+const VOICE_SIGNATURE_WORD_LIMIT: usize = 64;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -82,6 +84,7 @@ pub(crate) struct SpeechGateContext {
     pub(crate) max_words: usize,
     pub(crate) anchors: Vec<String>,
     pub(crate) recent_lines: Vec<String>,
+    pub(crate) recent_speaker_shingle_hashes: Vec<u64>,
     pub(crate) has_proposed_action: bool,
     pub(crate) envelope_valid: bool,
     pub(crate) candidate_round: u8,
@@ -275,6 +278,7 @@ pub(crate) fn certified_test_speech(
         max_words: 80,
         anchors: vec!["Keeper Brass Key".to_string()],
         recent_lines: Vec::new(),
+        recent_speaker_shingle_hashes: Vec::new(),
         has_proposed_action: false,
         envelope_valid: true,
         candidate_round: 1,
@@ -484,7 +488,8 @@ fn evaluate_checks(
             !context
                 .recent_lines
                 .iter()
-                .any(|recent| near_duplicate(text, recent)),
+                .any(|recent| near_duplicate(text, recent))
+                && !shares_recent_speaker_phrase(text, &context.recent_speaker_shingle_hashes),
         ),
         (
             PublicationCheckCode::VoiceUnsafeTone,
@@ -571,6 +576,32 @@ fn has_repeated_ngram(value: &str, width: usize) -> bool {
     words
         .windows(width)
         .any(|window| !seen.insert(window.join("\u{1f}")))
+}
+
+pub(crate) fn voice_signature_shingle_hashes(value: &str) -> Vec<u64> {
+    let words = normalized_words(value)
+        .into_iter()
+        .take(VOICE_SIGNATURE_WORD_LIMIT)
+        .collect::<Vec<_>>();
+    words
+        .windows(VOICE_SIGNATURE_SHINGLE_WIDTH)
+        .map(|window| {
+            crate::stable_hash_u64(&["voice-signature-shingle/v1", &window.join("\u{1f}")])
+        })
+        .collect()
+}
+
+fn shares_recent_speaker_phrase(value: &str, recent_shingle_hashes: &[u64]) -> bool {
+    if recent_shingle_hashes.is_empty() {
+        return false;
+    }
+    let recent = recent_shingle_hashes
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    voice_signature_shingle_hashes(value)
+        .into_iter()
+        .any(|hash| recent.contains(&hash))
 }
 
 fn has_multiple_speakers(value: &str, speaker_name: &str) -> bool {
@@ -828,6 +859,7 @@ mod tests {
             max_words: 8,
             anchors: anchors.to_vec(),
             recent_lines: recent.to_vec(),
+            recent_speaker_shingle_hashes: Vec::new(),
             has_proposed_action: false,
             envelope_valid: true,
             candidate_round: 1,
@@ -1042,6 +1074,31 @@ mod tests {
     }
 
     #[test]
+    fn voice_recent_duplicate_rejects_the_real_cross_line_catchphrase_shape() {
+        let prior = "Bethlehem at last! My biscuit survived the journey, though my knees are filing a formal complaint.";
+        let candidate = "Bethlehem at last—my biscuit survived the journey, though it now has the structural integrity of damp parchment.";
+        let mut gate = context(&["Bethlehem".to_string()], &[]);
+        gate.max_words = 30;
+        gate.recent_speaker_shingle_hashes = voice_signature_shingle_hashes(prior);
+
+        assert_eq!(
+            rejected_code(candidate, gate),
+            PublicationCheckCode::VoiceRecentDuplicate
+        );
+    }
+
+    #[test]
+    fn voice_recent_duplicate_does_not_reject_a_three_word_coincidence() {
+        let prior = "My boots filed a formal complaint beside the Bethlehem gate.";
+        let candidate = "Bethlehem's bell made a formal complaint at dusk.";
+        let mut gate = context(&["Bethlehem".to_string()], &[]);
+        gate.recent_speaker_shingle_hashes = voice_signature_shingle_hashes(prior);
+
+        certify_speech(None, completion(candidate), candidate, gate)
+            .expect("a shared phrase shorter than four words remains eligible");
+    }
+
+    #[test]
     fn voice_unsafe_tone_check_is_deterministic() {
         let anchors = vec!["teapot".to_string()];
         assert_eq!(
@@ -1243,6 +1300,7 @@ mod tests {
                 max_words: 20,
                 anchors: vec!["teapot".to_string()],
                 recent_lines: Vec::new(),
+                recent_speaker_shingle_hashes: Vec::new(),
                 has_proposed_action: false,
                 envelope_valid: true,
                 candidate_round: 1,
@@ -1303,6 +1361,7 @@ mod tests {
                 max_words: 12,
                 anchors: vec!["teapot".to_string()],
                 recent_lines: Vec::new(),
+                recent_speaker_shingle_hashes: Vec::new(),
                 has_proposed_action: false,
                 envelope_valid: true,
                 candidate_round: 1,

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -1437,6 +1437,7 @@ mod tests {
             max_words: 20,
             anchors: vec!["teapot".to_string()],
             recent_lines: Vec::new(),
+            recent_speaker_shingle_hashes: Vec::new(),
             has_proposed_action: false,
             envelope_valid: true,
             candidate_round: 1,
@@ -1820,6 +1821,61 @@ mod tests {
             .unwrap();
         assert_eq!(status, "unavailable");
         let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn repeated_signature_phrase_exhaustion_stays_inside_the_attempt_budget() {
+        let config = three_candidates(VoiceRoutingConfig {
+            max_attempts: 3,
+            hedge_width: 2,
+            ..VoiceRoutingConfig::default()
+        });
+        let backend = MockBackend::with_outputs([
+            (
+                "provider/tiny-a",
+                "Bethlehem at last, my biscuit survived the journey beneath clear bells.",
+                0,
+            ),
+            (
+                "provider/tiny-b",
+                "Bethlehem at last, my biscuit survived the journey through silver rain.",
+                0,
+            ),
+            (
+                "provider/small-c",
+                "Bethlehem at last, my biscuit survived the journey beside warm lanterns.",
+                0,
+            ),
+        ]);
+        let mut publication_gate = gate("signature-exhausted-beat");
+        publication_gate.max_words = 24;
+        publication_gate.anchors = vec!["Bethlehem".to_string()];
+        publication_gate.recent_speaker_shingle_hashes =
+            crate::ai_publication::voice_signature_shingle_hashes(
+                "Bethlehem at last! My biscuit survived the journey, though my knees are filing a formal complaint.",
+            );
+
+        let error = route_certified_voice_with(
+            &config,
+            None,
+            request("dialogue_avatar"),
+            publication_gate,
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect_err("every candidate repeats the same speaker's signature phrase");
+
+        assert_eq!(error.code(), "voice_candidates_exhausted");
+        assert_eq!(error.rejections().len(), 3);
+        assert!(error.rejections().iter().all(|rejection| {
+            rejection.failure_code
+                == crate::ai_publication::PublicationCheckCode::VoiceRecentDuplicate
+        }));
+        assert_eq!(
+            backend.call_count(),
+            3,
+            "phrase rejection never creates an unbounded retry loop"
+        );
     }
 
     #[tokio::test]

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -13538,10 +13538,8 @@ impl RuntimeWorld {
             )
         };
         let views = self.views_from_buffer(&events);
-        self.event_log.extend(views.iter().cloned());
-        if self.event_log.len() > 512 {
-            let excess = self.event_log.len() - 512;
-            self.event_log.drain(0..excess);
+        for view in &views {
+            self.push_projected_event(view.clone());
         }
         (status, views)
     }
@@ -20551,7 +20549,6 @@ impl RuntimeWorld {
             .rev()
             .take(2)
             .find_map(|line| self.conversation_subject(line, target_actor_id));
-
         Some(AvatarChatPlan {
             actor_id,
             location_id: actor.location_id,
@@ -20583,6 +20580,7 @@ impl RuntimeWorld {
             location_memory: location_meta.memory,
             cast: self.room_cast_names(actor.location_id),
             recent_lines,
+            recent_speaker_shingle_hashes: self.resident_recent_voice_shingle_hashes(actor_id),
             fresh_subject,
             missing_need,
             publication_beat_id: String::new(),

--- a/v2/orchestrator-rust/src/prompts.rs
+++ b/v2/orchestrator-rust/src/prompts.rs
@@ -183,6 +183,8 @@ pub(super) struct AvatarChatPlan {
     pub(super) location_memory: Vec<String>,
     pub(super) cast: Vec<String>,
     pub(super) recent_lines: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(super) recent_speaker_shingle_hashes: Vec<u64>,
     pub(super) fresh_subject: Option<String>,
     pub(super) missing_need: Option<String>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -546,6 +548,7 @@ fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGate
         max_words: if followup { 28 } else { 34 },
         anchors,
         recent_lines: plan.recent_lines.clone(),
+        recent_speaker_shingle_hashes: plan.recent_speaker_shingle_hashes.clone(),
         has_proposed_action: false,
         envelope_valid: true,
         candidate_round: 1,
@@ -574,6 +577,7 @@ fn resident_gate_context(plan: &AvatarReplyPlan, has_proposed_action: bool) -> S
         max_words: resident_word_budget(plan),
         anchors,
         recent_lines: plan.recent_lines.clone(),
+        recent_speaker_shingle_hashes: plan.resident_continuity.recent_voice_shingle_hashes.clone(),
         has_proposed_action,
         envelope_valid: true,
         candidate_round: 1,

--- a/v2/orchestrator-rust/src/residents/continuity.rs
+++ b/v2/orchestrator-rust/src/residents/continuity.rs
@@ -20,6 +20,8 @@ pub(crate) struct ResidentContinuityState {
     pub(crate) pending_planning: Option<ResidentPlanningTrace>,
     #[serde(default)]
     pub(crate) last_planning_disposition: Option<ResidentPlanningDisposition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) recent_voice_shingle_hashes: Vec<u64>,
     pub(crate) open_obligations: Vec<String>,
     pub(crate) current_intent: Option<String>,
     pub(crate) last_observed_event_seq: u64,
@@ -57,6 +59,7 @@ impl ResidentContinuityState {
             pending_action: None,
             pending_planning: None,
             last_planning_disposition: None,
+            recent_voice_shingle_hashes: Vec::new(),
             open_obligations: Vec::new(),
             current_intent: None,
             last_observed_event_seq: 0,
@@ -87,12 +90,18 @@ struct ResidentContinuitySnapshot {
 
 impl ResidentContinuitySnapshot {
     fn from_runtime(runtime: &RuntimeWorld) -> Self {
+        let residents = runtime.world.actors[..runtime.world.actor_count]
+            .iter()
+            .copied()
+            .filter(|resident| RuntimeWorld::actor_can_act(*resident))
+            .map(|resident| (resident.id, runtime.resident_continuity_for(resident)))
+            .collect();
         Self {
             version: 1,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             world_tick: runtime.world.tick,
             latest_event_seq: runtime.world.next_event_seq.saturating_sub(1),
-            residents: runtime.resident_continuities.clone(),
+            residents,
         }
     }
 }
@@ -252,6 +261,8 @@ impl RuntimeWorld {
         continuity.stable_identity = identity;
         continuity.relationship_notes_by_actor = self.resident_relationship_notes(resident.id);
         continuity.memory_atoms = self.resident_continuity_atoms(resident.id, 6);
+        continuity.recent_voice_shingle_hashes =
+            self.resident_recent_voice_shingle_hashes(resident.id);
         let (open_obligations, current_intent) =
             self.resident_open_obligations_and_intent(resident);
         continuity.open_obligations = open_obligations;
@@ -267,6 +278,40 @@ impl RuntimeWorld {
             .last_observed_event_seq
             .max(self.latest_observed_event_seq_for_resident(resident));
         continuity
+    }
+
+    pub(crate) fn resident_recent_voice_shingle_hashes(&self, resident_id: u64) -> Vec<u64> {
+        const RECENT_VOICE_LINE_LIMIT: usize = 12;
+        const RECENT_VOICE_SHINGLE_LIMIT: usize = 192;
+
+        let mut lines = self
+            .recent_room_lines
+            .values()
+            .flat_map(|events| events.iter())
+            .filter(|event| {
+                event.success
+                    && event.type_name == "message.created"
+                    && event.actor_id == Some(resident_id)
+                    && event.content.is_some()
+            })
+            .collect::<Vec<_>>();
+        lines.sort_by_key(|event| event.seq);
+
+        let mut seen = BTreeSet::new();
+        let mut hashes = Vec::new();
+        for line in lines.into_iter().rev().take(RECENT_VOICE_LINE_LIMIT) {
+            for hash in crate::ai_publication::voice_signature_shingle_hashes(
+                line.content.as_deref().unwrap_or_default(),
+            ) {
+                if seen.insert(hash) {
+                    hashes.push(hash);
+                    if hashes.len() == RECENT_VOICE_SHINGLE_LIMIT {
+                        return hashes;
+                    }
+                }
+            }
+        }
+        hashes
     }
 
     pub(crate) fn resident_continuity_for_reaction(
@@ -742,6 +787,60 @@ mod tests {
             .as_deref()
             .map(|intent| !intent.trim().is_empty())
             .unwrap_or(false));
+        let projected = runtime.resident_continuity_for(
+            runtime
+                .actor_by_id(RATI_ACTOR_ID)
+                .expect("Rati remains in the seeded world"),
+        );
+        assert!(!projected.recent_voice_shingle_hashes.is_empty());
+    }
+
+    #[test]
+    fn resident_voice_shingles_follow_the_speaker_across_rooms_and_exclude_other_speakers() {
+        let mut runtime = RuntimeWorld::seeded();
+        runtime.recent_room_lines.clear();
+        runtime.resident_continuities.clear();
+        let rati_line =
+            "Bethlehem at last! My biscuit survived the journey beneath the clear bells.";
+        let other_line = "Only Gust keeps this unrelated lavender umbrella phrase in another room.";
+        runtime.push_projected_event(EventView {
+            seq: 9_001,
+            type_name: "message.created".to_string(),
+            success: true,
+            actor_id: Some(RATI_ACTOR_ID),
+            actor_name: Some("Rati".to_string()),
+            location_id: Some(RAIN_SOFT_GARDEN_LOCATION_ID),
+            content: Some(rati_line.to_string()),
+            ..EventView::default()
+        });
+        runtime.push_projected_event(EventView {
+            seq: 9_002,
+            type_name: "message.created".to_string(),
+            success: true,
+            actor_id: Some(WHISKERWIND_ACTOR_ID),
+            actor_name: Some("Gust".to_string()),
+            location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            content: Some(other_line.to_string()),
+            ..EventView::default()
+        });
+
+        let resident = runtime
+            .actor_by_id(RATI_ACTOR_ID)
+            .expect("Rati exists in the seeded world");
+        let continuity = runtime.resident_continuity_for(resident);
+        let own_hashes = crate::ai_publication::voice_signature_shingle_hashes(rati_line);
+        let other_hashes = crate::ai_publication::voice_signature_shingle_hashes(other_line);
+
+        assert!(own_hashes
+            .iter()
+            .any(|hash| continuity.recent_voice_shingle_hashes.contains(hash)));
+        assert!(!other_hashes
+            .iter()
+            .any(|hash| continuity.recent_voice_shingle_hashes.contains(hash)));
+        assert!(
+            continuity.recent_voice_shingle_hashes.len() <= 192,
+            "the persisted speaker memory stays bounded"
+        );
     }
 
     #[test]
@@ -859,6 +958,7 @@ mod tests {
         assert!(continuity_json.contains("\"version\": 1"));
         assert!(continuity_json.contains("\"residents\""));
         assert!(continuity_json.contains("\"promises\""));
+        assert!(continuity_json.contains("\"recent_voice_shingle_hashes\""));
 
         let mut restored =
             RuntimeWorld::load_snapshot(&snapshot_path).expect("world snapshot restores");
@@ -889,6 +989,7 @@ mod tests {
                 .map(|action| action.kind.as_str()),
             Some("search")
         );
+        assert!(!restored_continuity.recent_voice_shingle_hashes.is_empty());
 
         let _ = fs::remove_file(snapshot_path);
         let _ = fs::remove_file(continuity_path);

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -75,4 +75,6 @@
 # 74356 -> 74293: move Scout request/access projection and offer/choice planning into
 # movement.rs so gated routes validate and resolve against the same access set, while
 # the remaining handlers reuse the same access-aware rejection and journey seams.
-74293
+# 74293 -> 74291: route kernel events through the existing bounded projected-event
+# append so recent-room and same-speaker publication context stays current.
+74291


### PR DESCRIPTION
## Summary
- reject four-word signature phrases reused by the same speaker even after they move rooms
- derive a bounded 192-hash continuity ring from the replay-safe recent-message index without storing duplicate raw speech
- route kernel messages through the existing bounded event append so room and speaker publication context stays current
- keep retries inside the configured voice attempt and spend budgets

## Verification
- npm test (506 tests)
- npm run v2:worldpack
- npm run v2:kernel
- npm run v2:rust:test (829 tests)
- npm run v2:architecture
- npm run v2:syntax
- npm run v2:browser:check

Closes #552