### PR TITLE
chore(rust): clear fixture reassignment lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.276",
+  "version": "0.0.277",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.276",
+      "version": "0.0.277",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.276",
+  "version": "0.0.277",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.276"
+version = "0.0.277"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.276"
+version = "0.0.277"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -1618,10 +1618,12 @@ mod tests {
     #[test]
     fn completed_combat_project_clears_combat_actions() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = MOONLIT_TRAIL_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: MOONLIT_TRAIL_LOCATION_ID,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 7180);
         create_record.actor_meta_upserts.insert(
             5000,

--- a/v2/orchestrator-rust/src/project_push_tests.rs
+++ b/v2/orchestrator-rust/src/project_push_tests.rs
@@ -3,10 +3,12 @@ use super::*;
 #[test]
 fn defend_sets_up_active_room_project() {
     let mut runtime = RuntimeWorld::seeded();
-    let mut create = CwAction::default();
-    create.kind = CW_ACTION_CREATE_ACTOR;
-    create.actor_id = 5000;
-    create.location_id = MOONLIT_TRAIL_LOCATION_ID;
+    let create = CwAction {
+        kind: CW_ACTION_CREATE_ACTOR,
+        actor_id: 5000,
+        location_id: MOONLIT_TRAIL_LOCATION_ID,
+        ..CwAction::default()
+    };
     let mut create_record = JournalRecord::new(create, 7160);
     create_record.actor_meta_upserts.insert(
         5000,
@@ -55,9 +57,11 @@ fn defend_sets_up_active_room_project() {
         1
     );
 
-    let mut defend_action = CwAction::default();
-    defend_action.kind = CW_ACTION_DEFEND;
-    defend_action.actor_id = 5000;
+    let defend_action = CwAction {
+        kind: CW_ACTION_DEFEND,
+        actor_id: 5000,
+        ..CwAction::default()
+    };
     let (status, events) = runtime.apply_journal_record(&JournalRecord::new(defend_action, 7161));
     assert_eq!(status, CW_OK);
     assert!(events.iter().any(|event| {
@@ -113,10 +117,12 @@ fn multi_room_project_makes_partial_evidence_useful_and_complete_evidence_best()
         .get_mut("solar-abyss.drowned-bell")
         .expect("solar project clock")
         .segments = 6;
-    let mut create = CwAction::default();
-    create.kind = CW_ACTION_CREATE_ACTOR;
-    create.actor_id = 5000;
-    create.location_id = 36;
+    let create = CwAction {
+        kind: CW_ACTION_CREATE_ACTOR,
+        actor_id: 5000,
+        location_id: 36,
+        ..CwAction::default()
+    };
     let mut create_record = JournalRecord::new(create, 7143);
     create_record.actor_meta_upserts.insert(
         5000,

--- a/v2/orchestrator-rust/src/residents/needs.rs
+++ b/v2/orchestrator-rust/src/residents/needs.rs
@@ -475,10 +475,12 @@ mod tests {
     #[test]
     fn resident_refuses_to_trade_attached_items() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = COSY_COTTAGE_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            ..CwAction::default()
+        };
         assert_eq!(
             runtime
                 .apply_journal_record(&JournalRecord::new(create, 7834))
@@ -541,10 +543,12 @@ mod tests {
     #[test]
     fn requested_attachment_can_be_given_back_even_when_not_evolution_item() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = COSY_COTTAGE_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 78343);
         create_record.actor_meta_upserts.insert(
             5000,
@@ -629,10 +633,12 @@ mod tests {
     #[test]
     fn resident_economy_projects_desires_and_trade_willingness() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = COSY_COTTAGE_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 7833);
         create_record.actor_meta_upserts.insert(
             5000,
@@ -835,10 +841,12 @@ mod tests {
     fn content_authored_personal_desires_drive_requests_and_reasons() {
         let mut runtime = RuntimeWorld::seeded();
         runtime.world.tick = 0;
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = 40;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: 40,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 78332);
         create_record.actor_meta_upserts.insert(
             5000,
@@ -907,10 +915,12 @@ mod tests {
     #[test]
     fn resident_economy_requests_player_held_healing_item() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = COSY_COTTAGE_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 78335);
         create_record.actor_meta_upserts.insert(
             5000,
@@ -967,10 +977,12 @@ mod tests {
     #[test]
     fn resident_economy_requests_medicine_for_hurt_companion() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = COSY_COTTAGE_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 78337);
         create_record.actor_meta_upserts.insert(
             5000,
@@ -1024,10 +1036,12 @@ mod tests {
     #[test]
     fn resident_economy_values_items_useful_to_the_current_room() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = COSY_COTTAGE_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 78336);
         create_record.actor_meta_upserts.insert(
             5000,
@@ -1082,10 +1096,12 @@ mod tests {
     #[test]
     fn content_authored_attachments_explain_trade_refusals() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = COSY_COTTAGE_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: COSY_COTTAGE_LOCATION_ID,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 78341);
         create_record.actor_meta_upserts.insert(
             5000,

--- a/v2/orchestrator-rust/src/rest.rs
+++ b/v2/orchestrator-rust/src/rest.rs
@@ -1105,10 +1105,12 @@ mod tests {
     #[test]
     fn listen_and_rest_move_public_clocks_and_tags() {
         let mut runtime = RuntimeWorld::seeded();
-        let mut create = CwAction::default();
-        create.kind = CW_ACTION_CREATE_ACTOR;
-        create.actor_id = 5000;
-        create.location_id = MOONLIT_TRAIL_LOCATION_ID;
+        let create = CwAction {
+            kind: CW_ACTION_CREATE_ACTOR,
+            actor_id: 5000,
+            location_id: MOONLIT_TRAIL_LOCATION_ID,
+            ..CwAction::default()
+        };
         let mut create_record = JournalRecord::new(create, 7084);
         create_record.actor_meta_upserts.insert(
             5000,
@@ -1139,11 +1141,13 @@ mod tests {
             actor.stats.wisdom = 32;
         }
 
-        let mut listen = CwAction::default();
-        listen.kind = CW_ACTION_ABILITY_CHECK;
-        listen.actor_id = 5000;
-        listen.ability = LISTEN_ABILITY;
-        listen.dc = LISTEN_DC;
+        let listen = CwAction {
+            kind: CW_ACTION_ABILITY_CHECK,
+            actor_id: 5000,
+            ability: LISTEN_ABILITY,
+            dc: LISTEN_DC,
+            ..CwAction::default()
+        };
         let (status, events) = runtime.apply_journal_record(&JournalRecord::new(listen, 7085));
         assert_eq!(status, CW_OK);
         assert!(events.iter().any(|event| {
@@ -1221,9 +1225,11 @@ mod tests {
             .iter()
             .any(|option| option.kind == "rest"));
 
-        let mut rest_action = CwAction::default();
-        rest_action.kind = CW_ACTION_NONE;
-        rest_action.actor_id = 5000;
+        let rest_action = CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id: 5000,
+            ..CwAction::default()
+        };
         let mut rest_record = JournalRecord::new(rest_action, 7087);
         rest_record
             .projection_mutations

--- a/v2/scripts/rust-lint-warning-ceiling.txt
+++ b/v2/scripts/rust-lint-warning-ceiling.txt
@@ -3,4 +3,10 @@
 #
 # 273 -> 269: deleting the six dead `merged_inline_resident_*` helpers left
 # behind by the #322 move removed their never-used warnings.
-269
+#
+# 269 -> 254: rewrote every `field_reassign_with_default` outside main.rs as a
+# struct literal (combat.rs, project_push_tests.rs, residents/needs.rs,
+# rest.rs). The remaining 160 instances of that lint all live in main.rs and are
+# deliberately left alone while several branches are in flight there; fixing
+# them is mechanical and safe once main.rs is quieter.
+254


### PR DESCRIPTION
## Summary

- integrate stale PR #582 onto current main
- rewrite all 15 `field_reassign_with_default` test-fixture sites outside `main.rs` as struct literals
- remove the now-unnecessary mutable bindings
- lower the Clippy warning ceiling from 269 to 254
- release as 0.0.277

## Risk boundary

All changed Rust sites are test fixtures in `combat.rs`, `project_push_tests.rs`, `residents/needs.rs`, and `rest.rs`. No production path, persistence format, ABI, or gameplay behavior changes.

## Verification

- mandatory pre-push `npm run check`: 515 Node tests, worldpack/content/kernel gates, 860 Rust tests, architecture, Clippy, and syntax all pass
- `main.rs`: 73,806 / 73,806
- Clippy: 254 / 254
- `cargo fmt --all -- --check`
- `npm run check:version`
- `git diff --check`

Supersedes #582.
