### PR TITLE
Record threshold and referee contract

### DIFF
--- a/docs/actor-action-surface.md
+++ b/docs/actor-action-surface.md
@@ -34,14 +34,18 @@ generated line for a `direct_input` avatar is public proxy speech on that
 player's behalf: it cannot create a private belief, promise, desire, pending
 intent, or extra mechanical action.
 
-The surface includes Notice/Search, Study, Scout, Travel, Craft, Prepare,
+The scene projects free obvious sensory truth, then the action surface includes
+focused Notice, Search, Study, Scout, Travel, Mark, Open, Craft, Prepare,
 Work/Help, Take, Set Down, Give, Use, Trade, Influence, Rest, Defend/Flee, and
-bounded Attack when their authoritative targets exist. Kernel offers, room
-state, authored content, inventory, clocks, combat state, and access rules
-certify candidates. Gifts may target any co-located avatar that can carry the
-item; an authored request ranks a gift but does not make it legal. Trades use
-the same transfer rule but require the recipient controller's acceptance
-policy. No controller may add an action or target.
+bounded Attack when their authoritative targets exist. Per
+[ADR 0005](decisions/0005-thresholds-trails-and-strict-referee.md), reveal,
+access, safety, transfer, and movement remain distinct: Scout does not Travel,
+Open does not Take, and Search does neither. Kernel offers, room state,
+authored content, inventory, clocks, combat state, and access rules certify
+candidates. Gifts may target any co-located avatar that can carry the item; an
+authored request ranks a gift but does not make it legal. Trades use the same
+transfer rule but require the recipient controller's acceptance policy. No
+controller may add an action or target.
 
 Inference-controller selection is deterministic. Safety, recovery, active
 projects, represented delivery needs, witnessed item memories, possessed

--- a/docs/backlog/action-verbs-and-economy.md
+++ b/docs/backlog/action-verbs-and-economy.md
@@ -15,6 +15,7 @@ authorize or imply full SRD 5.2.1 compatibility.
 - Generated-place lifecycle contract (dedicated document pending)
 - [ADR-001: SRD 5.2.1 Action-Card Profile](../decisions/001-srd-action-card-profile.md)
 - [ADR 0002: the action hand is authoritative state](../decisions/0002-action-hand-is-authoritative-state.md)
+- [ADR 0005: thresholds, trails, and the strict referee](../decisions/0005-thresholds-trails-and-strict-referee.md)
 
 The current rules substrate is sounder than its vocabulary. Stable rule
 bindings, targets, resolvers, traces, and stale-offer rejection exist, but
@@ -54,6 +55,25 @@ decision. #529's amendment to ADR 0002 settles item 1 now:
 6. Dash, Disengage, and Hide land only with the movement, engagement,
    visibility, and replay state that makes them real. Adding names to the
    registry or browser is not implementation.
+
+ADR 0005 settles the discovery and threshold vocabulary rather than leaving it
+for AVE implementation to reinvent:
+
+- scene notice is free obvious sensory truth;
+- focused Notice resolves one broad authored sensory result;
+- Search examines one named local physical target;
+- Study interprets an already perceived target;
+- Inspect is an approved Search or Study reskin only when the offer declares
+  which binding it uses;
+- Scout follows one exact geographic Lead from an Anchor or active foray and
+  reveals without moving;
+- Travel is the separate movement commit;
+- Mark is a temporary expedition return cue;
+- Open resolves one Gate method; and
+- Take performs a separate custody/capacity-checked transfer.
+
+Reveal never implies Open, Take, or Travel. These meanings are accepted product
+law; AVE tickets own presentation and reachability work around them.
 
 ---
 
@@ -105,7 +125,7 @@ Every ticket in this epic must preserve these constraints:
 | Remember | Resolve an active Bond | It does not disclose that the active Bond ends | **Close this chapter with Rati**, with an explicit consequence |
 | Make room for Watch Bell | Spend advancement to unlock a bracelet slot | It may sound like equipping or granting the charm | **Add a bracelet slot for Watch Bell** |
 | Prepare | Create a scoped, consumable project setup | It does not name what is prepared or what consumes it | **Lay out the repair tools** / **Brace the lantern frame** |
-| Inspect | Study in product copy; Look in the terminal alias table | The same word invokes different domains | Reserve Inspect for analytical Study; use Look for read-only examination |
+| Inspect | Search or Study reskin in product copy; Look in the terminal alias table | The same word can hide different domains | Require each Inspect offer to declare Search or Study; keep Look read-only |
 | Help | SRD Help in product copy; command help in the terminal | The same word is both gameplay and interface | Gameplay keeps Help; terminal documentation becomes Commands or `?` |
 | Defend / Dodge | One current combat action under two primary names | Players cannot form a stable combat vocabulary | Dodge is canonical; Defend remains an input-only compatibility alias |
 
@@ -160,8 +180,16 @@ Every ticket in this epic must preserve these constraints:
 ### What to do
 
 - Adopt one canonical player meaning for each core word:
-  - Notice → perceptual Search;
-  - Inspect → analytical Study;
+  - scene notice → free obvious sensory projection;
+  - Notice → one focused broad sensory result;
+  - Search → exhaustive examination of one named local physical target;
+  - Study → interpretation of an already perceived target;
+  - Inspect → a target-bound Search or Study reskin whose binding is explicit;
+  - Scout → exact geographic Lead pursuit and reveal without movement;
+  - Travel → movement through a revealed accessible route;
+  - Mark → a temporary expedition return cue;
+  - Open → one certified Gate method;
+  - Take → custody/capacity-checked item transfer;
   - Use → Utilize;
   - Cast → Magic;
   - Help → the Help action;
@@ -174,7 +202,8 @@ Every ticket in this epic must preserve these constraints:
     or creating a Bond, and name it truthfully.
 - Move terminal documentation from `help` to `commands` and/or `?`, leaving
   Help available as a gameplay verb.
-- Make Look the read-only examination verb and Inspect the Study-bound action.
+- Make Look the read-only examination verb and require every Inspect action to
+  declare whether it binds Search or Study.
 - Retain old words as input-only compatibility aliases where replay or muscle
   memory warrants it. Do not render two primary names for one mechanic.
 - Generate aliases and help output from the same registry consumed by action

--- a/docs/backlog/rest-travel-and-weariness.md
+++ b/docs/backlog/rest-travel-and-weariness.md
@@ -25,6 +25,7 @@ issues are the source of truth for each slice's implementation state.
 - [SRD-Backed Action and Collectible System](../systems/04-action-system.md)
 - [CosyWorld RPG System Bible](../systems/09-cosyworld-rpg-system.md)
 - [ADR 0002: the action hand is authoritative state](../decisions/0002-action-hand-is-authoritative-state.md)
+- [ADR 0005: thresholds, trails, and the strict referee](../decisions/0005-thresholds-trails-and-strict-referee.md)
 
 **Related backlog**: [Action Verbs And Economy](action-verbs-and-economy.md).
 AVE owns the verb lexicon, per-offer cost/risk presentation, and complete legal
@@ -88,6 +89,16 @@ an expedition system instead of bookkeeping.
    not appear in player copy (`PRD.md:56`).
 8. Old journaled rest records keep their tag-clearing meaning. A new grade
    semantic needs a new action code, never a reinterpretation.
+9. A cairn, Signal Anchor, temporary Mark, active Lead, route familiarity, or
+   discovered place is navigation state, not shelter or rest entitlement.
+   Camp still requires equipped shelter; Lodged and Hearth keep their own
+   eligibility.
+
+ADR 0005 does not change current weariness or Rest behavior. The proposed
+short-rest/fatigue cadence is owned by
+[#603](https://github.com/cenetex/cosyworld/issues/603) and must explicitly
+supersede any conflicting current rule before implementation in #604. Scout
+and Pressure consume that decision; they cannot embed a second fatigue ladder.
 
 ---
 

--- a/docs/backlog/thresholds-trails-and-strict-referee.md
+++ b/docs/backlog/thresholds-trails-and-strict-referee.md
@@ -1,0 +1,105 @@
+# Thresholds, trails, and the strict referee
+
+**Epic**: [#586](https://github.com/cenetex/cosyworld/issues/586)
+
+**Status**: Product contract accepted in
+[ADR 0005](../decisions/0005-thresholds-trails-and-strict-referee.md);
+runtime and schema implementation remains dependency-ordered below.
+
+## Shared model
+
+Doors, containers, seals, traps, hidden passages, frontier tracks, and
+chase-like scenes compose five small components:
+
+| Component | Question |
+| --- | --- |
+| Discovery Slot | What bounded hidden truth may exist here, and what fixed result or table stocks it once? |
+| Lead | What exact truth may this actor, expedition, or the world pursue? |
+| Gate | What method permits this target to open, yield, or be crossed? |
+| Hazard | What is telegraphed, what triggers it, and what follows? |
+| Pressure | What makes relevant committed delay or repeated work consequential? |
+
+Topology, legibility, access, and safety remain separate. AI receives only
+certified visible facts and committed outcomes; it cannot choose truth,
+methods, table rows, consequences, access, topology, or rewards.
+
+## Player procedures
+
+- **Scene notice** is free obvious sensory truth.
+- **Notice** spends one turn on one unresolved broad sensory result.
+- **Search** exhaustively examines one named local physical target.
+- **Study** interprets an already perceived target.
+- **Scout** pursues one exact geographic Lead from an Anchor or active foray
+  and reveals the authorized next segment or target without moving.
+- **Travel** performs movement through a revealed, accessible route.
+- **Mark** creates a temporary expedition return cue.
+- **Open** resolves one certified Gate method.
+- **Take** transfers one revealed, accessible item after custody and capacity
+  checks.
+
+Reveal never implies Open, Take, or Travel.
+
+## Product invariants
+
+- No danger, no success roll.
+- Telegraph every Hazard before dangerous commitment.
+- No committed unchanged “nothing found” result.
+- Stock hidden truth once; never reroll it through retry, reconnect, or model
+  failure.
+- Required discoveries have a finite Sign budget or deterministic fallback.
+- Required progression preserves retreat, camp, aid, rescue, alternate-route,
+  or recovery reachability.
+- A cairn stabilizes a traversed return leg and may authorize later branching;
+  it does not reveal forward topology, settle a place, provide shelter, grant a
+  rest grade, or create sanctuary.
+- Navigation stability, route familiarity, place settlement, shelter, and rest
+  grade are independent state.
+
+## Delivery order
+
+| Order | Issue | Outcome |
+| --- | --- | --- |
+| 1 | [#587](https://github.com/cenetex/cosyworld/issues/587) | Product, vocabulary, compatibility, and migration law. |
+| 2 | [#600](https://github.com/cenetex/cosyworld/issues/600) | Discovery Slot and deterministic stocking receipt. |
+| 3 | [#588](https://github.com/cenetex/cosyworld/issues/588) | Lead, Gate, Hazard, Pressure, and Anchor descriptors. |
+| 4 | [#589](https://github.com/cenetex/cosyworld/issues/589) | Kernel-owned conditional transitions. |
+| 5 | [#590](https://github.com/cenetex/cosyworld/issues/590) | Custody, recovery, and route reachability proof. |
+| 6 | [#591](https://github.com/cenetex/cosyworld/issues/591) | Concrete methods and consequence-first offers. |
+| 7 | [#592](https://github.com/cenetex/cosyworld/issues/592) | Telegraphed method-aware Hazards. |
+| 8 | [#601](https://github.com/cenetex/cosyworld/issues/601) | One discovery pipeline across Notice, Search, Study, and Scout. |
+| 9 | [#593](https://github.com/cenetex/cosyworld/issues/593) | Bounded Pressure scenes and event rolls. |
+| 10 | [#602](https://github.com/cenetex/cosyworld/issues/602) | Bounded item and location materialization. |
+| 11 | [#594](https://github.com/cenetex/cosyworld/issues/594) | Perishable frontier Leads and forays. |
+| 12 | [#595](https://github.com/cenetex/cosyworld/issues/595) | Fail-closed referee presentation packet. |
+| 13 | [#596](https://github.com/cenetex/cosyworld/issues/596) | Worldpack validation and developer inspection. |
+| 14 | [#597](https://github.com/cenetex/cosyworld/issues/597) | End-to-end door, chest/item, and marked-trail proof. |
+
+Rest/fatigue numbers remain outside this epic. [#603](https://github.com/cenetex/cosyworld/issues/603)
+must decide them before [#604](https://github.com/cenetex/cosyworld/issues/604)
+implements them. Threshold and Scout work consumes that decision and may not
+invent a parallel fatigue system.
+
+## Compatibility gate
+
+Current Scout is `scout_v1`: the journal stores legacy Search plus an
+`explore_path` projection mutation that reveals one edge without movement.
+Existing hidden-exit chance, route discovery/unlock, local Lead, loot, clock,
+rest, cairn, and Scout records retain their exact historical meaning.
+
+New work uses append-only procedure and descriptor versions. A migration may
+project old state into the new inspector, but must not reroll hidden truth,
+re-award a claim, add a consequence, change topology, or newly authorize
+access. The complete field-by-field inventory is normative in ADR 0005.
+
+## Definition of ready for downstream issues
+
+A downstream issue may start only when all its listed predecessors are closed
+and its implementation:
+
+1. names the exact component and descriptor version it owns;
+2. preserves the four-way topology/legibility/access/safety split;
+3. records deterministic claim and replay evidence;
+4. provides authored fallback presentation without AI;
+5. proves no-null-commit, no-reroll, finite-required-discovery, and recovery
+   reachability where applicable; and
+6. keeps direct and inference-controlled action legality identical.

--- a/docs/decisions/0004-rest-grades-and-expedition-depth.md
+++ b/docs/decisions/0004-rest-grades-and-expedition-depth.md
@@ -91,6 +91,19 @@ Future HP or wound presentation may coexist with expedition depth, but not as
 another ring. The ring belongs exclusively to expedition depth; wounds change
 the portrait treatment. There are no concentric HP and expedition arcs.
 
+### Navigation Anchors are not rest
+
+[ADR 0005](0005-thresholds-trails-and-strict-referee.md) gives cairns, Signal
+Anchors, and other pack-authored navigation fixtures one narrow role: they make
+an already traversed return leg durable and may authorize later branching.
+They are not shelter, lodging, Hearths, or settlement. They never grant Camp,
+Lodged, or Hearth recovery and never change this ADR's grade derivation.
+
+Camp still requires valid equipped shelter. Lodged still requires an authored
+lodging feature and satisfied gate. Hearth still requires sanctuary. Route
+familiarity, a temporary Mark, an active Lead, and place discovery are likewise
+irrelevant to rest grade.
+
 ### Replay and compatibility
 
 Existing projection-only Rest journal records retain their historical
@@ -109,6 +122,9 @@ once, without coupling the rest ladder to either outcome.
 This ADR also does not tune danger-clock movement, define the shelter or
 lodging feature schemas, author an inn, change Rest offer ranking, or implement
 the kernel procedure or ring. Those are follow-up implementation slices.
+The later rest/fatigue cadence decision belongs to
+[#603](https://github.com/cenetex/cosyworld/issues/603); Scout and Pressure may
+consume that contract but cannot define a second fatigue system.
 
 ## Consequences
 

--- a/docs/decisions/0005-thresholds-trails-and-strict-referee.md
+++ b/docs/decisions/0005-thresholds-trails-and-strict-referee.md
@@ -1,0 +1,292 @@
+# ADR 0005: thresholds, trails, and the strict referee
+
+- Status: Accepted
+- Date: 2026-07-30
+- Decision owners: CosyWorld maintainers
+- Related: [#586](https://github.com/cenetex/cosyworld/issues/586),
+  [#587](https://github.com/cenetex/cosyworld/issues/587),
+  [#600](https://github.com/cenetex/cosyworld/issues/600),
+  [#601](https://github.com/cenetex/cosyworld/issues/601)
+
+## Context
+
+CosyWorld already has authored and hidden exits, route discovery, generated
+waypoints, local Leads, locked flags, item custody, deterministic loot
+receipts, clocks, cairn-like place fixtures, and graded rest. They do not yet
+share one product law. In particular, a route can exist without being known, a
+known route can be locked, a safe-looking threshold can contain a Hazard, and
+a discovered place can still lack a durable return. Treating those facts as one
+state would make replay, recovery, and player-facing explanations dishonest.
+
+The threshold substrate therefore composes five small components. It does not
+create a universal obstacle object:
+
+| Component | Owns | Does not own |
+| --- | --- | --- |
+| **Discovery Slot** | The bounded kind and quantity of hidden truth, plus the fixed result or versioned stocking table that selects it once. | Whether anyone can perceive, reach, cross, carry, or safely interact with the result. |
+| **Lead** | The exact hidden truth an actor, expedition, or the world may currently pursue or interpret. | The existence of topology or permission to cross it. |
+| **Gate** | The conditions and authored methods that permit a target to open, yield, or be crossed. | Whether the target exists, has been noticed, or is safe. |
+| **Hazard** | A sensory tell, trigger, affected targets, bypasses, and deterministic consequences. | Access permission or multi-turn scene cadence. |
+| **Pressure** | Consequence-bearing played time for a layered or opposed situation. | Stocking hidden truth or choosing permanent topology and rewards. |
+
+A trapped hidden door can compose a Discovery Slot, Lead, Gate, and Hazard. A
+chase can be Pressure without a Gate. Components keep stable pack-owned
+identities and may reference one another, but they remain independently
+inspectable and versioned.
+
+## Decision
+
+### Four independent questions
+
+Every offer, resolver, inspector, and migration must answer these questions
+separately:
+
+1. **Topology:** does the route, target, item, actor, or fact exist?
+2. **Legibility:** who has enough evidence to perceive or pursue it?
+3. **Access:** who may open, take, use, or cross it by which method?
+4. **Safety:** what has been telegraphed, what can trigger, and what consequence
+   is at stake?
+
+Revealing a target never opens it. Opening a container never Takes its
+contents. Making a route accessible never reveals it. Disarming a Hazard never
+unlocks its Gate. No presentation layer may collapse those transitions.
+
+### Authority and ownership
+
+| Concern | Authority | Required record |
+| --- | --- | --- |
+| Authored bounds, fixed outcomes, table membership, tells, methods, recovery declarations, and presentation fallbacks | Versioned worldpack compiled by the host | Pack/version, canonical IDs, descriptor versions, and validation result |
+| Stocking selection | Server-owned deterministic resolver | Slot/table/version, eligible inputs, algorithm version, seed input, selected row, claim key, fallback, and materialized IDs |
+| Opening, passage, item placement/custody/charges, irreversible transitions, and authoritative consequences | C kernel, or a temporary bounded journal reducer that cannot contradict it | Accepted intent, evidence, expected entity versions, action/event versions, and resulting events |
+| Lead scope, route discovery, Anchor/foray state, and compatibility projections | Journaled runtime state until the matching kernel substrate lands | Stable identities, scope, source event, expected revision, transition, and result |
+| Pressure cadence and clocks | Server scheduler over journaled authoritative state | Participants, strategies, played-time event, progress/danger movement, and terminal result |
+| Offer enumeration and disabled reasons | Server projection from current authoritative state | Exact component, target, method, requirement, cost, effect, consequence, and state revision |
+| Narration and decorative media | Authored fallback first; validated AI may realize only the certified packet | Fixed facts and committed outcome; never hidden rows, seeds, predicates, or uncommitted alternatives |
+| Rendering and input | Client | Select an exact certified offer and acknowledge presentation; never supply rules evidence or results |
+
+AI is the referee's voice, never the referee's authority. Model failure uses
+deterministic fallback copy and cannot prevent or alter a committed mechanical
+result.
+
+### Canonical procedures and player verbs
+
+Internal procedure IDs are versioned. Player copy may use an approved
+pack-specific reskin, but the binding below cannot change.
+
+| Procedure | Player verb | Contract |
+| --- | --- | --- |
+| `scene_notice_v1` | no button; the scene simply shows it | Free on arrival or relevant state change. Publish obvious exits, creatures, objects, landmark cues, sensory Signs, and perceivable Hazard tells. Never roll and never consume played time. |
+| `focused_notice_v2` | **Notice** | Spend one turn to resolve one broad, authored sensory Lead or stateful safety/environment result. Offer it only while an unresolved result exists. Under Pressure, a check avoids a named consequence; it never decides whether stocked truth exists. |
+| `search_v2` | **Search** | Spend one turn exhaustively examining one named local physical target. A safe Search is certain. It may reveal a frozen item, mechanism, secret feature, actor trace, or evidence, but never opens, Takes, equips, or moves through the result. |
+| `study_v2` | **Study** | Spend one turn interpreting an already perceived target. Reveal requirements, operation, provenance, meaning, or a better method. Study cannot materialize physical truth. |
+| `scout_v2` | **Scout** | Spend played time pursuing one exact geographic Lead from a legal Anchor or along its active foray. Reveal only the authorized next segment or target. Scout never moves the actor; **Travel** is a separate commit. |
+| `travel_v1` | **Travel** | Move through one revealed route whose Gate permits this actor or expedition. Travel does not stock, reveal, or secure a destination. |
+| `mark_v1` | **Mark** | Create an expedition-scoped, potentially perishable navigation mark on a traversed leg. It supports the active return chain but does not create topology, reveal forward truth, authorize an independent branch, or establish an Anchor. |
+| `open_v1` | **Open** | Apply one certified Gate method to a named door, seal, or container. The offer states its requirement, cost, effect, and telegraphed consequence. Open does not reveal hidden contents or transfer them. |
+| `take_v1` | **Take** | Transfer one revealed, accessible item into legal custody after capacity and placement checks. Take does not reveal, Open, equip, install, or use it. |
+
+`Inspect` is approved copy only when it binds to `search_v2` for physical
+examination or `study_v2` for interpretation. It is not a third resolver.
+`Listen` and `Tune In` may reskin focused Notice. `Head To` may reskin Travel.
+
+The currently journaled route procedure is named `scout_v1`: it uses the
+legacy Search action and an `explore_path` projection mutation to reveal one
+adjacent segment without moving. It remains replay-readable. `scout_v2` keeps
+the honest no-movement result but adds an exact Lead, Anchor/active-foray
+evidence, descriptor versions, and no-null-commit law. New code must use a new
+append-only action or procedure version rather than reinterpret `scout_v1`.
+
+### Shared discovery progression
+
+The common vocabulary is:
+
+`latent → signed → lead → revealed → accessible → secured`
+
+These words describe separable transitions, not one mega-enum. `revealed` is
+normally monotonic shared truth; `accessible` may change when a key, charge,
+installed item, standing, or Hazard state changes. A lost or forgotten Lead
+does not erase topology or a prior shared reveal.
+
+| Kind | Latent | Signed | Lead | Revealed | Accessible | Secured |
+| --- | --- | --- | --- | --- | --- | --- |
+| Item | A fixed authored item or frozen Slot result exists. | A sensory tell is perceivable. | A scoped opportunity names where/how to look. | The item and placement are visible. | Container/Gate/Hazard permits interaction. | Legal custody or an authored durable cache records it. |
+| Location | A bounded point of interest and its topology are fixed. | A geographic Sign is perceivable. | An exact foray target is active. | The place becomes shared world truth. | A revealed route and Gate permit arrival. | A durable navigation Anchor records a return; settlement remains separate. |
+| Route/edge | The canonical edge exists. | A trail, draft, notation, or other tell is perceivable. | An exact destination/edge may be pursued. | The edge is shared and may be offered. | Its Gate permits Travel for the relevant scope. | A traversed return leg is durably anchored; familiarity remains separate. |
+| Actor | An authored or frozen actor result exists. | Tracks, voice, rumor, or presence cue is perceivable. | A scoped opportunity points to the actor. | Identity/presence is visible according to its policy. | Interaction rules permit the attempted action. | Not applicable to personhood; rescue, relationship, custody of items, or completed objectives use their own state. |
+| Lore | A fixed fact exists. | Evidence is perceivable. | A question or source can be pursued. | The proposition is known to its declared scope. | Required language, source, access, or interpretation method is satisfied. | A durable journal, memory, or authored record preserves it when the content declares that terminal state. |
+
+Kinds may stop at the last meaningful phase, but they may not silently skip
+Gate, Hazard, custody, capacity, or movement checks.
+
+### Three table classes
+
+1. **Stocking tables** create bounded hidden truth once. The server freezes the
+   table/version/inputs/algorithm/seed/row/claim before reveal. Reconnect,
+   controller change, abandonment, repeat Search, model failure, and replay
+   cannot reroll it. A location row can fill only topology authorized by its
+   Slot.
+2. **Event tables** apply typed Pressure after relevant committed played time.
+   They may alter a Lead, position, resource, Hazard, clock, or method
+   availability. They cannot invent permanent topology, unique loot, required
+   keys, or rewards outside a previously frozen Slot.
+3. **Presentation tables** vary wording or media for facts already fixed. They
+   have no claim key and no authority over quantities, targets, rules, access,
+   consequences, or state transitions.
+
+The existing quest-loot weighted receipt is the seed/weight/unique/fallback
+implementation to generalize. A second deterministic table algorithm must not
+be invented without a new ADR and replay version.
+
+### Anchors, forays, Marks, cairns, and settlement
+
+- An **Anchor** is a durable navigation role held by an authored stable place
+  or an authored worldpack-specific fixture.
+- A new Lead or independent branch begins at an Anchor.
+- One active Lead may continue through provisional nodes while its return
+  chain remains recoverable. It does not require a new fixture at every step.
+- Mark records a temporary expedition return cue. Losing it changes Lead or
+  return confidence, never canonical topology.
+- A **cairn** makes an already traversed return leg durable and may authorize a
+  later independent branch. It does not invent topology, reveal the way ahead,
+  provide shelter, grant a rest grade, create sanctuary, or settle a place.
+- Project 89's **Signal Anchor** is a pack-specific presentation of the same
+  navigation role. It remains place-bound infrastructure, never inventory.
+- Existing generated-place `anchor_clock_id`, `anchor_job_id`, and
+  `generated-place:<id>:anchor-fixture` state are retained. Their completion
+  means a durable navigation Anchor. The distinct connection and settlement
+  jobs still own connection and settlement; no historical event gains a new
+  side effect.
+
+Five facts must remain independent:
+
+| Fact | Current representation | Law |
+| --- | --- | --- |
+| Navigation stability | Authored stable place or completed anchor fixture | Permits durable return and later branching only. |
+| Route familiarity | Generated-pathway `familiar`, traffic class, and familiarity job/clock | Describes repeated shared use; it neither reveals an edge nor settles a place. |
+| Place settlement | Generated-place connection/settlement jobs, clocks, and room safety transition | May change services or sanctuary only through its own committed contract. |
+| Shelter | Authored room feature or equipped `camp_shelter` capability | Determines whether Camp can be offered; a navigation fixture is not shelter. |
+| Rest grade | ADR 0004 Hearth/Lodged/Camp derivation | Never inferred from a cairn, Mark, Lead, familiarity, or route reveal. |
+
+Rest/fatigue cadence is owned by #356 and the decision in #603. Scout and
+Pressure consume that contract after it is accepted; they do not invent short
+rests, fatigue thresholds, or a second recovery system.
+
+### Product laws
+
+- **No danger, no roll.** Ordinary skilled work with the required method is
+  certain when no meaningful consequence is at stake, although it may cost
+  played time.
+- **Telegraph before danger.** Every Hazard and dangerous method exposes an
+  authored sensory tell before commitment.
+- **No null commit.** A committed procedure resolves the target, produces a
+  Lead/fact, changes Pressure, proves the target safe/empty, consumes a
+  resource, changes position, or removes that method. It never returns
+  unchanged “nothing found; try again.”
+- **No reroll.** Stocking truth and unique results freeze once. Player action
+  reveals or interacts with the receipt; it cannot select another row.
+- **Finite required discovery.** Required progression has a finite Sign budget
+  or deterministic fallback. Optional missable content must declare itself
+  optional.
+- **Recovery reachability.** A required key, reclosable Gate, provisional
+  foray, Lead loss, or future fatigue transition cannot remove every legal
+  retreat, camp, aid, rescue, alternate route, or recovery source.
+- **Controller parity.** Direct and inference controllers receive the same
+  certified methods and authoritative outcomes.
+
+Simple obstacles resolve in one action. Pressure is reserved for situations
+with at least two meaningful beats, differentiated strategies, and a terminal
+consequence.
+
+## Migration inventory
+
+This ADR adds no runtime state. It assigns each existing field a migration
+disposition so #600, #588, and later slices can add versioned state without
+guessing.
+
+### Topology, legibility, and access
+
+| Existing field/state | Current authority | Migration disposition |
+| --- | --- | --- |
+| `SeedExitContent.{pack_id,from_location_id,to_location_id,direction,flags,distance,directionality,fallback_location_id,discovery}` | Compiled worldpack seed | Retain as authored topology. Compile `discovery` into initial legibility; never infer access or safety from it. |
+| `CwExit.{from_location_id,to_location_id,flags}` and `CW_EXIT_LOCKED` | Kernel | Retain exactly for historical crossing. New `Gate v1` compiles an equivalent legacy lock projection until all authored locks migrate. |
+| `RouteRecordState.{id,canonical_id,edges,owner,owner_pack_id,owner_pack_version,generation_policy,provenance,directionality,fallback_location_id,lifecycle,discovery,unlocks,entity_version}` | Journaled route state | Retain as canonical route identity/lifecycle and compatibility discovery/unlock history. New Slot, Lead, and Gate references point to `canonical_id` plus `entity_version`; they do not replace route existence. |
+| `RouteEdgeState.{from_location_id,to_location_id,flags}` | Journaled route projection | Retain topology and legacy lock flags. Do not add legibility or Hazard meaning to `flags`. |
+| `RouteDiscoveryState.{actor_id,event_seq,reason}` | Journaled projection | Retain as historical first-discovery evidence. New scoped `Lead v1`/reveal receipts provide explicit actor/expedition/world scope. |
+| `RouteUnlockState.{from_location_id,to_location_id,actor_id,event_seq,reason}` | Journaled projection feeding kernel exits | Retain as historical unlock evidence. New Gate transitions use append-only descriptor/action versions. |
+| `RouteLifecycle::{latent,open,blocked,frozen}` | Journaled route state | Retain as topology lifecycle only. `blocked` must not stand in for unknown, unsafe, or inaccessible-to-one-actor. |
+| `SeedHiddenExitContent.{id,pack_id,from_location_id,to_location_id,feature_key,direction,return_direction,reveal_chance_percent,source,discovery_text}` | Compiled seed plus legacy Search projection | Retain for old saves/events. `reveal_chance_percent` is legacy reveal/selection coupling and is forbidden for newly authored `DiscoverySlot v1`; new truth freezes before reveal and safe Search is certain. |
+
+### Generated routes, Leads, and Anchors
+
+| Existing field/state | Current authority | Migration disposition |
+| --- | --- | --- |
+| `GeneratedPathwayState.{id,identity_version,canonical_id,source_route_id,source_route_version,owner_pack_id,owner_pack_version,generation_policy,origin_location_id,destination_location_id,distance,created_by_actor_id,way_class,traffic_count,waypoints,generation,revealed_edges,art_eligible,familiar}` | Journaled generated topology | Retain all identity, ownership, topology, prose provenance, reveal, traffic, art, and familiarity fields. New Slot/Lead/Anchor state references the pathway and route version. `revealed_edges` remains the `scout_v1` compatibility projection; `familiar` is never an Anchor or reveal. |
+| `GeneratedWaypointState.{id,canonical_id,name,meta,generation_policy}` | Journaled generated topology/presentation | Retain. New location Slots may authorize creation, but presentation generation cannot alter IDs, topology, Gate, Hazard, or ownership. |
+| `JourneyState.{actor_id,pathway_id,origin_location_id,destination_location_id,destination_name,path,current_step,explorer}` | Journaled active traversal | Retain for `scout_v1` and Travel replay. `scout_v2` adds exact Lead and Anchor/return-chain references rather than inferring them from `explorer`. |
+| `LocalLeadState.{id,actor_id,source_actor_id,source_offer_id,source_reference,source_event_seq,origin_location_id,destination_location_id,destination_hint,received_tick,consumed,settled,forgotten,consumed_event_seq,settled_event_seq}` | Journaled actor-scoped lead | Retain and compile into `Lead v1` compatibility state. `forgotten` maps to lost legibility, not deleted topology; `settled` maps to resolved Lead, not place settlement. |
+| `GeneratedPlaceState.{schema_version,location_id,canonical_id,pathway_id,connected_from_location_id,discovered_by_actor_id,discovered_event_seq,source_generation,pack_id,pack_version,generation_policy,anchor_clock_id,connection_clock_id,settlement_clock_id,anchor_job_id,connection_job_id,settlement_job_id,building_proposal}` | Journaled generated-place progression | Retain. Anchor completion projects navigation stability; connection and settlement remain distinct. New Anchor state references the committed fixture event without changing past milestones. |
+| `generated-place:<id>:anchor-fixture`, cairn policy copy, and Project 89 Signal Anchor policy copy | Journaled tag plus pack presentation | Retain. Standardize their mechanical role as durable navigation Anchor; worldpack terminology remains presentation. |
+| `rpg_claims`, `listen_attempt_claims`, route discovery/unlock receipts, and Visit Ledger marks | Journaled compatibility claim sets/records | Preserve exact keys for replay. New Slot/Lead receipts use namespaced versioned claim IDs; migration may backfill references but never re-award or reinterpret a historical claim. |
+
+### Items, custody, and deterministic stocking
+
+| Existing field/state | Current authority | Migration disposition |
+| --- | --- | --- |
+| `SeedItemContent.{pack_id,id,name,description,kind,charges,location_id,role,capabilities,weight_tenths,size,container_capacity_tenths,skill_id,skill_bonus,mechanics,container_opening_size,allowed_contents,access_cost,nested_containers}` | Compiled item seed | Retain as fixed authored item/template data. A Discovery Slot may reference a fixed item or template but cannot override mechanics, capacity, or placement law. |
+| `SeedPlayableItemMechanics.{binding,equipment_profile,target_predicate,resolver,effect_budget,uses,exhaustion,recovery,transfer_policy,theft_policy,magic_effect}` | Compiled rules binding | Retain. Gate predicates may reference closed capabilities or exact items; generated text cannot author these fields. |
+| `CwItem.{id,kind,charges,max_charges,weight_tenths,container_capacity_tenths,size_class,role,zone,recovery,recovery_zone,location_id,holder_actor_id,container_item_id,held_since_tick,recharge_at_tick}` | Kernel | Retain as custody, placement, capacity, charge, exhaustion, and recovery authority. Discovery never mutates these except through an explicit kernel transition. |
+| `ItemProvenanceState.{item_id,origin,acquisition,previous_holder_actor_id,current_holder_actor_id,current_location_id,transfer_count,source_event_seq,possession_journey}` | Journaled provenance projection | Retain for explanation and recovery validation; kernel custody remains authoritative. |
+| Equipped charms, prepared spells, card zones, materialization/craft receipts, transfer offers, and item placement events | Kernel plus journaled receipts | Retain. New Gate/Take/Open methods consume their existing exact state and stale-offer checks. |
+| Loot table catalog `{schema_version,replay_version,item_templates,tables}` and table `{id,version,allocation_policy,quantity,eligibility,entries,fallback_template_id,already_present_policy,unavailable_policy,presentation}` | Compiled worldpack | Generalize as the only stocking algorithm family. Presentation stays non-authoritative. |
+| `LootAllocationState.{schema_version,id,job_id,quest_template_id,table_id,table_version,replay_version,pack_id,pack_version,rules_profile,completion_event_seq,allocation_event_seq,roll_seed,roll_input,selected_template_ids,item_ids,allocation_policy,destination_kind,destination_id,recipient_actor_id,location_id}` | Journaled deterministic receipt | Reuse as the model for `DiscoveryReceipt v1`; never discard or recompute an existing selection. |
+
+### Clocks, Pressure, settlement, and rest
+
+| Existing field/state | Current authority | Migration disposition |
+| --- | --- | --- |
+| `ClockState.{id,scope,scope_id,kind,zone,label,segments,filled,visible_to_players,status,presentation,on_fill,recent_contributions,completion,created_event_seq,updated_event_seq}` | Journaled clock state | Retain. `Pressure v1` may bind existing progress/danger clocks only for layered situations; a clock never stocks hidden truth or replaces a Gate/Hazard descriptor. |
+| `JobState.{pack_id,id,premise,stakes,location_ids,participant_ids,progress_clock_id,danger_clock_id,status,reward,consequence,memory_summary,action_copy,contribution_schema_version,contribution_strategies,narrated_thresholds,delivery,loot,focused_profile,focused_encounter}` | Journaled project state | Retain. Pressure may reuse strategies and clocks; reward/loot still requires its existing typed commit and receipt. |
+| Focused encounter `objective_clock_id`, optional `danger_clock_id`, `pressure_trigger`, participant order, round/current actor, completion/stop/retreat predicates, and profile/version | Server projection over journaled combat/project state | Retain as ordered-scene binding. Objective and danger IDs reference ordinary `ClockState`; they do not create a fourth table class or let a scene reroll hidden truth. |
+| Room sheet `safety`/`zone`, generated-place connection/settlement jobs, and pathway familiarity job/clock | Compiled seed plus journaled state | Keep separate from discovery and Anchor state. Only their own versioned transitions may alter sanctuary, settlement, or familiarity. |
+| `SeedRoomFeatureContent.lodging.gate.kind`, equipped `camp_shelter`, and kernel `CW_REST_GRADE_{CAMP,LODGED,HEARTH}` | Compiled eligibility plus kernel rest authority | Retain ADR 0004 exactly. Anchor/cairn/Mark/Lead/familiarity never grants a rest grade. |
+| `tired`, `trained_since_rest`, `frontier_travel_since_rest:*`, rest actions, item recovery profiles, and expedition projection | Kernel/journal compatibility state | Retain historical meaning. #603 owns any new cadence/fatigue state and must use append-only versions. |
+
+### Action and replay compatibility
+
+| Historical operation | Compatibility law |
+| --- | --- |
+| `CW_ACTION_ABILITY_CHECK` (4) | Legacy generic checks replay unchanged; they do not become focused Notice, Gate, or Hazard receipts. |
+| `CW_ACTION_SEARCH` (13) | Legacy hidden-item and `scout_v1` Search records replay unchanged, including their existing projection mutations. |
+| `CW_ACTION_RULES_SEARCH` (21) and `CW_ACTION_RULES_STUDY` (22) | Keep their current learn-once claim semantics. New focused Notice/Search/Study bind exact Slots and descriptors through append-only procedure versions. |
+| `CW_ACTION_UNLOCK_EXIT` (28) | Keep historical lock clearing. New Gate transitions must not reinterpret its evidence or scope. |
+| `CW_ACTION_REVEAL_ITEM` (29) | Keep historical item reveal. Reveal remains separate from Open, Take, equip, and use. |
+| Existing hidden-exit chance, route discovery, local Lead, loot, clock, rest, cairn, and Scout events | Remain readable and reconstruct their original state. Migration may emit explicit compatibility projections but cannot reroll, re-award, add a consequence, or newly authorize behavior. |
+
+Snapshots and event exports continue to carry canonical content context. New
+descriptors and receipts must be append-only, pack/version bound, and
+self-describing enough to inspect after active content changes. Unknown
+versions fail closed for new execution while historical records remain
+inspectable.
+
+## Consequences
+
+- #600 can define one bounded Slot/receipt contract without deciding player
+  verbs or inventing another loot algorithm.
+- #588 can define Lead, Gate, Hazard, Pressure, and Anchor descriptors against
+  explicit ownership boundaries.
+- #601 can unify discovery procedures without coupling reveal to Open, Take,
+  or Travel.
+- Route, item, rest, and generated-place migrations have an explicit source
+  inventory and compatibility disposition.
+- Cairns and Signal Anchors gain one shared navigation meaning without
+  becoming shelter, settlement, or a universal visual noun.
+- Content validation can reject null commits, rerolls, untelegraphed Hazards,
+  unbounded required discovery, and unrecoverable progression before runtime.
+
+## References
+
+- [Thresholds, trails, and the strict referee backlog](../backlog/thresholds-trails-and-strict-referee.md)
+- [CosyWorld RPG System Bible](../systems/09-cosyworld-rpg-system.md)
+- [SRD-backed action and collectible system](../systems/04-action-system.md)
+- [ADR 0004: rest grades and expedition depth](0004-rest-grades-and-expedition-depth.md)
+- [Worldpacks](../../v2/docs/worldpacks.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,9 @@ do not define V2 behavior.
 - **[CosyWorld RPG System Bible](systems/09-cosyworld-rpg-system.md)** —
   Callings, Bonds, Clocks, Jobs, Fronts, Covenants, the Visit Ledger, and
   progression invariants.
+- **[ADR 0005: Thresholds, Trails, and the Strict Referee](decisions/0005-thresholds-trails-and-strict-referee.md)** —
+  topology/legibility/access/safety ownership, discovery procedures, table
+  authority, Anchor/foray law, and migration compatibility.
 - **[Economy](../ECONOMY.md)** — Orbs, Boxes, packs, provenance, and the optional
   NFT bridge.
 - **[AI](../AI.md)** — inference, payer modes, media, and the boundary between AI
@@ -84,6 +87,9 @@ do not define V2 behavior.
 - **[Holy Land Integration Playtest](backlog/holy-land-integration-playtest.md)** —
   legal-action reachability, generated pilgrimage-road presentation, and
   direct-avatar continuity boundaries found in the first end-to-end journey.
+- **[Thresholds, Trails, and the Strict Referee](backlog/thresholds-trails-and-strict-referee.md)** —
+  dependency-ordered Discovery Slot, Lead, Gate, Hazard, Pressure, trail, and
+  recovery work following ADR 0005.
 
 GitHub Issues are the live execution backlog. These local backlogs carry the
 long-form contracts and acceptance gates that do not fit cleanly in an issue.
@@ -101,4 +107,4 @@ current PRD take precedence:
 - [Historical fixes](fixes/)
 - [X402 agentic economy report](X402_AGENTIC_ECONOMY_REPORT.md)
 
-Last reviewed: 2026-07-28.
+Last reviewed: 2026-07-30.

--- a/docs/systems/04-action-system.md
+++ b/docs/systems/04-action-system.md
@@ -90,10 +90,16 @@ mechanical offer declares its stable identity:
 
 | Current/product wording | Stable meaning |
 | --- | --- |
-| Listen, Notice, Tune In | Search, normally using Wisdom. |
-| Inspect, Investigate, Recall | Study, normally using Intelligence; use Search when perception is decisive. |
-| Scout, Scope Out | Search or Study followed by movement, not a new universal action. |
-| Travel, Head To | Movement through a legal exit. |
+| Scene notice | Free obvious sensory projection on arrival or relevant state change; never a roll or action. |
+| Listen, Notice, Tune In | Focused Notice: one played broad sensory result, currently Search-compatible and target `focused_notice_v2`; absent when no unresolved authored result exists. |
+| Search | Exhaustive physical examination of one named local target; safe Search is certain and does not Open or Take. |
+| Study, Recall | Interpretation of an already perceived target; exposes meaning, operation, requirements, provenance, or a better method without materializing physical truth. |
+| Inspect, Investigate | Search when physical examination is decisive; Study when interpretation is decisive. The offer must declare which binding it uses. |
+| Scout, Scope Out | The CosyWorld geographic procedure: pursue an exact Lead from an Anchor or active foray and reveal an authorized segment/target without moving. It is not a universal SRD action. |
+| Travel, Head To | Movement through a revealed route whose Gate permits the actor; it performs no discovery. |
+| Mark | A temporary expedition return cue on a traversed leg; no topology, forward reveal, independent branch, or Anchor. |
+| Open | One certified Gate method on a door, seal, or container; no implicit reveal or transfer. |
+| Take | Transfer one revealed accessible item after custody and capacity checks; no implicit Open, equip, install, or use. |
 | Chat | Spend one banked advancement point to begin a friendship with an eligible nearby resident; absent when that growth option is unavailable. |
 | Say | Ordinary moderated room communication; Influence only when changing attitude or cooperation is at stake. |
 | Use | Utilize for a nonmagical object; Magic for a spell, magic feature, or magic item. |
@@ -107,6 +113,12 @@ mechanical offer declares its stable identity:
 The compiler should reject a label that omits its mechanical binding. A reskin
 may change `label`, `detail`, art, and narration; it may not change costs,
 targets, checks, effects, or timing.
+
+The threshold bindings and their compatibility versions are normative in
+[ADR 0005](../decisions/0005-thresholds-trails-and-strict-referee.md).
+Current `scout_v1` records remain legacy Search plus an `explore_path`
+projection mutation. New discovery procedures must use append-only versions
+and may not reinterpret those records.
 
 ## Cards Are Offers and Playable Things
 

--- a/docs/systems/09-cosyworld-rpg-system.md
+++ b/docs/systems/09-cosyworld-rpg-system.md
@@ -344,22 +344,31 @@ Influence and Magic, Pick Up/Use/Give/Drop/Trade items, theft, crafting, and the
 versioned combat encounter actions. Journaled Rust reducers own the bounded
 project, loadout, materialization, and progression operations.
 
-### Current Product Verbs
+### Product Verb Contract
 
 Friendly labels now map to stable SRD 5.2.1 actions or explicit non-action
 operations in the compiled registry. The same authoritative envelopes drive
 the browser, terminal, inspector, and submission endpoint; see
 [the action-system design](04-action-system.md) and
 [the implementation ledger](../backlog/srd-action-card-foundation.md).
+[ADR 0005](../decisions/0005-thresholds-trails-and-strict-referee.md)
+separates topology, legibility, access, and safety and versions the target
+discovery procedures. Existing v1 journal records keep their historical
+bindings until those procedures land.
 
 | Product verb | Kernel or projection | Purpose |
 | --- | --- | --- |
 | Chat | kernel Say plus AI generation | Public in-character line and resident response; deepens bonds. |
-| Notice | kernel Ability Check | Receive an ambient room lead, mark the ledger, advance memory. |
-| Inspect | kernel Ability Check | Examine a named target to reveal hidden content. |
-| Scout | projection pathway action | Reveal the next adjacent route segment toward a named destination without moving. |
-| Travel | kernel Move | Move through legal, accessible exits; crossing into frontier is explicit. |
-| Take | kernel Pick Up Item | Move item to inventory. |
+| Scene notice | free server projection; no action | Show obvious exits, creatures, objects, landmark cues, sensory Signs, and perceivable Hazard tells on arrival or relevant state change. It never rolls or consumes played time. |
+| Notice | current rules Search/legacy check; target `focused_notice_v2` | Spend one turn resolving one broad authored sensory Lead or safety/environment result. It is absent when no unresolved result exists. |
+| Search | current rules Search; target `search_v2` | Exhaustively examine one named local physical target. Safe Search is certain and reveal never implies Open or Take. |
+| Study | current rules Study; target `study_v2` | Interpret an already perceived target to learn requirements, operation, provenance, meaning, or a better method; never materialize physical truth. |
+| Inspect | approved Search or Study reskin | Bind to Search for physical examination or Study for interpretation; never a third resolver. |
+| Scout | current `scout_v1` projection; target `scout_v2` | Pursue one exact geographic Lead from an Anchor or active foray and reveal one authorized segment or target without moving. |
+| Travel | kernel Move | Move through a revealed route whose Gate permits this actor or expedition. Travel never reveals the way. |
+| Mark | target `mark_v1` procedure | Leave a temporary expedition return cue on a traversed leg. It creates no topology, forward reveal, independent branch, or Anchor. |
+| Open | current kernel unlock where applicable; target `open_v1` Gate procedure | Apply one certified method to a door, seal, or container. Open does not reveal hidden contents or transfer them. |
+| Take | kernel Pick Up Item | Transfer one revealed, accessible item after custody and capacity checks; never implicitly reveal, Open, equip, install, or use it. |
 | Give | kernel Give Item | Resident evolution, bonds, job delivery, covenant contribution. |
 | Use | kernel Use Item | Consumables, tools, relics, room effects. |
 | Attack | kernel Attack | Rare frontier conflict, resolved as a risk toward an objective. |
@@ -369,7 +378,23 @@ the browser, terminal, inspector, and submission endpoint; see
 | Rest | New append-only kernel procedure for authoritative card refresh; legacy projection-only records keep their historical meaning | Follow [ADR 0004](../decisions/0004-rest-grades-and-expedition-depth.md): Camp clears `tired` and one spell; Lodged also clears `trained_since_rest` and refreshes the whole spell hand; Hearth additionally clears expedition depth and refreshes charms and relics; frontier Rest without equipped shelter is not offered. |
 | Contribute | kernel Push action plus projection clock application | Advance one named job or covenant clock through job-specific Push and, when available, Help strategies. |
 
-Generated long-distance pathways use these same verbs and UI rules. Scout reveals one adjacent stretch as shared geography without moving, but it never replaces the rest of the hand or locks future movement. When an Explorer first opens a route, bounded structured generation may create every hidden waypoint's narrative identity from its deterministic biome and terrain; each identity remains concealed until its Scout edge is revealed. Invalid or disabled generation keeps the deterministic identity, and neither form may change topology or rules. Generated waypoint rooms begin risky and frontier-zoned. Every generated route receives one shared familiarity job and progress clock across its waypoint rooms; Push and Help are strategies on one contribution card and advance that same clock. Filling the clock settles the route into sanctuary rules and unlocks generated landscape art, while the deterministic SVG remains available throughout discovery and as the inference fallback.
+Generated long-distance pathways use these same verbs and UI rules. The
+deployed `scout_v1` reveals one adjacent stretch as shared geography without
+moving. Canonical `scout_v2` keeps that no-movement result but additionally
+binds the exact Lead, legal Anchor or active foray, route/entity version, and
+no-null-commit evidence. Travel is always the later movement commit. When an
+Explorer first opens a route, bounded structured generation may create every
+hidden waypoint's narrative identity from its deterministic biome and terrain;
+each identity remains concealed until its Scout edge is revealed. Invalid or
+disabled generation keeps the deterministic identity, and neither form may
+change topology or rules. Generated waypoint rooms begin risky and
+frontier-zoned. Every generated route receives one shared familiarity job and
+progress clock across its waypoint rooms; Push and Help are strategies on one
+contribution card and advance that same clock. Familiarity is separate from
+route reveal, navigation Anchors, place settlement, shelter, and rest grade.
+Filling the existing familiarity clock settles the route under its own
+versioned contract and unlocks generated landscape art, while the deterministic
+SVG remains available throughout discovery and as the inference fallback.
 
 Project Push resolution is append-only at kernel action `31`. Its recorded input
 contains the direct progress, authored preparation bonus, prepared flag,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.279",
+  "version": "0.0.280",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.279",
+      "version": "0.0.280",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.279",
+  "version": "0.0.280",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -373,6 +373,33 @@ current-format persistence with missing identity fields is rejected. During the
 v12 snapshot upgrade, legacy `route:generated:*` keys are replaced by canonical
 segment keys without changing route lifecycle, discovery, or entity version.
 
+### Threshold state separation
+
+[ADR 0005](../../docs/decisions/0005-thresholds-trails-and-strict-referee.md)
+is the route and threshold product contract. A pack and the compiler must keep
+four questions independent:
+
+- topology says whether a canonical target or edge exists;
+- legibility says who has a Sign, Lead, or shared reveal;
+- access says which Gate method permits this actor, expedition, or the world
+  to Open, Take, use, or Travel; and
+- safety says which Hazard tell, trigger, bypass, and consequence applies.
+
+`discovery: known|scout`, route lifecycle, locked exit flags,
+`revealed_edges`, and route familiarity are compatibility projections of
+different questions; none may be treated as the others. A new authored hidden
+truth uses a versioned bounded Discovery Slot. A stocking table freezes truth
+once, an event table applies Pressure only after relevant committed play, and a
+presentation table changes wording only.
+
+Scout pursues one exact geographic Lead from a legal Anchor or active foray and
+reveals the authorized next segment or target without moving. Travel is the
+separate movement commit. A cairn or worldpack-specific Signal Anchor can make
+a traversed return leg durable and authorize later branching, but cannot
+invent or reveal topology, settle a place, provide shelter, grant a rest grade,
+or create sanctuary. Generated-pathway familiarity and generated-place
+settlement remain separate versioned state.
+
 Snapshots, action-journal records, and stored world events now carry a
 `content_context` containing the mapping version, every relevant canonical
 reference, owning pack version, runtime handle, legacy id when applicable, and

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.279"
+version = "0.0.280"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.279"
+version = "0.0.280"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- accept ADR 0005 as the product and compatibility law for Discovery Slots, Leads, Gates, Hazards, Pressure, Anchors, forays, and cairns
- separate topology, legibility, access, and safety across the RPG Bible, action vocabulary, worldpack route contract, rest contract, actor surface, and epic backlog
- define canonical Scene Notice, Notice, Search, Study, Scout, Travel, Mark, Open, and Take meanings
- inventory existing exits, locks, routes, generated pathways, Leads, items/custody, loot receipts, clocks, rest state, and historical action codes for migration
- add the dependency-ordered threshold implementation backlog
- release version `0.0.280`

## Compatibility

This change adds no runtime or schema state. Existing `scout_v1`, hidden-exit chance, route discovery/unlock, local Lead, loot, clock, rest, cairn, and action records retain their exact historical meaning. Future implementations use append-only procedure and descriptor versions.

## Validation

- documentation build passed, including both new documents
- changed relative Markdown links resolve
- 515 JavaScript tests passed
- worldpack, proof-world, kernel, architecture, and syntax gates passed
- 864 Rust tests passed
- `main.rs` remains at 73,806 lines
- clippy remains at the enforced 254-warning ceiling

Closes #587.
