### PR TITLE
Separate Journal context, threads, and history

### DIFF
--- a/docs/backlog/player-journal-semantic-chronicle.md
+++ b/docs/backlog/player-journal-semantic-chronicle.md
@@ -124,18 +124,16 @@ language.
 
 ## Disclosure contract
 
-A collapsed row answers **what happened**. An expanded row must add at least
-one distinct fact:
+Every row contains one semantic category tag and one complete prose string.
+Collapsed prose is clamped to one visual line. An expansion affordance appears
+only when that prose actually overflows at the current rendered width.
+Expanding the row unclamps and wraps the same prose node in place; it does not
+reveal a duplicate headline or separate detail block.
 
-- the durable state change;
-- how or where the outcome happened;
-- a lasting consequence; or
-- what remains unresolved.
-
-If no additive detail exists, render a non-disclosure row with no plus marker.
-Do not repeat the headline with punctuation added. Do not place raw source
-events in the production disclosure. Journal disclosures explain state; they
-do not become a second action menu.
+Non-overflowing rows have no marker and are not keyboard-focusable
+disclosures. Overflow must be re-evaluated after viewport, text-size, and font
+changes. Expanded prose never exposes raw source events or becomes a second
+action menu.
 
 ## Screenshot chain rewritten as beats
 
@@ -143,10 +141,8 @@ The reported Rain-Soft Garden sequence should project approximately as:
 
 | Source events or state | Region | Player-facing result |
 | --- | --- | --- |
-| `location.searched` + pathway tag/mutation + `pathway.discovered` | Story so far | **Discovery — Elsie discovered a path to the Old Oak Tree.** |
-| Discovery detail | Expanded detail | She found it while searching Rain-Soft Garden. The route is now available for travel. |
-| `actor.moved` + `journey.paused` | Story so far | **Travel — Elsie left Rain-Soft Garden for the Cosy Cottage.** |
-| Paused journey state | Expanded detail | The journey to the Old Oak Tree is paused and can be resumed later. |
+| `location.searched` + pathway tag/mutation + `pathway.discovered` | Story so far | **Discovery — Elsie discovered a path to the Old Oak Tree while searching Rain-Soft Garden; the route is now available for travel.** |
+| `actor.moved` + `journey.paused` | Story so far | **Travel — Elsie left Rain-Soft Garden for the Cosy Cottage; the journey to the Old Oak Tree is paused and can be resumed later.** |
 | Banked growth or available advancement | Open threads, only if actionable | **Growth — A growth choice is ready for Elsie.** |
 
 The search, tag, raw pathway event, move mutation, and pause event do not each
@@ -230,8 +226,8 @@ earn their own top-level row.
 - Project movement plus journey start/progress/pause/complete as one travel
   beat unless two independently meaningful outcomes occurred.
 - Name origin, destination, and resumable paused destination when available.
-- Do not hide a meaningful consequence merely to reach one row; place it in
-  additive detail.
+- Do not hide a meaningful consequence merely to reach one row; include it in
+  the row's complete prose string.
 
 ### Acceptance
 
@@ -260,8 +256,9 @@ earn their own top-level row.
   the unresolved matter.
 - Keep chronological history ordered consistently and cap it without changing
   canonical storage.
-- Replace unconditional `<details>` rows with a row that is interactive only
-  when additive detail exists.
+- Replace unconditional disclosures with rows that are interactive only when
+  their complete prose actually overflows one visual line.
+- Re-evaluate overflow after resize and text-size or font changes.
 - Preserve keyboard navigation, region labels, and useful focus states.
 - Keep actions in the action hand. A thread may describe availability but does
   not submit an action from the Journal.
@@ -270,10 +267,9 @@ earn their own top-level row.
 
 - A player can distinguish current state, unresolved matters, and completed
   history without interpreting labels or chronology.
-- Rows with no additive detail have no plus marker and are not focusable
-  disclosures.
-- Expanding every interactive row reveals information not present in its
-  headline.
+- Non-overflowing rows have no plus marker and are not focusable disclosures.
+- Expanding every interactive row wraps the complete same prose without a
+  duplicate detail block.
 - Current-place copy does not reappear as the newest story beat.
 
 ---
@@ -322,7 +318,7 @@ earn their own top-level row.
   clock progress, and an unknown event.
 - Assert causal grouping and source-sequence coverage in Rust tests.
 - Replace the browser assertion that the first row is always expandable with a
-  truthful-disclosure contract.
+  truthful overflow-disclosure contract.
 - Assert that the ticker text exactly matches the latest visible beat headline.
 - Add a production-copy lint for dotted event keys, `> event`, `> tag`, `->`,
   `"Something changed"`, and subjectless `is now`/`shakes off` fragments.
@@ -333,7 +329,7 @@ earn their own top-level row.
 
 - The screenshot regression is represented by a deterministic fixture.
 - CI fails when a newly admitted event lacks an explicit projection policy.
-- CI fails when a disclosure repeats its headline without adding a fact.
+- CI fails when a disclosure duplicates its prose in a separate detail block.
 - CI proves that non-disclosure rows do not expose an expansion affordance.
 - Presentation tests validate useful semantics as well as layout mechanics.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.254",
+  "version": "0.0.255",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.254",
+      "version": "0.0.255",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.254",
+  "version": "0.0.255",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.254"
+version = "0.0.255"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.254"
+version = "0.0.255"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -3516,6 +3516,23 @@
     .journal-stream > [hidden] {
       display: none;
     }
+    .journal-region {
+      min-width: 0;
+      margin: 0;
+      padding: 8px 0 0;
+    }
+    .journal-region + .journal-region {
+      margin-top: 6px;
+      border-top: 1px solid rgba(239, 201, 107, 0.16);
+    }
+    .journal-region-heading {
+      margin: 0;
+      padding: 0 0 3px;
+      color: var(--faint);
+      font: 750 9px/1.2 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
     .shared-questions,
     .updates,
     .room-memory,
@@ -3553,7 +3570,7 @@
       min-height: 30px;
       padding: 5px 0;
       display: grid;
-      grid-template-columns: minmax(10ch, 16ch) minmax(0, 1fr) auto auto;
+      grid-template-columns: minmax(10ch, 16ch) minmax(0, 1fr) auto;
       gap: 6px;
       align-items: center;
       list-style: none;
@@ -3585,99 +3602,35 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-    .journal-row-progress {
-      color: var(--green);
-      font-size: 10px;
-      font-weight: 850;
-      white-space: nowrap;
-    }
     .journal-row-marker {
       color: var(--faint);
       font-size: 12px;
       font-weight: 850;
     }
-    .journal-row.journal-beat:not(.is-overflowing) > summary {
+    .journal-row.journal-prose-row:not(.is-overflowing) > summary {
       cursor: default;
     }
-    .journal-row.journal-beat:not(.is-overflowing) .journal-row-marker {
+    .journal-row.journal-prose-row:not(.is-overflowing) .journal-row-marker {
       display: none;
+    }
+    .journal-row[open] > summary {
+      align-items: start;
+    }
+    .journal-row[open] .journal-row-summary {
+      overflow: visible;
+      text-overflow: clip;
+      white-space: normal;
+    }
+    .journal-row.is-measuring-overflow .journal-row-summary {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
     .journal-row[open] .journal-row-marker::before {
       content: "−";
     }
     .journal-row:not([open]) .journal-row-marker::before {
       content: "+";
-    }
-    .journal-row-detail {
-      margin: -1px 0 7px;
-      padding: 0 20px 0 min(14ch, 104px);
-      display: flex;
-      flex-wrap: wrap;
-      align-items: baseline;
-      gap: 10px;
-      color: var(--text);
-    }
-    .journal-row:not([open]) > .journal-row-detail {
-      display: none;
-    }
-    .journal-row-detail p {
-      min-width: 0;
-      margin: 0;
-      font-size: 12px;
-      line-height: 1.4;
-      overflow-wrap: anywhere;
-    }
-    .journal-row-lines {
-      flex: 1 1 100%;
-      min-width: 0;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 3px;
-      list-style: none;
-      color: var(--dim);
-      font-size: 11px;
-      line-height: 1.35;
-    }
-    .journal-row-lines li {
-      overflow-wrap: anywhere;
-    }
-    .journal-row-lines li::before {
-      content: "$ ";
-      color: var(--faint);
-    }
-    .journal-row-inspector {
-      flex-basis: 100%;
-      margin: 2px 0 0;
-      padding: 6px 0 0;
-      border-top: 1px solid var(--line);
-      list-style: none;
-      color: var(--dim);
-      font-size: 10px;
-    }
-    .journal-row-inspector li {
-      display: grid;
-      grid-template-columns: minmax(15ch, auto) 1fr;
-      gap: 8px;
-      padding: 2px 0;
-    }
-    .journal-row-detail button {
-      flex: 0 0 auto;
-      border: 0;
-      border-bottom: 1px solid var(--line-strong);
-      background: transparent;
-      color: var(--dim);
-      min-height: 28px;
-      padding: 4px 0;
-      font: inherit;
-      font-size: 10px;
-      cursor: pointer;
-    }
-    .journal-row-detail button:hover,
-    .journal-row-detail button:focus-visible {
-      border-bottom-color: var(--amber);
-      color: var(--amber);
-      outline: 0;
     }
     .terminal.journal-open {
       grid-template-columns: minmax(0, 1fr) minmax(300px, 38%);
@@ -3754,12 +3707,8 @@
       }
       .journal-row > summary {
         min-height: 36px;
-        grid-template-columns: minmax(8ch, 11ch) minmax(0, 1fr) auto auto;
+        grid-template-columns: minmax(8ch, 11ch) minmax(0, 1fr) auto;
         gap: 6px;
-      }
-      .journal-row-detail {
-        padding-left: 0;
-        padding-right: 18px;
       }
     }
 
@@ -3770,7 +3719,6 @@
     body.large-text .room-copy,
     body.large-text .line,
     body.large-text .journal-row-summary,
-    body.large-text .journal-row-detail p,
     body.large-text .library-pack-copy,
     body.large-text .account-row {
       font-size: 1rem;
@@ -4096,10 +4044,19 @@
           <span id="journal-location"></span>
         </header>
         <div class="journal-stream">
-          <section class="shared-questions" id="shared-questions" aria-label="Current story and shared questions in this place" hidden></section>
-          <section class="updates" id="updates" aria-live="polite" aria-label="First tale" hidden></section>
-          <div class="room-memory" id="room-memory" hidden></div>
-          <section class="journal-log" id="journal-log" role="region" aria-label="Room history"></section>
+          <section class="journal-region journal-current-place" id="journal-current-place" aria-labelledby="journal-current-place-heading">
+            <h3 class="journal-region-heading" id="journal-current-place-heading">Current place</h3>
+            <div class="room-memory" id="room-memory" hidden></div>
+          </section>
+          <section class="journal-region journal-open-threads" id="journal-open-threads" aria-labelledby="journal-open-threads-heading" hidden>
+            <h3 class="journal-region-heading" id="journal-open-threads-heading">Open threads</h3>
+            <section class="shared-questions" id="shared-questions" aria-label="Unresolved matters in this place" hidden></section>
+            <section class="updates" id="updates" aria-live="polite" aria-label="First tale" hidden></section>
+          </section>
+          <section class="journal-region journal-story-history" id="journal-story-history" aria-labelledby="journal-story-history-heading">
+            <h3 class="journal-region-heading" id="journal-story-history-heading">Story so far</h3>
+            <section class="journal-log" id="journal-log" aria-label="Chronological story history"></section>
+          </section>
         </div>
       </section>
       <section class="log" id="log" role="log" aria-live="polite" aria-relevant="additions text" aria-label="Shared room transcript"></section>
@@ -4311,7 +4268,8 @@
     let roomCopyExpanded = false;
     let journalOpen = false;
     let roomLogTickerFrame = null;
-    let journalBeatOverflowFrame = null;
+    let journalRowOverflowFrame = null;
+    let journalRowResizeObserver = null;
     let lastRoomCopyLocationId = null;
     let economyFlash = null;
     let economyFlashTimer = null;
@@ -8613,48 +8571,15 @@
       return /[.!?…]["')\]]*$/.test(sentence) ? sentence : `${sentence}.`;
     }
 
-    function journalClause(value) {
-      return journalSentence(value).replace(/[.!?…]+["')\]]*$/, "").trim();
-    }
-
-    function journalSummary(value) {
-      const text = cleanStatusText(value);
-      if (text.length <= 150) return text;
-      return `${text.slice(0, 147).trimEnd()}…`;
-    }
-
-    function journalRowHtml({
-      label = "note",
-      summary = "",
-      detail = "",
-      progress = "",
+    function journalProseRowHtml({
+      category = "story",
+      prose = "",
       kind = "",
       attrs = "",
-      action = "",
-      inspector = [],
-      detailLines = [],
     } = {}) {
-      const compactSummary = journalSummary(summary || detail || "Something changed");
-      const sentence = journalSentence(detail || summary || "Something changed");
-      const progressParts = String(progress || "").match(/^(\d+)\/(\d+)$/);
-      const progressHtml = progress
-        ? `<span class="journal-row-progress"${progressParts ? ` role="progressbar" aria-label="Progress" aria-valuemin="0" aria-valuemax="${Number(progressParts[2])}" aria-valuenow="${Number(progressParts[1])}"` : ""}>${escapeHtml(progress)}</span>`
-        : "";
-      const inspectorHtml = inspector.length
-        ? `<ul class="journal-row-inspector" aria-label="Raw events">${inspector.map((entry) => `<li><code>#${Number(entry.seq || 0)} ${escapeHtml(entry.type || "event")}</code><span>${escapeHtml(cleanStatusText(eventText(entry)))}</span></li>`).join("")}</ul>`
-        : "";
-      const lines = (Array.isArray(detailLines) ? detailLines : [])
-        .map(cleanStatusText)
-        .filter(Boolean)
-        .slice(0, 12);
-      const detailLinesHtml = lines.length
-        ? `<ul class="journal-row-lines">${lines.map((line) => `<li>${escapeHtml(line)}</li>`).join("")}</ul>`
-        : "";
-      const detailHtml = sentence || detailLinesHtml || inspectorHtml || action
-        ? `<div class="journal-row-detail">${sentence ? `<p>${escapeHtml(sentence)}</p>` : ""}${detailLinesHtml}${inspectorHtml}${action}</div>`
-        : "";
-      const aria = [label, compactSummary, progress].filter(Boolean).join(". ");
-      return `<details class="journal-row ${escapeAttr(kind)}"${attrs} aria-label="${escapeAttr(aria)}"><summary><span class="journal-row-label">${escapeHtml(label)}</span><span class="journal-row-summary">${escapeHtml(compactSummary)}</span>${progressHtml}<span class="journal-row-marker" aria-hidden="true"></span></summary>${detailHtml}</details>`;
+      const text = cleanStatusText(prose);
+      if (!text) return "";
+      return `<details class="journal-row journal-prose-row ${escapeAttr(kind)}"${attrs} aria-label="${escapeAttr(`${category}. ${text}`)}"><summary tabindex="-1" aria-disabled="true"><span class="journal-row-label">${escapeHtml(category)}</span><span class="journal-row-summary">${escapeHtml(text)}</span><span class="journal-row-marker" aria-hidden="true"></span></summary></details>`;
     }
 
     function syncJournalMode() {
@@ -8678,7 +8603,7 @@
       if (open) {
         scheduleVisibleWorldBeatReceipts();
         scheduleVisibleClockPresentationReceipts();
-        scheduleJournalBeatOverflowSync();
+        scheduleJournalRowOverflowSync();
       }
     }
 
@@ -8692,6 +8617,7 @@
       renderRoomMemory();
       renderJournalLog();
       renderLog();
+      syncJournalRegions();
       syncJournalMode();
     }
 
@@ -8709,28 +8635,17 @@
       if (firstThread) {
         firstTaleStageSeen = Math.max(firstTaleStageSeen, Number(firstThread.stage || 0));
       }
-      firstTaleCelebration = Boolean(
-        currentActorId && state?.first_tale?.phase === "complete"
-      );
+      firstTaleCelebration = Boolean(currentActorId && state?.first_tale?.phase === "complete");
       firstTaleCompletionSeen = firstTaleCelebration;
-      updates.hidden = !firstThread && !firstTaleCelebration;
-      const firstTaleEnding = firstTaleCompletionText(state);
+      updates.hidden = !firstThread;
       const html = firstThread
-        ? journalRowHtml({
-            label: "next",
-            summary: firstThread.text,
-            detail: `Your first tale continues when you ${lowerInitial(firstThread.text)}`,
+        ? journalProseRowHtml({
+            category: "story",
+            prose: `Your first tale continues when you ${lowerInitial(firstThread.text)}`,
             kind: "first-thread",
           })
-        : firstTaleCelebration
-          ? journalRowHtml({
-              label: "tale",
-              summary: "Your first tale is yours",
-              detail: firstTaleEnding,
-              kind: "first-thread complete",
-            })
-          : "";
-      const signature = `${currentActorId}:${state?.first_tale?.phase || ""}:${state?.first_tale?.trace_event_seq || 0}:${firstThread?.text || firstTaleEnding}`;
+        : "";
+      const signature = `${currentActorId}:${state?.first_tale?.phase || ""}:${state?.first_tale?.trace_event_seq || 0}:${firstThread?.text || ""}`;
       if (signature !== firstTaleRenderSignature) {
         updates.innerHTML = html;
         firstTaleRenderSignature = signature;
@@ -8863,10 +8778,28 @@
       toggle.hidden = false;
       renderRoomLogLatest(latestText);
       panel.hidden = false;
-      panel.innerHTML = journalRowHtml({
-        label: "room",
-        summary: atmosphericMemoryBeat(memory.latest) || memory.latest.text,
-        detail: memory.summary || openingBeat(state),
+      const latestMemoryProse = cleanStatusText(atmosphericMemoryBeat(memory.latest) || memory.latest.text);
+      const memorySummary = cleanStatusText(memory.summary || openingBeat(state));
+      const latestIsHistory = Boolean(
+        latestJournalBeat
+        && latestMemoryProse === cleanStatusText(latestJournalBeat.headline)
+      );
+      const placeProse = (
+        !latestIsHistory
+        && latestMemoryProse
+        && !memorySummary.toLowerCase().includes(memoryPhrase(latestMemoryProse).toLowerCase())
+      )
+        ? `${memorySummary} ${latestMemoryProse}`
+        : memorySummary;
+      const distinctPlaceProse = (
+        latestJournalBeat
+        && placeProse === cleanStatusText(latestJournalBeat.headline)
+      )
+        ? cleanStatusText(openingBeat(state))
+        : placeProse;
+      panel.innerHTML = journalProseRowHtml({
+        category: "story",
+        prose: distinctPlaceProse,
         kind: "memory",
       });
     }
@@ -8899,114 +8832,51 @@
 
     function sharedQuestionsForPresentation(view = state) {
       const questions = Array.isArray(view?.shared_questions) ? view.shared_questions : [];
-      const promoted = questions
+      return questions
         .filter((question) => question.promoted && question.presentation_state === "active")
         .sort((left, right) => Number(left.promotion_rank || 999) - Number(right.promotion_rank || 999));
-      if (promoted.length) return promoted;
-      return questions
-        .filter((question) => question.presentation_state === "completed_memory")
-        .sort((left, right) => Number(right.updated_event_seq || 0) - Number(left.updated_event_seq || 0))
-        .slice(0, 1);
     }
 
     function frontsForPresentation(view = state) {
       const fronts = Array.isArray(view?.fronts) ? view.fronts : [];
-      return fronts.filter((front) => front.presentation_state !== "dormant");
-    }
-
-    function narrativeNames(names) {
-      const values = (names || []).map((name) => String(name || "").trim()).filter(Boolean);
-      if (values.length < 2) return values[0] || "";
-      if (values.length === 2) return `${values[0]} and ${values[1]}`;
-      return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+      return fronts.filter((front) => (
+        ["active", "persisted", "escalated"].includes(String(front.presentation_state || "active"))
+      ));
     }
 
     function sharedFrontHtml(front) {
       const stateName = String(front.presentation_state || "active");
-      const stakes = (front.stakes_questions || []).filter(Boolean);
-      const names = narrativeNames(front.participant_names);
+      const unresolved = (front.stakes_questions || []).map(cleanStatusText).find(Boolean) || "";
       const outcome = String(front.outcome_statement || "").trim();
-      const label = {
-        persisted: "front:persisted",
-        resolved: "front:resolved",
-        escalated: "front:escalated",
-      }[stateName] || "front:active";
-      const detailLines = [
-        ...stakes.map(journalClause),
-        names ? `the answer still matters to ${names}` : "",
-        outcome,
-      ].filter(Boolean);
-      return journalRowHtml({
-        label,
-        summary: front.premise,
-        detailLines,
+      const prose = [
+        cleanStatusText(front.premise),
+        unresolved,
+        ["persisted", "escalated"].includes(stateName) ? cleanStatusText(outcome) : "",
+      ].filter(Boolean).join(" ");
+      return journalProseRowHtml({
+        category: stateName === "escalated" ? "consequence" : "story",
+        prose,
         kind: `story-front ${stateName}`,
       });
     }
 
     function sharedQuestionHtml(question) {
-      const completed = question.presentation_state === "completed_memory";
-      const rhythm = String(question.rhythm || "shared").replaceAll("_", " ");
       const progress = `${Number(question.filled || 0)}/${Number(question.segments || 0)}`;
-      const available = (question.strategies || []).filter((strategy) => strategy.available);
-      const helpers = available
-        .slice(0, 3)
-        .map((strategy) => [
-          journalClause(strategy.label || "contribute"),
-          strategy.target_label ? `at ${journalClause(strategy.target_label)}` : "",
-        ].filter(Boolean).join(" "))
-        .filter(Boolean);
-      const participants = (question.participant_names || []).slice(0, 4).filter(Boolean);
-      const recent = (question.recent_contributions || []).slice(0, 2);
-      const attrs = ` data-clock-presentation data-clock-id="${escapeAttr(question.progress_clock_id || "")}" data-question-state="${completed ? "completed_memory" : "active"}"`;
-      const action = `<button type="button" data-question-comprehension>${completed ? "understood" : "mark understood"}</button>`;
-      if (completed) {
-        const hands = recent
-          .map((entry) => `${entry.actor_name || "a traveler"} ${lowerInitial(entry.strategy_label || "helped")}`)
-          .join(" and ");
-        const detailLines = [
-          journalClause(question.completion_memory || question.situation),
-          hands ? `${hands} helped change it` : "",
-          participants.length ? `${participants.join(", ")} were involved` : "",
-        ].filter(Boolean);
-        return journalRowHtml({
-          label: "changed",
-          summary: question.completion_memory || question.situation,
-          detailLines,
-          kind: "completed-memory",
-          attrs,
-          action,
-        });
-      }
-      const suggestions = (question.suggested_actions || []).slice(0, 2);
-      const suggestionLines = suggestions.map((suggestion, index) => {
-        const risk = journalClause(suggestion.risk || "no special risk is expected");
-        return [
-          `choice ${index + 1}/${suggestions.length}: ${journalClause(suggestion.label)}`,
-          suggestion.target_label ? `target ${journalClause(suggestion.target_label)}` : "",
-          suggestion.source ? `source ${journalClause(suggestion.source)}` : "",
-          suggestion.likely_effect ? `likely ${lowerInitial(journalClause(suggestion.likely_effect))}` : "",
-          risk ? `risk ${lowerInitial(risk)}` : "",
-        ].filter(Boolean).join(" · ");
-      });
-      const detailLines = [
-        journalClause(question.situation),
-        `progress is ${progress}`,
-        question.danger_segments ? `danger is ${Number(question.danger_filled || 0)}/${Number(question.danger_segments || 0)}` : "",
-        question.danger_situation ? `danger now: ${journalClause(question.danger_situation)}` : "",
-        question.danger_consequence ? `if danger fills: ${lowerInitial(journalClause(question.danger_consequence))}` : "",
-        question.outcome ? `finishing could ${lowerInitial(journalClause(question.outcome))}` : "",
-        ...suggestionLines,
-        suggestions.length === 0 && helpers.length ? `help by ${helpers.join(", ")}` : "",
-      ].filter(Boolean);
-      return journalRowHtml({
-        label: `question:${rhythm}`,
-        summary: question.question,
-        detailLines,
-        progress,
+      const danger = question.danger_segments
+        ? `${Number(question.danger_filled || 0)}/${Number(question.danger_segments || 0)} danger`
+        : "";
+      const status = [progress !== "0/0" ? `${progress} progress` : "", danger].filter(Boolean).join(" and ");
+      const prose = [
+        cleanStatusText(question.question),
+        cleanStatusText(question.situation),
+        status ? `The unresolved work stands at ${status}.` : "",
+      ].filter(Boolean).join(" ");
+      const attrs = ` data-clock-presentation data-clock-id="${escapeAttr(question.progress_clock_id || "")}" data-question-state="active"`;
+      return journalProseRowHtml({
+        category: "work",
+        prose,
         kind: "active-question",
         attrs,
-        action,
       });
     }
 
@@ -9020,6 +8890,11 @@
         ...questions.map(sharedQuestionHtml),
       ].join("");
       if (questions.length && journalOpen) scheduleVisibleClockPresentationReceipts();
+    }
+
+    function syncJournalRegions() {
+      const openThreads = $("journal-open-threads");
+      openThreads.hidden = $("shared-questions").hidden && $("updates").hidden;
     }
 
     const journalBeatCategories = new Set([
@@ -9056,28 +8931,35 @@
       const receiptAttrs = beat.world_beat_exposure_id
         ? ` data-world-beat-receipt data-journal-beat-index="${Number(index)}"`
         : "";
-      return `<details class="journal-row journal-beat ${escapeAttr(category)}"${receiptAttrs} aria-label="${escapeAttr(`${category}. ${headline}`)}"><summary tabindex="-1" aria-disabled="true"><span class="journal-row-label">${escapeHtml(category)}</span><span class="journal-row-summary">${escapeHtml(headline)}</span><span class="journal-row-marker" aria-hidden="true"></span></summary><div class="journal-row-detail"><p>${escapeHtml(headline)}</p></div></details>`;
-    }
-
-    function scheduleJournalBeatOverflowSync() {
-      if (journalBeatOverflowFrame !== null) {
-        window.cancelAnimationFrame(journalBeatOverflowFrame);
-      }
-      journalBeatOverflowFrame = window.requestAnimationFrame(() => {
-        journalBeatOverflowFrame = null;
-        syncJournalBeatOverflow();
+      return journalProseRowHtml({
+        category,
+        prose: headline,
+        kind: `journal-beat ${category}`,
+        attrs: receiptAttrs,
       });
     }
 
-    function syncJournalBeatOverflow() {
-      for (const row of document.querySelectorAll("#journal-log .journal-beat")) {
+    function scheduleJournalRowOverflowSync() {
+      if (journalRowOverflowFrame !== null) {
+        window.cancelAnimationFrame(journalRowOverflowFrame);
+      }
+      journalRowOverflowFrame = window.requestAnimationFrame(() => {
+        journalRowOverflowFrame = null;
+        syncJournalRowOverflow();
+      });
+    }
+
+    function syncJournalRowOverflow() {
+      for (const row of document.querySelectorAll("#journal-view .journal-prose-row")) {
         const summary = row.querySelector(":scope > summary");
         const headline = summary?.querySelector(".journal-row-summary");
+        row.classList.add("is-measuring-overflow");
         const overflowing = Boolean(
           headline
           && headline.clientWidth > 0
           && headline.scrollWidth > headline.clientWidth + 2
         );
+        row.classList.remove("is-measuring-overflow");
         row.classList.toggle("is-overflowing", overflowing);
         if (!overflowing) row.open = false;
         if (summary) {
@@ -9101,13 +8983,12 @@
       const beats = journalBeatsForPresentation();
       panel.innerHTML = beats.length
         ? beats.map(journalBeatHtml).join("")
-        : journalRowHtml({
-            label: "room",
-            summary: "Nothing has been written here yet",
-            detail: "Explore the room or change the world to leave the first trace",
+        : journalProseRowHtml({
+            category: "story",
+            prose: "Nothing has been written here yet. Explore the room or change the world to leave the first trace.",
             kind: "empty",
           });
-      scheduleJournalBeatOverflowSync();
+      scheduleJournalRowOverflowSync();
       if (stream) {
         stream.scrollTop = wasAtBottom ? stream.scrollHeight : previousScrollTop;
       }
@@ -13274,6 +13155,7 @@
         "reduce-motion",
         localStorage.getItem("cosyworld.ui.reduceMotion") === "true",
       );
+      scheduleJournalRowOverflowSync();
     }
 
     function escapeHtml(value) {
@@ -13942,8 +13824,8 @@
 
     $("log").addEventListener("scroll", scheduleVisibleWorldBeatReceipts, { passive: true });
     $("journal-log").closest(".journal-stream")?.addEventListener("scroll", scheduleVisibleWorldBeatReceipts, { passive: true });
-    $("journal-log").addEventListener("click", (event) => {
-      const summary = event.target.closest(".journal-beat > summary");
+    $("journal-view").addEventListener("click", (event) => {
+      const summary = event.target.closest(".journal-prose-row > summary");
       if (summary && !summary.parentElement?.classList.contains("is-overflowing")) {
         event.preventDefault();
       }
@@ -13958,19 +13840,6 @@
       ));
       if (question) void acknowledgeClockPresentation(question, "explanation_opened");
     }, true);
-    $("shared-questions").addEventListener("click", (event) => {
-      const button = event.target.closest("[data-question-comprehension]");
-      if (!button) return;
-      const row = button.closest("[data-clock-presentation][data-clock-id]");
-      const clockId = String(row?.dataset.clockId || "");
-      const question = (state?.shared_questions || []).find((candidate) => (
-        String(candidate?.progress_clock_id || "") === clockId
-      ));
-      if (!question) return;
-      button.disabled = true;
-      button.textContent = "Story understood";
-      void acknowledgeClockPresentation(question, "comprehension_confirmed");
-    });
     window.addEventListener("scroll", scheduleVisibleClockPresentationReceipts, { passive: true });
     document.addEventListener("visibilitychange", () => {
       if (document.visibilityState === "visible") {
@@ -13987,10 +13856,16 @@
         renderRoomLogLatest($("room-log-toggle").dataset.latest || "");
         reconcileHand();
         renderCommands();
-        scheduleJournalBeatOverflowSync();
+        scheduleJournalRowOverflowSync();
         scheduleVisibleClockPresentationReceipts();
       }
     });
+
+    if (typeof ResizeObserver === "function") {
+      journalRowResizeObserver = new ResizeObserver(scheduleJournalRowOverflowSync);
+      journalRowResizeObserver.observe($("journal-view"));
+    }
+    document.fonts?.addEventListener?.("loadingdone", scheduleJournalRowOverflowSync);
 
     applyUiPreferences();
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -49186,7 +49186,7 @@ mod tests {
         assert!(INDEX_HTML.contains("aria-expanded=\"false\" aria-controls=\"journal-view\""));
         assert!(INDEX_HTML.contains("function setJournalOpen"));
         assert!(INDEX_HTML.contains("terminal?.classList.toggle(\"journal-open\", open)"));
-        assert!(INDEX_HTML.contains("function journalRowHtml"));
+        assert!(INDEX_HTML.contains("function journalProseRowHtml"));
         assert!(INDEX_HTML.contains("white-space: nowrap;"));
         assert!(!INDEX_HTML.contains("Why this matters"));
         assert!(INDEX_HTML.contains("eventIsStatusUpdate"));
@@ -49219,20 +49219,18 @@ mod tests {
         assert!(INDEX_HTML.contains("/actions/set-charm-equipped"));
         assert!(INDEX_HTML.contains("data-export-journal"));
         assert!(INDEX_HTML
-            .contains("id=\"shared-questions\" aria-label=\"Current story and shared questions in this place\""));
+            .contains("id=\"shared-questions\" aria-label=\"Unresolved matters in this place\""));
         assert!(INDEX_HTML.contains("function renderSharedQuestions"));
         assert!(INDEX_HTML.contains("role=\"progressbar\""));
-        assert!(INDEX_HTML.contains("question.strategies"));
-        assert!(INDEX_HTML.contains("strategy.target_label"));
+        assert!(INDEX_HTML.contains("id=\"journal-current-place\""));
+        assert!(INDEX_HTML.contains("id=\"journal-story-history\""));
         assert!(INDEX_HTML.contains("/story/clock-presentations"));
         assert!(INDEX_HTML.contains("explanation_opened"));
         assert!(INDEX_HTML.contains("return_change_seen"));
-        assert!(INDEX_HTML.contains("comprehension_confirmed"));
-        assert!(INDEX_HTML.contains("data-question-comprehension"));
-        assert!(
-            INDEX_HTML.contains("finishing could ${lowerInitial(journalClause(question.outcome))}")
-        );
-        assert!(INDEX_HTML.contains("help by ${helpers.join(\", \")}"));
+        assert!(INDEX_HTML.contains("id=\"journal-open-threads\""));
+        assert!(INDEX_HTML.contains("function syncJournalRegions"));
+        assert!(INDEX_HTML.contains("function syncJournalRowOverflow"));
+        assert!(INDEX_HTML.contains("document.fonts?.addEventListener"));
         assert!(INDEX_HTML.contains("function causalJobContributionEvent"));
         assert!(INDEX_HTML.contains("function jobContributionDescendants"));
         assert!(
@@ -49369,7 +49367,7 @@ mod tests {
         assert!(INDEX_HTML.contains("local tale"));
         assert!(!INDEX_HTML.contains(": \"nothing yet\""));
         assert!(!INDEX_HTML.contains(": \"no one yet\""));
-        assert!(INDEX_HTML.contains("Your first tale is yours"));
+        assert!(INDEX_HTML.contains("Your first tale continues when you"));
         assert!(INDEX_HTML.contains("firstTaleCelebration"));
         assert!(INDEX_HTML.contains("function dealtStoryGuide"));
         assert!(!INDEX_HTML.contains("storyGuideActionKeys"));

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -83,4 +83,6 @@
 # keep observed actions distinct from literal speech, and re-check room, safety
 # consent, and inference ownership at each asynchronous commit. The added lines
 # also pin those context and causality boundaries with focused regressions.
-74648
+# 74648 -> 74646: replace legacy Journal detail assertions with the smaller
+# semantic-region and truthful-overflow contract.
+74646

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -664,7 +664,6 @@ async function main() {
         roomClean: Boolean(journal?.hidden && node?.getClientRects().length === 0),
         text: node?.textContent?.trim().replace(/\s+/g, " ") || "",
         aria: firstThread?.getAttribute("aria-label") || "",
-        detail: firstThread?.querySelector(".journal-row-detail p")?.textContent?.trim() || "",
         cue: firstThread?.querySelector(".journal-row-label")?.textContent?.trim() || "",
         layout: firstThreadText ? {
           whiteSpace: getComputedStyle(firstThreadText).whiteSpace,
@@ -914,7 +913,6 @@ async function main() {
           visible: !node.hidden,
           text: node.textContent.trim().replace(/\s+/g, " "),
           aria: node.querySelector(".journal-row")?.getAttribute("aria-label") || "",
-          detail: node.querySelector(".journal-row-detail p")?.textContent?.trim() || "",
         };
         result.completionText = firstTaleCompletionText();
         firstTaleCelebration = false;
@@ -973,7 +971,7 @@ async function main() {
       return result;
     });
     assert(guide.visible && guide.roomClean, `new-avatar guidance should exist inside the closed Journal without occupying chat: ${JSON.stringify(guide)}`);
-    assert(guide.cue === "next" && /notice what the rain has changed/i.test(guide.aria), `fresh first-thread guidance should be one compact next beat: ${JSON.stringify(guide)}`);
+    assert(guide.cue === "story" && /notice what the rain has changed/i.test(guide.aria), `fresh first-thread guidance should be one compact semantic thread: ${JSON.stringify(guide)}`);
     assert(!/[●○]|chapter\s+\d+\s+of\s+\d+/i.test(`${guide.text} ${guide.aria}`), `first-tale guidance should feel like a story, not a progress meter: ${JSON.stringify(guide)}`);
     assert(/notice what the rain has changed/i.test(guide.text), `fresh first-tale guide should explain the first world question simply: ${JSON.stringify(guide)}`);
     assert(guide.layout?.whiteSpace === "nowrap" && guide.layout?.overflow === "hidden", `collapsed Journal guidance should stay on one line: ${JSON.stringify(guide)}`);
@@ -994,19 +992,18 @@ async function main() {
     );
     assert(guide.chatBeforeListenStep?.stage === 1 && /first useful lead is guaranteed/i.test(guide.chatBeforeListenStep?.text || ""), `a chat memory must not pretend the first lead was found: ${JSON.stringify(guide)}`);
     assert(guide.missedListenWithOtherAdvancementStep?.stage === 1 && /notice what the rain has changed/i.test(guide.missedListenWithOtherAdvancementStep?.text || ""), `unrelated advancement must not skip a missed first lead: ${JSON.stringify(guide)}`);
-    assert(guide.completionBeat?.visible && /your first tale is yours/i.test(guide.completionBeat?.text || ""), `finishing the opening should earn a visible celebration: ${JSON.stringify(guide)}`);
-    assert(/helped uncover the first stones/i.test(guide.completionBeat?.detail || ""), `the ending should recap the durable shared-world consequence in one expanded sentence: ${JSON.stringify(guide)}`);
+    assert(!guide.completionBeat?.visible, `completed first-tale memory should leave the unresolved Open threads region: ${JSON.stringify(guide)}`);
     assert(guide.completionText === "You noticed the washed path, helped uncover the first stones, and left the next visitor a clearer way.", `the first-tale ending should be server-authored consequence memory: ${JSON.stringify(guide)}`);
-    assert(guide.completionRepeats === true, `the first-tale memory should survive rerender and reconnect: ${JSON.stringify(guide)}`);
+    assert(guide.completionRepeats === false, `completed first-tale memory should not reappear as an open thread after rerender: ${JSON.stringify(guide)}`);
     assert(guide.travelThread?.text === "A path to Rain-Soft Garden is waiting." && guide.travelThread?.actionKey === "exit:2", `an open route should become a grounded clickable room thread: ${JSON.stringify(guide)}`);
     assert(guide.giftThread?.text === "Rati is waiting for Story Button.", `a wanted gift should outrank generic exploration in the room thread: ${JSON.stringify(guide)}`);
     assert(guide.ordinaryGiftThread?.kind === "search", `an optional gift should not be misrepresented as a resident waiting for it: ${JSON.stringify(guide)}`);
     assert(guide.searchThread?.text === "Something in The Cosy Cottage is still waiting to be found.", `a searchable room should offer a gentle discovery thread: ${JSON.stringify(guide)}`);
     assert(guide.roomHookThread?.text === "The hearth notices unfinished promises.", `an authored room hook should remain as the non-mechanical fallback thread: ${JSON.stringify(guide)}`);
     assert(
-      guide.roomThreadSurfaceAfterCompletion?.visible === true
+      guide.roomThreadSurfaceAfterCompletion?.visible === false
         && guide.roomThreadSurfaceAfterCompletion.storyThread === false,
-      `the completed first-tale memory should stay visible without restoring the redundant room-thread strip: ${JSON.stringify(guide)}`,
+      `completed first-tale state should not restore a redundant open-thread strip: ${JSON.stringify(guide)}`,
     );
     assert(
       guide.roomThreadHand?.labels?.join(",") === "chat,travel"
@@ -6380,13 +6377,17 @@ async function main() {
       }]);
       renderTimelines();
       setJournalOpen(true);
-      syncJournalBeatOverflow();
+      syncJournalRowOverflow();
       const storyRow = document.querySelector("#journal-log .journal-row.work");
       if (storyRow?.classList.contains("is-overflowing")) storyRow.open = true;
       return {
         latest: document.querySelector("#room-log-latest")?.textContent?.trim() || "",
         summary: storyRow?.querySelector(".journal-row-summary")?.textContent?.trim() || "",
-        detail: storyRow?.querySelector(".journal-row-detail p")?.textContent?.trim() || "",
+        proseNodeCount: storyRow?.querySelectorAll(".journal-row-summary").length || 0,
+        detailBlockCount: storyRow?.querySelectorAll(".journal-row-detail").length || 0,
+        expandedWhiteSpace: storyRow
+          ? getComputedStyle(storyRow.querySelector(".journal-row-summary")).whiteSpace
+          : "",
         sourceLeakCount: [...raw].filter((event) => (
           storyRow?.innerHTML.includes(event.type)
           || storyRow?.innerHTML.includes(`#${event.seq}`)
@@ -6396,9 +6397,11 @@ async function main() {
     assert(evidence.latest === result.text, `receipt evidence should show the exact authored scene status: ${JSON.stringify(evidence)}`);
     assert(
       evidence.summary === result.text
-        && evidence.detail === result.text
+        && evidence.proseNodeCount === 1
+        && evidence.detailBlockCount === 0
+        && (!evidence.expandedWhiteSpace || evidence.expandedWhiteSpace === "normal")
         && evidence.sourceLeakCount === 0,
-      `receipt evidence should reuse one complete headline without raw event identifiers: ${JSON.stringify(evidence)}`,
+      `receipt evidence should render one complete prose node without duplicate detail or raw event identifiers: ${JSON.stringify(evidence)}`,
     );
     await page.setViewportSize({ width: 980, height: 820 });
     await page.screenshot({ path: evidencePath, fullPage: false });
@@ -6579,15 +6582,11 @@ async function main() {
       };
       return {
         frontText: front?.textContent || "",
-        frontSummary: front?.querySelector(".journal-row-summary")?.textContent || "",
-        frontDescription: [...(front?.querySelectorAll(".journal-row-lines li") || [])]
-          .map((line) => line.textContent || "")
-          .join(" "),
+        frontProse: front?.querySelector(".journal-row-summary")?.textContent || "",
         frontInspectorLists: front?.querySelectorAll(".journal-row-inspector").length || 0,
         questionText: question?.textContent || "",
-        questionDescription: [...(question?.querySelectorAll(".journal-row-lines li") || [])]
-          .map((line) => line.textContent || "")
-          .join(" "),
+        questionProse: question?.querySelector(".journal-row-summary")?.textContent || "",
+        questionDetailBlocks: question?.querySelectorAll(".journal-row-detail").length || 0,
         meters,
         buttons,
         roomStoryCount: document.querySelectorAll(".room .story-front, .room .active-question, #promoted-question").length,
@@ -6599,30 +6598,23 @@ async function main() {
       };
     });
     assert(
-      evidence.frontSummary.includes("beacon's shadow has learned Rowan's shape")
-        && evidence.frontDescription.includes("Can Rowan be separated from the shadow")
-        && evidence.frontDescription.includes("Will the party restore a guiding light")
-        && evidence.frontDescription.includes("the answer still matters to Pip Thistle, Moth-Eaten Knight, and Rowan Vale")
+      evidence.frontProse.includes("beacon's shadow has learned Rowan's shape")
+        && evidence.frontProse.includes("Can Rowan be separated from the shadow")
         && evidence.frontInspectorLists === 0,
-      `the Journal should present the front as compact accessible narrative, not a roster: ${JSON.stringify(evidence)}`,
+      `the Journal should name the unresolved front as one compact prose string: ${JSON.stringify(evidence)}`,
     );
     assert(
-      evidence.questionText.includes("Can the Mothwood beacon be relit")
-        && evidence.questionDescription.includes("progress is 2/6")
-        && evidence.questionDescription.includes("danger is 1/6")
-        && evidence.questionDescription.includes("if danger fills")
-        && evidence.questionDescription.includes("finishing could")
-        && evidence.questionDescription.includes("choice 1/2")
-        && evidence.questionDescription.includes("choice 2/2")
-        && evidence.questionDescription.includes("target the brass beacon shutters")
-        && evidence.questionDescription.includes("risk trouble may draw nearer while you rest"),
-      `the compact Journal question should preserve clocks, outcomes, and both rationales: ${JSON.stringify(evidence)}`,
+      evidence.questionProse.includes("Can the Mothwood beacon be relit")
+        && evidence.questionProse.includes("One more road lamp has gone out")
+        && evidence.questionProse.includes("2/6 progress")
+        && evidence.questionProse.includes("1/6 danger")
+        && !/choice 1\/2|target the brass beacon shutters|risk trouble/i.test(evidence.questionText)
+        && evidence.questionDetailBlocks === 0,
+      `the Open threads question should name the unresolved matter without duplicating action-hand choices: ${JSON.stringify(evidence)}`,
     );
     assert(
-      JSON.stringify(evidence.meters) === JSON.stringify([
-        { label: "Progress", now: "2", max: "6" },
-      ]),
-      `the collapsed Journal row should expose exact progress without dashboard meter chrome: ${JSON.stringify(evidence)}`,
+      evidence.meters.length === 0,
+      `the one-prose Journal row should keep progress in prose rather than extra meter chrome: ${JSON.stringify(evidence)}`,
     );
     assert(
       evidence.roomStoryCount === 0
@@ -6662,26 +6654,19 @@ async function main() {
         };
         render();
         const front = document.querySelector("#shared-questions .story-front");
-        front.open = true;
+        if (front) front.open = true;
         return {
           presentationState: frontCase.presentation_state,
           text: front?.textContent || "",
-          describedText: [...(front?.querySelectorAll(".journal-row-lines li") || [])]
-            .map((line) => line.textContent || "")
-            .join(" "),
+          prose: front?.querySelector(".journal-row-summary")?.textContent || "",
         };
       });
     });
     assert(
-      evidence.frontOutcomes.every((outcome) => (
-        outcome.text.includes(outcome.presentationState === "persisted"
-          ? "remains unresolved"
-          : `larger trouble ${outcome.presentationState === "resolved" ? "is resolved" : "has escalated"}`)
-        && outcome.describedText.includes(outcome.presentationState === "persisted"
-          ? "remains unresolved"
-          : `larger trouble ${outcome.presentationState === "resolved" ? "is resolved" : "has escalated"}`)
-      )),
-      `front outcomes should keep their visible and described story truth aligned: ${JSON.stringify(evidence)}`,
+      evidence.frontOutcomes.find((outcome) => outcome.presentationState === "persisted")?.prose.includes("remains unresolved")
+        && evidence.frontOutcomes.find((outcome) => outcome.presentationState === "escalated")?.prose.includes("has escalated")
+        && evidence.frontOutcomes.find((outcome) => outcome.presentationState === "resolved")?.text === "",
+      `only unresolved fronts should remain in Open threads, with one visible prose string: ${JSON.stringify(evidence)}`,
     );
     evidence.terminal = await page.evaluate(() => {
       const activeQuestion = state.shared_questions[0];
@@ -6705,8 +6690,7 @@ async function main() {
       render();
       const front = document.querySelector("#shared-questions .story-front");
       const memory = document.querySelector("#shared-questions .completed-memory");
-      front.open = true;
-      memory.open = true;
+      if (front) front.open = true;
       return {
         frontText: front?.textContent || "",
         text: memory?.textContent || "",
@@ -6716,11 +6700,10 @@ async function main() {
     });
     assert(
       evidence.terminal.frontText.includes("the larger trouble remains unresolved")
-        && evidence.terminal.text.includes("road went fully dark")
-        && evidence.terminal.text.includes("Mara Wick, Road Reader were involved")
+        && evidence.terminal.text === ""
         && evidence.terminal.progressbars === 0
         && evidence.terminal.suggestions === 0,
-      `terminal question should retire task bars to contributor memory: ${JSON.stringify(evidence)}`,
+      `completed questions should retire from Open threads while unresolved fronts remain: ${JSON.stringify(evidence)}`,
     );
     await writeFile(metadataPath, `${JSON.stringify(evidence, null, 2)}\n`);
     await page.evaluate(() => {
@@ -7907,15 +7890,15 @@ async function main() {
         rendered: !node.hidden,
         roomClean: document.querySelector("#journal-view")?.hidden === true,
         text: node.textContent.trim().replace(/\s+/g, " "),
-        detail: node.querySelector(".journal-row-detail p")?.textContent?.trim() || "",
+        memory: firstTaleCompletionText(state),
       }));
       assert(
-        completion.rendered && completion.roomClean && /your first tale is yours/i.test(completion.text),
-        `the opening should end with a warm completion beat inside the closed Journal: ${JSON.stringify(completion)}`,
+        !completion.rendered && completion.roomClean && completion.text === "",
+        `the completed opening should leave Open threads without occupying chat: ${JSON.stringify(completion)}`,
       );
       assert(
-        /uncovered line toward the riverside/i.test(completion.detail),
-        `the completion beat should offer one causal next invitation: ${JSON.stringify(completion)}`,
+        /uncovered line toward the riverside/i.test(completion.memory),
+        `the authoritative completion memory should remain available to semantic history: ${JSON.stringify(completion)}`,
       );
     } else if (Number(current.ledger?.learned_truth_count || 0) > 0) {
       assert(
@@ -9746,18 +9729,23 @@ async function main() {
       );
       const rows = [...document.querySelectorAll("#journal-view .journal-row")];
       const summaries = rows.map((row) => row.querySelector(".journal-row-summary")).filter(Boolean);
-      const detailNodes = rows.map((row) => row.querySelector(".journal-row-detail")).filter(Boolean);
       const terminalRect = document.querySelector(".terminal")?.getBoundingClientRect();
       const journalRect = document.querySelector("#journal-view")?.getBoundingClientRect();
       const chatRect = document.querySelector("#log")?.getBoundingClientRect();
       const journalStyle = getComputedStyle(document.querySelector("#journal-view"));
+      const regionNames = [...document.querySelectorAll("#journal-view .journal-region")]
+        .filter(visible)
+        .map((region) => {
+          const headingId = region.getAttribute("aria-labelledby") || "";
+          return document.getElementById(headingId)?.textContent?.trim() || "";
+        });
       return {
         expanded: document.querySelector("#room-log-toggle")?.getAttribute("aria-expanded") || "",
         journalVisible: visible(document.querySelector("#journal-view")),
         heroVisible: visible(document.querySelector("#room-hero")),
         transcriptVisible: visible(document.querySelector("#log")),
         promptVisible: visible(document.querySelector("footer.prompt")),
-        role: document.querySelector("#journal-log")?.getAttribute("role") || "",
+        regionNames,
         heading: document.querySelector(".journal-heading h2")?.textContent || "",
         fontFamily: journalStyle.fontFamily,
         rowCount: rows.length,
@@ -9769,7 +9757,10 @@ async function main() {
             && style.overflow === "hidden"
             && node.scrollHeight <= Math.ceil(Number.parseFloat(style.lineHeight) * 1.5);
         }),
-        detailsHidden: detailNodes.every((node) => !visible(node)),
+        oneProseNodePerRow: rows.every((row) => (
+          row.querySelectorAll(".journal-row-summary").length === 1
+          && row.querySelectorAll(".journal-row-detail").length === 0
+        )),
         noDashboardCopy: !/why this matters|what we know/i.test(document.querySelector("#journal-view")?.textContent || ""),
         noCardChrome: document.querySelectorAll("#journal-view article, #journal-view img, #journal-view .shared-question-meter, #journal-view .shared-question-suggestions").length === 0,
         panesDoNotOverlap: Boolean(
@@ -9797,8 +9788,19 @@ async function main() {
     }, room.stateSignature);
     assert(journal.expanded === "true" && journal.journalVisible, `${label}: Journal should open from beside the location name: ${JSON.stringify(journal)}`);
     assert(journal.transcriptVisible && journal.promptVisible && journal.panesDoNotOverlap, `${label}: Journal must remain separate from visible chat and actions: ${JSON.stringify(journal)}`);
-    assert(journal.role === "region" && journal.rowCount >= 2, `${label}: Journal should expose current context and chronological history without replaying it as a live log: ${JSON.stringify(journal)}`);
-    assert(journal.allCollapsed && journal.rowsCompact && journal.summariesOneLine && journal.detailsHidden, `${label}: Journal rows should begin as true one-line summaries: ${JSON.stringify(journal)}`);
+    assert(
+      journal.regionNames.includes("Current place")
+        && journal.regionNames.includes("Story so far")
+        && journal.rowCount >= 2,
+      `${label}: Journal should expose labeled current-place and chronological-history regions: ${JSON.stringify(journal)}`,
+    );
+    assert(
+      journal.allCollapsed
+        && journal.rowsCompact
+        && journal.summariesOneLine
+        && journal.oneProseNodePerRow,
+      `${label}: Journal rows should begin as one semantic tag beside one prose line: ${JSON.stringify(journal)}`,
+    );
     assert(
       journal.heading === "journal://"
         && /mono|menlo|consolas/i.test(journal.fontFamily)
@@ -9813,13 +9815,11 @@ async function main() {
       const row = document.querySelector("#journal-log .journal-beat");
       const summary = row?.querySelector(":scope > summary");
       const headline = summary?.querySelector(".journal-row-summary");
-      const detail = row?.querySelector(".journal-row-detail p");
       const marker = row?.querySelector(".journal-row-marker");
-      if (!row || !summary || !headline || !detail || !marker) return { exists: false };
+      if (!row || !summary || !headline || !marker) return { exists: false };
 
       headline.textContent = "A brief note.";
-      detail.textContent = "A brief note.";
-      syncJournalBeatOverflow();
+      syncJournalRowOverflow();
       const short = {
         overflowing: row.classList.contains("is-overflowing"),
         markerVisible: getComputedStyle(marker).display !== "none",
@@ -9830,8 +9830,7 @@ async function main() {
 
       const complete = "A deliberately complete Journal headline keeps going until it cannot fit on one visual line, so the disclosure is useful without replacing or inventing any prose.";
       headline.textContent = complete;
-      detail.textContent = complete;
-      syncJournalBeatOverflow();
+      syncJournalRowOverflow();
       const long = {
         overflowing: row.classList.contains("is-overflowing"),
         markerVisible: getComputedStyle(marker).display !== "none",
@@ -9839,8 +9838,10 @@ async function main() {
       };
       summary.click();
       long.openAfterClick = row.open;
-      long.sameCompleteHeadline = headline.textContent === detail.textContent
-        && headline.textContent === complete;
+      long.sameCompleteHeadline = headline.textContent === complete;
+      long.expandedWhiteSpace = getComputedStyle(headline).whiteSpace;
+      long.proseNodeCount = row.querySelectorAll(".journal-row-summary").length;
+      long.detailBlockCount = row.querySelectorAll(".journal-row-detail").length;
       renderJournalLog();
       return { exists: true, short, long };
     });
@@ -9857,31 +9858,24 @@ async function main() {
         && beatDisclosure.long.markerVisible
         && beatDisclosure.long.tabIndex === 0
         && beatDisclosure.long.openAfterClick
-        && beatDisclosure.long.sameCompleteHeadline,
-      `${label}: only an overflowing beat should disclose the same complete headline: ${JSON.stringify(beatDisclosure)}`,
+        && beatDisclosure.long.sameCompleteHeadline
+        && beatDisclosure.long.expandedWhiteSpace === "normal"
+        && beatDisclosure.long.proseNodeCount === 1
+        && beatDisclosure.long.detailBlockCount === 0,
+      `${label}: only an overflowing beat should unclip the same complete prose node: ${JSON.stringify(beatDisclosure)}`,
     );
 
-    const rowCount = await page.locator("#journal-view .journal-row > summary").count();
-    assert(rowCount >= 1, `${label}: Journal should have an expandable row`);
-    await page.locator("#journal-view .journal-row > summary").first().click();
-    const expandedRow = await page.evaluate(() => {
-      const open = document.querySelector("#journal-view .journal-row[open]");
-      const detail = open?.querySelector(".journal-row-detail")?.textContent?.trim() || "";
-      return {
-        detail,
-        lineCount: open?.querySelectorAll(".journal-row-lines li").length || 0,
-        paragraphCount: open?.querySelectorAll(".journal-row-detail > p").length || 0,
-        chromeCount: open?.querySelectorAll("h1, h2, h3, article, img").length || 0,
-        openCount: document.querySelectorAll("#journal-view .journal-row[open]").length,
-      };
-    });
+    const rowContract = await page.evaluate(() => ({
+      rows: document.querySelectorAll("#journal-view .journal-prose-row").length,
+      proseNodes: document.querySelectorAll("#journal-view .journal-row-summary").length,
+      duplicateDetails: document.querySelectorAll("#journal-view .journal-row-detail").length,
+      actionControls: document.querySelectorAll("#journal-view button").length,
+    }));
     assert(
-      expandedRow.openCount === 1
-        && expandedRow.detail
-        && expandedRow.lineCount <= 12
-        && expandedRow.paragraphCount <= 1
-        && expandedRow.chromeCount === 0,
-      `${label}: expanding a row should reveal bounded console detail without card chrome: ${JSON.stringify(expandedRow)}`,
+      rowContract.rows === rowContract.proseNodes
+        && rowContract.duplicateDetails === 0
+        && rowContract.actionControls === 0,
+      `${label}: every Journal row should contain one prose string and no duplicate detail or action surface: ${JSON.stringify(rowContract)}`,
     );
 
     await page.locator("#room-log-toggle").click();


### PR DESCRIPTION
Closes #509.

## Summary

- separates the production Journal into labeled Current place, Open threads, and Story so far regions
- renders every Journal row as one semantic category tag plus one complete prose string
- makes the expansion affordance appear only when that prose overflows, then unclamps the same text node in place
- re-evaluates overflow after viewport, text-size, and font changes
- removes duplicate detail blocks, Journal action controls, completed questions from Open threads, and room-memory reuse through the generic history renderer
- preserves non-history room facts in Current place while preventing exact duplication of the newest semantic history beat
- synchronizes the Journal contract and locks the `main.rs` ceiling reduction at 74,289 lines
- bumps the release version to 0.0.255

## Validation

- `npm test` — 506/506
- `npm run v2:worldpack` — official, compositions, strict proof
- `npm run v2:kernel`
- `npm run v2:rust:test` — 844/844
- `npm run v2:architecture` — 74,646/74,646 lines, 273/273 clippy budget
- `npm run v2:syntax`
- `npm run v2:composition:smoke`
- `node v2/scripts/smoke-production-profile.mjs`
- `npm run v2:browser:check` — standard and living-world stress suites
