### PR TITLE
Record which ability an ordinary check resolved against

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.247",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.240",
+      "version": "0.0.247",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.247",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -803,6 +803,11 @@ static cw_status apply_ability_check(cw_world *world, const cw_action *action, u
     event->modifier = modifier;
     event->total = total;
     event->dc = dc;
+    /* Record which ability the check resolved against. The field already
+       existed but was left at zero, so every projected check looked like a
+       Strength check. Reporting it is what lets a client name the attribute
+       without guessing. See issue #464. */
+    event->ability = action->ability;
   }
   return CW_OK;
 }

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.247"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.247"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -131,6 +131,7 @@ pub const CW_ACTION_PROJECT_PUSH: u8 = 31;
 pub const CW_ACTION_REST: u8 = 32;
 
 pub const CW_EVENT_ACTOR_CREATED: u8 = 2;
+pub const CW_EVENT_ABILITY_CHECK_ROLLED: u8 = 6;
 pub const CW_EVENT_ITEM_PICKED_UP: u8 = 7;
 pub const CW_EVENT_ITEM_USED: u8 = 8;
 pub const CW_EVENT_COMBAT_ATTACK_ATTEMPT: u8 = 10;

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -13819,6 +13819,12 @@ impl RuntimeWorld {
                 | CW_EVENT_COMBAT_ATTACK_MISS
                 | CW_EVENT_COMBAT_KNOCKOUT
         );
+        // An ordinary check rolls against an ability just as an attack does, and
+        // the kernel records which one on the event. Only combat used to project
+        // it, so a check could not name the attribute it was resolved against
+        // without the client guessing. See issue #464.
+        let resolves_against_ability =
+            is_combat_attack || event.type_ == CW_EVENT_ABILITY_CHECK_ROLLED;
         EventView {
             world_id: official_world_id(),
             world_epoch: official_world_epoch(),
@@ -13850,7 +13856,7 @@ impl RuntimeWorld {
                 self.item_name(event.item_id)
                     .unwrap_or_else(|| "Unarmed strike".to_string())
             }),
-            ability: is_combat_attack
+            ability: resolves_against_ability
                 .then(|| combat::combat_ability_name(event.ability).to_string()),
             clock_id: None,
             clock_scope: None,
@@ -42975,6 +42981,45 @@ mod tests {
                 "missing browser contract: {contract}"
             );
         }
+    }
+
+    /// Issue #464: the projection only sent `ability` for combat attacks, so an
+    /// ordinary check could not name the attribute the kernel resolved it
+    /// against and any client showing one would have been guessing.
+    #[test]
+    fn an_ordinary_check_projects_the_attribute_it_resolved_against() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Careful Listener",
+        );
+        let record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_ABILITY_CHECK,
+                actor_id: 5000,
+                ability: CW_ABILITY_WISDOM,
+                dc: 10,
+                ..CwAction::default()
+            },
+            7_460,
+        );
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        let rolled = events
+            .iter()
+            .find(|event| event.type_name == "ability_check.rolled")
+            .expect("the check is projected");
+        assert_eq!(
+            rolled.ability.as_deref(),
+            Some(combat::combat_ability_name(CW_ABILITY_WISDOM)),
+            "an ordinary check must name its attribute"
+        );
+        // The arithmetic the shared formatter needs is all present.
+        assert!(rolled.raw_roll.is_some(), "natural roll is projected");
+        assert!(rolled.total.is_some(), "committed total is projected");
+        assert_eq!(rolled.dc, Some(10));
     }
 
     #[test]

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -64,4 +64,10 @@
 # with its SSE transcript, and the accompanying cross-surface contract pins
 # the speaker-specific pending UI. This remains in main.rs beside the existing
 # chat orchestration and its browser integration contract.
-74481
+# 74481 -> 74526: issue #464 projects the ability an ordinary check resolved
+# against -- the `resolves_against_ability` condition and its use -- plus the
+# regression that pins it, which needs `event_view` and so belongs here. The
+# fate-tag UI the issue also asks for is deliberately not here: the browser
+# smoke gate forbids exposing dice arithmetic (smoke-browser.mjs:4402), so that
+# half needs a product decision first.
+74526


### PR DESCRIPTION
Groundwork for #464, and a latent bug found along the way.

## The bug

`cw_event` has carried an `ability` field all along, but `apply_ability_check` never set it:

```c
event->raw_roll = raw;
event->modifier = modifier;
event->total = total;
event->dc = dc;
/* ability: never assigned -> stays 0 */
```

So **every projected ability check reported ability 0 — Strength — regardless of what was rolled.** A Wisdom check looked like a Strength check.

The projection hid this by only sending `ability` for combat attacks, where the field *is* populated. Relaxing that gate without fixing the kernel would have surfaced a confidently wrong attribute, which is how I found it: the new test asserted `Wisdom` and got `Strength`.

## The fix

Set `event->ability = action->ability` in the kernel, and let the projection send it for `CW_EVENT_ABILITY_CHECK_ROLLED` too. Also mirrors `CW_EVENT_ABILITY_CHECK_ROLLED` into `kernel.rs`, which had every other event constant but not this one.

**No ABI change** — the field already existed — and no world state changes, so replay is unaffected. Only the emitted event becomes truthful, and no kernel version bump is needed.

## Why the #464 UI is not here

I built the fate tag (`🎲 6 + 3 · Heart = 8`), wired it through one shared formatter for both transcript and Log, and ran `npm run v2:check`. It failed on a **landed, deliberate design rule**:

```js
// v2/scripts/smoke-browser.mjs:4402
assert(!/d20|modifier|total|\bdc\b|>9<|>12</i.test(result.rollMarkup),
  `chance feedback should not expose dice arithmetic`);
```

The surrounding assertions reinforce it — *"should end with a plain outcome"*, *"the narrative card shape"*, *"one vivid lead instead of an inventory"*. **#464's contract directly contradicts an enforced product decision.** I reverted the UI rather than delete the guard, because removing it would silently reverse that decision. #464 needs a product call first; I've commented there with the detail.

## Verification

- `cargo test` — **817 passed, 0 failed**, including the new `an_ordinary_check_projects_the_attribute_it_resolved_against`
- `npm run v2:kernel`, `npm test` (483), `check:version`, `cargo fmt --check`, `git diff --check` clean
- `v2:architecture` — clippy 273 (ceiling 273); main.rs ceiling raised 74481 → 74526 with the reason recorded in the ceiling file
- `npm run v2:check` — the dice-arithmetic assertion **passes** with the UI reverted. One unrelated assertion fails (`queued Chat should announce that the conversation is unfolding`), and I verified it fails **identically on clean `main` with my changes stashed** — pre-existing, consistent with #531 being in flight, not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)