### PR TITLE
Recover stale community image retries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.256",
+  "version": "0.0.257",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.256",
+      "version": "0.0.257",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.256",
+  "version": "0.0.257",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.256"
+version = "0.0.257"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.256"
+version = "0.0.257"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -1808,6 +1808,58 @@ pub(super) fn schedule_community_art_generation(
     });
 }
 
+pub(super) fn pending_community_art_resumption_plans(
+    runtime: &RuntimeWorld,
+    generated_asset_dir: &Path,
+) -> Vec<(u64, CommunityArtPlan)> {
+    runtime
+        .community_art_generations
+        .values()
+        .filter(|generation| {
+            generation.funded_orbs >= generation.required_orbs
+                && matches!(
+                    generation.status.as_str(),
+                    "funded" | "generating" | "reviewing"
+                )
+        })
+        .filter_map(|generation| {
+            generation.contributions.keys().copied().find_map(|actor_id| {
+                let plan = runtime
+                    .community_art_plan(
+                        actor_id,
+                        &generation.subject_kind,
+                        generation.subject_id,
+                    )
+                    .ok()?;
+                let candidate_exists =
+                    community_art_candidate_availability(generated_asset_dir, &plan)
+                        != CommunityArtCandidateAvailability::Absent;
+                plan.generation_retryable(generation, candidate_exists)
+                    .then_some((actor_id, plan))
+            })
+        })
+        .collect()
+}
+
+/// Replaces the in-memory worker that disappears when a deployment interrupts
+/// a funded generation. The durable generation record remains authoritative;
+/// only eligible work with a still-visible contributor is resumed.
+pub(super) fn resume_pending_community_art_generations(state: &AppState) {
+    if state.avatar_art_config.as_ref().is_none() {
+        return;
+    }
+    let state = state.clone();
+    tokio::spawn(async move {
+        let resumptions = {
+            let runtime = state.inner.lock().await;
+            pending_community_art_resumption_plans(&runtime, &state.generated_asset_dir)
+        };
+        for (actor_id, plan) in resumptions {
+            schedule_community_art_generation(&state, actor_id, plan);
+        }
+    });
+}
+
 pub(super) fn publish_community_art_candidate(
     generated_asset_dir: &Path,
     plan: &CommunityArtPlan,

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -20,9 +20,9 @@ use tracing::warn;
 use crate::media_recipes::media_verdict::{
     bounded_brief_constraints, make_visual_verdict, media_candidate_approved,
     media_candidate_digest, media_candidate_violations, media_provider_route_available,
-    prepare_media_candidate, record_media_provider_failure, record_media_review_unavailable,
-    record_media_visual_verdict, FrozenMediaBrief, MediaCandidateInput, MediaVerdictDisposition,
-    MediaViolation,
+    prepare_media_candidate, prepare_rejected_media_candidate_replacement,
+    record_media_provider_failure, record_media_review_unavailable, record_media_visual_verdict,
+    FrozenMediaBrief, MediaCandidateInput, MediaVerdictDisposition, MediaViolation,
 };
 use crate::{
     active_content, backfill_legacy_community_asset, broadcast_events,
@@ -112,9 +112,11 @@ pub(super) struct CommunityArtGenerationState {
     pub(super) status_event_seq: Option<u64>,
     #[serde(default)]
     pub(super) evolution_job: Option<FrozenCommunityArtEvolutionJob>,
+    #[serde(default)]
+    pub(super) frozen_plan: Option<CommunityArtPlan>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(super) struct CommunityArtPlan {
     pub(super) subject_kind: String,
     pub(super) subject_id: u64,
@@ -124,7 +126,7 @@ pub(super) struct CommunityArtPlan {
     pub(super) required_orbs: i32,
     pub(super) history_through_seq: u64,
     pub(super) prompt: String,
-    pub(super) aspect_ratio: &'static str,
+    pub(super) aspect_ratio: String,
     pub(super) image_policy: Option<CommunityArtImagePolicy>,
     pub(super) persisted_identity: String,
     pub(super) persisted_visual_description: String,
@@ -180,7 +182,7 @@ pub(super) fn freeze_community_art_evolution(
         plan.history_through_seq,
         plan.level,
         1,
-        plan.aspect_ratio,
+        &plan.aspect_ratio,
     )?);
     Ok(())
 }
@@ -197,7 +199,8 @@ fn frozen_evolution_reference(job: &FrozenCommunityArtEvolutionJob) -> FrozenMed
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub(super) enum CommunityArtImagePolicy {
     LocationLandscape,
 }
@@ -574,6 +577,19 @@ impl RuntimeWorld {
         let level = self
             .community_art_subject_level(subject_kind, subject_id)
             .ok_or_else(|| "That card does not have community-generated art.".to_string())?;
+        let generation_profile_version = community_art_generation_profile_version(subject_kind);
+        if let Some(frozen_plan) = self
+            .community_art_generations
+            .get(&community_art_generation_key(
+                subject_kind,
+                subject_id,
+                level,
+            ))
+            .and_then(|generation| generation.frozen_plan.as_ref())
+            .filter(|plan| plan.generation_profile_version >= generation_profile_version)
+        {
+            return Ok(frozen_plan.clone());
+        }
         let (card, visible, aspect_ratio, subject_details, image_policy) = match subject_kind {
             "actor" => {
                 let actor = self
@@ -726,12 +742,12 @@ impl RuntimeWorld {
             subject_kind: subject_kind.to_string(),
             subject_id,
             level,
-            generation_profile_version: community_art_generation_profile_version(subject_kind),
+            generation_profile_version,
             generation_policy,
             required_orbs: i32::from(level.max(1)),
             history_through_seq,
             prompt,
-            aspect_ratio,
+            aspect_ratio: aspect_ratio.to_string(),
             image_policy,
             persisted_identity,
             persisted_visual_description,
@@ -776,6 +792,7 @@ impl RuntimeWorld {
                 last_error_code: None,
                 status_event_seq: None,
                 evolution_job: evolution_job.clone(),
+                frozen_plan: None,
             });
         if generation.evolution_job.is_none() {
             generation.evolution_job = evolution_job;
@@ -852,6 +869,7 @@ impl RuntimeWorld {
         provider_attempt: bool,
         generation_profile_version: u8,
         generation_policy: &GeneratedPolicyBinding,
+        frozen_plan: Option<&CommunityArtPlan>,
     ) -> Option<EventView> {
         let key = community_art_generation_key(subject_kind, subject_id, level);
         let generation = self.community_art_generations.get_mut(&key)?;
@@ -863,6 +881,9 @@ impl RuntimeWorld {
         if generation_profile_version > generation.generation_profile_version {
             generation.generation_profile_version = generation_profile_version;
             generation.provider_attempts = 0;
+            generation.frozen_plan = frozen_plan.cloned();
+        } else if generation.frozen_plan.is_none() {
+            generation.frozen_plan = frozen_plan.cloned();
         }
         if provider_attempt {
             generation.provider_attempts = generation.provider_attempts.saturating_add(1);
@@ -977,14 +998,20 @@ pub(super) fn prepare_community_art_generation(
     let config = resolve_generation_media_config(
         config,
         plan.generation_policy.media.as_ref(),
-        plan.aspect_ratio,
+        &plan.aspect_ratio,
     )
     .map_err(CommunityArtGenerationError::Preflight)?;
     let media_brief = community_art_media_brief(plan);
     media_brief
         .validate()
         .map_err(CommunityArtGenerationError::BriefInvalid)?;
-    let job_key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
+    let job_key = media_brief.job_key.clone();
+    if prepare_rejected_media_candidate_replacement(generated_asset_dir, media_brief.clone())
+        .map_err(CommunityArtGenerationError::Storage)?
+    {
+        remove_community_art_candidate(generated_asset_dir, plan)
+            .map_err(CommunityArtGenerationError::Storage)?;
+    }
     let evolution_route = match plan.evolution_job.as_ref() {
         Some(job) => evolution_runtime_observation(&job.evaluation_profile)
             .and_then(|observation| evolution_rollout_route(job, observation.as_ref()))
@@ -1025,7 +1052,7 @@ pub(super) fn prepare_community_art_generation(
         prepare_replicate_art(
             &config,
             community_art_generation_request(&config, plan),
-            plan.aspect_ratio,
+            &plan.aspect_ratio,
             &plan.subject_kind,
             plan.subject_id,
             plan.level,
@@ -1126,7 +1153,7 @@ async fn generate_and_store_prepared_community_art(
         source,
     } = prepared;
     let config = &config;
-    let job_key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
+    let job_key = media_brief.job_key.clone();
     let mut provider_executions = Vec::new();
     let (image, reused_candidate, evolution_canary) = match source {
         PreparedCommunityArtSource::Candidate {
@@ -1363,7 +1390,7 @@ async fn generate_and_store_prepared_community_art(
                 &image.bytes,
                 &image.content_type,
                 &frozen_reference,
-                plan.aspect_ratio,
+                &plan.aspect_ratio,
                 provenance,
             )
         } else {
@@ -1457,7 +1484,7 @@ pub(super) fn community_art_media_brief(plan: &CommunityArtPlan) -> FrozenMediaB
         ),
         format!("public {} progression art", plan.subject_kind),
         &plan.prompt,
-        plan.aspect_ratio,
+        &plan.aspect_ratio,
     );
     brief.required_subjects = if plan.subject_kind == "location" {
         Vec::new()
@@ -1597,6 +1624,7 @@ pub(super) async fn begin_community_art_generation(
             provider_attempt,
             generation_profile_version: plan.generation_profile_version,
             generation_policy: plan.generation_policy.clone(),
+            frozen_plan: Some(Box::new(plan.clone())),
         });
     let (commit_status, events) = commit_journal_record(state, &mut runtime, record).ok()?;
     drop(runtime);
@@ -1784,6 +1812,20 @@ pub(super) fn schedule_community_art_generation(
                 );
             }
         }
+        let retry_rejected = if status == "policy_rejected" && events.is_some() {
+            match remove_community_art_candidate(&state.generated_asset_dir, &plan) {
+                Ok(()) => true,
+                Err(error) => {
+                    warn!(
+                        "failed to remove rejected community art candidate for {}: {}",
+                        key, error
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
         for execution in &outcome.provider_executions {
             record_ai_usage_for_provider(
                 &state,
@@ -1805,6 +1847,9 @@ pub(super) fn schedule_community_art_generation(
         if let Ok(mut jobs) = community_art_jobs().lock() {
             jobs.remove(&key);
         }
+        if retry_rejected {
+            schedule_community_art_generation(&state, actor_id, plan);
+        }
     });
 }
 
@@ -1816,27 +1861,35 @@ pub(super) fn pending_community_art_resumption_plans(
         .community_art_generations
         .values()
         .filter(|generation| {
+            let interrupted = matches!(
+                generation.status.as_str(),
+                "funded" | "generating" | "reviewing"
+            );
+            let rejected_candidate = generation.status == "policy_rejected";
+            let stale_brief =
+                generation.last_error_code.as_deref() == Some("community_art_storage_failed");
             generation.funded_orbs >= generation.required_orbs
-                && matches!(
-                    generation.status.as_str(),
-                    "funded" | "generating" | "reviewing"
-                )
+                && (interrupted || rejected_candidate || stale_brief)
         })
         .filter_map(|generation| {
-            generation.contributions.keys().copied().find_map(|actor_id| {
-                let plan = runtime
-                    .community_art_plan(
-                        actor_id,
-                        &generation.subject_kind,
-                        generation.subject_id,
-                    )
-                    .ok()?;
-                let candidate_exists =
-                    community_art_candidate_availability(generated_asset_dir, &plan)
-                        != CommunityArtCandidateAvailability::Absent;
-                plan.generation_retryable(generation, candidate_exists)
-                    .then_some((actor_id, plan))
-            })
+            generation
+                .contributions
+                .keys()
+                .copied()
+                .find_map(|actor_id| {
+                    let plan = runtime
+                        .community_art_plan(
+                            actor_id,
+                            &generation.subject_kind,
+                            generation.subject_id,
+                        )
+                        .ok()?;
+                    let candidate_exists =
+                        community_art_candidate_availability(generated_asset_dir, &plan)
+                            != CommunityArtCandidateAvailability::Absent;
+                    plan.generation_retryable(generation, candidate_exists)
+                        .then_some((actor_id, plan))
+                })
         })
         .collect()
 }

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -67,7 +67,7 @@ fn location_art_plan(
         required_orbs: 1,
         history_through_seq: 99,
         prompt: "A quiet chalk lane with no figures.".to_string(),
-        aspect_ratio,
+        aspect_ratio: aspect_ratio.to_string(),
         image_policy: Some(CommunityArtImagePolicy::LocationLandscape),
         persisted_identity,
         persisted_visual_description,
@@ -180,6 +180,59 @@ fn test_candidate_quarantine_root(root: &Path, plan: &CommunityArtPlan) -> PathB
 }
 
 #[test]
+fn funded_generation_retries_reuse_the_journaled_frozen_plan() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        RAIN_SOFT_GARDEN_LOCATION_ID,
+        "Frozen Plan Patron",
+    );
+    let original = runtime
+        .community_art_plan(5000, "actor", 5000)
+        .expect("initial actor plan");
+    fund_test_community_art(&mut runtime, 5000, &original, "frozen-plan", 8801);
+    runtime
+        .apply_begin_community_art_generation_projection(
+            5000,
+            "actor",
+            5000,
+            1,
+            true,
+            original.generation_profile_version,
+            &original.generation_policy,
+            Some(&original),
+        )
+        .expect("begin generation freezes the plan");
+
+    runtime.callings.insert(
+        5000,
+        CallingState {
+            actor_id: 5000,
+            statement: "I now carry changing world details.".to_string(),
+            source_event_seq: Some(8802),
+        },
+    );
+    runtime.world.next_event_seq = runtime.world.next_event_seq.saturating_add(50);
+    let retry = runtime
+        .community_art_plan(5000, "actor", 5000)
+        .expect("retry plan");
+    assert_eq!(retry.prompt, original.prompt);
+    assert_eq!(retry.history_through_seq, original.history_through_seq);
+    assert_eq!(
+        community_art_media_brief(&retry).digest().unwrap(),
+        community_art_media_brief(&original).digest().unwrap()
+    );
+
+    let restored: BTreeMap<String, CommunityArtGenerationState> =
+        serde_json::from_slice(&serde_json::to_vec(&runtime.community_art_generations).unwrap())
+            .unwrap();
+    assert!(restored[&community_art_generation_key("actor", 5000, 1)]
+        .frozen_plan
+        .is_some());
+}
+
+#[test]
 fn policy_preflight_fixture_is_a_real_sized_png() {
     let encoded = POLICY_PREFLIGHT_IMAGE_URL
         .strip_prefix("data:image/png;base64,")
@@ -231,6 +284,19 @@ fn funded_avatar_generation_is_selected_for_boot_resumption() {
     assert_eq!(resumptions[0].0, 5000);
     assert_eq!(resumptions[0].1.subject_kind, "actor");
     assert_eq!(resumptions[0].1.subject_id, 5000);
+
+    let generation = runtime
+        .community_art_generations
+        .get_mut(&key)
+        .expect("stale-brief generation");
+    generation.status = "failed".to_string();
+    generation.last_error_code = Some("community_art_storage_failed".to_string());
+    let stale_brief_resumptions = pending_community_art_resumption_plans(&runtime, &asset_root);
+    assert_eq!(
+        stale_brief_resumptions.len(),
+        1,
+        "a legacy frozen-brief failure is repaired automatically on boot"
+    );
     let _ = std::fs::remove_dir_all(asset_root);
 }
 
@@ -599,7 +665,7 @@ fn location_generation_replaces_portrait_prompt_without_disabling_the_style_lora
             &history,
             Some(CommunityArtImagePolicy::LocationLandscape),
         ),
-        aspect_ratio: "16:9",
+        aspect_ratio: "16:9".to_string(),
         image_policy: Some(CommunityArtImagePolicy::LocationLandscape),
         persisted_identity: "Quiet Rise".to_string(),
         persisted_visual_description: "chalky lanes and reed beds".to_string(),
@@ -744,7 +810,7 @@ async fn location_policy_400_fails_before_orb_debit_or_replicate_schedule() {
             required_orbs: 1,
             history_through_seq: 0,
             prompt: String::new(),
-            aspect_ratio: "16:9",
+            aspect_ratio: "16:9".to_string(),
             image_policy: Some(CommunityArtImagePolicy::LocationLandscape),
             persisted_identity: "test location".to_string(),
             persisted_visual_description: "test landscape".to_string(),
@@ -814,7 +880,7 @@ async fn policy_retry_reuses_the_saved_candidate_without_calling_replicate() {
         required_orbs: 1,
         history_through_seq: 99,
         prompt: "A quiet rain-soft path with no figures.".to_string(),
-        aspect_ratio: "16:9",
+        aspect_ratio: "16:9".to_string(),
         image_policy: Some(CommunityArtImagePolicy::LocationLandscape),
         persisted_identity: "Quiet Rise".to_string(),
         persisted_visual_description: "rain-soft path".to_string(),
@@ -932,7 +998,7 @@ fn rollback_and_incumbent_routes_quarantine_a_stored_canary_before_publication()
         required_orbs: 2,
         history_through_seq: 72,
         prompt: "incumbent prompt".to_string(),
-        aspect_ratio: "2:3",
+        aspect_ratio: "2:3".to_string(),
         image_policy: None,
         persisted_identity: "Rollback Patron".to_string(),
         persisted_visual_description: "a rust-red fox with a green scarf".to_string(),
@@ -1058,6 +1124,7 @@ fn provider_attempt_budget_is_journaled_and_survives_serialization() {
                 provider_attempt: true,
                 generation_profile_version: LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION,
                 generation_policy: GeneratedPolicyBinding::default(),
+                frozen_plan: None,
             });
         record
             .projection_mutations
@@ -1210,6 +1277,7 @@ fn failed_evolution_retries_charge_no_extra_orbs_and_keep_prior_art_public() {
                 provider_attempt: true,
                 generation_profile_version: LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION,
                 generation_policy: GeneratedPolicyBinding::default(),
+                frozen_plan: None,
             });
         failure
             .projection_mutations
@@ -1303,6 +1371,7 @@ fn newer_location_prompt_profile_reopens_a_paid_exhausted_job() {
                     .generated_pathway_for_location(subject_id)
                     .map(|pathway| pathway.generation_policy.clone())
                     .unwrap_or_default(),
+                frozen_plan: None,
             });
         record
             .projection_mutations
@@ -1350,6 +1419,7 @@ fn newer_location_prompt_profile_reopens_a_paid_exhausted_job() {
                 .generated_pathway_for_location(subject_id)
                 .map(|pathway| pathway.generation_policy.clone())
                 .unwrap_or_default(),
+            frozen_plan: None,
         });
     assert_eq!(runtime.apply_journal_record(&retry).0, CW_OK);
 

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -193,6 +193,47 @@ fn policy_preflight_fixture_is_a_real_sized_png() {
     assert_eq!(u32::from_be_bytes(bytes[20..24].try_into().unwrap()), 64);
 }
 
+#[test]
+fn funded_avatar_generation_is_selected_for_boot_resumption() {
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Restarted Art Patron",
+    );
+    let plan = runtime
+        .community_art_plan(5000, "actor", 5000)
+        .expect("active patron can fund their visible avatar");
+    fund_test_community_art(
+        &mut runtime,
+        5000,
+        &plan,
+        "test-boot-community-art-resumption",
+        9001,
+    );
+    let key = community_art_generation_key("actor", 5000, plan.level);
+    let generation = runtime
+        .community_art_generations
+        .get_mut(&key)
+        .expect("funded avatar generation");
+    generation.status = "generating".to_string();
+    generation.provider_attempts = 1;
+
+    let asset_root = std::env::temp_dir().join(format!(
+        "cosyworld-community-art-resume-{}-{}",
+        std::process::id(),
+        now_seed()
+    ));
+    std::fs::create_dir_all(&asset_root).expect("create temporary generated-asset root");
+    let resumptions = pending_community_art_resumption_plans(&runtime, &asset_root);
+    assert_eq!(resumptions.len(), 1);
+    assert_eq!(resumptions[0].0, 5000);
+    assert_eq!(resumptions[0].1.subject_kind, "actor");
+    assert_eq!(resumptions[0].1.subject_id, 5000);
+    let _ = std::fs::remove_dir_all(asset_root);
+}
+
 #[tokio::test]
 async fn location_art_funding_fails_before_debit_without_policy_review() {
     let mut runtime = RuntimeWorld::seeded();

--- a/v2/orchestrator-rust/src/generation_policy.rs
+++ b/v2/orchestrator-rust/src/generation_policy.rs
@@ -1355,6 +1355,7 @@ mod tests {
                 provider_attempt: true,
                 generation_profile_version: LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION,
                 generation_policy: binding.clone(),
+                frozen_plan: None,
             }],
             ..JournalRecord::new(
                 CwAction {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1025,6 +1025,8 @@ enum ProjectionMutation {
         generation_profile_version: u8,
         #[serde(default)]
         generation_policy: GeneratedPolicyBinding,
+        #[serde(default)]
+        frozen_plan: Option<Box<CommunityArtPlan>>,
     },
     CompleteCommunityArtGeneration {
         subject_kind: String,
@@ -10608,6 +10610,7 @@ impl RuntimeWorld {
                     provider_attempt,
                     generation_profile_version,
                     generation_policy,
+                    frozen_plan,
                 } => {
                     let generation_policy = if generation_policy.is_empty()
                         && subject_kind == "location"
@@ -10636,6 +10639,7 @@ impl RuntimeWorld {
                         *provider_attempt,
                         *generation_profile_version,
                         &generation_policy,
+                        frozen_plan.as_deref(),
                     ) {
                         events.push(event);
                     }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -5400,6 +5400,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _canonical_capacity_scheduler = start_canonical_capacity_scheduler(state.clone());
     start_focused_encounter_scheduler(state.clone());
     start_actor_job_worker(state.clone());
+    resume_pending_community_art_generations(&state);
     start_event_store_retry_scheduler(state.clone());
     start_ownership_refresh_scheduler(state.clone());
     start_hosted_access_scheduler(state.clone());

--- a/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
+++ b/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
@@ -411,6 +411,59 @@ pub(crate) fn prepare_media_candidate(
     Ok(disposition)
 }
 
+/// Retires a rejected candidate's immutable review record when a legacy retry
+/// must adopt a newly frozen brief. Approved or still-pending work remains
+/// fail-closed: only an explicitly rejected active candidate may be replaced.
+///
+/// The retired record is preserved beside the live record for audit. Returning
+/// `true` tells the community-art pipeline to remove its staged candidate before
+/// spending another capped provider attempt.
+pub(crate) fn prepare_rejected_media_candidate_replacement(
+    root: &Path,
+    brief: FrozenMediaBrief,
+) -> Result<bool, String> {
+    brief.validate()?;
+    let brief_digest = brief.digest()?;
+    let _guard = media_verdict_lock()?;
+    let record = match load_record_by_job(root, &brief.job_key) {
+        Ok(record) => record,
+        Err(error) if error.contains("not found") => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let active_rejected = record
+        .active_candidate_digest
+        .as_deref()
+        .and_then(|digest| {
+            record
+                .candidates
+                .iter()
+                .find(|candidate| candidate.provenance.digest == digest)
+        })
+        .is_some_and(|candidate| {
+            matches!(
+                candidate.disposition,
+                MediaVerdictDisposition::Rejected | MediaVerdictDisposition::ReplaceRequested
+            )
+        });
+    if !active_rejected || record.disabled {
+        return Ok(false);
+    }
+    if record.brief_digest == brief_digest && record.brief == brief {
+        return Ok(true);
+    }
+    if record.candidates.iter().any(|candidate| {
+        matches!(
+            candidate.disposition,
+            MediaVerdictDisposition::Approved | MediaVerdictDisposition::ReviewPending
+        )
+    }) {
+        return Err("generated-image frozen brief changed for an existing job".to_string());
+    }
+    retire_record(root, &record)?;
+    store_record(root, &new_record(brief, &brief_digest))?;
+    Ok(true)
+}
+
 pub(crate) fn record_media_visual_verdict(
     root: &Path,
     job_key: &str,
@@ -958,21 +1011,39 @@ fn load_or_create_record(
             }
             Ok(record)
         }
-        Err(error) if error.contains("not found") => Ok(PersistedMediaVerdict {
-            schema_version: MEDIA_VERDICT_SCHEMA_VERSION,
-            record_id,
-            brief,
-            brief_digest: brief_digest.to_string(),
-            active_candidate_digest: None,
-            candidates: Vec::new(),
-            provider_failures: 0,
-            provider_cooldown_until_ms: None,
-            provider_route: "primary".to_string(),
-            disabled: false,
-            updated_at_ms: crate::now_millis(),
-        }),
+        Err(error) if error.contains("not found") => Ok(new_record(brief, brief_digest)),
         Err(error) => Err(error),
     }
+}
+
+fn new_record(brief: FrozenMediaBrief, brief_digest: &str) -> PersistedMediaVerdict {
+    PersistedMediaVerdict {
+        schema_version: MEDIA_VERDICT_SCHEMA_VERSION,
+        record_id: sha256_hex(brief.job_key.as_bytes()),
+        brief,
+        brief_digest: brief_digest.to_string(),
+        active_candidate_digest: None,
+        candidates: Vec::new(),
+        provider_failures: 0,
+        provider_cooldown_until_ms: None,
+        provider_route: "primary".to_string(),
+        disabled: false,
+        updated_at_ms: crate::now_millis(),
+    }
+}
+
+fn retire_record(root: &Path, record: &PersistedMediaVerdict) -> Result<(), String> {
+    let retired = record_dir(root, &record.record_id)
+        .join("retired")
+        .join(format!("{}.json", record.brief_digest));
+    let parent = retired
+        .parent()
+        .ok_or_else(|| "retired media verdict path has no parent".to_string())?;
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    atomic_write(
+        &retired,
+        &serde_json::to_vec(record).map_err(|error| error.to_string())?,
+    )
 }
 
 fn load_record_by_job(root: &Path, job_key: &str) -> Result<PersistedMediaVerdict, String> {

--- a/v2/orchestrator-rust/src/media_verdict_tests.rs
+++ b/v2/orchestrator-rust/src/media_verdict_tests.rs
@@ -338,6 +338,55 @@ fn approved_verdict_survives_restart_and_is_bound_to_brief_candidate_and_referen
 }
 
 #[test]
+fn rejected_candidate_can_be_replaced_under_a_new_frozen_brief_with_audit_retained() {
+    let root = root("rejected-brief-replacement");
+    let original = brief("rejected-brief-job");
+    let rejected = image(patterned_png(16, 9, 31), "image/png", "watermarked");
+    assert_eq!(
+        prepare(&root, original.clone(), &rejected, None, None),
+        MediaVerdictDisposition::ReviewPending
+    );
+    let rejected_digest = sha256_hex(&rejected.bytes);
+    let verdict = make_visual_verdict(
+        &original,
+        rejected_digest,
+        "fixture-reviewer",
+        "fixture-reviewer/1",
+        false,
+        vec![MediaViolation::Watermark],
+        "Visible watermark.",
+        1,
+        5,
+        1,
+    )
+    .unwrap();
+    record_media_visual_verdict(&root, "rejected-brief-job", verdict).unwrap();
+
+    let mut replacement_brief = original.clone();
+    replacement_brief.crop = "full room, subject centered".to_string();
+    assert!(
+        prepare_rejected_media_candidate_replacement(&root, replacement_brief.clone()).unwrap(),
+        "an explicitly rejected active candidate may move to a newly frozen retry brief"
+    );
+    let retired = root
+        .join("media-verdicts/v1")
+        .join(sha256_hex(b"rejected-brief-job"))
+        .join("retired")
+        .join(format!("{}.json", original.digest().unwrap()));
+    assert!(
+        retired.is_file(),
+        "the rejected immutable record is retained"
+    );
+
+    let replacement = image(patterned_png(16, 9, 32), "image/png", "replacement");
+    assert_eq!(
+        prepare(&root, replacement_brief, &replacement, None, None),
+        MediaVerdictDisposition::ReviewPending,
+        "the replacement candidate is reviewed against the new frozen brief"
+    );
+}
+
+#[test]
 fn reviewer_outage_reuses_one_candidate_and_provider_failures_enter_cooldown() {
     let root = root("outage");
     let frozen = brief("outage-job");

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -85,4 +85,7 @@
 # also pin those context and causality boundaries with focused regressions.
 # 74648 -> 74646: replace legacy Journal detail assertions with the smaller
 # semantic-region and truthful-overflow contract.
-74646
+# 74646 -> 74647: boot wiring resumes durable, fully funded community-art jobs
+# interrupted by a process restart; selection and tests remain in the focused
+# community_art seam.
+74647

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -88,4 +88,7 @@
 # 74646 -> 74647: boot wiring resumes durable, fully funded community-art jobs
 # interrupted by a process restart; selection and tests remain in the focused
 # community_art seam.
-74647
+# 74647 -> 74651: persist the frozen community-art plan with the existing
+# begin-generation projection so retries survive content evolution without
+# weakening their media-verdict binding.
+74651


### PR DESCRIPTION
Refs #504

## Summary

- resume already-funded community image jobs after restart from their durable frozen plans
- preserve the frozen generation plan through projection and snapshot replay
- retire only explicitly rejected stale candidate verdicts, retaining the immutable verdict under its brief digest before requesting one bounded replacement
- keep approved and pending candidates fail-closed, and keep the large projection payload boxed within the existing Clippy budget

## Production diagnosis

Before this fix, a real Mossy Verge retry on production entered the visible `image workshop starting…` state and returned to retry without spending another Orb or provider attempt. The server rejected the reused candidate because its visual-review verdict was not bound to the current frozen brief. This change gives that explicitly rejected candidate a safe audited replacement path and also makes funded work resumable after process restart.

## Validation

- `npm run check` — 506 JavaScript tests, all worldpack/kernel checks, 849 Rust tests, architecture ceiling 74651/74651, Clippy 273/273, syntax checks
- `npm run lint`
- `npm run v2:browser:check`
- `npm run v2:composition:smoke`
- `node v2/scripts/smoke-production-profile.mjs`

The issue will remain open until the merged build is deployed and the same real production job completes end to end with stage timing and no duplicate Orb debit.
