### PR TITLE
Remove full-world commit rollback clone and alert on OOM exits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
           npm test
           npm run v2:worldpack
           npm run v2:kernel
-          npm run v2:deploy:guards
           npm run v2:syntax
 
   runtime:

--- a/.github/workflows/oom-alert.yml
+++ b/.github/workflows/oom-alert.yml
@@ -1,0 +1,38 @@
+name: Fly OOM alert
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: fly-oom-alert-${{ github.repository }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  oom:
+    name: ${{ matrix.app }} has no OOM exits
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - cosyworld
+          - cosyworld-lonelyforest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check Fly OOM metric
+        run: node v2/scripts/check-fly-oom.mjs personal "${{ matrix.app }}" 30m
+        env:
+          FLY_METRICS_READ_TOKEN: ${{ secrets.FLY_METRICS_READ_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.257",
+  "version": "0.0.258",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.257",
+      "version": "0.0.258",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.257",
+  "version": "0.0.258",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,
@@ -50,7 +50,7 @@
     "v2:media:evolution": "node v2/scripts/report-media-evolution.mjs",
     "v2:proof-world": "node v2/scripts/check-proof-world.mjs",
     "v2:spike:deck-gated": "node v2/scripts/spike-deck-gated-actions.mjs",
-    "v2:syntax": "node --check v2/scripts/smoke-browser.mjs && node --check v2/scripts/smoke-production-profile.mjs && node --check v2/scripts/smoke-deployed-ruby-high.mjs && node --check v2/scripts/smoke-standalone-compositions.mjs && node --check v2/scripts/smoke-core-ruby-composition.mjs && node --check v2/scripts/inspect-action-journal.mjs && node --check v2/scripts/check-deploy-worldpack.mjs && node --check v2/scripts/report-media-evolution.mjs && python3 -m py_compile v2/cli/cosy_cli.py",
+    "v2:syntax": "node --check v2/scripts/smoke-browser.mjs && node --check v2/scripts/smoke-production-profile.mjs && node --check v2/scripts/smoke-deployed-ruby-high.mjs && node --check v2/scripts/smoke-standalone-compositions.mjs && node --check v2/scripts/smoke-core-ruby-composition.mjs && node --check v2/scripts/inspect-action-journal.mjs && node --check v2/scripts/check-deploy-worldpack.mjs && node --check v2/scripts/check-fly-oom.mjs && node --check v2/scripts/report-media-evolution.mjs && python3 -m py_compile v2/cli/cosy_cli.py",
     "reset-setup": "node scripts/reset-setup.mjs",
     "build": "npm run clean && npm run build:js && npm run docs",
     "clean": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\"",

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -9,6 +9,10 @@ const volumeHeadroomWorkflow = readFileSync(
   new URL('../../.github/workflows/volume-headroom.yml', import.meta.url),
   'utf8'
 );
+const oomAlertWorkflow = readFileSync(
+  new URL('../../.github/workflows/oom-alert.yml', import.meta.url),
+  'utf8'
+);
 const primaryFlyConfig = readFileSync(
   new URL('../../fly.toml', import.meta.url),
   'utf8'
@@ -82,6 +86,18 @@ describe('deploy workflow', () => {
     );
     expect(volumeHeadroomWorkflow).toContain(
       'FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}'
+    );
+  });
+
+  it('alerts on OOM exits for both Fly apps every fifteen minutes', () => {
+    expect(oomAlertWorkflow).toContain('cron: "*/15 * * * *"');
+    expect(oomAlertWorkflow).toContain('- cosyworld');
+    expect(oomAlertWorkflow).toContain('- cosyworld-lonelyforest');
+    expect(oomAlertWorkflow).toContain(
+      'node v2/scripts/check-fly-oom.mjs personal "${{ matrix.app }}" 30m'
+    );
+    expect(oomAlertWorkflow).toContain(
+      'FLY_METRICS_READ_TOKEN: ${{ secrets.FLY_METRICS_READ_TOKEN }}'
     );
   });
 

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -5,6 +5,13 @@ const workflow = readFileSync(
   new URL('../../.github/workflows/deploy.yml', import.meta.url),
   'utf8'
 );
+const ciWorkflow = readFileSync(
+  new URL('../../.github/workflows/ci.yml', import.meta.url),
+  'utf8'
+);
+const packageScripts = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+).scripts;
 const volumeHeadroomWorkflow = readFileSync(
   new URL('../../.github/workflows/volume-headroom.yml', import.meta.url),
   'utf8'
@@ -34,6 +41,13 @@ const job = (name, nextName) => {
 };
 
 describe('deploy workflow', () => {
+  it('only invokes package scripts that exist', () => {
+    const invokedScripts = [...ciWorkflow.matchAll(/\bnpm run ([\w:-]+)/g)].map(
+      ([, script]) => script
+    );
+    expect(invokedScripts.filter((script) => !packageScripts[script])).toEqual([]);
+  });
+
   it('serializes deployments across branch and tag refs', () => {
     expect(workflow).toContain('group: deploy-${{ github.repository }}');
     expect(workflow).toContain('cancel-in-progress: false');

--- a/test/infrastructure/fly-oom-alert.test.mjs
+++ b/test/infrastructure/fly-oom-alert.test.mjs
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOomQuery,
+  checkFlyOom,
+  flyAuthorization,
+  parseOomMetric,
+} from '../../v2/scripts/check-fly-oom.mjs';
+
+describe('Fly OOM alert', () => {
+  it('creates a bounded app-scoped query', () => {
+    expect(buildOomQuery('cosyworld-lonelyforest', '2h')).toBe(
+      'max(max_over_time(fly_instance_exit_oom{app="cosyworld-lonelyforest"}[2h]))'
+    );
+    expect(() => buildOomQuery('cosyworld"} or vector(1)', '30m')).toThrow(/app must/);
+    expect(() => buildOomQuery('cosyworld', '30 minutes')).toThrow(/window must/);
+  });
+
+  it('accepts raw and already-prefixed Fly tokens', () => {
+    expect(flyAuthorization('secret-token')).toBe('FlyV1 secret-token');
+    expect(flyAuthorization(' FlyV1 secret-token \n')).toBe('FlyV1 secret-token');
+    expect(() => flyAuthorization('')).toThrow(/required/);
+  });
+
+  it('treats zero as healthy and one as an OOM', () => {
+    expect(
+      parseOomMetric({
+        status: 'success',
+        data: { result: [{ value: [1_750_000_000, '0'] }] },
+      })
+    ).toBe(0);
+    expect(
+      parseOomMetric({
+        status: 'success',
+        data: { result: [{ value: [1_750_000_000, '1'] }] },
+      })
+    ).toBe(1);
+  });
+
+  it('fails closed on missing and malformed metrics', () => {
+    expect(() => parseOomMetric({ status: 'success', data: { result: [] } })).toThrow(
+      /no OOM series/
+    );
+    expect(() =>
+      parseOomMetric({
+        status: 'success',
+        data: { result: [{ value: [1_750_000_000, 'not-a-number'] }] },
+      })
+    ).toThrow(/nonnumeric/);
+    expect(() =>
+      parseOomMetric({ status: 'error', errorType: 'bad_data', error: 'invalid' })
+    ).toThrow(/bad_data: invalid/);
+  });
+
+  it('sends the least-privilege FlyV1 request', async () => {
+    let request;
+    const result = await checkFlyOom({
+      org: 'personal',
+      app: 'cosyworld',
+      token: 'read-only-token',
+      fetchImpl: async (url, options) => {
+        request = { url, options };
+        return new Response(
+          JSON.stringify({
+            status: 'success',
+            data: { result: [{ value: [1_750_000_000, '0'] }] },
+          })
+        );
+      },
+    });
+    expect(result.maxOom).toBe(0);
+    expect(request.options.headers.Authorization).toBe('FlyV1 read-only-token');
+    expect(request.url.hostname).toBe('api.fly.io');
+    expect(request.url.pathname).toBe('/prometheus/personal/api/v1/query');
+    expect(request.url.searchParams.get('query')).toBe(buildOomQuery('cosyworld'));
+  });
+
+  it('rejects HTTP and invalid JSON responses', async () => {
+    await expect(
+      checkFlyOom({
+        org: 'personal',
+        app: 'cosyworld',
+        token: 'token',
+        fetchImpl: async () => new Response('unauthorized', { status: 401 }),
+      })
+    ).rejects.toThrow(/HTTP 401/);
+    await expect(
+      checkFlyOom({
+        org: 'personal',
+        app: 'cosyworld',
+        token: 'token',
+        fetchImpl: async () => new Response('not-json'),
+      })
+    ).rejects.toThrow(/invalid JSON/);
+  });
+});

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.257"
+version = "0.0.258"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.257"
+version = "0.0.258"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -39029,7 +39029,6 @@ fn commit_journal_record(
                 return Err(error);
             }
         };
-        let runtime_before_commit = runtime.clone();
         let committed = (|| -> io::Result<(u32, Vec<EventView>, bool, u64)> {
             let commit_time = now_millis();
             let lease_ttl = authority_lease_ttl_ms(state);
@@ -39288,12 +39287,7 @@ fn commit_journal_record(
             Ok(committed) => committed,
             Err(error) => {
                 let rollback_error = tx.rollback().map_err(sqlite_error).err();
-                let restore_error = if rollback_error.is_none() {
-                    *runtime = runtime_before_commit;
-                    None
-                } else {
-                    restore_runtime_from_durable_state(state, runtime, path).err()
-                };
+                let restore_error = restore_runtime_from_durable_state(state, runtime, path).err();
                 let error = journal_commit_recovery_error(error, rollback_error, restore_error);
                 if let Some(context) = command_context.as_ref() {
                     context.abort_commit();
@@ -39353,11 +39347,44 @@ fn commit_journal_record(
     Ok((status, events))
 }
 
+#[cfg(test)]
+thread_local! {
+    static DURABLE_COMMIT_RECOVERY_CALLS: std::cell::Cell<u64> =
+        const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn durable_commit_recovery_calls() -> u64 {
+    DURABLE_COMMIT_RECOVERY_CALLS.with(std::cell::Cell::get)
+}
+
 fn restore_runtime_from_durable_state(
     state: &AppState,
     runtime: &mut RuntimeWorld,
     event_store_path: &Path,
 ) -> io::Result<()> {
+    #[cfg(test)]
+    DURABLE_COMMIT_RECOVERY_CALLS.with(|calls| calls.set(calls.get().saturating_add(1)));
+    let restored = std::thread::scope(|scope| {
+        let recovery = std::thread::Builder::new()
+            .name("cosyworld-durable-recovery".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn_scoped(scope, || {
+                rebuild_runtime_from_durable_state(state, event_store_path)
+            })
+            .map_err(|error| io::Error::other(format!("spawn durable recovery: {error}")))?;
+        recovery
+            .join()
+            .map_err(|_| io::Error::other("durable recovery thread panicked"))?
+    })?;
+    *runtime = *restored;
+    Ok(())
+}
+
+fn rebuild_runtime_from_durable_state(
+    state: &AppState,
+    event_store_path: &Path,
+) -> io::Result<Box<RuntimeWorld>> {
     let mut restored = journal_checkpoint::replay_journal_continuity!(
         event_store_path,
         state.snapshot_path.as_deref().map(PathBuf::as_path),
@@ -39375,8 +39402,7 @@ fn restore_runtime_from_durable_state(
         let placement_rotation = placement_rotation_index_for_runtime(&restored);
         restored.apply_wallet_overlap_placements(&ownership, placement_rotation);
     }
-    *runtime = restored;
-    Ok(())
+    Ok(Box::new(restored))
 }
 
 fn journal_commit_recovery_error(
@@ -52443,7 +52469,18 @@ mod tests {
     }
 
     #[test]
-    fn actor_outbox_failure_rolls_back_the_entire_player_card_commit() {
+    fn actor_outbox_failure_restores_the_identical_durable_runtime() {
+        let commit_source = include_str!("main.rs")
+            .split_once("fn commit_journal_record(")
+            .expect("commit function exists")
+            .1
+            .split_once("fn restore_runtime_from_durable_state(")
+            .expect("recovery function follows commit")
+            .0;
+        assert!(
+            !commit_source.contains("runtime.clone()"),
+            "the accepted-command path must not clone the full runtime"
+        );
         let path = std::env::temp_dir().join(format!(
             "cosyworld-v2-actor-outbox-rollback-{}-{}.sqlite",
             std::process::id(),
@@ -52478,6 +52515,8 @@ mod tests {
                     .0,
                 CW_OK
             );
+            restore_runtime_from_durable_state(&state, &mut runtime, &path)
+                .expect("normalize the baseline from durable state");
         }
         let conn = open_event_store(&path).expect("open actor outbox");
         conn.execute_batch(
@@ -52490,12 +52529,6 @@ mod tests {
             [],
         )
         .expect("finish the baseline heartbeat before failure injection");
-        conn.execute(
-            "UPDATE action_journal SET record_json = '{broken replay'
-             WHERE journal_seq = (SELECT MIN(journal_seq) FROM action_journal)",
-            [],
-        )
-        .expect("make full replay unavailable after rollback");
         drop(conn);
         let baseline_counts = {
             let conn = open_event_store(&path).expect("count rollback baseline rows");
@@ -52512,6 +52545,9 @@ mod tests {
                 .collect::<BTreeMap<_, _>>()
         };
         let mut runtime = state.inner.blocking_lock();
+        let before_runtime =
+            serde_json::to_string(&RuntimeSnapshot::from_runtime(&runtime)).unwrap();
+        let recoveries_before = durable_commit_recovery_calls();
         let before_tick = runtime.world.tick;
         let before_next_event_seq = runtime.world.next_event_seq;
         let mut record = JournalRecord::new(
@@ -52542,10 +52578,31 @@ mod tests {
         let error = commit_journal_record(&state, &mut runtime, record)
             .expect_err("injected actor outbox failure");
         assert!(error.to_string().contains("injected actor outbox failure"));
-        assert!(!error.to_string().contains("runtime restore failed"));
+        assert!(!error
+            .to_string()
+            .contains("runtime journal recovery failed"));
+        assert_eq!(
+            durable_commit_recovery_calls(),
+            recoveries_before.saturating_add(1),
+            "the failed accepted command must rebuild from durable state"
+        );
         assert_eq!(runtime.world.tick, before_tick);
         assert_eq!(runtime.world.next_event_seq, before_next_event_seq);
         assert!(!runtime.tags.contains_key("test:outbox:rollback"));
+        let after_runtime =
+            serde_json::to_string(&RuntimeSnapshot::from_runtime(&runtime)).unwrap();
+        if after_runtime != before_runtime {
+            let before = serde_json::from_str::<serde_json::Value>(&before_runtime).unwrap();
+            let after = serde_json::from_str::<serde_json::Value>(&after_runtime).unwrap();
+            let differing_fields = before
+                .as_object()
+                .unwrap()
+                .keys()
+                .filter(|field| before.get(*field) != after.get(*field))
+                .cloned()
+                .collect::<Vec<_>>();
+            panic!("forced commit failure changed durable runtime fields: {differing_fields:?}");
+        }
         drop(runtime);
         let conn = open_event_store(&path).expect("inspect rolled back outbox");
         for table in ["action_journal", "world_events", "actor_jobs"] {

--- a/v2/scripts/check-fly-oom.mjs
+++ b/v2/scripts/check-fly-oom.mjs
@@ -1,0 +1,109 @@
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const DURATION_PATTERN = /^[1-9][0-9]*(?:s|m|h|d|w)$/;
+
+const requireIdentifier = (value, label) => {
+  if (!value || !IDENTIFIER_PATTERN.test(value)) {
+    throw new Error(`${label} must contain only letters, numbers, ".", "_", or "-"`);
+  }
+  return value;
+};
+
+export const buildOomQuery = (app, window = '30m') => {
+  requireIdentifier(app, 'app');
+  if (!DURATION_PATTERN.test(window)) {
+    throw new Error('window must be a positive Prometheus duration such as 30m or 2h');
+  }
+  return `max(max_over_time(fly_instance_exit_oom{app="${app}"}[${window}]))`;
+};
+
+export const flyAuthorization = (token) => {
+  const trimmed = token?.trim();
+  if (!trimmed) {
+    throw new Error('FLY_METRICS_READ_TOKEN is required');
+  }
+  return trimmed.startsWith('FlyV1 ') ? trimmed : `FlyV1 ${trimmed}`;
+};
+
+export const parseOomMetric = (payload) => {
+  if (payload?.status !== 'success') {
+    const detail = [payload?.errorType, payload?.error].filter(Boolean).join(': ');
+    throw new Error(`Fly metrics query failed${detail ? `: ${detail}` : ''}`);
+  }
+  const result = payload?.data?.result;
+  if (!Array.isArray(result) || result.length === 0) {
+    throw new Error('Fly metrics query returned no OOM series');
+  }
+  const values = result.map((series) => Number(series?.value?.[1]));
+  if (values.some((value) => !Number.isFinite(value))) {
+    throw new Error('Fly metrics query returned a nonnumeric OOM value');
+  }
+  return Math.max(...values);
+};
+
+export const checkFlyOom = async ({
+  org,
+  app,
+  window = '30m',
+  token,
+  fetchImpl = fetch,
+}) => {
+  requireIdentifier(org, 'organization');
+  const query = buildOomQuery(app, window);
+  const url = new URL(
+    `https://api.fly.io/prometheus/${encodeURIComponent(org)}/api/v1/query`
+  );
+  url.searchParams.set('query', query);
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/json',
+        Authorization: flyAuthorization(token),
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (error) {
+    throw new Error(`Fly metrics request failed: ${error.message}`);
+  }
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`Fly metrics request returned HTTP ${response.status}`);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    throw new Error('Fly metrics request returned invalid JSON');
+  }
+  return { app, maxOom: parseOomMetric(payload), query, window };
+};
+
+const main = async () => {
+  const [org, app, window = '30m', ...extra] = process.argv.slice(2);
+  if (!org || !app || extra.length > 0) {
+    throw new Error('usage: check-fly-oom.mjs <organization> <app> [window]');
+  }
+  const result = await checkFlyOom({
+    org,
+    app,
+    window,
+    token: process.env.FLY_METRICS_READ_TOKEN,
+  });
+  if (result.maxOom > 0) {
+    console.error(
+      `::error title=Fly OOM detected::${result.app} recorded an OOM exit in the last ${result.window}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `${result.app}: no OOM exits in the last ${result.window} (metric=${result.maxOom})`
+  );
+};
+
+if (process.argv[1] && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  main().catch((error) => {
+    console.error(`::error title=Fly OOM check failed::${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -91,4 +91,8 @@
 # 74647 -> 74651: persist the frozen community-art plan with the existing
 # begin-generation projection so retries survive content evolution without
 # weakening their media-verdict binding.
-74651
+# 74651 -> 74708: replace the accepted-command full-world rollback clone with
+# durable-state recovery and pin the failure path with an exact snapshot
+# regression. The recovery wiring stays at the existing persistence boundary;
+# no new gameplay system is added.
+74708


### PR DESCRIPTION
Closes #483. Refs #487.

Removes the O(world) RuntimeWorld clone from every accepted journal command. Failed commits now rollback SQLite and rebuild runtime state from the durable snapshot/journal boundary on a dedicated recovery stack. The regression injects an actor-outbox failure, proves the recovery path ran, verifies exact RuntimeSnapshot equality, and guards the accepted-command source against runtime.clone().

Adds a fail-closed 15-minute GitHub alert for Fly's built-in fly_instance_exit_oom metric across cosyworld and cosyworld-lonelyforest, authenticated by the least-privilege FLY_METRICS_READ_TOKEN secret.

Release: 0.0.258

Validated locally:
- npm run check (513 Node tests; 849 Rust tests; worldpack/kernel/architecture/syntax)
- npm run lint
- production-profile smoke
- standalone composition and Core + Ruby replay smokes