### PR TITLE
Bound generated waypoint media briefs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.250",
+  "version": "0.0.251",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.250",
+      "version": "0.0.251",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.250",
+  "version": "0.0.251",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.250"
+version = "0.0.251"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.250"
+version = "0.0.251"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -18,10 +18,11 @@ use sha2::{Digest, Sha256};
 use tracing::warn;
 
 use crate::media_recipes::media_verdict::{
-    make_visual_verdict, media_candidate_approved, media_candidate_digest,
-    media_candidate_violations, media_provider_route_available, prepare_media_candidate,
-    record_media_provider_failure, record_media_review_unavailable, record_media_visual_verdict,
-    FrozenMediaBrief, MediaCandidateInput, MediaVerdictDisposition, MediaViolation,
+    bounded_brief_constraints, make_visual_verdict, media_candidate_approved,
+    media_candidate_digest, media_candidate_violations, media_provider_route_available,
+    prepare_media_candidate, record_media_provider_failure, record_media_review_unavailable,
+    record_media_visual_verdict, FrozenMediaBrief, MediaCandidateInput, MediaVerdictDisposition,
+    MediaViolation,
 };
 use crate::{
     active_content, backfill_legacy_community_asset, broadcast_events,
@@ -1482,21 +1483,6 @@ pub(super) fn community_art_media_brief(plan: &CommunityArtPlan) -> FrozenMediaB
             .push(job.prior_asset_digest.clone());
     }
     brief
-}
-
-/// `FrozenMediaBrief::validate` rejects any constraint that is empty after
-/// trimming or longer than the shared component budget, and the plan fields
-/// that feed those constraints are joins of already-bounded traits, so they can
-/// be arbitrarily longer than a single component. Bounding each constraint here
-/// keeps the frozen brief valid by construction: an over-long constraint is
-/// truncated rather than dropped, and only a constraint with no content left is
-/// omitted.
-fn bounded_brief_constraints(values: impl IntoIterator<Item = String>) -> Vec<String> {
-    values
-        .into_iter()
-        .map(|value| crate::bounded_component(&value))
-        .filter(|value| !value.trim().is_empty())
-        .collect()
 }
 
 fn media_violation_from_policy(value: &str) -> MediaViolation {

--- a/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
+++ b/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
@@ -35,6 +35,17 @@ const PROVIDER_COOLDOWN_MS: u64 = 5 * 60 * 1000;
 
 static MEDIA_VERDICT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+/// Bound every producer-authored constraint to the byte budget enforced by
+/// `FrozenMediaBrief::validate`. `bounded_component` cuts only at UTF-8
+/// boundaries; constraints with no content after trimming are omitted.
+pub(crate) fn bounded_brief_constraints(values: impl IntoIterator<Item = String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| crate::bounded_component(&value))
+        .filter(|value| !value.trim().is_empty())
+        .collect()
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct FrozenMediaBrief {
     pub(crate) schema_version: u8,

--- a/v2/orchestrator-rust/src/room_scene.rs
+++ b/v2/orchestrator-rust/src/room_scene.rs
@@ -18,10 +18,10 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::media_recipes::media_verdict::{
-    make_visual_verdict, media_candidate_approved, media_candidate_violations,
-    media_provider_route_available, prepare_media_candidate, record_media_provider_failure,
-    record_media_visual_verdict, FrozenMediaBrief, MediaCandidateInput, MediaVerdictDisposition,
-    MediaViolation,
+    bounded_brief_constraints, make_visual_verdict, media_candidate_approved,
+    media_candidate_violations, media_provider_route_available, prepare_media_candidate,
+    record_media_provider_failure, record_media_visual_verdict, FrozenMediaBrief,
+    MediaCandidateInput, MediaVerdictDisposition, MediaViolation,
 };
 use crate::{
     active_content, allow_actor_mutation, client_actor_authorized_for_state,
@@ -208,30 +208,33 @@ fn room_scene_media_brief(job: &FrozenRoomSceneJob) -> FrozenMediaBrief {
         &job.prompt,
         job.aspect_ratio.clone(),
     );
-    brief.required_subjects = job
-        .actors
-        .iter()
-        .map(|actor| format!("actor {} ({})", actor.actor_id, actor.name))
-        .collect();
-    brief.required_environment = std::iter::once(job.location_name.clone())
-        .chain(job.environmental_facts.iter().cloned())
-        .collect();
-    brief.required_item_holder = job.selected_item.as_ref().map(|item| {
-        format!(
+    brief.required_subjects = bounded_brief_constraints(
+        job.actors
+            .iter()
+            .map(|actor| format!("actor {} ({})", actor.actor_id, actor.name)),
+    );
+    brief.required_environment = bounded_brief_constraints(
+        std::iter::once(job.location_name.clone()).chain(job.environmental_facts.iter().cloned()),
+    );
+    brief.required_item_holder = job.selected_item.as_ref().and_then(|item| {
+        bounded_brief_constraints([format!(
             "item {} ({}) held by {}",
             item.item_id,
             item.name,
             item.holder_actor_id
                 .map(|actor_id| actor_id.to_string())
                 .unwrap_or_else(|| "room floor".to_string())
-        )
+        )])
+        .into_iter()
+        .next()
     });
     brief.crop = job.crop.clone();
-    brief.safe_areas = job.safe_areas.clone();
-    brief.forbidden.extend(job.forbidden_facts.clone());
-    brief
-        .pack_negative_constraints
-        .extend(job.style_constraints.clone());
+    brief.safe_areas = bounded_brief_constraints(job.safe_areas.iter().cloned());
+    brief.forbidden.extend(bounded_brief_constraints(
+        job.forbidden_facts.iter().cloned(),
+    ));
+    brief.pack_negative_constraints =
+        bounded_brief_constraints(job.style_constraints.iter().cloned());
     brief.approved_reference_digests = job
         .references
         .iter()

--- a/v2/orchestrator-rust/src/room_scene_tests.rs
+++ b/v2/orchestrator-rust/src/room_scene_tests.rs
@@ -154,6 +154,74 @@ fn scene_fixture(label: &str) -> SceneFixture {
 }
 
 #[test]
+fn generated_waypoint_scene_brief_bounds_every_constraint_by_bytes() {
+    let root = temp_root("generated-waypoint-brief");
+    let mut runtime = RuntimeWorld::seeded();
+    let pathway = runtime
+        .generated_pathway(ACTOR_A, 12, 50, 3)
+        .expect("build a real generated pathway");
+    let waypoint_id = pathway.waypoints[0].id;
+    runtime
+        .generated_pathways
+        .insert(pathway.id.clone(), pathway.clone());
+    runtime.ensure_generated_pathway_edge(&pathway, 12, waypoint_id);
+    create_test_human(&mut runtime, ACTOR_A, waypoint_id, "Aster");
+
+    let event_seq = runtime.world.next_event_seq;
+    let reference_seq = event_seq.saturating_sub(1).max(1);
+    approve_reference(&root, "location", waypoint_id, 1, reference_seq);
+    approve_reference(&root, "actor", ACTOR_A, 1, reference_seq);
+    runtime.event_log.push(EventView {
+        seq: event_seq,
+        type_name: "pathway.arrived".to_string(),
+        success: true,
+        actor_id: Some(ACTOR_A),
+        actor_name: Some("Aster".to_string()),
+        location_id: Some(waypoint_id),
+        location_name: runtime.location_name(waypoint_id),
+        content: Some("Aster reaches the newly discovered crossing.".to_string()),
+        ..EventView::default()
+    });
+    runtime.world.next_event_seq = event_seq.saturating_add(1);
+
+    let job = runtime
+        .freeze_room_scene(&root, ACTOR_A, event_seq)
+        .expect("freeze a generated-waypoint scene");
+    let raw_environment = job
+        .environmental_facts
+        .iter()
+        .find(|fact| fact.starts_with("approved environment:"))
+        .expect("generated waypoint preserves its approved art prompt");
+    assert!(
+        raw_environment.len() > crate::media_recipes::media_verdict::MEDIA_BRIEF_CONSTRAINT_LIMIT,
+        "the production waypoint prompt must reproduce the former overflow"
+    );
+
+    let brief = room_scene_media_brief(&job);
+    brief
+        .validate()
+        .expect("a real generated-waypoint room scene must pass the media gate");
+    for constraint in brief
+        .required_subjects
+        .iter()
+        .chain(&brief.required_environment)
+        .chain(brief.required_item_holder.iter())
+        .chain(&brief.safe_areas)
+        .chain(&brief.forbidden)
+        .chain(&brief.pack_negative_constraints)
+    {
+        assert!(!constraint.trim().is_empty());
+        assert!(
+            constraint.len() <= crate::media_recipes::media_verdict::MEDIA_BRIEF_CONSTRAINT_LIMIT,
+            "constraint is {} bytes: {constraint}",
+            constraint.len()
+        );
+        assert!(constraint.is_char_boundary(constraint.len()));
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn complete_scene_is_byte_traceable_ordered_and_idempotent() {
     assert!(
         serde_json::from_value::<ReviewRoomSceneRequest>(serde_json::json!({


### PR DESCRIPTION
## Summary
- centralize byte-safe frozen-media constraint bounding at the verdict boundary
- apply it to all caller-authored room-scene constraint fields and retain the existing community-art behavior
- add a production-shaped generated-waypoint regression that reproduces the former >240-byte environment fact and proves the derived brief validates
- bump the release version to 0.0.251

## Verification
- `npm test` — 45 files / 506 tests
- `npm run v2:worldpack` — official, every composition, and strict proof
- `npm run v2:kernel`
- `npm run v2:rust:test` — 830/830
- `npm run v2:architecture` — main 74291/74291, clippy 273/273
- `npm run v2:syntax`
- `npm run v2:browser:check` — fresh-seed and living-world stress gates
- `cargo fmt --all`
- `git diff --check`

Closes #550