### PR TITLE
fix(performance): move state refresh outside world lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.264",
+  "version": "0.0.265",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.264",
+      "version": "0.0.265",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.264",
+  "version": "0.0.265",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.264"
+version = "0.0.265"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.264"
+version = "0.0.265"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/canonical_journal.rs
+++ b/v2/orchestrator-rust/src/canonical_journal.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 const COMMAND_RECEIPT_ZSTD_PREFIX: &str = "zstd-base64:";
 const COMMAND_RECEIPT_COMPRESSION_THRESHOLD: usize = 4 * 1024;
 // The newest finalized receipt always survives, even if that single response

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -1203,7 +1203,7 @@ pub(super) async fn apply_combat_choice(
     }
     let observation = if need_time {
         if status == CW_OK {
-            append_action_receipt(&state, &runtime, actor_id, &mut events);
+            append_action_receipt(&runtime, actor_id, &mut events);
         }
         None
     } else {

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -7309,7 +7309,7 @@
       pushEvents(result.events || []);
       if (!result.ok) {
         setError(actionFailureMessage(path, result));
-      } else if (["/actions/move", "/actions/flee", "/actions/explore-path", "/actions/timeout"].includes(path)) {
+      } else {
         await refresh();
       }
       if (result.ok && clearFirstTaleAfterAction) firstTaleCelebration = false;
@@ -7706,7 +7706,15 @@
       if (event?.type !== "action.receipt" || !event.content) return false;
       try {
         const receipt = JSON.parse(event.content);
-        if (!receipt?.state) return false;
+        if (!receipt?.state) {
+          if (!state || !Number.isFinite(Number(receipt?.state_revision))) return false;
+          state.world_tick = Number(receipt.world_tick || state.world_tick || 0);
+          state.state_revision = Math.max(
+            Number(state.state_revision || 0),
+            Number(receipt.state_revision || 0),
+          );
+          return true;
+        }
         const previousLocationId = state?.location?.id || null;
         const previousAccess = state?.access || null;
         const previousAccount = state?.account || null;
@@ -12985,6 +12993,7 @@
           setError(commandFailureMessage(result));
           return result;
         }
+        await refresh();
         advanceHandPage();
         renderCommands();
         renderAllActionsModal();

--- a/v2/orchestrator-rust/src/journal_checkpoint.rs
+++ b/v2/orchestrator-rust/src/journal_checkpoint.rs
@@ -568,8 +568,9 @@ fn compact_event_store_after_snapshot_now(
     )
     .map_err(sqlite_error)?;
     tx.commit().map_err(sqlite_error)?;
-    conn.execute_batch("PRAGMA incremental_vacuum(1024);")
-        .map_err(sqlite_error)?;
+    // Deleted pages are intentional reusable headroom. Vacuuming synchronously
+    // here rewrites the volume while the world lock is held and stalls player
+    // commands; SQLite will reuse these pages for later journal appends.
     Ok(PersistenceCompactionReport {
         action_journal_floor_seq,
         canonical_commit_floor_journal_seq,

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -30303,26 +30303,10 @@ fn commit_resident_reply_record(
     (status == CW_OK).then_some(events)
 }
 
-fn append_action_receipt(
-    state: &AppState,
-    runtime: &RuntimeWorld,
-    actor_id: u64,
-    events: &mut Vec<EventView>,
-) {
-    let access = AccessContext::for_linked_actor_receipt(state, actor_id);
-    let active_direct_actors = active_actor_ids_for_state(state);
-    let mut next_state = runtime.state_response_with_presence(
-        Some(actor_id),
-        &access,
-        Some(&active_direct_actors),
-        false,
-    );
-    next_state.turn = actor_room_turn_view(state, runtime, actor_id, &active_direct_actors)
-        .unwrap_or_else(|| RoomTurnView::idle(next_state.location.id));
+fn append_action_receipt(runtime: &RuntimeWorld, actor_id: u64, events: &mut Vec<EventView>) {
     let Ok(content) = serde_json::to_string(&serde_json::json!({
         "world_tick": runtime.world.tick,
         "state_revision": runtime.world.next_event_seq.saturating_sub(1),
-        "state": next_state,
     })) else {
         return;
     };
@@ -35190,7 +35174,7 @@ async fn unlock_charm_slot(
         });
     };
     if status == CW_OK && !events.is_empty() {
-        append_action_receipt(&state, &runtime, payload.actor_id, &mut events);
+        append_action_receipt(&runtime, payload.actor_id, &mut events);
     }
     drop(runtime);
     broadcast_events(&state, &events);
@@ -41744,7 +41728,10 @@ fn read_economy_audit(path: &Path, limit: usize) -> io::Result<ModerationEconomy
 
 fn open_event_store(path: &Path) -> io::Result<Connection> {
     let conn = Connection::open(path).map_err(sqlite_error)?;
-    conn.busy_timeout(Duration::from_secs(5))
+    // Background reconciliation and canonical commands share one WAL writer.
+    // A short busy window turned bounded queueing into false refresh failures
+    // during six-player bursts; wait within the HTTP command deadline instead.
+    conn.busy_timeout(Duration::from_secs(30))
         .map_err(sqlite_error)?;
     configure_event_store_pragmas(&conn)?;
     Ok(conn)
@@ -50857,7 +50844,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bracelet_growth_returns_authoritative_state_and_cannot_repeat_without_advancement() {
+    async fn bracelet_growth_returns_compact_receipt_and_cannot_repeat_without_advancement() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
             &mut runtime,
@@ -50916,27 +50903,25 @@ mod tests {
             .find(|event| event.type_name == "action.receipt")
             .and_then(|event| event.content.as_deref())
             .and_then(|content| serde_json::from_str::<serde_json::Value>(content).ok())
-            .expect("bracelet growth returns its updated authoritative state");
-        assert_eq!(receipt["state"]["deck"]["bracelet_slots"], 2);
-        assert_eq!(receipt["state"]["ledger"]["spent_count"], 1);
-        assert_eq!(receipt["state"]["ledger"]["advancement_points"], 0);
-        assert_eq!(
-            receipt["state"]["deck"]["carried_cards"]
-                .as_array()
-                .map(Vec::len),
-            Some(carried_count)
-        );
-        assert_eq!(
-            receipt["state"]["deck"]["equipped_charms"]
-                .as_array()
-                .map(Vec::len),
-            Some(1)
-        );
-        assert!(receipt["state"]["primary_action"]["options"]
-            .as_array()
-            .is_some_and(|options| options
-                .iter()
-                .all(|option| option["kind"] != "unlock_charm_slot")));
+            .expect("bracelet growth returns a compact state revision receipt");
+        assert!(receipt.get("state").is_none());
+        assert!(receipt["state_revision"].as_u64().unwrap_or_default() > 0);
+        assert!(serde_json::to_vec(&receipt).unwrap().len() < 256);
+        let current = state
+            .inner
+            .lock()
+            .await
+            .state_response(Some(5000), &AccessContext::default());
+        assert_eq!(current.deck.bracelet_slots, 2);
+        assert_eq!(current.ledger.spent_count, 1);
+        assert_eq!(current.ledger.advancement_points, 0);
+        assert_eq!(current.deck.carried_cards.len(), carried_count);
+        assert_eq!(current.deck.equipped_charms.len(), 1);
+        assert!(current
+            .primary_action
+            .options
+            .iter()
+            .all(|option| option.kind != "unlock_charm_slot"));
 
         let repeat = unlock_charm_slot(
             ConnectInfo("127.0.0.1:43010".parse().expect("client address")),
@@ -61209,20 +61194,22 @@ mod tests {
             .find(|event| event.type_name == "action.receipt")
             .and_then(|event| event.content.as_deref())
             .and_then(|content| serde_json::from_str::<serde_json::Value>(content).ok())
-            .expect("Need time returns ordered scene state");
+            .expect("Need time returns a compact state revision receipt");
         assert_eq!(need_time_receipt["world_tick"], before_tick);
-        assert_eq!(need_time_receipt["state"]["turn"]["policy"], "scene-turn");
-        assert!(
-            need_time_receipt["state"]["turn"]["grace_period_ms"]
-                .as_u64()
-                .unwrap_or_default()
-                > 8_000
-        );
-        assert_eq!(need_time_receipt["state"]["turn"]["current_actor_id"], 5000);
+        assert!(need_time_receipt.get("state").is_none());
+        assert!(serde_json::to_vec(&need_time_receipt).unwrap().len() < 256);
+        let active_direct_actors = active_actor_ids_for_state(&state);
+        let runtime = state.inner.lock().await;
+        let turn = actor_room_turn_view(&state, &runtime, 5000, &active_direct_actors)
+            .expect("Need time keeps the ordered scene current");
+        assert_eq!(turn.policy, "scene-turn");
+        assert!(turn.grace_period_ms > 8_000);
+        assert_eq!(turn.current_actor_id, Some(5000));
         assert_eq!(
-            need_time_receipt["state"]["turn"]["grace_period_ms"],
+            turn.grace_period_ms,
             ORDERED_SCENE_BASE_GRACE_MS + ORDERED_SCENE_NEED_TIME_MS
         );
+        drop(runtime);
 
         let mut incompatible_command = command_request(5000, "work");
         incompatible_command.actor_session = Some(actor_session.clone());

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -498,7 +498,7 @@ pub(crate) async fn commit_shuffle_hand_command(
         });
     };
     if status == CW_OK && !events.is_empty() {
-        append_action_receipt(state, &runtime, payload.actor_id, &mut events);
+        append_action_receipt(&runtime, payload.actor_id, &mut events);
     }
     drop(runtime);
     broadcast_events(state, &events);

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -1177,6 +1177,7 @@ pub(super) fn room_turn_view_for_runtime(
         .unwrap_or_else(|| RoomTurnView::idle(location_id))
 }
 
+#[cfg(test)]
 pub(super) fn actor_room_turn_view(
     state: &AppState,
     runtime: &RuntimeWorld,
@@ -1398,7 +1399,7 @@ pub(super) fn advance_turn_and_capture_player_tick_observation(
     advance_actor_room_turn_after_commit(state, runtime, location_id, actor_id, status, events);
     let observation = player_tick_observation(runtime, location_id, actor_id, status, events);
     if status == CW_OK {
-        append_action_receipt(state, runtime, actor_id, events);
+        append_action_receipt(runtime, actor_id, events);
     }
     observation
 }
@@ -1823,7 +1824,7 @@ async fn apply_focused_control(
     };
     let observation = if control == "need_time" {
         if status == CW_OK {
-            append_action_receipt(&state, &runtime, actor_id, &mut events);
+            append_action_receipt(&runtime, actor_id, &mut events);
         }
         None
     } else {

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -100,4 +100,6 @@
 # 74498 -> 74462: move durable command-receipt encoding and capacity enforcement
 # into the existing canonical_journal seam.
 # 74462 -> 74460: keep the actor-job contention regression outside main.rs.
-74460
+# 74460 -> 74447: replace the full-state action receipt with bounded revision
+# metadata; clients refresh the authoritative projection after the world lock.
+74447

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -5675,6 +5675,19 @@ async function main() {
           pendingCount: pendingChats.length,
           events: logEvents.map((event) => ({ seq: event.seq, content: event.content })),
         };
+        const compactReceiptApplied = applyActionReceipt({
+          type: "action.receipt",
+          content: JSON.stringify({
+            world_tick: 13,
+            state_revision: 35,
+          }),
+        });
+        const afterCompactReceipt = {
+          applied: compactReceiptApplied,
+          worldTick: state.world_tick,
+          stateRevision: state.state_revision,
+          locationId: state.location?.id,
+        };
         return {
           collapsed,
           collapsedHtml,
@@ -5692,6 +5705,7 @@ async function main() {
           detectsServerTimelineRewind,
           acceptsForwardTimeline,
           afterTravelReceipt,
+          afterCompactReceipt,
         };
       } finally {
         logEvents = previousLogEvents;
@@ -5720,6 +5734,7 @@ async function main() {
     assert(result.afterReplayReset.length === 1 && result.afterReplayReset[0]?.content === "fresh firelight", `rebuilding replay should keep only unique chat after the latest world reset: ${JSON.stringify(result)}`);
     assert(result.detectsServerTimelineRewind && result.acceptsForwardTimeline, `a reconnect should replace rewound server history without mistaking a forward timeline for a reset: ${JSON.stringify(result)}`);
     assert(result.afterTravelReceipt?.applied && result.afterTravelReceipt.pendingCount === 0 && result.afterTravelReceipt.events.length === 1 && result.afterTravelReceipt.events[0]?.content === "new room history", `a live travel receipt should clear pending chat and replace the old room transcript: ${JSON.stringify(result)}`);
+    assert(result.afterCompactReceipt?.applied && result.afterCompactReceipt.worldTick === 13 && result.afterCompactReceipt.stateRevision === 35 && result.afterCompactReceipt.locationId === 2, `a compact action receipt should advance revision metadata without replacing the current state projection: ${JSON.stringify(result)}`);
   }
 
   async function assertCombatStaysInSharedRoomTranscript() {


### PR DESCRIPTION
## Summary
- replace full embedded action-state receipts with bounded world tick/revision metadata
- refresh the browser's authoritative state after successful actions, while retaining legacy full-state receipt support
- stop synchronous incremental vacuum work from running under the world lock and extend SQLite busy handling to the command deadline window
- release as 0.0.265

## Why
Production six-player acceptance on 0.0.264 found action responses growing to ~179 KB and sequential latency rising from ~3.5s to ~17s. The full state projection was being constructed while the global world lock was held, and snapshot compaction could also rewrite the SQLite volume synchronously in that lock.

## Validation
- repository pre-push `npm run check` (515 Node tests, worldpacks, kernel, 857 Rust tests, architecture, syntax)
- `npm run v2:browser:check` complete gameplay smoke
- compact receipt unit assertions (<256 bytes) and browser compatibility coverage
- `main.rs` 74,447 lines at exact ceiling; Clippy 273 warnings at exact ceiling

Refs #500