### PR TITLE
fix(performance): reuse canonical SQLite writer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.267",
+  "version": "0.0.268",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.267",
+      "version": "0.0.268",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.267",
+  "version": "0.0.268",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.267"
+version = "0.0.268"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.267"
+version = "0.0.268"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/canonical_journal.rs
+++ b/v2/orchestrator-rust/src/canonical_journal.rs
@@ -6,7 +6,9 @@ use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs, io,
+    ops::{Deref, DerefMut},
     path::Path,
+    sync::{Mutex, MutexGuard},
     time::Duration,
 };
 
@@ -17,6 +19,47 @@ const COMMAND_RECEIPT_COMPRESSION_THRESHOLD: usize = 4 * 1024;
 // exceeds the byte budget, so its immediate crash-retry remains recoverable.
 pub(super) const MAX_DURABLE_COMMAND_RECEIPT_ENTRIES: usize = 512;
 pub(super) const MAX_DURABLE_COMMAND_RECEIPT_BYTES: usize = 32 * 1024 * 1024;
+
+pub(super) enum EventStoreConnection<'a> {
+    Shared(MutexGuard<'a, Connection>),
+    Owned(Connection),
+}
+
+impl Deref for EventStoreConnection<'_> {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Shared(connection) => connection,
+            Self::Owned(connection) => connection,
+        }
+    }
+}
+
+impl DerefMut for EventStoreConnection<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Shared(connection) => connection,
+            Self::Owned(connection) => connection,
+        }
+    }
+}
+
+/// Reuse the process-lifetime WAL connection for durable commits. Besides
+/// preserving SQLite's page cache, the mutex queues in-process writers before
+/// they enter SQLite's cross-process busy loop.
+pub(super) fn event_store_writer<'a>(
+    shared: Option<&'a Mutex<Connection>>,
+    path: &Path,
+) -> io::Result<EventStoreConnection<'a>> {
+    match shared {
+        Some(connection) => connection
+            .lock()
+            .map(EventStoreConnection::Shared)
+            .map_err(|_| io::Error::other("event-store writer lock is poisoned")),
+        None => open_event_store(path).map(EventStoreConnection::Owned),
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(super) struct AuthorityLease {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -185,7 +185,7 @@ struct AppState {
     last_snapshot_at_ms: Arc<AtomicU64>,
     resident_continuity_path: Option<Arc<PathBuf>>,
     event_store_path: Option<Arc<PathBuf>>,
-    _event_store_keepalive: Option<Arc<StdMutex<Connection>>>,
+    event_store_writer: Option<Arc<StdMutex<Connection>>>,
     event_store_health: Arc<StdMutex<EventStoreHealth>>,
     account_auth: Arc<AccountAuth>,
     ownership_index: Arc<RwLock<OwnershipIndex>>,
@@ -5843,7 +5843,7 @@ impl AppState {
                 now,
             )?;
         }
-        let event_store_keepalive = event_store_path
+        let event_store_writer = event_store_path
             .as_deref()
             .map(|path| open_event_store_keepalive(path))
             .transpose()?;
@@ -5856,7 +5856,7 @@ impl AppState {
             last_snapshot_at_ms: Arc::new(AtomicU64::new(0)),
             resident_continuity_path,
             event_store_path,
-            _event_store_keepalive: event_store_keepalive
+            event_store_writer: event_store_writer
                 .map(|connection| Arc::new(StdMutex::new(connection))),
             event_store_health: Arc::new(StdMutex::new(event_store_health)),
             account_auth,
@@ -39017,7 +39017,7 @@ fn commit_journal_record(
     let (status, events, _actor_job_inserted, committed_journal_seq) = if let Some(path) =
         state.event_store_path.as_deref()
     {
-        let mut conn = match open_event_store(path) {
+        let mut conn = match event_store_writer(state.event_store_writer.as_deref(), path) {
             Ok(conn) => conn,
             Err(error) => {
                 if let Some(context) = command_context.as_ref() {
@@ -73733,7 +73733,7 @@ mod tests {
             last_snapshot_at_ms: Arc::new(AtomicU64::new(0)),
             resident_continuity_path: None,
             event_store_path: None,
-            _event_store_keepalive: None,
+            event_store_writer: None,
             event_store_health: Arc::new(StdMutex::new(EventStoreHealth::default())),
             account_auth: AccountAuth::for_test(None),
             ownership_index: Arc::new(RwLock::new(initial)),

--- a/v2/orchestrator-rust/src/test_support.rs
+++ b/v2/orchestrator-rust/src/test_support.rs
@@ -80,7 +80,7 @@ pub(super) fn test_app_state(runtime: RuntimeWorld, event_store_path: Option<Pat
         last_snapshot_at_ms: Arc::new(AtomicU64::new(0)),
         resident_continuity_path: None,
         event_store_path: event_store_path.clone().map(Arc::new),
-        _event_store_keepalive: event_store_keepalive,
+        event_store_writer: event_store_keepalive,
         event_store_health: Arc::new(StdMutex::new(EventStoreHealth::default())),
         account_auth: AccountAuth::for_test(event_store_path.clone().map(Arc::new)),
         ownership_index: Arc::new(RwLock::new(OwnershipIndex::default())),


### PR DESCRIPTION
## Summary
- turn the process-lifetime WAL keeper into the canonical transaction connection
- preserve SQLite page/cache state across commands instead of reopening the writer for every commit
- queue in-process durable writers on a mutex before SQLite busy handling
- retain an owned-connection fallback for stores without an app-level writer
- release as 0.0.268

## Production evidence
0.0.267 removed steady-state lease writes and repeated journal-mode mutation, but live reads were 116–382 ms while sequential shuffle commits remained 3.75–4.00 s (first cold call 8.17 s). The remaining write path still discarded the existing lifetime connection and opened a new writer per transaction.

## Validation
- npm run check (515 Node tests; 859 Rust tests; worldpack/kernel/architecture/syntax green)
- canonical hot-room/regional chaos and single-winner race tests green
- npm run v2:browser:check green against 0.0.268
- cargo clippy ceiling unchanged at 273
- main.rs ceiling unchanged at 74,431 lines

Progresses #500; live latency and memory acceptance will run after deployment before closure.