### PR TITLE
fix(journal): distinguish default arrival calling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.272",
+  "version": "0.0.273",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.272",
+      "version": "0.0.273",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.272",
+  "version": "0.0.273",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.272"
+version = "0.0.273"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.272"
+version = "0.0.273"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -9290,6 +9290,9 @@
       }
       if (kind === "calling") {
         const purpose = text.replace(/^what draws you in:\s*/i, "");
+        if (/^arrives\b/i.test(purpose)) {
+          return finishSentence(actor ? `${actor} ${purpose}` : purpose);
+        }
         return finishSentence(actor ? `${actor} chose a purpose: ${purpose}` : purpose);
       }
       if (kind === "bank") return finishSentence(actor ? `${actor} grew from what happened` : text);
@@ -9350,6 +9353,9 @@
         return { kind: "bond", label: "dialogue unavailable", text: "The promised resident reply could not run. No substitute speech was created." };
       }
       if (event.type === "calling.set") {
+        if (callingEventReason(event) === "avatar_created") {
+          return { kind: "calling", label: "purpose", text: "arrives with a purpose still to choose" };
+        }
         if (event.actor_id === actorId) {
           return { kind: "calling", label: "purpose", text: `What draws you in: ${cleanStatusText(callingEventLabel(event))}` };
         }
@@ -10797,6 +10803,15 @@
       const content = String(event.content || "").trim();
       const reasonIndex = content.lastIndexOf(":");
       return reasonIndex > 0 ? content.slice(0, reasonIndex) : content || "a small truth";
+    }
+
+    // The server embeds why a calling was recorded. An arriving avatar is handed
+    // a starting statement it never picked, so that case must not be reported as
+    // a chosen purpose (#360).
+    function callingEventReason(event) {
+      const content = String(event.content || "").trim();
+      const reasonIndex = content.lastIndexOf(":");
+      return reasonIndex > 0 ? content.slice(reasonIndex + 1).trim() : "";
     }
 
     function ledgerEventLabel(event) {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -11730,7 +11730,7 @@ impl RuntimeWorld {
         let reason = initial_calling
             .and_then(normalize_calling_statement)
             .map(|_| "chosen_calling")
-            .unwrap_or("avatar_created");
+            .unwrap_or(CALLING_REASON_AVATAR_CREATED);
         let mut projection_events =
             vec![self.append_calling_event("calling.set", &calling, reason)];
         if let Some(skill_id) = initial_skill.filter(|skill_id| skill_label(skill_id).is_some()) {
@@ -31671,13 +31671,17 @@ fn room_memory_log_text_at_location(event: &EventView, location_id: u64) -> Opti
         }
         "calling.set" | "calling.revised" => {
             let content = event.content.as_deref().unwrap_or_default().trim();
-            let statement = content
+            let (statement, reason) = content
                 .rsplit_once(':')
-                .map(|(statement, _reason)| statement)
-                .unwrap_or(content)
-                .trim()
-                .trim_end_matches('.');
-            if statement.is_empty() {
+                .map(|(statement, reason)| (statement, reason.trim()))
+                .unwrap_or((content, ""));
+            let statement = statement.trim().trim_end_matches('.');
+            // An arriving avatar is given a starting statement it never picked.
+            // Calling that a choice was the lie #360 reports: the journal
+            // claimed a purpose was chosen, then Class selection replaced it.
+            if reason == CALLING_REASON_AVATAR_CREATED {
+                format!("{actor_name} arrives with a purpose still to choose")
+            } else if statement.is_empty() {
                 format!("{actor_name} chose what matters to them")
             } else {
                 format!("{actor_name} chose a purpose: {statement}")
@@ -37600,6 +37604,10 @@ const AUTHORED_CALLING_STATEMENTS: [&str; 13] = [
     "I listen for the safer road no one has named yet.",
     EXPLORER_CALLING_STATEMENT,
 ];
+
+/// Reason recorded when an arriving avatar is given a starting calling it did
+/// not pick. Player-facing copy must not report this as a chosen purpose (#360).
+pub(crate) const CALLING_REASON_AVATAR_CREATED: &str = "avatar_created";
 
 fn default_calling_statement() -> &'static str {
     AUTHORED_CALLING_STATEMENTS[0]
@@ -46653,6 +46661,66 @@ mod tests {
             assert!(!text.contains("roll"));
             assert!(!text.contains("/4"));
             assert!(!text.contains("DC"));
+        }
+    }
+
+    /// Issue #360: an arriving avatar is handed a starting calling it never
+    /// picked, and every surface reported that as "chose a purpose" — then Class
+    /// selection replaced it, so the journal carried two contradictory claims of
+    /// choice. A default arrival now reads as an arrival.
+    #[test]
+    fn a_default_arrival_calling_is_not_reported_as_a_chosen_purpose() {
+        let arrival = [EventView {
+            seq: 1,
+            type_name: "calling.set".to_string(),
+            success: true,
+            actor_name: Some("Moss Lantern".to_string()),
+            content: Some(format!(
+                "I listen for odd jobs.:{CALLING_REASON_AVATAR_CREATED}"
+            )),
+            ..EventView::default()
+        }];
+        let entries = room_memory_entries(COSY_COTTAGE_LOCATION_ID, &arrival);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, "calling");
+        assert_eq!(
+            entries[0].text,
+            "Moss Lantern arrives with a purpose still to choose"
+        );
+        // The statement the avatar did not pick is not presented as its purpose.
+        assert!(
+            !entries[0].text.contains("odd jobs"),
+            "an unchosen statement must not be shown as the purpose: {}",
+            entries[0].text
+        );
+
+        // A calling the player actually chose still reads as a choice.
+        let chosen = [EventView {
+            seq: 2,
+            type_name: "calling.set".to_string(),
+            success: true,
+            actor_name: Some("Moss Lantern".to_string()),
+            content: Some("I listen for odd jobs.:chosen_calling".to_string()),
+            ..EventView::default()
+        }];
+        assert_eq!(
+            room_memory_entries(COSY_COTTAGE_LOCATION_ID, &chosen)[0].text,
+            "Moss Lantern chose a purpose: I listen for odd jobs"
+        );
+    }
+
+    #[test]
+    fn the_browser_also_declines_to_call_a_default_arrival_a_choice() {
+        for contract in [
+            "function callingEventReason(event)",
+            "callingEventReason(event) === \"avatar_created\"",
+            "arrives with a purpose still to choose",
+            "/^arrives\\b/i.test(purpose)",
+        ] {
+            assert!(
+                INDEX_HTML.contains(contract),
+                "missing arrival-calling contract: {contract}"
+            );
         }
     }
 

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -112,4 +112,8 @@
 # 74360 -> 74376: versioned fast replay for the existing presentation-only
 # hand-shuffle projection, bypassing unrelated world reconciliation while
 # preserving the historical path for already committed journal records.
-74376
+# 74376 -> 74444: issue #360 stops reporting a default arrival calling as a
+# chosen purpose. Six lines branch the existing calling copy on the reason the
+# server already embeds; the rest is the two regressions, which need
+# `room_memory_entries` and `INDEX_HTML` and so belong beside them.
+74444


### PR DESCRIPTION
## Summary
- integrate the behavior and regression coverage from #599 onto current main
- render an avatar-created default calling as a purpose still to choose
- preserve chosen-calling copy for an actual player selection
- keep Rust room memory and browser transcript copy aligned
- release as 0.0.273

## Validation
- cargo fmt --check
- a_default_arrival_calling_is_not_reported_as_a_chosen_purpose
- the_browser_also_declines_to_call_a_default_arrival_a_choice
- room_memory_purpose_entries_hide_calling_model_language
- npm run check:version
- npm run v2:architecture (main.rs 74444/74444; clippy 273/273)
- git diff --check

Supersedes stale/conflicting PR #599. Delivers one acceptance slice of #360; does not close it.