### PR TITLE
fix(performance): keep SQLite WAL open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.265",
+  "version": "0.0.266",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.265",
+      "version": "0.0.266",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.265",
+  "version": "0.0.266",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.265"
+version = "0.0.266"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.265"
+version = "0.0.266"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/canonical_journal.rs
+++ b/v2/orchestrator-rust/src/canonical_journal.rs
@@ -2255,12 +2255,26 @@ fn ensure_column(conn: &Connection, table: &str, column: &str, alter_sql: &str) 
     Ok(())
 }
 
+pub(super) fn open_event_store(path: &Path) -> io::Result<Connection> {
+    open_canonical_store(path)
+}
+
+/// Retain an activated WAL reader for the process lifetime so closing each
+/// short-lived writer does not checkpoint the whole database.
+pub(super) fn open_event_store_keepalive(path: &Path) -> io::Result<Connection> {
+    let connection = open_event_store(path)?;
+    let _: i64 = connection
+        .query_row("SELECT COUNT(*) FROM world_events", [], |row| row.get(0))
+        .map_err(sqlite_error)?;
+    Ok(connection)
+}
+
 fn open_canonical_store(path: &Path) -> io::Result<Connection> {
     let conn = Connection::open(path).map_err(sqlite_error)?;
     conn.busy_timeout(SQLITE_BUSY_TIMEOUT)
         .map_err(sqlite_error)?;
-    // Match the event-store durability profile: WAL plus crash-safe,
-    // non-fsync-per-commit writes (see configure_event_store_pragmas).
+    // WAL lets readers continue beside the single writer; NORMAL avoids an
+    // fsync per commit while retaining crash-safe journal recovery.
     conn.pragma_update(None, "journal_mode", "WAL")
         .map_err(sqlite_error)?;
     conn.pragma_update(None, "synchronous", "NORMAL")
@@ -2287,7 +2301,7 @@ fn sqlite_error(error: rusqlite::Error) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::{fs, path::PathBuf};
 
     fn temp_db(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -2320,6 +2334,35 @@ mod tests {
         )
         .unwrap();
         init_canonical_journal(&conn, "world://test", 1).unwrap();
+    }
+
+    #[test]
+    fn process_keepalive_prevents_a_checkpoint_on_every_writer_close() {
+        let path = temp_db("wal-keepalive");
+        initialize(&path);
+        let keepalive =
+            open_event_store_keepalive(&path).expect("open active process WAL keepalive");
+        let writer = crate::open_event_store(&path).expect("open short-lived writer");
+        writer
+            .execute(
+                "INSERT INTO world_events
+                    (seq, event_type, payload_json, created_at_ms)
+                 VALUES (1, 'test.committed', '{}', 1)",
+                [],
+            )
+            .expect("commit through short-lived writer");
+        drop(writer);
+
+        let wal_path = PathBuf::from(format!("{}-wal", path.display()));
+        assert!(
+            wal_path.metadata().is_ok_and(|metadata| metadata.len() > 0),
+            "the process connection must keep WAL mode open between commands"
+        );
+
+        drop(keepalive);
+        let _ = fs::remove_file(&wal_path);
+        let _ = fs::remove_file(PathBuf::from(format!("{}-shm", path.display())));
+        let _ = fs::remove_file(path);
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -185,6 +185,7 @@ struct AppState {
     last_snapshot_at_ms: Arc<AtomicU64>,
     resident_continuity_path: Option<Arc<PathBuf>>,
     event_store_path: Option<Arc<PathBuf>>,
+    _event_store_keepalive: Option<Arc<StdMutex<Connection>>>,
     event_store_health: Arc<StdMutex<EventStoreHealth>>,
     account_auth: Arc<AccountAuth>,
     ownership_index: Arc<RwLock<OwnershipIndex>>,
@@ -5842,6 +5843,10 @@ impl AppState {
                 now,
             )?;
         }
+        let event_store_keepalive = event_store_path
+            .as_deref()
+            .map(|path| open_event_store_keepalive(path))
+            .transpose()?;
 
         Ok(Self {
             inner: Arc::new(Mutex::new(runtime)),
@@ -5851,6 +5856,8 @@ impl AppState {
             last_snapshot_at_ms: Arc::new(AtomicU64::new(0)),
             resident_continuity_path,
             event_store_path,
+            _event_store_keepalive: event_store_keepalive
+                .map(|connection| Arc::new(StdMutex::new(connection))),
             event_store_health: Arc::new(StdMutex::new(event_store_health)),
             account_auth,
             ownership_index,
@@ -41726,30 +41733,6 @@ fn read_economy_audit(path: &Path, limit: usize) -> io::Result<ModerationEconomy
     })
 }
 
-fn open_event_store(path: &Path) -> io::Result<Connection> {
-    let conn = Connection::open(path).map_err(sqlite_error)?;
-    // Background reconciliation and canonical commands share one WAL writer.
-    // A short busy window turned bounded queueing into false refresh failures
-    // during six-player bursts; wait within the HTTP command deadline instead.
-    conn.busy_timeout(Duration::from_secs(30))
-        .map_err(sqlite_error)?;
-    configure_event_store_pragmas(&conn)?;
-    Ok(conn)
-}
-
-/// WAL lets readers proceed alongside the single writer and
-/// `synchronous=NORMAL` keeps commits crash-safe without an fsync per
-/// accepted action. `journal_mode` persists in the database header, so the
-/// update is a no-op once the store is in WAL; `synchronous` is
-/// per-connection and must be set on every open.
-fn configure_event_store_pragmas(conn: &Connection) -> io::Result<()> {
-    conn.pragma_update(None, "journal_mode", "WAL")
-        .map_err(sqlite_error)?;
-    conn.pragma_update(None, "synchronous", "NORMAL")
-        .map_err(sqlite_error)?;
-    Ok(())
-}
-
 fn canonical_command_receipt_key(world_id: &str, intent_id: &str) -> String {
     format!("{world_id}\u{0}{intent_id}")
 }
@@ -73750,6 +73733,7 @@ mod tests {
             last_snapshot_at_ms: Arc::new(AtomicU64::new(0)),
             resident_continuity_path: None,
             event_store_path: None,
+            _event_store_keepalive: None,
             event_store_health: Arc::new(StdMutex::new(EventStoreHealth::default())),
             account_auth: AccountAuth::for_test(None),
             ownership_index: Arc::new(RwLock::new(initial)),

--- a/v2/orchestrator-rust/src/test_support.rs
+++ b/v2/orchestrator-rust/src/test_support.rs
@@ -66,6 +66,12 @@ pub(super) fn test_app_state(runtime: RuntimeWorld, event_store_path: Option<Pat
     } else {
         format!("test-memory:{}", random_hex(8))
     };
+    let event_store_keepalive = event_store_path
+        .as_deref()
+        .map(open_event_store_keepalive)
+        .transpose()
+        .expect("open test WAL keepalive")
+        .map(|connection| Arc::new(StdMutex::new(connection)));
     AppState {
         inner: Arc::new(Mutex::new(runtime)),
         tx,
@@ -74,6 +80,7 @@ pub(super) fn test_app_state(runtime: RuntimeWorld, event_store_path: Option<Pat
         last_snapshot_at_ms: Arc::new(AtomicU64::new(0)),
         resident_continuity_path: None,
         event_store_path: event_store_path.clone().map(Arc::new),
+        _event_store_keepalive: event_store_keepalive,
         event_store_health: Arc::new(StdMutex::new(EventStoreHealth::default())),
         account_auth: AccountAuth::for_test(event_store_path.clone().map(Arc::new)),
         ownership_index: Arc::new(RwLock::new(OwnershipIndex::default())),

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -102,4 +102,6 @@
 # 74462 -> 74460: keep the actor-job contention regression outside main.rs.
 # 74460 -> 74447: replace the full-state action receipt with bounded revision
 # metadata; clients refresh the authoritative projection after the world lock.
-74447
+# 74447 -> 74431: centralize SQLite opening in the canonical-journal seam while
+# retaining one process-lifetime WAL handle between short-lived writers.
+74431


### PR DESCRIPTION
## Summary
- retain one activated SQLite WAL connection for the process lifetime
- centralize event/canonical store opening so every connection uses the same 30s busy timeout and WAL/NORMAL durability profile
- add a file-level regression proving a short-lived writer close leaves a non-empty WAL instead of checkpointing the database
- release as 0.0.266

## Production finding
0.0.265 fixed action responses from ~179 KB to 2.2–3.0 KB, but the six-player acceptance still measured durable `shuffle` commands at ~3.5s while read-only `look` took 116–332ms. The snapshot timestamp advanced only once across two slow commits, and the live 633 MB event store had no `-wal` file between requests. Each short-lived writer was therefore becoming the last SQLite connection and checkpointing the whole database on close.

A 60-command partial acceptance committed 60/60 with no errors, but throughput was too low to continue the 600-command proof responsibly. This change keeps WAL lifecycle state resident so ordinary writers remain append-oriented and bounded autocheckpointing can work as intended.

## Validation
- full pre-push `npm run check`: 515 Node tests, worldpacks, kernel, 858 Rust tests, architecture, syntax
- complete fresh-seed `npm run v2:browser:check`
- exact WAL lifecycle regression passes
- `main.rs` 74,431 lines at exact ceiling; Clippy 273 warnings at exact ceiling

Refs #500