### PR TITLE
fix(checks): project resolved ability truthfully

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.273",
+  "version": "0.0.274",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.273",
+      "version": "0.0.274",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.273",
+  "version": "0.0.274",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -803,6 +803,11 @@ static cw_status apply_ability_check(cw_world *world, const cw_action *action, u
     event->modifier = modifier;
     event->total = total;
     event->dc = dc;
+    /* Record which ability the check resolved against. The field already
+       existed but was left at zero, so every projected check looked like a
+       Strength check. Reporting it is what lets a client name the attribute
+       without guessing. See issue #464. */
+    event->ability = action->ability;
   }
   return CW_OK;
 }

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.273"
+version = "0.0.274"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.273"
+version = "0.0.274"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -138,6 +138,7 @@ pub const CW_ACTION_REST: u8 = 32;
 pub const CW_ACTION_COMBAT_ABANDON: u8 = 33;
 
 pub const CW_EVENT_ACTOR_CREATED: u8 = 2;
+pub const CW_EVENT_ABILITY_CHECK_ROLLED: u8 = 6;
 pub const CW_EVENT_ITEM_PICKED_UP: u8 = 7;
 pub const CW_EVENT_ITEM_USED: u8 = 8;
 pub const CW_EVENT_COMBAT_ATTACK_ATTEMPT: u8 = 10;

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -13850,6 +13850,12 @@ impl RuntimeWorld {
                 | CW_EVENT_COMBAT_ATTACK_MISS
                 | CW_EVENT_COMBAT_KNOCKOUT
         );
+        // An ordinary check rolls against an ability just as an attack does, and
+        // the kernel records which one on the event. Only combat used to project
+        // it, so a check could not name the attribute it was resolved against
+        // without the client guessing. See issue #464.
+        let resolves_against_ability =
+            is_combat_attack || event.type_ == CW_EVENT_ABILITY_CHECK_ROLLED;
         EventView {
             world_id: official_world_id(),
             world_epoch: official_world_epoch(),
@@ -13881,7 +13887,7 @@ impl RuntimeWorld {
                 self.item_name(event.item_id)
                     .unwrap_or_else(|| "Unarmed strike".to_string())
             }),
-            ability: is_combat_attack
+            ability: resolves_against_ability
                 .then(|| combat::combat_ability_name(event.ability).to_string()),
             clock_id: None,
             clock_scope: None,
@@ -42794,6 +42800,45 @@ mod tests {
                 "missing browser contract: {contract}"
             );
         }
+    }
+
+    /// Issue #464: the projection only sent `ability` for combat attacks, so an
+    /// ordinary check could not name the attribute the kernel resolved it
+    /// against and any client showing one would have been guessing.
+    #[test]
+    fn an_ordinary_check_projects_the_attribute_it_resolved_against() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Careful Listener",
+        );
+        let record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_ABILITY_CHECK,
+                actor_id: 5000,
+                ability: CW_ABILITY_WISDOM,
+                dc: 10,
+                ..CwAction::default()
+            },
+            7_460,
+        );
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        let rolled = events
+            .iter()
+            .find(|event| event.type_name == "ability_check.rolled")
+            .expect("the check is projected");
+        assert_eq!(
+            rolled.ability.as_deref(),
+            Some(combat::combat_ability_name(CW_ABILITY_WISDOM)),
+            "an ordinary check must name its attribute"
+        );
+        // The arithmetic the shared formatter needs is all present.
+        assert!(rolled.raw_roll.is_some(), "natural roll is projected");
+        assert!(rolled.total.is_some(), "committed total is projected");
+        assert_eq!(rolled.dc, Some(10));
     }
 
     #[test]

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -116,4 +116,10 @@
 # chosen purpose. Six lines branch the existing calling copy on the reason the
 # server already embeds; the rest is the two regressions, which need
 # `room_memory_entries` and `INDEX_HTML` and so belong beside them.
-74444
+# 74444 -> 74489: issue #464 projects the ability an ordinary check resolved
+# against -- the `resolves_against_ability` condition and its use -- plus the
+# regression that pins it, which needs `event_view` and so belongs here. The
+# fate-tag UI the issue also asks for is deliberately not here: the browser
+# smoke gate forbids exposing dice arithmetic (smoke-browser.mjs:4402), so that
+# half needs a product decision first.
+74489


### PR DESCRIPTION
## Summary
- integrate PR #584 onto current main
- populate the existing kernel event ability field for ordinary ability checks
- project that ability for ability_check.rolled events as well as combat attacks
- add a regression proving a Wisdom check is not mislabeled Strength
- intentionally leave the disputed dice-arithmetic fate-tag UI out
- release as 0.0.274

## Validation
- cargo fmt --check
- focused ordinary-check ability projection regression
- npm run v2:kernel
- npm run check:version
- npm run v2:architecture (main.rs 74489/74489; clippy 273/273)
- git diff --check

Supersedes stale/conflicting PR #584. Groundwork for #464; does not close it.