### PR TITLE
Enforce kernel threshold authority

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.282",
+  "version": "0.0.283",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.282",
+      "version": "0.0.283",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.282",
+  "version": "0.0.283",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/core-c/include/cosy_kernel.h
+++ b/v2/core-c/include/cosy_kernel.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /* Version 9 is reserved by #411 for project-push ABI state. */
-#define CW_KERNEL_VERSION 11u
+#define CW_KERNEL_VERSION 12u
 
 #define CW_MAX_ACTORS 512u
 #define CW_MAX_ITEMS 1024u
@@ -20,6 +20,14 @@ extern "C" {
 #define CW_MAX_EVENTS 256u
 #define CW_MAX_COMBAT_ENCOUNTERS 32u
 #define CW_MAX_COMBAT_PARTICIPANTS 16u
+#define CW_MAX_GATES 32u
+#define CW_MAX_GATE_METHODS 8u
+#define CW_MAX_GATE_PREDICATES 8u
+#define CW_MAX_GATE_METHOD_RECORDS 64u
+#define CW_MAX_GATE_PREDICATE_RECORDS 256u
+#define CW_MAX_GATE_FACTS 8u
+#define CW_MAX_GATE_ACTOR_STATES 128u
+#define CW_MAX_GATE_CLAIMS 128u
 
 #define CW_ITEM_DEFAULT_WEIGHT_TENTHS 10u
 
@@ -58,6 +66,9 @@ typedef enum {
   CW_REASON_COMBAT_ACTION_REQUIRED = 20,
   CW_REASON_CAPACITY_EXCEEDED = 21,
   CW_REASON_REST_GRADE_OVERCLAIMED = 22,
+  CW_REASON_GATE_CLOSED = 23,
+  CW_REASON_STALE_GATE_OFFER = 24,
+  CW_REASON_GATE_CLAIM_CONFLICT = 25,
   CW_REASON_COUNT
 } cw_rejection_reason;
 
@@ -135,6 +146,62 @@ typedef enum {
 } cw_item_recovery;
 
 typedef enum {
+  CW_ITEM_FLAG_NONE = 0,
+  CW_ITEM_FLAG_INERT = 1u << 0
+} cw_item_flags;
+
+typedef enum {
+  CW_GATE_TARGET_NONE = 0,
+  CW_GATE_TARGET_EXIT = 1,
+  CW_GATE_TARGET_CONTAINER = 2
+} cw_gate_target_kind;
+
+typedef enum {
+  CW_GATE_SCOPE_NONE = 0,
+  CW_GATE_SCOPE_WORLD = 1,
+  CW_GATE_SCOPE_ACTOR = 2,
+  CW_GATE_SCOPE_EXPEDITION = 3,
+  CW_GATE_SCOPE_HOLDER = 4
+} cw_gate_scope;
+
+typedef enum {
+  CW_GATE_STATE_NONE = 0,
+  CW_GATE_STATE_CLOSED = 1,
+  CW_GATE_STATE_OPEN = 2,
+  CW_GATE_STATE_BROKEN = 3,
+  CW_GATE_STATE_INERT = 4
+} cw_gate_state;
+
+typedef enum {
+  CW_GATE_COMPAT_NONE = 0,
+  /* A historical CW_EXIT_LOCKED bit remains recorded on the route. Once a
+     descriptor is bound, this gate decision supersedes that bit. */
+  CW_GATE_COMPAT_RECORDED_LOCK = 1
+} cw_gate_compatibility;
+
+typedef enum {
+  CW_GATE_PREDICATE_NONE = 0,
+  CW_GATE_PREDICATE_HELD_ITEM = 1,
+  CW_GATE_PREDICATE_HELD_ITEM_CAPABILITY = 2,
+  CW_GATE_PREDICATE_INSTALLED_ITEM = 3,
+  CW_GATE_PREDICATE_MINIMUM_CHARGES = 4,
+  CW_GATE_PREDICATE_ACTOR_FACT = 5,
+  CW_GATE_PREDICATE_WORLD_FACT = 6
+} cw_gate_predicate_kind;
+
+typedef enum {
+  CW_GATE_TRANSITION_NONE = 0,
+  CW_GATE_TRANSITION_OPEN = 1,
+  CW_GATE_TRANSITION_CLOSE = 2,
+  CW_GATE_TRANSITION_BREAK = 3,
+  CW_GATE_TRANSITION_RELOCK = 4,
+  CW_GATE_TRANSITION_INSTALL = 5,
+  CW_GATE_TRANSITION_REMOVE = 6,
+  CW_GATE_TRANSITION_EXHAUST = 7,
+  CW_GATE_TRANSITION_RENDER_INERT = 8
+} cw_gate_transition_kind;
+
+typedef enum {
   CW_REST_GRADE_NONE = 0,
   CW_REST_GRADE_CAMP = 1,
   CW_REST_GRADE_LODGED = 2,
@@ -209,7 +276,8 @@ typedef enum {
      orchestrator commits this only after bounded recovery attempts fail
      deterministically; it resolves the encounter with no winning side so a
      stuck scene releases its participants instead of retrying forever. */
-  CW_ACTION_COMBAT_ABANDON = 33
+  CW_ACTION_COMBAT_ABANDON = 33,
+  CW_ACTION_GATE_TRANSITION = 34
 } cw_action_kind;
 
 typedef enum {
@@ -256,7 +324,11 @@ typedef enum {
   CW_EVENT_ITEM_REVEALED = 40,
   CW_EVENT_PROJECT_PUSH_RESOLVED = 41,
   /* Event 41 is reserved by #411 for CW_EVENT_PROJECT_PUSH_RESOLVED. */
-  CW_EVENT_ITEM_REFRESHED = 42
+  CW_EVENT_ITEM_REFRESHED = 42,
+  CW_EVENT_GATE_TRANSITION_APPLIED = 43,
+  CW_EVENT_ITEM_INSTALLED = 44,
+  CW_EVENT_ITEM_REMOVED = 45,
+  CW_EVENT_ITEM_RENDERED_INERT = 46
 } cw_event_type;
 
 typedef enum {
@@ -359,6 +431,94 @@ _Static_assert(offsetof(cw_item, location_id) == 24, "cw_item id ABI offset drif
 #endif
 
 typedef struct {
+  cw_id subject_id;
+  cw_id fact_id;
+  uint64_t value;
+  uint64_t source_version;
+} cw_gate_fact;
+
+typedef struct {
+  uint8_t kind;
+  uint8_t amount;
+  uint16_t reserved;
+  uint32_t reserved2;
+  cw_id subject_id;
+  cw_id target_id;
+  cw_id fact_id;
+  uint64_t expected_value;
+} cw_gate_predicate;
+
+typedef struct {
+  cw_id id;
+  size_t predicate_start;
+  size_t predicate_count;
+} cw_gate_method;
+
+typedef struct {
+  cw_id id;
+  size_t predicate_count;
+  cw_gate_predicate predicates[CW_MAX_GATE_PREDICATES];
+} cw_gate_method_definition;
+
+typedef struct {
+  cw_id id;
+  uint64_t version;
+  uint32_t descriptor_version;
+  uint8_t target_kind;
+  uint8_t scope;
+  uint8_t state;
+  uint8_t compatibility;
+  cw_id from_location_id;
+  cw_id to_location_id;
+  cw_id target_item_id;
+  size_t method_start;
+  size_t method_count;
+} cw_gate;
+
+typedef struct {
+  cw_id gate_id;
+  cw_id actor_id;
+  uint64_t version;
+  uint8_t state;
+  uint8_t reserved[7];
+} cw_gate_actor_state;
+
+typedef struct {
+  cw_id id;
+  cw_id gate_id;
+  cw_id actor_id;
+  cw_id item_id;
+  cw_id method_id;
+  uint8_t transition;
+  uint8_t reserved[7];
+} cw_gate_claim;
+
+typedef struct {
+  cw_id gate_id;
+  cw_id method_id;
+  uint64_t gate_version;
+  uint64_t access_revision;
+  uint64_t evidence_digest;
+  uint32_t evidence_mask;
+  uint16_t reason;
+  uint8_t state;
+  uint8_t allowed;
+} cw_gate_decision;
+
+typedef struct {
+  cw_id gate_id;
+  cw_id method_id;
+  cw_id claim_id;
+  uint64_t expected_gate_version;
+  uint64_t expected_access_revision;
+  uint64_t expected_evidence_digest;
+  size_t fact_count;
+  cw_gate_fact facts[CW_MAX_GATE_FACTS];
+  uint8_t transition;
+  uint8_t reserved[7];
+} cw_threshold_input;
+
+typedef struct {
   uint8_t requested_grade;
   uint8_t entitled_grade;
 } cw_rest_input;
@@ -400,6 +560,7 @@ typedef struct {
   uint16_t reserved2;
   cw_project_push_input project_push;
   cw_rest_input rest;
+  cw_threshold_input threshold;
 } cw_action;
 
 typedef struct {
@@ -421,6 +582,15 @@ typedef struct {
   int16_t damage;
   int16_t current_hp;
   uint8_t ability;
+  uint8_t gate_transition;
+  uint16_t reserved;
+  uint32_t gate_evidence_mask;
+  cw_id gate_id;
+  cw_id gate_method_id;
+  cw_id gate_claim_id;
+  uint64_t gate_version;
+  uint64_t access_revision;
+  uint64_t gate_evidence_digest;
 } cw_event;
 
 typedef struct {
@@ -481,6 +651,17 @@ typedef struct {
   cw_evolution_track evolution_tracks[CW_MAX_EVOLUTION_TRACKS];
   size_t combat_encounter_count;
   cw_combat_encounter combat_encounters[CW_MAX_COMBAT_ENCOUNTERS];
+  uint64_t access_revision;
+  size_t gate_count;
+  cw_gate gates[CW_MAX_GATES];
+  size_t gate_method_count;
+  cw_gate_method gate_methods[CW_MAX_GATE_METHOD_RECORDS];
+  size_t gate_predicate_count;
+  cw_gate_predicate gate_predicates[CW_MAX_GATE_PREDICATE_RECORDS];
+  size_t gate_actor_state_count;
+  cw_gate_actor_state gate_actor_states[CW_MAX_GATE_ACTOR_STATES];
+  size_t gate_claim_count;
+  cw_gate_claim gate_claims[CW_MAX_GATE_CLAIMS];
 } cw_world;
 
 void cw_world_init(cw_world *world);
@@ -489,6 +670,9 @@ cw_status cw_world_set_item_profile(cw_world *world, cw_id item_id, uint16_t wei
 cw_status cw_world_set_item_recovery_profile(cw_world *world, cw_id item_id, uint8_t max_charges, uint8_t recovery, uint8_t ready_zone);
 cw_status cw_world_set_item_zone(cw_world *world, cw_id item_id, uint8_t zone, cw_id container_item_id);
 cw_status cw_world_set_evolution_track(cw_world *world, cw_id actor_id, const cw_evolution_requirement *requirements, size_t requirement_count);
+cw_status cw_world_set_gate(cw_world *world, const cw_gate *gate, const cw_gate_method_definition *methods, size_t method_count);
+void cw_world_access_changed(cw_world *world);
+cw_status cw_gate_evaluate(const cw_world *world, cw_id gate_id, cw_id actor_id, const cw_gate_fact *facts, size_t fact_count, cw_id method_id, cw_gate_decision *out_decision);
 /* Deterministic apply without clock advancement. Player-card callers own the tick. */
 cw_status cw_world_apply(cw_world *world, const cw_action *action, uint64_t seed, cw_event_buffer *out_events);
 cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uint64_t seed, uint8_t advance_tick, cw_event_buffer *out_events);

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -132,6 +132,173 @@ static const cw_item *find_item_const(const cw_world *world, cw_id item_id) {
   return 0;
 }
 
+static cw_gate *find_gate(cw_world *world, cw_id gate_id) {
+  for (size_t i = 0; i < world->gate_count; ++i) {
+    if (world->gates[i].id == gate_id) return &world->gates[i];
+  }
+  return 0;
+}
+
+static const cw_gate *find_gate_const(const cw_world *world, cw_id gate_id) {
+  for (size_t i = 0; i < world->gate_count; ++i) {
+    if (world->gates[i].id == gate_id) return &world->gates[i];
+  }
+  return 0;
+}
+
+static const cw_gate *find_exit_gate_const(
+    const cw_world *world,
+    cw_id from_location_id,
+    cw_id to_location_id) {
+  for (size_t i = 0; i < world->gate_count; ++i) {
+    const cw_gate *gate = &world->gates[i];
+    if (gate->target_kind == CW_GATE_TARGET_EXIT
+        && gate->from_location_id == from_location_id
+        && gate->to_location_id == to_location_id) {
+      return gate;
+    }
+  }
+  return 0;
+}
+
+static cw_gate_actor_state *find_gate_actor_state(
+    cw_world *world,
+    cw_id gate_id,
+    cw_id actor_id) {
+  for (size_t i = 0; i < world->gate_actor_state_count; ++i) {
+    cw_gate_actor_state *state = &world->gate_actor_states[i];
+    if (state->gate_id == gate_id && state->actor_id == actor_id) return state;
+  }
+  return 0;
+}
+
+static const cw_gate_actor_state *find_gate_actor_state_const(
+    const cw_world *world,
+    cw_id gate_id,
+    cw_id actor_id) {
+  for (size_t i = 0; i < world->gate_actor_state_count; ++i) {
+    const cw_gate_actor_state *state = &world->gate_actor_states[i];
+    if (state->gate_id == gate_id && state->actor_id == actor_id) return state;
+  }
+  return 0;
+}
+
+static const cw_gate_claim *find_gate_claim_const(const cw_world *world, cw_id claim_id) {
+  for (size_t i = 0; i < world->gate_claim_count; ++i) {
+    if (world->gate_claims[i].id == claim_id) return &world->gate_claims[i];
+  }
+  return 0;
+}
+
+static uint64_t gate_digest_mix(uint64_t digest, uint64_t value) {
+  digest ^= value;
+  digest *= 1099511628211ull;
+  return digest;
+}
+
+static const cw_gate_fact *find_gate_fact(
+    const cw_gate_fact *facts,
+    size_t fact_count,
+    cw_id subject_id,
+    cw_id fact_id) {
+  for (size_t i = 0; i < fact_count; ++i) {
+    if (facts[i].subject_id == subject_id && facts[i].fact_id == fact_id) return &facts[i];
+  }
+  return 0;
+}
+
+static uint8_t effective_gate_state(
+    const cw_world *world,
+    const cw_gate *gate,
+    cw_id actor_id) {
+  if (gate->scope == CW_GATE_SCOPE_ACTOR || gate->scope == CW_GATE_SCOPE_HOLDER) {
+    const cw_gate_actor_state *state =
+        find_gate_actor_state_const(world, gate->id, actor_id);
+    if (state) return state->state;
+  }
+  return gate->state;
+}
+
+static int gate_predicate_holds(
+    const cw_world *world,
+    const cw_gate_predicate *predicate,
+    cw_id actor_id,
+    const cw_gate_fact *facts,
+    size_t fact_count,
+    uint64_t *digest) {
+  int holds = 0;
+  uint64_t observed = 0;
+  const cw_item *item = 0;
+  const cw_gate_fact *fact = 0;
+  switch (predicate->kind) {
+    case CW_GATE_PREDICATE_HELD_ITEM:
+      item = find_item_const(world, predicate->subject_id);
+      holds = item && item->holder_actor_id == actor_id
+          && !(item->reserved & CW_ITEM_FLAG_INERT);
+      observed = item ? item->holder_actor_id : 0;
+      break;
+    case CW_GATE_PREDICATE_HELD_ITEM_CAPABILITY:
+      for (size_t i = 0; i < world->item_count; ++i) {
+        const cw_item *candidate = &world->items[i];
+        if (candidate->holder_actor_id != actor_id
+            || (candidate->reserved & CW_ITEM_FLAG_INERT)) continue;
+        fact = find_gate_fact(
+            facts,
+            fact_count,
+            candidate->id,
+            predicate->fact_id);
+        if (fact && fact->value == predicate->expected_value) {
+          holds = 1;
+          observed = gate_digest_mix(candidate->id, fact->source_version);
+          break;
+        }
+      }
+      break;
+    case CW_GATE_PREDICATE_INSTALLED_ITEM:
+      item = find_item_const(world, predicate->subject_id);
+      holds = item && item->holder_actor_id == 0
+          && item->zone == CW_CARD_ZONE_INSTALLED
+          && item->location_id == predicate->target_id
+          && !(item->reserved & CW_ITEM_FLAG_INERT);
+      observed = item
+          ? gate_digest_mix(item->location_id, gate_digest_mix(item->zone, item->reserved))
+          : 0;
+      break;
+    case CW_GATE_PREDICATE_MINIMUM_CHARGES:
+      item = find_item_const(world, predicate->subject_id);
+      holds = item && item->charges >= predicate->amount
+          && !(item->reserved & CW_ITEM_FLAG_INERT);
+      observed = item ? item->charges : 0;
+      break;
+    case CW_GATE_PREDICATE_ACTOR_FACT:
+      fact = find_gate_fact(facts, fact_count, actor_id, predicate->fact_id);
+      holds = fact && fact->value == predicate->expected_value;
+      observed = fact
+          ? gate_digest_mix(fact->value, fact->source_version)
+          : 0;
+      break;
+    case CW_GATE_PREDICATE_WORLD_FACT:
+      fact = find_gate_fact(facts, fact_count, predicate->subject_id, predicate->fact_id);
+      holds = fact && fact->value == predicate->expected_value;
+      observed = fact
+          ? gate_digest_mix(fact->value, fact->source_version)
+          : 0;
+      break;
+    default:
+      holds = 0;
+      observed = UINT64_MAX;
+      break;
+  }
+  *digest = gate_digest_mix(*digest, predicate->kind);
+  *digest = gate_digest_mix(*digest, predicate->subject_id);
+  *digest = gate_digest_mix(*digest, predicate->target_id);
+  *digest = gate_digest_mix(*digest, predicate->fact_id);
+  *digest = gate_digest_mix(*digest, predicate->expected_value);
+  *digest = gate_digest_mix(*digest, observed);
+  *digest = gate_digest_mix(*digest, (uint64_t)holds);
+  return holds;
+}
+
 static cw_evolution_track *find_evolution_track(cw_world *world, cw_id actor_id) {
   for (size_t i = 0; i < world->evolution_track_count; ++i) {
     if (world->evolution_tracks[i].actor_id == actor_id) return &world->evolution_tracks[i];
@@ -185,6 +352,23 @@ static int append_event(cw_world *world, cw_event_buffer *buffer, uint8_t type) 
   return 1;
 }
 
+static void decorate_gate_event(
+    cw_event *event,
+    const cw_gate_decision *decision,
+    const cw_threshold_input *input) {
+  if (!event || !decision) return;
+  event->gate_id = decision->gate_id;
+  event->gate_method_id = decision->method_id;
+  event->gate_version = decision->gate_version;
+  event->access_revision = decision->access_revision;
+  event->gate_evidence_digest = decision->evidence_digest;
+  event->gate_evidence_mask = decision->evidence_mask;
+  if (input) {
+    event->gate_claim_id = input->claim_id;
+    event->gate_transition = input->transition;
+  }
+}
+
 static cw_status reject(cw_world *world, cw_event_buffer *buffer, const cw_action *action, uint16_t reason) {
   append_event(world, buffer, CW_EVENT_RULE_REJECTED);
   if (buffer && buffer->count > 0) {
@@ -198,6 +382,13 @@ static cw_status reject(cw_world *world, cw_event_buffer *buffer, const cw_actio
       event->destination_location_id = action->destination_location_id;
       event->content_id = action->content_id;
       event->item_id = action->item_id;
+      event->gate_id = action->threshold.gate_id;
+      event->gate_method_id = action->threshold.method_id;
+      event->gate_claim_id = action->threshold.claim_id;
+      event->gate_version = action->threshold.expected_gate_version;
+      event->access_revision = action->threshold.expected_access_revision;
+      event->gate_evidence_digest = action->threshold.expected_evidence_digest;
+      event->gate_transition = action->threshold.transition;
     }
   }
   return CW_ERR_RULE;
@@ -371,6 +562,201 @@ void cw_world_init(cw_world *world) {
   world->version = CW_KERNEL_VERSION;
   world->tick = 1;
   world->next_event_seq = 1;
+  world->access_revision = 1;
+}
+
+void cw_world_access_changed(cw_world *world) {
+  if (!world) return;
+  world->access_revision = world->access_revision == UINT64_MAX
+      ? UINT64_MAX
+      : world->access_revision + 1;
+}
+
+cw_status cw_world_set_gate(
+    cw_world *world,
+    const cw_gate *gate,
+    const cw_gate_method_definition *methods,
+    size_t method_count) {
+  if (!world || !gate || !gate->id || !gate->descriptor_version
+      || gate->version == 0
+      || gate->target_kind < CW_GATE_TARGET_EXIT
+      || gate->target_kind > CW_GATE_TARGET_CONTAINER
+      || gate->scope < CW_GATE_SCOPE_WORLD
+      || gate->scope > CW_GATE_SCOPE_HOLDER
+      || gate->state < CW_GATE_STATE_CLOSED
+      || gate->state > CW_GATE_STATE_INERT
+      || gate->compatibility > CW_GATE_COMPAT_RECORDED_LOCK
+      || !methods || method_count == 0
+      || method_count > CW_MAX_GATE_METHODS) {
+    return CW_ERR_INVALID;
+  }
+  if (gate->target_kind == CW_GATE_TARGET_EXIT) {
+    const cw_exit *exit =
+        find_exit_const(world, gate->from_location_id, gate->to_location_id);
+    if (!exit || gate->target_item_id) return CW_ERR_NOT_FOUND;
+    if (gate->compatibility == CW_GATE_COMPAT_RECORDED_LOCK
+        && !(exit->flags & CW_EXIT_LOCKED)) {
+      return CW_ERR_RULE;
+    }
+  } else {
+    if (!gate->target_item_id || !find_item_const(world, gate->target_item_id)
+        || gate->from_location_id || gate->to_location_id
+        || gate->compatibility != CW_GATE_COMPAT_NONE) {
+      return CW_ERR_NOT_FOUND;
+    }
+  }
+  size_t predicate_count = 0;
+  for (size_t method_index = 0; method_index < method_count; ++method_index) {
+    const cw_gate_method_definition *method = &methods[method_index];
+    if (!method->id || method->predicate_count > CW_MAX_GATE_PREDICATES) {
+      return CW_ERR_INVALID;
+    }
+    predicate_count += method->predicate_count;
+    for (size_t predicate_index = 0;
+         predicate_index < method->predicate_count;
+         ++predicate_index) {
+      const cw_gate_predicate *predicate = &method->predicates[predicate_index];
+      if (predicate->kind < CW_GATE_PREDICATE_HELD_ITEM
+          || predicate->kind > CW_GATE_PREDICATE_WORLD_FACT
+          || ((predicate->kind == CW_GATE_PREDICATE_HELD_ITEM
+                  || predicate->kind == CW_GATE_PREDICATE_INSTALLED_ITEM
+                  || predicate->kind == CW_GATE_PREDICATE_MINIMUM_CHARGES)
+              && !predicate->subject_id)
+          || (predicate->kind == CW_GATE_PREDICATE_MINIMUM_CHARGES
+              && !predicate->amount)
+          || ((predicate->kind == CW_GATE_PREDICATE_HELD_ITEM_CAPABILITY
+                  || predicate->kind == CW_GATE_PREDICATE_ACTOR_FACT
+                  || predicate->kind == CW_GATE_PREDICATE_WORLD_FACT)
+              && !predicate->fact_id)) {
+        return CW_ERR_INVALID;
+      }
+    }
+  }
+  if (world->gate_method_count + method_count > CW_MAX_GATE_METHOD_RECORDS
+      || world->gate_predicate_count + predicate_count > CW_MAX_GATE_PREDICATE_RECORDS) {
+    return CW_ERR_FULL;
+  }
+  cw_gate *target = find_gate(world, gate->id);
+  if (!target) {
+    if (world->gate_count >= CW_MAX_GATES) return CW_ERR_FULL;
+    target = &world->gates[world->gate_count++];
+  } else if (target->version > gate->version) {
+    return CW_ERR_RULE;
+  }
+  *target = *gate;
+  target->method_start = world->gate_method_count;
+  target->method_count = method_count;
+  for (size_t method_index = 0; method_index < method_count; ++method_index) {
+    const cw_gate_method_definition *definition = &methods[method_index];
+    cw_gate_method *method = &world->gate_methods[world->gate_method_count++];
+    memset(method, 0, sizeof(*method));
+    method->id = definition->id;
+    method->predicate_start = world->gate_predicate_count;
+    method->predicate_count = definition->predicate_count;
+    for (size_t predicate_index = 0;
+         predicate_index < definition->predicate_count;
+         ++predicate_index) {
+      world->gate_predicates[world->gate_predicate_count++] =
+          definition->predicates[predicate_index];
+    }
+  }
+  world->access_revision = world->access_revision == UINT64_MAX
+      ? UINT64_MAX
+      : world->access_revision + 1;
+  return CW_OK;
+}
+
+cw_status cw_gate_evaluate(
+    const cw_world *world,
+    cw_id gate_id,
+    cw_id actor_id,
+    const cw_gate_fact *facts,
+    size_t fact_count,
+    cw_id method_id,
+    cw_gate_decision *out_decision) {
+  if (!world || !gate_id || !actor_id || !out_decision
+      || fact_count > CW_MAX_GATE_FACTS || (fact_count && !facts)) {
+    return CW_ERR_INVALID;
+  }
+  memset(out_decision, 0, sizeof(*out_decision));
+  const cw_gate *gate = find_gate_const(world, gate_id);
+  if (!gate) return CW_ERR_NOT_FOUND;
+  if (gate->method_start > world->gate_method_count
+      || gate->method_count > world->gate_method_count - gate->method_start) {
+    return CW_ERR_INVALID;
+  }
+  const cw_actor *actor = find_actor_const(world, actor_id);
+  if (!actor) return CW_ERR_NOT_FOUND;
+
+  uint8_t state = effective_gate_state(world, gate, actor_id);
+  uint64_t digest = 1469598103934665603ull;
+  digest = gate_digest_mix(digest, gate->id);
+  digest = gate_digest_mix(digest, gate->version);
+  digest = gate_digest_mix(digest, gate->descriptor_version);
+  digest = gate_digest_mix(digest, world->access_revision);
+  digest = gate_digest_mix(digest, actor_id);
+  digest = gate_digest_mix(digest, actor->location_id);
+  digest = gate_digest_mix(digest, state);
+
+  out_decision->gate_id = gate->id;
+  out_decision->gate_version = gate->version;
+  out_decision->access_revision = world->access_revision;
+  out_decision->state = state;
+  if (state == CW_GATE_STATE_OPEN || state == CW_GATE_STATE_BROKEN) {
+    out_decision->allowed = 1;
+    out_decision->evidence_digest = gate_digest_mix(digest, 1);
+    return CW_OK;
+  }
+  if (state == CW_GATE_STATE_INERT || !actor_is_active(actor)) {
+    out_decision->reason = CW_REASON_GATE_CLOSED;
+    out_decision->evidence_digest = gate_digest_mix(digest, 0);
+    return CW_OK;
+  }
+
+  for (size_t method_index = 0; method_index < gate->method_count; ++method_index) {
+    const cw_gate_method *method =
+        &world->gate_methods[gate->method_start + method_index];
+    if (method->predicate_start > world->gate_predicate_count
+        || method->predicate_count
+            > world->gate_predicate_count - method->predicate_start) {
+      return CW_ERR_INVALID;
+    }
+    if (method_id && method->id != method_id) continue;
+    uint64_t method_digest = gate_digest_mix(digest, method->id);
+    uint32_t evidence_mask = 0;
+    int allowed = 1;
+    for (size_t predicate_index = 0;
+         predicate_index < method->predicate_count;
+         ++predicate_index) {
+      int holds = gate_predicate_holds(
+          world,
+          &world->gate_predicates[method->predicate_start + predicate_index],
+          actor_id,
+          facts,
+          fact_count,
+          &method_digest);
+      if (holds) evidence_mask |= (uint32_t)1u << predicate_index;
+      else allowed = 0;
+    }
+    if (allowed) {
+      out_decision->method_id = method->id;
+      out_decision->evidence_mask = evidence_mask;
+      out_decision->allowed = 1;
+      out_decision->evidence_digest = gate_digest_mix(method_digest, 1);
+      return CW_OK;
+    }
+    if (method_id) {
+      out_decision->method_id = method->id;
+      out_decision->evidence_mask = evidence_mask;
+      out_decision->evidence_digest = gate_digest_mix(method_digest, 0);
+      out_decision->reason = CW_REASON_GATE_CLOSED;
+      return CW_OK;
+    }
+    digest = gate_digest_mix(digest, method_digest);
+  }
+  out_decision->reason = CW_REASON_GATE_CLOSED;
+  out_decision->evidence_digest = gate_digest_mix(digest, 0);
+  return CW_OK;
 }
 
 cw_status cw_world_set_item_profile(
@@ -754,7 +1140,52 @@ static cw_status apply_move(cw_world *world, const cw_action *action, cw_event_b
     return CW_ERR_RULE;
   }
 
-  if (exit->flags & CW_EXIT_LOCKED) {
+  cw_gate_decision gate_decision = {0};
+  const cw_gate *gate =
+      find_exit_gate_const(world, actor->location_id, destination_id);
+  if (gate) {
+    if (action->threshold.gate_id != gate->id
+        || cw_gate_evaluate(
+               world,
+               gate->id,
+               actor->id,
+               action->threshold.facts,
+               action->threshold.fact_count,
+               action->threshold.method_id,
+               &gate_decision) != CW_OK
+        || action->threshold.expected_gate_version != gate_decision.gate_version
+        || action->threshold.expected_access_revision != gate_decision.access_revision
+        || action->threshold.expected_evidence_digest != gate_decision.evidence_digest) {
+      append_event(world, out_events, CW_EVENT_MOVE_BLOCKED);
+      if (out_events && out_events->count > 0) {
+        cw_event *event = &out_events->events[out_events->count - 1];
+        event->success = 0;
+        event->reason = CW_REASON_STALE_GATE_OFFER;
+        event->actor_id = actor->id;
+        event->location_id = actor->location_id;
+        event->destination_location_id = destination_id;
+        decorate_gate_event(event, &gate_decision, &action->threshold);
+      }
+      return CW_ERR_RULE;
+    }
+    if (!gate_decision.allowed
+        || ((exit->flags & CW_EXIT_LOCKED)
+            && gate->compatibility != CW_GATE_COMPAT_RECORDED_LOCK)) {
+      append_event(world, out_events, CW_EVENT_MOVE_BLOCKED);
+      if (out_events && out_events->count > 0) {
+        cw_event *event = &out_events->events[out_events->count - 1];
+        event->success = 0;
+        event->reason = gate_decision.allowed
+            ? CW_REASON_EXIT_LOCKED
+            : CW_REASON_GATE_CLOSED;
+        event->actor_id = actor->id;
+        event->location_id = actor->location_id;
+        event->destination_location_id = destination_id;
+        decorate_gate_event(event, &gate_decision, &action->threshold);
+      }
+      return CW_ERR_RULE;
+    }
+  } else if (exit->flags & CW_EXIT_LOCKED) {
     append_event(world, out_events, CW_EVENT_MOVE_BLOCKED);
     if (out_events && out_events->count > 0) {
       cw_event *event = &out_events->events[out_events->count - 1];
@@ -777,6 +1208,7 @@ static cw_status apply_move(cw_world *world, const cw_action *action, cw_event_b
     event->actor_id = actor->id;
     event->location_id = from_location_id;
     event->destination_location_id = destination_id;
+    decorate_gate_event(event, gate ? &gate_decision : 0, &action->threshold);
   }
   return CW_OK;
 }
@@ -1344,6 +1776,12 @@ static cw_status apply_unlock_exit(cw_world *world, const cw_action *action, cw_
   }
   cw_exit *exit = find_exit(world, action->location_id, action->destination_location_id);
   if (!exit) return reject(world, out_events, action, CW_REASON_NO_EXIT);
+  if (find_exit_gate_const(
+          world,
+          action->location_id,
+          action->destination_location_id)) {
+    return reject(world, out_events, action, CW_REASON_STALE_GATE_OFFER);
+  }
   if (!(exit->flags & CW_EXIT_LOCKED)) {
     return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
   }
@@ -1357,6 +1795,228 @@ static cw_status apply_unlock_exit(cw_world *world, const cw_action *action, cw_
     event->location_id = action->location_id;
     event->destination_location_id = action->destination_location_id;
   }
+  return CW_OK;
+}
+
+static int gate_transition_requires_method(uint8_t transition) {
+  return transition == CW_GATE_TRANSITION_OPEN
+      || transition == CW_GATE_TRANSITION_BREAK
+      || transition == CW_GATE_TRANSITION_INSTALL
+      || transition == CW_GATE_TRANSITION_EXHAUST
+      || transition == CW_GATE_TRANSITION_RENDER_INERT;
+}
+
+static uint8_t gate_transition_state(uint8_t transition) {
+  switch (transition) {
+    case CW_GATE_TRANSITION_OPEN: return CW_GATE_STATE_OPEN;
+    case CW_GATE_TRANSITION_CLOSE:
+    case CW_GATE_TRANSITION_RELOCK: return CW_GATE_STATE_CLOSED;
+    case CW_GATE_TRANSITION_BREAK: return CW_GATE_STATE_BROKEN;
+    default: return CW_GATE_STATE_NONE;
+  }
+}
+
+static cw_status set_effective_gate_state(
+    cw_world *world,
+    cw_gate *gate,
+    cw_id actor_id,
+    uint8_t state) {
+  if (!state) return CW_OK;
+  if (gate->scope == CW_GATE_SCOPE_ACTOR || gate->scope == CW_GATE_SCOPE_HOLDER) {
+    cw_gate_actor_state *actor_state =
+        find_gate_actor_state(world, gate->id, actor_id);
+    if (!actor_state) {
+      if (world->gate_actor_state_count >= CW_MAX_GATE_ACTOR_STATES) return CW_ERR_FULL;
+      actor_state = &world->gate_actor_states[world->gate_actor_state_count++];
+      memset(actor_state, 0, sizeof(*actor_state));
+      actor_state->gate_id = gate->id;
+      actor_state->actor_id = actor_id;
+      actor_state->version = 1;
+    } else {
+      actor_state->version = actor_state->version == UINT64_MAX
+          ? UINT64_MAX
+          : actor_state->version + 1;
+    }
+    actor_state->state = state;
+  } else {
+    gate->state = state;
+  }
+  gate->version = gate->version == UINT64_MAX ? UINT64_MAX : gate->version + 1;
+  return CW_OK;
+}
+
+static cw_status apply_gate_transition(
+    cw_world *world,
+    const cw_action *action,
+    cw_event_buffer *out_events) {
+  cw_actor *actor = 0;
+  cw_status status = require_active_actor(world, action, out_events, &actor);
+  if (status != CW_OK) return status;
+  const cw_threshold_input *input = &action->threshold;
+  if (!input->gate_id || !input->claim_id
+      || input->transition < CW_GATE_TRANSITION_OPEN
+      || input->transition > CW_GATE_TRANSITION_RENDER_INERT
+      || input->fact_count > CW_MAX_GATE_FACTS) {
+    return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
+  }
+  cw_gate *gate = find_gate(world, input->gate_id);
+  if (!gate) return reject(world, out_events, action, CW_REASON_TARGET_NOT_FOUND);
+
+  const cw_gate_claim *existing = find_gate_claim_const(world, input->claim_id);
+  if (existing) {
+    if (existing->gate_id == gate->id
+        && existing->actor_id == actor->id
+        && existing->item_id == action->item_id
+        && existing->method_id == input->method_id
+        && existing->transition == input->transition) {
+      return CW_OK;
+    }
+    return reject(world, out_events, action, CW_REASON_GATE_CLAIM_CONFLICT);
+  }
+
+  cw_gate_decision decision = {0};
+  if (cw_gate_evaluate(
+          world,
+          gate->id,
+          actor->id,
+          input->facts,
+          input->fact_count,
+          input->method_id,
+          &decision) != CW_OK
+      || input->expected_gate_version != decision.gate_version
+      || input->expected_access_revision != decision.access_revision
+      || input->expected_evidence_digest != decision.evidence_digest) {
+    return reject(world, out_events, action, CW_REASON_STALE_GATE_OFFER);
+  }
+  if (gate_transition_requires_method(input->transition)
+      && (!decision.allowed || !input->method_id
+          || decision.method_id != input->method_id)) {
+    return reject(world, out_events, action, CW_REASON_GATE_CLOSED);
+  }
+
+  uint8_t resulting_state = gate_transition_state(input->transition);
+  uint8_t current_state = effective_gate_state(world, gate, actor->id);
+  if (resulting_state && current_state == resulting_state) {
+    return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
+  }
+  cw_item *item = action->item_id ? find_item(world, action->item_id) : 0;
+  switch (input->transition) {
+    case CW_GATE_TRANSITION_INSTALL:
+      if (!item || item->holder_actor_id != actor->id
+          || (item->reserved & CW_ITEM_FLAG_INERT)) {
+        return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
+      }
+      break;
+    case CW_GATE_TRANSITION_REMOVE:
+      if (!item || item->holder_actor_id != 0
+          || item->zone != CW_CARD_ZONE_INSTALLED
+          || item->location_id != actor->location_id
+          || !actor_can_exchange(world, actor, 0, item)) {
+        return reject(
+            world,
+            out_events,
+            action,
+            item && item->location_id == actor->location_id
+                ? CW_REASON_CAPACITY_EXCEEDED
+                : CW_REASON_ITEM_NOT_AVAILABLE);
+      }
+      break;
+    case CW_GATE_TRANSITION_EXHAUST:
+    case CW_GATE_TRANSITION_RENDER_INERT:
+      if (!item || item->charges == 0
+          || (item->holder_actor_id != actor->id
+              && !(item->holder_actor_id == 0
+                  && item->location_id == actor->location_id
+                  && item->zone == CW_CARD_ZONE_INSTALLED))) {
+        return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
+      }
+      break;
+    default:
+      if (action->item_id) {
+        return reject(world, out_events, action, CW_REASON_INVALID_ACTION);
+      }
+      break;
+  }
+  if (world->gate_claim_count >= CW_MAX_GATE_CLAIMS
+      || ((gate->scope == CW_GATE_SCOPE_ACTOR || gate->scope == CW_GATE_SCOPE_HOLDER)
+          && resulting_state
+          && !find_gate_actor_state(world, gate->id, actor->id)
+          && world->gate_actor_state_count >= CW_MAX_GATE_ACTOR_STATES)) {
+    return reject(world, out_events, action, CW_REASON_CAPACITY_EXCEEDED);
+  }
+
+  cw_gate_claim *claim = &world->gate_claims[world->gate_claim_count++];
+  memset(claim, 0, sizeof(*claim));
+  claim->id = input->claim_id;
+  claim->gate_id = gate->id;
+  claim->actor_id = actor->id;
+  claim->item_id = action->item_id;
+  claim->method_id = input->method_id;
+  claim->transition = input->transition;
+
+  status = set_effective_gate_state(
+      world,
+      gate,
+      actor->id,
+      resulting_state);
+  if (status != CW_OK) return status;
+
+  uint8_t item_event_type = CW_EVENT_NONE;
+  switch (input->transition) {
+    case CW_GATE_TRANSITION_INSTALL:
+      item->holder_actor_id = 0;
+      item->location_id = actor->location_id;
+      item->held_since_tick = 0;
+      item->zone = CW_CARD_ZONE_INSTALLED;
+      item->container_item_id = 0;
+      item_event_type = CW_EVENT_ITEM_INSTALLED;
+      break;
+    case CW_GATE_TRANSITION_REMOVE:
+      item->holder_actor_id = actor->id;
+      item->location_id = 0;
+      item->held_since_tick = world->tick;
+      item->zone = CW_CARD_ZONE_CARRIED;
+      item->container_item_id = 0;
+      item_event_type = CW_EVENT_ITEM_REMOVED;
+      break;
+    case CW_GATE_TRANSITION_EXHAUST:
+      item->charges = 0;
+      exhaust_item(item);
+      item_event_type = CW_EVENT_ITEM_EXHAUSTED;
+      break;
+    case CW_GATE_TRANSITION_RENDER_INERT:
+      item->charges = 0;
+      item->reserved |= CW_ITEM_FLAG_INERT;
+      item_event_type = CW_EVENT_ITEM_RENDERED_INERT;
+      break;
+    default:
+      break;
+  }
+
+  append_event(world, out_events, CW_EVENT_GATE_TRANSITION_APPLIED);
+  if (out_events && out_events->count > 0) {
+    cw_event *event = &out_events->events[out_events->count - 1];
+    event->success = 1;
+    event->actor_id = actor->id;
+    event->location_id = actor->location_id;
+    event->destination_location_id = gate->to_location_id;
+    event->item_id = action->item_id;
+    decorate_gate_event(event, &decision, input);
+  }
+  if (item_event_type != CW_EVENT_NONE) {
+    append_event(world, out_events, item_event_type);
+    if (out_events && out_events->count > 0) {
+      cw_event *event = &out_events->events[out_events->count - 1];
+      event->success = 1;
+      event->actor_id = actor->id;
+      event->location_id = actor->location_id;
+      event->item_id = action->item_id;
+      decorate_gate_event(event, &decision, input);
+    }
+  }
+  world->access_revision = world->access_revision == UINT64_MAX
+      ? UINT64_MAX
+      : world->access_revision + 1;
   return CW_OK;
 }
 
@@ -1792,7 +2452,32 @@ static cw_status apply_flee(cw_world *world, const cw_action *action, cw_event_b
   if (!exit) {
     return reject(world, out_events, action, CW_REASON_NO_EXIT);
   }
-  if (exit->flags & CW_EXIT_LOCKED) {
+  cw_gate_decision gate_decision = {0};
+  const cw_gate *gate =
+      find_exit_gate_const(world, actor->location_id, destination_id);
+  if (gate) {
+    if (action->threshold.gate_id != gate->id
+        || cw_gate_evaluate(
+               world,
+               gate->id,
+               actor->id,
+               action->threshold.facts,
+               action->threshold.fact_count,
+               action->threshold.method_id,
+               &gate_decision) != CW_OK
+        || action->threshold.expected_gate_version != gate_decision.gate_version
+        || action->threshold.expected_access_revision != gate_decision.access_revision
+        || action->threshold.expected_evidence_digest != gate_decision.evidence_digest) {
+      return reject(world, out_events, action, CW_REASON_STALE_GATE_OFFER);
+    }
+    if (!gate_decision.allowed) {
+      return reject(world, out_events, action, CW_REASON_GATE_CLOSED);
+    }
+    if ((exit->flags & CW_EXIT_LOCKED)
+        && gate->compatibility != CW_GATE_COMPAT_RECORDED_LOCK) {
+      return reject(world, out_events, action, CW_REASON_EXIT_LOCKED);
+    }
+  } else if (exit->flags & CW_EXIT_LOCKED) {
     return reject(world, out_events, action, CW_REASON_EXIT_LOCKED);
   }
 
@@ -1807,6 +2492,7 @@ static cw_status apply_flee(cw_world *world, const cw_action *action, cw_event_b
     event->actor_id = actor->id;
     event->location_id = from_location_id;
     event->destination_location_id = destination_id;
+    decorate_gate_event(event, gate ? &gate_decision : 0, &action->threshold);
   }
   return CW_OK;
 }
@@ -2315,7 +3001,34 @@ static cw_status apply_combat_escape(cw_world *world, const cw_action *action, c
   }
   const cw_exit *exit = find_exit_const(world, actor->location_id, destination_id);
   if (!exit) return reject(world, out_events, action, CW_REASON_NO_EXIT);
-  if (exit->flags & CW_EXIT_LOCKED) return reject(world, out_events, action, CW_REASON_EXIT_LOCKED);
+  cw_gate_decision gate_decision = {0};
+  const cw_gate *gate =
+      find_exit_gate_const(world, actor->location_id, destination_id);
+  if (gate) {
+    if (action->threshold.gate_id != gate->id
+        || cw_gate_evaluate(
+               world,
+               gate->id,
+               actor->id,
+               action->threshold.facts,
+               action->threshold.fact_count,
+               action->threshold.method_id,
+               &gate_decision) != CW_OK
+        || action->threshold.expected_gate_version != gate_decision.gate_version
+        || action->threshold.expected_access_revision != gate_decision.access_revision
+        || action->threshold.expected_evidence_digest != gate_decision.evidence_digest) {
+      return reject(world, out_events, action, CW_REASON_STALE_GATE_OFFER);
+    }
+    if (!gate_decision.allowed) {
+      return reject(world, out_events, action, CW_REASON_GATE_CLOSED);
+    }
+    if ((exit->flags & CW_EXIT_LOCKED)
+        && gate->compatibility != CW_GATE_COMPAT_RECORDED_LOCK) {
+      return reject(world, out_events, action, CW_REASON_EXIT_LOCKED);
+    }
+  } else if (exit->flags & CW_EXIT_LOCKED) {
+    return reject(world, out_events, action, CW_REASON_EXIT_LOCKED);
+  }
 
   cw_id from_location_id = actor->location_id;
   actor->location_id = destination_id;
@@ -2330,6 +3043,7 @@ static cw_status apply_combat_escape(cw_world *world, const cw_action *action, c
     event->location_id = from_location_id;
     event->destination_location_id = destination_id;
     event->content_id = encounter->id;
+    decorate_gate_event(event, gate ? &gate_decision : 0, &action->threshold);
   }
   finish_or_advance_combat_turn(world, encounter, action, out_events);
   return CW_OK;
@@ -2338,6 +3052,25 @@ static cw_status apply_combat_escape(cw_world *world, const cw_action *action, c
 cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uint64_t seed, uint8_t advance_tick, cw_event_buffer *out_events) {
   if (!world || !action) return CW_ERR_INVALID;
   if (out_events) memset(out_events, 0, sizeof(*out_events));
+  if (action->kind == CW_ACTION_GATE_TRANSITION
+      && action->threshold.claim_id) {
+    const cw_gate_claim *existing =
+        find_gate_claim_const(world, action->threshold.claim_id);
+    if (existing) {
+      if (existing->gate_id == action->threshold.gate_id
+          && existing->actor_id == action->actor_id
+          && existing->item_id == action->item_id
+          && existing->method_id == action->threshold.method_id
+          && existing->transition == action->threshold.transition) {
+        return CW_OK;
+      }
+      return reject(
+          world,
+          out_events,
+          action,
+          CW_REASON_GATE_CLAIM_CONFLICT);
+    }
+  }
   cw_combat_encounter *active_encounter = find_active_combat_encounter_for_actor(world, action->actor_id);
   if (active_encounter
       && action->kind != CW_ACTION_SAY
@@ -2458,16 +3191,47 @@ cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uin
     case CW_ACTION_REVEAL_ITEM:
       status = apply_reveal_item(world, action, out_events);
       break;
+    case CW_ACTION_GATE_TRANSITION:
+      status = apply_gate_transition(world, action, out_events);
+      break;
     default:
       status = reject(world, out_events, action, CW_REASON_INVALID_ACTION);
       break;
   }
   if (status != CW_OK && advance_tick) world->tick = previous_tick;
+  if (status == CW_OK && action->kind != CW_ACTION_GATE_TRANSITION) {
+    world->access_revision = world->access_revision == UINT64_MAX
+        ? UINT64_MAX
+        : world->access_revision + 1;
+  }
   return status;
 }
 
 cw_status cw_world_apply(cw_world *world, const cw_action *action, uint64_t seed, cw_event_buffer *out_events) {
   return cw_world_apply_with_tick(world, action, seed, 0, out_events);
+}
+
+static int actor_can_cross_exit_without_external_facts(
+    const cw_world *world,
+    const cw_actor *actor,
+    const cw_exit *exit) {
+  const cw_gate *gate =
+      find_exit_gate_const(world, exit->from_location_id, exit->to_location_id);
+  if (!gate) return !(exit->flags & CW_EXIT_LOCKED);
+  if ((exit->flags & CW_EXIT_LOCKED)
+      && gate->compatibility != CW_GATE_COMPAT_RECORDED_LOCK) {
+    return 0;
+  }
+  cw_gate_decision decision = {0};
+  return cw_gate_evaluate(
+             world,
+             gate->id,
+             actor->id,
+             0,
+             0,
+             0,
+             &decision) == CW_OK
+      && decision.allowed;
 }
 
 cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_offers *out_offers) {
@@ -2486,7 +3250,8 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
       out_offers->option_flags = CW_OFFER_ATTACK | CW_OFFER_DEFEND;
       for (size_t exit_index = 0; exit_index < world->exit_count; ++exit_index) {
         const cw_exit *exit = &world->exits[exit_index];
-        if (exit->from_location_id == actor->location_id && !(exit->flags & CW_EXIT_LOCKED)) {
+        if (exit->from_location_id == actor->location_id
+            && actor_can_cross_exit_without_external_facts(world, actor, exit)) {
           out_offers->option_flags |= CW_OFFER_FLEE;
           break;
         }
@@ -2511,7 +3276,8 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
       out_offers->option_flags |= CW_OFFER_ATTACK | CW_OFFER_DEFEND;
       for (size_t i = 0; i < world->exit_count; ++i) {
         const cw_exit *exit = &world->exits[i];
-        if (exit->from_location_id == actor->location_id && !(exit->flags & CW_EXIT_LOCKED)) {
+        if (exit->from_location_id == actor->location_id
+            && actor_can_cross_exit_without_external_facts(world, actor, exit)) {
           out_offers->option_flags |= CW_OFFER_FLEE;
           break;
         }
@@ -2521,7 +3287,8 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
 
   for (size_t i = 0; i < world->exit_count; ++i) {
     const cw_exit *exit = &world->exits[i];
-    if (exit->from_location_id == actor->location_id && !(exit->flags & CW_EXIT_LOCKED)) {
+    if (exit->from_location_id == actor->location_id
+        && actor_can_cross_exit_without_external_facts(world, actor, exit)) {
       out_offers->option_flags |= CW_OFFER_MOVE;
       break;
     }
@@ -2630,6 +3397,10 @@ const char *cw_event_type_name(uint8_t type) {
     case CW_EVENT_ITEM_REVEALED: return "item.revealed";
     case CW_EVENT_PROJECT_PUSH_RESOLVED: return "project.push.resolved";
     case CW_EVENT_ITEM_REFRESHED: return "item.refreshed";
+    case CW_EVENT_GATE_TRANSITION_APPLIED: return "gate.transition.applied";
+    case CW_EVENT_ITEM_INSTALLED: return "item.installed";
+    case CW_EVENT_ITEM_REMOVED: return "item.removed";
+    case CW_EVENT_ITEM_RENDERED_INERT: return "item.rendered_inert";
     default: return "unknown";
   }
 }

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -29,6 +29,13 @@ static cw_exit *test_find_exit(cw_world *world, cw_id from_location_id, cw_id to
   return 0;
 }
 
+static cw_gate *test_find_gate(cw_world *world, cw_id gate_id) {
+  for (size_t i = 0; i < world->gate_count; ++i) {
+    if (world->gates[i].id == gate_id) return &world->gates[i];
+  }
+  return 0;
+}
+
 static void test_kernel_capacities_are_runtime_sized(void) {
   assert(CW_MAX_ACTORS >= 512u);
   assert(CW_MAX_ITEMS >= 1024u);
@@ -36,6 +43,9 @@ static void test_kernel_capacities_are_runtime_sized(void) {
   assert(CW_MAX_EXITS >= 1024u);
   assert(CW_MAX_EVENTS >= 128u);
   assert(CW_MAX_EVOLUTION_TRACKS >= 128u);
+  assert(CW_MAX_GATES >= 32u);
+  assert(CW_MAX_GATE_CLAIMS >= 128u);
+  assert(sizeof(cw_world) <= 170000u);
 }
 
 static void test_seed_and_chat(void) {
@@ -1674,6 +1684,311 @@ static void test_authoritative_world_effect_actions(void) {
   assert(cw_world_apply(&world, &reveal, 84, &events) == CW_ERR_RULE);
 }
 
+static cw_gate_decision bind_gate_action(
+    const cw_world *world,
+    cw_action *action,
+    cw_id gate_id,
+    cw_id method_id,
+    uint8_t transition,
+    cw_id claim_id) {
+  cw_gate_decision decision = {0};
+  assert(cw_gate_evaluate(
+      world,
+      gate_id,
+      action->actor_id,
+      action->threshold.facts,
+      action->threshold.fact_count,
+      method_id,
+      &decision) == CW_OK);
+  action->threshold.gate_id = gate_id;
+  action->threshold.method_id = method_id;
+  action->threshold.claim_id = claim_id;
+  action->threshold.expected_gate_version = decision.gate_version;
+  action->threshold.expected_access_revision = decision.access_revision;
+  action->threshold.expected_evidence_digest = decision.evidence_digest;
+  action->threshold.transition = transition;
+  return decision;
+}
+
+static void test_kernel_gate_authority_stale_offers_and_claims(void) {
+  cw_world world;
+  cw_event_buffer events;
+  cw_world_init(&world);
+  assert(cw_seed_cosy_cottage(&world, &events) == CW_OK);
+
+  cw_action create = {0};
+  create.kind = CW_ACTION_CREATE_ACTOR;
+  create.actor_id = 5001;
+  create.location_id = 1;
+  assert(cw_world_apply(&world, &create, 90, &events) == CW_OK);
+
+  cw_action pickup = {0};
+  pickup.kind = CW_ACTION_PICK_UP_ITEM;
+  pickup.actor_id = 1001;
+  pickup.item_id = 2001;
+  assert(cw_world_apply(&world, &pickup, 91, &events) == CW_OK);
+
+  cw_exit *historical_exit = test_find_exit(&world, 1, 2);
+  assert(historical_exit);
+  historical_exit->flags |= CW_EXIT_LOCKED;
+  cw_gate holder_gate = {0};
+  holder_gate.id = 7001;
+  holder_gate.version = 1;
+  holder_gate.descriptor_version = 1;
+  holder_gate.target_kind = CW_GATE_TARGET_EXIT;
+  holder_gate.scope = CW_GATE_SCOPE_HOLDER;
+  holder_gate.state = CW_GATE_STATE_CLOSED;
+  holder_gate.compatibility = CW_GATE_COMPAT_RECORDED_LOCK;
+  holder_gate.from_location_id = 1;
+  holder_gate.to_location_id = 2;
+  cw_gate_method_definition holder_methods[1] = {0};
+  holder_methods[0].id = 7101;
+  holder_methods[0].predicate_count = 1;
+  holder_methods[0].predicates[0].kind = CW_GATE_PREDICATE_HELD_ITEM;
+  holder_methods[0].predicates[0].subject_id = 2001;
+  assert(cw_world_set_gate(&world, &holder_gate, holder_methods, 1) == CW_OK);
+
+  cw_action legacy_unlock = {0};
+  legacy_unlock.kind = CW_ACTION_UNLOCK_EXIT;
+  legacy_unlock.actor_id = 1001;
+  legacy_unlock.location_id = 1;
+  legacy_unlock.destination_location_id = 2;
+  assert(cw_world_apply(&world, &legacy_unlock, 91, &events) == CW_ERR_RULE);
+  assert(events.events[0].reason == CW_REASON_STALE_GATE_OFFER);
+  assert(historical_exit->flags & CW_EXIT_LOCKED);
+
+  cw_gate_decision holder_decision = {0};
+  assert(cw_gate_evaluate(&world, 7001, 1001, 0, 0, 7101, &holder_decision) == CW_OK);
+  assert(holder_decision.allowed);
+  cw_gate_decision companion_decision = {0};
+  assert(cw_gate_evaluate(&world, 7001, 5001, 0, 0, 7101, &companion_decision) == CW_OK);
+  assert(!companion_decision.allowed);
+  assert(companion_decision.reason == CW_REASON_GATE_CLOSED);
+
+  cw_action holder_move = {0};
+  holder_move.kind = CW_ACTION_MOVE;
+  holder_move.actor_id = 1001;
+  holder_move.destination_location_id = 2;
+  bind_gate_action(&world, &holder_move, 7001, 7101, CW_GATE_TRANSITION_NONE, 0);
+  assert(cw_world_apply(&world, &holder_move, 92, &events) == CW_OK);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_ACTOR_MOVED);
+  assert(events.events[0].gate_id == 7001);
+  assert(historical_exit->flags & CW_EXIT_LOCKED);
+
+  cw_action denied_move = {0};
+  denied_move.kind = CW_ACTION_MOVE;
+  denied_move.actor_id = 5001;
+  denied_move.destination_location_id = 2;
+  bind_gate_action(&world, &denied_move, 7001, 7101, CW_GATE_TRANSITION_NONE, 0);
+  assert(cw_world_apply(&world, &denied_move, 93, &events) == CW_ERR_RULE);
+  assert(events.events[0].reason == CW_REASON_GATE_CLOSED);
+
+  cw_action return_move = {0};
+  return_move.kind = CW_ACTION_MOVE;
+  return_move.actor_id = 1001;
+  return_move.destination_location_id = 1;
+  assert(cw_world_apply(&world, &return_move, 94, &events) == CW_OK);
+
+  cw_action stale_holder_move = {0};
+  stale_holder_move.kind = CW_ACTION_MOVE;
+  stale_holder_move.actor_id = 1001;
+  stale_holder_move.destination_location_id = 2;
+  bind_gate_action(
+      &world,
+      &stale_holder_move,
+      7001,
+      7101,
+      CW_GATE_TRANSITION_NONE,
+      0);
+
+  cw_action give = {0};
+  give.kind = CW_ACTION_GIVE_ITEM;
+  give.actor_id = 1001;
+  give.target_actor_id = 5001;
+  give.item_id = 2001;
+  assert(cw_world_apply(&world, &give, 95, &events) == CW_OK);
+  assert(cw_world_apply(&world, &stale_holder_move, 96, &events) == CW_ERR_RULE);
+  assert(events.events[0].reason == CW_REASON_STALE_GATE_OFFER);
+
+  cw_gate installed_gate = {0};
+  installed_gate.id = 7002;
+  installed_gate.version = 1;
+  installed_gate.descriptor_version = 1;
+  installed_gate.target_kind = CW_GATE_TARGET_EXIT;
+  installed_gate.scope = CW_GATE_SCOPE_WORLD;
+  installed_gate.state = CW_GATE_STATE_CLOSED;
+  installed_gate.from_location_id = 1;
+  installed_gate.to_location_id = 11;
+  cw_gate_method_definition installed_methods[2] = {0};
+  installed_methods[0].id = 7201;
+  installed_methods[0].predicate_count = 1;
+  installed_methods[0].predicates[0].kind = CW_GATE_PREDICATE_HELD_ITEM;
+  installed_methods[0].predicates[0].subject_id = 2001;
+  installed_methods[1].id = 7202;
+  installed_methods[1].predicate_count = 1;
+  installed_methods[1].predicates[0].kind = CW_GATE_PREDICATE_INSTALLED_ITEM;
+  installed_methods[1].predicates[0].subject_id = 2001;
+  installed_methods[1].predicates[0].target_id = 1;
+  assert(cw_world_set_gate(&world, &installed_gate, installed_methods, 2) == CW_OK);
+
+  cw_action install = {0};
+  install.kind = CW_ACTION_GATE_TRANSITION;
+  install.actor_id = 5001;
+  install.item_id = 2001;
+  bind_gate_action(
+      &world,
+      &install,
+      7002,
+      7201,
+      CW_GATE_TRANSITION_INSTALL,
+      7301);
+  assert(cw_world_apply(&world, &install, 97, &events) == CW_OK);
+  assert(events.count == 2);
+  assert(events.events[0].type == CW_EVENT_GATE_TRANSITION_APPLIED);
+  assert(events.events[1].type == CW_EVENT_ITEM_INSTALLED);
+  assert(test_find_item(&world, 2001)->zone == CW_CARD_ZONE_INSTALLED);
+
+  cw_action installed_move = {0};
+  installed_move.kind = CW_ACTION_MOVE;
+  installed_move.actor_id = 1001;
+  installed_move.destination_location_id = 11;
+  bind_gate_action(
+      &world,
+      &installed_move,
+      7002,
+      7202,
+      CW_GATE_TRANSITION_NONE,
+      0);
+
+  cw_action remove = {0};
+  remove.kind = CW_ACTION_GATE_TRANSITION;
+  remove.actor_id = 5001;
+  remove.item_id = 2001;
+  bind_gate_action(
+      &world,
+      &remove,
+      7002,
+      7202,
+      CW_GATE_TRANSITION_REMOVE,
+      7302);
+  assert(cw_world_apply(&world, &remove, 98, &events) == CW_OK);
+  assert(test_find_actor(&world, 1001)->location_id == 1);
+  assert(test_find_item(&world, 2001)->holder_actor_id == 5001);
+  assert(cw_world_apply(&world, &installed_move, 99, &events) == CW_ERR_RULE);
+  assert(events.events[0].reason == CW_REASON_STALE_GATE_OFFER);
+  bind_gate_action(
+      &world,
+      &installed_move,
+      7002,
+      7202,
+      CW_GATE_TRANSITION_NONE,
+      0);
+  assert(cw_world_apply(&world, &installed_move, 100, &events) == CW_ERR_RULE);
+  assert(events.events[0].reason == CW_REASON_GATE_CLOSED);
+
+  cw_action gate_state = {0};
+  gate_state.kind = CW_ACTION_GATE_TRANSITION;
+  gate_state.actor_id = 5001;
+  bind_gate_action(
+      &world,
+      &gate_state,
+      7002,
+      7201,
+      CW_GATE_TRANSITION_OPEN,
+      7401);
+  assert(cw_world_apply(&world, &gate_state, 100, &events) == CW_OK);
+  assert(test_find_gate(&world, 7002)->state == CW_GATE_STATE_OPEN);
+  bind_gate_action(
+      &world,
+      &gate_state,
+      7002,
+      0,
+      CW_GATE_TRANSITION_CLOSE,
+      7402);
+  assert(cw_world_apply(&world, &gate_state, 100, &events) == CW_OK);
+  assert(test_find_gate(&world, 7002)->state == CW_GATE_STATE_CLOSED);
+  bind_gate_action(
+      &world,
+      &gate_state,
+      7002,
+      7201,
+      CW_GATE_TRANSITION_OPEN,
+      7403);
+  assert(cw_world_apply(&world, &gate_state, 100, &events) == CW_OK);
+  bind_gate_action(
+      &world,
+      &gate_state,
+      7002,
+      0,
+      CW_GATE_TRANSITION_RELOCK,
+      7404);
+  assert(cw_world_apply(&world, &gate_state, 100, &events) == CW_OK);
+  assert(test_find_gate(&world, 7002)->state == CW_GATE_STATE_CLOSED);
+  bind_gate_action(
+      &world,
+      &gate_state,
+      7002,
+      7201,
+      CW_GATE_TRANSITION_BREAK,
+      7405);
+  assert(cw_world_apply(&world, &gate_state, 100, &events) == CW_OK);
+  assert(test_find_gate(&world, 7002)->state == CW_GATE_STATE_BROKEN);
+  bind_gate_action(
+      &world,
+      &gate_state,
+      7002,
+      0,
+      CW_GATE_TRANSITION_CLOSE,
+      7406);
+  assert(cw_world_apply(&world, &gate_state, 100, &events) == CW_OK);
+
+  cw_item *inert_item = test_find_item(&world, 2002);
+  assert(inert_item);
+  inert_item->holder_actor_id = 5001;
+  inert_item->location_id = 0;
+  inert_item->zone = CW_CARD_ZONE_CARRIED;
+  cw_action render_inert = {0};
+  render_inert.kind = CW_ACTION_GATE_TRANSITION;
+  render_inert.actor_id = 5001;
+  render_inert.item_id = 2002;
+  bind_gate_action(
+      &world,
+      &render_inert,
+      7002,
+      7201,
+      CW_GATE_TRANSITION_RENDER_INERT,
+      7501);
+  assert(cw_world_apply(&world, &render_inert, 100, &events) == CW_OK);
+  assert(events.events[1].type == CW_EVENT_ITEM_RENDERED_INERT);
+  assert(inert_item->reserved & CW_ITEM_FLAG_INERT);
+
+  cw_action exhaust = {0};
+  exhaust.kind = CW_ACTION_GATE_TRANSITION;
+  exhaust.actor_id = 5001;
+  exhaust.item_id = 2001;
+  bind_gate_action(
+      &world,
+      &exhaust,
+      7002,
+      7201,
+      CW_GATE_TRANSITION_EXHAUST,
+      7303);
+  assert(cw_world_apply(&world, &exhaust, 101, &events) == CW_OK);
+  assert(events.count == 2);
+  assert(events.events[1].type == CW_EVENT_ITEM_EXHAUSTED);
+  assert(test_find_item(&world, 2001)->charges == 0);
+  uint64_t revision_after_exhaust = world.access_revision;
+  uint64_t sequence_after_exhaust = world.next_event_seq;
+  uint64_t tick_after_exhaust = world.tick;
+  assert(cw_world_apply_with_tick(&world, &exhaust, 102, 1, &events) == CW_OK);
+  assert(events.count == 0);
+  assert(world.access_revision == revision_after_exhaust);
+  assert(world.next_event_seq == sequence_after_exhaust);
+  assert(world.tick == tick_after_exhaust);
+  assert(world.gate_claim_count == 10);
+}
+
 static uint8_t test_combat_side(const cw_combat_encounter *encounter, cw_id actor_id) {
   for (size_t i = 0; i < encounter->participant_count; ++i) {
     if (encounter->participants[i].actor_id == actor_id) {
@@ -1888,6 +2203,7 @@ int main(void) {
   test_inventory_uses_weight_and_container_capacity();
   test_search_and_craft_create_without_consuming_inputs();
   test_authoritative_world_effect_actions();
+  test_kernel_gate_authority_stale_offers_and_claims();
   test_combat_join_preserves_legacy_sides_and_accepts_explicit_sides();
   test_project_push_resolution_matrix_and_action_event();
   test_deterministic_replay();

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.282"
+version = "0.0.283"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.282"
+version = "0.0.283"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/beliefs_tests.rs
+++ b/v2/orchestrator-rust/src/beliefs_tests.rs
@@ -207,7 +207,7 @@ fn legacy_search_and_resident_memories_migrate_into_canonical_beliefs() {
 
     let current = serde_json::to_value(RuntimeSnapshot::from_runtime(&restored))
         .expect("current snapshot serializes");
-    assert_eq!(current["version"], 14);
+    assert_eq!(current["version"], 15);
     assert!(current.get("beliefs").is_some());
     assert!(current.get("resident_memories").is_none());
     assert!(current.get("search_memories").is_none());

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -1164,7 +1164,7 @@ impl RuntimeWorld {
         let Some(actor) = self.actor_by_id(actor_id) else {
             return Vec::new();
         };
-        let exits = self.exit_views(actor.location_id, access);
+        let exits = self.exit_views(Some(actor_id), actor.location_id, access);
         if let Some(journey) = self.journey_at_actor_location(actor_id) {
             let next_step = journey.current_step + 1;
             let next_location_id = journey.path.get(next_step).copied();
@@ -1538,7 +1538,7 @@ impl RuntimeWorld {
                             .and_then(|journey| journey.next_location_id)
                     })
                     .flatten();
-                self.exit_views(actor.location_id, access)
+                self.exit_views(Some(actor_id), actor.location_id, access)
                     .into_iter()
                     .filter(|exit| exit.accessible && !exit.locked)
                     .min_by_key(|exit| {

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -4,6 +4,11 @@ use super::*;
 mod discovery_authority;
 #[path = "threshold_descriptors.rs"]
 mod threshold_descriptors;
+pub(super) use threshold_descriptors::{
+    threshold_kernel_id, threshold_record_claim_already_applied,
+    threshold_record_preconditions_hold, AcceptedThresholdIntent, ThresholdFactSource,
+    ThresholdGateSource, ThresholdKernelSnapshot,
+};
 
 const LANTERN_KEEPER_PACK_ID: &str = "cosyworld.campaign.the-lantern-keeper";
 const LANTERN_KEEPER_JOB_ID: &str = "lantern-keeper:rekindle-the-beacon";

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -18,10 +18,18 @@ pub const CW_MAX_EVOLUTION_TRACKS: usize = 128;
 pub const CW_MAX_EVOLUTION_REQUIREMENTS: usize = 4;
 pub const CW_MAX_COMBAT_ENCOUNTERS: usize = 32;
 pub const CW_MAX_COMBAT_PARTICIPANTS: usize = 16;
+pub const CW_MAX_GATES: usize = 32;
+pub const CW_MAX_GATE_METHODS: usize = 8;
+pub const CW_MAX_GATE_PREDICATES: usize = 8;
+pub const CW_MAX_GATE_METHOD_RECORDS: usize = 64;
+pub const CW_MAX_GATE_PREDICATE_RECORDS: usize = 256;
+pub const CW_MAX_GATE_FACTS: usize = 8;
+pub const CW_MAX_GATE_ACTOR_STATES: usize = 128;
+pub const CW_MAX_GATE_CLAIMS: usize = 128;
 pub const CW_ITEM_DEFAULT_WEIGHT_TENTHS: u16 = 10;
 
 // Kernel version 9 is reserved by #411 for project-push ABI state.
-pub const CW_KERNEL_VERSION: u32 = 11;
+pub const CW_KERNEL_VERSION: u32 = 12;
 
 pub const CW_OK: u32 = 0;
 pub const CW_ERR_INVALID: u32 = 1;
@@ -47,6 +55,41 @@ pub const CW_CONDITION_DODGING: u32 = 1 << 3;
 pub const CW_LOCATION_ALLOW_COMBAT: u32 = 1 << 0;
 
 pub const CW_EXIT_LOCKED: u32 = 1 << 0;
+
+pub const CW_ITEM_FLAG_INERT: u8 = 1 << 0;
+
+pub const CW_GATE_TARGET_EXIT: u8 = 1;
+pub const CW_GATE_TARGET_CONTAINER: u8 = 2;
+
+pub const CW_GATE_SCOPE_WORLD: u8 = 1;
+pub const CW_GATE_SCOPE_ACTOR: u8 = 2;
+pub const CW_GATE_SCOPE_EXPEDITION: u8 = 3;
+pub const CW_GATE_SCOPE_HOLDER: u8 = 4;
+
+pub const CW_GATE_STATE_CLOSED: u8 = 1;
+pub const CW_GATE_STATE_OPEN: u8 = 2;
+pub const CW_GATE_STATE_BROKEN: u8 = 3;
+pub const CW_GATE_STATE_INERT: u8 = 4;
+
+pub const CW_GATE_COMPAT_NONE: u8 = 0;
+pub const CW_GATE_COMPAT_RECORDED_LOCK: u8 = 1;
+
+pub const CW_GATE_PREDICATE_HELD_ITEM: u8 = 1;
+pub const CW_GATE_PREDICATE_HELD_ITEM_CAPABILITY: u8 = 2;
+pub const CW_GATE_PREDICATE_INSTALLED_ITEM: u8 = 3;
+pub const CW_GATE_PREDICATE_MINIMUM_CHARGES: u8 = 4;
+pub const CW_GATE_PREDICATE_ACTOR_FACT: u8 = 5;
+pub const CW_GATE_PREDICATE_WORLD_FACT: u8 = 6;
+
+pub const CW_GATE_TRANSITION_NONE: u8 = 0;
+pub const CW_GATE_TRANSITION_OPEN: u8 = 1;
+pub const CW_GATE_TRANSITION_CLOSE: u8 = 2;
+pub const CW_GATE_TRANSITION_BREAK: u8 = 3;
+pub const CW_GATE_TRANSITION_RELOCK: u8 = 4;
+pub const CW_GATE_TRANSITION_INSTALL: u8 = 5;
+pub const CW_GATE_TRANSITION_REMOVE: u8 = 6;
+pub const CW_GATE_TRANSITION_EXHAUST: u8 = 7;
+pub const CW_GATE_TRANSITION_RENDER_INERT: u8 = 8;
 
 pub const CW_PLACEMENT_ACTOR_HAND: u8 = 1;
 pub const CW_PLACEMENT_LOCATION_FLOOR: u8 = 2;
@@ -136,6 +179,7 @@ pub const CW_ACTION_REST: u8 = 32;
 // only by the focused-encounter scheduler after bounded deterministic recovery
 // failures; see `combat::start_focused_encounter_scheduler`.
 pub const CW_ACTION_COMBAT_ABANDON: u8 = 33;
+pub const CW_ACTION_GATE_TRANSITION: u8 = 34;
 
 pub const CW_EVENT_ACTOR_CREATED: u8 = 2;
 pub const CW_EVENT_ABILITY_CHECK_ROLLED: u8 = 6;
@@ -174,6 +218,10 @@ pub const CW_EVENT_ITEM_REVEALED: u8 = 40;
 pub const CW_EVENT_PROJECT_PUSH_RESOLVED: u8 = 41;
 // Event 41 is reserved by #411 for CW_EVENT_PROJECT_PUSH_RESOLVED.
 pub const CW_EVENT_ITEM_REFRESHED: u8 = 42;
+pub const CW_EVENT_GATE_TRANSITION_APPLIED: u8 = 43;
+pub const CW_EVENT_ITEM_INSTALLED: u8 = 44;
+pub const CW_EVENT_ITEM_REMOVED: u8 = 45;
+pub const CW_EVENT_ITEM_RENDERED_INERT: u8 = 46;
 
 // These append-only values mirror the authoritative `CW_REASON_*` enum in
 // core-c. The numeric value remains the replay contract; player-facing copy is
@@ -200,7 +248,10 @@ pub const CW_REASON_ENCOUNTER_ACTIVE: u16 = 19;
 pub const CW_REASON_COMBAT_ACTION_REQUIRED: u16 = 20;
 pub const CW_REASON_CAPACITY_EXCEEDED: u16 = 21;
 pub const CW_REASON_REST_GRADE_OVERCLAIMED: u16 = 22;
-pub const CW_REASON_MAX_KNOWN: u16 = CW_REASON_REST_GRADE_OVERCLAIMED;
+pub const CW_REASON_GATE_CLOSED: u16 = 23;
+pub const CW_REASON_STALE_GATE_OFFER: u16 = 24;
+pub const CW_REASON_GATE_CLAIM_CONFLICT: u16 = 25;
+pub const CW_REASON_MAX_KNOWN: u16 = CW_REASON_GATE_CLAIM_CONFLICT;
 
 pub const CW_CRAFT_INPUT_PERSISTS: u8 = 0;
 pub const CW_CRAFT_INPUT_CONSUMED: u8 = 1;
@@ -311,6 +362,135 @@ fn is_zero_u8(value: &u8) -> bool {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwGateFact {
+    pub subject_id: u64,
+    pub fact_id: u64,
+    pub value: u64,
+    pub source_version: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwGatePredicate {
+    pub kind: u8,
+    pub amount: u8,
+    pub reserved: u16,
+    pub reserved2: u32,
+    pub subject_id: u64,
+    pub target_id: u64,
+    pub fact_id: u64,
+    pub expected_value: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwGateMethod {
+    pub id: u64,
+    pub predicate_start: usize,
+    pub predicate_count: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwGateMethodDefinition {
+    pub id: u64,
+    pub predicate_count: usize,
+    pub predicates: [CwGatePredicate; CW_MAX_GATE_PREDICATES],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwGate {
+    pub id: u64,
+    pub version: u64,
+    pub descriptor_version: u32,
+    pub target_kind: u8,
+    pub scope: u8,
+    pub state: u8,
+    pub compatibility: u8,
+    pub from_location_id: u64,
+    pub to_location_id: u64,
+    pub target_item_id: u64,
+    pub method_start: usize,
+    pub method_count: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwGateActorState {
+    pub gate_id: u64,
+    pub actor_id: u64,
+    pub version: u64,
+    pub state: u8,
+    pub reserved: [u8; 7],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwGateClaim {
+    pub id: u64,
+    pub gate_id: u64,
+    pub actor_id: u64,
+    pub item_id: u64,
+    pub method_id: u64,
+    pub transition: u8,
+    pub reserved: [u8; 7],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwGateDecision {
+    pub gate_id: u64,
+    pub method_id: u64,
+    pub gate_version: u64,
+    pub access_revision: u64,
+    pub evidence_digest: u64,
+    pub evidence_mask: u32,
+    pub reason: u16,
+    pub state: u8,
+    pub allowed: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwThresholdInput {
+    pub gate_id: u64,
+    pub method_id: u64,
+    pub claim_id: u64,
+    pub expected_gate_version: u64,
+    pub expected_access_revision: u64,
+    pub expected_evidence_digest: u64,
+    pub fact_count: usize,
+    pub facts: [CwGateFact; CW_MAX_GATE_FACTS],
+    pub transition: u8,
+    pub reserved: [u8; 7],
+}
+
+impl Default for CwThresholdInput {
+    fn default() -> Self {
+        Self {
+            gate_id: 0,
+            method_id: 0,
+            claim_id: 0,
+            expected_gate_version: 0,
+            expected_access_revision: 0,
+            expected_evidence_digest: 0,
+            fact_count: 0,
+            facts: [CwGateFact::default(); CW_MAX_GATE_FACTS],
+            transition: 0,
+            reserved: [0; 7],
+        }
+    }
+}
+
+impl CwThresholdInput {
+    fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CwRestInput {
     pub requested_grade: u8,
     pub entitled_grade: u8,
@@ -415,6 +595,8 @@ pub struct CwAction {
     pub project_push: CwProjectPushInput,
     #[serde(default, skip_serializing_if = "CwRestInput::is_empty")]
     pub rest: CwRestInput,
+    #[serde(default, skip_serializing_if = "CwThresholdInput::is_empty")]
+    pub threshold: CwThresholdInput,
 }
 
 #[repr(C)]
@@ -438,6 +620,15 @@ pub struct CwEvent {
     pub damage: i16,
     pub current_hp: i16,
     pub ability: u8,
+    pub gate_transition: u8,
+    pub reserved: u16,
+    pub gate_evidence_mask: u32,
+    pub gate_id: u64,
+    pub gate_method_id: u64,
+    pub gate_claim_id: u64,
+    pub gate_version: u64,
+    pub access_revision: u64,
+    pub gate_evidence_digest: u64,
 }
 
 #[repr(C)]
@@ -521,6 +712,17 @@ pub struct CwWorld {
     pub evolution_tracks: [CwEvolutionTrack; CW_MAX_EVOLUTION_TRACKS],
     pub combat_encounter_count: usize,
     pub combat_encounters: [CwCombatEncounter; CW_MAX_COMBAT_ENCOUNTERS],
+    pub access_revision: u64,
+    pub gate_count: usize,
+    pub gates: [CwGate; CW_MAX_GATES],
+    pub gate_method_count: usize,
+    pub gate_methods: [CwGateMethod; CW_MAX_GATE_METHOD_RECORDS],
+    pub gate_predicate_count: usize,
+    pub gate_predicates: [CwGatePredicate; CW_MAX_GATE_PREDICATE_RECORDS],
+    pub gate_actor_state_count: usize,
+    pub gate_actor_states: [CwGateActorState; CW_MAX_GATE_ACTOR_STATES],
+    pub gate_claim_count: usize,
+    pub gate_claims: [CwGateClaim; CW_MAX_GATE_CLAIMS],
 }
 
 impl Default for CwWorld {
@@ -541,6 +743,17 @@ impl Default for CwWorld {
             evolution_tracks: [CwEvolutionTrack::default(); CW_MAX_EVOLUTION_TRACKS],
             combat_encounter_count: 0,
             combat_encounters: [CwCombatEncounter::default(); CW_MAX_COMBAT_ENCOUNTERS],
+            access_revision: 0,
+            gate_count: 0,
+            gates: [CwGate::default(); CW_MAX_GATES],
+            gate_method_count: 0,
+            gate_methods: [CwGateMethod::default(); CW_MAX_GATE_METHOD_RECORDS],
+            gate_predicate_count: 0,
+            gate_predicates: [CwGatePredicate::default(); CW_MAX_GATE_PREDICATE_RECORDS],
+            gate_actor_state_count: 0,
+            gate_actor_states: [CwGateActorState::default(); CW_MAX_GATE_ACTOR_STATES],
+            gate_claim_count: 0,
+            gate_claims: [CwGateClaim::default(); CW_MAX_GATE_CLAIMS],
         }
     }
 }
@@ -574,6 +787,22 @@ extern "C" {
         actor_id: u64,
         requirements: *const CwEvolutionRequirement,
         requirement_count: usize,
+    ) -> u32;
+    pub fn cw_world_set_gate(
+        world: *mut CwWorld,
+        gate: *const CwGate,
+        methods: *const CwGateMethodDefinition,
+        method_count: usize,
+    ) -> u32;
+    pub fn cw_world_access_changed(world: *mut CwWorld);
+    pub fn cw_gate_evaluate(
+        world: *const CwWorld,
+        gate_id: u64,
+        actor_id: u64,
+        facts: *const CwGateFact,
+        fact_count: usize,
+        method_id: u64,
+        out_decision: *mut CwGateDecision,
     ) -> u32;
     pub fn cw_world_apply(
         world: *mut CwWorld,

--- a/v2/orchestrator-rust/src/kernel/rejections.rs
+++ b/v2/orchestrator-rust/src/kernel/rejections.rs
@@ -61,6 +61,15 @@ pub(crate) fn kernel_rejection_message(reason: u16) -> &'static str {
         CW_REASON_REST_GRADE_OVERCLAIMED => {
             "That rest is not available here. Choose a rest option this shelter supports."
         }
+        CW_REASON_GATE_CLOSED => {
+            "That threshold is still closed to you. Meet one of its shown requirements or choose another way."
+        }
+        CW_REASON_STALE_GATE_OFFER => {
+            "That threshold changed after this choice was offered. Refresh the room and choose again."
+        }
+        CW_REASON_GATE_CLAIM_CONFLICT => {
+            "That threshold transition was already claimed by another result. Refresh the room before trying again."
+        }
         _ => UNKNOWN_KERNEL_REJECTION_MESSAGE,
     }
 }
@@ -87,8 +96,8 @@ mod tests {
             .map(kernel_rejection_message)
             .collect::<Vec<_>>();
 
-        assert_eq!(messages.len(), 22);
-        assert_eq!(messages.iter().copied().collect::<HashSet<_>>().len(), 22);
+        assert_eq!(messages.len(), 25);
+        assert_eq!(messages.iter().copied().collect::<HashSet<_>>().len(), 25);
         assert!(messages
             .iter()
             .all(|message| *message != UNKNOWN_KERNEL_REJECTION_MESSAGE));

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1687,6 +1687,7 @@ struct RuntimeWorld {
     jobs: BTreeMap<String, JobState>,
     room_sheets: BTreeMap<u64, RoomSheetState>,
     routes: BTreeMap<String, RouteRecordState>,
+    threshold_gate_sources: BTreeMap<u64, ThresholdGateSource>,
     generated_pathways: BTreeMap<String, GeneratedPathwayState>,
     generated_places: BTreeMap<u64, GeneratedPlaceState>,
     governance_decisions: BTreeMap<String, GovernanceDecisionState>,
@@ -1772,6 +1773,8 @@ struct RuntimeSnapshot {
     world_exits: Vec<CwExit>,
     #[serde(default)]
     routes: BTreeMap<String, RouteRecordState>,
+    #[serde(default)]
+    threshold_authority: ThresholdKernelSnapshot,
     #[serde(default)]
     world_evolution_tracks: Vec<CwEvolutionTrack>,
     #[serde(default)]
@@ -2004,6 +2007,8 @@ struct JournalRecord {
     action: CwAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     route_binding: Option<RouteOfferBinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    threshold_intent: Option<AcceptedThresholdIntent>,
     seed: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     ripple_source: Option<RippleSource>,
@@ -2037,7 +2042,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 14;
+const JOURNAL_RECORD_VERSION: u32 = 15;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -2081,6 +2086,7 @@ impl JournalRecord {
             focused_policy_version: 1,
             action,
             route_binding: None,
+            threshold_intent: None,
             seed,
             ripple_source: None,
             queued_actor_job: None,
@@ -3171,109 +3177,6 @@ struct EventView {
     source_location_id: Option<u64>,
     #[serde(default, skip_serializing_if = "content_reference_context_is_empty")]
     content_context: ContentReferenceContext,
-}
-
-impl Default for EventView {
-    fn default() -> Self {
-        Self {
-            world_id: official_world_id(),
-            world_epoch: official_world_epoch(),
-            seq: 0,
-            type_name: String::new(),
-            success: false,
-            reason: 0,
-            actor_id: None,
-            actor_name: None,
-            target_actor_id: None,
-            target_actor_name: None,
-            location_id: None,
-            location_name: None,
-            destination_location_id: None,
-            destination_location_name: None,
-            content_id: None,
-            content: None,
-            item_id: None,
-            item_name: None,
-            target_item_id: None,
-            target_item_name: None,
-            raw_roll: None,
-            modifier: None,
-            total: None,
-            dc: None,
-            damage: None,
-            current_hp: None,
-            combat_method: None,
-            ability: None,
-            clock_id: None,
-            clock_scope: None,
-            clock_scope_id: None,
-            clock_kind: None,
-            clock_label: None,
-            clock_filled: None,
-            clock_segments: None,
-            clock_delta: None,
-            tag_id: None,
-            tag_scope: None,
-            tag_scope_id: None,
-            tag_kind: None,
-            tag_label: None,
-            caused_by_event_seq: None,
-            source_world_tick: None,
-            observed_through_seq: None,
-            source_location_id: None,
-            content_context: ContentReferenceContext::default(),
-        }
-    }
-}
-
-impl EventView {
-    fn apply_async_causality(&mut self, record: &JournalRecord) {
-        self.caused_by_event_seq = record.caused_by_event_seq;
-        self.source_world_tick = record.source_world_tick;
-        self.observed_through_seq = record.observed_through_seq;
-        self.source_location_id = record.source_location_id;
-    }
-
-    fn refresh_content_context(&mut self) {
-        let mut handles = Vec::new();
-        for (kind, handle) in [
-            ("actor", self.actor_id),
-            ("actor", self.target_actor_id),
-            ("location", self.location_id),
-            ("location", self.destination_location_id),
-            ("location", self.source_location_id),
-            ("item", self.item_id),
-            ("item", self.target_item_id),
-        ] {
-            if let Some(handle) = handle {
-                handles.push((kind, handle));
-            }
-        }
-        let mut refreshed = content_registry().content_reference_context(handles);
-        if self.content_context.mapping_version != 0
-            && self.content_context.mapping_version != refreshed.mapping_version
-        {
-            return;
-        }
-        let mut references = self
-            .content_context
-            .references
-            .iter()
-            .cloned()
-            .map(|reference| (reference.canonical_ref.clone(), reference))
-            .collect::<BTreeMap<_, _>>();
-        references.extend(
-            refreshed
-                .references
-                .drain(..)
-                .map(|reference| (reference.canonical_ref.clone(), reference)),
-        );
-        refreshed.references = references.into_values().collect();
-        if !self.content_context.active_rulesets.is_empty() {
-            refreshed.active_rulesets = self.content_context.active_rulesets.clone();
-        }
-        self.content_context = refreshed;
-    }
 }
 
 fn content_reference_context_is_empty(context: &ContentReferenceContext) -> bool {
@@ -6322,7 +6225,7 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 14,
+            version: 15,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
@@ -6342,6 +6245,7 @@ impl RuntimeSnapshot {
             world_locations: runtime.world.locations[..runtime.world.location_count].to_vec(),
             world_exits: runtime.world.exits[..runtime.world.exit_count].to_vec(),
             routes: runtime.routes.clone(),
+            threshold_authority: ThresholdKernelSnapshot::from_runtime(runtime),
             world_evolution_tracks: runtime.world.evolution_tracks
                 [..runtime.world.evolution_track_count]
                 .to_vec(),
@@ -6465,6 +6369,9 @@ impl RuntimeSnapshot {
         if self.world_combat_encounters.len() > CW_MAX_COMBAT_ENCOUNTERS {
             return Err(snapshot_error("too many combat encounters in snapshot"));
         }
+        self.threshold_authority
+            .validate()
+            .map_err(snapshot_error)?;
         for encounter in &self.world_combat_encounters {
             if encounter.id == 0 || encounter.location_id == 0 {
                 return Err(snapshot_error("combat encounter has no id or location"));
@@ -6542,6 +6449,7 @@ impl RuntimeSnapshot {
         for (idx, encounter) in self.world_combat_encounters.into_iter().enumerate() {
             world.combat_encounters[idx] = encounter;
         }
+        let threshold_gate_sources = self.threshold_authority.restore_into(&mut world);
 
         let max_seq = self
             .event_log
@@ -6617,6 +6525,7 @@ impl RuntimeSnapshot {
             jobs: self.jobs,
             room_sheets: self.room_sheets,
             routes: self.routes,
+            threshold_gate_sources,
             generated_pathways: self.generated_pathways,
             generated_places: self.generated_places,
             governance_decisions: self.governance_decisions,
@@ -7029,6 +6938,7 @@ impl RuntimeWorld {
             jobs: BTreeMap::new(),
             room_sheets: BTreeMap::new(),
             routes: BTreeMap::new(),
+            threshold_gate_sources: BTreeMap::new(),
             generated_pathways: BTreeMap::new(),
             generated_places: BTreeMap::new(),
             governance_decisions: BTreeMap::new(),
@@ -7113,6 +7023,7 @@ impl RuntimeWorld {
         self.ensure_seed_items();
         self.normalize_card_zones();
         self.ensure_seed_evolution_tracks();
+        self.ensure_seed_threshold_gates();
     }
 
     fn update_item_provenance(&mut self, events: &[EventView]) -> Vec<DeliveryEvidence> {
@@ -10227,11 +10138,15 @@ impl RuntimeWorld {
     fn apply_journal_record(&mut self, record: &JournalRecord) -> (u32, Vec<EventView>) {
         if !focused_encounter_journal_context_is_supported(self, record)
             || !self.route_record_preconditions_hold(record)
+            || !threshold_record_preconditions_hold(record)
             || !self.job_contribution_record_preconditions_hold(record)
             || !self.ai_publication_preconditions_hold(record)
             || !self.proxim8_materialization_record_preconditions_hold(record)
         {
             return (CW_ERR_RULE, Vec::new());
+        }
+        if threshold_record_claim_already_applied(self, record) {
+            return (CW_OK, Vec::new());
         }
         let enforce_active_contribution_contract =
             record.worldpack_bundle_hash == active_content().manifest.bundle_hash;
@@ -10471,6 +10386,7 @@ impl RuntimeWorld {
             self.ensure_active_actor_rules_facets();
             self.bump_entity_versions_for_events(&events);
         }
+        self.touch_threshold_access_after_projection(record, status);
         self.refresh_canonical_events(&mut events);
         (status, events)
     }
@@ -16441,6 +16357,9 @@ The relationship statement they are preserving is: {statement}"
     }
 
     fn kernel_offer_allows_action(&self, action: &CwAction) -> bool {
+        if action.threshold.gate_id != 0 {
+            return self.threshold_action_is_current_and_allowed(action);
+        }
         if action.kind == CW_ACTION_CRAFT
             && self
                 .recipe_by_id(action.content_id)
@@ -38836,7 +38755,11 @@ fn commit_journal_record(
     let durable_started_at = Instant::now();
     bind_focused_encounter_context(runtime, &mut record);
     runtime.bind_route_precondition(&mut record);
+    runtime.bind_threshold_intent(&mut record);
     if !runtime.route_record_preconditions_hold(&record) {
+        return Ok((CW_ERR_RULE, Vec::new()));
+    }
+    if !threshold_record_preconditions_hold(&record) {
         return Ok((CW_ERR_RULE, Vec::new()));
     }
     if hosted_guest_record_restricted(state, runtime, &record) {

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -467,7 +467,7 @@ impl RuntimeWorld {
             .filter(|target| target.kind == "location")
             .and_then(|target| target.id)
             .ok_or_else(|| "Travel has no exact destination.".to_string())?;
-        if let Some((action, mutation, narration)) =
+        if let Some((mut action, mutation, narration)) =
             self.plan_journey_move(actor_id, destination_location_id)?
         {
             if action.kind != CW_ACTION_MOVE {
@@ -475,18 +475,32 @@ impl RuntimeWorld {
                     "That route still needs scouting before it can be travelled.".to_string(),
                 );
             }
+            if let Some(threshold) = offer
+                .route
+                .as_ref()
+                .and_then(|route| route.threshold.as_ref())
+            {
+                bind_threshold_action(&mut action, threshold)?;
+            }
             return Ok(MovementPlan::Journey {
                 action,
                 mutation: Box::new(mutation),
                 narration,
             });
         }
-        let action = CwAction {
+        let mut action = CwAction {
             kind: CW_ACTION_MOVE,
             actor_id,
             destination_location_id,
             ..CwAction::default()
         };
+        if let Some(threshold) = offer
+            .route
+            .as_ref()
+            .and_then(|route| route.threshold.as_ref())
+        {
+            bind_threshold_action(&mut action, threshold)?;
+        }
         if !self.kernel_offer_allows_action(&action) {
             return Err("The kernel no longer offers that route.".to_string());
         }
@@ -515,7 +529,7 @@ impl RuntimeWorld {
             .journey_view(actor_id)
             .and_then(|journey| journey.next_location_id);
         let mut exits = self
-            .exit_views(actor.location_id, access)
+            .exit_views(Some(actor_id), actor.location_id, access)
             .into_iter()
             .filter(|exit| exit.accessible && !exit.locked)
             .collect::<Vec<_>>();
@@ -574,6 +588,7 @@ impl RuntimeWorld {
             route_version: exit.route_version,
             directionality: route.map(|route| route.directionality).unwrap_or_default(),
             fallback_location_id: route.and_then(|route| route.fallback_location_id),
+            threshold: exit.threshold.clone(),
         });
         if let Some(fallback_location_id) = offer
             .route
@@ -639,6 +654,23 @@ impl RuntimeWorld {
     pub(super) fn has_accessible_exit(&self, actor_id: u64, access: &AccessContext) -> bool {
         !self.accessible_movement_exits(actor_id, access).is_empty()
     }
+}
+
+fn bind_threshold_action(
+    action: &mut CwAction,
+    binding: &ThresholdOfferBinding,
+) -> Result<(), String> {
+    if binding.facts.len() > CW_MAX_GATE_FACTS {
+        return Err("That threshold offer contains too much predicate evidence.".to_string());
+    }
+    action.threshold.gate_id = binding.gate_id;
+    action.threshold.method_id = binding.method_id;
+    action.threshold.expected_gate_version = binding.gate_version;
+    action.threshold.expected_access_revision = binding.access_revision;
+    action.threshold.expected_evidence_digest = binding.evidence_digest;
+    action.threshold.fact_count = binding.facts.len();
+    action.threshold.facts[..binding.facts.len()].copy_from_slice(&binding.facts);
+    Ok(())
 }
 
 fn first_tale_destination_claim_key(actor_id: u64) -> Option<String> {

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -1850,7 +1850,7 @@ impl RuntimeWorld {
                     });
                 }
                 let destination = if rest.trim().is_empty() {
-                    self.first_accessible_exit(actor.location_id, access)
+                    self.first_accessible_exit(actor.id, actor.location_id, access)
                         .ok_or_else(|| command_error(&command, "flee", 404, "There is nowhere clear to flee."))?
                 } else {
                     self.resolve_exit_destination(actor, rest, access).map_err(|output| {
@@ -3314,9 +3314,9 @@ impl RuntimeWorld {
             .map(|item| self.item_view(item).name)
             .collect::<Vec<_>>();
         let exits = self
-            .exit_views(location_id, access)
+            .exit_views(Some(actor.id), location_id, access)
             .into_iter()
-            .filter(|exit| exit.accessible)
+            .filter(|exit| exit.accessible && !exit.locked)
             .map(|exit| {
                 exit.direction
                     .as_deref()
@@ -3771,9 +3771,9 @@ impl RuntimeWorld {
         access: &AccessContext,
     ) -> Result<u64, &'static str> {
         let exits = self
-            .exit_views(actor.location_id, access)
+            .exit_views(Some(actor.id), actor.location_id, access)
             .into_iter()
-            .filter(|exit| exit.accessible)
+            .filter(|exit| exit.accessible && !exit.locked)
             .collect::<Vec<_>>();
         if query.trim().is_empty() && exits.len() == 1 {
             return exits
@@ -3817,10 +3817,15 @@ impl RuntimeWorld {
             .ok_or("No accessible exit matches that command.")
     }
 
-    fn first_accessible_exit(&self, location_id: u64, access: &AccessContext) -> Option<u64> {
-        self.exit_views(location_id, access)
+    fn first_accessible_exit(
+        &self,
+        actor_id: u64,
+        location_id: u64,
+        access: &AccessContext,
+    ) -> Option<u64> {
+        self.exit_views(Some(actor_id), location_id, access)
             .into_iter()
-            .find(|exit| exit.accessible)
+            .find(|exit| exit.accessible && !exit.locked)
             .map(|exit| exit.destination_location_id)
     }
 }

--- a/v2/orchestrator-rust/src/threshold_descriptors.rs
+++ b/v2/orchestrator-rust/src/threshold_descriptors.rs
@@ -288,7 +288,7 @@ pub(super) struct ThresholdPressure {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub(super) struct AcceptedThresholdIntent {
+pub(crate) struct AcceptedThresholdIntent {
     pub(super) schema_version: u8,
     pub(super) intent_version: String,
     pub(super) id: String,
@@ -323,6 +323,112 @@ pub(super) struct ThresholdIntentRequest<'a> {
     pub(super) requirement_facts: BTreeMap<String, String>,
     pub(super) discovery_receipt_refs: Vec<String>,
     pub(super) materialized_entity_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ThresholdGateSource {
+    pub(super) descriptor_id: String,
+    pub(super) descriptor_version: u8,
+    pub(super) pack_id: String,
+    pub(super) pack_version: String,
+    pub(super) pack_integrity: String,
+    pub(super) scope: String,
+    pub(super) target: ThresholdTargetRef,
+    pub(super) methods: BTreeMap<u64, String>,
+    #[serde(default)]
+    pub(crate) facts: BTreeMap<u64, ThresholdFactSource>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum ThresholdFactSource {
+    ItemCapability { capability: String },
+    ActorTag { tag_id: String },
+    ClockStatus { clock_id: String, status: String },
+    JobStatus { job_id: String, status: String },
+    BondState { target_actor_id: u64, state: String },
+    AccessGrant { grant_id: String },
+    PerActorClaim { claim_id: String },
+}
+
+type CompiledThresholdMethods = (
+    Vec<CwGateMethodDefinition>,
+    BTreeMap<u64, String>,
+    BTreeMap<u64, ThresholdFactSource>,
+);
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct ThresholdKernelSnapshot {
+    #[serde(default)]
+    sources: BTreeMap<u64, ThresholdGateSource>,
+    #[serde(default)]
+    access_revision: u64,
+    #[serde(default)]
+    gates: Vec<CwGate>,
+    #[serde(default)]
+    methods: Vec<CwGateMethod>,
+    #[serde(default)]
+    predicates: Vec<CwGatePredicate>,
+    #[serde(default)]
+    actor_states: Vec<CwGateActorState>,
+    #[serde(default)]
+    claims: Vec<CwGateClaim>,
+}
+
+impl ThresholdKernelSnapshot {
+    pub(crate) fn from_runtime(runtime: &RuntimeWorld) -> Self {
+        Self {
+            sources: runtime.threshold_gate_sources.clone(),
+            access_revision: runtime.world.access_revision,
+            gates: runtime.world.gates[..runtime.world.gate_count].to_vec(),
+            methods: runtime.world.gate_methods[..runtime.world.gate_method_count].to_vec(),
+            predicates: runtime.world.gate_predicates[..runtime.world.gate_predicate_count]
+                .to_vec(),
+            actor_states: runtime.world.gate_actor_states[..runtime.world.gate_actor_state_count]
+                .to_vec(),
+            claims: runtime.world.gate_claims[..runtime.world.gate_claim_count].to_vec(),
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if self.gates.len() > CW_MAX_GATES
+            || self.methods.len() > CW_MAX_GATE_METHOD_RECORDS
+            || self.predicates.len() > CW_MAX_GATE_PREDICATE_RECORDS
+            || self.actor_states.len() > CW_MAX_GATE_ACTOR_STATES
+            || self.claims.len() > CW_MAX_GATE_CLAIMS
+        {
+            return Err("threshold authority exceeds a kernel snapshot capacity".to_string());
+        }
+        if self.gates.iter().any(|gate| {
+            gate.id == 0
+                || gate.version == 0
+                || gate.method_start > self.methods.len()
+                || gate.method_count > self.methods.len() - gate.method_start
+        }) || self.methods.iter().any(|method| {
+            method.id == 0
+                || method.predicate_start > self.predicates.len()
+                || method.predicate_count > self.predicates.len() - method.predicate_start
+        }) {
+            return Err("threshold authority has invalid method or predicate bounds".to_string());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn restore_into(self, world: &mut CwWorld) -> BTreeMap<u64, ThresholdGateSource> {
+        world.access_revision = self.access_revision.max(1);
+        world.gate_count = self.gates.len();
+        world.gate_method_count = self.methods.len();
+        world.gate_predicate_count = self.predicates.len();
+        world.gate_actor_state_count = self.actor_states.len();
+        world.gate_claim_count = self.claims.len();
+        world.gates[..self.gates.len()].copy_from_slice(&self.gates);
+        world.gate_methods[..self.methods.len()].copy_from_slice(&self.methods);
+        world.gate_predicates[..self.predicates.len()].copy_from_slice(&self.predicates);
+        world.gate_actor_states[..self.actor_states.len()].copy_from_slice(&self.actor_states);
+        world.gate_claims[..self.claims.len()].copy_from_slice(&self.claims);
+        self.sources
+    }
 }
 
 fn parse_catalog(pack: &SeedWorldpackPack) -> Result<Option<ThresholdDescriptorCatalog>, String> {
@@ -1002,6 +1108,562 @@ fn validate_existing_intent(intent: &AcceptedThresholdIntent) -> Result<(), Stri
     Ok(())
 }
 
+pub(crate) fn threshold_kernel_id(value: &str) -> u64 {
+    let mut digest = 14_695_981_039_346_656_037u64;
+    for byte in value.as_bytes() {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(1_099_511_628_211);
+    }
+    digest.max(1)
+}
+
+fn threshold_intent_matches_kernel_action(
+    intent: &AcceptedThresholdIntent,
+    action: &CwAction,
+    rules_profile: &str,
+    worldpack_bundle_hash: &str,
+) -> bool {
+    validate_existing_intent(intent).is_ok()
+        && !rules_profile.trim().is_empty()
+        && intent
+            .requirement_facts
+            .get("worldpack_bundle_hash")
+            .is_none_or(|hash| hash == worldpack_bundle_hash)
+        && intent.actor_id == action.actor_id
+        && intent
+            .requirement_facts
+            .get("target_id")
+            .and_then(|value| value.parse::<u64>().ok())
+            == Some(action.threshold.gate_id)
+        && intent
+            .requirement_facts
+            .get("method_id")
+            .and_then(|value| value.parse::<u64>().ok())
+            == Some(action.threshold.method_id)
+        && (action.kind != CW_ACTION_GATE_TRANSITION
+            || threshold_kernel_id(&intent.id) == action.threshold.claim_id)
+}
+
+pub(crate) fn threshold_record_preconditions_hold(record: &JournalRecord) -> bool {
+    let action = &record.action;
+    if action.threshold.gate_id == 0 {
+        return record.threshold_intent.is_none()
+            && action.threshold == CwThresholdInput::default();
+    }
+    let Some(intent) = record.threshold_intent.as_ref() else {
+        return false;
+    };
+    if action.threshold.fact_count > CW_MAX_GATE_FACTS
+        || !threshold_intent_matches_kernel_action(
+            intent,
+            action,
+            &record.rules_profile,
+            &record.worldpack_bundle_hash,
+        )
+    {
+        return false;
+    }
+    let action_shape_is_valid = match action.kind {
+        CW_ACTION_MOVE | CW_ACTION_FLEE | CW_ACTION_COMBAT_ESCAPE => {
+            action.threshold.transition == CW_GATE_TRANSITION_NONE && action.threshold.claim_id == 0
+        }
+        CW_ACTION_GATE_TRANSITION => {
+            action.threshold.transition != CW_GATE_TRANSITION_NONE && action.threshold.claim_id != 0
+        }
+        _ => false,
+    };
+    action_shape_is_valid
+        && record
+            .route_binding
+            .as_ref()
+            .and_then(|route| route.threshold.as_ref())
+            .is_none_or(|binding| {
+                binding.actor_id == action.actor_id
+                    && binding.gate_id == action.threshold.gate_id
+                    && binding.method_id == action.threshold.method_id
+                    && binding.gate_version == action.threshold.expected_gate_version
+                    && binding.access_revision == action.threshold.expected_access_revision
+                    && binding.evidence_digest == action.threshold.expected_evidence_digest
+                    && binding.facts.as_slice()
+                        == &action.threshold.facts[..action.threshold.fact_count]
+            })
+}
+
+pub(crate) fn threshold_record_claim_already_applied(
+    runtime: &RuntimeWorld,
+    record: &JournalRecord,
+) -> bool {
+    let threshold = &record.action.threshold;
+    record.action.kind == CW_ACTION_GATE_TRANSITION
+        && threshold.claim_id != 0
+        && runtime.world.gate_claims[..runtime.world.gate_claim_count]
+            .iter()
+            .any(|claim| {
+                claim.id == threshold.claim_id
+                    && claim.gate_id == threshold.gate_id
+                    && claim.actor_id == record.action.actor_id
+                    && claim.item_id == record.action.item_id
+                    && claim.method_id == threshold.method_id
+                    && claim.transition == threshold.transition
+            })
+}
+
+pub(super) fn accepted_intent_for_kernel_binding(
+    source: &ThresholdGateSource,
+    action: &CwAction,
+    accepted_turn: u64,
+    worldpack_bundle_hash: &str,
+) -> Option<AcceptedThresholdIntent> {
+    let selected_method = if action.threshold.method_id == 0 {
+        "gate_state"
+    } else {
+        source.methods.get(&action.threshold.method_id)?.as_str()
+    };
+    let scope_id = match source.scope.as_str() {
+        "world" => "world".to_string(),
+        "expedition" => format!("expedition:{}", action.actor_id),
+        "actor" | "holder" => action.actor_id.to_string(),
+        _ => return None,
+    };
+    let mut requirement_facts = BTreeMap::from([
+        ("actor_id".to_string(), action.actor_id.to_string()),
+        ("scope_id".to_string(), scope_id.clone()),
+        (
+            "target_id".to_string(),
+            action.threshold.gate_id.to_string(),
+        ),
+        (
+            "method_id".to_string(),
+            action.threshold.method_id.to_string(),
+        ),
+        (
+            "worldpack_bundle_hash".to_string(),
+            worldpack_bundle_hash.to_string(),
+        ),
+    ]);
+    requirement_facts.retain(|key, _| ACCEPTED_FACTS.contains(&key.as_str()));
+    let id = format!(
+        "threshold-intent:{}@{}:{}:{}:{}:{}:{}:{}",
+        source.descriptor_id,
+        source.descriptor_version,
+        action.actor_id,
+        accepted_turn,
+        action.threshold.gate_id,
+        action.threshold.method_id,
+        action.threshold.transition,
+        action.item_id
+    );
+    Some(AcceptedThresholdIntent {
+        schema_version: THRESHOLD_SCHEMA_VERSION,
+        intent_version: THRESHOLD_INTENT_VERSION.to_string(),
+        id,
+        descriptor_kind: "gate".to_string(),
+        descriptor_id: source.descriptor_id.clone(),
+        descriptor_version: source.descriptor_version,
+        pack_id: source.pack_id.clone(),
+        pack_version: source.pack_version.clone(),
+        pack_integrity: source.pack_integrity.clone(),
+        actor_id: action.actor_id,
+        scope: source.scope.clone(),
+        scope_id,
+        selected_method: selected_method.to_string(),
+        target: source.target.clone(),
+        accepted_turn,
+        requirement_facts,
+        discovery_receipt_refs: Vec::new(),
+        materialized_entity_ids: Vec::new(),
+    })
+}
+
+impl RuntimeWorld {
+    pub(crate) fn bind_threshold_intent(&self, record: &mut JournalRecord) {
+        if record.action.threshold.gate_id == 0 || record.threshold_intent.is_some() {
+            return;
+        }
+        let Some(source) = self
+            .threshold_gate_sources
+            .get(&record.action.threshold.gate_id)
+        else {
+            return;
+        };
+        let Some(intent) = accepted_intent_for_kernel_binding(
+            source,
+            &record.action,
+            self.world.tick,
+            &record.worldpack_bundle_hash,
+        ) else {
+            return;
+        };
+        if record.action.kind == CW_ACTION_GATE_TRANSITION && record.action.threshold.claim_id == 0
+        {
+            record.action.threshold.claim_id = threshold_kernel_id(&intent.id);
+        }
+        record.threshold_intent = Some(intent);
+    }
+
+    pub(crate) fn touch_threshold_access_after_projection(
+        &mut self,
+        record: &JournalRecord,
+        status: u32,
+    ) {
+        if status == CW_OK
+            && record.action.kind == CW_ACTION_NONE
+            && !record.projection_mutations.is_empty()
+        {
+            unsafe { cw_world_access_changed(&mut self.world) };
+        }
+    }
+
+    fn threshold_item_handle(&self, canonical_ref: &str) -> Option<u64> {
+        self.runtime_handle_for_canonical_ref("item", canonical_ref)
+            .or_else(|| {
+                active_content().items.iter().find_map(|item| {
+                    content_registry()
+                        .content_reference("item", item.id)
+                        .is_some_and(|entry| entry.canonical_ref == canonical_ref)
+                        .then_some(item.id)
+                })
+            })
+    }
+
+    fn threshold_actor_handle(&self, canonical_ref: &str) -> Option<u64> {
+        self.runtime_handle_for_canonical_ref("actor", canonical_ref)
+            .or_else(|| {
+                active_content().actors.iter().find_map(|actor| {
+                    content_registry()
+                        .content_reference("actor", actor.id)
+                        .is_some_and(|entry| entry.canonical_ref == canonical_ref)
+                        .then_some(actor.id)
+                })
+            })
+    }
+
+    fn compile_threshold_predicate(
+        &self,
+        predicate: &ThresholdPredicate,
+        default_location_id: u64,
+    ) -> Result<(CwGatePredicate, Option<(u64, ThresholdFactSource)>), String> {
+        let compiled = match predicate {
+            ThresholdPredicate::ExactItem { item_id } => CwGatePredicate {
+                kind: CW_GATE_PREDICATE_HELD_ITEM,
+                subject_id: self
+                    .threshold_item_handle(item_id)
+                    .ok_or_else(|| format!("threshold item {item_id} is not materialized"))?,
+                ..CwGatePredicate::default()
+            },
+            ThresholdPredicate::ItemCapability { capability } => {
+                let fact_id = threshold_kernel_id(&format!("item-capability:{capability}"));
+                return Ok((
+                    CwGatePredicate {
+                        kind: CW_GATE_PREDICATE_HELD_ITEM_CAPABILITY,
+                        fact_id,
+                        expected_value: 1,
+                        ..CwGatePredicate::default()
+                    },
+                    Some((
+                        fact_id,
+                        ThresholdFactSource::ItemCapability {
+                            capability: capability.clone(),
+                        },
+                    )),
+                ));
+            }
+            ThresholdPredicate::InstalledItem { item_id, target_id } => {
+                let target_location_id = self
+                    .runtime_handle_for_canonical_ref("location", target_id)
+                    .unwrap_or(default_location_id);
+                CwGatePredicate {
+                    kind: CW_GATE_PREDICATE_INSTALLED_ITEM,
+                    subject_id: self
+                        .threshold_item_handle(item_id)
+                        .ok_or_else(|| format!("threshold item {item_id} is not materialized"))?,
+                    target_id: target_location_id,
+                    ..CwGatePredicate::default()
+                }
+            }
+            ThresholdPredicate::MinimumCharges { item_id, amount } => CwGatePredicate {
+                kind: CW_GATE_PREDICATE_MINIMUM_CHARGES,
+                amount: *amount,
+                subject_id: self
+                    .threshold_item_handle(item_id)
+                    .ok_or_else(|| format!("threshold item {item_id} is not materialized"))?,
+                ..CwGatePredicate::default()
+            },
+            ThresholdPredicate::ActorTag { tag_id } => {
+                let fact_id = threshold_kernel_id(&format!("actor-tag:{tag_id}"));
+                return Ok((
+                    CwGatePredicate {
+                        kind: CW_GATE_PREDICATE_ACTOR_FACT,
+                        fact_id,
+                        expected_value: 1,
+                        ..CwGatePredicate::default()
+                    },
+                    Some((
+                        fact_id,
+                        ThresholdFactSource::ActorTag {
+                            tag_id: tag_id.clone(),
+                        },
+                    )),
+                ));
+            }
+            ThresholdPredicate::ClockStatus { clock_id, status } => {
+                let fact_id = threshold_kernel_id(&format!("clock-status:{clock_id}"));
+                return Ok((
+                    CwGatePredicate {
+                        kind: CW_GATE_PREDICATE_WORLD_FACT,
+                        subject_id: threshold_kernel_id(clock_id),
+                        fact_id,
+                        expected_value: threshold_kernel_id(status),
+                        ..CwGatePredicate::default()
+                    },
+                    Some((
+                        fact_id,
+                        ThresholdFactSource::ClockStatus {
+                            clock_id: clock_id.clone(),
+                            status: status.clone(),
+                        },
+                    )),
+                ));
+            }
+            ThresholdPredicate::JobStatus { job_id, status } => {
+                let fact_id = threshold_kernel_id(&format!("job-status:{job_id}"));
+                return Ok((
+                    CwGatePredicate {
+                        kind: CW_GATE_PREDICATE_WORLD_FACT,
+                        subject_id: threshold_kernel_id(job_id),
+                        fact_id,
+                        expected_value: threshold_kernel_id(status),
+                        ..CwGatePredicate::default()
+                    },
+                    Some((
+                        fact_id,
+                        ThresholdFactSource::JobStatus {
+                            job_id: job_id.clone(),
+                            status: status.clone(),
+                        },
+                    )),
+                ));
+            }
+            ThresholdPredicate::MinimumStanding { faction_id, .. } => {
+                return Err(format!(
+                    "threshold standing {faction_id} has no authoritative runtime projection"
+                ))
+            }
+            ThresholdPredicate::BondState { actor_id, state } => {
+                let target_actor_id = self
+                    .threshold_actor_handle(actor_id)
+                    .ok_or_else(|| format!("threshold actor {actor_id} is not materialized"))?;
+                let fact_id = threshold_kernel_id(&format!("bond-state:{actor_id}"));
+                return Ok((
+                    CwGatePredicate {
+                        kind: CW_GATE_PREDICATE_ACTOR_FACT,
+                        fact_id,
+                        expected_value: threshold_kernel_id(state),
+                        ..CwGatePredicate::default()
+                    },
+                    Some((
+                        fact_id,
+                        ThresholdFactSource::BondState {
+                            target_actor_id,
+                            state: state.clone(),
+                        },
+                    )),
+                ));
+            }
+            ThresholdPredicate::AccessGrant { grant_id } => {
+                let fact_id = threshold_kernel_id(&format!("access-grant:{grant_id}"));
+                return Ok((
+                    CwGatePredicate {
+                        kind: CW_GATE_PREDICATE_ACTOR_FACT,
+                        fact_id,
+                        expected_value: 1,
+                        ..CwGatePredicate::default()
+                    },
+                    Some((
+                        fact_id,
+                        ThresholdFactSource::AccessGrant {
+                            grant_id: grant_id.clone(),
+                        },
+                    )),
+                ));
+            }
+            ThresholdPredicate::PerActorClaim { claim_id } => {
+                let fact_id = threshold_kernel_id(&format!("actor-claim:{claim_id}"));
+                return Ok((
+                    CwGatePredicate {
+                        kind: CW_GATE_PREDICATE_ACTOR_FACT,
+                        fact_id,
+                        expected_value: 1,
+                        ..CwGatePredicate::default()
+                    },
+                    Some((
+                        fact_id,
+                        ThresholdFactSource::PerActorClaim {
+                            claim_id: claim_id.clone(),
+                        },
+                    )),
+                ));
+            }
+        };
+        Ok((compiled, None))
+    }
+
+    fn compile_threshold_methods(
+        &self,
+        gate: &ThresholdGate,
+        default_location_id: u64,
+    ) -> Result<CompiledThresholdMethods, String> {
+        let mut compiled = Vec::with_capacity(gate.methods.len());
+        let mut names = BTreeMap::new();
+        let mut facts = BTreeMap::new();
+        for method in &gate.methods {
+            let method_id = threshold_kernel_id(&format!("{}:{}", gate.id, method.id));
+            let mut definition = CwGateMethodDefinition {
+                id: method_id,
+                ..CwGateMethodDefinition::default()
+            };
+            for predicate in &method.requirements.clauses {
+                let (predicate, fact) =
+                    self.compile_threshold_predicate(predicate, default_location_id)?;
+                definition.predicates[definition.predicate_count] = predicate;
+                definition.predicate_count += 1;
+                if let Some((fact_id, source)) = fact {
+                    facts.insert(fact_id, source);
+                }
+            }
+            names.insert(method_id, method.id.clone());
+            compiled.push(definition);
+        }
+        Ok((compiled, names, facts))
+    }
+
+    pub(crate) fn ensure_seed_threshold_gates(&mut self) {
+        for pack in &active_content().manifest.packs {
+            let Some(catalog) = parse_catalog(pack).unwrap_or_else(|error| panic!("{error}"))
+            else {
+                continue;
+            };
+            for authored in &catalog.gates {
+                let targets = match authored.target_ref.kind.as_str() {
+                    "route" => {
+                        let route = self
+                            .routes
+                            .values()
+                            .find(|route| {
+                                route.id == authored.target_ref.id
+                                    || route.canonical_id == authored.target_ref.id
+                            })
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "threshold route {} is not materialized",
+                                    authored.target_ref.id
+                                )
+                            });
+                        route
+                            .edges
+                            .iter()
+                            .filter(|edge| {
+                                self.world.exits[..self.world.exit_count]
+                                    .iter()
+                                    .any(|exit| {
+                                        exit.from_location_id == edge.from_location_id
+                                            && exit.to_location_id == edge.to_location_id
+                                    })
+                            })
+                            .map(|edge| {
+                                (
+                                    CW_GATE_TARGET_EXIT,
+                                    edge.from_location_id,
+                                    edge.to_location_id,
+                                    0,
+                                    edge.flags,
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                    }
+                    "item" => {
+                        let item_id = self
+                            .threshold_item_handle(&authored.target_ref.id)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "threshold item {} is not materialized",
+                                    authored.target_ref.id
+                                )
+                            });
+                        vec![(CW_GATE_TARGET_CONTAINER, 0, 0, item_id, 0)]
+                    }
+                    target_kind => panic!(
+                        "threshold gate {} targets unsupported {target_kind}",
+                        authored.id
+                    ),
+                };
+                for (target_kind, from_location_id, to_location_id, target_item_id, flags) in
+                    targets
+                {
+                    let gate_id = threshold_kernel_id(&format!(
+                        "{}:{from_location_id}:{to_location_id}:{target_item_id}",
+                        authored.id
+                    ));
+                    let (methods, method_names, facts) = self
+                        .compile_threshold_methods(authored, from_location_id)
+                        .unwrap_or_else(|error| panic!("threshold gate {}: {error}", authored.id));
+                    self.threshold_gate_sources
+                        .entry(gate_id)
+                        .or_insert_with(|| ThresholdGateSource {
+                            descriptor_id: authored.id.clone(),
+                            descriptor_version: authored.version,
+                            pack_id: pack.id.clone(),
+                            pack_version: pack.version.clone(),
+                            pack_integrity: pack.integrity.clone(),
+                            scope: authored.scope.clone(),
+                            target: authored.target_ref.clone(),
+                            methods: method_names,
+                            facts,
+                        });
+                    if self.world.gates[..self.world.gate_count]
+                        .iter()
+                        .any(|gate| gate.id == gate_id)
+                    {
+                        continue;
+                    }
+                    let scope = match authored.scope.as_str() {
+                        "world" => CW_GATE_SCOPE_WORLD,
+                        "actor" => CW_GATE_SCOPE_ACTOR,
+                        "expedition" => CW_GATE_SCOPE_EXPEDITION,
+                        "holder" => CW_GATE_SCOPE_HOLDER,
+                        _ => unreachable!("validated threshold scope"),
+                    };
+                    let gate = CwGate {
+                        id: gate_id,
+                        version: u64::from(authored.version),
+                        descriptor_version: u32::from(THRESHOLD_SCHEMA_VERSION),
+                        target_kind,
+                        scope,
+                        state: CW_GATE_STATE_CLOSED,
+                        compatibility: if flags & CW_EXIT_LOCKED != 0 {
+                            CW_GATE_COMPAT_RECORDED_LOCK
+                        } else {
+                            CW_GATE_COMPAT_NONE
+                        },
+                        from_location_id,
+                        to_location_id,
+                        target_item_id,
+                        ..CwGate::default()
+                    };
+                    let status = unsafe {
+                        cw_world_set_gate(&mut self.world, &gate, methods.as_ptr(), methods.len())
+                    };
+                    assert_eq!(
+                        status, CW_OK,
+                        "threshold gate {} did not compile into the kernel",
+                        authored.id
+                    );
+                }
+            }
+        }
+    }
+}
+
 pub(super) fn freeze_threshold_intent(
     catalog: &ThresholdDescriptorCatalog,
     request: ThresholdIntentRequest<'_>,
@@ -1141,6 +1803,385 @@ mod tests {
         }
     }
 
+    fn install_holder_gate(runtime: &mut RuntimeWorld) -> (u64, u64) {
+        let gate_id = threshold_kernel_id("test:gate/holder-threshold");
+        let method_id = threshold_kernel_id("test:gate/holder-threshold:present-token");
+        let gate = CwGate {
+            id: gate_id,
+            version: 1,
+            descriptor_version: 1,
+            target_kind: CW_GATE_TARGET_EXIT,
+            scope: CW_GATE_SCOPE_HOLDER,
+            state: CW_GATE_STATE_CLOSED,
+            from_location_id: COSY_COTTAGE_LOCATION_ID,
+            to_location_id: RAIN_SOFT_GARDEN_LOCATION_ID,
+            ..CwGate::default()
+        };
+        let mut method = CwGateMethodDefinition {
+            id: method_id,
+            predicate_count: 1,
+            ..CwGateMethodDefinition::default()
+        };
+        method.predicates[0] = CwGatePredicate {
+            kind: CW_GATE_PREDICATE_HELD_ITEM,
+            subject_id: HEARTH_TONIC_ITEM_ID,
+            ..CwGatePredicate::default()
+        };
+        assert_eq!(
+            unsafe { cw_world_set_gate(&mut runtime.world, &gate, &method, 1) },
+            CW_OK
+        );
+        runtime.threshold_gate_sources.insert(
+            gate_id,
+            ThresholdGateSource {
+                descriptor_id: "test:gate/holder-threshold".to_string(),
+                descriptor_version: 1,
+                pack_id: "test".to_string(),
+                pack_version: "1.0.0".to_string(),
+                pack_integrity: "sha256:test".to_string(),
+                scope: "holder".to_string(),
+                target: ThresholdTargetRef {
+                    kind: "route".to_string(),
+                    id: "test:route/cottage-garden".to_string(),
+                    version: 1,
+                },
+                methods: BTreeMap::from([(method_id, "present_token".to_string())]),
+                facts: BTreeMap::new(),
+            },
+        );
+        (gate_id, method_id)
+    }
+
+    fn bind_threshold(
+        action: &mut CwAction,
+        runtime: &RuntimeWorld,
+        gate_id: u64,
+        method_id: u64,
+        transition: u8,
+    ) {
+        let mut decision = CwGateDecision::default();
+        assert_eq!(
+            unsafe {
+                cw_gate_evaluate(
+                    &runtime.world,
+                    gate_id,
+                    action.actor_id,
+                    std::ptr::null(),
+                    0,
+                    method_id,
+                    &mut decision,
+                )
+            },
+            CW_OK
+        );
+        assert_eq!(decision.allowed, 1);
+        action.threshold = CwThresholdInput {
+            gate_id,
+            method_id,
+            expected_gate_version: decision.gate_version,
+            expected_access_revision: decision.access_revision,
+            expected_evidence_digest: decision.evidence_digest,
+            transition,
+            ..CwThresholdInput::default()
+        };
+    }
+
+    fn install_projection_fact_gate(
+        runtime: &mut RuntimeWorld,
+        actor_id: u64,
+    ) -> (u64, String, String, String) {
+        let from_location_id = COSY_COTTAGE_LOCATION_ID;
+        let to_location_id = 11;
+        assert!(runtime.world.exits[..runtime.world.exit_count]
+            .iter()
+            .any(|exit| {
+                exit.from_location_id == from_location_id && exit.to_location_id == to_location_id
+            }));
+        let job = runtime.jobs.values().next().expect("seed threshold job");
+        let job_id = job.id.clone();
+        let job_status = job.status.clone();
+        let tag_id = "test:tag/threshold-ready".to_string();
+        let grant_id = "test:grant/threshold-pass".to_string();
+        runtime.tags.insert(
+            tag_id.clone(),
+            RpgTagState {
+                id: tag_id.clone(),
+                scope: "actor".to_string(),
+                scope_id: actor_id,
+                label: "Threshold ready".to_string(),
+                kind: "state".to_string(),
+                active: true,
+                source_event_seq: Some(77),
+                expires: None,
+            },
+        );
+
+        let gate_id = threshold_kernel_id("test:gate/projection-facts");
+        let method_id = threshold_kernel_id("test:gate/projection-facts:qualify");
+        let tag_fact_id = threshold_kernel_id(&format!("actor-tag:{tag_id}"));
+        let job_fact_id = threshold_kernel_id(&format!("job-status:{job_id}"));
+        let grant_fact_id = threshold_kernel_id(&format!("access-grant:{grant_id}"));
+        let gate = CwGate {
+            id: gate_id,
+            version: 1,
+            descriptor_version: 1,
+            target_kind: CW_GATE_TARGET_EXIT,
+            scope: CW_GATE_SCOPE_ACTOR,
+            state: CW_GATE_STATE_CLOSED,
+            from_location_id,
+            to_location_id,
+            ..CwGate::default()
+        };
+        let mut method = CwGateMethodDefinition {
+            id: method_id,
+            predicate_count: 3,
+            ..CwGateMethodDefinition::default()
+        };
+        method.predicates[0] = CwGatePredicate {
+            kind: CW_GATE_PREDICATE_ACTOR_FACT,
+            fact_id: tag_fact_id,
+            expected_value: 1,
+            ..CwGatePredicate::default()
+        };
+        method.predicates[1] = CwGatePredicate {
+            kind: CW_GATE_PREDICATE_WORLD_FACT,
+            subject_id: threshold_kernel_id(&job_id),
+            fact_id: job_fact_id,
+            expected_value: threshold_kernel_id(&job_status),
+            ..CwGatePredicate::default()
+        };
+        method.predicates[2] = CwGatePredicate {
+            kind: CW_GATE_PREDICATE_ACTOR_FACT,
+            fact_id: grant_fact_id,
+            expected_value: 1,
+            ..CwGatePredicate::default()
+        };
+        assert_eq!(
+            unsafe { cw_world_set_gate(&mut runtime.world, &gate, &method, 1) },
+            CW_OK
+        );
+        runtime.threshold_gate_sources.insert(
+            gate_id,
+            ThresholdGateSource {
+                descriptor_id: "test:gate/projection-facts".to_string(),
+                descriptor_version: 1,
+                pack_id: "test".to_string(),
+                pack_version: "1.0.0".to_string(),
+                pack_integrity: "sha256:test".to_string(),
+                scope: "actor".to_string(),
+                target: ThresholdTargetRef {
+                    kind: "route".to_string(),
+                    id: "test:route/projection-facts".to_string(),
+                    version: 1,
+                },
+                methods: BTreeMap::from([(method_id, "qualify".to_string())]),
+                facts: BTreeMap::from([
+                    (
+                        tag_fact_id,
+                        ThresholdFactSource::ActorTag {
+                            tag_id: tag_id.clone(),
+                        },
+                    ),
+                    (
+                        job_fact_id,
+                        ThresholdFactSource::JobStatus {
+                            job_id: job_id.clone(),
+                            status: job_status.clone(),
+                        },
+                    ),
+                    (
+                        grant_fact_id,
+                        ThresholdFactSource::AccessGrant {
+                            grant_id: grant_id.clone(),
+                        },
+                    ),
+                ]),
+            },
+        );
+        (gate_id, tag_id, job_id, grant_id)
+    }
+
+    #[test]
+    fn kernel_threshold_receipts_snapshot_and_claim_retries_are_exact() {
+        let mut runtime = Box::new(RuntimeWorld::seeded());
+        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Token Holder");
+        create_test_human(&mut runtime, 5001, COSY_COTTAGE_LOCATION_ID, "Companion");
+        let item_index = runtime.world.items[..runtime.world.item_count]
+            .iter()
+            .position(|item| item.id == HEARTH_TONIC_ITEM_ID)
+            .expect("seed threshold item");
+        runtime.world.items[item_index].holder_actor_id = 5000;
+        runtime.world.items[item_index].location_id = 0;
+        runtime.world.items[item_index].zone = CW_CARD_ZONE_CARRIED;
+        let (gate_id, method_id) = install_holder_gate(&mut runtime);
+
+        let (holder_offer, holder_allowed) = runtime
+            .threshold_offer_binding_for_exit(
+                5000,
+                COSY_COTTAGE_LOCATION_ID,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+            )
+            .expect("holder threshold offer");
+        let (_, companion_allowed) = runtime
+            .threshold_offer_binding_for_exit(
+                5001,
+                COSY_COTTAGE_LOCATION_ID,
+                RAIN_SOFT_GARDEN_LOCATION_ID,
+            )
+            .expect("companion threshold offer");
+        assert!(holder_allowed);
+        assert!(!companion_allowed);
+
+        let mut route_binding = runtime
+            .route_offer_binding(COSY_COTTAGE_LOCATION_ID, RAIN_SOFT_GARDEN_LOCATION_ID)
+            .expect("route binding");
+        route_binding.threshold = Some(holder_offer);
+        assert!(runtime.route_binding_is_current(&route_binding));
+        runtime.world.items[item_index].holder_actor_id = 5001;
+        assert!(!runtime.route_binding_is_current(&route_binding));
+        runtime.world.items[item_index].holder_actor_id = 5000;
+
+        let (_, tag_id, job_id, grant_id) = install_projection_fact_gate(&mut runtime, 5000);
+        let access = AccessContext {
+            granted_entitlement_ids: BTreeSet::from([grant_id]),
+            ..AccessContext::default()
+        };
+        let (projection_offer, projection_allowed) = runtime
+            .threshold_offer_binding_for_exit_with_access(
+                5000,
+                COSY_COTTAGE_LOCATION_ID,
+                11,
+                &access,
+            )
+            .expect("projection threshold offer");
+        assert!(projection_allowed);
+        let mut projected_move = CwAction {
+            kind: CW_ACTION_MOVE,
+            actor_id: 5000,
+            destination_location_id: 11,
+            ..CwAction::default()
+        };
+        projected_move.threshold = CwThresholdInput {
+            gate_id: projection_offer.gate_id,
+            method_id: projection_offer.method_id,
+            expected_gate_version: projection_offer.gate_version,
+            expected_access_revision: projection_offer.access_revision,
+            expected_evidence_digest: projection_offer.evidence_digest,
+            fact_count: projection_offer.facts.len(),
+            ..CwThresholdInput::default()
+        };
+        projected_move.threshold.facts[..projection_offer.facts.len()]
+            .copy_from_slice(&projection_offer.facts);
+        assert!(runtime.threshold_action_is_current_and_allowed(&projected_move));
+        let mut projection_route = runtime
+            .route_offer_binding(COSY_COTTAGE_LOCATION_ID, 11)
+            .expect("projection route binding");
+        projection_route.threshold = Some(projection_offer);
+        runtime.tags.get_mut(&tag_id).expect("threshold tag").active = false;
+        unsafe { cw_world_access_changed(&mut runtime.world) };
+        assert!(!runtime.route_binding_is_current(&projection_route));
+        assert!(!runtime.threshold_action_is_current_and_allowed(&projected_move));
+        assert!(
+            !runtime
+                .threshold_offer_binding_for_exit_with_access(
+                    5000,
+                    COSY_COTTAGE_LOCATION_ID,
+                    11,
+                    &access
+                )
+                .expect("closed tag threshold")
+                .1
+        );
+        runtime.tags.get_mut(&tag_id).expect("threshold tag").active = true;
+        runtime.jobs.get_mut(&job_id).expect("threshold job").status = "changed".to_string();
+        unsafe { cw_world_access_changed(&mut runtime.world) };
+        assert!(
+            !runtime
+                .threshold_offer_binding_for_exit_with_access(
+                    5000,
+                    COSY_COTTAGE_LOCATION_ID,
+                    11,
+                    &access
+                )
+                .expect("closed job threshold")
+                .1
+        );
+
+        let mut exhaust = CwAction {
+            kind: CW_ACTION_GATE_TRANSITION,
+            actor_id: 5000,
+            item_id: HEARTH_TONIC_ITEM_ID,
+            ..CwAction::default()
+        };
+        bind_threshold(
+            &mut exhaust,
+            &runtime,
+            gate_id,
+            method_id,
+            CW_GATE_TRANSITION_EXHAUST,
+        );
+        let mut record = JournalRecord::new(exhaust, 70_589);
+        runtime.bind_threshold_intent(&mut record);
+        record.orb_deltas.push(OrbDelta {
+            actor_id: 5000,
+            delta: 2,
+            reason: "threshold-test-reward".to_string(),
+        });
+        assert!(threshold_record_preconditions_hold(&record));
+        assert_eq!(
+            serde_json::to_value(&record)
+                .expect("serialize threshold journal")
+                .pointer("/threshold_intent/intent_version")
+                .and_then(serde_json::Value::as_str),
+            Some(THRESHOLD_INTENT_VERSION)
+        );
+
+        let balance_before = runtime.orb_balance(5000);
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert!(events
+            .iter()
+            .any(|event| event.type_name == "gate.transition.applied"));
+        assert_eq!(runtime.orb_balance(5000), balance_before + 2);
+        assert_eq!(runtime.world.gate_claim_count, 1);
+        let tick_after_first_apply = runtime.world.tick;
+        let sequence_after_first_apply = runtime.world.next_event_seq;
+
+        let (retry_status, retry_events) = runtime.apply_journal_record(&record);
+        assert_eq!(retry_status, CW_OK);
+        assert!(retry_events.is_empty());
+        assert_eq!(runtime.orb_balance(5000), balance_before + 2);
+        assert_eq!(runtime.world.tick, tick_after_first_apply);
+        assert_eq!(runtime.world.next_event_seq, sequence_after_first_apply);
+
+        let restored = Box::new(
+            RuntimeSnapshot::from_runtime(&runtime)
+                .into_runtime()
+                .expect("threshold authority restores"),
+        );
+        assert_eq!(
+            &restored.world.gates[..restored.world.gate_count],
+            &runtime.world.gates[..runtime.world.gate_count]
+        );
+        assert_eq!(
+            &restored.world.gate_methods[..restored.world.gate_method_count],
+            &runtime.world.gate_methods[..runtime.world.gate_method_count]
+        );
+        assert_eq!(
+            &restored.world.gate_predicates[..restored.world.gate_predicate_count],
+            &runtime.world.gate_predicates[..runtime.world.gate_predicate_count]
+        );
+        assert_eq!(
+            &restored.world.gate_claims[..restored.world.gate_claim_count],
+            &runtime.world.gate_claims[..runtime.world.gate_claim_count]
+        );
+        assert_eq!(
+            restored.threshold_gate_sources,
+            runtime.threshold_gate_sources
+        );
+        assert_eq!(restored.orb_balance(5000), balance_before + 2);
+    }
+
     #[test]
     fn fixture_covers_shared_threshold_primitives_and_examples() {
         let fixture = fixture();
@@ -1157,6 +2198,42 @@ mod tests {
             fixture.thresholds.leads[0].transitions[1].method,
             "build_cairn"
         );
+    }
+
+    #[test]
+    fn authored_gate_methods_compile_to_bounded_kernel_predicates() {
+        let runtime = RuntimeWorld::seeded();
+        let fixture = fixture();
+        let mut gate = fixture.thresholds.gates[3].clone();
+        let item_ref = content_registry()
+            .content_reference("item", HEARTH_TONIC_ITEM_ID)
+            .expect("seed item canonical reference")
+            .canonical_ref
+            .clone();
+        gate.methods[0].requirements.clauses = vec![
+            ThresholdPredicate::ExactItem { item_id: item_ref },
+            ThresholdPredicate::ActorTag {
+                tag_id: "test:tag/ready".to_string(),
+            },
+            ThresholdPredicate::JobStatus {
+                job_id: "test:job/threshold".to_string(),
+                status: "active".to_string(),
+            },
+            ThresholdPredicate::AccessGrant {
+                grant_id: "test:grant/pass".to_string(),
+            },
+        ];
+        let (methods, names, facts) = runtime
+            .compile_threshold_methods(&gate, COSY_COTTAGE_LOCATION_ID)
+            .expect("authored methods compile");
+        assert_eq!(methods.len(), 1);
+        assert_eq!(methods[0].predicate_count, 4);
+        assert_eq!(methods[0].predicates[0].kind, CW_GATE_PREDICATE_HELD_ITEM);
+        assert_eq!(methods[0].predicates[1].kind, CW_GATE_PREDICATE_ACTOR_FACT);
+        assert_eq!(methods[0].predicates[2].kind, CW_GATE_PREDICATE_WORLD_FACT);
+        assert_eq!(methods[0].predicates[3].kind, CW_GATE_PREDICATE_ACTOR_FACT);
+        assert_eq!(names.len(), 1);
+        assert_eq!(facts.len(), 3);
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -75,6 +75,20 @@ pub(super) struct RouteOfferBinding {
     pub(super) directionality: RouteDirectionality,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) fallback_location_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) threshold: Option<ThresholdOfferBinding>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct ThresholdOfferBinding {
+    pub(super) actor_id: u64,
+    pub(super) gate_id: u64,
+    pub(super) method_id: u64,
+    pub(super) gate_version: u64,
+    pub(super) access_revision: u64,
+    pub(super) evidence_digest: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(super) facts: Vec<CwGateFact>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1832,7 +1846,244 @@ impl RuntimeWorld {
             route_version: route.entity_version,
             directionality: route.directionality,
             fallback_location_id: route.fallback_location_id,
+            threshold: None,
         }
+    }
+
+    pub(super) fn threshold_offer_binding_for_exit(
+        &self,
+        actor_id: u64,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) -> Option<(ThresholdOfferBinding, bool)> {
+        self.threshold_offer_binding_for_exit_with_access(
+            actor_id,
+            from_location_id,
+            to_location_id,
+            &AccessContext::default(),
+        )
+    }
+
+    fn threshold_facts_for_method(
+        &self,
+        gate: &CwGate,
+        method: &CwGateMethod,
+        actor_id: u64,
+        access: &AccessContext,
+    ) -> Vec<CwGateFact> {
+        let Some(source) = self.threshold_gate_sources.get(&gate.id) else {
+            return Vec::new();
+        };
+        let mut facts = Vec::new();
+        for predicate in &self.world.gate_predicates
+            [method.predicate_start..method.predicate_start + method.predicate_count]
+        {
+            let Some(fact_source) = source.facts.get(&predicate.fact_id) else {
+                continue;
+            };
+            let mut push_fact = |subject_id, value, source_version| {
+                if facts.len() < CW_MAX_GATE_FACTS
+                    && !facts.iter().any(|fact: &CwGateFact| {
+                        fact.subject_id == subject_id && fact.fact_id == predicate.fact_id
+                    })
+                {
+                    facts.push(CwGateFact {
+                        subject_id,
+                        fact_id: predicate.fact_id,
+                        value,
+                        source_version,
+                    });
+                }
+            };
+            match fact_source {
+                ThresholdFactSource::ItemCapability { capability } => {
+                    for item in self.world.items[..self.world.item_count]
+                        .iter()
+                        .filter(|item| item.holder_actor_id == actor_id)
+                        .filter(|item| {
+                            self.seed_item_contract_for_instance(item.id)
+                                .is_some_and(|seed| seed.capabilities.contains(capability))
+                        })
+                    {
+                        push_fact(
+                            item.id,
+                            1,
+                            threshold_kernel_id(&format!("{capability}:{}", item.id)),
+                        );
+                    }
+                }
+                ThresholdFactSource::ActorTag { tag_id } => {
+                    let tag = self.tags.values().find(|tag| {
+                        tag.id == *tag_id
+                            && (tag.scope == "world"
+                                || tag.scope_id == 0
+                                || tag.scope_id == actor_id)
+                    });
+                    push_fact(
+                        actor_id,
+                        u64::from(tag.is_some_and(|tag| tag.active)),
+                        tag.and_then(|tag| tag.source_event_seq).unwrap_or(0),
+                    );
+                }
+                ThresholdFactSource::ClockStatus { clock_id, .. } => {
+                    let clock = self.clocks.get(clock_id);
+                    push_fact(
+                        predicate.subject_id,
+                        clock
+                            .map(|clock| threshold_kernel_id(&clock.status))
+                            .unwrap_or(0),
+                        clock.and_then(|clock| clock.updated_event_seq).unwrap_or(0),
+                    );
+                }
+                ThresholdFactSource::JobStatus { job_id, .. } => {
+                    let job = self.jobs.get(job_id);
+                    push_fact(
+                        predicate.subject_id,
+                        job.map(|job| threshold_kernel_id(&job.status)).unwrap_or(0),
+                        job.map(|job| threshold_kernel_id(&job.status)).unwrap_or(0),
+                    );
+                }
+                ThresholdFactSource::BondState {
+                    target_actor_id, ..
+                } => {
+                    let bond = self.bonds.values().find(|bond| {
+                        (bond.actor_id == actor_id && bond.target_actor_id == *target_actor_id)
+                            || (bond.target_actor_id == actor_id
+                                && bond.actor_id == *target_actor_id)
+                    });
+                    push_fact(
+                        actor_id,
+                        bond.map(|bond| threshold_kernel_id(&bond.status))
+                            .unwrap_or(0),
+                        bond.and_then(|bond| bond.updated_event_seq.or(bond.source_event_seq))
+                            .unwrap_or(0),
+                    );
+                }
+                ThresholdFactSource::AccessGrant { grant_id } => {
+                    let allowed = access.granted_entitlement_ids.contains(grant_id)
+                        || access.owned_card_ids.contains(grant_id);
+                    let source_version = threshold_kernel_id(
+                        &access
+                            .granted_entitlement_ids
+                            .iter()
+                            .chain(&access.owned_card_ids)
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join("\u{1f}"),
+                    );
+                    push_fact(actor_id, u64::from(allowed), source_version);
+                }
+                ThresholdFactSource::PerActorClaim { claim_id } => {
+                    let key = format!("{claim_id}:{actor_id}");
+                    push_fact(
+                        actor_id,
+                        u64::from(
+                            self.rpg_claims.contains(claim_id) || self.rpg_claims.contains(&key),
+                        ),
+                        self.world.access_revision,
+                    );
+                }
+            }
+        }
+        facts
+    }
+
+    pub(super) fn threshold_offer_binding_for_exit_with_access(
+        &self,
+        actor_id: u64,
+        from_location_id: u64,
+        to_location_id: u64,
+        access: &AccessContext,
+    ) -> Option<(ThresholdOfferBinding, bool)> {
+        let gate = self.world.gates[..self.world.gate_count]
+            .iter()
+            .find(|gate| {
+                gate.target_kind == CW_GATE_TARGET_EXIT
+                    && gate.from_location_id == from_location_id
+                    && gate.to_location_id == to_location_id
+            })?;
+        let mut open_decision = CwGateDecision::default();
+        if unsafe {
+            cw_gate_evaluate(
+                &self.world,
+                gate.id,
+                actor_id,
+                std::ptr::null(),
+                0,
+                0,
+                &mut open_decision,
+            )
+        } != CW_OK
+        {
+            return None;
+        }
+        let (decision, facts) = if open_decision.allowed != 0 && open_decision.method_id == 0 {
+            (open_decision, Vec::new())
+        } else {
+            let mut selected = None;
+            for method in
+                &self.world.gate_methods[gate.method_start..gate.method_start + gate.method_count]
+            {
+                let facts = self.threshold_facts_for_method(gate, method, actor_id, access);
+                let mut decision = CwGateDecision::default();
+                if unsafe {
+                    cw_gate_evaluate(
+                        &self.world,
+                        gate.id,
+                        actor_id,
+                        facts.as_ptr(),
+                        facts.len(),
+                        method.id,
+                        &mut decision,
+                    )
+                } != CW_OK
+                {
+                    continue;
+                }
+                let allowed = decision.allowed != 0;
+                if allowed {
+                    selected = Some((decision, facts));
+                    break;
+                } else if selected.is_none() {
+                    selected = Some((decision, facts));
+                }
+            }
+            selected.unwrap_or((open_decision, Vec::new()))
+        };
+        let legacy_lock_allows = self.world.exits[..self.world.exit_count]
+            .iter()
+            .find(|exit| {
+                exit.from_location_id == from_location_id && exit.to_location_id == to_location_id
+            })
+            .is_some_and(|exit| {
+                exit.flags & CW_EXIT_LOCKED == 0
+                    || gate.compatibility == CW_GATE_COMPAT_RECORDED_LOCK
+            });
+        Some((
+            ThresholdOfferBinding {
+                actor_id,
+                gate_id: decision.gate_id,
+                method_id: decision.method_id,
+                gate_version: decision.gate_version,
+                access_revision: decision.access_revision,
+                evidence_digest: decision.evidence_digest,
+                facts,
+            },
+            decision.allowed != 0 && legacy_lock_allows,
+        ))
+    }
+
+    pub(super) fn route_offer_binding_for_actor(
+        &self,
+        actor_id: u64,
+        from_location_id: u64,
+        to_location_id: u64,
+    ) -> Option<RouteOfferBinding> {
+        let mut binding = self.route_offer_binding(from_location_id, to_location_id)?;
+        binding.threshold = self
+            .threshold_offer_binding_for_exit(actor_id, from_location_id, to_location_id)
+            .map(|(threshold, _)| threshold);
+        Some(binding)
     }
 
     pub(super) fn route_offer_binding(
@@ -1862,8 +2113,59 @@ impl RuntimeWorld {
     }
 
     pub(super) fn route_binding_is_current(&self, binding: &RouteOfferBinding) -> bool {
-        self.route_for_persisted_id(&binding.route_id)
-            .is_some_and(|route| route.entity_version == binding.route_version)
+        if self
+            .route_for_persisted_id(&binding.route_id)
+            .is_none_or(|route| route.entity_version != binding.route_version)
+        {
+            return false;
+        }
+        let Some(threshold) = binding.threshold.as_ref() else {
+            return true;
+        };
+        if threshold.facts.len() > CW_MAX_GATE_FACTS {
+            return false;
+        }
+        let mut decision = CwGateDecision::default();
+        let status = unsafe {
+            cw_gate_evaluate(
+                &self.world,
+                threshold.gate_id,
+                threshold.actor_id,
+                threshold.facts.as_ptr(),
+                threshold.facts.len(),
+                threshold.method_id,
+                &mut decision,
+            )
+        };
+        status == CW_OK
+            && decision.allowed != 0
+            && decision.gate_version == threshold.gate_version
+            && decision.access_revision == threshold.access_revision
+            && decision.evidence_digest == threshold.evidence_digest
+    }
+
+    pub(super) fn threshold_action_is_current_and_allowed(&self, action: &CwAction) -> bool {
+        let threshold = &action.threshold;
+        if threshold.gate_id == 0 || threshold.fact_count > CW_MAX_GATE_FACTS {
+            return false;
+        }
+        let mut decision = CwGateDecision::default();
+        (unsafe {
+            cw_gate_evaluate(
+                &self.world,
+                threshold.gate_id,
+                action.actor_id,
+                threshold.facts.as_ptr(),
+                threshold.fact_count,
+                threshold.method_id,
+                &mut decision,
+            )
+        }) == CW_OK
+            && decision.allowed != 0
+            && decision.method_id == threshold.method_id
+            && decision.gate_version == threshold.expected_gate_version
+            && decision.access_revision == threshold.expected_access_revision
+            && decision.evidence_digest == threshold.expected_evidence_digest
     }
 
     pub(super) fn transition_route(
@@ -2100,8 +2402,31 @@ impl RuntimeWorld {
         let Some(actor) = self.actor_by_id(record.action.actor_id) else {
             return;
         };
-        record.route_binding =
-            self.route_offer_binding(actor.location_id, record.action.destination_location_id);
+        if record.action.threshold.gate_id != 0
+            && record.action.threshold.fact_count <= CW_MAX_GATE_FACTS
+        {
+            record.route_binding = self
+                .route_offer_binding(actor.location_id, record.action.destination_location_id)
+                .map(|mut binding| {
+                    binding.threshold = Some(ThresholdOfferBinding {
+                        actor_id: record.action.actor_id,
+                        gate_id: record.action.threshold.gate_id,
+                        method_id: record.action.threshold.method_id,
+                        gate_version: record.action.threshold.expected_gate_version,
+                        access_revision: record.action.threshold.expected_access_revision,
+                        evidence_digest: record.action.threshold.expected_evidence_digest,
+                        facts: record.action.threshold.facts[..record.action.threshold.fact_count]
+                            .to_vec(),
+                    });
+                    binding
+                });
+        } else {
+            record.route_binding = self.route_offer_binding_for_actor(
+                record.action.actor_id,
+                actor.location_id,
+                record.action.destination_location_id,
+            );
+        }
     }
 }
 
@@ -3405,6 +3730,7 @@ mod tests {
             route_version: 9,
             directionality: RouteDirectionality::Reciprocal,
             fallback_location_id: None,
+            threshold: None,
         };
         assert!(replayed.route_binding_is_current(&legacy_binding));
     }

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -1,5 +1,108 @@
 use super::*;
 
+impl Default for EventView {
+    fn default() -> Self {
+        Self {
+            world_id: official_world_id(),
+            world_epoch: official_world_epoch(),
+            seq: 0,
+            type_name: String::new(),
+            success: false,
+            reason: 0,
+            actor_id: None,
+            actor_name: None,
+            target_actor_id: None,
+            target_actor_name: None,
+            location_id: None,
+            location_name: None,
+            destination_location_id: None,
+            destination_location_name: None,
+            content_id: None,
+            content: None,
+            item_id: None,
+            item_name: None,
+            target_item_id: None,
+            target_item_name: None,
+            raw_roll: None,
+            modifier: None,
+            total: None,
+            dc: None,
+            damage: None,
+            current_hp: None,
+            combat_method: None,
+            ability: None,
+            clock_id: None,
+            clock_scope: None,
+            clock_scope_id: None,
+            clock_kind: None,
+            clock_label: None,
+            clock_filled: None,
+            clock_segments: None,
+            clock_delta: None,
+            tag_id: None,
+            tag_scope: None,
+            tag_scope_id: None,
+            tag_kind: None,
+            tag_label: None,
+            caused_by_event_seq: None,
+            source_world_tick: None,
+            observed_through_seq: None,
+            source_location_id: None,
+            content_context: ContentReferenceContext::default(),
+        }
+    }
+}
+
+impl EventView {
+    pub(crate) fn apply_async_causality(&mut self, record: &JournalRecord) {
+        self.caused_by_event_seq = record.caused_by_event_seq;
+        self.source_world_tick = record.source_world_tick;
+        self.observed_through_seq = record.observed_through_seq;
+        self.source_location_id = record.source_location_id;
+    }
+
+    pub(crate) fn refresh_content_context(&mut self) {
+        let mut handles = Vec::new();
+        for (kind, handle) in [
+            ("actor", self.actor_id),
+            ("actor", self.target_actor_id),
+            ("location", self.location_id),
+            ("location", self.destination_location_id),
+            ("location", self.source_location_id),
+            ("item", self.item_id),
+            ("item", self.target_item_id),
+        ] {
+            if let Some(handle) = handle {
+                handles.push((kind, handle));
+            }
+        }
+        let mut refreshed = content_registry().content_reference_context(handles);
+        if self.content_context.mapping_version != 0
+            && self.content_context.mapping_version != refreshed.mapping_version
+        {
+            return;
+        }
+        let mut references = self
+            .content_context
+            .references
+            .iter()
+            .cloned()
+            .map(|reference| (reference.canonical_ref.clone(), reference))
+            .collect::<BTreeMap<_, _>>();
+        references.extend(
+            refreshed
+                .references
+                .drain(..)
+                .map(|reference| (reference.canonical_ref.clone(), reference)),
+        );
+        refreshed.references = references.into_values().collect();
+        if !self.content_context.active_rulesets.is_empty() {
+            refreshed.active_rulesets = self.content_context.active_rulesets.clone();
+        }
+        self.content_context = refreshed;
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub(super) struct JourneyView {
     pub(super) destination_location_id: u64,
@@ -892,6 +995,8 @@ pub(super) struct ExitView {
     pub(super) required_grant_id: Option<String>,
     pub(super) required_card_id: Option<String>,
     pub(super) access_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) threshold: Option<ThresholdOfferBinding>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -2342,7 +2447,12 @@ impl RuntimeWorld {
         })
     }
 
-    pub(super) fn exit_views(&self, location_id: u64, access: &AccessContext) -> Vec<ExitView> {
+    pub(super) fn exit_views(
+        &self,
+        actor_id: Option<u64>,
+        location_id: u64,
+        access: &AccessContext,
+    ) -> Vec<ExitView> {
         self.world.exits[..self.world.exit_count]
             .iter()
             .copied()
@@ -2350,9 +2460,20 @@ impl RuntimeWorld {
             .filter(|exit| {
                 self.exit_discovered_for_projection(exit.from_location_id, exit.to_location_id)
             })
-            .filter(|exit| exit.flags & CW_EXIT_LOCKED == 0)
             .filter_map(|exit| {
                 let route = self.route_for_edge(exit.from_location_id, exit.to_location_id)?;
+                let threshold = actor_id.and_then(|actor_id| {
+                    self.threshold_offer_binding_for_exit_with_access(
+                        actor_id,
+                        exit.from_location_id,
+                        exit.to_location_id,
+                        access,
+                    )
+                });
+                let locked = threshold
+                    .as_ref()
+                    .map(|(_, allowed)| !allowed)
+                    .unwrap_or(exit.flags & CW_EXIT_LOCKED != 0);
                 let access_rule = location_access_rule(exit.to_location_id);
                 let accessible = location_access_allowed(exit.to_location_id, access);
                 Some(ExitView {
@@ -2366,7 +2487,7 @@ impl RuntimeWorld {
                         .route_label_for_edge(exit.from_location_id, exit.to_location_id),
                     direction: self.exit_direction(exit.from_location_id, exit.to_location_id),
                     distance: self.pathway_distance(exit.from_location_id, exit.to_location_id),
-                    locked: false,
+                    locked,
                     accessible,
                     required_grant_id: access_rule.required_grant_id.map(ToString::to_string),
                     required_card_id: access_rule.required_card_id.map(ToString::to_string),
@@ -2375,6 +2496,7 @@ impl RuntimeWorld {
                     } else {
                         access_rule.reason.map(ToString::to_string)
                     },
+                    threshold: threshold.map(|(binding, _)| binding),
                 })
             })
             .collect()
@@ -2428,7 +2550,7 @@ impl RuntimeWorld {
             .map(|item| self.item_view(item))
             .collect();
 
-        let exits = self.exit_views(location_id, access);
+        let exits = self.exit_views(client_actor_id, location_id, access);
         let cards =
             self.card_registry_for(&location, &actors, &items, &exits, access, client_actor_id);
         let card_transactions =
@@ -3972,7 +4094,7 @@ impl RuntimeWorld {
                     })
                     .unwrap_or_default();
                 let exits = accessible
-                    .then(|| self.exit_views(location.id, access))
+                    .then(|| self.exit_views(client_actor_id, location.id, access))
                     .unwrap_or_default();
                 let card = location_cards
                     .get(&location.id)

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -128,4 +128,7 @@
 # than moved, so the suite ran each twice, and six superseded
 # `merged_inline_resident_*` helpers were left behind dead. Deleting both leaves
 # one copy of each test in the module that owns the code.
-73806
+#
+# 73806 -> 73729: issue #589 adds threshold journal and snapshot wiring while
+# moving EventView's default and context projection into its owning views.rs seam.
+73729


### PR DESCRIPTION
Closes #589.

## What changed

- adds bounded, kernel-owned Gate state, method predicates, evidence receipts, actor/holder state, and transition claims
- makes MOVE, FLEE, and COMBAT_ESCAPE validate exact Gate version, access revision, method, and evidence in C
- implements open, close, break, relock, install, remove, exhaust, and render-inert transitions with pre-mutation claims
- preserves historical locked exits through an explicit recorded-lock compatibility mode
- compiles authored threshold descriptors into kernel gates and projects actor-specific travel legality
- journals accepted threshold intent and evidence, snapshots Gate state/sources/claims, and short-circuits exact retries before ticks, rewards, or events
- bumps the release to 0.0.283 and kernel ABI to version 12

## Why

Threshold legality previously had descriptor contracts but no authoritative runtime enforcement. This makes the C kernel—not Rust, clients, or AI—the source of truth for conditional passage and irreversible item/Gate transitions, including stale-offer rejection after custody or access changes.

## Impact

Co-present actors can receive different holder-only travel legality. Removing an installed item changes future passage without relocating actors or erasing routes. Crash/reconnect retries cannot duplicate claimed transitions, item mutation, rewards, ticks, or event chains.

## Validation

- `npm run check` under Node 24.10.0
- 515 JavaScript tests
- 879 Rust tests
- C kernel tests
- official and standalone worldpack/proof checks
- `main.rs` 73,729-line ceiling
- Clippy 254-warning locked baseline
- syntax checks
- pre-push hook reran the full suite successfully on commit `c864249371ad7bb79d8a2386d4d0961524db012c`