### PR TITLE
Treat reporting apps without exit history as OOM-free

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.258",
+  "version": "0.0.259",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.258",
+      "version": "0.0.259",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.258",
+  "version": "0.0.259",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/fly-oom-alert.test.mjs
+++ b/test/infrastructure/fly-oom-alert.test.mjs
@@ -11,6 +11,7 @@ describe('Fly OOM alert', () => {
   it('creates a bounded app-scoped query', () => {
     expect(buildOomQuery('cosyworld-lonelyforest', '2h')).toBe(
       'max(max_over_time(fly_instance_exit_oom{app="cosyworld-lonelyforest"}[2h]))'
+        + ' or (0 * max(fly_instance_up{app="cosyworld-lonelyforest"}))'
     );
     expect(() => buildOomQuery('cosyworld"} or vector(1)', '30m')).toThrow(/app must/);
     expect(() => buildOomQuery('cosyworld', '30 minutes')).toThrow(/window must/);

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.258"
+version = "0.0.259"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.258"
+version = "0.0.259"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/check-fly-oom.mjs
+++ b/v2/scripts/check-fly-oom.mjs
@@ -13,7 +13,10 @@ export const buildOomQuery = (app, window = '30m') => {
   if (!DURATION_PATTERN.test(window)) {
     throw new Error('window must be a positive Prometheus duration such as 30m or 2h');
   }
-  return `max(max_over_time(fly_instance_exit_oom{app="${app}"}[${window}]))`;
+  return (
+    `max(max_over_time(fly_instance_exit_oom{app="${app}"}[${window}]))`
+    + ` or (0 * max(fly_instance_up{app="${app}"}))`
+  );
 };
 
 export const flyAuthorization = (token) => {


### PR DESCRIPTION
Refs #487

## Summary
- make the Fly OOM alert return zero when the exact app is actively reporting but has no exit-history series
- keep missing or unknown apps fail-closed
- release both production apps as 0.0.259

## Validation
- full pre-push gate: 514 Node tests and 849 Rust tests
- clippy warning ceiling and main.rs size guard
- branch workflow run passed for both cosyworld and cosyworld-lonelyforest
- https://github.com/cenetex/cosyworld/actions/runs/30510554853