### PR TITLE
Gate semantic Journal disclosures in CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.255",
+  "version": "0.0.256",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.255",
+      "version": "0.0.256",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.255",
+  "version": "0.0.256",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.255"
+version = "0.0.256"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.255"
+version = "0.0.256"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -8637,15 +8637,27 @@
       }
       firstTaleCelebration = Boolean(currentActorId && state?.first_tale?.phase === "complete");
       firstTaleCompletionSeen = firstTaleCelebration;
-      updates.hidden = !firstThread;
-      const html = firstThread
-        ? journalProseRowHtml({
-            category: "story",
-            prose: `Your first tale continues when you ${lowerInitial(firstThread.text)}`,
-            kind: "first-thread",
-          })
-        : "";
-      const signature = `${currentActorId}:${state?.first_tale?.phase || ""}:${state?.first_tale?.trace_event_seq || 0}:${firstThread?.text || ""}`;
+      const growthReady = currentActorId && Number(state?.ledger?.advancement_points || 0) > 0;
+      const growthActorName = String(actorForId(currentActorId)?.name || "Your avatar").trim();
+      const rows = [
+        firstThread
+          ? journalProseRowHtml({
+              category: "story",
+              prose: `Your first tale continues when you ${lowerInitial(firstThread.text)}`,
+              kind: "first-thread",
+            })
+          : "",
+        growthReady
+          ? journalProseRowHtml({
+              category: "growth",
+              prose: `A growth choice is ready for ${growthActorName}.`,
+              kind: "growth-thread",
+            })
+          : "",
+      ].filter(Boolean);
+      updates.hidden = rows.length === 0;
+      const html = rows.join("");
+      const signature = `${currentActorId}:${state?.first_tale?.phase || ""}:${state?.first_tale?.trace_event_seq || 0}:${firstThread?.text || ""}:${Number(state?.ledger?.advancement_points || 0)}`;
       if (signature !== firstTaleRenderSignature) {
         updates.innerHTML = html;
         firstTaleRenderSignature = signature;

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -40,6 +40,86 @@ pub(super) enum JournalBeatCategory {
     Consequence,
 }
 
+const JOURNAL_BEAT_POLICIES: &[(&str, JournalBeatCategory)] = &[
+    ("actor.created", JournalBeatCategory::Story),
+    ("actor.entered_location", JournalBeatCategory::Story),
+    ("first_tale.public_trace", JournalBeatCategory::Story),
+    ("governance.selected", JournalBeatCategory::Story),
+    ("actor.moved", JournalBeatCategory::Travel),
+    ("combat.flee.success", JournalBeatCategory::Travel),
+    ("journey.started", JournalBeatCategory::Travel),
+    ("journey.progressed", JournalBeatCategory::Travel),
+    ("journey.narrated", JournalBeatCategory::Travel),
+    ("journey.completed", JournalBeatCategory::Travel),
+    ("journey.backtracked", JournalBeatCategory::Travel),
+    ("journey.paused", JournalBeatCategory::Travel),
+    ("exit.discovered", JournalBeatCategory::Discovery),
+    ("avatar.discovered", JournalBeatCategory::Discovery),
+    ("exit.unlocked", JournalBeatCategory::Discovery),
+    ("pathway.discovered", JournalBeatCategory::Discovery),
+    ("pathway.familiarized", JournalBeatCategory::Discovery),
+    ("natural_feature.revealed", JournalBeatCategory::Discovery),
+    ("feature.searched", JournalBeatCategory::Search),
+    ("location.searched", JournalBeatCategory::Search),
+    ("ability_check.rolled", JournalBeatCategory::Search),
+    ("bond.deepened", JournalBeatCategory::Relationship),
+    ("bond.created", JournalBeatCategory::Relationship),
+    ("bond.revised", JournalBeatCategory::Relationship),
+    ("bond.resolved", JournalBeatCategory::Relationship),
+    ("ledger.marked", JournalBeatCategory::Growth),
+    ("ledger.banked", JournalBeatCategory::Growth),
+    ("advancement.spent", JournalBeatCategory::Growth),
+    ("skill.stepped", JournalBeatCategory::Growth),
+    ("calling.set", JournalBeatCategory::Growth),
+    ("calling.revised", JournalBeatCategory::Growth),
+    ("avatar.evolved", JournalBeatCategory::Growth),
+    ("job.contribution.resolved", JournalBeatCategory::Work),
+    ("job.updated", JournalBeatCategory::Work),
+    ("building.construction_opened", JournalBeatCategory::Work),
+    ("building.completed", JournalBeatCategory::Work),
+    ("building.upgraded", JournalBeatCategory::Work),
+    ("world.trade.flowed", JournalBeatCategory::Work),
+    ("world.trade.disrupted", JournalBeatCategory::Work),
+    ("world.delivery.needed", JournalBeatCategory::Work),
+    ("world.logistics.completed", JournalBeatCategory::Work),
+    ("quest.loot_allocated", JournalBeatCategory::Item),
+    ("item.picked_up", JournalBeatCategory::Item),
+    ("item.dropped", JournalBeatCategory::Item),
+    ("item.used", JournalBeatCategory::Item),
+    ("item.given", JournalBeatCategory::Item),
+    ("item.traded", JournalBeatCategory::Item),
+    ("item.found", JournalBeatCategory::Item),
+    ("item.revealed", JournalBeatCategory::Item),
+    ("item.crafted", JournalBeatCategory::Item),
+    ("item.created", JournalBeatCategory::Item),
+    ("item.transformed", JournalBeatCategory::Item),
+    ("move.blocked", JournalBeatCategory::Consequence),
+    ("clock.updated", JournalBeatCategory::Consequence),
+    ("combat.attack.attempt", JournalBeatCategory::Consequence),
+    ("combat.encounter.started", JournalBeatCategory::Consequence),
+    ("combat.dodge", JournalBeatCategory::Consequence),
+    (
+        "combat.encounter.resolved",
+        JournalBeatCategory::Consequence,
+    ),
+    ("world.weather.shifted", JournalBeatCategory::Consequence),
+    ("world.weather.held", JournalBeatCategory::Consequence),
+    (
+        "world.faction.influence_shifted",
+        JournalBeatCategory::Consequence,
+    ),
+    (
+        "world.conflict.pressure_grew",
+        JournalBeatCategory::Consequence,
+    ),
+    (
+        "world.conflict.pressure_eased",
+        JournalBeatCategory::Consequence,
+    ),
+    ("world.conflict.escalated", JournalBeatCategory::Consequence),
+    ("magic.spell_cast", JournalBeatCategory::Consequence),
+];
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub(super) struct JournalBeatView {
     pub(super) id: String,
@@ -149,70 +229,11 @@ fn journal_beat_category(event: &EventView) -> Option<JournalBeatCategory> {
         return semantic_receipts::semantic_story_receipt(event)
             .map(|receipt| semantic_receipt_journal_category(&receipt.narration_key));
     }
-    let category = match event.type_name.as_str() {
-        "actor.created"
-        | "actor.entered_location"
-        | "first_tale.public_trace"
-        | "governance.selected" => JournalBeatCategory::Story,
-        "actor.moved"
-        | "combat.flee.success"
-        | "journey.started"
-        | "journey.progressed"
-        | "journey.narrated"
-        | "journey.completed"
-        | "journey.backtracked"
-        | "journey.paused" => JournalBeatCategory::Travel,
-        "exit.discovered"
-        | "avatar.discovered"
-        | "exit.unlocked"
-        | "pathway.discovered"
-        | "pathway.familiarized"
-        | "natural_feature.revealed" => JournalBeatCategory::Discovery,
-        "feature.searched" | "location.searched" | "ability_check.rolled" => {
-            JournalBeatCategory::Search
-        }
-        "bond.deepened" | "bond.created" | "bond.revised" | "bond.resolved" => {
-            JournalBeatCategory::Relationship
-        }
-        "ledger.marked" | "ledger.banked" | "advancement.spent" | "skill.stepped"
-        | "calling.set" | "calling.revised" | "avatar.evolved" => JournalBeatCategory::Growth,
-        "job.contribution.resolved"
-        | "job.updated"
-        | "building.construction_opened"
-        | "building.completed"
-        | "building.upgraded"
-        | "world.trade.flowed"
-        | "world.trade.disrupted"
-        | "world.delivery.needed"
-        | "world.logistics.completed" => JournalBeatCategory::Work,
-        "quest.loot_allocated"
-        | "item.picked_up"
-        | "item.dropped"
-        | "item.used"
-        | "item.given"
-        | "item.traded"
-        | "item.found"
-        | "item.revealed"
-        | "item.crafted"
-        | "item.created"
-        | "item.transformed" => JournalBeatCategory::Item,
-        "move.blocked"
-        | "clock.updated"
-        | "combat.attack.attempt"
-        | "combat.encounter.started"
-        | "combat.dodge"
-        | "combat.encounter.resolved"
-        | "world.weather.shifted"
-        | "world.weather.held"
-        | "world.faction.influence_shifted"
-        | "world.conflict.pressure_grew"
-        | "world.conflict.pressure_eased"
-        | "world.conflict.escalated"
-        | "magic.spell_cast" => JournalBeatCategory::Consequence,
-        type_name if type_name.starts_with("combat.") => JournalBeatCategory::Consequence,
-        _ => return None,
-    };
-    Some(category)
+    JOURNAL_BEAT_POLICIES
+        .iter()
+        .find_map(|(type_name, category)| {
+            (*type_name == event.type_name.as_str()).then_some(*category)
+        })
 }
 
 fn complete_journal_headline(value: &str) -> Option<String> {
@@ -4029,6 +4050,47 @@ mod tests {
     use super::*;
 
     #[test]
+    fn journal_admission_uses_unique_explicit_projection_policies() {
+        let mut admitted = BTreeSet::new();
+        for (type_name, category) in JOURNAL_BEAT_POLICIES {
+            assert!(
+                admitted.insert(*type_name),
+                "duplicate Journal projection policy for {type_name}"
+            );
+            let event = EventView {
+                type_name: (*type_name).to_string(),
+                ..EventView::default()
+            };
+            assert_eq!(
+                journal_beat_category(&event),
+                Some(*category),
+                "admitted Journal source {type_name} must keep an explicit policy"
+            );
+        }
+
+        for internal_type in [
+            "combat.action.required",
+            "combat.initiative.rolled",
+            "combat.participant.joined",
+            "combat.turn.started",
+            "combat.turn.ended",
+            "tag.applied",
+            "tag.cleared",
+            "future.internal.telemetry",
+        ] {
+            let event = EventView {
+                type_name: internal_type.to_string(),
+                ..EventView::default()
+            };
+            assert_eq!(
+                journal_beat_category(&event),
+                None,
+                "internal source {internal_type} must not enter the player Journal through a wildcard"
+            );
+        }
+    }
+
+    #[test]
     fn front_presentation_names_active_persisted_resolved_and_escalated_truths() {
         let impending = "Every road lamp accepts the shadow as keeper.";
         assert_eq!(
@@ -4349,6 +4411,102 @@ mod tests {
                     )
                 }))
         );
+    }
+
+    #[test]
+    fn journal_projection_golden_fixtures_cover_travel_relationship_and_clock_progress() {
+        let ordinary_travel = EventView {
+            seq: 300,
+            type_name: "actor.moved".to_string(),
+            actor_id: Some(5000),
+            actor_name: Some("Elsie".to_string()),
+            location_id: Some(7),
+            location_name: Some("Rain-Soft Garden".to_string()),
+            destination_location_id: Some(8),
+            destination_location_name: Some("the Cosy Cottage".to_string()),
+            ..EventView::default()
+        };
+        let completed_step = EventView {
+            seq: 310,
+            type_name: "actor.moved".to_string(),
+            actor_id: Some(5000),
+            actor_name: Some("Elsie".to_string()),
+            location_id: Some(7),
+            location_name: Some("Rain-Soft Garden".to_string()),
+            destination_location_id: Some(8),
+            destination_location_name: Some("the Cosy Cottage".to_string()),
+            ..EventView::default()
+        };
+        let completed_journey = EventView {
+            seq: 314,
+            type_name: "journey.completed".to_string(),
+            actor_id: Some(5000),
+            actor_name: Some("Elsie".to_string()),
+            location_id: Some(8),
+            location_name: Some("the Cosy Cottage".to_string()),
+            destination_location_id: Some(9),
+            destination_location_name: Some("the Old Oak Tree".to_string()),
+            caused_by_event_seq: Some(310),
+            ..EventView::default()
+        };
+        let relationship = EventView {
+            seq: 320,
+            type_name: "bond.deepened".to_string(),
+            actor_id: Some(5000),
+            actor_name: Some("Elsie".to_string()),
+            target_actor_id: Some(5001),
+            target_actor_name: Some("Pip Marrow".to_string()),
+            location_id: Some(7),
+            location_name: Some("Rain-Soft Garden".to_string()),
+            ..EventView::default()
+        };
+        let clock = EventView {
+            seq: 330,
+            type_name: "clock.updated".to_string(),
+            actor_id: Some(5000),
+            actor_name: Some("Elsie".to_string()),
+            location_id: Some(7),
+            location_name: Some("Rain-Soft Garden".to_string()),
+            clock_label: Some("The washed path".to_string()),
+            clock_filled: Some(2),
+            clock_segments: Some(4),
+            clock_delta: Some(1),
+            ..EventView::default()
+        };
+
+        let ordinary = journal_beat_views(&[ordinary_travel], 7);
+        assert_eq!(ordinary.len(), 1);
+        assert_eq!(ordinary[0].category, JournalBeatCategory::Travel);
+        assert_eq!(ordinary[0].headline, "Elsie left for the Cosy Cottage.");
+        assert_eq!(ordinary[0].source_event_seqs, vec![300]);
+
+        let completed = journal_beat_views(&[completed_journey, completed_step], 7);
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].category, JournalBeatCategory::Travel);
+        assert_eq!(
+            completed[0].headline,
+            "Elsie traveled from Rain-Soft Garden to the Cosy Cottage and completed the journey to the Old Oak Tree."
+        );
+        assert_eq!(completed[0].source_event_seqs, vec![310, 314]);
+
+        let semantic = journal_beat_views(&[clock, relationship], 7);
+        assert_eq!(semantic.len(), 2);
+        assert_eq!(semantic[0].category, JournalBeatCategory::Relationship);
+        assert_eq!(semantic[0].headline, "Elsie grew closer to Pip Marrow.");
+        assert_eq!(semantic[0].source_event_seqs, vec![320]);
+        assert_eq!(semantic[1].category, JournalBeatCategory::Consequence);
+        assert_eq!(semantic[1].headline, "The washed path draws closer.");
+        assert_eq!(semantic[1].source_event_seqs, vec![330]);
+
+        for beat in ordinary.iter().chain(&completed).chain(&semantic) {
+            let copy = beat.headline.as_str();
+            assert!(copy.ends_with(['.', '!', '?', '…']));
+            assert!(!copy.contains("->"));
+            assert!(!copy.contains("Something changed"));
+            assert!(!copy.contains("journey."));
+            assert!(!copy.starts_with("is now "));
+            assert!(!copy.starts_with("shakes off "));
+        }
     }
 
     #[test]

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -992,7 +992,12 @@ async function main() {
     );
     assert(guide.chatBeforeListenStep?.stage === 1 && /first useful lead is guaranteed/i.test(guide.chatBeforeListenStep?.text || ""), `a chat memory must not pretend the first lead was found: ${JSON.stringify(guide)}`);
     assert(guide.missedListenWithOtherAdvancementStep?.stage === 1 && /notice what the rain has changed/i.test(guide.missedListenWithOtherAdvancementStep?.text || ""), `unrelated advancement must not skip a missed first lead: ${JSON.stringify(guide)}`);
-    assert(!guide.completionBeat?.visible, `completed first-tale memory should leave the unresolved Open threads region: ${JSON.stringify(guide)}`);
+    assert(
+      guide.completionBeat?.visible
+        && guide.completionBeat.text === "growthA growth choice is ready for Your avatar."
+        && guide.completionBeat.aria === "growth. A growth choice is ready for Your avatar.",
+      `completed first-tale memory should retire while an unrelated banked growth choice remains open: ${JSON.stringify(guide)}`,
+    );
     assert(guide.completionText === "You noticed the washed path, helped uncover the first stones, and left the next visitor a clearer way.", `the first-tale ending should be server-authored consequence memory: ${JSON.stringify(guide)}`);
     assert(guide.completionRepeats === false, `completed first-tale memory should not reappear as an open thread after rerender: ${JSON.stringify(guide)}`);
     assert(guide.travelThread?.text === "A path to Rain-Soft Garden is waiting." && guide.travelThread?.actionKey === "exit:2", `an open route should become a grounded clickable room thread: ${JSON.stringify(guide)}`);
@@ -1001,9 +1006,9 @@ async function main() {
     assert(guide.searchThread?.text === "Something in The Cosy Cottage is still waiting to be found.", `a searchable room should offer a gentle discovery thread: ${JSON.stringify(guide)}`);
     assert(guide.roomHookThread?.text === "The hearth notices unfinished promises.", `an authored room hook should remain as the non-mechanical fallback thread: ${JSON.stringify(guide)}`);
     assert(
-      guide.roomThreadSurfaceAfterCompletion?.visible === false
+      guide.roomThreadSurfaceAfterCompletion?.visible === true
         && guide.roomThreadSurfaceAfterCompletion.storyThread === false,
-      `completed first-tale state should not restore a redundant open-thread strip: ${JSON.stringify(guide)}`,
+      `completed first-tale state should not restore a redundant story thread beside the valid growth thread: ${JSON.stringify(guide)}`,
     );
     assert(
       guide.roomThreadHand?.labels?.join(",") === "chat,travel"
@@ -7890,11 +7895,22 @@ async function main() {
         rendered: !node.hidden,
         roomClean: document.querySelector("#journal-view")?.hidden === true,
         text: node.textContent.trim().replace(/\s+/g, " "),
+        growthReady: Number(state?.ledger?.advancement_points || 0) > 0,
+        growthActorName: String(actorForId(actorId)?.name || "Your avatar").trim(),
+        growthCategory: node.querySelector(".growth-thread .journal-row-label")?.textContent?.trim() || "",
+        growthProse: node.querySelector(".growth-thread .journal-row-summary")?.textContent?.trim() || "",
         memory: firstTaleCompletionText(state),
       }));
       assert(
-        !completion.rendered && completion.roomClean && completion.text === "",
-        `the completed opening should leave Open threads without occupying chat: ${JSON.stringify(completion)}`,
+        completion.roomClean
+          && (
+            completion.growthReady
+              ? completion.rendered
+                && completion.growthCategory === "growth"
+                && completion.growthProse === `A growth choice is ready for ${completion.growthActorName}.`
+              : !completion.rendered && completion.text === ""
+          ),
+        `the completed opening should retire while any independent growth choice remains in Open threads without occupying chat: ${JSON.stringify(completion)}`,
       );
       assert(
         /uncovered line toward the riverside/i.test(completion.memory),
@@ -9751,6 +9767,15 @@ async function main() {
         rowCount: rows.length,
         allCollapsed: rows.every((row) => !row.open),
         rowsCompact: rows.every((row) => row.getBoundingClientRect().height <= 42),
+        semanticRows: rows.map((row) => {
+          const category = row.querySelector(".journal-row-label")?.textContent?.trim() || "";
+          const prose = row.querySelector(".journal-row-summary")?.textContent?.trim().replace(/\s+/g, " ") || "";
+          return {
+            category,
+            prose,
+            aria: row.getAttribute("aria-label")?.trim().replace(/\s+/g, " ") || "",
+          };
+        }),
         summariesOneLine: summaries.every((node) => {
           const style = getComputedStyle(node);
           return style.whiteSpace === "nowrap"
@@ -9800,6 +9825,17 @@ async function main() {
         && journal.summariesOneLine
         && journal.oneProseNodePerRow,
       `${label}: Journal rows should begin as one semantic tag beside one prose line: ${JSON.stringify(journal)}`,
+    );
+    assert(
+      journal.semanticRows.every(({ category, prose, aria }) => (
+        ["story", "discovery", "travel", "search", "relationship", "growth", "work", "item", "consequence"].includes(category)
+        && !["event", "tag"].includes(category)
+        && prose.length > 0
+        && /[.!?…]["')\]]*$/.test(prose)
+        && aria === `${category}. ${prose}`
+        && !/->|Something changed|\b(?:journey|pathway)\.[a-z_]+|^(?:is now|shakes off)\b/i.test(prose)
+      )),
+      `${label}: every visible Journal row needs one closed-vocabulary tag, complete prose, matching accessible copy, and no raw fallback grammar: ${JSON.stringify(journal.semanticRows)}`,
     );
     assert(
       journal.heading === "journal://"
@@ -9865,6 +9901,166 @@ async function main() {
       `${label}: only an overflowing beat should unclip the same complete prose node: ${JSON.stringify(beatDisclosure)}`,
     );
 
+    const disclosureViewport = page.viewportSize();
+    await page.setViewportSize({ width: 1600, height: 900 });
+    const wideDisclosure = await page.evaluate(() => {
+      const row = document.querySelector("#journal-log .journal-beat");
+      const summary = row?.querySelector(":scope > summary");
+      const headline = summary?.querySelector(".journal-row-summary");
+      if (!row || !summary || !headline) return { exists: false };
+      let chosen = "Elsie found the path.";
+      for (let index = 1; index <= 8; index += 1) {
+        const candidate = `Elsie found the path.${" It led toward the Old Oak Tree.".repeat(index)}`;
+        headline.textContent = candidate;
+        syncJournalRowOverflow();
+        if (row.classList.contains("is-overflowing")) break;
+        chosen = candidate;
+      }
+      headline.textContent = chosen;
+      syncJournalRowOverflow();
+      return {
+        exists: true,
+        prose: chosen,
+        overflowing: row.classList.contains("is-overflowing"),
+        tabIndex: summary.tabIndex,
+      };
+    });
+    assert(
+      wideDisclosure.exists
+        && wideDisclosure.prose.length > 40
+        && !wideDisclosure.overflowing
+        && wideDisclosure.tabIndex === -1,
+      `${label}: the responsive disclosure fixture should fit at a wide viewport: ${JSON.stringify(wideDisclosure)}`,
+    );
+    await page.setViewportSize({ width: 320, height: 760 });
+    await page.waitForFunction(() => (
+      document.querySelector("#journal-log .journal-beat")?.classList.contains("is-overflowing")
+    ));
+    const narrowDisclosure = await page.evaluate((prose) => {
+      const row = document.querySelector("#journal-log .journal-beat");
+      const summary = row?.querySelector(":scope > summary");
+      const headline = summary?.querySelector(".journal-row-summary");
+      const marker = row?.querySelector(".journal-row-marker");
+      const collapsed = {
+        sameProse: headline?.textContent === prose,
+        overflowing: row?.classList.contains("is-overflowing") || false,
+        markerVisible: marker ? getComputedStyle(marker).display !== "none" : false,
+        tabIndex: summary?.tabIndex,
+        whiteSpace: headline ? getComputedStyle(headline).whiteSpace : "",
+      };
+      summary?.click();
+      const expanded = {
+        open: row?.open || false,
+        sameProse: headline?.textContent === prose,
+        whiteSpace: headline ? getComputedStyle(headline).whiteSpace : "",
+        proseNodes: row?.querySelectorAll(".journal-row-summary").length || 0,
+      };
+      summary?.click();
+      const recollapsed = {
+        open: row?.open || false,
+        sameProse: headline?.textContent === prose,
+        whiteSpace: headline ? getComputedStyle(headline).whiteSpace : "",
+      };
+      return { collapsed, expanded, recollapsed };
+    }, wideDisclosure.prose);
+    assert(
+      narrowDisclosure.collapsed.sameProse
+        && narrowDisclosure.collapsed.overflowing
+        && narrowDisclosure.collapsed.markerVisible
+        && narrowDisclosure.collapsed.tabIndex === 0
+        && narrowDisclosure.collapsed.whiteSpace === "nowrap"
+        && narrowDisclosure.expanded.open
+        && narrowDisclosure.expanded.sameProse
+        && narrowDisclosure.expanded.whiteSpace === "normal"
+        && narrowDisclosure.expanded.proseNodes === 1
+        && !narrowDisclosure.recollapsed.open
+        && narrowDisclosure.recollapsed.sameProse
+        && narrowDisclosure.recollapsed.whiteSpace === "nowrap",
+      `${label}: viewport resize should reveal a truthful affordance, expand the same prose, and collapse it back to one line: ${JSON.stringify(narrowDisclosure)}`,
+    );
+    if (disclosureViewport) await page.setViewportSize(disclosureViewport);
+    await page.evaluate(() => renderJournalLog());
+
+    const textSizeFixture = await page.evaluate(() => {
+      const row = document.querySelector("#journal-log .journal-beat");
+      const summary = row?.querySelector(":scope > summary");
+      const headline = summary?.querySelector(".journal-row-summary");
+      if (!row || !summary || !headline) return { exists: false };
+      const previousPreference = localStorage.getItem("cosyworld.ui.largeText");
+      localStorage.setItem("cosyworld.ui.largeText", "false");
+      applyUiPreferences();
+      row.style.width = "700px";
+      headline.textContent = "Elsie discovered the rain-bright path home.";
+      const ruler = headline.cloneNode(true);
+      const headlineStyle = getComputedStyle(headline);
+      ruler.style.cssText = [
+        "position:fixed",
+        "left:-10000px",
+        "top:0",
+        "width:max-content",
+        "visibility:hidden",
+        "white-space:nowrap",
+        `font:${headlineStyle.font}`,
+      ].join(";");
+      document.body.append(ruler);
+      const normalTextWidth = ruler.getBoundingClientRect().width;
+      ruler.remove();
+      headline.style.width = `${Math.ceil(normalTextWidth + 3)}px`;
+      syncJournalRowOverflow();
+      window.__cosyJournalTextSizeFixture = { previousPreference };
+      return {
+        exists: true,
+        prose: headline.textContent,
+        normalOverflowing: row.classList.contains("is-overflowing"),
+        normalTabIndex: summary.tabIndex,
+      };
+    });
+    assert(
+      textSizeFixture.exists
+        && !textSizeFixture.normalOverflowing
+        && textSizeFixture.normalTabIndex === -1,
+      `${label}: the text-size fixture should begin as a non-overflowing row: ${JSON.stringify(textSizeFixture)}`,
+    );
+    await page.evaluate(() => {
+      localStorage.setItem("cosyworld.ui.largeText", "true");
+      applyUiPreferences();
+    });
+    await page.waitForFunction(() => (
+      document.body.classList.contains("large-text")
+      && document.querySelector("#journal-log .journal-beat")?.classList.contains("is-overflowing")
+    ));
+    const largeTextDisclosure = await page.evaluate((prose) => {
+      const row = document.querySelector("#journal-log .journal-beat");
+      const summary = row?.querySelector(":scope > summary");
+      const headline = summary?.querySelector(".journal-row-summary");
+      const marker = row?.querySelector(".journal-row-marker");
+      const result = {
+        sameProse: headline?.textContent === prose,
+        overflowing: row?.classList.contains("is-overflowing") || false,
+        markerVisible: marker ? getComputedStyle(marker).display !== "none" : false,
+        tabIndex: summary?.tabIndex,
+      };
+      const previousPreference = window.__cosyJournalTextSizeFixture?.previousPreference;
+      if (previousPreference === null) {
+        localStorage.removeItem("cosyworld.ui.largeText");
+      } else {
+        localStorage.setItem("cosyworld.ui.largeText", previousPreference);
+      }
+      delete window.__cosyJournalTextSizeFixture;
+      row?.style.removeProperty("width");
+      headline?.style.removeProperty("width");
+      applyUiPreferences();
+      renderJournalLog();
+      return result;
+    }, textSizeFixture.prose);
+    assert(
+      largeTextDisclosure.sameProse
+        && largeTextDisclosure.overflowing
+        && largeTextDisclosure.markerVisible
+        && largeTextDisclosure.tabIndex === 0,
+      `${label}: larger-text preference should recalculate and expose the disclosure affordance without changing prose: ${JSON.stringify(largeTextDisclosure)}`,
+    );
+
     const rowContract = await page.evaluate(() => ({
       rows: document.querySelectorAll("#journal-view .journal-prose-row").length,
       proseNodes: document.querySelectorAll("#journal-view .journal-row-summary").length,
@@ -9876,6 +10072,47 @@ async function main() {
         && rowContract.duplicateDetails === 0
         && rowContract.actionControls === 0,
       `${label}: every Journal row should contain one prose string and no duplicate detail or action surface: ${JSON.stringify(rowContract)}`,
+    );
+
+    const growthThread = await page.evaluate(() => {
+      const previousState = state;
+      try {
+        const current = actorForId(actorId);
+        const actorName = String(current?.name || "Your avatar").trim();
+        state = {
+          ...state,
+          first_tale: state?.first_tale ? { ...state.first_tale, phase: "complete" } : null,
+          ledger: {
+            ...(state?.ledger || {}),
+            advancement_points: 1,
+          },
+        };
+        renderStatusUpdates();
+        syncJournalRegions();
+        const row = document.querySelector("#updates .growth-thread");
+        return {
+          actorName,
+          category: row?.querySelector(".journal-row-label")?.textContent?.trim() || "",
+          prose: row?.querySelector(".journal-row-summary")?.textContent?.trim() || "",
+          proseNodes: row?.querySelectorAll(".journal-row-summary").length || 0,
+          detailBlocks: row?.querySelectorAll(".journal-row-detail").length || 0,
+          actionControls: row?.querySelectorAll("button").length || 0,
+          openThreadsVisible: document.querySelector("#journal-open-threads")?.hidden === false,
+        };
+      } finally {
+        state = previousState;
+        renderStatusUpdates();
+        syncJournalRegions();
+      }
+    });
+    assert(
+      growthThread.category === "growth"
+        && growthThread.prose === `A growth choice is ready for ${growthThread.actorName}.`
+        && growthThread.proseNodes === 1
+        && growthThread.detailBlocks === 0
+        && growthThread.actionControls === 0
+        && growthThread.openThreadsVisible,
+      `${label}: banked growth should project as a concrete Open thread without duplicating an action: ${JSON.stringify(growthThread)}`,
     );
 
     await page.locator("#room-log-toggle").click();


### PR DESCRIPTION
Closes #511

## Summary

- replace the broad combat wildcard with explicit Journal source/category admission policies
- project banked advancement as a concrete growth Open thread without adding Journal action controls
- add Rust golden fixtures for travel, journey completion, relationships, clocks, omission, copy, and ordering
- gate semantic categories, complete prose, accessible copy, ticker behavior, and same-row disclosure under real viewport and larger-text overflow

## Validation

- `npm run check` (506 JavaScript tests, 846 Rust tests, worldpack/kernel/architecture/Clippy/syntax gates)
- `npm run lint`
- `npm run v2:browser:check`
- `npm run v2:composition:smoke`
- `node v2/scripts/smoke-production-profile.mjs`
