### PR TITLE
Handle Fly SSH preamble in volume guard

### DIFF
--- a/docs/backlog/thresholds-trails-and-strict-referee.md
+++ b/docs/backlog/thresholds-trails-and-strict-referee.md
@@ -68,7 +68,7 @@ Reveal never implies Open, Take, or Travel.
 | 3 | [#588](https://github.com/cenetex/cosyworld/issues/588) | Lead, Gate, Hazard, Pressure, and Anchor descriptors. Shipped in 0.0.282. |
 | 4 | [#589](https://github.com/cenetex/cosyworld/issues/589) | Kernel-owned conditional transitions. |
 | 5 | [#590](https://github.com/cenetex/cosyworld/issues/590) | Custody, recovery, and route reachability proof. |
-| 6 | [#591](https://github.com/cenetex/cosyworld/issues/591) | Concrete methods and consequence-first offers. Shipped in 0.0.286. |
+| 6 | [#591](https://github.com/cenetex/cosyworld/issues/591) | Concrete methods and consequence-first offers. Shipped in 0.0.287. |
 | 7 | [#592](https://github.com/cenetex/cosyworld/issues/592) | Telegraphed method-aware Hazards. |
 | 8 | [#601](https://github.com/cenetex/cosyworld/issues/601) | One discovery pipeline across Notice, Search, Study, and Scout. |
 | 9 | [#593](https://github.com/cenetex/cosyworld/issues/593) | Bounded Pressure scenes and event rolls. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.286",
+  "version": "0.0.287",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.286",
+      "version": "0.0.287",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.286",
+  "version": "0.0.287",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/scripts/check-fly-volume-space.sh
+++ b/scripts/check-fly-volume-space.sh
@@ -26,7 +26,10 @@ if ! df_output="$(flyctl ssh console -a "$APP" -C "df -P $MOUNT" 2>&1)"; then
   exit 1
 fi
 
-df_line="$(echo "$df_output" | awk 'NR==2 {print}')"
+df_line="$(
+  printf '%s\n' "$df_output" \
+    | awk -v mount="$MOUNT" '$5 ~ /^[0-9]+%$/ && $6 == mount { print; exit }'
+)"
 if [ -z "$df_line" ]; then
   df_output="${df_output//$'\n'/ }"
   echo "::error::could not read df for $MOUNT on app $APP — refusing to deploy blind. flyctl: $df_output" >&2

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -134,7 +134,8 @@ describe('deploy workflow', () => {
 
   it('accepts a healthy volume report below the configured threshold', () => {
     const result = runVolumeGuard(
-      'echo "Filesystem 1024-blocks Used Available Capacity Mounted on"\n'
+      'echo "Connecting to fdaa:73:809:a7b:8c:51:4894:2..." >&2\n'
+      + 'echo "Filesystem 1024-blocks Used Available Capacity Mounted on"\n'
       + 'echo "/dev/vdb 100000 42000 58000 42% /data"'
     );
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.286"
+version = "0.0.287"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.286"
+version = "0.0.287"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Incident
The 0.0.286 main deploy stopped safely before production because `flyctl ssh console` emitted a `Connecting…` line on stderr. After stderr preservation was added in #632, the fixed-row parser selected the `df` header instead of the filesystem row.

## Fix
- select the POSIX `df` row by numeric capacity plus exact mount rather than line number
- retain full Fly diagnostics on true SSH/parse failure
- cover the real stderr preamble in the infrastructure regression test
- bump the production release to 0.0.287

## Verification
- both live guards pass: `cosyworld` 43%, `cosyworld-lonelyforest` 30%
- `npm run check` (517 JS tests; 882 Rust tests; worldpack, kernel, architecture, syntax)
- `npm run check:version`