### PR TITLE
Add typed deterministic Journal beats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.251",
+  "version": "0.0.252",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.251",
+      "version": "0.0.252",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.251",
+  "version": "0.0.252",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.251"
+version = "0.0.252"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.251"
+version = "0.0.252"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -3596,6 +3596,12 @@
       font-size: 12px;
       font-weight: 850;
     }
+    .journal-row.journal-beat:not(.is-overflowing) > summary {
+      cursor: default;
+    }
+    .journal-row.journal-beat:not(.is-overflowing) .journal-row-marker {
+      display: none;
+    }
     .journal-row[open] .journal-row-marker::before {
       content: "−";
     }
@@ -4305,6 +4311,7 @@
     let roomCopyExpanded = false;
     let journalOpen = false;
     let roomLogTickerFrame = null;
+    let journalBeatOverflowFrame = null;
     let lastRoomCopyLocationId = null;
     let economyFlash = null;
     let economyFlashTimer = null;
@@ -8026,6 +8033,16 @@
       if (!actorId || !actorSession || document.visibilityState !== "visible" || activeModal()) return;
       const log = journalOpen ? $("journal-view") : $("log");
       if (!log || log.hidden || log.getClientRects().length === 0 || libraryPanelPinned || accountPanelPinned) return;
+      if (journalOpen) {
+        const beats = journalBeatsForPresentation();
+        for (const row of log.querySelectorAll("[data-world-beat-receipt][data-journal-beat-index]")) {
+          if (!worldBeatRowIsActuallyVisible(row, log)) continue;
+          const beat = beats[Number(row.dataset.journalBeatIndex || -1)];
+          if (!beat?.world_beat_exposure_id || !cleanStatusText(beat.headline)) continue;
+          void acknowledgeWorldBeatExposureId(beat.world_beat_exposure_id);
+        }
+        return;
+      }
       for (const row of log.querySelectorAll("[data-world-beat-exposure][data-world-beat-seq]")) {
         if (!worldBeatRowIsActuallyVisible(row, log)) continue;
         const seq = Number(row.dataset.worldBeatSeq || 0);
@@ -8037,6 +8054,10 @@
 
     async function acknowledgeWorldBeatExposure(event) {
       const exposureId = worldBeatExposureId(event);
+      await acknowledgeWorldBeatExposureId(exposureId);
+    }
+
+    async function acknowledgeWorldBeatExposureId(exposureId) {
       if (!exposureId) return;
       const previous = worldBeatReceiptState.get(exposureId);
       if (["in_flight", "acknowledged", "rejected"].includes(previous?.status)) return;
@@ -8657,6 +8678,7 @@
       if (open) {
         scheduleVisibleWorldBeatReceipts();
         scheduleVisibleClockPresentationReceipts();
+        scheduleJournalBeatOverflowSync();
       }
     }
 
@@ -8832,11 +8854,9 @@
       const toggle = $("room-log-toggle");
       const panel = $("room-memory");
       const memory = roomMemoryModel();
-      const latestJournalEvent = narratedTranscriptEvents(
-        logEvents.filter(eventIsJournalEvent),
-      ).at(-1);
-      const latestText = latestJournalEvent
-        ? journalEventSummary(latestJournalEvent)
+      const latestJournalBeat = journalBeatsForPresentation().at(-1);
+      const latestText = latestJournalBeat
+        ? latestJournalBeat.headline
         : memory.hasLatestEvent
           ? atmosphericMemoryBeat(memory.latest) || memory.latest.text
           : "";
@@ -9002,61 +9022,73 @@
       if (questions.length && journalOpen) scheduleVisibleClockPresentationReceipts();
     }
 
-    function eventIsJournalEvent(event) {
-      if (!event || eventIsMuted(event) || eventIsHiddenContext(event) || eventIsLowSignalStatus(event)) return false;
-      if (
-        (event.location_id || event.destination_location_id)
-        && !eventMatchesCurrentLocation(event)
-      ) return false;
-      if (event.type === "message.created") return false;
-      const meta = statusUpdateMeta(event);
-      return Boolean(meta?.text || sceneCardEventText(event));
+    const journalBeatCategories = new Set([
+      "story",
+      "discovery",
+      "travel",
+      "search",
+      "relationship",
+      "growth",
+      "work",
+      "item",
+      "consequence",
+    ]);
+
+    function journalBeatsForPresentation(view = state) {
+      return (Array.isArray(view?.journal_beats) ? view.journal_beats : [])
+        .filter((beat) => (
+          beat
+          && journalBeatCategories.has(String(beat.category || ""))
+          && cleanStatusText(beat.headline)
+        ))
+        .slice()
+        .sort((left, right) => (
+          Number(left.ordering_seq || 0) - Number(right.ordering_seq || 0)
+          || String(left.id || "").localeCompare(String(right.id || ""))
+        ))
+        .slice(-60);
     }
 
-    function journalEventSummary(event) {
-      if (isRollEvent(event)) {
-        const roll = rollMeta(event);
-        return journalSummary(`${roll.title} · ${roll.result}`);
-      }
-      const meta = statusUpdateMeta(event);
-      return journalSummary(meta?.text || sceneCardEventText(event));
-    }
-
-    function journalEventHtml(event) {
-      const storyReceipt = semanticStoryReceipt(event);
-      if (storyReceipt) {
-        const covered = new Set((storyReceipt.event_seqs || []).map(Number));
-        return journalRowHtml({
-          label: "story",
-          summary: journalSummary(storyReceipt.text),
-          detail: storyReceipt.text,
-          kind: "story",
-          inspector: logEvents.filter((candidate) => covered.has(Number(candidate?.seq || 0))),
-        });
-      }
-      if (isRollEvent(event)) {
-        const roll = rollMeta(event);
-        return journalRowHtml({
-          label: roll.label || "roll",
-          summary: journalEventSummary(event),
-          detail: roll.story || [roll.detail, roll.result].filter(Boolean).join("; "),
-          kind: event.success ? "success" : "failure",
-        });
-      }
-      const meta = statusUpdateMeta(event);
-      const summary = journalEventSummary(event);
-      if (!summary) return "";
-      const exposureId = worldBeatExposureId(event);
-      const attrs = exposureId
-        ? ` data-world-beat-exposure="${escapeAttr(exposureId)}" data-world-beat-seq="${Number(event.seq)}"`
+    function journalBeatHtml(beat, index) {
+      const category = String(beat.category || "");
+      const headline = cleanStatusText(beat.headline);
+      if (!journalBeatCategories.has(category) || !headline) return "";
+      const receiptAttrs = beat.world_beat_exposure_id
+        ? ` data-world-beat-receipt data-journal-beat-index="${Number(index)}"`
         : "";
-      return journalRowHtml({
-        label: meta?.label || "event",
-        summary,
-        detail: sceneCardEventText(event) || summary,
-        kind: meta?.kind || "status",
-        attrs,
+      return `<details class="journal-row journal-beat ${escapeAttr(category)}"${receiptAttrs} aria-label="${escapeAttr(`${category}. ${headline}`)}"><summary tabindex="-1" aria-disabled="true"><span class="journal-row-label">${escapeHtml(category)}</span><span class="journal-row-summary">${escapeHtml(headline)}</span><span class="journal-row-marker" aria-hidden="true"></span></summary><div class="journal-row-detail"><p>${escapeHtml(headline)}</p></div></details>`;
+    }
+
+    function scheduleJournalBeatOverflowSync() {
+      if (journalBeatOverflowFrame !== null) {
+        window.cancelAnimationFrame(journalBeatOverflowFrame);
+      }
+      journalBeatOverflowFrame = window.requestAnimationFrame(() => {
+        journalBeatOverflowFrame = null;
+        syncJournalBeatOverflow();
       });
+    }
+
+    function syncJournalBeatOverflow() {
+      for (const row of document.querySelectorAll("#journal-log .journal-beat")) {
+        const summary = row.querySelector(":scope > summary");
+        const headline = summary?.querySelector(".journal-row-summary");
+        const overflowing = Boolean(
+          headline
+          && headline.clientWidth > 0
+          && headline.scrollWidth > headline.clientWidth + 2
+        );
+        row.classList.toggle("is-overflowing", overflowing);
+        if (!overflowing) row.open = false;
+        if (summary) {
+          summary.tabIndex = overflowing ? 0 : -1;
+          if (overflowing) {
+            summary.removeAttribute("aria-disabled");
+          } else {
+            summary.setAttribute("aria-disabled", "true");
+          }
+        }
+      }
     }
 
     function renderJournalLog() {
@@ -9066,15 +9098,16 @@
       const wasAtBottom = !stream
         || stream.scrollHeight <= stream.clientHeight + 1
         || stream.scrollHeight - stream.scrollTop - stream.clientHeight < 28;
-      const events = narratedTranscriptEvents(logEvents.filter(eventIsJournalEvent)).slice(-60);
-      panel.innerHTML = events.length
-        ? events.map(journalEventHtml).join("")
+      const beats = journalBeatsForPresentation();
+      panel.innerHTML = beats.length
+        ? beats.map(journalBeatHtml).join("")
         : journalRowHtml({
             label: "room",
             summary: "Nothing has been written here yet",
             detail: "Explore the room or change the world to leave the first trace",
             kind: "empty",
           });
+      scheduleJournalBeatOverflowSync();
       if (stream) {
         stream.scrollTop = wasAtBottom ? stream.scrollHeight : previousScrollTop;
       }
@@ -13909,6 +13942,12 @@
 
     $("log").addEventListener("scroll", scheduleVisibleWorldBeatReceipts, { passive: true });
     $("journal-log").closest(".journal-stream")?.addEventListener("scroll", scheduleVisibleWorldBeatReceipts, { passive: true });
+    $("journal-log").addEventListener("click", (event) => {
+      const summary = event.target.closest(".journal-beat > summary");
+      if (summary && !summary.parentElement?.classList.contains("is-overflowing")) {
+        event.preventDefault();
+      }
+    });
     $("shared-questions").addEventListener("toggle", (event) => {
       const details = event.target.closest("details");
       if (!details?.open) return;
@@ -13948,6 +13987,7 @@
         renderRoomLogLatest($("room-log-toggle").dataset.latest || "");
         reconcileHand();
         renderCommands();
+        scheduleJournalBeatOverflowSync();
         scheduleVisibleClockPresentationReceipts();
       }
     });

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -49086,9 +49086,9 @@ mod tests {
         ));
         assert!(INDEX_HTML.contains("return event?.type === \"message.created\""));
         assert!(INDEX_HTML.contains("function renderJournalLog"));
-        assert!(
-            INDEX_HTML.contains("narratedTranscriptEvents(logEvents.filter(eventIsJournalEvent))")
-        );
+        assert!(INDEX_HTML.contains("const beats = journalBeatsForPresentation()"));
+        assert!(INDEX_HTML.contains("headline.scrollWidth > headline.clientWidth + 2"));
+        assert!(!INDEX_HTML.contains("function journalEventHtml"));
         assert!(INDEX_HTML.contains("function transcriptEventHtml"));
         assert!(!INDEX_HTML.contains("function openingRoomLineHtml"));
         assert!(!INDEX_HTML.contains("visibleEvents.map(timelineEventHtml)"));
@@ -49304,8 +49304,8 @@ mod tests {
         assert!(INDEX_HTML.contains("world.logistics.completed"));
         assert!(INDEX_HTML.contains("world.faction.influence_shifted"));
         assert!(INDEX_HTML.contains("world.conflict.escalated"));
-        assert!(INDEX_HTML.contains("function eventIsJournalEvent"));
-        assert!(INDEX_HTML.contains("&& !eventMatchesCurrentLocation(event)"));
+        assert!(INDEX_HTML.contains("function journalBeatsForPresentation"));
+        assert!(INDEX_HTML.contains("const journalBeatCategories = new Set(["));
         assert!(INDEX_HTML.contains("function sceneCardEventHtml"));
         assert!(INDEX_HTML.contains("Story beat. ${text}"));
         assert!(INDEX_HTML.contains("makes room for ${actor}"));

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -26,6 +26,32 @@ pub(super) struct FirstTaleView {
     pub(super) trace_event_seq: Option<u64>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum JournalBeatCategory {
+    Story,
+    Discovery,
+    Travel,
+    Search,
+    Relationship,
+    Growth,
+    Work,
+    Item,
+    Consequence,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct JournalBeatView {
+    pub(super) id: String,
+    pub(super) source_event_seqs: Vec<u64>,
+    pub(super) category: JournalBeatCategory,
+    pub(super) headline: String,
+    pub(super) location_id: u64,
+    pub(super) ordering_seq: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) world_beat_exposure_id: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub(super) struct StateResponse {
     pub(super) world_id: String,
@@ -63,6 +89,7 @@ pub(super) struct StateResponse {
     pub(super) branch: Option<BranchView>,
     pub(super) safety: ActorSafetyView,
     pub(super) recent_events: Vec<EventView>,
+    pub(super) journal_beats: Vec<JournalBeatView>,
     pub(super) room_memory: RoomMemoryView,
     pub(super) primary_action: PrimaryAction,
     pub(super) action_offers: Vec<RankedActionOffer>,
@@ -70,6 +97,213 @@ pub(super) struct StateResponse {
     pub(super) inspector: InspectorView,
     pub(super) character_creation: Vec<CharacterCreationProfileView>,
     pub(super) character_identity: Option<CharacterIdentityView>,
+}
+
+fn semantic_receipt_journal_category(narration_key: &str) -> JournalBeatCategory {
+    let key = narration_key.to_ascii_lowercase();
+    if key.contains("work") || key.contains("build") || key.contains("job") {
+        JournalBeatCategory::Work
+    } else if key.contains("journey")
+        || key.contains("travel")
+        || key.contains("arrival")
+        || key.contains("move")
+    {
+        JournalBeatCategory::Travel
+    } else if key.contains("search") || key.contains("check") || key.contains("study") {
+        JournalBeatCategory::Search
+    } else if key.contains("discover")
+        || key.contains("reveal")
+        || key.contains("pathway")
+        || key.contains("scout")
+    {
+        JournalBeatCategory::Discovery
+    } else if key.contains("bond") || key.contains("friend") || key.contains("relationship") {
+        JournalBeatCategory::Relationship
+    } else if key.contains("growth")
+        || key.contains("skill")
+        || key.contains("calling")
+        || key.contains("ledger")
+        || key.contains("evolve")
+    {
+        JournalBeatCategory::Growth
+    } else if key.contains("item")
+        || key.contains("loot")
+        || key.contains("craft")
+        || key.contains("gift")
+        || key.contains("trade")
+    {
+        JournalBeatCategory::Item
+    } else if key.contains("combat")
+        || key.contains("danger")
+        || key.contains("consequence")
+        || key.contains("failure")
+    {
+        JournalBeatCategory::Consequence
+    } else {
+        JournalBeatCategory::Story
+    }
+}
+
+fn journal_beat_category(event: &EventView) -> Option<JournalBeatCategory> {
+    if event.type_name == semantic_receipts::STORY_RECEIPT_EVENT_TYPE {
+        return semantic_receipts::semantic_story_receipt(event)
+            .map(|receipt| semantic_receipt_journal_category(&receipt.narration_key));
+    }
+    let category = match event.type_name.as_str() {
+        "actor.created"
+        | "actor.entered_location"
+        | "first_tale.public_trace"
+        | "governance.selected" => JournalBeatCategory::Story,
+        "actor.moved"
+        | "combat.flee.success"
+        | "journey.started"
+        | "journey.progressed"
+        | "journey.narrated"
+        | "journey.completed"
+        | "journey.backtracked"
+        | "journey.paused" => JournalBeatCategory::Travel,
+        "exit.discovered"
+        | "exit.unlocked"
+        | "pathway.discovered"
+        | "pathway.familiarized"
+        | "natural_feature.revealed" => JournalBeatCategory::Discovery,
+        "feature.searched" | "location.searched" | "ability_check.rolled" => {
+            JournalBeatCategory::Search
+        }
+        "bond.deepened" | "bond.created" | "bond.revised" | "bond.resolved" => {
+            JournalBeatCategory::Relationship
+        }
+        "ledger.marked" | "ledger.banked" | "advancement.spent" | "skill.stepped"
+        | "calling.set" | "calling.revised" | "avatar.evolved" => JournalBeatCategory::Growth,
+        "job.contribution.resolved"
+        | "job.updated"
+        | "building.construction_opened"
+        | "building.completed"
+        | "building.upgraded"
+        | "world.trade.flowed"
+        | "world.trade.disrupted"
+        | "world.delivery.needed"
+        | "world.logistics.completed" => JournalBeatCategory::Work,
+        "quest.loot_allocated"
+        | "item.picked_up"
+        | "item.dropped"
+        | "item.used"
+        | "item.given"
+        | "item.traded"
+        | "item.found"
+        | "item.revealed"
+        | "item.crafted"
+        | "item.created"
+        | "item.transformed" => JournalBeatCategory::Item,
+        "move.blocked"
+        | "clock.updated"
+        | "tag.applied"
+        | "tag.cleared"
+        | "combat.attack.attempt"
+        | "combat.encounter.started"
+        | "combat.dodge"
+        | "combat.encounter.resolved"
+        | "world.weather.shifted"
+        | "world.weather.held"
+        | "world.faction.influence_shifted"
+        | "world.conflict.pressure_grew"
+        | "world.conflict.pressure_eased"
+        | "world.conflict.escalated"
+        | "magic.spell_cast" => JournalBeatCategory::Consequence,
+        type_name if type_name.starts_with("combat.") => JournalBeatCategory::Consequence,
+        _ => return None,
+    };
+    if event.type_name == "tag.applied"
+        && matches!(
+            event.content.as_deref(),
+            Some("search_location") | Some("search_feature")
+        )
+    {
+        None
+    } else {
+        Some(category)
+    }
+}
+
+fn complete_journal_headline(value: &str) -> Option<String> {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.is_empty() {
+        return None;
+    }
+    if compact.ends_with(['.', '!', '?', '…']) {
+        Some(compact)
+    } else {
+        Some(format!("{compact}."))
+    }
+}
+
+fn journal_world_beat_exposure_id(event: &EventView) -> Option<String> {
+    matches!(
+        event.type_name.as_str(),
+        "world.weather.shifted"
+            | "world.weather.held"
+            | "world.trade.flowed"
+            | "world.trade.disrupted"
+            | "world.delivery.needed"
+            | "world.logistics.completed"
+            | "world.faction.influence_shifted"
+            | "world.conflict.pressure_grew"
+            | "world.conflict.pressure_eased"
+            | "world.conflict.escalated"
+    )
+    .then(|| format!("world-beat:v1:{}", event.seq))
+}
+
+fn journal_beat_views(events: &[EventView], location_id: u64) -> Vec<JournalBeatView> {
+    let covered_event_seqs = semantic_receipts::semantic_receipt_covered_event_seqs(events);
+    let mut beats = events
+        .iter()
+        .filter(|event| !covered_event_seqs.contains(&event.seq))
+        .filter_map(|event| {
+            let category = journal_beat_category(event)?;
+            let (headline, mut source_event_seqs) =
+                if let Some(receipt) = semantic_receipts::semantic_story_receipt(event) {
+                    (
+                        complete_journal_headline(&receipt.text)?,
+                        receipt.event_seqs,
+                    )
+                } else if journal_world_beat_exposure_id(event).is_some() {
+                    (
+                        complete_journal_headline(event.content.as_deref()?)?,
+                        vec![event.seq],
+                    )
+                } else {
+                    (
+                        complete_journal_headline(&room_memory_log_text_at_location(
+                            event,
+                            location_id,
+                        )?)?,
+                        vec![event.seq],
+                    )
+                };
+            source_event_seqs.push(event.seq);
+            source_event_seqs.sort_unstable();
+            source_event_seqs.dedup();
+            Some(JournalBeatView {
+                id: format!("journal-beat:v1:{location_id}:{}", event.seq),
+                source_event_seqs,
+                category,
+                headline,
+                location_id,
+                ordering_seq: event.seq,
+                world_beat_exposure_id: journal_world_beat_exposure_id(event),
+            })
+        })
+        .collect::<Vec<_>>();
+    beats.sort_by(|left, right| {
+        left.ordering_seq
+            .cmp(&right.ordering_seq)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    if beats.len() > 60 {
+        beats.drain(0..beats.len() - 60);
+    }
+    beats
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1894,6 +2128,7 @@ impl RuntimeWorld {
             .take(80)
             .cloned()
             .collect::<Vec<_>>();
+        let journal_beats = journal_beat_views(&recent_events, location_id);
         let room_memory = fallback_room_memory_view(&location, &recent_events);
         StateResponse {
             world_id: OFFICIAL_WORLD_ID.to_string(),
@@ -1971,6 +2206,7 @@ impl RuntimeWorld {
             branch: None,
             safety: self.actor_safety_view(client_actor_id),
             recent_events,
+            journal_beats,
             room_memory,
             primary_action,
             action_offers,
@@ -3458,7 +3694,7 @@ impl RuntimeWorld {
 
 #[cfg(test)]
 mod tests {
-    use super::front_presentation;
+    use super::*;
 
     #[test]
     fn front_presentation_names_active_persisted_resolved_and_escalated_truths() {
@@ -3485,6 +3721,147 @@ mod tests {
                 "escalated",
                 format!("The larger trouble has escalated. {impending}")
             )
+        );
+    }
+
+    #[test]
+    fn journal_beats_group_semantic_receipts_with_their_source_evidence() {
+        let raw = EventView {
+            seq: 41,
+            type_name: "job.contribution.resolved".to_string(),
+            actor_name: Some("Pip Marrow".to_string()),
+            location_id: Some(804),
+            content: Some(
+                serde_json::json!({
+                    "job_id": "lantern-keeper:rekindle-the-beacon",
+                    "strategy_id": "rekindle",
+                    "strategy_label": "Rekindle the beacon",
+                    "narration_key": "lantern-keeper.work",
+                    "action_kind": "work",
+                    "target": {"kind": "feature", "id": "beacon", "label": "the beacon"},
+                    "resolution": "ability_check",
+                    "outcome": "success",
+                    "baseline_progress": 1,
+                    "success_progress": 1,
+                    "prepared_bonus_progress": 0,
+                    "total_progress": 2,
+                    "clock_id": "lantern-keeper.light",
+                    "source_event_seqs": [41],
+                    "rules_profile": "cosy",
+                    "rules_pack_id": "cosy",
+                    "rules_pack_version": "1",
+                    "pack_id": "official",
+                    "pack_version": "1"
+                })
+                .to_string(),
+            ),
+            ..EventView::default()
+        };
+        let receipt = EventView {
+            seq: 43,
+            type_name: semantic_receipts::STORY_RECEIPT_EVENT_TYPE.to_string(),
+            actor_name: Some("Pip Marrow".to_string()),
+            location_id: Some(804),
+            content: Some(
+                serde_json::json!({
+                    "schema_version": 1,
+                    "narration_key": "lantern-keeper.work",
+                    "text": "Pip Marrow rekindles the beacon",
+                    "event_seqs": [41, 42],
+                    "next_response": "carry the news home"
+                })
+                .to_string(),
+            ),
+            ..EventView::default()
+        };
+
+        let beats = journal_beat_views(&[receipt, raw], 804);
+
+        assert_eq!(
+            beats,
+            vec![JournalBeatView {
+                id: "journal-beat:v1:804:43".to_string(),
+                source_event_seqs: vec![41, 42, 43],
+                category: JournalBeatCategory::Work,
+                headline: "Pip Marrow rekindles the beacon.".to_string(),
+                location_id: 804,
+                ordering_seq: 43,
+                world_beat_exposure_id: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn journal_beats_are_typed_ordered_and_omit_unknown_events() {
+        let movement = EventView {
+            seq: 9,
+            type_name: "actor.moved".to_string(),
+            actor_name: Some("Pip Marrow".to_string()),
+            location_id: Some(2),
+            destination_location_id: Some(3),
+            destination_location_name: Some("Moonlit Trail".to_string()),
+            ..EventView::default()
+        };
+        let unknown = EventView {
+            seq: 10,
+            type_name: "future.internal.telemetry".to_string(),
+            location_id: Some(2),
+            content: Some("this must never become Journal prose".to_string()),
+            ..EventView::default()
+        };
+
+        let beats = journal_beat_views(&[unknown, movement], 2);
+
+        assert_eq!(beats.len(), 1);
+        assert_eq!(beats[0].category, JournalBeatCategory::Travel);
+        assert_eq!(beats[0].headline, "Pip Marrow left for Moonlit Trail.");
+        assert_eq!(beats[0].source_event_seqs, vec![9]);
+    }
+
+    #[test]
+    fn journal_beats_serialize_identically_across_replay_order() {
+        let earlier = EventView {
+            seq: 20,
+            type_name: "item.found".to_string(),
+            actor_name: Some("Pip Marrow".to_string()),
+            location_id: Some(7),
+            item_name: Some("Story Button".to_string()),
+            ..EventView::default()
+        };
+        let later = EventView {
+            seq: 21,
+            type_name: "bond.deepened".to_string(),
+            actor_name: Some("Pip Marrow".to_string()),
+            target_actor_name: Some("Moss Stitch".to_string()),
+            location_id: Some(7),
+            ..EventView::default()
+        };
+
+        let chronological =
+            serde_json::to_vec(&journal_beat_views(&[earlier.clone(), later.clone()], 7)).unwrap();
+        let replayed = serde_json::to_vec(&journal_beat_views(&[later, earlier], 7)).unwrap();
+
+        assert_eq!(chronological, replayed);
+    }
+
+    #[test]
+    fn journal_world_beats_keep_authored_prose_and_receipt_identity() {
+        let event = EventView {
+            seq: 31,
+            type_name: "world.weather.shifted".to_string(),
+            location_id: Some(7),
+            content: Some("Rain thins into pearl-grey mist".to_string()),
+            ..EventView::default()
+        };
+
+        let beats = journal_beat_views(&[event], 7);
+
+        assert_eq!(beats.len(), 1);
+        assert_eq!(beats[0].category, JournalBeatCategory::Consequence);
+        assert_eq!(beats[0].headline, "Rain thins into pearl-grey mist.");
+        assert_eq!(
+            beats[0].world_beat_exposure_id.as_deref(),
+            Some("world-beat:v1:31")
         );
     }
 }

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4669,10 +4669,7 @@ async function main() {
       },
       rejectedOffer: {
         lowSignal: eventIsLowSignalStatus({ type: "action.offer_rejected" }),
-        journaled: eventIsJournalEvent({
-          type: "action.offer_rejected",
-          content: "that offer expired; refresh the scene",
-        }),
+        rawJournalFallbackAvailable: typeof eventIsJournalEvent === "function",
       },
       asyncChatFailure: sceneCardEventText({ type: "chat.failed" }),
     }));
@@ -4688,8 +4685,8 @@ async function main() {
       `asynchronous Chat failure should be visible without implying a refund for a free action: ${JSON.stringify(result)}`,
     );
     assert(
-      result.rejectedOffer.lowSignal && !result.rejectedOffer.journaled,
-      `offer rejection telemetry should stay out of the player Journal: ${JSON.stringify(result.rejectedOffer)}`,
+      result.rejectedOffer.lowSignal && !result.rejectedOffer.rawJournalFallbackAvailable,
+      `offer rejection telemetry should stay out of the server-owned player Journal: ${JSON.stringify(result.rejectedOffer)}`,
     );
     const visibleCopy = [...Object.values(result.action), ...Object.values(result.command)];
     assert(!/session expired|action bar|command could not|action could not|write committed|current state|status 4|status 5/i.test(visibleCopy.join(" ")), `failure feedback should not leak implementation language: ${JSON.stringify(result)}`);
@@ -5435,6 +5432,18 @@ async function main() {
           location_name: "The Cosy Cottage",
           content: "Rain thins into pearl-grey mist around the cottage windows.",
         };
+        state = {
+          ...state,
+          journal_beats: [{
+            id: "journal-beat:v1:1:990500001",
+            source_event_seqs: [990500001],
+            category: "consequence",
+            headline: authored.content,
+            location_id: 1,
+            ordering_seq: authored.seq,
+            world_beat_exposure_id: "world-beat:v1:990500001",
+          }],
+        };
         logEvents = [authored];
         seenSeq.clear();
         seenSeq.add(authored.seq);
@@ -5447,7 +5456,7 @@ async function main() {
         renderTimelines();
         await waitForFrames();
         await new Promise((resolve) => window.setTimeout(resolve, 25));
-        const row = document.querySelector(`[data-world-beat-exposure="world-beat:v1:${authored.seq}"]`);
+        const row = document.querySelector("[data-world-beat-receipt][data-journal-beat-index]");
         const visibleAuthoredText = row?.textContent?.trim().replace(/\s+/g, " ") || "";
 
         renderJournalLog();
@@ -5469,6 +5478,7 @@ async function main() {
           location_id: 1,
           content: "raw uncovered state",
         }];
+        state = { ...state, journal_beats: [] };
         renderTimelines();
         await waitForFrames();
         await new Promise((resolve) => window.setTimeout(resolve, 25));
@@ -5476,6 +5486,18 @@ async function main() {
 
         accountPanelPinned = true;
         logEvents = [{ ...authored, seq: 990500004 }];
+        state = {
+          ...state,
+          journal_beats: [{
+            id: "journal-beat:v1:1:990500004",
+            source_event_seqs: [990500004],
+            category: "consequence",
+            headline: authored.content,
+            location_id: 1,
+            ordering_seq: 990500004,
+            world_beat_exposure_id: "world-beat:v1:990500004",
+          }],
+        };
         renderTimelines();
         await waitForFrames();
         await new Promise((resolve) => window.setTimeout(resolve, 25));
@@ -5487,7 +5509,8 @@ async function main() {
           callsAfterSuppressedEvents,
           callsWhileMenuHidden,
           visibleAuthoredText,
-          exposureAttribute: row?.getAttribute("data-world-beat-exposure") || "",
+          receiptable: row?.hasAttribute("data-world-beat-receipt") || false,
+          sourceSeqLeaked: row?.outerHTML.includes(String(authored.seq)) || false,
         };
       } finally {
         window.fetch = previous.fetch;
@@ -5510,7 +5533,12 @@ async function main() {
     assert(result.callsAfterRepeatedRender === 1, `repeat renders and reconnect-style rebuilds should remain idempotent: ${JSON.stringify(result)}`);
     assert(result.callsAfterSuppressedEvents === 1, `raw or suppressed world events must not send exposure receipts: ${JSON.stringify(result)}`);
     assert(result.callsWhileMenuHidden === 1, `a transcript hidden behind Menu must not send exposure receipts: ${JSON.stringify(result)}`);
-    assert(result.exposureAttribute === "world-beat:v1:990500001", `world-beat exposure ids should bind presentation v1 to journal sequence: ${JSON.stringify(result)}`);
+    assert(
+      result.receiptable
+        && !result.sourceSeqLeaked
+        && result.calls[0]?.exposure_id === "world-beat:v1:990500001",
+      `world-beat receipts should bind presentation v1 without exposing source sequences in production HTML: ${JSON.stringify(result)}`,
+    );
     assert(result.visibleAuthoredText.includes("Rain thins into pearl-grey mist"), `a receipted beat must have authored prose on screen: ${JSON.stringify(result)}`);
     assert(
       result.calls[0]?.transport === "browser"
@@ -5876,6 +5904,7 @@ async function main() {
     const result = await page.evaluate(() => {
       const previousLogEvents = logEvents.slice();
       const previousSeen = new Set(seenSeq);
+      const previousState = state;
       try {
         logEvents = [];
         seenSeq.clear();
@@ -5959,6 +5988,27 @@ async function main() {
           tag_label: "searched Scarf Basket",
           content: "search_feature",
         });
+        state = {
+          ...state,
+          journal_beats: [
+            {
+              id: "journal-beat:v1:1:990002",
+              source_event_seqs: [990001, 990002],
+              category: "growth",
+              headline: "Thimble Guest got better at Lorecraft.",
+              location_id: Number(state?.location?.id || 1),
+              ordering_seq: 990002,
+            },
+            {
+              id: "journal-beat:v1:1:990003",
+              source_event_seqs: [990003, 990004],
+              category: "search",
+              headline: "Thimble Guest looks closely around The Cosy Cottage.",
+              location_id: Number(state?.location?.id || 1),
+              ordering_seq: 990003,
+            },
+          ],
+        };
         renderTimelines();
         return {
           log: document.querySelector("#log")?.textContent || "",
@@ -6080,6 +6130,7 @@ async function main() {
           }),
         };
       } finally {
+        state = previousState;
         logEvents = previousLogEvents;
         seenSeq.clear();
         for (const seq of previousSeen) seenSeq.add(seq);
@@ -6189,19 +6240,31 @@ async function main() {
         pushEvents(batch);
         const narrated = narratedTranscriptEvents(logEvents);
         const replayed = narratedTranscriptEvents(batch);
-        const journal = journalEventHtml(receipt);
+        const beat = {
+          id: "journal-beat:v1:804:991103",
+          source_event_seqs: [...raw.map((event) => event.seq), receipt.seq],
+          category: "work",
+          headline: text,
+          location_id: 804,
+          ordering_seq: receipt.seq,
+        };
+        const journal = journalBeatHtml(beat);
         return {
           text,
+          beat,
           narratedTypes: narrated.map((event) => event.type),
           narratedText: narrated.map(sceneCardEventText),
           replayedTypes: replayed.map((event) => event.type),
           statusText: statusUpdateMeta(receipt).text,
           eventText: eventText(receipt),
           memoryText: roomMemoryEntryForEvent(receipt)?.text || "",
-          rawTypesStillInspectable: raw.every((event) => (
+          sourceEvidenceGrouped: beat.source_event_seqs.every((seq) => (
+            seq === receipt.seq || raw.some((event) => event.seq === seq)
+          )),
+          rawEvidenceAbsentFromProductionHtml: raw.every((event) => (
             logEvents.some((logged) => logged.seq === event.seq)
-            && journal.includes(event.type)
-            && journal.includes(`#${event.seq}`)
+            && !journal.includes(event.type)
+            && !journal.includes(`#${event.seq}`)
           )),
           malformed: [
             "grew from what happened",
@@ -6233,7 +6296,10 @@ async function main() {
         && result.memoryText === result.text,
       `every browser surface should render the same authored receipt: ${JSON.stringify(result)}`,
     );
-    assert(result.rawTypesStillInspectable, `expanded Journal should retain covered raw event evidence: ${JSON.stringify(result)}`);
+    assert(
+      result.sourceEvidenceGrouped && result.rawEvidenceAbsentFromProductionHtml,
+      `the typed beat should retain grouped source evidence without exposing raw identifiers in production HTML: ${JSON.stringify(result)}`,
+    );
     assert(result.malformed.length === 0, `semantic receipt should exclude every reported malformed sentence: ${JSON.stringify(result)}`);
 
     const previousViewport = page.viewportSize();
@@ -6249,6 +6315,14 @@ async function main() {
       state = {
         ...state,
         location: { ...(state?.location || {}), id: 804, name: "Lantern Tower" },
+        journal_beats: [{
+          id: "journal-beat:v1:804:991103",
+          source_event_seqs: [991100, 991101, 991102, 991103],
+          category: "work",
+          headline: text,
+          location_id: 804,
+          ordering_seq: 991103,
+        }],
       };
       logEvents = [];
       seenSeq.clear();
@@ -6306,16 +6380,26 @@ async function main() {
       }]);
       renderTimelines();
       setJournalOpen(true);
-      const storyRow = document.querySelector("#journal-log .journal-row.story");
-      if (storyRow) storyRow.open = true;
+      syncJournalBeatOverflow();
+      const storyRow = document.querySelector("#journal-log .journal-row.work");
+      if (storyRow?.classList.contains("is-overflowing")) storyRow.open = true;
       return {
-        latest: document.querySelector("#room-log-latest")?.textContent || "",
-        story: storyRow?.textContent || "",
-        rawCount: storyRow?.querySelectorAll(".journal-row-inspector li").length || 0,
+        latest: document.querySelector("#room-log-latest")?.textContent?.trim() || "",
+        summary: storyRow?.querySelector(".journal-row-summary")?.textContent?.trim() || "",
+        detail: storyRow?.querySelector(".journal-row-detail p")?.textContent?.trim() || "",
+        sourceLeakCount: [...raw].filter((event) => (
+          storyRow?.innerHTML.includes(event.type)
+          || storyRow?.innerHTML.includes(`#${event.seq}`)
+        )).length,
       };
     }, result.text);
-    assert(evidence.latest.includes("Kit Featherstep rekindles"), `receipt evidence should show the authored scene status: ${JSON.stringify(evidence)}`);
-    assert(evidence.story.includes("Kit Featherstep rekindles") && evidence.rawCount === 3, `receipt evidence should expand its three covered raw events: ${JSON.stringify(evidence)}`);
+    assert(evidence.latest === result.text, `receipt evidence should show the exact authored scene status: ${JSON.stringify(evidence)}`);
+    assert(
+      evidence.summary === result.text
+        && evidence.detail === result.text
+        && evidence.sourceLeakCount === 0,
+      `receipt evidence should reuse one complete headline without raw event identifiers: ${JSON.stringify(evidence)}`,
+    );
     await page.setViewportSize({ width: 980, height: 820 });
     await page.screenshot({ path: evidencePath, fullPage: false });
     await page.evaluate(() => {
@@ -6332,7 +6416,7 @@ async function main() {
     steps.push({
       label: "Lantern Keeper semantic receipt",
       screenshot: evidencePath,
-      rawEvents: evidence.rawCount,
+      groupedSourceEvents: result.beat.source_event_seqs.length,
     });
   }
 
@@ -9569,6 +9653,7 @@ async function main() {
         stateSignature: JSON.stringify({
           sharedQuestions: state?.shared_questions,
           roomMemory: state?.room_memory,
+          journalBeats: state?.journal_beats,
           stateRevision: state?.state_revision,
         }),
       };
@@ -9705,6 +9790,7 @@ async function main() {
         stateUnchanged: stateSignature === JSON.stringify({
           sharedQuestions: state?.shared_questions,
           roomMemory: state?.room_memory,
+          journalBeats: state?.journal_beats,
           stateRevision: state?.state_revision,
         }),
       };
@@ -9721,6 +9807,58 @@ async function main() {
         && journal.insideTerminal
         && journal.stateUnchanged,
       `${label}: Journal should stay a minimalist console without changing inference-facing state: ${JSON.stringify(journal)}`,
+    );
+
+    const beatDisclosure = await page.evaluate(() => {
+      const row = document.querySelector("#journal-log .journal-beat");
+      const summary = row?.querySelector(":scope > summary");
+      const headline = summary?.querySelector(".journal-row-summary");
+      const detail = row?.querySelector(".journal-row-detail p");
+      const marker = row?.querySelector(".journal-row-marker");
+      if (!row || !summary || !headline || !detail || !marker) return { exists: false };
+
+      headline.textContent = "A brief note.";
+      detail.textContent = "A brief note.";
+      syncJournalBeatOverflow();
+      const short = {
+        overflowing: row.classList.contains("is-overflowing"),
+        markerVisible: getComputedStyle(marker).display !== "none",
+        tabIndex: summary.tabIndex,
+      };
+      summary.click();
+      short.openAfterClick = row.open;
+
+      const complete = "A deliberately complete Journal headline keeps going until it cannot fit on one visual line, so the disclosure is useful without replacing or inventing any prose.";
+      headline.textContent = complete;
+      detail.textContent = complete;
+      syncJournalBeatOverflow();
+      const long = {
+        overflowing: row.classList.contains("is-overflowing"),
+        markerVisible: getComputedStyle(marker).display !== "none",
+        tabIndex: summary.tabIndex,
+      };
+      summary.click();
+      long.openAfterClick = row.open;
+      long.sameCompleteHeadline = headline.textContent === detail.textContent
+        && headline.textContent === complete;
+      renderJournalLog();
+      return { exists: true, short, long };
+    });
+    assert(
+      beatDisclosure.exists
+        && !beatDisclosure.short.overflowing
+        && !beatDisclosure.short.markerVisible
+        && beatDisclosure.short.tabIndex === -1
+        && !beatDisclosure.short.openAfterClick,
+      `${label}: a one-line Journal beat should have no disclosure affordance: ${JSON.stringify(beatDisclosure)}`,
+    );
+    assert(
+      beatDisclosure.long.overflowing
+        && beatDisclosure.long.markerVisible
+        && beatDisclosure.long.tabIndex === 0
+        && beatDisclosure.long.openAfterClick
+        && beatDisclosure.long.sameCompleteHeadline,
+      `${label}: only an overflowing beat should disclose the same complete headline: ${JSON.stringify(beatDisclosure)}`,
     );
 
     const rowCount = await page.locator("#journal-view .journal-row > summary").count();


### PR DESCRIPTION
Closes #507

## What changed
- project a server-owned JournalBeatView with stable ids, grouped source-event evidence, closed semantic categories, complete headlines, location, and ordering sequence
- collapse semantic story receipts over covered raw events and omit unknown event types instead of formatting them in the browser
- render only category tag + complete prose; show a disclosure affordance only when that prose visually overflows one line, with the same headline inside
- keep world-beat exposure receipts working without putting source sequences in production Journal HTML
- make the room ticker mirror the newest typed Journal headline exactly
- bump the release to 0.0.252

## Verification
- npm run check (506 JS tests, worldpack compositions and strict proof, kernel, 834 Rust tests, architecture/clippy ceilings, syntax)
- npm run v2:browser:check (fresh-seed browser flow and living-world stress)
- focused replay, receipt grouping, unknown-event omission, world-beat prose, and overflow-only disclosure regressions