### PR TITLE
Stop reporting a default arrival calling as a chosen purpose

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.249",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.240",
+      "version": "0.0.249",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.240",
+  "version": "0.0.249",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.249"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.240"
+version = "0.0.249"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -9130,6 +9130,9 @@
       }
       if (kind === "calling") {
         const purpose = text.replace(/^what draws you in:\s*/i, "");
+        if (/^arrives\b/i.test(purpose)) {
+          return finishSentence(actor ? `${actor} ${purpose}` : purpose);
+        }
         return finishSentence(actor ? `${actor} chose a purpose: ${purpose}` : purpose);
       }
       if (kind === "bank") return finishSentence(actor ? `${actor} grew from what happened` : text);
@@ -9190,6 +9193,9 @@
         return { kind: "bond", label: "dialogue unavailable", text: "The promised resident reply could not run. No substitute speech was created." };
       }
       if (event.type === "calling.set") {
+        if (callingEventReason(event) === "avatar_created") {
+          return { kind: "calling", label: "purpose", text: "arrives with a purpose still to choose" };
+        }
         if (event.actor_id === actorId) {
           return { kind: "calling", label: "purpose", text: `What draws you in: ${cleanStatusText(callingEventLabel(event))}` };
         }
@@ -10637,6 +10643,15 @@
       const content = String(event.content || "").trim();
       const reasonIndex = content.lastIndexOf(":");
       return reasonIndex > 0 ? content.slice(0, reasonIndex) : content || "a small truth";
+    }
+
+    // The server embeds why a calling was recorded. An arriving avatar is handed
+    // a starting statement it never picked, so that case must not be reported as
+    // a chosen purpose (#360).
+    function callingEventReason(event) {
+      const content = String(event.content || "").trim();
+      const reasonIndex = content.lastIndexOf(":");
+      return reasonIndex > 0 ? content.slice(reasonIndex + 1).trim() : "";
     }
 
     function ledgerEventLabel(event) {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -11697,7 +11697,7 @@ impl RuntimeWorld {
         let reason = initial_calling
             .and_then(normalize_calling_statement)
             .map(|_| "chosen_calling")
-            .unwrap_or("avatar_created");
+            .unwrap_or(CALLING_REASON_AVATAR_CREATED);
         let mut projection_events =
             vec![self.append_calling_event("calling.set", &calling, reason)];
         if let Some(skill_id) = initial_skill.filter(|skill_id| skill_label(skill_id).is_some()) {
@@ -31457,13 +31457,17 @@ fn room_memory_log_text_at_location(event: &EventView, location_id: u64) -> Opti
         }
         "calling.set" | "calling.revised" => {
             let content = event.content.as_deref().unwrap_or_default().trim();
-            let statement = content
+            let (statement, reason) = content
                 .rsplit_once(':')
-                .map(|(statement, _reason)| statement)
-                .unwrap_or(content)
-                .trim()
-                .trim_end_matches('.');
-            if statement.is_empty() {
+                .map(|(statement, reason)| (statement, reason.trim()))
+                .unwrap_or((content, ""));
+            let statement = statement.trim().trim_end_matches('.');
+            // An arriving avatar is given a starting statement it never picked.
+            // Calling that a choice was the lie #360 reports: the journal
+            // claimed a purpose was chosen, then Class selection replaced it.
+            if reason == CALLING_REASON_AVATAR_CREATED {
+                format!("{actor_name} arrives with a purpose still to choose")
+            } else if statement.is_empty() {
                 format!("{actor_name} chose what matters to them")
             } else {
                 format!("{actor_name} chose a purpose: {statement}")
@@ -37387,6 +37391,10 @@ const AUTHORED_CALLING_STATEMENTS: [&str; 13] = [
     "I listen for the safer road no one has named yet.",
     EXPLORER_CALLING_STATEMENT,
 ];
+
+/// Reason recorded when an arriving avatar is given a starting calling it did
+/// not pick. Player-facing copy must not report this as a chosen purpose (#360).
+pub(crate) const CALLING_REASON_AVATAR_CREATED: &str = "avatar_created";
 
 fn default_calling_statement() -> &'static str {
     AUTHORED_CALLING_STATEMENTS[0]
@@ -46842,6 +46850,66 @@ mod tests {
             assert!(!text.contains("roll"));
             assert!(!text.contains("/4"));
             assert!(!text.contains("DC"));
+        }
+    }
+
+    /// Issue #360: an arriving avatar is handed a starting calling it never
+    /// picked, and every surface reported that as "chose a purpose" — then Class
+    /// selection replaced it, so the journal carried two contradictory claims of
+    /// choice. A default arrival now reads as an arrival.
+    #[test]
+    fn a_default_arrival_calling_is_not_reported_as_a_chosen_purpose() {
+        let arrival = [EventView {
+            seq: 1,
+            type_name: "calling.set".to_string(),
+            success: true,
+            actor_name: Some("Moss Lantern".to_string()),
+            content: Some(format!(
+                "I listen for odd jobs.:{CALLING_REASON_AVATAR_CREATED}"
+            )),
+            ..EventView::default()
+        }];
+        let entries = room_memory_entries(COSY_COTTAGE_LOCATION_ID, &arrival);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, "calling");
+        assert_eq!(
+            entries[0].text,
+            "Moss Lantern arrives with a purpose still to choose"
+        );
+        // The statement the avatar did not pick is not presented as its purpose.
+        assert!(
+            !entries[0].text.contains("odd jobs"),
+            "an unchosen statement must not be shown as the purpose: {}",
+            entries[0].text
+        );
+
+        // A calling the player actually chose still reads as a choice.
+        let chosen = [EventView {
+            seq: 2,
+            type_name: "calling.set".to_string(),
+            success: true,
+            actor_name: Some("Moss Lantern".to_string()),
+            content: Some("I listen for odd jobs.:chosen_calling".to_string()),
+            ..EventView::default()
+        }];
+        assert_eq!(
+            room_memory_entries(COSY_COTTAGE_LOCATION_ID, &chosen)[0].text,
+            "Moss Lantern chose a purpose: I listen for odd jobs"
+        );
+    }
+
+    #[test]
+    fn the_browser_also_declines_to_call_a_default_arrival_a_choice() {
+        for contract in [
+            "function callingEventReason(event)",
+            "callingEventReason(event) === \"avatar_created\"",
+            "arrives with a purpose still to choose",
+            "/^arrives\\b/i.test(purpose)",
+        ] {
+            assert!(
+                INDEX_HTML.contains(contract),
+                "missing arrival-calling contract: {contract}"
+            );
         }
     }
 

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -64,4 +64,8 @@
 # with its SSE transcript, and the accompanying cross-surface contract pins
 # the speaker-specific pending UI. This remains in main.rs beside the existing
 # chat orchestration and its browser integration contract.
-74481
+# 74481 -> 74549: issue #360 stops reporting a default arrival calling as a
+# chosen purpose. Six lines branch the existing calling copy on the reason the
+# server already embeds; the rest is the two regressions, which need
+# `room_memory_entries` and `INDEX_HTML` and so belong beside them.
+74549


### PR DESCRIPTION
Delivers one of #360's seven acceptance criteria: *"No classless arrival publishes a purpose that is silently replaced moments later."*

## The lie

An arriving avatar with no chosen calling is handed `AUTHORED_CALLING_STATEMENTS[0]`, and the event is recorded with reason `avatar_created`:

```rust
let reason = initial_calling
    .and_then(normalize_calling_statement)
    .map(|_| "chosen_calling")
    .unwrap_or("avatar_created");
```

Every surface then rendered that as **"Moss Lantern chose a purpose: I listen for odd jobs"** — a choice the player never made, showing a statement they never picked. Class selection later revised the calling, so the journal carried **two contradictory claims of choice**, which is exactly the defect the issue reports.

## The fix

The reason was already available everywhere and simply thrown away. `append_calling_event` embeds it in the event content as `"<statement>:<reason>"`, and *both* the Rust copy and the browser already split it off to read the statement — then discarded the half that says whether a choice happened. Branch on it instead:

| reason | before | after |
|---|---|---|
| `avatar_created` | Moss Lantern chose a purpose: I listen for odd jobs | **Moss Lantern arrives with a purpose still to choose** |
| `chosen_calling` | Moss Lantern chose a purpose: I listen for odd jobs | *unchanged* |

Both surfaces are fixed together: `CALLING_REASON_AVATAR_CREATED` replaces the bare literal in Rust, and `callingEventReason` sits beside the existing `callingEventLabel` in the browser. The client also stops re-prefixing an arrival clause with "chose a purpose".

No journal or event-shape change — only the copy stops overclaiming.

## Tests

- `a_default_arrival_calling_is_not_reported_as_a_chosen_purpose` — asserts the arrival copy, and that the unchosen statement ("odd jobs") is **not** presented as the purpose, then re-asserts that a genuinely chosen calling still reads as a choice
- `the_browser_also_declines_to_call_a_default_arrival_a_choice` — pins the browser side
- The pre-existing `room_memory_purpose_entries_hide_calling_model_language` uses `chosen_calling` and is unchanged, which is the regression guard for the other branch

## Verification

- `cargo test` — **818 passed, 0 failed**
- `npm test` 483, `v2:kernel`, `check:version`, `cargo fmt --check`, `git diff --check` clean
- `v2:architecture` — clippy 273 (ceiling 273); main.rs ceiling raised 74481 → 74549 with the reason recorded
- `npm run v2:check` — the only failure is `queued Chat should announce that the conversation is unfolding`, which **fails identically on clean `main`** (verified earlier with changes stashed). It occurs *after* the purpose-copy assertions, which passed.

## What remains on #360

The other six criteria need first-action evidence in the class-selection projection and replay record, authored recommendation mappings, and Class card mechanical facts. Note that **criterion 6** — *"The first relevant check shows the exact ability, skill/technique source, modifier, roll, and result"* — collides with the same enforced browser rule that blocks #464 (`smoke-browser.mjs:4402` forbids exposing dice arithmetic). #360 cannot fully close until that product decision is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)