### PR TITLE
fix(persistence): batch compaction writer work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.263",
+  "version": "0.0.264",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.263",
+      "version": "0.0.264",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.263",
+  "version": "0.0.264",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.263"
+version = "0.0.264"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.263"
+version = "0.0.264"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_job_contention_tests.rs
+++ b/v2/orchestrator-rust/src/actor_job_contention_tests.rs
@@ -1,0 +1,42 @@
+use super::*;
+
+#[test]
+fn actor_job_claim_waits_for_a_competing_writer() {
+    let path = std::env::temp_dir().join(format!(
+        "cosyworld-v2-actor-claim-contention-{}-{}.sqlite",
+        std::process::id(),
+        now_seed()
+    ));
+    let _ = fs::remove_file(&path);
+    let observation = PlayerTickObservation {
+        source_actor_id: 5000,
+        source_world_tick: 41,
+        caused_by_event_seq: Some(401),
+        observed_through_seq: 401,
+        source_location_id: Some(COSY_COTTAGE_LOCATION_ID),
+        allow_ordinary_speech: true,
+        source_events: Vec::new(),
+        ripple_source: None,
+        relationship_reply: None,
+    };
+    assert!(append_actor_job(&path, &observation).expect("queue actor job"));
+    release_pending_actor_jobs(&path, ACTOR_JOB_KIND_PLAYER_TICK).expect("release actor job");
+
+    let mut blocker = open_event_store(&path).expect("open competing writer");
+    let blocker_tx = blocker
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .expect("hold competing writer");
+    let claim_path = path.clone();
+    let claimant = std::thread::spawn(move || claim_next_actor_job(&claim_path));
+    std::thread::sleep(Duration::from_millis(100));
+    blocker_tx.commit().expect("release competing writer");
+
+    let claimed = claimant
+        .join()
+        .expect("join actor-job claimant")
+        .expect("claim actor job")
+        .expect("pending actor job");
+    assert_eq!(claimed.actor_id, observation.source_actor_id);
+    complete_actor_job(&path, claimed.id).expect("complete actor job");
+    let _ = fs::remove_file(path);
+}

--- a/v2/orchestrator-rust/src/journal_checkpoint.rs
+++ b/v2/orchestrator-rust/src/journal_checkpoint.rs
@@ -336,7 +336,46 @@ const PRUNE_COMPACTED_COMMIT_RANGES_SQL: &str = "DELETE FROM canonical_compacted
                  AND canonical_compacted_commit_ranges.last_world_seq
        )";
 
+// Snapshots stay frequent for recovery, while pruning is batched so the
+// single SQLite writer is not churned for every tiny suffix. The row bound
+// makes a high-traffic burst compact before the time interval elapses.
+const PERSISTENCE_COMPACTION_MIN_INTERVAL_MS: u64 = 5 * 60 * 1_000;
+const PERSISTENCE_COMPACTION_MAX_JOURNAL_DELTA: u64 = 512;
+
+fn persistence_compaction_due(
+    report: &PersistenceCompactionReport,
+    checkpoint_seq: u64,
+    now_ms: u64,
+) -> bool {
+    let journal_delta = checkpoint_seq.saturating_sub(report.action_journal_floor_seq);
+    journal_delta >= PERSISTENCE_COMPACTION_MAX_JOURNAL_DELTA
+        || report
+            .last_compacted_at_ms
+            .is_none_or(|last_compacted_at_ms| {
+                now_ms.saturating_sub(last_compacted_at_ms)
+                    >= PERSISTENCE_COMPACTION_MIN_INTERVAL_MS
+            })
+}
+
 pub(super) fn compact_event_store_after_snapshot(
+    path: &Path,
+    checkpoint_seq: u64,
+    through_event_seq: u64,
+    retained_world_events: usize,
+) -> io::Result<PersistenceCompactionReport> {
+    let report = read_persistence_compaction_report(path)?;
+    if !persistence_compaction_due(&report, checkpoint_seq, now_millis()) {
+        return Ok(PersistenceCompactionReport::default());
+    }
+    compact_event_store_after_snapshot_now(
+        path,
+        checkpoint_seq,
+        through_event_seq,
+        retained_world_events,
+    )
+}
+
+fn compact_event_store_after_snapshot_now(
     path: &Path,
     checkpoint_seq: u64,
     through_event_seq: u64,
@@ -344,7 +383,9 @@ pub(super) fn compact_event_store_after_snapshot(
 ) -> io::Result<PersistenceCompactionReport> {
     init_event_store(path)?;
     let mut conn = open_event_store(path)?;
-    let tx = conn.transaction().map_err(sqlite_error)?;
+    let tx = conn
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
     let journal_head = tx
         .query_row(
             "SELECT COALESCE(MAX(journal_seq), 0) FROM action_journal",
@@ -686,6 +727,31 @@ mod tests {
     }
 
     #[test]
+    fn persistence_compaction_batches_by_time_or_journal_delta() {
+        let recent = PersistenceCompactionReport {
+            action_journal_floor_seq: 1_000,
+            last_compacted_at_ms: Some(10_000),
+            ..PersistenceCompactionReport::default()
+        };
+        assert!(!persistence_compaction_due(&recent, 1_001, 10_001));
+        assert!(persistence_compaction_due(
+            &recent,
+            1_000 + PERSISTENCE_COMPACTION_MAX_JOURNAL_DELTA,
+            10_001
+        ));
+        assert!(persistence_compaction_due(
+            &recent,
+            1_001,
+            10_000 + PERSISTENCE_COMPACTION_MIN_INTERVAL_MS
+        ));
+        assert!(persistence_compaction_due(
+            &PersistenceCompactionReport::default(),
+            0,
+            0
+        ));
+    }
+
+    #[test]
     fn snapshot_checkpoint_preserves_migration_state_and_replays_only_the_suffix() {
         std::thread::Builder::new()
             .name("journal-checkpoint-replay".to_string())
@@ -968,7 +1034,7 @@ mod tests {
         append_event_store(&journal_path, &events).expect("append world-event fixtures");
 
         let compacted =
-            compact_event_store_after_snapshot(&journal_path, 3, 1_003, MAX_EVENT_STORE_SCAN)
+            compact_event_store_after_snapshot_now(&journal_path, 3, 1_003, MAX_EVENT_STORE_SCAN)
                 .expect("compact checkpointed store");
         assert_eq!(compacted.action_journal_floor_seq, 3);
         assert_eq!(compacted.canonical_commit_floor_journal_seq, 3);
@@ -1080,7 +1146,7 @@ mod tests {
             .expect("save next compactable checkpoint");
 
         let next_compaction =
-            compact_event_store_after_snapshot(&journal_path, 4, 1_003, MAX_EVENT_STORE_SCAN)
+            compact_event_store_after_snapshot_now(&journal_path, 4, 1_003, MAX_EVENT_STORE_SCAN)
                 .expect("compact next checkpointed store");
         assert_eq!(next_compaction.action_journal_floor_seq, 4);
         assert_eq!(next_compaction.canonical_commit_floor_journal_seq, 4);

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -2,6 +2,8 @@ mod account_auth;
 mod activation;
 #[cfg(test)]
 mod actor_autonomy_tests;
+#[cfg(test)]
+mod actor_job_contention_tests;
 mod actor_practice;
 mod actor_presence;
 mod actor_rules_facets;
@@ -40357,10 +40359,9 @@ fn claim_next_actor_job_filtered(
     claimed_kind: Option<&str>,
 ) -> io::Result<Option<ActorJob>> {
     init_event_store(path)?;
-    let mut conn = open_event_store(path)?;
-    let tx = conn.transaction().map_err(sqlite_error)?;
+    let conn = open_event_store(path)?;
     let now = now_millis() as i64;
-    let row = tx
+    let row = conn
         .query_row(
             "SELECT id, kind, actor_id, attempts, context_json
              FROM actor_jobs
@@ -40391,26 +40392,23 @@ fn claim_next_actor_job_filtered(
         .optional()
         .map_err(sqlite_error)?;
     let Some((id, kind, actor_id, attempts, context_json)) = row else {
-        tx.commit().map_err(sqlite_error)?;
         return Ok(None);
     };
     let next_attempt = attempts.max(0).saturating_add(1);
     let lease_until = now.saturating_add(ACTOR_JOB_LEASE_MS as i64);
-    let claimed = tx
+    let claimed = conn
         .execute(
             "UPDATE actor_jobs
              SET status = 'running', attempts = ?2, lease_until_ms = ?3, updated_at_ms = ?4
              WHERE id = ?1
                AND ((status = 'pending' AND available_at_ms <= ?4)
-                 OR (status = 'running' AND lease_until_ms IS NOT NULL AND lease_until_ms <= ?4))",
-            params![id, next_attempt, lease_until, now],
+                 OR (status = 'running' AND lease_until_ms IS NOT NULL AND lease_until_ms <= ?4)) AND attempts = ?5",
+            params![id, next_attempt, lease_until, now, attempts],
         )
         .map_err(sqlite_error)?;
     if claimed == 0 {
-        tx.commit().map_err(sqlite_error)?;
         return Ok(None);
     }
-    tx.commit().map_err(sqlite_error)?;
     let payload = serde_json::from_str(&context_json)
         .or_else(|primary_error| {
             if kind == ACTOR_JOB_KIND_PLAYER_TICK {

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -99,4 +99,5 @@
 # compacted event-range hydration into the existing journal_checkpoint seam.
 # 74498 -> 74462: move durable command-receipt encoding and capacity enforcement
 # into the existing canonical_journal seam.
-74462
+# 74462 -> 74460: keep the actor-job contention regression outside main.rs.
+74460


### PR DESCRIPTION
## Summary
- keep five-second recovery snapshots, but batch destructive SQLite compaction until five minutes elapse or 512 journal rows accumulate
- begin compaction with an immediate writer transaction so it waits before snapshot validation instead of risking a deferred read-to-write upgrade
- claim durable actor jobs with a read followed by an optimistic autocommit update, avoiding SQLite's immediate `SQLITE_BUSY` on deferred transaction upgrades
- retain compare-and-set protection on the selected job attempt
- release as `0.0.264` and lower the `main.rs` ceiling from 74,462 to 74,460

## Production evidence
The 0.0.263 acceptance proved the primary event-store file and durable receipt store stayed exactly bounded, but concurrent avatar/player activity produced repeated `database is locked` warnings from the durable actor worker and a refresh write. The actor worker was using a deferred transaction: it acquired a WAL read snapshot, then attempted to upgrade to a writer while another writer was active. SQLite returns `SQLITE_BUSY` immediately for that upgrade even with a five-second busy timeout. Compaction was also being invoked after every five-second snapshot, creating avoidable writer churn for one or two rows at a time.

## Validation
- 857/857 Rust tests, including a competing-writer regression and time/row compaction batching
- 515/515 Node tests
- official and standalone worldpack checks + strict proof world
- kernel tests
- `main.rs` 74,460/74,460 lines
- Clippy 273/273 warning ceiling
- syntax checks

Production load acceptance will continue after deployment before #500 is closed.