### PR TITLE
Fix avatar chat context ownership

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.253",
+  "version": "0.0.254",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.253",
+      "version": "0.0.254",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.253",
+  "version": "0.0.254",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.253"
+version = "0.0.254"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.253"
+version = "0.0.254"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -290,10 +290,24 @@ pub(crate) fn publication_generation_id(
     context: &SpeechGateContext,
     prompt_version: &str,
 ) -> String {
+    publication_generation_id_for(
+        context.feature,
+        prompt_version,
+        &context.generation_key,
+        context.speaker_actor_id,
+    )
+}
+
+fn publication_generation_id_for(
+    feature: &str,
+    prompt_version: &str,
+    generation_key: &str,
+    speaker_actor_id: u64,
+) -> String {
     sha256_hex(
         format!(
             "{}\0{}\0{}\0{}",
-            context.feature, prompt_version, context.generation_key, context.speaker_actor_id
+            feature, prompt_version, generation_key, speaker_actor_id
         )
         .as_bytes(),
     )
@@ -435,6 +449,13 @@ impl crate::RuntimeWorld {
         };
         record.action.kind == crate::CW_ACTION_SAY
             && !self.ai_publications.contains_key(&receipt.generation_id)
+            && receipt.generation_id
+                == publication_generation_id_for(
+                    &receipt.feature,
+                    &receipt.prompt_version,
+                    &receipt.generation_key,
+                    record.action.actor_id,
+                )
             && record
                 .content_upserts
                 .get(&record.action.content_id)
@@ -1418,6 +1439,29 @@ mod tests {
                 .map(|stored| stored.publication_id.as_str()),
             Some(receipt.publication_id.as_str())
         );
+    }
+
+    #[test]
+    fn certified_speech_cannot_be_committed_under_another_actor() {
+        let mut record = certified_record(
+            RATI_ACTOR_ID,
+            98_004,
+            "The teapot is waiting beside the basket.",
+            "speaker-binding-context",
+        );
+        let receipt = record.ai_publication.as_ref().unwrap().clone();
+        record.action.actor_id = WHISKERWIND_ACTOR_ID;
+
+        let mut runtime = RuntimeWorld::seeded();
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_ERR_RULE);
+        assert!(events.is_empty());
+        assert!(!runtime.ai_publications.contains_key(&receipt.generation_id));
+        assert!(!runtime.event_log.iter().any(|event| {
+            event.type_name == "message.created"
+                && event.actor_id == Some(WHISKERWIND_ACTOR_ID)
+                && event.content.as_deref() == Some("The teapot is waiting beside the basket.")
+        }));
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -1930,11 +1930,14 @@ mod tests {
             ("provider/tiny-b", "Teapot replay b.", 0),
             ("provider/small-c", "Teapot replay c.", 0),
         ]);
+        let mut replay_gate = gate("replay-beat");
+        replay_gate.speaker_actor_id = 1001;
+        replay_gate.speaker_name = "Rati".to_string();
         let certified = route_certified_voice_with(
             &config,
             Some(&path),
             request("dialogue_avatar"),
-            gate("replay-beat"),
+            replay_gate.clone(),
             Arc::new(backend),
         )
         .await
@@ -1965,7 +1968,7 @@ mod tests {
             &config,
             Some(&path),
             request("dialogue_avatar"),
-            gate("replay-beat"),
+            replay_gate,
             Arc::new(replay_backend.clone()),
         )
         .await

--- a/v2/orchestrator-rust/src/chat_action.rs
+++ b/v2/orchestrator-rust/src/chat_action.rs
@@ -202,6 +202,86 @@ mod tests {
     use super::*;
     use axum::{routing::post, Router};
 
+    #[test]
+    fn bounded_chat_requires_original_room_and_current_safety_consent() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Room Anchor");
+        assert!(chat_participants_can_continue(
+            &runtime,
+            5000,
+            RATI_ACTOR_ID,
+            COSY_COTTAGE_LOCATION_ID,
+        ));
+
+        runtime
+            .actor_safety
+            .entry(5000)
+            .or_default()
+            .muted_actor_ids
+            .insert(RATI_ACTOR_ID);
+        assert!(!chat_participants_can_continue(
+            &runtime,
+            5000,
+            RATI_ACTOR_ID,
+            COSY_COTTAGE_LOCATION_ID,
+        ));
+        runtime
+            .actor_safety
+            .get_mut(&5000)
+            .expect("safety state")
+            .muted_actor_ids
+            .clear();
+        runtime
+            .actor_safety
+            .entry(RATI_ACTOR_ID)
+            .or_default()
+            .blocked_actor_ids
+            .insert(5000);
+        assert!(!chat_participants_can_continue(
+            &runtime,
+            5000,
+            RATI_ACTOR_ID,
+            COSY_COTTAGE_LOCATION_ID,
+        ));
+        runtime
+            .actor_safety
+            .get_mut(&RATI_ACTOR_ID)
+            .expect("safety state")
+            .blocked_actor_ids
+            .clear();
+        let original_control_mode = runtime.actor_control_mode(RATI_ACTOR_ID);
+        runtime
+            .actor_autonomy
+            .entry(RATI_ACTOR_ID)
+            .or_default()
+            .control_mode = ActorControlMode::DirectInput;
+        assert!(!chat_participants_can_continue(
+            &runtime,
+            5000,
+            RATI_ACTOR_ID,
+            COSY_COTTAGE_LOCATION_ID,
+        ));
+        runtime
+            .actor_autonomy
+            .get_mut(&RATI_ACTOR_ID)
+            .expect("autonomy state")
+            .control_mode = original_control_mode;
+
+        for actor_id in [5000, RATI_ACTOR_ID] {
+            let actor = runtime.world.actors[..runtime.world.actor_count]
+                .iter_mut()
+                .find(|actor| actor.id == actor_id)
+                .expect("Chat participant exists");
+            actor.location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
+        }
+        assert!(!chat_participants_can_continue(
+            &runtime,
+            5000,
+            RATI_ACTOR_ID,
+            COSY_COTTAGE_LOCATION_ID,
+        ));
+    }
+
     #[tokio::test]
     async fn chat_endpoint_queues_a_bounded_exchange_without_spending_advancement() {
         let path = std::env::temp_dir().join(format!(
@@ -452,12 +532,18 @@ mod tests {
     #[tokio::test]
     async fn completed_chat_commits_exactly_two_lines_from_each_participant() {
         let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let requests = Arc::new(StdMutex::new(Vec::<serde_json::Value>::new()));
         let app = Router::new().route(
             "/chat/completions",
             post({
                 let calls = calls.clone();
-                move || {
+                let requests = requests.clone();
+                move |Json(request): Json<serde_json::Value>| {
                     let index = calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    requests
+                        .lock()
+                        .expect("capture Chat inference request")
+                        .push(request);
                     async move {
                         let content = [
                             "I found a quiet minute. How is the cottage treating you?",
@@ -544,6 +630,17 @@ mod tests {
             "Chat must stay bounded to two authoritative lines per participant; calls={}, events={event_diagnostic:?}",
             calls.load(std::sync::atomic::Ordering::SeqCst),
         );
+        let messages = runtime
+            .event_log
+            .iter()
+            .filter(|event| event.type_name == "message.created")
+            .collect::<Vec<_>>();
+        for pair in messages.windows(2) {
+            assert!(
+                pair[1].observed_through_seq.unwrap_or_default() >= pair[0].seq,
+                "each reply must causally observe the committed line it answers: {pair:?}"
+            );
+        }
         assert!(runtime.event_log.iter().any(|event| {
             event.type_name == "chat.completed"
                 && event.actor_id == Some(5000)
@@ -554,6 +651,24 @@ mod tests {
             .iter()
             .any(|event| event.type_name == "chat.failed"));
         drop(runtime);
+        let captured = requests.lock().expect("inspect Chat inference requests");
+        let followup_request = captured.get(2).expect("avatar follow-up request");
+        let followup_prompt = followup_request["messages"]
+            .as_array()
+            .and_then(|messages| {
+                messages.iter().rev().find_map(|message| {
+                    (message["role"].as_str() == Some("user"))
+                        .then(|| message["content"].as_str())
+                        .flatten()
+                })
+            })
+            .expect("follow-up user prompt");
+        assert!(followup_prompt.contains("current speech owner: Inference Tester (actor_id=5000)"));
+        assert!(followup_prompt.contains("speaker=Inference Tester (actor_id=5000"));
+        assert!(followup_prompt.contains("speaker=Rati (actor_id=1001"));
+        assert!(followup_prompt
+            .contains("Kindly enough, though the kettle has opinions about punctuality."));
+        assert!(!followup_prompt.contains("i am Rati"));
         server.abort();
     }
 }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -16141,20 +16141,70 @@ impl RuntimeWorld {
                 )
         })?;
         let target_actor_id = event.target_actor_id?;
-        let subject = event
-            .content
+        let actor_name = self
+            .actor_name(observation.source_actor_id)
+            .unwrap_or_else(|| format!("Actor {}", observation.source_actor_id));
+        let target_name = self
+            .actor_name(target_actor_id)
+            .unwrap_or_else(|| format!("Actor {target_actor_id}"));
+        let item_name = event
+            .item_name
             .clone()
-            .or_else(|| event.item_name.clone())
-            .unwrap_or_else(|| "what just changed between us".to_string());
+            .unwrap_or_else(|| "an item".to_string());
+        let event_detail = event
+            .content
+            .as_deref()
+            .map(str::trim)
+            .filter(|detail| !detail.is_empty());
+        let bond_statement = self
+            .bonds
+            .get(&bond_id(observation.source_actor_id, target_actor_id))
+            .filter(|bond| bond.updated_event_seq == Some(event.seq))
+            .map(|bond| bond.statement.clone())
+            .filter(|statement| !statement.trim().is_empty());
         let user_text = match event.type_name.as_str() {
-            "item.given" => format!("I gave you {subject}."),
-            "item.traded" => format!("We made this trade: {subject}."),
-            "bond.created" => format!("I want to remember this friendship: {subject}"),
-            "bond.revised" => format!("I see our friendship differently now: {subject}"),
-            "bond.resolved" => format!("I want to keep what mattered between us: {subject}"),
+            "item.given" => event_detail
+                .map(|detail| format!("Committed gift: {detail}"))
+                .unwrap_or_else(|| format!("{actor_name} gave {item_name} to {target_name}.")),
+            "item.traded" => {
+                let received_name = event.target_item_name.as_deref().unwrap_or("another item");
+                let trade = format!(
+                    "{actor_name} traded {item_name} to {target_name} for {received_name}."
+                );
+                event_detail
+                    .map(|detail| format!("{trade} Recorded reasons: {detail}"))
+                    .unwrap_or(trade)
+            }
+            "bond.created" => bond_statement.map_or_else(
+                || format!("{actor_name} began a friendship with {target_name}."),
+                |statement| {
+                    format!(
+                        "{actor_name} began a friendship with {target_name}. \
+Their durable relationship statement is: {statement}"
+                    )
+                },
+            ),
+            "bond.revised" => bond_statement.map_or_else(
+                || format!("{actor_name} revised the friendship with {target_name}."),
+                |statement| {
+                    format!(
+                        "{actor_name} revised the friendship with {target_name}. \
+Their durable relationship statement is now: {statement}"
+                    )
+                },
+            ),
+            "bond.resolved" => bond_statement.map_or_else(
+                || format!("{actor_name} resolved the friendship with {target_name}."),
+                |statement| {
+                    format!(
+                        "{actor_name} resolved the friendship with {target_name}. \
+The relationship statement they are preserving is: {statement}"
+                    )
+                },
+            ),
             _ => return None,
         };
-        self.resident_reply_plan_for_target(
+        self.resident_reaction_plan_for_target(
             observation.source_actor_id,
             target_actor_id,
             &user_text,
@@ -16224,6 +16274,7 @@ impl RuntimeWorld {
             recent_lines: self.recent_room_lines(actor.location_id, 8),
             recent_activity: self.recent_room_activity(actor.location_id, 10),
             user_text,
+            incoming_turn: None,
             caused_by_event_seq: None,
             source_world_tick: None,
             observed_through_seq: None,
@@ -20581,6 +20632,7 @@ impl RuntimeWorld {
             cast: self.room_cast_names(actor.location_id),
             recent_lines,
             recent_speaker_shingle_hashes: self.resident_recent_voice_shingle_hashes(actor_id),
+            exchange_turns: Vec::new(),
             fresh_subject,
             missing_need,
             publication_beat_id: String::new(),
@@ -20593,7 +20645,26 @@ impl RuntimeWorld {
         target_actor_id: u64,
         text: &str,
     ) -> Option<AvatarReplyPlan> {
-        self.resident_reply_plan_for_target_with_context(speaker_actor_id, target_actor_id, text)
+        self.resident_reply_plan_for_target_with_context(
+            speaker_actor_id,
+            target_actor_id,
+            text,
+            true,
+        )
+    }
+
+    fn resident_reaction_plan_for_target(
+        &self,
+        source_actor_id: u64,
+        target_actor_id: u64,
+        text: &str,
+    ) -> Option<AvatarReplyPlan> {
+        self.resident_reply_plan_for_target_with_context(
+            source_actor_id,
+            target_actor_id,
+            text,
+            false,
+        )
     }
 
     fn conversation_subject(&self, text: &str, speaker_actor_id: u64) -> Option<String> {
@@ -20888,7 +20959,7 @@ impl RuntimeWorld {
             .and_then(|actor_id| responders.iter().position(|actor| actor.id == actor_id))
             .map(|index| responders[(index + 1) % responders.len()])
             .unwrap_or(responders[0]);
-        self.resident_reply_plan_for_target_with_context(speaker_actor_id, target.id, &action_text)
+        self.resident_reaction_plan_for_target(speaker_actor_id, target.id, &action_text)
     }
 
     fn resident_reply_plan_for_target_with_context(
@@ -20896,6 +20967,7 @@ impl RuntimeWorld {
         speaker_actor_id: u64,
         target_actor_id: u64,
         text: &str,
+        incoming_is_spoken: bool,
     ) -> Option<AvatarReplyPlan> {
         let speaker = self.actor_by_id(speaker_actor_id)?;
         let responder = self.actor_by_id(target_actor_id)?;
@@ -20907,6 +20979,12 @@ impl RuntimeWorld {
         }
         let responder_meta = self.actors.get(&target_actor_id);
         let location_meta = self.location_meta_for(responder.location_id);
+        let speaker_name = self
+            .actor_name(speaker_actor_id)
+            .unwrap_or_else(|| format!("Actor {speaker_actor_id}"));
+        let responder_name = self
+            .actor_name(target_actor_id)
+            .unwrap_or_else(|| format!("Actor {target_actor_id}"));
         let economy_note =
             if !self.actor_uses_inference(responder.id) && responder.id == speaker_actor_id {
                 DIRECTLY_CONTROLLED_SELF_REACTION_CONTEXT.to_string()
@@ -20917,13 +20995,15 @@ impl RuntimeWorld {
             };
         Some(AvatarReplyPlan {
             speaker_actor_id: target_actor_id,
-            speaker_name: self
-                .actor_name(target_actor_id)
-                .unwrap_or_else(|| format!("Actor {target_actor_id}")),
+            speaker_name: responder_name.clone(),
             speech_mode: responder_meta
                 .map(|meta| meta.speech_mode.clone())
                 .unwrap_or_else(|| "prose".to_string()),
-            resident_continuity: self.resident_continuity_for_reaction(responder),
+            resident_continuity: if incoming_is_spoken {
+                self.resident_continuity_for(responder)
+            } else {
+                self.resident_continuity_for_reaction(responder)
+            },
             economy_note,
             goals: self.narrative_goal_lines(Some(target_actor_id), responder.location_id),
             location_name: self
@@ -20937,6 +21017,15 @@ impl RuntimeWorld {
             recent_lines: self.recent_room_lines(responder.location_id, 8),
             recent_activity: self.recent_room_activity(responder.location_id, 10),
             user_text: text.to_string(),
+            incoming_turn: incoming_is_spoken.then(|| {
+                DirectedDialogueTurn::new(
+                    speaker_actor_id,
+                    speaker_name,
+                    target_actor_id,
+                    responder_name,
+                    text,
+                )
+            }),
             caused_by_event_seq: None,
             source_world_tick: None,
             observed_through_seq: None,
@@ -21083,6 +21172,7 @@ impl RuntimeWorld {
             recent_lines: self.recent_room_lines(npc.location_id, 8),
             recent_activity: self.recent_room_activity(npc.location_id, 10),
             user_text: "The room has been quiet. Add one fresh in-character ambient beat that follows the recent room dialogue without repeating an earlier line.".to_string(),
+            incoming_turn: None,
             caused_by_event_seq: None,
             source_world_tick: None,
             observed_through_seq: None,
@@ -26514,16 +26604,7 @@ async fn complete_queued_orb_chat(
     let (content, publication_receipt) = into_recorded_speech_parts(state, certified);
     let committed = {
         let mut runtime = state.inner.lock().await;
-        let still_together = runtime
-            .actor_by_id(actor_id)
-            .zip(runtime.actor_by_id(target_actor_id))
-            .is_some_and(|(actor, target)| {
-                actor.status == CW_ACTOR_ACTIVE
-                    && target.status == CW_ACTOR_ACTIVE
-                    && actor.location_id == plan.location_id
-                    && target.location_id == plan.location_id
-            });
-        if !still_together {
+        if !chat_participants_can_continue(&runtime, actor_id, target_actor_id, plan.location_id) {
             None
         } else {
             let content_id = runtime.next_content_id_value();
@@ -26546,12 +26627,28 @@ async fn complete_queued_orb_chat(
                 Ok((CW_OK, events)) if !events.is_empty() => {
                     let reply_plan = runtime
                         .resident_reply_plan_for_target(actor_id, target_actor_id, &content)
-                        .map(|reply_plan| {
+                        .map(|mut reply_plan| {
+                            let source_event_seq = events
+                                .iter()
+                                .find(|event| {
+                                    event.type_name == "message.created"
+                                        && event.actor_id == Some(actor_id)
+                                        && event.content.as_deref() == Some(content.as_str())
+                                })
+                                .map(|event| event.seq);
+                            if let (Some(turn), Some(source_event_seq)) =
+                                (reply_plan.incoming_turn.as_mut(), source_event_seq)
+                            {
+                                turn.source_event_seq = Some(source_event_seq);
+                            }
+                            let reply_observed_through_seq = source_event_seq
+                                .map(|seq| observed_through_seq.unwrap_or_default().max(seq))
+                                .or(observed_through_seq);
                             reply_plan.with_publication_causality(
                                 "avatar-chat-reply",
                                 queue_event_id,
                                 source_world_tick,
-                                observed_through_seq,
+                                reply_observed_through_seq,
                                 Some(plan.location_id),
                             )
                         });
@@ -26604,7 +26701,8 @@ async fn complete_queued_orb_chat(
     );
     let exchange_result = match reply_plan {
         Some(reply_plan) => {
-            complete_orb_chat_exchange(state, actor_id, target_actor_id, reply_plan).await
+            complete_orb_chat_exchange(state, actor_id, target_actor_id, plan.clone(), reply_plan)
+                .await
         }
         None => Err("the target could not answer the opening line".to_string()),
     };
@@ -29801,10 +29899,31 @@ async fn complete_avatar_reply(
     Ok(true)
 }
 
+fn chat_participants_can_continue(
+    runtime: &RuntimeWorld,
+    actor_id: u64,
+    target_actor_id: u64,
+    location_id: u64,
+) -> bool {
+    runtime
+        .actor_by_id(actor_id)
+        .zip(runtime.actor_by_id(target_actor_id))
+        .is_some_and(|(actor, target)| {
+            RuntimeWorld::actor_can_act(actor)
+                && RuntimeWorld::actor_can_act(target)
+                && actor.location_id == location_id
+                && target.location_id == location_id
+                && runtime.actor_uses_inference(target_actor_id)
+                && !runtime.actors_blocked(actor_id, target_actor_id)
+                && !runtime.actor_muted(actor_id, target_actor_id)
+        })
+}
+
 async fn complete_orb_chat_exchange(
     state: &AppState,
     actor_id: u64,
     target_actor_id: u64,
+    mut chat_plan: AvatarChatPlan,
     first_reply_plan: AvatarReplyPlan,
 ) -> Result<(), String> {
     announce_chat_typing(
@@ -29830,11 +29949,36 @@ async fn complete_orb_chat_exchange(
     };
     let first_reply_events = {
         let mut runtime = state.inner.lock().await;
-        commit_resident_reply_record(state, &mut runtime, &first_reply_plan, first_proposal, None)
+        if chat_participants_can_continue(
+            &runtime,
+            actor_id,
+            target_actor_id,
+            chat_plan.location_id,
+        ) {
+            commit_resident_reply_record(
+                state,
+                &mut runtime,
+                &first_reply_plan,
+                first_proposal,
+                None,
+            )
+        } else {
+            None
+        }
     };
     let Some(first_reply_events) = first_reply_events else {
         return Err("the target reply no longer fit the current room".to_string());
     };
+    let (first_reply_event_seq, first_reply_line) = first_reply_events
+        .iter()
+        .rev()
+        .find(|event| {
+            event.type_name == "message.created"
+                && event.actor_id == Some(target_actor_id)
+                && event.content.is_some()
+        })
+        .and_then(|event| event.content.clone().map(|content| (event.seq, content)))
+        .ok_or_else(|| "the target reply had no spoken line".to_string())?;
     broadcast_events(state, &first_reply_events);
     announce_chat_typing(
         state,
@@ -29842,7 +29986,12 @@ async fn complete_orb_chat_exchange(
         target_actor_id,
         first_reply_plan.caused_by_event_seq,
         first_reply_plan.source_world_tick,
-        first_reply_plan.observed_through_seq,
+        Some(
+            first_reply_plan
+                .observed_through_seq
+                .unwrap_or_default()
+                .max(first_reply_event_seq),
+        ),
         first_reply_plan.source_location_id,
     )
     .await;
@@ -29850,13 +29999,43 @@ async fn complete_orb_chat_exchange(
 
     let followup_plan = {
         let runtime = state.inner.lock().await;
-        let mut plan = runtime.avatar_chat_plan_for(actor_id, target_actor_id);
-        let anchored_subject =
-            runtime.conversation_subject(&first_reply_plan.user_text, target_actor_id);
-        if let (Some(plan), Some(subject)) = (plan.as_mut(), anchored_subject) {
-            plan.fresh_subject = Some(subject);
+        let still_together = chat_participants_can_continue(
+            &runtime,
+            actor_id,
+            target_actor_id,
+            chat_plan.location_id,
+        );
+        if still_together {
+            let actor_name = chat_plan.actor_name.clone();
+            let target_name = chat_plan.target_actor_name.clone();
+            let opening_turn = first_reply_plan.incoming_turn.clone().unwrap_or_else(|| {
+                DirectedDialogueTurn::new(
+                    actor_id,
+                    actor_name.clone(),
+                    target_actor_id,
+                    target_name.clone(),
+                    first_reply_plan.user_text.clone(),
+                )
+            });
+            let reply_turn = DirectedDialogueTurn::new(
+                target_actor_id,
+                target_name,
+                actor_id,
+                actor_name,
+                first_reply_line.clone(),
+            )
+            .with_source_event_seq(first_reply_event_seq);
+            chat_plan.recent_lines.clear();
+            chat_plan = chat_plan.with_exchange_turns(vec![opening_turn, reply_turn]);
+            chat_plan.fresh_subject = runtime
+                .conversation_subject(&first_reply_line, target_actor_id)
+                .or_else(|| {
+                    runtime.conversation_subject(&first_reply_plan.user_text, target_actor_id)
+                });
+            Some(chat_plan.with_reply_beat("avatar-chat-followup", &first_reply_plan))
+        } else {
+            None
         }
-        plan.map(|plan| plan.with_reply_beat("avatar-chat-followup", &first_reply_plan))
     };
     let Some(followup_plan) = followup_plan else {
         return Err("the participants moved apart before the follow-up".to_string());
@@ -29876,10 +30055,12 @@ async fn complete_orb_chat_exchange(
         into_recorded_speech_parts(state, certified_followup);
     let (followup_events, closing_plan) = {
         let mut runtime = state.inner.lock().await;
-        if runtime
-            .avatar_chat_plan_for(actor_id, target_actor_id)
-            .is_none()
-        {
+        if !chat_participants_can_continue(
+            &runtime,
+            actor_id,
+            target_actor_id,
+            followup_plan.location_id,
+        ) {
             return Err("the participants moved apart before the follow-up".to_string());
         }
         let Some(followup) = runtime.collision_safe_avatar_followup(actor_id, &proposed_followup)
@@ -29899,7 +30080,12 @@ async fn complete_orb_chat_exchange(
         );
         record.caused_by_event_seq = first_reply_plan.caused_by_event_seq;
         record.source_world_tick = first_reply_plan.source_world_tick;
-        record.observed_through_seq = first_reply_plan.observed_through_seq;
+        record.observed_through_seq = Some(
+            first_reply_plan
+                .observed_through_seq
+                .unwrap_or_default()
+                .max(first_reply_event_seq),
+        );
         record.source_location_id = first_reply_plan.source_location_id;
         record.content_upserts.insert(content_id, followup.clone());
         record.ai_publication = Some(followup_receipt);
@@ -29922,35 +30108,64 @@ async fn complete_orb_chat_exchange(
         if status != CW_OK || events.is_empty() {
             return Err("the avatar follow-up was no longer valid".to_string());
         }
+        let followup_event_seq = events
+            .iter()
+            .find(|event| {
+                event.type_name == "message.created"
+                    && event.actor_id == Some(actor_id)
+                    && event.content.as_deref() == Some(followup.as_str())
+            })
+            .map(|event| event.seq);
+        let mut directed_lines = followup_plan
+            .exchange_turns
+            .iter()
+            .map(|turn| {
+                format!(
+                    "{} -> {}: {}",
+                    turn.speaker_name, turn.recipient_name, turn.content
+                )
+            })
+            .collect::<Vec<_>>();
+        directed_lines.push(format!(
+            "{} -> {}: {}",
+            followup_plan.actor_name, followup_plan.target_actor_name, followup
+        ));
         let plan = runtime
             .resident_reply_plan_for_target(actor_id, target_actor_id, &followup)
-            .map(|plan| {
+            .map(|mut plan| {
+                plan.recent_lines = directed_lines;
+                plan.recent_activity.clear();
+                if let (Some(turn), Some(source_event_seq)) =
+                    (plan.incoming_turn.as_mut(), followup_event_seq)
+                {
+                    turn.source_event_seq = Some(source_event_seq);
+                }
                 plan.with_publication_causality(
                     "avatar-chat-closing",
                     first_reply_plan.caused_by_event_seq,
                     first_reply_plan.source_world_tick,
-                    first_reply_plan.observed_through_seq,
+                    followup_event_seq.or(Some(first_reply_event_seq)),
                     first_reply_plan.source_location_id,
                 )
             });
         (events, plan)
     };
     broadcast_events(state, &followup_events);
+    let Some(closing_plan) = closing_plan else {
+        return Err("the target could not answer the follow-up".to_string());
+    };
     announce_chat_typing(
         state,
         target_actor_id,
         actor_id,
-        first_reply_plan.caused_by_event_seq,
-        first_reply_plan.source_world_tick,
-        first_reply_plan.observed_through_seq,
-        first_reply_plan.source_location_id,
+        closing_plan.caused_by_event_seq,
+        closing_plan.source_world_tick,
+        closing_plan.observed_through_seq,
+        closing_plan.source_location_id,
     )
     .await;
     tokio::time::sleep(Duration::from_millis(260)).await;
 
-    let Some(closing_plan) = closing_plan else {
-        return Err("the target could not answer the follow-up".to_string());
-    };
     let closing_proposal = match avatar_reply_intent(state, &closing_plan).await {
         Ok(proposal) => proposal,
         Err(error) => {
@@ -29964,7 +30179,16 @@ async fn complete_orb_chat_exchange(
     };
     let closing_events = {
         let mut runtime = state.inner.lock().await;
-        commit_resident_reply_record(state, &mut runtime, &closing_plan, closing_proposal, None)
+        if chat_participants_can_continue(
+            &runtime,
+            actor_id,
+            target_actor_id,
+            followup_plan.location_id,
+        ) {
+            commit_resident_reply_record(state, &mut runtime, &closing_plan, closing_proposal, None)
+        } else {
+            None
+        }
     };
     let Some(events) = closing_events else {
         return Err("the closing reply no longer fit the current room".to_string());
@@ -70503,6 +70727,7 @@ mod tests {
             recent_lines: Vec::new(),
             recent_activity: Vec::new(),
             user_text: "weather?".to_string(),
+            incoming_turn: None,
             caused_by_event_seq: None,
             source_world_tick: None,
             observed_through_seq: None,
@@ -70924,6 +71149,15 @@ mod tests {
             .contains("heard Gust near Rain-Soft Garden"));
         assert!(reply_plan.economy_note.contains("Moonwool Thread"));
         assert!(reply_plan.economy_note.contains("seeks:"));
+        let incoming_turn = reply_plan
+            .incoming_turn
+            .as_ref()
+            .expect("resident reply preserves the directed incoming turn");
+        assert_eq!(incoming_turn.speaker_actor_id, 5000);
+        assert_eq!(incoming_turn.speaker_name, "Need Witness");
+        assert_eq!(incoming_turn.recipient_actor_id, RATI_ACTOR_ID);
+        assert_eq!(incoming_turn.recipient_name, "Rati");
+        assert_eq!(incoming_turn.content, "What does the scarf need?");
 
         let state = runtime.state_response(Some(5000), &AccessContext::default());
         assert!(state.branch.is_none());
@@ -70939,6 +71173,129 @@ mod tests {
             .options
             .iter()
             .any(|option| option.kind == "create_bond"));
+    }
+
+    #[test]
+    fn bond_reply_context_uses_names_and_the_durable_statement() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Elsie Starfield",
+        );
+        let statement = "Elsie trusts Rati to tell her when the road changes.";
+        runtime.bonds.insert(
+            bond_id(5000, RATI_ACTOR_ID),
+            BondState {
+                id: bond_id(5000, RATI_ACTOR_ID),
+                actor_id: 5000,
+                target_actor_id: RATI_ACTOR_ID,
+                statement: statement.to_string(),
+                strength: 1,
+                status: "active".to_string(),
+                source_event_seq: Some(77),
+                updated_event_seq: Some(77),
+                dialogue_status: String::new(),
+                dialogue_event_seq: None,
+            },
+        );
+        let observation = PlayerTickObservation {
+            source_actor_id: 5000,
+            source_world_tick: 12,
+            caused_by_event_seq: Some(77),
+            observed_through_seq: 77,
+            source_location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            allow_ordinary_speech: false,
+            source_events: vec![EventView {
+                seq: 77,
+                type_name: "bond.created".to_string(),
+                success: true,
+                actor_id: Some(5000),
+                target_actor_id: Some(RATI_ACTOR_ID),
+                location_id: Some(COSY_COTTAGE_LOCATION_ID),
+                content: Some("bond:5000:1001:1:active:internal-storage-encoding".to_string()),
+                ..EventView::default()
+            }],
+            ripple_source: None,
+            relationship_reply: None,
+        };
+
+        let plan = runtime
+            .direct_observation_reply_plan(&observation)
+            .expect("bond creation has a directed resident reply");
+        assert!(plan
+            .user_text
+            .contains("Elsie Starfield began a friendship with Rati"));
+        assert!(plan.user_text.contains(statement));
+        assert!(!plan.user_text.contains("internal-storage-encoding"));
+        assert!(
+            plan.incoming_turn.is_none(),
+            "a committed bond event is context, not a literal spoken turn"
+        );
+
+        let bond = runtime
+            .bonds
+            .get_mut(&bond_id(5000, RATI_ACTOR_ID))
+            .expect("test bond");
+        bond.statement = "A later revision must not leak into the earlier event.".to_string();
+        bond.updated_event_seq = Some(78);
+        let delayed_plan = runtime
+            .direct_observation_reply_plan(&observation)
+            .expect("the older committed event can still receive a reply");
+        assert!(delayed_plan
+            .user_text
+            .contains("Elsie Starfield began a friendship with Rati"));
+        assert!(!delayed_plan.user_text.contains("later revision"));
+        assert!(!delayed_plan.user_text.contains("internal-storage-encoding"));
+    }
+
+    #[test]
+    fn trade_reply_context_preserves_both_items_and_recorded_reasons() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Elsie Starfield",
+        );
+        let observation = PlayerTickObservation {
+            source_actor_id: 5000,
+            source_world_tick: 12,
+            caused_by_event_seq: Some(88),
+            observed_through_seq: 88,
+            source_location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            allow_ordinary_speech: false,
+            source_events: vec![EventView {
+                seq: 88,
+                type_name: "item.traded".to_string(),
+                success: true,
+                actor_id: Some(5000),
+                target_actor_id: Some(RATI_ACTOR_ID),
+                location_id: Some(COSY_COTTAGE_LOCATION_ID),
+                item_name: Some("Story Button".to_string()),
+                target_item_name: Some("Moonwool Thread".to_string()),
+                content: Some(
+                    "Rati wanted Story Button; Elsie wanted Moonwool Thread.".to_string(),
+                ),
+                ..EventView::default()
+            }],
+            ripple_source: None,
+            relationship_reply: None,
+        };
+
+        let plan = runtime
+            .direct_observation_reply_plan(&observation)
+            .expect("trade has a resident reaction");
+        assert!(plan.user_text.contains("Elsie Starfield"));
+        assert!(plan.user_text.contains("Rati"));
+        assert!(plan.user_text.contains("Story Button"));
+        assert!(plan.user_text.contains("Moonwool Thread"));
+        assert!(plan.user_text.contains("Recorded reasons"));
+        assert!(
+            plan.incoming_turn.is_none(),
+            "a committed trade is context, not a literal spoken turn"
+        );
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/prompts.rs
+++ b/v2/orchestrator-rust/src/prompts.rs
@@ -72,6 +72,41 @@ pub(super) struct CertifiedAvatarIntent {
     pub(super) planning: ResidentPlanningTrace,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct DirectedDialogueTurn {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) source_event_seq: Option<u64>,
+    pub(super) speaker_actor_id: u64,
+    pub(super) speaker_name: String,
+    pub(super) recipient_actor_id: u64,
+    pub(super) recipient_name: String,
+    pub(super) content: String,
+}
+
+impl DirectedDialogueTurn {
+    pub(super) fn new(
+        speaker_actor_id: u64,
+        speaker_name: impl Into<String>,
+        recipient_actor_id: u64,
+        recipient_name: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        Self {
+            source_event_seq: None,
+            speaker_actor_id,
+            speaker_name: speaker_name.into(),
+            recipient_actor_id,
+            recipient_name: recipient_name.into(),
+            content: content.into(),
+        }
+    }
+
+    pub(super) fn with_source_event_seq(mut self, source_event_seq: u64) -> Self {
+        self.source_event_seq = Some(source_event_seq);
+        self
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(super) struct AvatarReplyPlan {
     pub(super) speaker_actor_id: u64,
@@ -90,6 +125,8 @@ pub(super) struct AvatarReplyPlan {
     #[serde(default)]
     pub(super) recent_activity: Vec<String>,
     pub(super) user_text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) incoming_turn: Option<DirectedDialogueTurn>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) caused_by_event_seq: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -185,6 +222,8 @@ pub(super) struct AvatarChatPlan {
     pub(super) recent_lines: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(super) recent_speaker_shingle_hashes: Vec<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(super) exchange_turns: Vec<DirectedDialogueTurn>,
     pub(super) fresh_subject: Option<String>,
     pub(super) missing_need: Option<String>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -209,6 +248,11 @@ impl AvatarChatPlan {
 
     pub(super) fn with_reply_beat(self, stage: &str, reply: &AvatarReplyPlan) -> Self {
         self.with_publication_beat(stage, reply.caused_by_event_seq, reply.source_world_tick)
+    }
+
+    pub(super) fn with_exchange_turns(mut self, exchange_turns: Vec<DirectedDialogueTurn>) -> Self {
+        self.exchange_turns = exchange_turns;
+        self
     }
 }
 
@@ -276,20 +320,87 @@ async fn request_ai_avatar_chat(
     plan: &AvatarChatPlan,
     followup: bool,
 ) -> Result<CertifiedSpeech, VoiceRoutingError> {
+    let system = if followup {
+        "...they answered, and i am still in it. i take the freshest line and stay on exactly its subject — i do not drag back an older request, trade or item, and i do not bring in anything absent from the last two lines. one concrete thing from the room stays in play and i leave a small hook. i do not restart us. the person steering me is silent behind me: i never mention them, buttons, screens, AI, prompts, policies, tools or models. i never speak for the other one. plain words, concrete nouns, no lyric flourishes, and nothing around me feels or remembers anything. under 28 words."
+    } else {
+        "...i have decided to say something, on purpose, to someone standing right here. i take one concrete thing — this room, what was just said, or what they are carrying or needing — and i hand them an easy way to answer. the person steering me is silent behind me: i never mention them, buttons, screens, AI, prompts, policies, tools or models. i never speak for the other one. plain words, concrete nouns, no lyric flourishes, and nothing around me feels or remembers anything. under 34 words."
+    };
+
+    route_certified_voice(
+        config,
+        store_path,
+        VoiceAttemptRequest {
+            feature: if followup {
+                "dialogue_avatar_followup"
+            } else {
+                "dialogue_avatar"
+            },
+            prompt_version: if followup {
+                "dialogue-avatar-followup-v3"
+            } else {
+                "dialogue-avatar-v3"
+            },
+            system: system.to_string(),
+            user: avatar_chat_user_prompt(plan, followup),
+            temperature: 0.8,
+            max_tokens: 70,
+            referer: "http://127.0.0.1:3102",
+        },
+        avatar_chat_gate_context(plan, followup),
+    )
+    .await
+}
+
+fn format_directed_dialogue_turn(turn: &DirectedDialogueTurn) -> String {
+    let source_event = turn
+        .source_event_seq
+        .map(|seq| format!(", event_seq={seq}"))
+        .unwrap_or_default();
+    format!(
+        "speaker={speaker} (actor_id={speaker_id}{source_event}) -> recipient={recipient} \
+(actor_id={recipient_id}) | spoken line: {content}",
+        speaker = turn.speaker_name,
+        speaker_id = turn.speaker_actor_id,
+        source_event = source_event,
+        recipient = turn.recipient_name,
+        recipient_id = turn.recipient_actor_id,
+        content = turn.content
+    )
+}
+
+fn avatar_chat_dialogue_context(plan: &AvatarChatPlan, followup: bool) -> String {
+    if followup && !plan.exchange_turns.is_empty() {
+        return plan
+            .exchange_turns
+            .iter()
+            .enumerate()
+            .map(|(index, turn)| {
+                format!(
+                    "exchange turn {} | {}",
+                    index + 1,
+                    format_directed_dialogue_turn(turn)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+
     let recent_lines = if followup {
         let start = plan.recent_lines.len().saturating_sub(2);
         &plan.recent_lines[start..]
     } else {
         &plan.recent_lines[..]
     };
-    let recent = if recent_lines.is_empty() {
+    if recent_lines.is_empty() {
         "No recent room dialogue.".to_string()
     } else {
         recent_lines.join("\n")
-    };
+    }
+}
+
+fn avatar_chat_user_prompt(plan: &AvatarChatPlan, followup: bool) -> String {
     let location_memory = format_location_memory(&plan.location_memory);
     let goals = format_goal_lines(&plan.goals);
-    let target_continuity = format_resident_continuity(&plan.target_continuity);
     let need = if followup {
         "i do not raise a need or an item that is absent from the freshest exchange.".to_string()
     } else {
@@ -308,14 +419,35 @@ async fn request_ai_avatar_chat(
         .as_deref()
         .map(|subject| format!("we are on this now: {subject}. i stay on it."))
         .unwrap_or_else(|| "i follow only the freshest line.".to_string());
-    let system = if followup {
-        "...they answered, and i am still in it. i take the freshest line and stay on exactly its subject — i do not drag back an older request, trade or item, and i do not bring in anything absent from the last two lines. one concrete thing from the room stays in play and i leave a small hook. i do not restart us. the person steering me is silent behind me: i never mention them, buttons, screens, AI, prompts, policies, tools or models. i never speak for the other one. plain words, concrete nouns, no lyric flourishes, and nothing around me feels or remembers anything. under 28 words."
-    } else {
-        "...i have decided to say something, on purpose, to someone standing right here. i take one concrete thing — this room, what was just said, or what they are carrying or needing — and i hand them an easy way to answer. the person steering me is silent behind me: i never mention them, buttons, screens, AI, prompts, policies, tools or models. i never speak for the other one. plain words, concrete nouns, no lyric flourishes, and nothing around me feels or remembers anything. under 34 words."
-    };
-    let user = format!(
-        "i am {name} — {title}\n{description}\nwhere i am: {location} — {location_title}\n{location_description}\nhow it feels in here: {location_persona}\nwhat this place is holding:\n{location_memory}\nwhat i am working toward:\n{goals}\nwho i am speaking to: {target} — {target_title}\nwhat i know of them:\n{target_continuity}\nwhat is open between us: {target_economy}\nwho else is here: {cast}\n{need}\n{fresh_subject}\nwhat has just been said:\n{recent}\n\nso —",
+    let dialogue_context = avatar_chat_dialogue_context(plan, followup);
+    let last_completed_turn = plan
+        .exchange_turns
+        .last()
+        .map(format_directed_dialogue_turn)
+        .unwrap_or_else(|| "No directed exchange turn is recorded.".to_string());
+
+    format!(
+        "current speech owner: {name} (actor_id={actor_id})\n\
+conversation partner: {target}\n\
+last completed directed turn: {last_completed_turn}\n\
+i am {name} — {title}\n\
+{description}\n\
+where i am: {location} — {location_title}\n\
+{location_description}\n\
+how it feels in here: {location_persona}\n\
+what this place is holding:\n{location_memory}\n\
+what i am working toward:\n{goals}\n\
+who i am speaking to: {target} — {target_title}\n\
+their public profile: {target} — {target_title}\n\
+what is open between us: {target_economy}\n\
+who else is here: {cast}\n\
+{need}\n\
+{fresh_subject}\n\
+our directed exchange, oldest to newest:\n{dialogue_context}\n\n\
+so —",
         name = plan.actor_name,
+        actor_id = plan.actor_id,
+        target = plan.target_actor_name,
         title = plan.actor_title,
         description = plan.actor_description,
         location = plan.location_name,
@@ -324,39 +456,14 @@ async fn request_ai_avatar_chat(
         location_persona = plan.location_persona,
         location_memory = location_memory,
         goals = goals,
-        target = plan.target_actor_name,
         target_title = plan.target_title,
-        target_continuity = target_continuity,
         target_economy = target_economy,
         cast = plan.cast.join(", "),
         need = need,
         fresh_subject = fresh_subject,
-        recent = recent,
-    );
-
-    route_certified_voice(
-        config,
-        store_path,
-        VoiceAttemptRequest {
-            feature: if followup {
-                "dialogue_avatar_followup"
-            } else {
-                "dialogue_avatar"
-            },
-            prompt_version: if followup {
-                "dialogue-avatar-followup-v2"
-            } else {
-                "dialogue-avatar-v2"
-            },
-            system: system.to_string(),
-            user,
-            temperature: 0.8,
-            max_tokens: 70,
-            referer: "http://127.0.0.1:3102",
-        },
-        avatar_chat_gate_context(plan, followup),
+        dialogue_context = dialogue_context,
+        last_completed_turn = last_completed_turn,
     )
-    .await
 }
 
 pub(super) async fn request_ai_avatar_intent(
@@ -383,7 +490,7 @@ pub(super) async fn request_ai_avatar_intent(
         store_path,
         VoiceAttemptRequest {
             feature: "dialogue_resident",
-            prompt_version: "dialogue-resident-voice-v2",
+            prompt_version: "dialogue-resident-voice-v3",
             system,
             user,
             temperature: 0.75,
@@ -423,8 +530,15 @@ fn resident_voice_user_prompt(plan: &AvatarReplyPlan, planning_brief: &str) -> S
     let location_memory = format_location_memory(&plan.location_memory);
     let goals = format_goal_lines(&plan.goals);
     let resident_continuity = format_resident_continuity(&plan.resident_continuity);
+    let incoming_turn = plan
+        .incoming_turn
+        .as_ref()
+        .map(format_directed_dialogue_turn)
+        .unwrap_or_else(|| "No directed incoming turn is recorded.".to_string());
     format!(
-        "where i am: {location} — {location_title}\n{location_description}\nhow it feels in here: {location_persona}\nwhat this place is holding:\n{location_memory}\nwhat i am working toward:\n{goals}\nwhat i carry with me:\n{resident_continuity}\nwhat i can spend: {economy_note}\nwho is here with me: {cast}\nwhat has been happening, oldest to newest:\n{recent_activity}\nwhat has just been said:\n{recent}\nwhat i am answering right now:\n{line}\nwhat i am only turning over: {planning_brief}\n\ni answer the thing in front of me first. the room log and the played cards are what actually happened, newer over older, even where my memory disagrees. i hook one concrete detail out of all that — and if it is a named item or place i use the name, so we do not quietly drift onto some other subject. only i speak, and only as {name}. what i am turning over is not what i have done.\n\nso —",
+        "current speech owner: {name} (actor_id={speaker_actor_id})\nwhat reached me as a directed turn: {incoming_turn}\nwhere i am: {location} — {location_title}\n{location_description}\nhow it feels in here: {location_persona}\nwhat this place is holding:\n{location_memory}\nwhat i am working toward:\n{goals}\nwhat i carry with me:\n{resident_continuity}\nwhat i can spend: {economy_note}\nwho is here with me: {cast}\nwhat has been happening, oldest to newest:\n{recent_activity}\nwhat has just been said:\n{recent}\nwhat i am answering right now:\n{line}\nwhat i am only turning over: {planning_brief}\n\ni answer the thing in front of me first. the room log and the played cards are what actually happened, newer over older, even where my memory disagrees. i hook one concrete detail out of all that — and if it is a named item or place i use the name, so we do not quietly drift onto some other subject. only i speak, and only as {name}. what i am turning over is not what i have done.\n\nso —",
+        speaker_actor_id = plan.speaker_actor_id,
+        incoming_turn = incoming_turn,
         location = plan.location_name,
         location_title = plan.location_title,
         location_description = plan.location_description,
@@ -521,6 +635,14 @@ fn resident_voice_action_brief(action: &AvatarProposedAction) -> String {
 }
 
 fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGateContext {
+    let recent_lines = if followup && !plan.exchange_turns.is_empty() {
+        plan.exchange_turns
+            .iter()
+            .map(|turn| turn.content.clone())
+            .collect()
+    } else {
+        plan.recent_lines.clone()
+    };
     let mut anchors = vec![
         plan.location_name.clone(),
         plan.location_title.clone(),
@@ -528,7 +650,14 @@ fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGate
     ];
     anchors.extend(plan.location_memory.iter().cloned());
     anchors.extend(plan.goals.iter().cloned());
-    anchors.extend(plan.recent_lines.iter().cloned());
+    anchors.extend(recent_lines.iter().cloned());
+    anchors.extend(plan.exchange_turns.iter().flat_map(|turn| {
+        [
+            turn.speaker_name.clone(),
+            turn.recipient_name.clone(),
+            turn.content.clone(),
+        ]
+    }));
     anchors.extend(plan.fresh_subject.iter().cloned());
     anchors.extend(plan.missing_need.iter().cloned());
     SpeechGateContext {
@@ -547,7 +676,7 @@ fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGate
         mode: SpeechMode::Prose,
         max_words: if followup { 28 } else { 34 },
         anchors,
-        recent_lines: plan.recent_lines.clone(),
+        recent_lines,
         recent_speaker_shingle_hashes: plan.recent_speaker_shingle_hashes.clone(),
         has_proposed_action: false,
         envelope_valid: true,
@@ -564,6 +693,13 @@ fn resident_gate_context(plan: &AvatarReplyPlan, has_proposed_action: bool) -> S
     anchors.extend(plan.location_memory.iter().cloned());
     anchors.extend(plan.recent_activity.iter().cloned());
     anchors.extend(plan.recent_lines.iter().cloned());
+    anchors.extend(plan.incoming_turn.iter().flat_map(|turn| {
+        [
+            turn.speaker_name.clone(),
+            turn.recipient_name.clone(),
+            turn.content.clone(),
+        ]
+    }));
     SpeechGateContext {
         feature: "dialogue_resident",
         generation_key: publication_beat_id(
@@ -898,10 +1034,12 @@ mod publication_tests {
     fn direct_controlled_chat_and_proxy_speech_build_gate_contexts() {
         let (mut chat, mut proxy) = seeded_plans();
         chat.actor_id = 5000;
+        chat.actor_name = "Elsie Starfield".to_string();
         chat.publication_beat_id = "direct-chat-event-71".to_string();
         let direct = avatar_chat_gate_context(&chat, false);
         assert_eq!(direct.feature, "dialogue_avatar");
         assert_eq!(direct.speaker_actor_id, 5000);
+        assert_eq!(direct.speaker_name, "Elsie Starfield");
         assert_eq!(direct.generation_key, "direct-chat-event-71");
 
         proxy.speaker_actor_id = 5001;
@@ -913,6 +1051,96 @@ mod publication_tests {
         assert_eq!(direct_proxy.speaker_actor_id, 5001);
         assert_eq!(direct_proxy.max_words, 34);
         assert_eq!(direct_proxy.generation_key, "direct-proxy-event-72");
+    }
+
+    #[test]
+    fn avatar_followup_prompt_preserves_elsies_turn_and_ignores_room_chatter() {
+        let (mut chat, _) = seeded_plans();
+        chat.actor_id = 5000;
+        chat.actor_name = "Elsie Starfield".to_string();
+        chat.target_actor_name = "Judas Iscariot".to_string();
+        chat.recent_lines = vec![
+            "Passerby: I changed the subject after the reply.".to_string(),
+            "Another passerby: Follow me instead.".to_string(),
+        ];
+        chat.exchange_turns = vec![
+            DirectedDialogueTurn::new(
+                5000,
+                "Elsie Starfield",
+                7013,
+                "Judas Iscariot",
+                "Judas, will you look at what changed here with me?",
+            ),
+            DirectedDialogueTurn::new(
+                7013,
+                "Judas Iscariot",
+                5000,
+                "Elsie Starfield",
+                "I will look with you first. Bethlehem can wait.",
+            ),
+        ];
+
+        let prompt = avatar_chat_user_prompt(&chat, true);
+        assert!(prompt.contains("current speech owner: Elsie Starfield (actor_id=5000)"));
+        assert!(prompt.contains(
+            "speaker=Judas Iscariot (actor_id=7013) -> recipient=Elsie Starfield (actor_id=5000)"
+        ));
+        assert!(prompt.contains("I will look with you first. Bethlehem can wait."));
+        assert!(!prompt.contains("Passerby"));
+
+        let gate = avatar_chat_gate_context(&chat, true);
+        assert_eq!(gate.speaker_actor_id, 5000);
+        assert_eq!(gate.speaker_name, "Elsie Starfield");
+        assert_eq!(
+            gate.recent_lines,
+            vec![
+                "Judas, will you look at what changed here with me?".to_string(),
+                "I will look with you first. Bethlehem can wait.".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn direct_avatar_prompt_never_adopts_the_targets_first_person_continuity() {
+        let (mut chat, _) = seeded_plans();
+        chat.actor_id = 5000;
+        chat.actor_name = "Elsie Starfield".to_string();
+        chat.target_actor_name = "Judas Iscariot".to_string();
+        chat.target_title = "traveller".to_string();
+        chat.target_continuity.stable_identity = "Judas Iscariot.".to_string();
+        chat.target_continuity.current_intent =
+            Some("I will count everyone on the Bethlehem road.".to_string());
+        chat.target_continuity.beliefs = vec![ResidentContinuityNote {
+            text: "I believe Elsie should keep the biscuit.".to_string(),
+            source: "test".to_string(),
+            confidence: 90,
+            source_event_seq: Some(77),
+        }];
+
+        let prompt = avatar_chat_user_prompt(&chat, false);
+        assert!(prompt.contains("current speech owner: Elsie Starfield (actor_id=5000)"));
+        assert!(prompt.contains("their public profile: Judas Iscariot — traveller"));
+        assert!(!prompt.contains("I will count everyone"));
+        assert!(!prompt.contains("I believe Elsie"));
+        assert!(!prompt.contains("i am Judas"));
+        assert_eq!(prompt.matches("i am Elsie Starfield").count(), 1);
+    }
+
+    #[test]
+    fn directed_exchange_context_survives_avatar_chat_plan_serialization() {
+        let (mut chat, _) = seeded_plans();
+        chat.exchange_turns = vec![DirectedDialogueTurn::new(
+            5000,
+            "Elsie Starfield",
+            7013,
+            "Judas Iscariot",
+            "Will you look at the road with me?",
+        )];
+
+        let encoded = serde_json::to_string(&chat).expect("serialize avatar Chat plan");
+        let decoded: AvatarChatPlan =
+            serde_json::from_str(&encoded).expect("deserialize avatar Chat plan");
+        assert_eq!(decoded.exchange_turns, chat.exchange_turns);
     }
 
     #[test]
@@ -979,7 +1207,7 @@ mod publication_tests {
         });
 
         let initial = runtime
-            .resident_reply_plan_for_target_with_context(
+            .resident_reaction_plan_for_target(
                 5000,
                 5000,
                 "Lila Wayfarer just arrived in Bethlehem.",
@@ -1009,7 +1237,7 @@ mod publication_tests {
         runtime.resident_continuities.insert(5000, stale);
 
         let direct = runtime
-            .resident_reply_plan_for_target_with_context(
+            .resident_reaction_plan_for_target(
                 5000,
                 5000,
                 "Lila Wayfarer just arrived in Bethlehem.",
@@ -1055,11 +1283,7 @@ mod publication_tests {
             .actor_by_id(RATI_ACTOR_ID)
             .expect("inference resident exists");
         let npc_initial = runtime
-            .resident_reply_plan_for_target_with_context(
-                RATI_ACTOR_ID,
-                RATI_ACTOR_ID,
-                "The kettle rattled.",
-            )
+            .resident_reply_plan_for_target(RATI_ACTOR_ID, RATI_ACTOR_ID, "The kettle rattled.")
             .expect("inference resident can speak");
         let mut npc_trace = ResidentPlanningTrace::absent(&npc_initial);
         npc_trace.status = ResidentPlanningStatus::Committed;
@@ -1077,11 +1301,7 @@ mod publication_tests {
             .resident_continuities
             .insert(RATI_ACTOR_ID, npc_continuity);
         let npc = runtime
-            .resident_reply_plan_for_target_with_context(
-                RATI_ACTOR_ID,
-                RATI_ACTOR_ID,
-                "The kettle rattled.",
-            )
+            .resident_reply_plan_for_target(RATI_ACTOR_ID, RATI_ACTOR_ID, "The kettle rattled.")
             .expect("inference resident keeps full continuity");
         assert_eq!(
             npc.resident_continuity.current_intent.as_deref(),

--- a/v2/orchestrator-rust/src/relationships.rs
+++ b/v2/orchestrator-rust/src/relationships.rs
@@ -287,7 +287,7 @@ impl RuntimeWorld {
         observation: &PlayerTickObservation,
     ) -> Option<AvatarReplyPlan> {
         let expectation = observation.relationship_reply.as_ref()?;
-        self.resident_reply_plan_for_target(
+        self.resident_reaction_plan_for_target(
             expectation.actor_id,
             expectation.target_actor_id,
             &expectation.user_text,

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -77,4 +77,10 @@
 # the remaining handlers reuse the same access-aware rejection and journey seams.
 # 74293 -> 74291: route kernel events through the existing bounded projected-event
 # append so recent-room and same-speaker publication context stays current.
-74291
+# 74291 -> 74648: preserve speaker/recipient ownership through the existing
+# bounded Chat worker. The new lines carry committed directed turns instead of
+# rebuilding from ambient room history, bind reply causality to those events,
+# keep observed actions distinct from literal speech, and re-check room, safety
+# consent, and inference ownership at each asynchronous commit. The added lines
+# also pin those context and causality boundaries with focused regressions.
+74648


### PR DESCRIPTION
## What changed

- carry committed directed Chat turns with explicit speaker, recipient, and event identity
- keep follow-up context scoped to the active avatar pair instead of rebuilding it from ambient room chatter
- remove the target resident's first-person continuity from the directly controlled avatar's self context
- distinguish observed actions from literal spoken turns
- bind certified speech to the actor that commits it and advance reply causality through each committed line
- re-check room, mute/block state, and inference ownership before every asynchronous Chat publication

## Why

The direct-avatar prompt could contain two competing first-person identities (for example, Elsie's self context plus `i am Judas` from Judas's continuity). Follow-ups also reconstructed context from the latest global room messages, losing speaker/recipient ownership and allowing unrelated chatter to replace the intended exchange.

## Impact

Avatar Chat remains bounded to four authoritative lines, but each beat now has explicit ownership and pair-scoped context. Existing queued jobs remain readable through Serde defaults. No database, journal, worldpack, or snapshot migration is required.

## Validation

- complete pre-push gate: 506 Node tests
- official worldpack/composition/proof checks
- kernel tests
- 844 Rust tests
- architecture line ceiling and clippy warning ceiling
- syntax checks
- end-to-end provider-request regression for the four-beat Chat exchange

Release version: `0.0.254`.