### PR TITLE
Fix duplicate avatar chat typing state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.255",
+  "version": "0.0.256",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.255",
+      "version": "0.0.256",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.255",
+  "version": "0.0.256",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.255"
+version = "0.0.256"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.255"
+version = "0.0.256"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/chat_action.rs
+++ b/v2/orchestrator-rust/src/chat_action.rs
@@ -17,7 +17,7 @@ pub(super) async fn chat(
         return action_rate_limited_response();
     }
 
-    let chat_lock = chat_action_lock(&state, payload.actor_id, payload.target_actor_id);
+    let chat_lock = chat_action_lock(&state, payload.actor_id);
     let _chat_guard = chat_lock.lock().await;
     {
         let runtime = state.inner.lock().await;
@@ -31,15 +31,33 @@ pub(super) async fn chat(
         }
     }
     if let Some(path) = state.event_store_path.as_deref() {
-        match active_orb_chat_job(path, payload.actor_id, payload.target_actor_id) {
-            Ok(true) => {
+        match active_orb_chat_target(path, payload.actor_id) {
+            Ok(Some(active_target_actor_id))
+                if active_target_actor_id == payload.target_actor_id =>
+            {
                 return Json(ActionResponse {
                     ok: true,
                     status: CW_OK,
                     events: Vec::new(),
                 });
             }
-            Ok(false) => {}
+            Ok(Some(_)) => {
+                return Json(ActionResponse {
+                    ok: false,
+                    status: 409,
+                    events: vec![EventView {
+                        type_name: "chat.failed".to_string(),
+                        actor_id: Some(payload.actor_id),
+                        target_actor_id: Some(payload.target_actor_id),
+                        content: Some(
+                            "Let the current conversation settle before starting another."
+                                .to_string(),
+                        ),
+                        ..EventView::default()
+                    }],
+                });
+            }
+            Ok(None) => {}
             Err(error) => {
                 warn!("could not inspect the durable Chat queue: {error}");
                 return Json(ActionResponse {
@@ -153,11 +171,8 @@ pub(super) async fn chat(
     })
 }
 
-fn chat_action_lock(state: &AppState, actor_id: u64, target_actor_id: u64) -> Arc<Mutex<()>> {
-    let key = format!(
-        "{:p}:{actor_id}:{target_actor_id}",
-        Arc::as_ptr(&state.inner)
-    );
+fn chat_action_lock(state: &AppState, actor_id: u64) -> Arc<Mutex<()>> {
+    let key = format!("{:p}:{actor_id}", Arc::as_ptr(&state.inner));
     let mut locks = CHAT_ACTION_LOCKS
         .get_or_init(|| StdMutex::new(BTreeMap::new()))
         .lock()
@@ -171,7 +186,7 @@ fn chat_action_lock(state: &AppState, actor_id: u64, target_actor_id: u64) -> Ar
     lock
 }
 
-fn active_orb_chat_job(path: &Path, actor_id: u64, target_actor_id: u64) -> io::Result<bool> {
+fn active_orb_chat_target(path: &Path, actor_id: u64) -> io::Result<Option<u64>> {
     let conn = open_event_store(path)?;
     let mut stmt = conn
         .prepare(
@@ -190,11 +205,9 @@ fn active_orb_chat_job(path: &Path, actor_id: u64, target_actor_id: u64) -> io::
         else {
             continue;
         };
-        if job.target_actor_id == target_actor_id {
-            return Ok(true);
-        }
+        return Ok(Some(job.target_actor_id));
     }
-    Ok(false)
+    Ok(None)
 }
 
 #[cfg(test)]
@@ -340,6 +353,28 @@ mod tests {
             !unauthorized_retry.ok,
             "an active Chat job must not bypass actor authorization"
         );
+        let overlapping_target = chat(
+            ConnectInfo("127.0.0.1:44001".parse().expect("client address")),
+            State(state.clone()),
+            Json(ChatRequest {
+                actor_id: 5000,
+                actor_session: Some(actor_session.clone()),
+                target_actor_id: WHISKERWIND_ACTOR_ID,
+            }),
+        )
+        .await
+        .0;
+        assert!(!overlapping_target.ok);
+        assert_eq!(overlapping_target.status, 409);
+        assert!(overlapping_target.events.iter().any(|event| {
+            event.type_name == "chat.failed"
+                && event.actor_id == Some(5000)
+                && event.target_actor_id == Some(WHISKERWIND_ACTOR_ID)
+                && event
+                    .content
+                    .as_deref()
+                    .is_some_and(|content| content.contains("current conversation"))
+        }));
         let retry = chat(
             ConnectInfo("127.0.0.1:44001".parse().expect("client address")),
             State(state.clone()),

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -7733,6 +7733,7 @@
 
     function pushEvents(events) {
       let changed = false;
+      const pendingChatCountBefore = pendingChats.length;
       for (const event of events) {
         if (captureDefeatTransition(event)) changed = true;
         if (applyActionReceipt(event)) {
@@ -7752,6 +7753,7 @@
         changed = true;
       }
       logEvents = logEvents.slice(-90);
+      if (pendingChats.length !== pendingChatCountBefore) renderCommands();
       return changed;
     }
 
@@ -7782,6 +7784,10 @@
 
     function beginPendingChat(action) {
       if (!actorId || action?.kind !== "orb-chat") return 0;
+      const active = pendingChats[0];
+      if (active) {
+        return { id: active.id, created: false };
+      }
       const target = reactionTargetForAction(action);
       if (!target) return 0;
       const id = nextPendingChatId++;
@@ -7796,45 +7802,64 @@
       });
       window.setTimeout(() => {
         if (!pendingChats.some((chat) => chat.id === id)) return;
-        cancelPendingChat(id);
+        cancelPendingChat({ id, created: true });
+        renderCommands();
         renderLog();
       }, 60000);
-      return id;
+      return { id, created: true };
     }
 
-    function cancelPendingChat(id) {
+    function cancelPendingChat(pending) {
+      if (!pending || pending.created === false) return;
+      const id = Number(pending.id || pending || 0);
       if (!id) return;
       pendingChats = pendingChats.filter((chat) => chat.id !== id);
+    }
+
+    function pendingChatMatchesEvent(chat, event) {
+      const eventSeq = Number(event?.seq || 0);
+      if (!eventSeq || eventSeq <= Number(chat.afterSeq || 0)) return false;
+      const pairMatches = (
+        (Number(event.actor_id || 0) === Number(actorId || 0)
+          && Number(event.target_actor_id || 0) === Number(chat.targetActorId || 0))
+        || (Number(event.actor_id || 0) === Number(chat.targetActorId || 0)
+          && Number(event.target_actor_id || 0) === Number(actorId || 0))
+      );
+      if (!pairMatches) return false;
+      const queueEventSeq = Number(chat.queueEventSeq || 0);
+      const eventQueueSeq = event.type === "chat.queued"
+        ? eventSeq
+        : Number(event.caused_by_event_seq || 0);
+      return !queueEventSeq || !eventQueueSeq || queueEventSeq === eventQueueSeq;
     }
 
     function resolvePendingChat(event) {
       if (!event || !pendingChats.length) return false;
       const eventSeq = Number(event.seq || 0);
-      const matchingChatIndex = pendingChats.findIndex((chat) => (
-        eventSeq > Number(chat.afterSeq || 0)
-        && (
-          (Number(event.actor_id || 0) === Number(actorId || 0)
-            && Number(event.target_actor_id || 0) === Number(chat.targetActorId || 0))
-          || (Number(event.actor_id || 0) === Number(chat.targetActorId || 0)
-            && Number(event.target_actor_id || 0) === Number(actorId || 0))
-        )
-      ));
-      if (event.type === "chat.typing") {
+      const matchingChatIndex = pendingChats.findIndex((chat) => pendingChatMatchesEvent(chat, event));
+      if (event.type === "chat.queued" || event.type === "chat.typing") {
         if (matchingChatIndex >= 0) {
+          const matchingChat = pendingChats[matchingChatIndex];
+          pendingChats = pendingChats.filter((chat, index) => (
+            index === matchingChatIndex || !pendingChatMatchesEvent(chat, event)
+          ));
+          matchingChat.queueEventSeq = event.type === "chat.queued"
+            ? eventSeq
+            : Number(matchingChat.queueEventSeq || event.caused_by_event_seq || 0);
+          if (event.type === "chat.queued") return true;
           const speakerId = Number(event.actor_id || 0);
           const speaker = actorForId(speakerId);
-          pendingChats[matchingChatIndex] = {
-            ...pendingChats[matchingChatIndex],
-            typingActorId: speakerId,
-            typingName: String(event.actor_name || (speaker ? actorLabel(speaker) : "Someone nearby")),
-          };
+          matchingChat.typingActorId = speakerId;
+          matchingChat.typingName = String(
+            event.actor_name || (speaker ? actorLabel(speaker) : "Someone nearby"),
+          );
           return true;
         }
         return false;
       }
       if (event.type === "chat.failed" || event.type === "chat.completed") {
         if (matchingChatIndex >= 0) {
-          pendingChats.splice(matchingChatIndex, 1);
+          pendingChats = pendingChats.filter((chat) => !pendingChatMatchesEvent(chat, event));
           return true;
         }
       }
@@ -12152,6 +12177,11 @@
 
     function openActionModal(action) {
       if (!action || actionBusy) return;
+      if (action.kind === "orb-chat" && pendingChats.length) {
+        setError("Let the current conversation settle before starting another.");
+        render();
+        return;
+      }
       actionConfirmAction = action;
       const label = action.modalTitle || actionTitle(action);
       const selectedChoice = Array.isArray(action?.choices)
@@ -12193,16 +12223,20 @@
         const groupId = `all-actions-group-${groupLabel.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
         const buttons = entries.map(({ action, actionIndex, choice, choiceIndex }) => {
           const suggested = suggestedKeys.has(actionHandKey(action));
+          const conversationBusy = action.kind === "orb-chat" && pendingChats.length > 0;
           const actionLabel = compactActionLabel(action) || action.label || action.command || "act";
-          const targetLabel = choice?.label || action.detail || action.accessibleLabel || "";
+          const targetLabel = conversationBusy
+            ? "current exchange unfolding…"
+            : choice?.label || action.detail || action.accessibleLabel || "";
           const detail = choice?.detail || (choice ? action.detail : "") || "";
           const ariaLabel = [
             actionLabel,
             targetLabel,
             detail,
             suggested ? "suggested now" : "",
+            conversationBusy ? "unavailable until the current conversation settles" : "",
           ].filter(Boolean).join(", ");
-          return `<button class="all-action${suggested ? " suggested" : ""}" type="button" data-all-action-index="${actionIndex}"${choice ? ` data-all-action-choice-index="${choiceIndex}"` : ""} aria-label="${escapeAttr(ariaLabel)}"><span class="all-action-label">${escapeHtml(actionLabel)}</span>${targetLabel ? `<span class="all-action-detail">${escapeHtml(targetLabel)}</span>` : ""}${detail && detail !== targetLabel ? `<span class="all-action-detail">${escapeHtml(detail)}</span>` : ""}${suggested ? `<span class="all-action-status">suggested now</span>` : ""}</button>`;
+          return `<button class="all-action${suggested ? " suggested" : ""}" type="button" data-all-action-index="${actionIndex}"${choice ? ` data-all-action-choice-index="${choiceIndex}"` : ""} aria-label="${escapeAttr(ariaLabel)}"${conversationBusy ? " disabled" : ""}><span class="all-action-label">${escapeHtml(actionLabel)}</span>${targetLabel ? `<span class="all-action-detail">${escapeHtml(targetLabel)}</span>` : ""}${!conversationBusy && detail && detail !== targetLabel ? `<span class="all-action-detail">${escapeHtml(detail)}</span>` : ""}${suggested ? `<span class="all-action-status">suggested now</span>` : ""}</button>`;
         }).join("");
         return `<section class="all-actions-group" aria-labelledby="${escapeAttr(groupId)}"><h3 class="all-actions-group-title" id="${escapeAttr(groupId)}">${escapeHtml(groupLabel)}</h3><div class="all-actions-list">${buttons}</div></section>`;
       }).join("");
@@ -12755,6 +12789,13 @@
         button.innerHTML = `<span class="thumb placeholder" aria-hidden="true"></span>`;
         return;
       }
+      if (action.kind === "orb-chat" && pendingChats.length) {
+        action = {
+          ...action,
+          busy: true,
+          busyDetail: "current exchange unfolding…",
+        };
+      }
       button.disabled = Boolean(action.busy);
       if (action.busy) button.setAttribute("aria-busy", "true");
       else button.removeAttribute("aria-busy");
@@ -13007,6 +13048,11 @@
 
     async function runAction(action) {
       if (actionBusy) return;
+      if (action?.kind === "orb-chat" && pendingChats.length) {
+        setError("Let the current conversation settle before starting another.");
+        render();
+        return;
+      }
       actionBusy = true;
       actionSlow = false;
       pendingAction = action;
@@ -13016,14 +13062,16 @@
         actionSlow = true;
         renderCommands();
       }, 3000);
-      const pendingChatId = beginPendingChat(action);
+      const pendingChat = beginPendingChat(action);
       renderCommands();
       renderLog();
       try {
         const result = await action.run();
-        if (result?.ok === false) cancelPendingChat(pendingChatId);
+        if (result?.ok === false) {
+          cancelPendingChat(pendingChat);
+        }
       } catch (error) {
-        cancelPendingChat(pendingChatId);
+        cancelPendingChat(pendingChat);
         setError(String(error.message || error));
       } finally {
         clearTimeout(actionSlowTimer);

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -49339,7 +49339,7 @@ mod tests {
         assert!(INDEX_HTML.contains("if (!result.ok) void queueRefresh();"));
         assert!(INDEX_HTML.contains("event?.type !== \"action.receipt\""));
         assert!(INDEX_HTML.contains("state.state_revision"));
-        assert!(INDEX_HTML.contains("if (result?.ok === false) cancelPendingChat"));
+        assert!(INDEX_HTML.contains("if (result?.ok === false) {"));
         assert!(INDEX_HTML.contains("state?.first_tale?.phase"));
         assert!(INDEX_HTML.contains("function quietRoomSceneHtml"));
         assert!(INDEX_HTML.contains("Chat with someone here or explore the room."));

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -10739,6 +10739,22 @@ async function main() {
     assert(targetActorId, "chat smoke needs a focused resident target");
     if (!chatPendingChecked) {
       await clickPrimaryAndAssertPending(label);
+      const optimisticRetry = await page.evaluate(() => {
+        const chatAction = actions.find((action) => action.kind === "orb-chat");
+        const retry = beginPendingChat(chatAction);
+        renderLog();
+        return {
+          created: retry?.created,
+          pendingCount: pendingChats.length,
+          renderedCount: document.querySelectorAll("#log .line.chat.pending").length,
+        };
+      });
+      assert(
+        optimisticRetry.created === false
+          && optimisticRetry.pendingCount === 1
+          && optimisticRetry.renderedCount === 1,
+        `a repeated Chat activation should reuse one optimistic lifecycle: ${JSON.stringify(optimisticRetry)}`,
+      );
       const duplicate = await page.evaluate(async (targetActorId) => {
         const actorId = Number(localStorage.getItem("cosyworld.actorId") || 0);
         const actorSession = localStorage.getItem("cosyworld.actorSession") || "";
@@ -10836,6 +10852,12 @@ async function main() {
       () => !document.querySelector("#primary")?.disabled,
       null,
       { timeout: 75_000 },
+    );
+    await page.waitForFunction(() => pendingChats.length === 0);
+    const pendingAfterCompletion = await page.locator("#log .line.chat.pending").count();
+    assert(
+      pendingAfterCompletion === 0,
+      `completed Chat should clear every optimistic typing row: ${pendingAfterCompletion}`,
     );
     await assertActionBarCapped("chat action bar");
     assert(!(await page.locator("#primary").isDisabled()), "chat button should re-enable after the server-authored line lands");


### PR DESCRIPTION
## What changed

- enforce one active Chat lifecycle per player avatar on the server, while keeping same-target retries idempotent
- reuse one optimistic pending-chat row in the browser and correlate it with the durable `chat.queued` sequence
- clear every matching pending row on completion/failure and rerender Chat availability on terminal/timeout paths
- disable additional Chat activations while the current exchange is unfolding
- add endpoint and browser coverage for rapid retries, overlapping targets, and pending-row cleanup
- bump the release to `0.0.256`

## Why

A rapid repeated Chat activation could be deduplicated correctly by the server but still create a second optimistic `typing…` row in the browser. The original lifecycle would advance to the other speaker while the orphaned retry row continued to show the player avatar typing, producing the contradictory state seen in production.

## Impact

Each avatar can now have only one active conversation. Repeated clicks reuse the same visible lifecycle, different-target overlaps are rejected clearly, and Chat becomes available again as soon as the exchange finishes.

## Validation

- `npm run check` — 506 Node tests and 844 Rust tests passed, plus worldpack, kernel, architecture, lint, and syntax gates
- `npm run v2:browser:check` on an isolated local port — standard browser smoke and living-world stress both passed
- focused Chat endpoint tests — 5 passed
- embedded browser shell contract — passed
- `npm run check:version` — passed