### PR TITLE
fix(speech): ground dialogue in the present cast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.274",
+  "version": "0.0.275",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.274",
+      "version": "0.0.275",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.274",
+  "version": "0.0.275",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.274"
+version = "0.0.275"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.274"
+version = "0.0.275"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/prompts.rs
+++ b/v2/orchestrator-rust/src/prompts.rs
@@ -660,6 +660,11 @@ fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGate
     }));
     anchors.extend(plan.fresh_subject.iter().cloned());
     anchors.extend(plan.missing_need.iter().cloned());
+    // Whoever is actually in the room grounds a line as well as the room's own
+    // name does. Without this the place name is the only anchor guaranteed to be
+    // present, which made announcing it the cheapest way to pass the gate. See
+    // issue #553.
+    anchors.extend(plan.cast.iter().cloned());
     SpeechGateContext {
         feature: if followup {
             "dialogue_avatar_followup"
@@ -700,6 +705,11 @@ fn resident_gate_context(plan: &AvatarReplyPlan, has_proposed_action: bool) -> S
             turn.content.clone(),
         ]
     }));
+    // As in avatar chat: the present cast and the speaker's own goals ground a
+    // line as well as the room's name, so naming the room stops being the only
+    // guaranteed way through the gate. See issue #553.
+    anchors.extend(plan.cast.iter().cloned());
+    anchors.extend(plan.goals.iter().cloned());
     SpeechGateContext {
         feature: "dialogue_resident",
         generation_key: publication_beat_id(
@@ -1028,6 +1038,74 @@ mod publication_tests {
             "the voice prompt still instructs a machine instead of being a mind:\n{system}"
         );
         assert!(system.contains("i have no catchphrase"));
+    }
+
+    fn gate_completion(text: &str) -> AiCompletion {
+        AiCompletion {
+            text: text.to_string(),
+            attempts: 1,
+            latency: std::time::Duration::from_millis(9),
+            model_attribution: None,
+            finish_reason: "stop".to_string(),
+            usage: AiTokenUsage {
+                prompt_tokens: Some(10),
+                completion_tokens: Some(6),
+                total_tokens: Some(16),
+            },
+            context_hash: "context".to_string(),
+            prompt_version: "test-v1".to_string(),
+        }
+    }
+
+    /// Issue #553: the anchor gate rejected any line without a deterministic
+    /// anchor, and the room name was the only anchor guaranteed to be present.
+    /// The cheapest way for a model to pass was therefore to front-load the
+    /// place name, which it did on nearly every line ("Mossbell Inn, I've
+    /// arrived—"). Whoever is actually in the room grounds a line just as well,
+    /// so the cast now counts and naming the room stops being the cheap default.
+    #[test]
+    fn a_line_grounded_on_the_present_cast_passes_without_naming_the_room() {
+        let (chat, _) = seeded_plans();
+        let context = avatar_chat_gate_context(&chat, false);
+        let companion = chat
+            .cast
+            .iter()
+            .find(|name| **name != chat.actor_name)
+            .cloned()
+            .expect("the seeded cottage has another present actor");
+        assert!(
+            context.anchors.contains(&companion),
+            "the present cast must be able to ground a line: {:?}",
+            context.anchors
+        );
+
+        // A line that speaks to the person in front of it and never announces
+        // where it is standing.
+        let text = format!("{companion}, your hands are cold. Come sit nearer the kettle.");
+        assert!(
+            !text.contains(&chat.location_name),
+            "the fixture line must not name the room: {text}"
+        );
+        certify_speech(
+            None,
+            gate_completion(&text),
+            &text,
+            avatar_chat_gate_context(&chat, false),
+        )
+        .expect("a cast-grounded line certifies without naming the room");
+    }
+
+    #[test]
+    fn resident_speech_is_grounded_by_the_cast_and_its_own_goals() {
+        let (_, reply) = seeded_plans();
+        let context = resident_gate_context(&reply, false);
+        for anchor in reply.cast.iter().chain(reply.goals.iter()) {
+            assert!(
+                context.anchors.contains(anchor),
+                "{anchor:?} must ground resident speech: {:?}",
+                context.anchors
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- integrate PR #577 onto current main
- let present cast members ground avatar and resident speech
- let resident goals ground resident speech
- preserve newer exchange-turn and incoming-turn anchors from main
- broaden accepted grounding without adding a new rejection/resampling path
- release as 0.0.275

## Validation
- cargo fmt --check
- exact present-cast grounding regression
- exact resident cast/goals grounding regression
- existing controlled/proxy gate-context regression
- npm run check:version
- npm run v2:architecture (main.rs 74489/74489; clippy 273/273)
- git diff --check

A broad local test-name filter also selected an unrelated localhost-binding test that the sandbox denied; both intended exact tests pass, and full CI runs in the normal test environment.

Supersedes stale/conflicting PR #577. Delivers the room-name incentive slice of #553; does not close its adjacent-place investigation.