### PR TITLE
Unify authored discovery procedures

### DIFF
--- a/docs/decisions/0005-thresholds-trails-and-strict-referee.md
+++ b/docs/decisions/0005-thresholds-trails-and-strict-referee.md
@@ -96,6 +96,18 @@ the honest no-movement result but adds an exact Lead, Anchor/active-foray
 evidence, descriptor versions, and no-null-commit law. New code must use a new
 append-only action or procedure version rather than reinterpret `scout_v1`.
 
+The `discovery-procedure-v2` runtime implements `focused_notice_v2`,
+`search_v2`, `study_v2`, and `scout_v2` as one slot-bound pipeline. A pack
+catalog freezes the receipt, claim scope, stocked result, and any pressure
+consequence before an offer is projected. Browser, terminal, API, and
+inference controllers select that same offer and receipt. A safe Search
+commits without an ability roll; under Pressure the roll only avoids the
+already-frozen consequence. The discovery projection records a Lead or Reveal
+and cannot Open, Travel, Take, equip, materialize, or award the result.
+Snapshots and journal records preserve the frozen claim, and exact retries or
+replay cannot roll or publish it twice. Legacy Search, Study, and `scout_v1`
+records retain their original meanings.
+
 ### Shared discovery progression
 
 The common vocabulary is:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.288",
+  "version": "0.0.289",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.288",
+      "version": "0.0.289",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.288",
+  "version": "0.0.289",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/cli/cosy_cli.py
+++ b/v2/cli/cosy_cli.py
@@ -541,6 +541,12 @@ class Game:
             "/actions/flee": {"flee"},
             "/actions/check": {"check"},
             "/actions/study": {"study"},
+            "/actions/discover": {
+                "focused_notice",
+                "search_discovery",
+                "study_discovery",
+                "scout_discovery",
+            },
             "/actions/influence": {"influence"},
             "/actions/cast-spell": {"cast_spell"},
             "/actions/pick-up": {"pick_up"},
@@ -568,6 +574,18 @@ class Game:
             if offer.get("kind") in kinds and not offer.get("disabled")
         ]
         for offer in offers:
+            discovery = offer.get("discovery") or {}
+            if path == "/actions/discover":
+                if (
+                    str(discovery.get("procedure") or "") != str(payload.get("procedure") or "")
+                    or str(discovery.get("slot_id") or "") != str(payload.get("slot_id") or "")
+                    or (
+                        payload.get("receipt_id")
+                        and str(discovery.get("receipt_id") or "")
+                        != str(payload.get("receipt_id") or "")
+                    )
+                ):
+                    continue
             target = offer.get("target") or {}
             expected = target.get("id")
             key = {

--- a/v2/core-c/include/cosy_kernel.h
+++ b/v2/core-c/include/cosy_kernel.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /* Version 9 is reserved by #411 for project-push ABI state. */
-#define CW_KERNEL_VERSION 12u
+#define CW_KERNEL_VERSION 13u
 
 #define CW_MAX_ACTORS 512u
 #define CW_MAX_ITEMS 1024u
@@ -289,7 +289,13 @@ typedef enum {
      deterministically; it resolves the encounter with no winning side so a
      stuck scene releases its participants instead of retrying forever. */
   CW_ACTION_COMBAT_ABANDON = 33,
-  CW_ACTION_GATE_TRANSITION = 34
+  CW_ACTION_GATE_TRANSITION = 34,
+  /* Append-only discovery procedures. These commit procedure use only; the
+     orchestrator-owned frozen claim decides what truth becomes revealed. */
+  CW_ACTION_FOCUSED_NOTICE_V2 = 35,
+  CW_ACTION_SEARCH_V2 = 36,
+  CW_ACTION_STUDY_V2 = 37,
+  CW_ACTION_SCOUT_V2 = 38
 } cw_action_kind;
 
 typedef enum {
@@ -340,7 +346,11 @@ typedef enum {
   CW_EVENT_GATE_TRANSITION_APPLIED = 43,
   CW_EVENT_ITEM_INSTALLED = 44,
   CW_EVENT_ITEM_REMOVED = 45,
-  CW_EVENT_ITEM_RENDERED_INERT = 46
+  CW_EVENT_ITEM_RENDERED_INERT = 46,
+  CW_EVENT_FOCUSED_NOTICE_COMMITTED = 47,
+  CW_EVENT_SEARCH_COMMITTED = 48,
+  CW_EVENT_STUDY_COMMITTED = 49,
+  CW_EVENT_SCOUT_COMMITTED = 50
 } cw_event_type;
 
 typedef enum {

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -1244,6 +1244,37 @@ static cw_status apply_ability_check(cw_world *world, const cw_action *action, u
   return CW_OK;
 }
 
+static cw_status apply_discovery_procedure(
+    cw_world *world,
+    const cw_action *action,
+    uint64_t seed,
+    uint8_t event_type,
+    cw_event_buffer *out_events) {
+  cw_actor *actor = 0;
+  cw_status status = require_active_actor(world, action, out_events, &actor);
+  if (status != CW_OK) return status;
+  if (!action->location_id
+      || action->location_id != actor->location_id
+      || !find_location_const(world, action->location_id)) {
+    return reject(world, out_events, action, CW_REASON_NOT_SAME_LOCATION);
+  }
+  /* Under pressure, the check only decides whether the separately frozen
+     event consequence fires. It never decides whether authored truth exists
+     or whether the procedure reveals it. */
+  if (action->dc) {
+    status = apply_ability_check(world, action, seed, out_events);
+    if (status != CW_OK) return status;
+  }
+  append_event(world, out_events, event_type);
+  if (out_events && out_events->count > 0) {
+    cw_event *event = &out_events->events[out_events->count - 1];
+    event->success = 1;
+    event->actor_id = actor->id;
+    event->location_id = actor->location_id;
+  }
+  return CW_OK;
+}
+
 static cw_status apply_pick_up_item(cw_world *world, const cw_action *action, cw_event_buffer *out_events) {
   cw_actor *actor = 0;
   cw_status status = require_active_actor(world, action, out_events, &actor);
@@ -3247,6 +3278,22 @@ cw_status cw_world_apply_with_tick(cw_world *world, const cw_action *action, uin
     case CW_ACTION_GATE_TRANSITION:
       status = apply_gate_transition(world, action, seed, out_events);
       break;
+    case CW_ACTION_FOCUSED_NOTICE_V2:
+      status = apply_discovery_procedure(
+          world, action, seed, CW_EVENT_FOCUSED_NOTICE_COMMITTED, out_events);
+      break;
+    case CW_ACTION_SEARCH_V2:
+      status = apply_discovery_procedure(
+          world, action, seed, CW_EVENT_SEARCH_COMMITTED, out_events);
+      break;
+    case CW_ACTION_STUDY_V2:
+      status = apply_discovery_procedure(
+          world, action, seed, CW_EVENT_STUDY_COMMITTED, out_events);
+      break;
+    case CW_ACTION_SCOUT_V2:
+      status = apply_discovery_procedure(
+          world, action, seed, CW_EVENT_SCOUT_COMMITTED, out_events);
+      break;
     default:
       status = reject(world, out_events, action, CW_REASON_INVALID_ACTION);
       break;
@@ -3454,6 +3501,10 @@ const char *cw_event_type_name(uint8_t type) {
     case CW_EVENT_ITEM_INSTALLED: return "item.installed";
     case CW_EVENT_ITEM_REMOVED: return "item.removed";
     case CW_EVENT_ITEM_RENDERED_INERT: return "item.rendered_inert";
+    case CW_EVENT_FOCUSED_NOTICE_COMMITTED: return "discovery.notice.committed";
+    case CW_EVENT_SEARCH_COMMITTED: return "discovery.search.committed";
+    case CW_EVENT_STUDY_COMMITTED: return "discovery.study.committed";
+    case CW_EVENT_SCOUT_COMMITTED: return "discovery.scout.committed";
     default: return "unknown";
   }
 }

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -2124,6 +2124,41 @@ static void test_project_push_resolution_matrix_and_action_event(void) {
   assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
 }
 
+static void test_discovery_procedures_reveal_regardless_of_pressure_check(void) {
+  cw_world world;
+  cw_event_buffer events;
+  cw_world_init(&world);
+  assert(cw_seed_cosy_cottage(&world, &events) == CW_OK);
+
+  cw_action search = {0};
+  search.kind = CW_ACTION_SEARCH_V2;
+  search.actor_id = 1001;
+  search.location_id = 1;
+  assert(cw_world_apply(&world, &search, 601, &events) == CW_OK);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_SEARCH_COMMITTED);
+  assert(strcmp(cw_event_type_name(events.events[0].type), "discovery.search.committed") == 0);
+
+  cw_action study = {0};
+  study.kind = CW_ACTION_STUDY_V2;
+  study.actor_id = 1001;
+  study.location_id = 1;
+  study.ability = CW_ABILITY_INTELLIGENCE;
+  study.dc = 30;
+  assert(cw_world_apply(&world, &study, 602, &events) == CW_OK);
+  assert(events.count == 2);
+  assert(events.events[0].type == CW_EVENT_ABILITY_CHECK_ROLLED);
+  assert(events.events[0].success == 0);
+  assert(events.events[1].type == CW_EVENT_STUDY_COMMITTED);
+  assert(events.events[1].success == 1);
+
+  search.location_id = 2;
+  assert(cw_world_apply(&world, &search, 603, &events) == CW_ERR_RULE);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_RULE_REJECTED);
+  assert(events.events[0].reason == CW_REASON_NOT_SAME_LOCATION);
+}
+
 static void apply_replay_sequence(cw_world *world, cw_event *events, size_t *event_count) {
   cw_event_buffer buffer;
   *event_count = 0;
@@ -2206,6 +2241,7 @@ int main(void) {
   test_kernel_gate_authority_stale_offers_and_claims();
   test_combat_join_preserves_legacy_sides_and_accepts_explicit_sides();
   test_project_push_resolution_matrix_and_action_event();
+  test_discovery_procedures_reveal_regardless_of_pressure_check();
   test_deterministic_replay();
   puts("cosy kernel tests passed");
   return 0;

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.288"
+version = "0.0.289"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.288"
+version = "0.0.289"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_resident_planning.rs
+++ b/v2/orchestrator-rust/src/ai_resident_planning.rs
@@ -10,6 +10,10 @@ const RESIDENT_PLANNER_ELIGIBLE_KINDS: &[&str] = &[
     "trade_item",
     "use_item",
     "open",
+    FOCUSED_NOTICE_OFFER_KIND,
+    DISCOVERY_SEARCH_OFFER_KIND,
+    DISCOVERY_STUDY_OFFER_KIND,
+    DISCOVERY_SCOUT_OFFER_KIND,
 ];
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -245,6 +249,16 @@ impl RuntimeWorld {
                 candidate.destination_location_id = Some(destination.parse().ok()?);
                 self.plan_threshold_method_offer_action(actor_id, offer)
                     .ok()?;
+            }
+            (
+                kind @ (FOCUSED_NOTICE_OFFER_KIND
+                | DISCOVERY_SEARCH_OFFER_KIND
+                | DISCOVERY_STUDY_OFFER_KIND
+                | DISCOVERY_SCOUT_OFFER_KIND),
+                _,
+            ) => {
+                self.discovery_record_for_offer(actor_id, offer, 0).ok()?;
+                candidate.kind = kind.to_string();
             }
             _ => return None,
         }
@@ -840,6 +854,40 @@ mod tests {
                 .map(|kind| (*kind).to_string())
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn planner_and_autonomy_consume_the_exact_frozen_discovery_offer() {
+        let mut runtime = RuntimeWorld::seeded();
+        let catalog: DiscoveryAuthorityCatalog =
+            serde_json::from_str(include_str!("../fixtures/discovery-authority-v1.json"))
+                .expect("discovery fixture");
+        runtime.install_discovery_catalog_for_test(
+            catalog,
+            "fixture.discovery",
+            "1.0.0",
+            COSY_COTTAGE_LOCATION_ID,
+            Some("fixture.discovery:region/mossy-verge"),
+        );
+        let actor = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
+        let offer = runtime
+            .discovery_action_offers(actor.id)
+            .into_iter()
+            .find(|offer| offer.kind == FOCUSED_NOTICE_OFFER_KIND)
+            .expect("focused discovery offer");
+        let candidate = runtime
+            .resident_planner_candidate_from_offer(actor.id, &offer)
+            .expect("planner accepts the exact offer");
+        assert_eq!(candidate.candidate_id, offer.offer_id);
+        assert_eq!(candidate.composition_id, offer.composition_id);
+        let record = runtime
+            .resident_record_for_shared_offer(actor, &offer, 92_001)
+            .expect("autonomy consumes the same offer");
+        assert!(runtime.resident_offer_matches_record(&offer, &record));
+        assert!(record.projection_mutations.iter().any(|mutation| {
+            matches!(mutation, ProjectionMutation::ResolveDiscovery { intent }
+                if intent.receipt.id == offer.discovery.as_ref().unwrap().receipt_id)
+        }));
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/beliefs_tests.rs
+++ b/v2/orchestrator-rust/src/beliefs_tests.rs
@@ -207,7 +207,7 @@ fn legacy_search_and_resident_memories_migrate_into_canonical_beliefs() {
 
     let current = serde_json::to_value(RuntimeSnapshot::from_runtime(&restored))
         .expect("current snapshot serializes");
-    assert_eq!(current["version"], 15);
+    assert_eq!(current["version"], 16);
     assert!(current.get("beliefs").is_some());
     assert!(current.get("resident_memories").is_none());
     assert!(current.get("search_memories").is_none());

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -56,6 +56,23 @@ fn submitted_feature_binding_matches(
             == Some(feature_key)
 }
 
+fn submitted_discovery_binding_matches(
+    offer: &RankedActionOffer,
+    payload: &serde_json::Value,
+) -> bool {
+    let Some(discovery) = offer.discovery.as_ref() else {
+        return true;
+    };
+    payload.get("procedure").and_then(serde_json::Value::as_str)
+        == Some(discovery.procedure.as_str())
+        && payload.get("slot_id").and_then(serde_json::Value::as_str)
+            == Some(discovery.slot_id.as_str())
+        && payload
+            .get("receipt_id")
+            .and_then(serde_json::Value::as_str)
+            .is_none_or(|receipt_id| receipt_id == discovery.receipt_id)
+}
+
 fn submitted_offer_legacy_id(submission: &ActionOfferSubmissionRequest) -> Option<&str> {
     let prefix = format!(
         "{}:{}:",
@@ -151,6 +168,8 @@ impl RuntimeWorld {
             Err("submitted payload target does not match the authoritative offer")
         } else if !submitted_feature_binding_matches(offer, &submission.payload) {
             Err("submitted feature binding does not match the authoritative offer")
+        } else if !submitted_discovery_binding_matches(offer, &submission.payload) {
+            Err("submitted discovery binding does not match the authoritative offer")
         } else if offer.project.as_ref().is_some_and(|project| {
             submission
                 .payload
@@ -510,6 +529,7 @@ impl RuntimeWorld {
                     state_revision,
                     route: None,
                     threshold_method: None,
+                    discovery: None,
                     category: action_offer_category(&option.kind).to_string(),
                     intention,
                     kind: option.kind,
@@ -544,6 +564,7 @@ impl RuntimeWorld {
         offers = self.expand_transfer_action_offers(actor_id, offers);
         offers = self.expand_route_action_offers(actor_id, access, offers);
         offers.extend(self.threshold_method_action_offers(actor_id, access));
+        offers.extend(self.discovery_action_offers(actor_id));
         if let Some(reason) = self.rest_offer_unavailable_reason(actor_id) {
             let mut unavailable = self.ranked_offer_from_parts(
                 "rest",
@@ -632,6 +653,7 @@ impl RuntimeWorld {
                 state_revision,
                 route,
                 threshold_method: None,
+                discovery: None,
                 category: action_offer_category(kind).to_string(),
                 verb,
                 label,
@@ -782,6 +804,7 @@ impl RuntimeWorld {
             state_revision,
             route: None,
             threshold_method: None,
+            discovery: None,
             kind: kind.to_string(),
             intention: action_offer_intention(kind).to_string(),
             category: action_offer_category(kind).to_string(),
@@ -1975,6 +1998,366 @@ impl RuntimeWorld {
                 .map(|bond| format!("bond_resolved:{}", bond.id)),
             _ => None,
         }
+    }
+}
+
+pub(super) fn action_provider(
+    kind: impl Into<String>,
+    id: impl Into<String>,
+    label: impl Into<String>,
+    reason: impl Into<String>,
+    priority: u8,
+) -> ActionProviderView {
+    ActionProviderView {
+        kind: kind.into(),
+        id: id.into(),
+        label: label.into(),
+        reason: reason.into(),
+        priority,
+    }
+}
+
+pub(super) fn calling_matches_inspect(statement: &str) -> bool {
+    let statement = statement.to_ascii_lowercase();
+    [
+        "clue", "lost", "stuck", "shy room", "strange", "warning", "errand",
+    ]
+    .iter()
+    .any(|needle| statement.contains(needle))
+}
+
+pub(super) fn action_offer_requires_target(kind: &str) -> bool {
+    matches!(
+        kind,
+        "chat"
+            | "influence"
+            | "attack"
+            | "defend"
+            | "flee"
+            | "pick_up"
+            | "use_item"
+            | "use_feature"
+            | "give_item"
+            | "trade_item"
+            | "search"
+            | "study"
+            | "work"
+            | "help"
+            | "craft"
+            | "move"
+            | "create_bond"
+            | "resolve_bond"
+            | "explore_path"
+            | FOCUSED_NOTICE_OFFER_KIND
+            | DISCOVERY_SEARCH_OFFER_KIND
+            | DISCOVERY_STUDY_OFFER_KIND
+            | DISCOVERY_SCOUT_OFFER_KIND
+            | "open"
+    )
+}
+
+pub(super) fn action_offer_is_reachable(offer: &RankedActionOffer) -> bool {
+    if offer.disabled {
+        return false;
+    }
+    if action_offer_requires_target(&offer.kind) && offer.target.is_none() {
+        return false;
+    }
+    if matches!(offer.kind.as_str(), "prepare" | "work" | "help" | "study")
+        && offer.project.is_none()
+    {
+        return false;
+    }
+    true
+}
+
+pub(super) fn action_offer_hand_group(offer: &RankedActionOffer) -> String {
+    if offer.intention == "contribute" {
+        return offer
+            .project
+            .as_ref()
+            .map(|project| format!("contribute:{}", project.progress_clock_id))
+            .unwrap_or_else(|| "contribute".to_string());
+    }
+    if matches!(offer.kind.as_str(), "give_item" | "trade_item") {
+        return offer.kind.clone();
+    }
+    if matches!(offer.kind.as_str(), "use_item" | "use_feature") {
+        return "use".to_string();
+    }
+    offer.id.clone()
+}
+
+pub(super) fn action_offer_is_generally_useful(offer: &RankedActionOffer) -> bool {
+    matches!(
+        offer.kind.as_str(),
+        "check"
+            | "search"
+            | FOCUSED_NOTICE_OFFER_KIND
+            | DISCOVERY_SEARCH_OFFER_KIND
+            | DISCOVERY_STUDY_OFFER_KIND
+            | DISCOVERY_SCOUT_OFFER_KIND
+            | "move"
+            | "chat"
+            | "rest"
+    )
+}
+
+pub(super) fn compose_action_hand(offers: &[RankedActionOffer]) -> ActionHandView {
+    const CAPACITY: usize = 2;
+    let mut candidates: Vec<_> = offers
+        .iter()
+        .filter(|offer| offer.ranked_hand_eligible && action_offer_is_reachable(offer))
+        .collect();
+    candidates.sort_by(|left, right| {
+        left.provider
+            .priority
+            .cmp(&right.provider.priority)
+            .then_with(|| left.rank.cmp(&right.rank))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let mut grouped = Vec::new();
+    let mut seen_groups = BTreeSet::new();
+    for offer in candidates {
+        if seen_groups.insert(action_offer_hand_group(offer)) {
+            grouped.push(offer);
+        }
+    }
+
+    let mut selected = Vec::new();
+    let mut provider_counts = BTreeMap::<String, u8>::new();
+    for offer in &grouped {
+        let provider_key = format!("{}:{}", offer.provider.kind, offer.provider.id);
+        let count = provider_counts.entry(provider_key).or_default();
+        if *count < 2 {
+            selected.push(*offer);
+            *count += 1;
+        }
+        if selected.len() == CAPACITY {
+            break;
+        }
+    }
+    if selected.len() < CAPACITY {
+        for offer in &grouped {
+            if selected.iter().any(|selected| selected.id == offer.id) {
+                continue;
+            }
+            selected.push(*offer);
+            if selected.len() == CAPACITY {
+                break;
+            }
+        }
+    }
+
+    if !selected
+        .iter()
+        .any(|offer| action_offer_is_generally_useful(offer))
+    {
+        if let Some(general) = grouped
+            .iter()
+            .copied()
+            .find(|offer| action_offer_is_generally_useful(offer))
+        {
+            if selected.len() < CAPACITY {
+                selected.push(general);
+            } else if let Some(last) = selected.last_mut() {
+                *last = general;
+            }
+        }
+    }
+
+    selected.sort_by(|left, right| {
+        left.provider
+            .priority
+            .cmp(&right.provider.priority)
+            .then_with(|| left.rank.cmp(&right.rank))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    selected.dedup_by(|left, right| left.id == right.id);
+
+    ActionHandView {
+        schema_version: 1,
+        capacity: CAPACITY as u8,
+        entries: selected
+            .into_iter()
+            .map(|offer| ActionHandEntryView {
+                offer_id: offer.offer_id.clone(),
+                kind: offer.kind.clone(),
+                intention: offer.intention.clone(),
+                provider: offer.provider.clone(),
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn action_offer_rank(kind: &str) -> u16 {
+    match kind {
+        "give_item" => 10,
+        "open" => 18,
+        "use_item" | "use_feature" => 20,
+        "rest" => 25,
+        "pick_up" | "drop_item" => 30,
+        "craft" => 31,
+        "prepare" => 32,
+        "attack" => 40,
+        "defend" => 45,
+        "work" => 48,
+        "help" => 49,
+        "flee" => 50,
+        FOCUSED_NOTICE_OFFER_KIND => 52,
+        DISCOVERY_SEARCH_OFFER_KIND => 53,
+        DISCOVERY_STUDY_OFFER_KIND => 54,
+        "explore_path" | DISCOVERY_SCOUT_OFFER_KIND => 55,
+        "search" => 58,
+        "check" => 60,
+        "study" => 61,
+        "cast_spell" => 22,
+        "chat" => 70,
+        "trade_item" => 74,
+        "train_skill" => 76,
+        "create_bond" => 77,
+        "resolve_bond" => 79,
+        "move" => 80,
+        _ => 500,
+    }
+}
+
+pub(super) fn practice_category_matches_offer(category: &str, kind: &str) -> bool {
+    match category {
+        "exploration" => matches!(
+            kind,
+            "explore_path"
+                | "search"
+                | "check"
+                | FOCUSED_NOTICE_OFFER_KIND
+                | DISCOVERY_SEARCH_OFFER_KIND
+                | DISCOVERY_SCOUT_OFFER_KIND
+                | "open"
+                | "move"
+        ),
+        "craft" => matches!(kind, "craft" | "use_feature"),
+        "delivery" => matches!(kind, "move" | "give_item" | "trade_item"),
+        "stewardship" => matches!(kind, "prepare" | "work" | "help"),
+        "care" => matches!(kind, "defend" | "use_item" | "rest"),
+        "mediation" => matches!(kind, "influence" | "chat" | "create_bond" | "resolve_bond"),
+        "lore" => matches!(
+            kind,
+            "study"
+                | "search"
+                | "check"
+                | FOCUSED_NOTICE_OFFER_KIND
+                | DISCOVERY_SEARCH_OFFER_KIND
+                | DISCOVERY_STUDY_OFFER_KIND
+        ),
+        _ => false,
+    }
+}
+
+pub(super) fn action_offer_intention(kind: &str) -> &str {
+    match kind {
+        "check" => "notice",
+        "search" => "inspect",
+        "explore_path" => "scout",
+        FOCUSED_NOTICE_OFFER_KIND => "notice",
+        DISCOVERY_SEARCH_OFFER_KIND => "inspect",
+        DISCOVERY_STUDY_OFFER_KIND => "study",
+        DISCOVERY_SCOUT_OFFER_KIND => "scout",
+        "move" => "travel",
+        "open" => "open",
+        "work" | "help" => "contribute",
+        _ => kind,
+    }
+}
+
+pub(super) fn contribution_resolution_label(policy: &ContributionResolutionPolicy) -> &'static str {
+    match policy {
+        ContributionResolutionPolicy::Certain => "certain",
+        ContributionResolutionPolicy::SrdCheck { .. } => "srd_check",
+        ContributionResolutionPolicy::ExistingKernelOutcome { .. } => "existing_kernel_outcome",
+    }
+}
+
+pub(super) fn default_action_offer_verb(kind: &str) -> &str {
+    match kind {
+        "check" => "Notice",
+        "search" => "Inspect",
+        "explore_path" => "Scout",
+        FOCUSED_NOTICE_OFFER_KIND => "Notice",
+        DISCOVERY_SEARCH_OFFER_KIND => "Search",
+        DISCOVERY_STUDY_OFFER_KIND => "Study",
+        DISCOVERY_SCOUT_OFFER_KIND => "Scout",
+        "move" => "Travel",
+        "open" => "Open",
+        "work" => "Push",
+        "help" => "Help",
+        "flee" => "Flee",
+        "prepare" => "Prepare",
+        "pick_up" => "Take",
+        "drop_item" => "Drop",
+        _ => "Act",
+    }
+}
+
+pub(super) fn non_empty_text(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}
+
+pub(super) fn action_target_phrase(verb: &str, preposition: &str, target: Option<&str>) -> String {
+    let Some(target) = target.and_then(non_empty_text) else {
+        return verb.to_string();
+    };
+    if preposition.is_empty()
+        || verb
+            .to_ascii_lowercase()
+            .ends_with(&format!(" {preposition}"))
+    {
+        format!("{verb} {target}")
+    } else {
+        format!("{verb} {preposition} {target}")
+    }
+}
+
+pub(super) fn fallback_job_action_label(job_id: &str) -> String {
+    let words = job_id
+        .rsplit_once(':')
+        .map(|(_, suffix)| suffix)
+        .unwrap_or(job_id)
+        .split(['-', '_'])
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    let fallback = if words.is_empty() {
+        "Contribute".to_string()
+    } else {
+        words.join(" ")
+    };
+    let mut characters = fallback.chars();
+    characters
+        .next()
+        .map(|first| first.to_uppercase().collect::<String>() + characters.as_str())
+        .unwrap_or_else(|| "Contribute".to_string())
+}
+
+pub(super) fn action_offer_category(kind: &str) -> &'static str {
+    match kind {
+        "create_avatar" => "system",
+        "move" | "flee" | "explore_path" => "travel",
+        "attack" | "defend" => "danger",
+        "pick_up" | "drop_item" | "use_item" | "use_feature" | "give_item" | "trade_item"
+        | "open" => "inventory",
+        "craft" => "craft",
+        "chat" | "help" | "create_bond" | "resolve_bond" => "social",
+        "check"
+        | "search"
+        | FOCUSED_NOTICE_OFFER_KIND
+        | DISCOVERY_SEARCH_OFFER_KIND
+        | DISCOVERY_STUDY_OFFER_KIND
+        | DISCOVERY_SCOUT_OFFER_KIND => "discovery",
+        "prepare" | "work" => "project",
+        "rest" => "recovery",
+        "train_skill" | "revise_calling" | "revise_bond" => "growth",
+        _ => "other",
     }
 }
 

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -4,6 +4,11 @@ use super::*;
 mod discovery_authority;
 #[path = "threshold_descriptors.rs"]
 mod threshold_descriptors;
+pub(super) use discovery_authority::{
+    discovery_authority_catalog, freeze_discovery_receipt, DiscoveryAuthorityCatalog,
+    DiscoveryEventTable, DiscoveryReceiptRequest, DiscoveryRollReceipt, DiscoverySelectionMode,
+    DiscoverySlotDefinition, DiscoveryStockingTable, DiscoveryTell,
+};
 pub(super) use threshold_descriptors::{
     threshold_kernel_id, threshold_record_claim_already_applied,
     threshold_record_preconditions_hold, AcceptedThresholdIntent, ThresholdFactSource,

--- a/v2/orchestrator-rust/src/discovery_authority.rs
+++ b/v2/orchestrator-rust/src/discovery_authority.rs
@@ -37,175 +37,175 @@ const EVENT_EFFECTS: [&str; 6] = [
     "change_method",
 ];
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryAuthorityCatalog {
-    pub(super) schema_version: u8,
-    pub(super) receipt_version: String,
-    pub(super) roll_algorithm: String,
-    pub(super) stocking_tables: Vec<DiscoveryStockingTable>,
+pub(crate) struct DiscoveryAuthorityCatalog {
+    pub(crate) schema_version: u8,
+    pub(crate) receipt_version: String,
+    pub(crate) roll_algorithm: String,
+    pub(crate) stocking_tables: Vec<DiscoveryStockingTable>,
     #[serde(default)]
-    pub(super) event_tables: Vec<DiscoveryEventTable>,
+    pub(crate) event_tables: Vec<DiscoveryEventTable>,
     #[serde(default)]
-    pub(super) presentation_tables: Vec<DiscoveryPresentationTable>,
-    pub(super) slots: Vec<DiscoverySlotDefinition>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryStockingTable {
-    pub(super) id: String,
-    pub(super) version: u8,
-    pub(super) target_kind: String,
-    pub(super) eligible_inputs: Vec<String>,
-    pub(super) rows: Vec<DiscoveryStockingRow>,
-    pub(super) fallback_row_id: String,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryStockingRow {
-    pub(super) id: String,
-    pub(super) weight: u16,
-    pub(super) result_ids: Vec<String>,
-    #[serde(default)]
-    pub(super) unique: bool,
-    #[serde(default)]
-    pub(super) topology_entity_ids: Vec<String>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryEventTable {
-    pub(super) id: String,
-    pub(super) version: u8,
-    pub(super) eligible_inputs: Vec<String>,
-    pub(super) rows: Vec<DiscoveryEventRow>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryEventRow {
-    pub(super) id: String,
-    pub(super) weight: u16,
-    pub(super) effect_kind: String,
-    pub(super) target_id: String,
-    pub(super) amount: u8,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryPresentationTable {
-    pub(super) id: String,
-    pub(super) version: u8,
-    pub(super) rows: Vec<DiscoveryPresentationRow>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryPresentationRow {
-    pub(super) id: String,
-    pub(super) text: String,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoverySlotDefinition {
-    pub(super) id: String,
-    pub(super) version: u8,
-    pub(super) target_kind: String,
-    pub(super) origin_id: String,
-    pub(super) scope: String,
-    pub(super) initial_phase: String,
-    pub(super) tells: Vec<DiscoveryTell>,
-    pub(super) reveal_methods: Vec<String>,
-    pub(super) claim_policy: String,
-    pub(super) stocking: DiscoveryStockingBinding,
-    #[serde(default)]
-    pub(super) authorized_topology_ids: Vec<String>,
-    #[serde(default)]
-    pub(super) gate_id: Option<String>,
-    #[serde(default)]
-    pub(super) hazard_id: Option<String>,
-    #[serde(default)]
-    pub(super) event_table_id: Option<String>,
-    #[serde(default)]
-    pub(super) event_table_version: Option<u8>,
-    #[serde(default)]
-    pub(super) presentation_table_id: Option<String>,
-    #[serde(default)]
-    pub(super) presentation_table_version: Option<u8>,
-    pub(super) progression: DiscoveryProgression,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryTell {
-    pub(super) id: String,
-    pub(super) sense: String,
-    pub(super) text: String,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryStockingBinding {
-    pub(super) kind: String,
-    #[serde(default)]
-    pub(super) table_id: Option<String>,
-    #[serde(default)]
-    pub(super) table_version: Option<u8>,
-    #[serde(default)]
-    pub(super) result_ids: Vec<String>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryProgression {
-    pub(super) kind: String,
-    #[serde(default)]
-    pub(super) sign_budget: Option<u8>,
-    #[serde(default)]
-    pub(super) fallback_row_id: Option<String>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum DiscoverySelectionMode {
-    Weighted,
-    RequiredFallback,
-}
-
-pub(super) struct DiscoveryReceiptRequest<'a> {
-    pub(super) pack_id: &'a str,
-    pub(super) pack_version: &'a str,
-    pub(super) slot_id: &'a str,
-    pub(super) scope_id: &'a str,
-    pub(super) server_facts: BTreeMap<String, String>,
-    pub(super) mode: DiscoverySelectionMode,
+    pub(crate) presentation_tables: Vec<DiscoveryPresentationTable>,
+    pub(crate) slots: Vec<DiscoverySlotDefinition>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub(super) struct DiscoveryRollReceipt {
-    pub(super) schema_version: u8,
-    pub(super) receipt_version: String,
-    pub(super) id: String,
-    pub(super) claim_key: String,
-    pub(super) slot_id: String,
-    pub(super) slot_version: u8,
-    pub(super) target_kind: String,
-    pub(super) scope: String,
-    pub(super) scope_id: String,
-    pub(super) pack_id: String,
-    pub(super) pack_version: String,
-    pub(super) table_id: Option<String>,
-    pub(super) table_version: Option<u8>,
-    pub(super) roll_algorithm: String,
-    pub(super) eligible_input_facts: BTreeMap<String, String>,
-    pub(super) seed_input: String,
-    pub(super) roll_seed: u64,
-    pub(super) selected_row_id: String,
-    pub(super) materialized_entity_ids: Vec<String>,
-    pub(super) fallback_decision: String,
+pub(crate) struct DiscoveryStockingTable {
+    pub(crate) id: String,
+    pub(crate) version: u8,
+    pub(crate) target_kind: String,
+    pub(crate) eligible_inputs: Vec<String>,
+    pub(crate) rows: Vec<DiscoveryStockingRow>,
+    pub(crate) fallback_row_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryStockingRow {
+    pub(crate) id: String,
+    pub(crate) weight: u16,
+    pub(crate) result_ids: Vec<String>,
+    #[serde(default)]
+    pub(crate) unique: bool,
+    #[serde(default)]
+    pub(crate) topology_entity_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryEventTable {
+    pub(crate) id: String,
+    pub(crate) version: u8,
+    pub(crate) eligible_inputs: Vec<String>,
+    pub(crate) rows: Vec<DiscoveryEventRow>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryEventRow {
+    pub(crate) id: String,
+    pub(crate) weight: u16,
+    pub(crate) effect_kind: String,
+    pub(crate) target_id: String,
+    pub(crate) amount: u8,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryPresentationTable {
+    pub(crate) id: String,
+    pub(crate) version: u8,
+    pub(crate) rows: Vec<DiscoveryPresentationRow>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryPresentationRow {
+    pub(crate) id: String,
+    pub(crate) text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoverySlotDefinition {
+    pub(crate) id: String,
+    pub(crate) version: u8,
+    pub(crate) target_kind: String,
+    pub(crate) origin_id: String,
+    pub(crate) scope: String,
+    pub(crate) initial_phase: String,
+    pub(crate) tells: Vec<DiscoveryTell>,
+    pub(crate) reveal_methods: Vec<String>,
+    pub(crate) claim_policy: String,
+    pub(crate) stocking: DiscoveryStockingBinding,
+    #[serde(default)]
+    pub(crate) authorized_topology_ids: Vec<String>,
+    #[serde(default)]
+    pub(crate) gate_id: Option<String>,
+    #[serde(default)]
+    pub(crate) hazard_id: Option<String>,
+    #[serde(default)]
+    pub(crate) event_table_id: Option<String>,
+    #[serde(default)]
+    pub(crate) event_table_version: Option<u8>,
+    #[serde(default)]
+    pub(crate) presentation_table_id: Option<String>,
+    #[serde(default)]
+    pub(crate) presentation_table_version: Option<u8>,
+    pub(crate) progression: DiscoveryProgression,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryTell {
+    pub(crate) id: String,
+    pub(crate) sense: String,
+    pub(crate) text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryStockingBinding {
+    pub(crate) kind: String,
+    #[serde(default)]
+    pub(crate) table_id: Option<String>,
+    #[serde(default)]
+    pub(crate) table_version: Option<u8>,
+    #[serde(default)]
+    pub(crate) result_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryProgression {
+    pub(crate) kind: String,
+    #[serde(default)]
+    pub(crate) sign_budget: Option<u8>,
+    #[serde(default)]
+    pub(crate) fallback_row_id: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DiscoverySelectionMode {
+    Weighted,
+    RequiredFallback,
+}
+
+pub(crate) struct DiscoveryReceiptRequest<'a> {
+    pub(crate) pack_id: &'a str,
+    pub(crate) pack_version: &'a str,
+    pub(crate) slot_id: &'a str,
+    pub(crate) scope_id: &'a str,
+    pub(crate) server_facts: BTreeMap<String, String>,
+    pub(crate) mode: DiscoverySelectionMode,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DiscoveryRollReceipt {
+    pub(crate) schema_version: u8,
+    pub(crate) receipt_version: String,
+    pub(crate) id: String,
+    pub(crate) claim_key: String,
+    pub(crate) slot_id: String,
+    pub(crate) slot_version: u8,
+    pub(crate) target_kind: String,
+    pub(crate) scope: String,
+    pub(crate) scope_id: String,
+    pub(crate) pack_id: String,
+    pub(crate) pack_version: String,
+    pub(crate) table_id: Option<String>,
+    pub(crate) table_version: Option<u8>,
+    pub(crate) roll_algorithm: String,
+    pub(crate) eligible_input_facts: BTreeMap<String, String>,
+    pub(crate) seed_input: String,
+    pub(crate) roll_seed: u64,
+    pub(crate) selected_row_id: String,
+    pub(crate) materialized_entity_ids: Vec<String>,
+    pub(crate) fallback_decision: String,
 }
 
 fn parse_catalog(pack: &SeedWorldpackPack) -> Result<Option<DiscoveryAuthorityCatalog>, String> {
@@ -215,6 +215,12 @@ fn parse_catalog(pack: &SeedWorldpackPack) -> Result<Option<DiscoveryAuthorityCa
     serde_json::from_value(value)
         .map(Some)
         .map_err(|error| format!("pack {} discovery authority: {error}", pack.id))
+}
+
+pub(crate) fn discovery_authority_catalog(
+    pack: &SeedWorldpackPack,
+) -> Result<Option<DiscoveryAuthorityCatalog>, String> {
+    parse_catalog(pack)
 }
 
 pub(super) struct DiscoverySlotContract {
@@ -628,7 +634,7 @@ fn validate_existing_receipt(receipt: &DiscoveryRollReceipt) -> Result<(), Strin
     Ok(())
 }
 
-pub(super) fn freeze_discovery_receipt(
+pub(crate) fn freeze_discovery_receipt(
     catalog: &DiscoveryAuthorityCatalog,
     request: DiscoveryReceiptRequest<'_>,
     existing: Option<&DiscoveryRollReceipt>,

--- a/v2/orchestrator-rust/src/discovery_pipeline.rs
+++ b/v2/orchestrator-rust/src/discovery_pipeline.rs
@@ -1,0 +1,1142 @@
+use super::*;
+
+pub(super) const DISCOVERY_PIPELINE_SCHEMA_VERSION: u8 = 1;
+pub(super) const DISCOVERY_PROCEDURE_VERSION: &str = "discovery-procedure-v2";
+pub(super) const FOCUSED_NOTICE_OFFER_KIND: &str = "focused_notice";
+pub(super) const DISCOVERY_SEARCH_OFFER_KIND: &str = "search_discovery";
+pub(super) const DISCOVERY_STUDY_OFFER_KIND: &str = "study_discovery";
+pub(super) const DISCOVERY_SCOUT_OFFER_KIND: &str = "scout_discovery";
+
+const DISCOVERY_EVENT_ROLL_DOMAIN: &str = "discovery-event-row";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct DiscoveryRuntimeSource {
+    schema_version: u8,
+    pack_id: String,
+    pack_version: String,
+    location_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    region_id: Option<String>,
+    slot_id: String,
+    catalog: DiscoveryAuthorityCatalog,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct DiscoveryClaimState {
+    receipt: DiscoveryRollReceipt,
+    phase: String,
+    revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    resolved_procedure: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    resolved_by_actor_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_event_seq: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct DiscoveryEventConsequence {
+    table_id: String,
+    table_version: u8,
+    row_id: String,
+    effect_kind: String,
+    target_id: String,
+    amount: u8,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct AcceptedDiscoveryIntent {
+    schema_version: u8,
+    procedure_version: String,
+    pub(super) procedure: String,
+    offer_kind: String,
+    actor_id: u64,
+    location_id: u64,
+    pack_id: String,
+    pack_version: String,
+    pub(super) slot_id: String,
+    slot_version: u8,
+    target_kind: String,
+    origin_id: String,
+    pub(super) claim_key: String,
+    expected_revision: u64,
+    phase_before: String,
+    phase_after: String,
+    resolution: String,
+    turn_cost: u8,
+    pub(super) receipt: DiscoveryRollReceipt,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    consequence: Option<DiscoveryEventConsequence>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(super) struct DiscoveryOfferView {
+    pub(super) schema_version: u8,
+    pub(super) procedure_version: String,
+    pub(super) procedure: String,
+    pub(super) slot_id: String,
+    pub(super) slot_version: u8,
+    pub(super) receipt_id: String,
+    pub(super) claim_key: String,
+    pub(super) phase: String,
+    pub(super) target_kind: String,
+    pub(super) origin_id: String,
+    pub(super) turn_cost: u8,
+    pub(super) resolution: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(super) struct DiscoverySceneNoticeView {
+    schema_version: u8,
+    slot_id: String,
+    slot_version: u8,
+    claim_key: String,
+    target_kind: String,
+    origin_id: String,
+    phase: String,
+    tells: Vec<DiscoveryTell>,
+    resolution: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct DiscoveryProcedureRequest {
+    pub(super) actor_id: u64,
+    pub(super) actor_session: Option<String>,
+    pub(super) procedure: String,
+    pub(super) slot_id: String,
+    #[serde(default)]
+    pub(super) receipt_id: Option<String>,
+}
+
+impl DiscoveryRuntimeSource {
+    fn slot(&self) -> Option<&DiscoverySlotDefinition> {
+        self.catalog
+            .slots
+            .iter()
+            .find(|slot| slot.id == self.slot_id)
+    }
+
+    fn stocking_table(&self) -> Option<&DiscoveryStockingTable> {
+        self.slot()
+            .and_then(|slot| slot.stocking.table_id.as_deref())
+            .and_then(|table_id| {
+                self.catalog
+                    .stocking_tables
+                    .iter()
+                    .find(|table| table.id == table_id)
+            })
+    }
+
+    fn event_table(&self) -> Option<&DiscoveryEventTable> {
+        self.slot()
+            .and_then(|slot| slot.event_table_id.as_deref())
+            .and_then(|table_id| {
+                self.catalog
+                    .event_tables
+                    .iter()
+                    .find(|table| table.id == table_id)
+            })
+    }
+
+    fn scope_id(&self, actor_id: u64) -> String {
+        match self.slot().map(|slot| slot.scope.as_str()) {
+            Some("actor") => format!("actor:{actor_id}"),
+            Some("expedition") => format!("expedition:{actor_id}"),
+            _ => "world".to_string(),
+        }
+    }
+
+    fn server_facts(&self) -> BTreeMap<String, String> {
+        let required = self
+            .stocking_table()
+            .map(|table| table.eligible_inputs.clone())
+            .unwrap_or_else(|| vec!["worldpack_bundle_hash".to_string()]);
+        required
+            .into_iter()
+            .filter_map(|key| {
+                let value = match key.as_str() {
+                    "world_seed" => {
+                        format!("{}:{}", OFFICIAL_WORLD_ID, OFFICIAL_WORLD_EPOCH)
+                    }
+                    "worldpack_bundle_hash" => active_content().manifest.bundle_hash.clone(),
+                    "region_id" => self
+                        .region_id
+                        .clone()
+                        .unwrap_or_else(|| format!("location:{}", self.location_id)),
+                    "rules_profile" => active_content().manifest.rules_profile.clone(),
+                    // The authority layer inserts these fields itself.
+                    "slot_id" | "slot_version" | "origin_id" | "claim_scope_id" => return None,
+                    _ => return None,
+                };
+                Some((key, value))
+            })
+            .collect()
+    }
+
+    fn freeze_receipt(
+        &self,
+        actor_id: u64,
+        existing: Option<&DiscoveryRollReceipt>,
+    ) -> Result<DiscoveryRollReceipt, String> {
+        freeze_discovery_receipt(
+            &self.catalog,
+            DiscoveryReceiptRequest {
+                pack_id: &self.pack_id,
+                pack_version: &self.pack_version,
+                slot_id: &self.slot_id,
+                scope_id: &self.scope_id(actor_id),
+                server_facts: if existing.is_some() {
+                    BTreeMap::new()
+                } else {
+                    self.server_facts()
+                },
+                mode: DiscoverySelectionMode::Weighted,
+            },
+            existing,
+        )
+    }
+
+    fn freeze_consequence(
+        &self,
+        receipt: &DiscoveryRollReceipt,
+    ) -> Option<DiscoveryEventConsequence> {
+        let table = self.event_table()?;
+        let weights = table.rows.iter().map(|row| row.weight).collect::<Vec<_>>();
+        let row = weighted_fnv1a_index(DISCOVERY_EVENT_ROLL_DOMAIN, receipt.roll_seed, 0, &weights)
+            .and_then(|index| table.rows.get(index))?;
+        Some(DiscoveryEventConsequence {
+            table_id: table.id.clone(),
+            table_version: table.version,
+            row_id: row.id.clone(),
+            effect_kind: row.effect_kind.clone(),
+            target_id: row.target_id.clone(),
+            amount: row.amount,
+        })
+    }
+}
+
+fn discovery_offer_kind(procedure: &str) -> Option<&'static str> {
+    match procedure {
+        "notice" => Some(FOCUSED_NOTICE_OFFER_KIND),
+        "search" => Some(DISCOVERY_SEARCH_OFFER_KIND),
+        "study" => Some(DISCOVERY_STUDY_OFFER_KIND),
+        "scout" => Some(DISCOVERY_SCOUT_OFFER_KIND),
+        _ => None,
+    }
+}
+
+fn discovery_action_kind(procedure: &str) -> Option<u8> {
+    match procedure {
+        "notice" => Some(CW_ACTION_FOCUSED_NOTICE_V2),
+        "search" => Some(CW_ACTION_SEARCH_V2),
+        "study" => Some(CW_ACTION_STUDY_V2),
+        "scout" => Some(CW_ACTION_SCOUT_V2),
+        _ => None,
+    }
+}
+
+fn discovery_ability(procedure: &str) -> u8 {
+    if procedure == "study" {
+        CW_ABILITY_INTELLIGENCE
+    } else {
+        CW_ABILITY_WISDOM
+    }
+}
+
+fn discovery_phase_after(procedure: &str) -> &'static str {
+    if procedure == "notice" {
+        "lead"
+    } else {
+        "revealed"
+    }
+}
+
+fn discovery_target_label(receipt: &DiscoveryRollReceipt) -> String {
+    receipt
+        .materialized_entity_ids
+        .first()
+        .and_then(|id| id.rsplit('/').next())
+        .unwrap_or(receipt.target_kind.as_str())
+        .replace(['-', '_'], " ")
+}
+
+impl RuntimeWorld {
+    fn discovery_origin_location(&self, slot: &DiscoverySlotDefinition) -> Option<u64> {
+        let (owner, path) = slot.origin_id.split_once(':')?;
+        let (kind, local_id) = path.split_once('/')?;
+        let canonical_ref = format!("pack://{owner}/{kind}/{local_id}");
+        match kind {
+            "location" => self.runtime_handle_for_canonical_ref("location", &canonical_ref),
+            "item" => self
+                .runtime_handle_for_canonical_ref("item", &canonical_ref)
+                .and_then(|item_id| self.item_by_id(item_id))
+                .and_then(|item| {
+                    if item.location_id != 0 {
+                        Some(item.location_id)
+                    } else {
+                        self.actor_by_id(item.holder_actor_id)
+                            .map(|actor| actor.location_id)
+                    }
+                }),
+            "feature" => active_content()
+                .room_features
+                .iter()
+                .find(|feature| {
+                    feature.key == local_id
+                        && active_content().locations.iter().any(|location| {
+                            location.id == feature.location_id && location.pack_id == owner
+                        })
+                })
+                .map(|feature| feature.location_id),
+            _ => None,
+        }
+    }
+
+    pub(super) fn ensure_seed_discovery_sources(&mut self) {
+        for pack in &active_content().manifest.packs {
+            let Ok(Some(catalog)) = discovery_authority_catalog(pack) else {
+                continue;
+            };
+            for slot in &catalog.slots {
+                let Some(location_id) = self.discovery_origin_location(slot) else {
+                    continue;
+                };
+                let source = DiscoveryRuntimeSource {
+                    schema_version: DISCOVERY_PIPELINE_SCHEMA_VERSION,
+                    pack_id: pack.id.clone(),
+                    pack_version: pack.version.clone(),
+                    location_id,
+                    region_id: None,
+                    slot_id: slot.id.clone(),
+                    catalog: catalog.clone(),
+                };
+                self.discovery_sources
+                    .entry(source.slot_id.clone())
+                    .or_insert(source);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn install_discovery_catalog_for_test(
+        &mut self,
+        catalog: DiscoveryAuthorityCatalog,
+        pack_id: &str,
+        pack_version: &str,
+        location_id: u64,
+        region_id: Option<&str>,
+    ) {
+        for slot in catalog.slots.clone() {
+            self.discovery_sources.insert(
+                slot.id.clone(),
+                DiscoveryRuntimeSource {
+                    schema_version: DISCOVERY_PIPELINE_SCHEMA_VERSION,
+                    pack_id: pack_id.to_string(),
+                    pack_version: pack_version.to_string(),
+                    location_id,
+                    region_id: region_id.map(str::to_string),
+                    slot_id: slot.id,
+                    catalog: catalog.clone(),
+                },
+            );
+        }
+    }
+
+    fn discovery_intent(
+        &self,
+        actor_id: u64,
+        procedure: &str,
+        slot_id: &str,
+    ) -> Result<AcceptedDiscoveryIntent, String> {
+        let actor = self
+            .actor_by_id(actor_id)
+            .filter(|actor| Self::actor_can_act(*actor))
+            .ok_or_else(|| "discovery actor is unavailable".to_string())?;
+        let source = self
+            .discovery_sources
+            .get(slot_id)
+            .filter(|source| source.location_id == actor.location_id)
+            .ok_or_else(|| "discovery source is not in this scene".to_string())?;
+        let slot = source
+            .slot()
+            .ok_or_else(|| "discovery source lost its authored slot".to_string())?;
+        if !slot.reveal_methods.iter().any(|method| method == procedure) {
+            return Err("discovery procedure is not authored for this slot".to_string());
+        }
+        let offer_kind = discovery_offer_kind(procedure)
+            .ok_or_else(|| "unknown discovery procedure".to_string())?;
+        let initial_receipt = source.freeze_receipt(actor_id, None)?;
+        let existing = self.discovery_claims.get(&initial_receipt.claim_key);
+        if existing.is_some_and(|state| state.phase == "revealed")
+            || (procedure == "notice"
+                && existing
+                    .is_some_and(|state| matches!(state.phase.as_str(), "lead" | "revealed")))
+        {
+            return Err("discovery claim is already resolved".to_string());
+        }
+        let receipt = if let Some(existing) = existing {
+            source.freeze_receipt(actor_id, Some(&existing.receipt))?
+        } else {
+            initial_receipt
+        };
+        let phase_before = existing
+            .map(|state| state.phase.clone())
+            .unwrap_or_else(|| slot.initial_phase.clone());
+        let expected_revision = existing.map(|state| state.revision).unwrap_or(0);
+        let consequence = source.freeze_consequence(&receipt);
+        Ok(AcceptedDiscoveryIntent {
+            schema_version: DISCOVERY_PIPELINE_SCHEMA_VERSION,
+            procedure_version: DISCOVERY_PROCEDURE_VERSION.to_string(),
+            procedure: procedure.to_string(),
+            offer_kind: offer_kind.to_string(),
+            actor_id,
+            location_id: source.location_id,
+            pack_id: source.pack_id.clone(),
+            pack_version: source.pack_version.clone(),
+            slot_id: slot.id.clone(),
+            slot_version: slot.version,
+            target_kind: slot.target_kind.clone(),
+            origin_id: slot.origin_id.clone(),
+            claim_key: receipt.claim_key.clone(),
+            expected_revision,
+            phase_before,
+            phase_after: discovery_phase_after(procedure).to_string(),
+            resolution: if consequence.is_some() {
+                "consequence_avoidance_check"
+            } else {
+                "certain"
+            }
+            .to_string(),
+            turn_cost: 1,
+            receipt,
+            consequence,
+        })
+    }
+
+    pub(super) fn discovery_scene_notices(&self, actor_id: u64) -> Vec<DiscoverySceneNoticeView> {
+        let Some(actor) = self.actor_by_id(actor_id) else {
+            return Vec::new();
+        };
+        self.discovery_sources
+            .values()
+            .filter(|source| source.location_id == actor.location_id)
+            .filter_map(|source| {
+                let slot = source.slot()?;
+                let initial_receipt = source.freeze_receipt(actor_id, None).ok()?;
+                let existing = self.discovery_claims.get(&initial_receipt.claim_key);
+                if existing.is_some_and(|state| state.phase == "revealed") {
+                    return None;
+                }
+                let receipt = if let Some(existing) = existing {
+                    source
+                        .freeze_receipt(actor_id, Some(&existing.receipt))
+                        .ok()?
+                } else {
+                    initial_receipt
+                };
+                Some(DiscoverySceneNoticeView {
+                    schema_version: DISCOVERY_PIPELINE_SCHEMA_VERSION,
+                    slot_id: slot.id.clone(),
+                    slot_version: slot.version,
+                    claim_key: receipt.claim_key,
+                    target_kind: slot.target_kind.clone(),
+                    origin_id: slot.origin_id.clone(),
+                    phase: existing
+                        .map(|state| state.phase.clone())
+                        .unwrap_or_else(|| slot.initial_phase.clone()),
+                    tells: slot.tells.clone(),
+                    resolution: "automatic_obvious_truth_no_roll".to_string(),
+                })
+            })
+            .collect()
+    }
+
+    pub(super) fn discovery_action_offers(&self, actor_id: u64) -> Vec<RankedActionOffer> {
+        let Some(actor) = self.actor_by_id(actor_id) else {
+            return Vec::new();
+        };
+        let mut offers = Vec::new();
+        for source in self
+            .discovery_sources
+            .values()
+            .filter(|source| source.location_id == actor.location_id)
+        {
+            let Some(slot) = source.slot() else {
+                continue;
+            };
+            for procedure in &slot.reveal_methods {
+                let Ok(intent) = self.discovery_intent(actor_id, procedure, &slot.id) else {
+                    continue;
+                };
+                let Some(binding) = resolved_action_binding(&intent.offer_kind) else {
+                    continue;
+                };
+                let label = discovery_target_label(&intent.receipt);
+                let target = ActionTargetView {
+                    kind: intent.target_kind.clone(),
+                    id: intent
+                        .receipt
+                        .materialized_entity_ids
+                        .first()
+                        .and_then(|id| {
+                            let canonical = discovery_canonical_ref(id)?;
+                            self.runtime_handle_for_canonical_ref(&intent.target_kind, &canonical)
+                        }),
+                    label: Some(label.clone()),
+                };
+                let state_revision = self.current_state_revision();
+                let legacy_id = format!("discovery:{}:{}", intent.procedure, intent.slot_id);
+                let offer_id = format!(
+                    "{}:{}:{}",
+                    active_content().manifest.rules_profile,
+                    state_revision,
+                    legacy_id
+                );
+                let source_collectible = self.location_source_collectible(actor_id);
+                let source_card_instances =
+                    source_collectible.clone().into_iter().collect::<Vec<_>>();
+                let composition_trace = self.action_composition_trace(
+                    Some(actor.location_id),
+                    state_revision,
+                    &binding,
+                    ActionCompositionContributions {
+                        source_card_instances,
+                        target: Some(target.clone()),
+                        applied_reskins: Vec::new(),
+                        contextual_offers: Vec::new(),
+                    },
+                );
+                let (verb, intention, category, rank) = match intent.procedure.as_str() {
+                    "notice" => ("Notice", "notice", "inspect", 52),
+                    "search" => ("Search", "inspect", "inspect", 53),
+                    "study" => ("Study", "study", "inspect", 54),
+                    "scout" => ("Scout", "scout", "travel", 55),
+                    _ => continue,
+                };
+                offers.push(RankedActionOffer {
+                    id: legacy_id,
+                    offer_id,
+                    kind: intent.offer_kind.clone(),
+                    intention: intention.to_string(),
+                    rules_action: binding.rules_action,
+                    operation: binding.operation,
+                    rules_profile: active_content().manifest.rules_profile.clone(),
+                    resolver: binding.resolver,
+                    source_collectible,
+                    pack_provenance: ActionPackProvenanceView {
+                        pack_id: binding.pack_id,
+                        pack_version: binding.pack_version,
+                        rules_namespace: binding.namespace,
+                    },
+                    composition_trace,
+                    composition_id: String::new(),
+                    state_revision,
+                    route: None,
+                    threshold_method: None,
+                    discovery: Some(DiscoveryOfferView {
+                        schema_version: intent.schema_version,
+                        procedure_version: intent.procedure_version.clone(),
+                        procedure: intent.procedure.clone(),
+                        slot_id: intent.slot_id.clone(),
+                        slot_version: intent.slot_version,
+                        receipt_id: intent.receipt.id.clone(),
+                        claim_key: intent.claim_key.clone(),
+                        phase: intent.phase_before.clone(),
+                        target_kind: intent.target_kind.clone(),
+                        origin_id: intent.origin_id.clone(),
+                        turn_cost: intent.turn_cost,
+                        resolution: intent.resolution.clone(),
+                    }),
+                    category: category.to_string(),
+                    verb: verb.to_string(),
+                    label: format!("{verb} {label}"),
+                    accessible_label: format!("{verb} {label}"),
+                    command: format!(
+                        "{} {}",
+                        intent.procedure,
+                        label.replace(' ', "-")
+                    ),
+                    rank,
+                    disabled: false,
+                    disabled_reason: None,
+                    zone: self
+                        .room_sheets
+                        .get(&actor.location_id)
+                        .map(room_sheet_zone)
+                        .unwrap_or_else(|| default_zone_for_scope("room", actor.location_id))
+                        .to_string(),
+                    source: "authored_discovery_slot".to_string(),
+                    provider: action_provider(
+                        "discovery",
+                        format!("discovery:{}", intent.slot_id),
+                        "Authored discovery",
+                        "Bound to one frozen discovery claim",
+                        20,
+                    ),
+                    target: Some(target),
+                    project: None,
+                    cost: None,
+                    risk: intent
+                        .consequence
+                        .as_ref()
+                        .map(|value| format!("{} if the pressure check fails", value.effect_kind)),
+                    effect: Some(if intent.procedure == "notice" {
+                        "establishes one authored Lead without creating or taking anything"
+                    } else {
+                        "reveals frozen authored truth without opening, moving, taking, or awarding"
+                    }
+                    .to_string()),
+                    progress: None,
+                    claim_key: Some(intent.claim_key),
+                    reason: "one slot-bound offer from the unified discovery pipeline".to_string(),
+                    ranked_hand_eligible: true,
+                });
+            }
+        }
+        offers
+    }
+
+    pub(super) fn discovery_record_for_offer(
+        &self,
+        actor_id: u64,
+        offer: &RankedActionOffer,
+        seed: u64,
+    ) -> Result<JournalRecord, String> {
+        let binding = offer
+            .discovery
+            .as_ref()
+            .ok_or_else(|| "offer has no discovery binding".to_string())?;
+        if offer.kind != discovery_offer_kind(&binding.procedure).unwrap_or_default() {
+            return Err("discovery offer kind changed".to_string());
+        }
+        let intent = self.discovery_intent(actor_id, &binding.procedure, &binding.slot_id)?;
+        if binding.receipt_id != intent.receipt.id
+            || binding.claim_key != intent.claim_key
+            || binding.phase != intent.phase_before
+        {
+            return Err("discovery offer is stale".to_string());
+        }
+        let action = CwAction {
+            kind: discovery_action_kind(&intent.procedure)
+                .ok_or_else(|| "unknown discovery procedure".to_string())?,
+            actor_id,
+            location_id: intent.location_id,
+            ability: discovery_ability(&intent.procedure),
+            dc: intent.consequence.as_ref().map(|_| LISTEN_DC).unwrap_or(0),
+            ..CwAction::default()
+        };
+        let mut record = JournalRecord::new(action, seed);
+        record.bind_offer_kind(&intent.offer_kind);
+        record
+            .projection_mutations
+            .push(ProjectionMutation::ResolveDiscovery { intent });
+        Ok(record)
+    }
+
+    pub(super) fn discovery_record(
+        &self,
+        actor_id: u64,
+        procedure: &str,
+        slot_id: &str,
+        receipt_id: Option<&str>,
+        seed: u64,
+    ) -> Result<JournalRecord, String> {
+        let offer = self
+            .discovery_action_offers(actor_id)
+            .into_iter()
+            .find(|offer| {
+                offer.discovery.as_ref().is_some_and(|binding| {
+                    binding.procedure == procedure
+                        && binding.slot_id == slot_id
+                        && receipt_id.is_none_or(|id| id == binding.receipt_id)
+                })
+            })
+            .ok_or_else(|| "discovery offer is no longer available".to_string())?;
+        self.discovery_record_for_offer(actor_id, &offer, seed)
+    }
+
+    pub(super) fn apply_discovery_projection(
+        &mut self,
+        intent: &AcceptedDiscoveryIntent,
+        committed_events: &[EventView],
+    ) -> Vec<EventView> {
+        let after = DiscoveryClaimState {
+            receipt: intent.receipt.clone(),
+            phase: intent.phase_after.clone(),
+            revision: intent.expected_revision.saturating_add(1),
+            resolved_procedure: Some(intent.procedure.clone()),
+            resolved_by_actor_id: Some(intent.actor_id),
+            source_event_seq: committed_events
+                .iter()
+                .filter(|event| event.actor_id == Some(intent.actor_id))
+                .map(|event| event.seq)
+                .max(),
+        };
+        if self.discovery_claims.get(&intent.claim_key) == Some(&after) {
+            return Vec::new();
+        }
+        self.discovery_claims
+            .insert(intent.claim_key.clone(), after);
+
+        let mut events = Vec::new();
+        let failed_pressure_check = intent.consequence.is_some()
+            && committed_events.iter().any(|event| {
+                event.type_name == "ability_check.rolled"
+                    && event.actor_id == Some(intent.actor_id)
+                    && !event.success
+            });
+        if failed_pressure_check {
+            if let Some(consequence) = &intent.consequence {
+                events.push(self.append_async_job_event(
+                    "discovery.consequence",
+                    intent.actor_id,
+                    None,
+                    serde_json::to_string(consequence).ok(),
+                ));
+            }
+        }
+        let content = serde_json::json!({
+            "procedure_version": intent.procedure_version,
+            "procedure": intent.procedure,
+            "slot_id": intent.slot_id,
+            "receipt_id": intent.receipt.id,
+            "claim_key": intent.claim_key,
+            "phase_before": intent.phase_before,
+            "phase_after": intent.phase_after,
+            "target_kind": intent.target_kind,
+            "origin_id": intent.origin_id,
+            "result_ids": intent.receipt.materialized_entity_ids,
+            "materialization": "not_performed",
+            "movement": "not_performed",
+            "custody": "not_performed",
+            "reward": "not_performed",
+        });
+        events.push(self.append_async_job_event(
+            if intent.phase_after == "lead" {
+                "discovery.lead"
+            } else {
+                "discovery.revealed"
+            },
+            intent.actor_id,
+            None,
+            serde_json::to_string(&content).ok(),
+        ));
+        events
+    }
+}
+
+fn discovery_canonical_ref(value: &str) -> Option<String> {
+    let (pack_id, path) = value.split_once(':')?;
+    Some(format!("pack://{pack_id}/{path}"))
+}
+
+pub(super) fn discovery_record_preconditions_hold(
+    runtime: &RuntimeWorld,
+    record: &JournalRecord,
+) -> bool {
+    let intents = record
+        .projection_mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+            ProjectionMutation::ResolveDiscovery { intent } => Some(intent),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if intents.is_empty() {
+        return true;
+    }
+    if intents.len() != 1 {
+        return false;
+    }
+    let intent = intents[0];
+    if intent.schema_version != DISCOVERY_PIPELINE_SCHEMA_VERSION
+        || intent.procedure_version != DISCOVERY_PROCEDURE_VERSION
+        || discovery_offer_kind(&intent.procedure) != Some(intent.offer_kind.as_str())
+        || discovery_action_kind(&intent.procedure) != Some(record.action.kind)
+        || record.action.actor_id != intent.actor_id
+        || record.action.location_id != intent.location_id
+        || record.action.ability != discovery_ability(&intent.procedure)
+        || record.action.dc != intent.consequence.as_ref().map(|_| LISTEN_DC).unwrap_or(0)
+    {
+        return false;
+    }
+    let Some(actor) = runtime.actor_by_id(intent.actor_id) else {
+        return false;
+    };
+    let Some(source) = runtime.discovery_sources.get(&intent.slot_id) else {
+        return false;
+    };
+    let Some(slot) = source.slot() else {
+        return false;
+    };
+    if actor.location_id != intent.location_id
+        || source.location_id != intent.location_id
+        || source.pack_id != intent.pack_id
+        || source.pack_version != intent.pack_version
+        || slot.version != intent.slot_version
+        || slot.target_kind != intent.target_kind
+        || slot.origin_id != intent.origin_id
+        || !slot.reveal_methods.contains(&intent.procedure)
+        || source
+            .freeze_receipt(intent.actor_id, Some(&intent.receipt))
+            .ok()
+            .as_ref()
+            != Some(&intent.receipt)
+        || source.freeze_consequence(&intent.receipt) != intent.consequence
+    {
+        return false;
+    }
+    let after = DiscoveryClaimState {
+        receipt: intent.receipt.clone(),
+        phase: intent.phase_after.clone(),
+        revision: intent.expected_revision.saturating_add(1),
+        resolved_procedure: Some(intent.procedure.clone()),
+        resolved_by_actor_id: Some(intent.actor_id),
+        source_event_seq: runtime
+            .discovery_claims
+            .get(&intent.claim_key)
+            .and_then(|state| state.source_event_seq),
+    };
+    match runtime.discovery_claims.get(&intent.claim_key) {
+        None => {
+            intent.expected_revision == 0
+                && intent.phase_before == slot.initial_phase
+                && intent.receipt.claim_key == intent.claim_key
+        }
+        Some(current) if current == &after => true,
+        Some(current) => {
+            current.receipt == intent.receipt
+                && current.revision == intent.expected_revision
+                && current.phase == intent.phase_before
+        }
+    }
+}
+
+pub(super) fn discovery_record_claim_already_applied(
+    runtime: &RuntimeWorld,
+    record: &JournalRecord,
+) -> bool {
+    record.projection_mutations.iter().any(|mutation| {
+        let ProjectionMutation::ResolveDiscovery { intent } = mutation else {
+            return false;
+        };
+        runtime
+            .discovery_claims
+            .get(&intent.claim_key)
+            .is_some_and(|state| {
+                state.receipt == intent.receipt
+                    && state.phase == intent.phase_after
+                    && state.revision == intent.expected_revision.saturating_add(1)
+                    && state.resolved_procedure.as_deref() == Some(intent.procedure.as_str())
+                    && state.resolved_by_actor_id == Some(intent.actor_id)
+            })
+    })
+}
+
+pub(super) async fn discover(
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    Json(payload): Json<DiscoveryProcedureRequest>,
+) -> Json<ActionResponse> {
+    if !allow_actor_mutation(
+        &state,
+        client_addr,
+        payload.actor_id,
+        "action-actor",
+        GENERAL_ACTION_LIMIT,
+    ) {
+        return action_rate_limited_response();
+    }
+    let plan = {
+        let runtime = state.inner.lock().await;
+        if !client_actor_authorized_for_state(
+            &runtime,
+            &state,
+            payload.actor_id,
+            payload.actor_session.as_deref(),
+        ) {
+            return client_actor_rejected_response();
+        }
+        if let Some(receipt_id) = payload.receipt_id.as_deref() {
+            if runtime.discovery_claims.values().any(|claim| {
+                claim.receipt.id == receipt_id
+                    && claim.receipt.slot_id == payload.slot_id
+                    && claim.phase == discovery_phase_after(&payload.procedure)
+            }) {
+                return Json(ActionResponse {
+                    ok: true,
+                    status: CW_OK,
+                    events: Vec::new(),
+                });
+            }
+        }
+        runtime.discovery_record(
+            payload.actor_id,
+            &payload.procedure,
+            &payload.slot_id,
+            payload.receipt_id.as_deref(),
+            runtime.next_seed_value(),
+        )
+    };
+    let Ok(record) = plan else {
+        return action_offer_rejected("That discovery claim or procedure is no longer available");
+    };
+    let intent = record
+        .projection_mutations
+        .into_iter()
+        .find_map(|mutation| match mutation {
+            ProjectionMutation::ResolveDiscovery { intent } => Some(intent),
+            _ => None,
+        })
+        .expect("planned discovery record has one intent");
+    apply_and_broadcast_with_mutations(
+        state,
+        record.action,
+        payload.actor_session.as_deref(),
+        vec![ProjectionMutation::ResolveDiscovery { intent }],
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> DiscoveryAuthorityCatalog {
+        serde_json::from_str(include_str!("../fixtures/discovery-authority-v1.json"))
+            .expect("discovery fixture")
+    }
+
+    fn prepared_runtime() -> RuntimeWorld {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Discovery Tester",
+        );
+        runtime.install_discovery_catalog_for_test(
+            fixture(),
+            "fixture.discovery",
+            "1.0.0",
+            COSY_COTTAGE_LOCATION_ID,
+            Some("fixture.discovery:region/mossy-verge"),
+        );
+        runtime
+    }
+
+    #[test]
+    fn scene_notice_is_free_obvious_truth_and_never_rolls() {
+        let runtime = prepared_runtime();
+        let notices = runtime.discovery_scene_notices(5_000);
+        assert_eq!(notices.len(), 5);
+        assert!(notices
+            .iter()
+            .all(|notice| notice.resolution == "automatic_obvious_truth_no_roll"));
+        assert!(runtime
+            .event_log
+            .iter()
+            .all(|event| event.type_name != "ability_check.rolled"));
+    }
+
+    #[test]
+    fn item_and_location_use_one_scale_specific_claim_pipeline() {
+        let runtime = prepared_runtime();
+        let offers = runtime.discovery_action_offers(5_000);
+        let search = offers
+            .iter()
+            .find(|offer| {
+                offer.kind == DISCOVERY_SEARCH_OFFER_KIND
+                    && offer
+                        .discovery
+                        .as_ref()
+                        .is_some_and(|binding| binding.target_kind == "item")
+            })
+            .expect("item Search");
+        let scout = offers
+            .iter()
+            .find(|offer| {
+                offer.kind == DISCOVERY_SCOUT_OFFER_KIND
+                    && offer
+                        .discovery
+                        .as_ref()
+                        .is_some_and(|binding| binding.target_kind == "location")
+            })
+            .expect("location Scout");
+        assert_eq!(search.discovery.as_ref().unwrap().procedure, "search");
+        assert_eq!(scout.discovery.as_ref().unwrap().procedure, "scout");
+        assert_ne!(search.claim_key, scout.claim_key);
+    }
+
+    #[test]
+    fn safe_search_reveals_without_a_roll_or_physical_side_effect() {
+        let mut runtime = prepared_runtime();
+        let before_items = runtime.world.items[..runtime.world.item_count].to_vec();
+        let before_locations = runtime.world.locations[..runtime.world.location_count].to_vec();
+        let offer = runtime
+            .discovery_action_offers(5_000)
+            .into_iter()
+            .find(|offer| {
+                offer.kind == DISCOVERY_SEARCH_OFFER_KIND
+                    && offer
+                        .discovery
+                        .as_ref()
+                        .is_some_and(|binding| binding.target_kind == "item")
+            })
+            .expect("safe item Search");
+        let record = runtime
+            .discovery_record_for_offer(5_000, &offer, 91_001)
+            .expect("record");
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert!(events
+            .iter()
+            .all(|event| event.type_name != "ability_check.rolled"));
+        assert!(events
+            .iter()
+            .any(|event| event.type_name == "discovery.revealed"));
+        assert_eq!(
+            runtime.world.items[..runtime.world.item_count],
+            before_items
+        );
+        assert_eq!(
+            runtime.world.locations[..runtime.world.location_count],
+            before_locations
+        );
+    }
+
+    #[test]
+    fn pressure_check_only_controls_the_frozen_consequence() {
+        let mut runtime = prepared_runtime();
+        let offer = runtime
+            .discovery_action_offers(5_000)
+            .into_iter()
+            .find(|offer| {
+                offer.kind == DISCOVERY_SEARCH_OFFER_KIND
+                    && offer
+                        .discovery
+                        .as_ref()
+                        .is_some_and(|binding| binding.target_kind == "resource")
+            })
+            .expect("pressured Search");
+        let record = runtime
+            .discovery_record_for_offer(5_000, &offer, 1)
+            .expect("record");
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert!(events
+            .iter()
+            .any(|event| event.type_name == "ability_check.rolled"));
+        assert!(events
+            .iter()
+            .any(|event| event.type_name == "discovery.revealed"));
+    }
+
+    #[test]
+    fn replay_retry_and_controller_paths_cannot_duplicate_or_reroll() {
+        let mut runtime = prepared_runtime();
+        let offer = runtime
+            .discovery_action_offers(5_000)
+            .into_iter()
+            .find(|offer| offer.kind == DISCOVERY_SEARCH_OFFER_KIND)
+            .expect("Search");
+        let record = runtime
+            .discovery_record_for_offer(5_000, &offer, 91_002)
+            .expect("record");
+        let receipt = match &record.projection_mutations[0] {
+            ProjectionMutation::ResolveDiscovery { intent } => intent.receipt.clone(),
+            _ => unreachable!(),
+        };
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+        let event_count = runtime.event_log.len();
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+        assert_eq!(runtime.event_log.len(), event_count);
+        assert_eq!(
+            runtime.discovery_claims[&receipt.claim_key].receipt,
+            receipt
+        );
+        assert!(runtime.discovery_action_offers(5_000).iter().all(|next| {
+            next.discovery
+                .as_ref()
+                .is_none_or(|binding| binding.claim_key != receipt.claim_key)
+        }));
+    }
+
+    #[test]
+    fn focused_notice_disappears_after_its_authored_claim_is_exhausted() {
+        let mut runtime = prepared_runtime();
+        let offer = runtime
+            .discovery_action_offers(5_000)
+            .into_iter()
+            .find(|offer| offer.kind == FOCUSED_NOTICE_OFFER_KIND)
+            .expect("Focused Notice");
+        let claim_key = offer.claim_key.clone().expect("claim");
+        let record = runtime
+            .discovery_record_for_offer(5_000, &offer, 91_003)
+            .expect("record");
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+        assert!(runtime.discovery_action_offers(5_000).iter().all(|next| {
+            next.kind != FOCUSED_NOTICE_OFFER_KIND
+                || next.claim_key.as_deref() != Some(claim_key.as_str())
+        }));
+    }
+
+    #[test]
+    fn actor_scoped_claims_do_not_consume_another_actors_offer() {
+        let mut catalog = fixture();
+        let slot = catalog
+            .slots
+            .iter_mut()
+            .find(|slot| slot.id.ends_with("secret-door"))
+            .expect("actor-scoped slot");
+        slot.scope = "actor".to_string();
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "First Discovery Tester",
+        );
+        create_test_human(
+            &mut runtime,
+            5_001,
+            COSY_COTTAGE_LOCATION_ID,
+            "Second Discovery Tester",
+        );
+        runtime.install_discovery_catalog_for_test(
+            catalog,
+            "fixture.discovery",
+            "1.0.0",
+            COSY_COTTAGE_LOCATION_ID,
+            Some("fixture.discovery:region/mossy-verge"),
+        );
+        let first = runtime
+            .discovery_action_offers(5_000)
+            .into_iter()
+            .find(|offer| {
+                offer.kind == FOCUSED_NOTICE_OFFER_KIND
+                    && offer
+                        .discovery
+                        .as_ref()
+                        .is_some_and(|binding| binding.slot_id.ends_with("secret-door"))
+            })
+            .expect("first actor offer");
+        let first_claim = first.claim_key.clone().expect("first actor claim");
+        let record = runtime
+            .discovery_record_for_offer(5_000, &first, 91_004)
+            .expect("first actor record");
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+        let second = runtime
+            .discovery_action_offers(5_001)
+            .into_iter()
+            .find(|offer| {
+                offer.kind == FOCUSED_NOTICE_OFFER_KIND
+                    && offer
+                        .discovery
+                        .as_ref()
+                        .is_some_and(|binding| binding.slot_id.ends_with("secret-door"))
+            })
+            .expect("second actor still has an offer");
+        assert_ne!(second.claim_key.as_deref(), Some(first_claim.as_str()));
+    }
+}

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5372,6 +5372,56 @@
       // They render in the turn banner so the card row stays reserved for
       // legal combat choices. See issue #461 and turnBannerControlSpecs.
       const built = [];
+      const discoveryKinds = new Set([
+        "focused_notice",
+        "search_discovery",
+        "study_discovery",
+        "scout_discovery",
+      ]);
+      for (const offer of (view.action_offers || []).filter((candidate) => (
+        discoveryKinds.has(String(candidate?.kind || ""))
+        && candidate?.discovery?.procedure
+        && candidate?.discovery?.slot_id
+        && candidate?.discovery?.receipt_id
+      ))) {
+        const binding = offer.discovery;
+        const targetId = Number(offer?.target?.id || 0);
+        const targetLabel = String(
+          offer?.target?.label || binding.target_kind || "authored clue"
+        ).trim();
+        const verb = offerVerb(offer, binding.procedure);
+        const label = targetBearingLabel(
+          binding.procedure === "scout" ? "scout" : "inspect",
+          verb,
+          targetLabel,
+        );
+        built.push({
+          ...semanticAction(offer, binding.procedure, label),
+          label: verb.toLowerCase(),
+          detail: targetLabel,
+          command: String(
+            offer.command || `${binding.procedure} ${targetLabel}`
+          ).trim(),
+          focusKey: `discovery:${binding.claim_key}:${binding.procedure}`,
+          card: binding.target_kind === "item" && targetId
+            ? cardForItem(targetId)
+            : cardForLocation(view.location?.id),
+          shape: binding.target_kind === "item" ? "item" : "location",
+          priority: Number(offer.rank || 55),
+          modalTitle: label.toLowerCase(),
+          modalSummary: binding.resolution === "consequence_avoidance_check"
+            ? "Reveal the frozen authored truth. The check only determines whether its frozen pressure consequence lands."
+            : "Reveal the frozen authored truth with no roll.",
+          effect: offer.effect,
+          risk: offer.risk,
+          run: () => action("/actions/discover", {
+            actor_id: actorId,
+            procedure: binding.procedure,
+            slot_id: binding.slot_id,
+            receipt_id: binding.receipt_id,
+          }),
+        });
+      }
       const journey = view.journey || null;
       const scoutOffers = (view.action_offers || []).filter((offer) => (
         offer.kind === "explore_path"
@@ -7252,6 +7302,12 @@
         "/actions/open": ["open"],
         "/actions/check": ["check"],
         "/actions/study": ["study"],
+        "/actions/discover": [
+          "focused_notice",
+          "search_discovery",
+          "study_discovery",
+          "scout_discovery",
+        ],
         "/actions/influence": ["influence"],
         "/actions/cast-spell": ["cast_spell"],
         "/actions/pick-up": ["pick_up"],
@@ -7321,6 +7377,13 @@
           || Number(offer.target.id) === submittedTarget;
         const providerMatches = path !== "/actions/use-item"
           || offer?.provider?.id === `item:${Number(payload.item_id || 0)}`;
+        const discoveryMatches = path !== "/actions/discover"
+          || (
+            String(offer?.discovery?.procedure || "") === String(payload.procedure || "")
+            && String(offer?.discovery?.slot_id || "") === String(payload.slot_id || "")
+            && (!payload.receipt_id
+              || String(offer?.discovery?.receipt_id || "") === String(payload.receipt_id || ""))
+          );
         const featureMatches = path !== "/actions/use-item"
           || offer.kind !== "use_feature"
           || String(offer.id || "").startsWith(
@@ -7332,6 +7395,7 @@
           && thresholdMethodMatches
           && targetMatches
           && providerMatches
+          && discoveryMatches
           && featureMatches;
       }) || null;
     }
@@ -8894,11 +8958,22 @@
       )
         ? cleanStatusText(openingBeat(state))
         : placeProse;
-      panel.innerHTML = journalProseRowHtml({
-        category: "story",
-        prose: distinctPlaceProse,
-        kind: "memory",
-      });
+      const obviousTells = (Array.isArray(state?.scene_notices) ? state.scene_notices : [])
+        .flatMap((notice) => Array.isArray(notice?.tells) ? notice.tells : [])
+        .map((tell) => cleanStatusText(tell?.text || ""))
+        .filter((text, index, values) => text && values.indexOf(text) === index);
+      panel.innerHTML = [
+        journalProseRowHtml({
+          category: "story",
+          prose: distinctPlaceProse,
+          kind: "memory",
+        }),
+        ...obviousTells.map((prose) => journalProseRowHtml({
+          category: "discovery",
+          prose,
+          kind: "scene-notice",
+        })),
+      ].join("");
     }
 
     function renderRoomLogLatest(text) {

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -29,7 +29,7 @@ pub const CW_MAX_GATE_CLAIMS: usize = 128;
 pub const CW_ITEM_DEFAULT_WEIGHT_TENTHS: u16 = 10;
 
 // Kernel version 9 is reserved by #411 for project-push ABI state.
-pub const CW_KERNEL_VERSION: u32 = 12;
+pub const CW_KERNEL_VERSION: u32 = 13;
 
 pub const CW_OK: u32 = 0;
 pub const CW_ERR_INVALID: u32 = 1;
@@ -185,6 +185,10 @@ pub const CW_ACTION_REST: u8 = 32;
 // failures; see `combat::start_focused_encounter_scheduler`.
 pub const CW_ACTION_COMBAT_ABANDON: u8 = 33;
 pub const CW_ACTION_GATE_TRANSITION: u8 = 34;
+pub const CW_ACTION_FOCUSED_NOTICE_V2: u8 = 35;
+pub const CW_ACTION_SEARCH_V2: u8 = 36;
+pub const CW_ACTION_STUDY_V2: u8 = 37;
+pub const CW_ACTION_SCOUT_V2: u8 = 38;
 
 pub const CW_EVENT_ACTOR_CREATED: u8 = 2;
 pub const CW_EVENT_ABILITY_CHECK_ROLLED: u8 = 6;
@@ -227,6 +231,10 @@ pub const CW_EVENT_GATE_TRANSITION_APPLIED: u8 = 43;
 pub const CW_EVENT_ITEM_INSTALLED: u8 = 44;
 pub const CW_EVENT_ITEM_REMOVED: u8 = 45;
 pub const CW_EVENT_ITEM_RENDERED_INERT: u8 = 46;
+pub const CW_EVENT_FOCUSED_NOTICE_COMMITTED: u8 = 47;
+pub const CW_EVENT_SEARCH_COMMITTED: u8 = 48;
+pub const CW_EVENT_STUDY_COMMITTED: u8 = 49;
+pub const CW_EVENT_SCOUT_COMMITTED: u8 = 50;
 
 // These append-only values mirror the authoritative `CW_REASON_*` enum in
 // core-c. The numeric value remains the replay contract; player-facing copy is
@@ -304,7 +312,7 @@ pub struct CwActor {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CwLocation {
     pub id: u64,
     pub flags: u32,
@@ -319,7 +327,7 @@ pub struct CwExit {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CwItem {
     pub id: u64,
     pub kind: u8,

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -32,6 +32,7 @@ mod content_policy;
 mod content_registry;
 mod contributions;
 mod crafting;
+mod discovery_pipeline;
 mod first_tale;
 mod generated_places;
 mod generation_policy;
@@ -103,12 +104,14 @@ use chat_action::*;
 use combat::*;
 use communal_governance::*;
 use community_art::*;
+use composition::*;
 use content_load::*;
 use content_packs::*;
 use content_policy::*;
 use content_registry::*;
 use contributions::*;
 use crafting::*;
+use discovery_pipeline::*;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use first_tale::*;
 use generated_places::*;
@@ -1070,6 +1073,9 @@ enum ProjectionMutation {
         narration: String,
         event_type: String,
     },
+    ResolveDiscovery {
+        intent: AcceptedDiscoveryIntent,
+    },
     UpgradePathwayIfReady {
         pathway_id: String,
         progress_clock_id: String,
@@ -1689,6 +1695,8 @@ struct RuntimeWorld {
     routes: BTreeMap<String, RouteRecordState>,
     threshold_gate_sources: BTreeMap<u64, ThresholdGateSource>,
     threshold_hazard_states: BTreeMap<String, ThresholdHazardRuntimeState>,
+    discovery_sources: BTreeMap<String, DiscoveryRuntimeSource>,
+    discovery_claims: BTreeMap<String, DiscoveryClaimState>,
     generated_pathways: BTreeMap<String, GeneratedPathwayState>,
     generated_places: BTreeMap<u64, GeneratedPlaceState>,
     governance_decisions: BTreeMap<String, GovernanceDecisionState>,
@@ -1776,6 +1784,10 @@ struct RuntimeSnapshot {
     routes: BTreeMap<String, RouteRecordState>,
     #[serde(default)]
     threshold_authority: ThresholdKernelSnapshot,
+    #[serde(default)]
+    discovery_sources: BTreeMap<String, DiscoveryRuntimeSource>,
+    #[serde(default)]
+    discovery_claims: BTreeMap<String, DiscoveryClaimState>,
     #[serde(default)]
     world_evolution_tracks: Vec<CwEvolutionTrack>,
     #[serde(default)]
@@ -2043,7 +2055,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 15;
+const JOURNAL_RECORD_VERSION: u32 = 16;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -3018,6 +3030,8 @@ struct RankedActionOffer {
     route: Option<RouteOfferBinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     threshold_method: Option<ThresholdMethodOfferView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    discovery: Option<DiscoveryOfferView>,
 
     category: String,
     verb: String,
@@ -6084,7 +6098,9 @@ fn active_rules_bundle() -> &'static SeedRuleBundle {
 fn resolved_action_binding(kind: &str) -> Option<ResolvedActionBinding> {
     let canonical_kind = match kind {
         "travel" => "move",
-        "explore_path" => "search",
+        "explore_path" | DISCOVERY_SCOUT_OFFER_KIND | DISCOVERY_SEARCH_OFFER_KIND => "search",
+        FOCUSED_NOTICE_OFFER_KIND => "check",
+        DISCOVERY_STUDY_OFFER_KIND => "study",
         "open" => "use_item",
         other => other,
     };
@@ -6148,6 +6164,10 @@ fn journal_binding_for_kernel_action(kind: u8) -> Option<ResolvedActionBinding> 
         CW_ACTION_TRADE_ITEM => "trade_item",
         CW_ACTION_USE_ITEM | CW_ACTION_RULES_UTILIZE_ITEM => "use_item",
         CW_ACTION_GATE_TRANSITION => "open",
+        CW_ACTION_FOCUSED_NOTICE_V2 => FOCUSED_NOTICE_OFFER_KIND,
+        CW_ACTION_SEARCH_V2 => DISCOVERY_SEARCH_OFFER_KIND,
+        CW_ACTION_STUDY_V2 => DISCOVERY_STUDY_OFFER_KIND,
+        CW_ACTION_SCOUT_V2 => DISCOVERY_SCOUT_OFFER_KIND,
         CW_ACTION_PROJECT_PUSH => "work",
         CW_ACTION_CRAFT => "craft",
         CW_ACTION_THEFT => "theft",
@@ -6230,7 +6250,7 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 15,
+            version: 16,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
@@ -6251,6 +6271,8 @@ impl RuntimeSnapshot {
             world_exits: runtime.world.exits[..runtime.world.exit_count].to_vec(),
             routes: runtime.routes.clone(),
             threshold_authority: ThresholdKernelSnapshot::from_runtime(runtime),
+            discovery_sources: runtime.discovery_sources.clone(),
+            discovery_claims: runtime.discovery_claims.clone(),
             world_evolution_tracks: runtime.world.evolution_tracks
                 [..runtime.world.evolution_track_count]
                 .to_vec(),
@@ -6533,6 +6555,8 @@ impl RuntimeSnapshot {
             routes: self.routes,
             threshold_gate_sources,
             threshold_hazard_states,
+            discovery_sources: self.discovery_sources,
+            discovery_claims: self.discovery_claims,
             generated_pathways: self.generated_pathways,
             generated_places: self.generated_places,
             governance_decisions: self.governance_decisions,
@@ -6947,6 +6971,8 @@ impl RuntimeWorld {
             routes: BTreeMap::new(),
             threshold_gate_sources: BTreeMap::new(),
             threshold_hazard_states: BTreeMap::new(),
+            discovery_sources: BTreeMap::new(),
+            discovery_claims: BTreeMap::new(),
             generated_pathways: BTreeMap::new(),
             generated_places: BTreeMap::new(),
             governance_decisions: BTreeMap::new(),
@@ -6998,6 +7024,7 @@ impl RuntimeWorld {
         runtime.ensure_seed_topology();
         runtime.ensure_active_actor_rules_facets();
         runtime.ensure_canonical_identities(0);
+        runtime.ensure_seed_discovery_sources();
         runtime.append_world_bootstrapped_event();
         runtime.ensure_seed_rpg_projection();
         runtime.refresh_all_canonical_events();
@@ -10151,10 +10178,13 @@ impl RuntimeWorld {
             || !self.job_contribution_record_preconditions_hold(record)
             || !self.ai_publication_preconditions_hold(record)
             || !self.proxim8_materialization_record_preconditions_hold(record)
+            || !discovery_record_preconditions_hold(self, record)
         {
             return (CW_ERR_RULE, Vec::new());
         }
-        if threshold_record_claim_already_applied(self, record) {
+        if threshold_record_claim_already_applied(self, record)
+            || discovery_record_claim_already_applied(self, record)
+        {
             return (CW_OK, Vec::new());
         }
         let enforce_active_contribution_contract =
@@ -10833,6 +10863,9 @@ impl RuntimeWorld {
                         event.seq,
                     );
                     events.push(event);
+                }
+                ProjectionMutation::ResolveDiscovery { intent } => {
+                    events.extend(self.apply_discovery_projection(intent, committed_events));
                 }
                 ProjectionMutation::UpgradePathwayIfReady {
                     pathway_id,
@@ -21594,6 +21627,13 @@ The relationship statement they are preserving is: {statement}"
                 record.projection_mutations.extend(mutations);
                 record
             }
+            FOCUSED_NOTICE_OFFER_KIND
+            | DISCOVERY_SEARCH_OFFER_KIND
+            | DISCOVERY_STUDY_OFFER_KIND
+            | DISCOVERY_SCOUT_OFFER_KIND => self
+                .discovery_record_for_offer(actor.id, &offer, seed)
+                .ok()?
+                .into_actor_consequence(self.world.tick, None),
             "influence" => {
                 let target_actor_id = offer
                     .target
@@ -22063,6 +22103,21 @@ The relationship statement they are preserving is: {statement}"
         let action = &record.action;
         if offer.kind != Self::resident_record_offer_kind(record) {
             return false;
+        }
+        if let Some(intent) = record
+            .projection_mutations
+            .iter()
+            .find_map(|mutation| match mutation {
+                ProjectionMutation::ResolveDiscovery { intent } => Some(intent),
+                _ => None,
+            })
+        {
+            return offer.discovery.as_ref().is_some_and(|binding| {
+                binding.procedure == intent.procedure
+                    && binding.slot_id == intent.slot_id
+                    && binding.receipt_id == intent.receipt.id
+                    && binding.claim_key == intent.claim_key
+            });
         }
         if let Some(destination_location_id) =
             record
@@ -25469,6 +25524,13 @@ fn action_path_accepts_kind(path: &str, kind: &str) -> bool {
         "/actions/chat" => kind == "chat",
         "/actions/move" => kind == "move",
         "/actions/explore-path" => kind == "explore_path",
+        "/actions/discover" => matches!(
+            kind,
+            FOCUSED_NOTICE_OFFER_KIND
+                | DISCOVERY_SEARCH_OFFER_KIND
+                | DISCOVERY_STUDY_OFFER_KIND
+                | DISCOVERY_SCOUT_OFFER_KIND
+        ),
         "/actions/flee" => kind == "flee",
         "/actions/check" => kind == "check",
         "/actions/study" => kind == "study",
@@ -25589,6 +25651,14 @@ async fn submit_action_offer(
                 ConnectInfo(client_addr),
                 State(state),
                 Json(parsed!(ScoutRequest)),
+            )
+            .await
+        }
+        "/actions/discover" => {
+            discover(
+                ConnectInfo(client_addr),
+                State(state),
+                Json(parsed!(DiscoveryProcedureRequest)),
             )
             .await
         }
@@ -27726,8 +27796,7 @@ async fn command_with_forwarding(
             warn!("failed to refresh canonical actor session: {}", error);
         }
     }
-    // The local lock serializes validation for commands that route to this
-    // process. Cross-process serialization and idempotency live in SQLite.
+    // Local validation is serialized here; cross-process idempotency lives in SQLite.
     let _command_guard = state.canonical_command_lock.lock().await;
     let compatibility_envelope = payload.envelope.is_none();
     let envelope = {
@@ -28817,6 +28886,25 @@ async fn command_inner(
                     dc: Some(LISTEN_DC),
                     job_id: None,
                     strategy_id: None,
+                }),
+            )
+            .await;
+            command_action_response_with_events(resolved, response, presence_events)
+        }
+        CommandDispatch::Discover {
+            procedure,
+            slot_id,
+            receipt_id,
+        } => {
+            let Json(response) = discover(
+                ConnectInfo(client_addr),
+                State(state),
+                Json(DiscoveryProcedureRequest {
+                    actor_id: payload.actor_id,
+                    actor_session: payload.actor_session,
+                    procedure,
+                    slot_id,
+                    receipt_id: Some(receipt_id),
                 }),
             )
             .await;
@@ -37953,321 +38041,6 @@ fn action_is_discovery_check(action: &CwAction) -> bool {
             && action.dc == LISTEN_DC)
 }
 
-fn action_provider(
-    kind: impl Into<String>,
-    id: impl Into<String>,
-    label: impl Into<String>,
-    reason: impl Into<String>,
-    priority: u8,
-) -> ActionProviderView {
-    ActionProviderView {
-        kind: kind.into(),
-        id: id.into(),
-        label: label.into(),
-        reason: reason.into(),
-        priority,
-    }
-}
-
-fn calling_matches_inspect(statement: &str) -> bool {
-    let statement = statement.to_ascii_lowercase();
-    [
-        "clue", "lost", "stuck", "shy room", "strange", "warning", "errand",
-    ]
-    .iter()
-    .any(|needle| statement.contains(needle))
-}
-
-fn action_offer_requires_target(kind: &str) -> bool {
-    matches!(
-        kind,
-        "chat"
-            | "influence"
-            | "attack"
-            | "defend"
-            | "flee"
-            | "pick_up"
-            | "use_item"
-            | "use_feature"
-            | "give_item"
-            | "trade_item"
-            | "search"
-            | "study"
-            | "work"
-            | "help"
-            | "craft"
-            | "move"
-            | "create_bond"
-            | "resolve_bond"
-            | "explore_path"
-            | "open"
-    )
-}
-
-fn action_offer_is_reachable(offer: &RankedActionOffer) -> bool {
-    if offer.disabled {
-        return false;
-    }
-    if action_offer_requires_target(&offer.kind) && offer.target.is_none() {
-        return false;
-    }
-    if matches!(offer.kind.as_str(), "prepare" | "work" | "help" | "study")
-        && offer.project.is_none()
-    {
-        return false;
-    }
-    true
-}
-
-fn action_offer_hand_group(offer: &RankedActionOffer) -> String {
-    if offer.intention == "contribute" {
-        return offer
-            .project
-            .as_ref()
-            .map(|project| format!("contribute:{}", project.progress_clock_id))
-            .unwrap_or_else(|| "contribute".to_string());
-    }
-    if matches!(offer.kind.as_str(), "give_item" | "trade_item") {
-        return offer.kind.clone();
-    }
-    if matches!(offer.kind.as_str(), "use_item" | "use_feature") {
-        return "use".to_string();
-    }
-    offer.id.clone()
-}
-
-fn action_offer_is_generally_useful(offer: &RankedActionOffer) -> bool {
-    matches!(
-        offer.kind.as_str(),
-        "check" | "search" | "move" | "chat" | "rest"
-    )
-}
-
-fn compose_action_hand(offers: &[RankedActionOffer]) -> ActionHandView {
-    const CAPACITY: usize = 2;
-    let mut candidates: Vec<_> = offers
-        .iter()
-        .filter(|offer| offer.ranked_hand_eligible && action_offer_is_reachable(offer))
-        .collect();
-    candidates.sort_by(|left, right| {
-        left.provider
-            .priority
-            .cmp(&right.provider.priority)
-            .then_with(|| left.rank.cmp(&right.rank))
-            .then_with(|| left.id.cmp(&right.id))
-    });
-
-    let mut grouped = Vec::new();
-    let mut seen_groups = BTreeSet::new();
-    for offer in candidates {
-        if seen_groups.insert(action_offer_hand_group(offer)) {
-            grouped.push(offer);
-        }
-    }
-
-    let mut selected = Vec::new();
-    let mut provider_counts = BTreeMap::<String, u8>::new();
-    for offer in &grouped {
-        let provider_key = format!("{}:{}", offer.provider.kind, offer.provider.id);
-        let count = provider_counts.entry(provider_key).or_default();
-        if *count < 2 {
-            selected.push(*offer);
-            *count += 1;
-        }
-        if selected.len() == CAPACITY {
-            break;
-        }
-    }
-    if selected.len() < CAPACITY {
-        for offer in &grouped {
-            if selected.iter().any(|selected| selected.id == offer.id) {
-                continue;
-            }
-            selected.push(*offer);
-            if selected.len() == CAPACITY {
-                break;
-            }
-        }
-    }
-
-    if !selected
-        .iter()
-        .any(|offer| action_offer_is_generally_useful(offer))
-    {
-        if let Some(general) = grouped
-            .iter()
-            .copied()
-            .find(|offer| action_offer_is_generally_useful(offer))
-        {
-            if selected.len() < CAPACITY {
-                selected.push(general);
-            } else if let Some(last) = selected.last_mut() {
-                *last = general;
-            }
-        }
-    }
-
-    selected.sort_by(|left, right| {
-        left.provider
-            .priority
-            .cmp(&right.provider.priority)
-            .then_with(|| left.rank.cmp(&right.rank))
-            .then_with(|| left.id.cmp(&right.id))
-    });
-    selected.dedup_by(|left, right| left.id == right.id);
-
-    ActionHandView {
-        schema_version: 1,
-        capacity: CAPACITY as u8,
-        entries: selected
-            .into_iter()
-            .map(|offer| ActionHandEntryView {
-                offer_id: offer.offer_id.clone(),
-                kind: offer.kind.clone(),
-                intention: offer.intention.clone(),
-                provider: offer.provider.clone(),
-            })
-            .collect(),
-    }
-}
-
-fn action_offer_rank(kind: &str) -> u16 {
-    match kind {
-        "give_item" => 10,
-        "open" => 18,
-        "use_item" | "use_feature" => 20,
-        "rest" => 25,
-        "pick_up" => 30,
-        "drop_item" => 30,
-        "craft" => 31,
-        "prepare" => 32,
-        "attack" => 40,
-        "defend" => 45,
-        "work" => 48,
-        "help" => 49,
-        "flee" => 50,
-        "explore_path" => 55,
-        "search" => 58,
-        "check" => 60,
-        "study" => 61,
-        "cast_spell" => 22,
-        "chat" => 70,
-        "trade_item" => 74,
-        "train_skill" => 76,
-        "create_bond" => 77,
-        "resolve_bond" => 79,
-        "move" => 80,
-        _ => 500,
-    }
-}
-
-fn practice_category_matches_offer(category: &str, kind: &str) -> bool {
-    match category {
-        "exploration" => matches!(kind, "explore_path" | "search" | "check" | "open" | "move"),
-        "craft" => matches!(kind, "craft" | "use_feature"),
-        "delivery" => matches!(kind, "move" | "give_item" | "trade_item"),
-        "stewardship" => matches!(kind, "prepare" | "work" | "help"),
-        "care" => matches!(kind, "defend" | "use_item" | "rest"),
-        "mediation" => matches!(kind, "influence" | "chat" | "create_bond" | "resolve_bond"),
-        "lore" => matches!(kind, "study" | "search" | "check"),
-        _ => false,
-    }
-}
-
-fn action_offer_intention(kind: &str) -> &str {
-    match kind {
-        "check" => "notice",
-        "search" => "inspect",
-        "explore_path" => "scout",
-        "move" => "travel",
-        "open" => "open",
-        "work" | "help" => "contribute",
-        _ => kind,
-    }
-}
-
-fn contribution_resolution_label(policy: &ContributionResolutionPolicy) -> &'static str {
-    match policy {
-        ContributionResolutionPolicy::Certain => "certain",
-        ContributionResolutionPolicy::SrdCheck { .. } => "srd_check",
-        ContributionResolutionPolicy::ExistingKernelOutcome { .. } => "existing_kernel_outcome",
-    }
-}
-
-fn default_action_offer_verb(kind: &str) -> &str {
-    match kind {
-        "check" => "Notice",
-        "search" => "Inspect",
-        "explore_path" => "Scout",
-        "move" => "Travel",
-        "open" => "Open",
-        "work" => "Push",
-        "help" => "Help",
-        "flee" => "Flee",
-        "prepare" => "Prepare",
-        "pick_up" => "Take",
-        "drop_item" => "Drop",
-        _ => "Act",
-    }
-}
-
-fn non_empty_text(value: &str) -> Option<&str> {
-    let value = value.trim();
-    (!value.is_empty()).then_some(value)
-}
-
-fn action_target_phrase(verb: &str, preposition: &str, target: Option<&str>) -> String {
-    let Some(target) = target.and_then(non_empty_text) else {
-        return verb.to_string();
-    };
-    if preposition.is_empty()
-        || verb
-            .to_ascii_lowercase()
-            .ends_with(&format!(" {preposition}"))
-    {
-        format!("{verb} {target}")
-    } else {
-        format!("{verb} {preposition} {target}")
-    }
-}
-
-fn fallback_job_action_label(job_id: &str) -> String {
-    let words = job_id
-        .rsplit_once(':')
-        .map(|(_, suffix)| suffix)
-        .unwrap_or(job_id)
-        .split(['-', '_'])
-        .filter(|word| !word.is_empty())
-        .collect::<Vec<_>>();
-    let fallback = if words.is_empty() {
-        "Contribute".to_string()
-    } else {
-        words.join(" ")
-    };
-    let mut characters = fallback.chars();
-    characters
-        .next()
-        .map(|first| first.to_uppercase().collect::<String>() + characters.as_str())
-        .unwrap_or_else(|| "Contribute".to_string())
-}
-
-fn action_offer_category(kind: &str) -> &'static str {
-    match kind {
-        "create_avatar" => "system",
-        "move" | "flee" | "explore_path" => "travel",
-        "attack" | "defend" => "danger",
-        "pick_up" | "drop_item" | "use_item" | "use_feature" | "give_item" | "trade_item"
-        | "open" => "inventory",
-        "craft" => "craft",
-        "chat" | "help" | "create_bond" | "resolve_bond" => "social",
-        "check" | "search" => "discovery",
-        "prepare" | "work" => "project",
-        "rest" => "recovery",
-        "train_skill" | "revise_calling" | "revise_bond" => "growth",
-        _ => "other",
-    }
-}
-
 fn committed_orb_deltas(
     record: &JournalRecord,
     events: &[EventView],
@@ -38690,6 +38463,9 @@ fn commit_journal_record(
         return Ok((CW_ERR_RULE, Vec::new()));
     }
     if !runtime.threshold_hazard_preconditions_hold(&record) {
+        return Ok((CW_ERR_RULE, Vec::new()));
+    }
+    if !discovery_record_preconditions_hold(runtime, &record) {
         return Ok((CW_ERR_RULE, Vec::new()));
     }
     if hosted_guest_record_restricted(state, runtime, &record) {

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -84,6 +84,11 @@ pub(crate) enum CommandDispatch {
     },
     Check,
     Study,
+    Discover {
+        procedure: String,
+        slot_id: String,
+        receipt_id: String,
+    },
     Chat {
         target_actor_id: u64,
     },
@@ -564,6 +569,9 @@ pub(crate) fn command_action_failure_output(resolved: &ResolvedCommand, status: 
         }
         CommandDispatch::Check => "The room did not catch that Listen. Try once more.",
         CommandDispatch::Study => "There is no authored subject to Study here now.",
+        CommandDispatch::Discover { .. } => {
+            "That discovery claim changed while you were choosing. Look again."
+        }
         CommandDispatch::Influence { .. } => "That bounded request is no longer available.",
         CommandDispatch::CastSpell { .. } => "That prepared spell cannot be cast right now.",
         CommandDispatch::PickUp { .. } => "Someone moved that item. Look around once more.",

--- a/v2/orchestrator-rust/src/offer_commands.rs
+++ b/v2/orchestrator-rust/src/offer_commands.rs
@@ -153,6 +153,17 @@ fn dispatch_for_offer(
             .map_err(|_| invalid()),
         "check" => Ok(CommandDispatch::Check),
         "study" => Ok(CommandDispatch::Study),
+        FOCUSED_NOTICE_OFFER_KIND
+        | DISCOVERY_SEARCH_OFFER_KIND
+        | DISCOVERY_STUDY_OFFER_KIND
+        | DISCOVERY_SCOUT_OFFER_KIND => {
+            let binding = offer.discovery.as_ref().ok_or_else(invalid)?;
+            Ok(CommandDispatch::Discover {
+                procedure: binding.procedure.clone(),
+                slot_id: binding.slot_id.clone(),
+                receipt_id: binding.receipt_id.clone(),
+            })
+        }
         "influence" => Ok(CommandDispatch::Influence {
             target_actor_id: required_target_id(offer, "actor")?,
         }),

--- a/v2/orchestrator-rust/src/resident_offer_scoring.rs
+++ b/v2/orchestrator-rust/src/resident_offer_scoring.rs
@@ -12,7 +12,16 @@ impl RuntimeWorld {
             .filter(|offer| {
                 matches!(
                     offer.kind.as_str(),
-                    "search" | "craft" | "influence" | "check" | "explore_path" | "open"
+                    "search"
+                        | "craft"
+                        | "influence"
+                        | "check"
+                        | "explore_path"
+                        | "open"
+                        | FOCUSED_NOTICE_OFFER_KIND
+                        | DISCOVERY_SEARCH_OFFER_KIND
+                        | DISCOVERY_STUDY_OFFER_KIND
+                        | DISCOVERY_SCOUT_OFFER_KIND
                 )
             })
             .filter_map(|offer| self.resident_record_for_shared_offer(actor, offer, seed))
@@ -76,19 +85,40 @@ impl RuntimeWorld {
         actor: CwActor,
         record: &JournalRecord,
     ) -> (u8, i16) {
+        let planner_selected_discovery = record
+            .projection_mutations
+            .iter()
+            .any(|mutation| matches!(mutation, ProjectionMutation::ResolveDiscovery { .. }))
+            && self
+                .resident_continuities
+                .get(&actor.id)
+                .and_then(|continuity| continuity.pending_action.as_ref())
+                .and_then(|proposal| proposal.candidate_id.as_deref())
+                .is_some_and(|candidate_id| {
+                    self.legal_action_candidates(Some(actor.id), &AccessContext::default())
+                        .1
+                        .iter()
+                        .any(|offer| {
+                            offer.offer_id == candidate_id
+                                && self.resident_offer_matches_record(offer, record)
+                        })
+                });
         let item_score = |item_id| {
             self.item_by_id(item_id)
                 .map(|item| self.resident_item_offer_score(actor, item))
                 .unwrap_or(RESIDENT_DEFAULT_ITEM_SCORE)
         };
-        let (rank, score) = if let Some(intent) =
+        let (rank, score) = if planner_selected_discovery {
+            (2, 0)
+        } else if let Some(intent) =
             record
                 .projection_mutations
                 .iter()
                 .find_map(|mutation| match mutation {
                     ProjectionMutation::ResolveJobContribution { intent } => Some(intent),
                     _ => None,
-                }) {
+                })
+        {
             (
                 35,
                 i16::from(self.contribution_progress_amount(actor.id, intent)),
@@ -128,6 +158,10 @@ impl RuntimeWorld {
                 "move" => (60, RESIDENT_DEFAULT_ITEM_SCORE),
                 "open" => (55, RESIDENT_DEFAULT_ITEM_SCORE),
                 "search" => (65, 0),
+                FOCUSED_NOTICE_OFFER_KIND => (64, 0),
+                DISCOVERY_SEARCH_OFFER_KIND => (65, 0),
+                DISCOVERY_STUDY_OFFER_KIND => (66, 0),
+                DISCOVERY_SCOUT_OFFER_KIND => (67, 0),
                 "craft"
                     if self.resident_needs_medicine(actor)
                         && record.projection_mutations.iter().any(|mutation| {

--- a/v2/orchestrator-rust/src/residents/continuity.rs
+++ b/v2/orchestrator-rust/src/residents/continuity.rs
@@ -816,6 +816,28 @@ impl RuntimeWorld {
                 self.plan_threshold_method_offer_action(actor.id, &offer)
                     .ok()
             }
+            FOCUSED_NOTICE_OFFER_KIND
+            | DISCOVERY_SEARCH_OFFER_KIND
+            | DISCOVERY_STUDY_OFFER_KIND
+            | DISCOVERY_SCOUT_OFFER_KIND => {
+                let candidate_id = proposal.candidate_id.as_deref()?;
+                let composition_id = proposal.composition_id.as_deref()?;
+                let state_revision = proposal.state_revision?;
+                let offer = self
+                    .legal_action_candidates(Some(actor.id), &AccessContext::default())
+                    .1
+                    .into_iter()
+                    .find(|offer| {
+                        offer.kind == proposal.kind
+                            && offer.offer_id == candidate_id
+                            && offer.composition_id == composition_id
+                            && offer.state_revision == state_revision
+                            && action_offer_is_reachable(offer)
+                    })?;
+                self.discovery_record_for_offer(actor.id, &offer, 0)
+                    .ok()
+                    .map(|record| record.action)
+            }
             _ => None,
         }
     }

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -167,6 +167,7 @@ pub(super) fn app_router(state: AppState) -> Router {
         .route("/actions/report", post(report_actor))
         .route("/actions/move", post(move_actor))
         .route("/actions/explore-path", post(explore_pathway))
+        .route("/actions/discover", post(discover))
         .route("/actions/check", post(ability_check))
         .route("/actions/study", post(study))
         .route("/actions/influence", post(influence))

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -1312,6 +1312,13 @@ pub(super) fn command_actor_turn_rejection(
         CommandDispatch::OpenThreshold { .. } => "open",
         CommandDispatch::Check => "check",
         CommandDispatch::Study => "study",
+        CommandDispatch::Discover { procedure, .. } => match procedure.as_str() {
+            "notice" => FOCUSED_NOTICE_OFFER_KIND,
+            "search" => DISCOVERY_SEARCH_OFFER_KIND,
+            "study" => DISCOVERY_STUDY_OFFER_KIND,
+            "scout" => DISCOVERY_SCOUT_OFFER_KIND,
+            _ => "",
+        },
         CommandDispatch::Prepare => "prepare",
         CommandDispatch::Contribute { action_kind, .. } => action_kind.as_str(),
         CommandDispatch::Work => "work",

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -247,6 +247,7 @@ pub(super) struct StateResponse {
     pub(super) items: Vec<ItemView>,
     pub(super) factions: Vec<FactionView>,
     pub(super) room_features: Vec<RoomFeatureView>,
+    pub(super) scene_notices: Vec<DiscoverySceneNoticeView>,
     pub(super) search_available: bool,
     pub(super) clocks: Vec<ClockView>,
     pub(super) shared_questions: Vec<SharedQuestionView>,
@@ -2619,6 +2620,9 @@ impl RuntimeWorld {
             items,
             factions: faction_views(),
             room_features: Vec::new(),
+            scene_notices: client_actor_id
+                .map(|id| self.discovery_scene_notices(id))
+                .unwrap_or_default(),
             search_available: client_actor_id
                 .map(|id| self.default_search_target(id).is_some())
                 .unwrap_or(false),

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -136,4 +136,4 @@
 # submission and threshold resolution wiring at the root boundary.
 # 73653 -> 73647: issue #592 moves the shared ability parser into the existing
 # rules_context.rs seam while adding Hazard state and projection wiring.
-73647
+73423


### PR DESCRIPTION
## Summary

- unify authored Focused Notice, Search, Study, and Scout procedures behind one frozen discovery pipeline
- expose exact discovery offers through browser, CLI, command, resident-planner, and autonomy surfaces
- preserve discovery receipts and scoped claims across retry, replay, and snapshots without granting physical side effects
- render obvious scene tells freely and project only Lead/Reveal journal events

## Validation

- `npm run check`
  - 517 Node tests
  - 75 discovery/worldpack contract tests plus all composition and strict proof-world checks
  - C kernel suite
  - 891 Rust tests
  - architecture and syntax gates

Fixes #601
