### PR TITLE
fix(persistence): bypass compatibility receipt writes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.262",
+  "version": "0.0.263",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.262",
+      "version": "0.0.263",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.262",
+  "version": "0.0.263",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.262"
+version = "0.0.263"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.262"
+version = "0.0.263"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/canonical_journal.rs
+++ b/v2/orchestrator-rust/src/canonical_journal.rs
@@ -2085,6 +2085,9 @@ pub(super) fn insert_atomic_command_receipt(
     conn: &Connection,
     row: &CanonicalReceiptRow<'_>,
 ) -> io::Result<()> {
+    if row.intent_id.starts_with("compat:") {
+        return Ok(());
+    }
     let response_json = encode_command_response_for_storage(row.response_json)?;
     conn.execute(
         "INSERT INTO canonical_command_receipts
@@ -2118,17 +2121,10 @@ pub(super) fn finalize_atomic_command_receipt(
     world_seq: u64,
     updated_at_ms: u64,
 ) -> io::Result<bool> {
-    let conn = open_canonical_store(path)?;
     let Some(response_json) = retained_response_json else {
-        let deleted = conn
-            .execute(
-                "DELETE FROM canonical_command_receipts
-                 WHERE world_id = ?1 AND intent_id = ?2 AND request_hash = ?3",
-                params![world_id, intent_id, request_hash],
-            )
-            .map_err(sqlite_error)?;
-        return Ok(deleted == 1);
+        return Ok(true);
     };
+    let conn = open_canonical_store(path)?;
     let response_json = encode_command_response_for_storage(response_json)?;
     let updated = conn
         .execute(
@@ -2455,7 +2451,7 @@ mod tests {
     }
 
     #[test]
-    fn compatibility_receipt_is_discarded_after_its_atomic_commit() {
+    fn compatibility_receipt_storage_is_a_no_op() {
         let path = temp_db("compatibility-receipt");
         initialize(&path);
         let conn = open_canonical_store(&path).unwrap();
@@ -2465,7 +2461,7 @@ mod tests {
                 world_id: "world://test",
                 intent_id: "compat:generated",
                 request_hash: "hash",
-                response_json: r#"{"ok":true}"#,
+                response_json: &"response".repeat(20_000),
                 commit_id: "commit:1",
                 world_epoch: 1,
                 world_seq: 1,


### PR DESCRIPTION
## Summary
- bypass provisional receipt compression and SQLite insertion for server-minted `compat:` commands
- skip the now-unnecessary post-commit delete for cache-only compatibility responses
- preserve compression, durable storage, legacy decoding, and crash replay for explicit client intent receipts
- release as `0.0.263`

## Production evidence motivating the hotfix
Release `0.0.262` held the primary event-store file exactly flat at 662,900,736 bytes and kept durable receipts under 32 MiB during a production load slice, but logged one `database is locked` warning. The compatibility path was compressing and inserting a full fallback response inside the atomic SQLite transaction, then deleting it immediately after commit.

## Validation
- 855/855 Rust tests
- 515/515 Node tests
- official and standalone worldpack checks + strict proof world
- kernel tests
- main.rs 74,462/74,462 lines
- Clippy 273/273 warning ceiling
- syntax checks

Closes no issue by itself; production acceptance will complete #500 after deployment.