### PR TITLE
Gate deploys on worldpack continuity with the live world

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      - name: Guard primary worldpack continuity
+        run: node scripts/check-worldpack-deploy-compat.mjs cosyworld
+
       - name: Deploy primary Fly app
         run: flyctl deploy --remote-only --config fly.toml
         env:
@@ -39,6 +42,9 @@ jobs:
         run: scripts/check-fly-volume-space.sh cosyworld-lonelyforest /data 85
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
+
+      - name: Guard Lonely Forest worldpack continuity
+        run: node scripts/check-worldpack-deploy-compat.mjs cosyworld-lonelyforest
 
       - name: Build and deploy Lonely Forest
         run: flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.242",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.240",
+      "version": "0.0.242",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.242",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,
@@ -50,7 +50,7 @@
     "v2:media:evolution": "node v2/scripts/report-media-evolution.mjs",
     "v2:proof-world": "node v2/scripts/check-proof-world.mjs",
     "v2:spike:deck-gated": "node v2/scripts/spike-deck-gated-actions.mjs",
-    "v2:syntax": "node --check v2/scripts/smoke-browser.mjs && node --check v2/scripts/smoke-production-profile.mjs && node --check v2/scripts/smoke-deployed-ruby-high.mjs && node --check v2/scripts/smoke-standalone-compositions.mjs && node --check v2/scripts/smoke-core-ruby-composition.mjs && node --check v2/scripts/inspect-action-journal.mjs && node --check v2/scripts/report-media-evolution.mjs && python3 -m py_compile v2/cli/cosy_cli.py",
+    "v2:syntax": "node --check v2/scripts/smoke-browser.mjs && node --check v2/scripts/smoke-production-profile.mjs && node --check v2/scripts/smoke-deployed-ruby-high.mjs && node --check v2/scripts/smoke-standalone-compositions.mjs && node --check v2/scripts/smoke-core-ruby-composition.mjs && node --check v2/scripts/inspect-action-journal.mjs && node --check v2/scripts/report-media-evolution.mjs && node --check scripts/check-worldpack-deploy-compat.mjs && bash -n scripts/check-fly-volume-space.sh && python3 -m py_compile v2/cli/cosy_cli.py",
     "reset-setup": "node scripts/reset-setup.mjs",
     "build": "npm run clean && npm run build:js && npm run docs",
     "clean": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\"",

--- a/scripts/check-worldpack-deploy-compat.mjs
+++ b/scripts/check-worldpack-deploy-compat.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Pre-deploy guard: refuse to swap a machine onto an image that cannot replay
+// the journal the target app already holds.
+//
+// The 2026-07-29 outage was exactly this. The deploy tree was 14 commits behind
+// origin/main and therefore missing the migration the live journal had been
+// written under, so every boot failed continuity:
+//
+//   production continuity cannot replay action journal ...:
+//   action journal worldpack sha256:29e213d6... does not match
+//   active worldpack  sha256:9b955ecb... and is not declared replay-compatible
+//
+// Both apps crash-looped to Fly's restart limit and recovery was an image
+// rollback. The fail-closed boot was correct — CLAUDE.md forbids erasing a
+// mismatched hash to force a load — but nothing checked compatibility before
+// the image was swapped, so the mismatch surfaced only once the old machine was
+// already gone. This check is cheap and almost entirely offline.
+//
+// Usage: check-worldpack-deploy-compat.mjs <fly-app> [meta-url] [worldpack-json]
+//
+// Fails closed, matching scripts/check-fly-volume-space.sh: an unreadable live
+// worldpack identity refuses the deploy rather than deploying blind. During an
+// incident, when the app may be unreachable and a deploy is the recovery, set
+// COSYWORLD_SKIP_WORLDPACK_DEPLOY_GATE=1 to override deliberately.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+export const DEFAULT_COMPILED_WORLDPACK = path.join(
+  repoRoot,
+  'v2',
+  'content',
+  'official',
+  'worldpack.json'
+);
+
+/**
+ * Decide whether the compiled bundle can replay what the target app holds.
+ *
+ * `liveBundleHash` is the running image's active worldpack, which is the hash
+ * the app is currently stamping onto new journal records. If the incoming
+ * bundle neither matches it nor declares it replay-compatible, the new image
+ * cannot replay records the current image is still writing.
+ *
+ * An empty live hash is a legacy unversioned world, which the runtime accepts.
+ */
+export function evaluateWorldpackDeployCompat({
+  app,
+  compiledBundleHash,
+  replayCompatibleHashes = [],
+  liveBundleHash,
+  compiledRulesProfile,
+  liveRulesProfile
+}) {
+  if (!compiledBundleHash) {
+    return {
+      ok: false,
+      message:
+        'compiled worldpack has no bundle_hash — run `npm run v2:worldpack` and commit the generated bundle'
+    };
+  }
+  if (liveBundleHash === undefined || liveBundleHash === null) {
+    return {
+      ok: false,
+      message:
+        `could not read the live worldpack identity for ${app} — refusing to deploy blind. ` +
+        'If the app is already down and this deploy is the recovery, re-run with ' +
+        'COSYWORLD_SKIP_WORLDPACK_DEPLOY_GATE=1'
+    };
+  }
+  if (liveBundleHash === '') {
+    return {
+      ok: true,
+      message: `${app} reports a legacy unversioned worldpack; replay accepts it`
+    };
+  }
+  if (liveRulesProfile && compiledRulesProfile && liveRulesProfile !== compiledRulesProfile) {
+    return {
+      ok: false,
+      message:
+        `${app} runs rules profile ${liveRulesProfile} but this tree compiles ` +
+        `${compiledRulesProfile}. Replay rejects a rules-profile change, so every boot ` +
+        'would fail continuity.'
+    };
+  }
+  if (liveBundleHash === compiledBundleHash) {
+    return {
+      ok: true,
+      message: `${app} worldpack ${compiledBundleHash} is unchanged by this deploy`
+    };
+  }
+  if (replayCompatibleHashes.includes(liveBundleHash)) {
+    return {
+      ok: true,
+      message:
+        `${app} worldpack ${liveBundleHash} is declared replay-compatible with ` +
+        `the incoming ${compiledBundleHash}`
+    };
+  }
+  return {
+    ok: false,
+    message:
+      `${app} would crash-loop on boot.\n` +
+      `  live worldpack     : ${liveBundleHash}\n` +
+      `  incoming worldpack : ${compiledBundleHash}\n` +
+      'The incoming bundle does not declare the live one replay-compatible, so continuity ' +
+      'fails on every boot and the release restarts until Fly gives up — the 2026-07-29 ' +
+      'outage. Resolve it one of these documented ways:\n' +
+      '  1. Deploy a tree that contains the migration the live world was written under. ' +
+      'A checkout behind origin/main is the usual cause — fetch and rebase.\n' +
+      '  2. Declare the migration: add the live hash to the pack\'s ' +
+      'persistence_compatibility.replay_compatible_bundle_hashes, run `npm run v2:worldpack`, ' +
+      'and commit the regenerated bundle.\n' +
+      '  3. Take the documented fresh-seed path if this world is meant to restart.\n' +
+      'Never erase the persisted hash to force a load.'
+  };
+}
+
+export function readCompiledWorldpack(worldpackPath = DEFAULT_COMPILED_WORLDPACK) {
+  const manifest = JSON.parse(readFileSync(worldpackPath, 'utf8'));
+  return {
+    compiledBundleHash: manifest.bundle_hash ?? '',
+    replayCompatibleHashes:
+      manifest.persistence_compatibility?.replay_compatible_bundle_hashes ?? [],
+    compiledRulesProfile: manifest.rules_profile ?? ''
+  };
+}
+
+async function readLiveWorldpack(metaUrl) {
+  try {
+    const response = await fetch(metaUrl, {
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(30_000)
+    });
+    if (!response.ok) {
+      process.stderr.write(`${metaUrl} responded ${response.status}\n`);
+      return {};
+    }
+    const meta = await response.json();
+    return {
+      liveBundleHash: meta?.worldpack?.bundle_hash,
+      liveRulesProfile: meta?.worldpack?.rules_profile
+    };
+  } catch (error) {
+    process.stderr.write(`reading ${metaUrl} failed: ${error.message}\n`);
+    return {};
+  }
+}
+
+async function main() {
+  const [app, metaUrlArg, worldpackArg] = process.argv.slice(2);
+  if (!app) {
+    process.stderr.write(
+      'usage: check-worldpack-deploy-compat.mjs <fly-app> [meta-url] [worldpack-json]\n'
+    );
+    process.exit(2);
+  }
+  if (process.env.COSYWORLD_SKIP_WORLDPACK_DEPLOY_GATE === '1') {
+    process.stdout.write(
+      `worldpack deploy gate skipped for ${app} by COSYWORLD_SKIP_WORLDPACK_DEPLOY_GATE\n`
+    );
+    process.exit(0);
+  }
+  const metaUrl = metaUrlArg || `https://${app}.fly.dev/meta`;
+  const compiled = readCompiledWorldpack(worldpackArg || DEFAULT_COMPILED_WORLDPACK);
+  const live = await readLiveWorldpack(metaUrl);
+  const verdict = evaluateWorldpackDeployCompat({ app, ...compiled, ...live });
+  if (verdict.ok) {
+    process.stdout.write(`${verdict.message}\n`);
+    process.exit(0);
+  }
+  process.stderr.write(`::error::${verdict.message}\n`);
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -50,6 +50,37 @@ describe('deploy workflow', () => {
     expect(job('github-release')).toContain('needs: [fly]');
   });
 
+  // Both apps run a single machine, so a deploy that boots badly is an outage by
+  // construction (#546, #551). Every guard must run before the swap it protects,
+  // never after, or it can only report an outage that already happened.
+  it('runs the volume and worldpack guards before each image swap', () => {
+    const fly = job('fly', 'github-release');
+    const tenants = [
+      {
+        volume: 'scripts/check-fly-volume-space.sh cosyworld /data 85',
+        worldpack: 'node scripts/check-worldpack-deploy-compat.mjs cosyworld',
+        deploy: 'flyctl deploy --remote-only --config fly.toml'
+      },
+      {
+        volume: 'scripts/check-fly-volume-space.sh cosyworld-lonelyforest /data 85',
+        worldpack: 'node scripts/check-worldpack-deploy-compat.mjs cosyworld-lonelyforest',
+        deploy: 'flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false'
+      }
+    ];
+
+    for (const tenant of tenants) {
+      for (const guard of [tenant.volume, tenant.worldpack]) {
+        expect(fly).toContain(guard);
+        expect(fly.indexOf(guard)).toBeLessThan(fly.indexOf(tenant.deploy));
+      }
+    }
+
+    // The Lonely Forest guards must not be satisfied by the primary app's run.
+    for (const guard of [tenants[1].volume, tenants[1].worldpack]) {
+      expect(fly.indexOf(guard)).toBeGreaterThan(fly.indexOf(tenants[0].deploy));
+    }
+  });
+
   it('keeps the image workshop configured on both Fly tenants', () => {
     const model = 'COSYWORLD_REPLICATE_AVATAR_MODEL = "black-forest-labs/flux-dev-lora"';
     const mirquoLora = 'COSYWORLD_REPLICATE_AVATAR_LORA = "immanencer/mirquo"';

--- a/test/infrastructure/worldpack-deploy-gate.test.mjs
+++ b/test/infrastructure/worldpack-deploy-gate.test.mjs
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateWorldpackDeployCompat,
+  readCompiledWorldpack
+} from '../../scripts/check-worldpack-deploy-compat.mjs';
+
+const INCOMING = 'sha256:29e213d646b50e015753b90346a6ecc82ab38c75b16125d533cb6188c07f1d1f';
+const MIGRATED = 'sha256:9b955ecb00000000000000000000000000000000000000000000000000000000';
+const FOREIGN = 'sha256:deadbeef00000000000000000000000000000000000000000000000000000000';
+
+const evaluate = (overrides) =>
+  evaluateWorldpackDeployCompat({
+    app: 'cosyworld',
+    compiledBundleHash: INCOMING,
+    replayCompatibleHashes: [MIGRATED],
+    liveBundleHash: INCOMING,
+    ...overrides
+  });
+
+describe('worldpack deploy gate', () => {
+  it('allows a deploy that does not change the worldpack', () => {
+    const verdict = evaluate({});
+    expect(verdict.ok).toBe(true);
+    expect(verdict.message).toMatch(/unchanged by this deploy/);
+  });
+
+  it('allows a deploy whose bundle declares the live one replay-compatible', () => {
+    const verdict = evaluate({ liveBundleHash: MIGRATED });
+    expect(verdict.ok).toBe(true);
+    expect(verdict.message).toMatch(/declared replay-compatible/);
+  });
+
+  it('allows a legacy unversioned world', () => {
+    expect(evaluate({ liveBundleHash: '' }).ok).toBe(true);
+  });
+
+  // The 2026-07-29 outage: a tree missing the migration the live world was
+  // written under. The gate must stop it before the image is swapped.
+  it('refuses an undeclared mismatch and names both hashes and the fix', () => {
+    const verdict = evaluate({ liveBundleHash: FOREIGN });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.message).toContain(FOREIGN);
+    expect(verdict.message).toContain(INCOMING);
+    expect(verdict.message).toMatch(/crash-loop/);
+    expect(verdict.message).toMatch(/behind origin\/main/);
+    expect(verdict.message).toMatch(/replay_compatible_bundle_hashes/);
+    expect(verdict.message).toMatch(/Never erase the persisted hash/);
+  });
+
+  it('refuses a rules-profile change', () => {
+    const verdict = evaluate({
+      compiledRulesProfile: 'cosyworld.srd5/2',
+      liveRulesProfile: 'cosyworld.srd5/1'
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.message).toMatch(/rules profile/);
+  });
+
+  it('refuses a bundle that was never compiled', () => {
+    const verdict = evaluate({ compiledBundleHash: '' });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.message).toMatch(/v2:worldpack/);
+  });
+
+  // Matches scripts/check-fly-volume-space.sh: never deploy blind. The override
+  // is the documented way through during an incident.
+  it('fails closed when the live identity cannot be read, and names the override', () => {
+    const verdict = evaluate({ liveBundleHash: undefined });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.message).toMatch(/refusing to deploy blind/);
+    expect(verdict.message).toMatch(/COSYWORLD_SKIP_WORLDPACK_DEPLOY_GATE=1/);
+  });
+
+  it('reads the committed bundle, which can replay its own world', () => {
+    const compiled = readCompiledWorldpack();
+    expect(compiled.compiledBundleHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(Array.isArray(compiled.replayCompatibleHashes)).toBe(true);
+    expect(compiled.replayCompatibleHashes).not.toContain(compiled.compiledBundleHash);
+    expect(
+      evaluateWorldpackDeployCompat({
+        app: 'cosyworld',
+        ...compiled,
+        liveBundleHash: compiled.compiledBundleHash
+      }).ok
+    ).toBe(true);
+  });
+});

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.242"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.242"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Closes the pre-deploy half of #551.

## Why

The 2026-07-29 outage was a deploy from a tree 14 commits behind `origin/main`, missing the migration the live journal had been written under. Every boot failed continuity, both apps crash-looped to Fly's restart limit, and recovery was an image rollback.

The fail-closed boot was correct — `CLAUDE.md` forbids erasing a mismatched hash to force a load. The gap was that **nothing checked compatibility before the image was swapped**, by which point the old machine was already gone.

## What this adds

`scripts/check-worldpack-deploy-compat.mjs` compares the compiled bundle against the worldpack the target app is actually running, and refuses an undeclared mismatch. Wired into the deploy workflow beside the volume guard from #557, ahead of each image swap.

The refusal names both hashes and the three documented resolutions, and never suggests erasing the persisted hash:

```
::error::cosyworld would crash-loop on boot.
  live worldpack     : sha256:deadbeef...
  incoming worldpack : sha256:531f7735...
The incoming bundle does not declare the live one replay-compatible, so continuity
fails on every boot and the release restarts until Fly gives up — the 2026-07-29
outage. Resolve it one of these documented ways:
  1. Deploy a tree that contains the migration the live world was written under.
     A checkout behind origin/main is the usual cause — fetch and rebase.
  2. Declare the migration: add the live hash to the pack's
     persistence_compatibility.replay_compatible_bundle_hashes, run
     `npm run v2:worldpack`, and commit the regenerated bundle.
  3. Take the documented fresh-seed path if this world is meant to restart.
Never erase the persisted hash to force a load.
```

**Fails closed** on an unreadable live identity, matching `check-fly-volume-space.sh`, with `COSYWORLD_SKIP_WORLDPACK_DEPLOY_GATE=1` as the documented override for an incident where the app is unreachable and the deploy *is* the recovery.

## Also: the #557 volume guard had no test

Added an ordering assertion covering both guards. A guard that runs after the swap can only report an outage that already happened, so the ordering is the invariant worth pinning.

## Known limitation

`/meta` exposes the running image's *active* worldpack, so this catches a bundle the live world cannot replay, but not a journal holding rows from an older pre-migration hash. Closing that needs the distinct journal hash set exposed on `/meta.persistence` — a `main.rs` change I deliberately left out of this PR. #551 stays open for it.

## Verification

- `npm test` — 492 passed (45 files), including 8 new gate tests and the ordering test
- `npm run v2:worldpack`, `npm run v2:kernel`, `npm run v2:syntax`, `npm run check:version`, `git diff --check` — all pass
- CLI exercised end-to-end: matching hash passes, declared-migration hash passes, legacy unversioned passes, foreign hash refuses with exit 1, unreachable app fails closed, override passes
- Run against **real production**: both `cosyworld` and `cosyworld-lonelyforest` report `sha256:531f7735...`, matching main's compiled bundle — main is currently deploy-safe

`v2:rust:test` and `v2:architecture` were not re-run: `git diff main..HEAD -- v2/orchestrator-rust/src v2/core-c v2/ai-model-rust` is **empty**, so the only Rust change is the version string required by the PR gate. The machine's data volume is at 100%, and building a redundant 5 GB target would have risked other agents' builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)