### PR TITLE
Enforce the generated-speech register at the publication gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.244",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.240",
+      "version": "0.0.244",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.244",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/writing-style.md
+++ b/v2/docs/writing-style.md
@@ -89,6 +89,22 @@ The speech-prompt base already enforces the output register ("punchlines over
 poetry", banned vocabulary, no objects that remember things) — keep new NPC
 prompts consistent with it.
 
+Generated dialogue is the largest body of player-visible prose in the game, so
+one part of that register is executable rather than prompt-only. The publication
+gate rejects **scenery acting with intent** (`voice_object_agency`): an
+inanimate scene noun as the subject of a verb of intent, judgement, or memory.
+
+- No: "the path is learning my name" / "these hills recruit me" / "the kettle
+  remembers every argument" / "Lantern Bend has welcomed me".
+- Yes: "the path is steep and my boots are wet" / "Elsie welcomes me every
+  single time" / "i remember the kettle, and i want it back".
+
+The rule is narrow on purpose. A *person* who wants, judges, or remembers is
+ordinary speech, and imagery is untouched — only the scenery doing the wanting
+breaks the register, which is the same ban §2 places on environment text. Wit
+itself is not gated: how much figurative license a character gets remains a
+voice decision, not a check.
+
 ### 6. Rare system moments (the magic budget)
 
 Lyricism is spent only where the system did something rare: hidden-exit

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.244"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.244"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -51,6 +51,9 @@ pub(crate) enum PublicationCheckCode {
     VoiceRecentDuplicate,
     VoiceUnsafeTone,
     VoiceProposedActionClaim,
+    // Append-only. Stored receipts keep the codes they were written with, so a
+    // new variant never changes how an old rejection reads.
+    VoiceObjectAgency,
 }
 
 impl PublicationCheckCode {
@@ -68,6 +71,7 @@ impl PublicationCheckCode {
             Self::VoiceRecentDuplicate => "voice_recent_duplicate",
             Self::VoiceUnsafeTone => "voice_unsafe_tone",
             Self::VoiceProposedActionClaim => "voice_proposed_action_claim",
+            Self::VoiceObjectAgency => "voice_object_agency",
         }
     }
 }
@@ -494,6 +498,10 @@ fn evaluate_checks(
             PublicationCheckCode::VoiceProposedActionClaim,
             !context.has_proposed_action || !claims_completed_action(&lowered),
         ),
+        (
+            PublicationCheckCode::VoiceObjectAgency,
+            !scene_object_acts_with_volition(&lowered),
+        ),
     ];
     checks
         .into_iter()
@@ -770,6 +778,152 @@ fn contains_unsafe_tone(value: &str) -> bool {
     .any(|needle| value.contains(needle))
 }
 
+/// Inanimate scene nouns. Deliberately does not include actor names: a person
+/// welcoming, remembering, or plotting is ordinary speech, and only the scenery
+/// doing it breaks the register.
+const SCENE_OBJECT_NOUNS: &[&str] = &[
+    "path", "paths", "road", "roads", "trail", "trails", "lane", "hill", "hills", "ridge", "bend",
+    "mile", "rise", "wall", "walls", "door", "doors", "gate", "window", "floor", "ceiling",
+    "bridge", "stone", "stones", "dust", "mud", "crumb", "crumbs", "kettle", "teapot", "lantern",
+    "hearth", "garden", "inn", "bramble", "brambles", "moss", "weather", "rain", "wind", "fog",
+    "mist", "sky", "cloud", "clouds", "sun", "moon", "shadow", "shadows", "light", "air",
+    "biscuit", "biscuits", "boots", "kitchen", "cottage", "well", "fence", "roof", "step", "steps",
+];
+
+/// Verbs that assert intent, judgement, or memory. `writing-style.md` §2 bans
+/// "objects that remember, weather with intentions" outright, and §5 states the
+/// same ban already applies to character voice — but only the speech prompt
+/// carried it, so nothing enforced it. This list is that ban made executable.
+/// Both the third-person singular and the bare plural form are listed, because a
+/// plural scene noun takes the bare verb: "these hills recruit me".
+const VOLITIONAL_VERBS: &[&str] = &[
+    "remember",
+    "remembers",
+    "remembered",
+    "forget",
+    "forgets",
+    "forgot",
+    "want",
+    "wants",
+    "wanted",
+    "decide",
+    "decides",
+    "decided",
+    "approve",
+    "approves",
+    "approving",
+    "disapprove",
+    "disapproves",
+    "pleased",
+    "delight",
+    "delights",
+    "delighted",
+    "welcome",
+    "welcomes",
+    "welcomed",
+    "greet",
+    "greets",
+    "greeted",
+    "learn",
+    "learns",
+    "learning",
+    "learned",
+    // Progressive forms: "the path is learning my name", "the teapot is
+    // staging a revolt". The auxiliary is absorbed by BRIDGES below.
+    "remembering",
+    "forgetting",
+    "wanting",
+    "deciding",
+    "welcoming",
+    "greeting",
+    "recruiting",
+    "auditioning",
+    "conspiring",
+    "insisting",
+    "refusing",
+    "judging",
+    "resenting",
+    "mocking",
+    "staging",
+    "intending",
+    "preferring",
+    "hoping",
+    "believing",
+    "delighting",
+    "recruit",
+    "recruits",
+    "recruited",
+    "audition",
+    "auditions",
+    "plot",
+    "plots",
+    "plotting",
+    "conspire",
+    "conspires",
+    "insist",
+    "insists",
+    "refuse",
+    "refuses",
+    "refused",
+    "judge",
+    "judges",
+    "resent",
+    "resents",
+    "mock",
+    "mocks",
+    "stage",
+    "stages",
+    "staged",
+    "intend",
+    "intends",
+    "prefer",
+    "prefers",
+    "hope",
+    "hopes",
+    "believe",
+    "believes",
+];
+
+/// Reject scenery acting with intent: "the path is learning my name", "the next
+/// hill auditions for villainy", "Lantern Bend has welcomed me".
+///
+/// Matches a scene noun followed by a volitional verb, allowing one auxiliary or
+/// article between them ("has welcomed", "is learning"). Wit is still allowed —
+/// §5 protects it — so this only fires when the *scenery itself* is the one
+/// wanting, judging, or remembering. Issue #555.
+fn scene_object_acts_with_volition(value: &str) -> bool {
+    let words = value
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '\'')
+        .filter(|word| !word.is_empty())
+        .map(|word| word.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    // Auxiliaries and determiners that may sit between the noun and its verb
+    // without changing who is doing the acting.
+    const BRIDGES: &[&str] = &[
+        "is", "are", "was", "were", "has", "have", "had", "keeps", "keep", "kept", "still", "now",
+        "already", "just", "even", "seems", "seem",
+    ];
+    for (index, word) in words.iter().enumerate() {
+        if !SCENE_OBJECT_NOUNS.contains(&word.as_str()) {
+            continue;
+        }
+        let mut cursor = index + 1;
+        let mut bridged = 0;
+        while cursor < words.len() && bridged < 2 {
+            let next = words[cursor].as_str();
+            if VOLITIONAL_VERBS.contains(&next) {
+                return true;
+            }
+            if !BRIDGES.contains(&next) {
+                break;
+            }
+            bridged += 1;
+            cursor += 1;
+        }
+    }
+    false
+}
+
 fn claims_completed_action(value: &str) -> bool {
     [
         "i gave ",
@@ -838,6 +992,64 @@ mod tests {
         certify_speech(None, completion(text), text, context)
             .expect_err("candidate should fail")
             .failure_code
+    }
+
+    /// Issue #555: `writing-style.md` §2 bans "objects that remember, weather
+    /// with intentions", and §5 says the same ban already covers character
+    /// voice — but only the speech prompt carried it, so generated dialogue was
+    /// the one large body of player-visible prose with no executable register
+    /// check. These are lines sampled from production.
+    #[test]
+    fn scenery_acting_with_intent_is_rejected() {
+        for line in [
+            "the path is learning my name",
+            "these hills recruit me as permanent furniture",
+            "the next hill auditions for villainy",
+            "my biscuit crumbs stage a rebellion",
+            "Lantern Bend has welcomed me",
+            "the kettle remembers every argument",
+            "the weather still wants an apology",
+        ] {
+            assert!(
+                scene_object_acts_with_volition(&line.to_ascii_lowercase()),
+                "scenery acts with intent but passed: {line:?}"
+            );
+        }
+    }
+
+    /// §5 protects wit in character voice. The check must fire on the scenery
+    /// doing the wanting, not on humour, imagery, or a person with intentions.
+    #[test]
+    fn wit_and_ordinary_actor_intent_still_pass_the_register_check() {
+        for line in [
+            "the path is steep and my boots are wet",
+            "Elsie welcomes me every single time, biscuit first",
+            "i remember the kettle, and i want it back",
+            "Rati decided the hill was not worth it today",
+            "rain on the sill, and a biscuit going soft",
+            "i learned this road the hard way",
+            "the lantern is out; someone should see to it",
+        ] {
+            assert!(
+                !scene_object_acts_with_volition(&line.to_ascii_lowercase()),
+                "ordinary voice was rejected as scenery agency: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_publication_gate_rejects_scenery_agency_with_its_own_code() {
+        assert_eq!(
+            rejected_code(
+                "the path is learning my name",
+                context(&["path".to_string()], &[])
+            ),
+            PublicationCheckCode::VoiceObjectAgency
+        );
+        assert_eq!(
+            PublicationCheckCode::VoiceObjectAgency.as_str(),
+            "voice_object_agency"
+        );
     }
 
     fn assert_check_failed(
@@ -1328,7 +1540,10 @@ mod tests {
         let record = certified_record(
             1001,
             98_001,
-            "The teapot is staging a tiny revolt.",
+            // Neutral prose on purpose: these fixtures exercise replay and
+            // snapshot round-tripping, and the register check now rejects
+            // scenery acting with intent (#555).
+            "The teapot sits beside the basket, lid askew.",
             "concurrent-context",
         );
         let receipt = record.ai_publication.as_ref().unwrap().clone();
@@ -1372,7 +1587,7 @@ mod tests {
         let record = certified_record(
             1001,
             98_002,
-            "The teapot is plotting beside the basket.",
+            "The teapot is still warm beside the basket.",
             "restart-context",
         );
         let receipt = record.ai_publication.as_ref().unwrap().clone();


### PR DESCRIPTION
Addresses #555.

## The gap

`CLAUDE.md`: *"Content and client copy follow `v2/docs/writing-style.md` and its executable register checks."* Those checks live in `check-worldpack.mjs` and run over **authored pack content only**. Generated dialogue is now the largest body of player-visible prose in the game and nothing checked its register at all.

`writing-style.md` §2 bans *"objects that remember, weather with intentions"*, and §5 already states that ban covers character voice — but only the speech prompt carried it, so nothing enforced it. Production output is saturated with scenery that acts:

```
the path is learning my name
these hills recruit me as permanent furniture
the next hill auditions for villainy
my biscuit crumbs stage a rebellion
```

None contain the word "remember", so the narrow vocabulary ban missed every one — the prohibition was written around a single verb while the failure mode is agency generally.

## The change

A `voice_object_agency` check rejects an inanimate scene noun as the subject of a verb of intent, judgement, or memory, allowing one auxiliary or determiner between them so progressive forms ("is learning", "has welcomed") are caught. The check code is **appended** to `PublicationCheckCode`, so stored receipts keep the codes they were written with.

§5 is updated to state the rule as testable, with yes/no examples, per the issue's step 1.

## Deliberately narrow

This does **not** try to answer "how much wit is allowed", which the issue correctly identifies as undecided — §5 protects wit and I left that a voice decision rather than a check. The check only fires when *the scenery itself* is doing the wanting:

| rejected | allowed |
|---|---|
| the path is learning my name | the path is steep and my boots are wet |
| the kettle remembers every argument | i remember the kettle, and i want it back |
| Lantern Bend has welcomed me | Elsie welcomes me every single time |

A person with intentions is ordinary speech, and imagery is untouched. Actor names are not in the noun list, so `<person> welcomes me` cannot trip it.

## Two fixtures were themselves the bug

`"The teapot is plotting beside the basket."` and `"The teapot is staging a tiny revolt."` were replay/snapshot fixtures — and both are exactly the prose the issue complains about. They now use neutral lines, since they exercise round-tripping rather than register.

## Verification

- `cargo test` — **819 passed, 0 failed**
- New tests assert the seven sampled production lines are caught, and that seven ordinary/witty lines are not
- `npm test` 483 passed, `v2:worldpack` (authored register checks still pass), `v2:kernel`, `v2:syntax`, `check:version`, `cargo fmt --check`, `git diff --check` all clean
- `v2:architecture` — main.rs 74481 (ceiling 74481), clippy 273 (ceiling 273)

## Not covered

The corpus-level half of #555 (step 3) is untouched — the #547 catchphrase collapse was invisible line-by-line and only obvious across 23 lines together. That belongs with #552 and #394. #555 should stay open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)