### PR TITLE
Let the present cast ground speech so the room name is not the cheap anchor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.243",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.240",
+      "version": "0.0.243",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.243",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.243"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.243"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/prompts.rs
+++ b/v2/orchestrator-rust/src/prompts.rs
@@ -525,6 +525,11 @@ fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGate
     anchors.extend(plan.recent_lines.iter().cloned());
     anchors.extend(plan.fresh_subject.iter().cloned());
     anchors.extend(plan.missing_need.iter().cloned());
+    // Whoever is actually in the room grounds a line as well as the room's own
+    // name does. Without this the place name is the only anchor guaranteed to be
+    // present, which made announcing it the cheapest way to pass the gate. See
+    // issue #553.
+    anchors.extend(plan.cast.iter().cloned());
     SpeechGateContext {
         feature: if followup {
             "dialogue_avatar_followup"
@@ -557,6 +562,11 @@ fn resident_gate_context(plan: &AvatarReplyPlan, has_proposed_action: bool) -> S
     anchors.extend(plan.location_memory.iter().cloned());
     anchors.extend(plan.recent_activity.iter().cloned());
     anchors.extend(plan.recent_lines.iter().cloned());
+    // As in avatar chat: the present cast and the speaker's own goals ground a
+    // line as well as the room's name, so naming the room stops being the only
+    // guaranteed way through the gate. See issue #553.
+    anchors.extend(plan.cast.iter().cloned());
+    anchors.extend(plan.goals.iter().cloned());
     SpeechGateContext {
         feature: "dialogue_resident",
         generation_key: publication_beat_id(
@@ -884,6 +894,74 @@ mod publication_tests {
             "the voice prompt still instructs a machine instead of being a mind:\n{system}"
         );
         assert!(system.contains("i have no catchphrase"));
+    }
+
+    fn gate_completion(text: &str) -> AiCompletion {
+        AiCompletion {
+            text: text.to_string(),
+            attempts: 1,
+            latency: std::time::Duration::from_millis(9),
+            model_attribution: None,
+            finish_reason: "stop".to_string(),
+            usage: AiTokenUsage {
+                prompt_tokens: Some(10),
+                completion_tokens: Some(6),
+                total_tokens: Some(16),
+            },
+            context_hash: "context".to_string(),
+            prompt_version: "test-v1".to_string(),
+        }
+    }
+
+    /// Issue #553: the anchor gate rejected any line without a deterministic
+    /// anchor, and the room name was the only anchor guaranteed to be present.
+    /// The cheapest way for a model to pass was therefore to front-load the
+    /// place name, which it did on nearly every line ("Mossbell Inn, I've
+    /// arrived—"). Whoever is actually in the room grounds a line just as well,
+    /// so the cast now counts and naming the room stops being the cheap default.
+    #[test]
+    fn a_line_grounded_on_the_present_cast_passes_without_naming_the_room() {
+        let (chat, _) = seeded_plans();
+        let context = avatar_chat_gate_context(&chat, false);
+        let companion = chat
+            .cast
+            .iter()
+            .find(|name| **name != chat.actor_name)
+            .cloned()
+            .expect("the seeded cottage has another present actor");
+        assert!(
+            context.anchors.contains(&companion),
+            "the present cast must be able to ground a line: {:?}",
+            context.anchors
+        );
+
+        // A line that speaks to the person in front of it and never announces
+        // where it is standing.
+        let text = format!("{companion}, your hands are cold. Come sit nearer the kettle.");
+        assert!(
+            !text.contains(&chat.location_name),
+            "the fixture line must not name the room: {text}"
+        );
+        certify_speech(
+            None,
+            gate_completion(&text),
+            &text,
+            avatar_chat_gate_context(&chat, false),
+        )
+        .expect("a cast-grounded line certifies without naming the room");
+    }
+
+    #[test]
+    fn resident_speech_is_grounded_by_the_cast_and_its_own_goals() {
+        let (_, reply) = seeded_plans();
+        let context = resident_gate_context(&reply, false);
+        for anchor in reply.cast.iter().chain(reply.goals.iter()) {
+            assert!(
+                context.anchors.contains(anchor),
+                "{anchor:?} must ground resident speech: {:?}",
+                context.anchors
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Implements #553's preferred option (2).

## The incentive, not the style

`VoiceAnchorMissing` rejects any line without a deterministic anchor. Both gate contexts already fed the plan's location name, title, memory and recent lines into the anchor set — but ignored `cast`, the actors actually present. Since `location_memory`, `goals` and `recent_activity` can all be empty, **the room name was the only anchor guaranteed to be there**.

So the cheapest way for a model to guarantee a pass was to front-load the place name, and it did, on nearly every line:

```
Mossbell Inn, I've arrived—
Rain-Soft Garden, I've arrived with wet boots and a biscuit—
Bethlehem at last!
Jerusalem-Road Lantern Bend has welcomed me...
```

#548 added `"i don't announce the room's name like a signpost"` to the shared voice base, but that is prompt guidance pushing against a gate-level incentive.

## The change

Add `cast` to both gate contexts, plus `goals` to resident speech (avatar chat already had it). Whoever is standing in the room grounds a line as well as the room's own name does, so naming the room stops being the default cheapest option.

This is deliberately the *broadening* option rather than rejecting signpost openings. The gate's intent is "do not silently change subject", not "name the room" — and broadening adds no new rejection path, so it cannot create the resampling loop that a new rejection would risk (which would land us in #545, invisible suppressed replies).

## Tests

- `a_line_grounded_on_the_present_cast_passes_without_naming_the_room` — builds the real seeded gate context and certifies `"<companion>, your hands are cold. Come sit nearer the kettle."` end-to-end through `certify_speech`, asserting the line does not contain the location name
- `resident_speech_is_grounded_by_the_cast_and_its_own_goals` — pins the wiring for resident speech

## Verification

- `cargo test` — **818 passed, 0 failed**. Worth noting: no existing gate test regressed, so the broadening did not turn any previously-rejected line into an accepted one
- `npm test` 483 passed, `v2:kernel`, `check:version`, `git diff --check`, `cargo fmt --check` all clean
- `npm run v2:architecture` — main.rs 74481 (ceiling 74481), clippy 273 (ceiling 273), so no new warnings or growth

## Note on scope

This does not address the second half of #553 — the report of a resident greeting an adjacent place it was not at. That needs confirmation of whether the anchor set includes adjacent or newly discovered locations, which I did not trace here. #553 should stay open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)