### PR TITLE
Fast-path presentation-only hand shuffles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.270",
+  "version": "0.0.271",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.270",
+      "version": "0.0.271",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.270",
+  "version": "0.0.271",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.270"
+version = "0.0.271"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.270"
+version = "0.0.271"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -2037,7 +2037,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 13;
+const JOURNAL_RECORD_VERSION: u32 = 14;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -10247,6 +10247,22 @@ impl RuntimeWorld {
 
         self.next_seed = record.seed;
         let action = self.action_with_skill_bonus(record.action);
+        // A hand shuffle is a presentation-only projection: it advances no
+        // clock and emits only its revisioned hand-shuffled event.
+        // Older records retain the full historical replay path so upgrading
+        // cannot reinterpret already committed projection side effects.
+        if record.version >= 14
+            && record.origin == JournalOrigin::PlayerControl
+            && action.kind == CW_ACTION_NONE
+            && record.projection_mutations.len() == 1
+        {
+            if let ProjectionMutation::ShuffleHand { reason } = &record.projection_mutations[0] {
+                let mut events = vec![self.append_hand_shuffled_event(action.actor_id, reason)];
+                self.bump_entity_versions_for_events(&events);
+                self.refresh_canonical_events(&mut events);
+                return (CW_OK, events);
+            }
+        }
         let resident_planning_lifecycle = self.resident_planning_lifecycle_snapshot(&action);
         let advances_world_tick = record.advances_world_tick();
         let authoritative_contribution_clock_ids = record

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -109,4 +109,7 @@
 # 74305 -> 74360: bounded slow-command phase telemetry at the existing
 # canonical command and journal-commit seams. This diagnoses production-only
 # SQLite latency without logging healthy commands or adding a gameplay system.
-74360
+# 74360 -> 74376: versioned fast replay for the existing presentation-only
+# hand-shuffle projection, bypassing unrelated world reconciliation while
+# preserving the historical path for already committed journal records.
+74376


### PR DESCRIPTION
## Summary
- route new player-controlled hand-shuffle records through a presentation-only projection path
- preserve actor, journal, and location version updates while skipping unrelated whole-world reconciliation
- version the journal format so records committed before this release retain their historical replay behavior
- bump the production release to 0.0.271

## Production evidence
Release 0.0.270 phase telemetry measured six hand shuffles at 3.3 to 3.6 seconds, with about 3.2 to 3.3 seconds consistently inside journal runtime application. Lease acquisition, transaction start, SQLite commit, event writes, jobs, and metadata were effectively 0 ms. The first post-deploy command also paid a one-time 4.5-second version/claim reconciliation.

## Validation
- cargo check --manifest-path v2/orchestrator-rust/Cargo.toml
- cargo test --manifest-path v2/orchestrator-rust/Cargo.toml shuffle_command_is_free_hand_redeal_hint
- git diff --check
- main.rs line ceiling exact at 74376