### PR TITLE
Make Lantern Keeper class revelation evidence-driven

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.289",
+  "version": "0.0.290",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/official/character_creation.json
+++ b/v2/content/official/character_creation.json
@@ -12,6 +12,18 @@
         "prompt": "What kind of traveler reaches the last light?",
         "class_prompt": "Which Lantern Keeper campaign path will you use?",
         "default_choice_id": "lantern-warden",
+        "class_recommendations": [
+          {
+            "offer_kind": "work",
+            "class_id": "lantern-warden",
+            "explanation": "You held to a shared task until it changed, the same steady practice a Lantern Warden brings to the road."
+          },
+          {
+            "offer_kind": "help",
+            "class_id": "hedge-mender",
+            "explanation": "You helped another traveler move a shared task forward, the same practical care a Hedge Mender brings to the road."
+          }
+        ],
         "default_species_id": "human",
         "default_origin_id": "wayside-inn",
         "species": [
@@ -21,7 +33,8 @@
             "detail": "adaptable, familiar, and hard to surprise twice",
             "title": "Human",
             "description": "A human traveler with practical hands and a face the road has not finished writing.",
-            "visual_prompt": "human traveler, expressive face, practical layered road clothes"
+            "visual_prompt": "human traveler, expressive face, practical layered road clothes",
+            "campaign_rule": "Story and portrait only: Human does not change available actions, ability checks, or modifiers."
           },
           {
             "id": "mouse",
@@ -29,7 +42,8 @@
             "detail": "small, quick, and attentive to overlooked things",
             "title": "Mouse",
             "description": "A small mouse traveler with bright eyes, careful paws, and an instinct for the useful edge of a room.",
-            "visual_prompt": "anthropomorphic mouse traveler, bright eyes, careful paws, small practical satchel"
+            "visual_prompt": "anthropomorphic mouse traveler, bright eyes, careful paws, small practical satchel",
+            "campaign_rule": "Story and portrait only: Mouse does not change available actions, ability checks, or modifiers."
           },
           {
             "id": "badger",
@@ -37,7 +51,8 @@
             "detail": "sturdy, patient, and difficult to hurry",
             "title": "Badger",
             "description": "A broad badger traveler with weathered fur, a patient stance, and room for one more burden.",
-            "visual_prompt": "anthropomorphic badger traveler, weathered fur, broad patient posture"
+            "visual_prompt": "anthropomorphic badger traveler, weathered fur, broad patient posture",
+            "campaign_rule": "Story and portrait only: Badger does not change available actions, ability checks, or modifiers."
           }
         ],
         "origins": [
@@ -47,7 +62,8 @@
             "detail": "you learned people by the state of their boots",
             "title": "the Wayside Inn",
             "description": "They grew up around kettle steam, wet cloaks, and stories told once the door was barred.",
-            "visual_prompt": "warm wayside inn details, kettle steam, patched travel cloak"
+            "visual_prompt": "warm wayside inn details, kettle steam, patched travel cloak",
+            "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
           },
           {
             "id": "open-road",
@@ -55,7 +71,8 @@
             "detail": "home was whichever milepost still had daylight",
             "title": "the Open Road",
             "description": "They learned to sleep lightly, mend straps in rain, and remember every honest milepost.",
-            "visual_prompt": "open road details, weathered map ribbon, rain-mended traveling gear"
+            "visual_prompt": "open road details, weathered map ribbon, rain-mended traveling gear",
+            "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
           },
           {
             "id": "old-chapel",
@@ -63,7 +80,8 @@
             "detail": "you know which old customs still keep people safe",
             "title": "the Old Chapel",
             "description": "They remember soot-black rafters, small bells, and rules whose reasons were never written down.",
-            "visual_prompt": "old roadside chapel details, small brass bell, soot-marked cloth"
+            "visual_prompt": "old roadside chapel details, small brass bell, soot-marked cloth",
+            "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
           }
         ],
         "choices": [
@@ -74,7 +92,8 @@
             "calling": "I keep a light burning when others lose the road.",
             "title": "Lantern Warden",
             "description": "A steady road-guard with a battered shield, a hooded lamp, and no habit of abandoning stragglers.",
-            "starting_skill_id": "steadiness"
+            "starting_skill_id": "steadiness",
+            "campaign_use": "Starts with Steadiness rank 1: +1 on Constitution checks, first useful when you endure danger or keep working under strain."
           },
           {
             "id": "mothwood-guide",
@@ -83,7 +102,8 @@
             "calling": "I find the path that still has living footprints on it.",
             "title": "Mothwood Guide",
             "description": "A weather-wise scout carrying chalk, twine, and a map corrected more often than it is folded.",
-            "starting_skill_id": "listening"
+            "starting_skill_id": "listening",
+            "campaign_use": "Starts with Listening rank 1: +1 on Wisdom checks, first useful when you listen, notice, or study the road ahead."
           },
           {
             "id": "hedge-mender",
@@ -92,7 +112,8 @@
             "calling": "I mend what the dark road tries to break.",
             "title": "Hedge Mender",
             "description": "A traveling fixer whose satchel holds bandages, wire, tea leaves, and exactly the wrong-sized screwdriver.",
-            "starting_skill_id": "kindness"
+            "starting_skill_id": "kindness",
+            "campaign_use": "Starts with Kindness rank 1: +1 on Charisma checks, first useful when you help, reassure, or win someone over."
           }
         ]
       }

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -794,7 +794,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:50205c5d58ef8e556744f5c383018ef1e2c440a7df2784ba013ecf75523d8f9f",
+    "bundle_hash": "sha256:9576956c1e4e526044e6bf67996d18ada8a52f140be77ea25d763b2f386dc790",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -2269,7 +2269,7 @@
           "type": "workspace",
           "path": "../../content/the-lantern-keeper"
         },
-        "integrity": "sha256:bb4475d96fc6bd7c1b3e89a78a3927b6c5a7984da4f7a0472bbc1f46cfc43321"
+        "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141"
       },
       {
         "id": "cosyworld.the-holy-land",
@@ -17361,6 +17361,18 @@
           "prompt": "What kind of traveler reaches the last light?",
           "class_prompt": "Which Lantern Keeper campaign path will you use?",
           "default_choice_id": "lantern-warden",
+          "class_recommendations": [
+            {
+              "offer_kind": "work",
+              "class_id": "lantern-warden",
+              "explanation": "You held to a shared task until it changed, the same steady practice a Lantern Warden brings to the road."
+            },
+            {
+              "offer_kind": "help",
+              "class_id": "hedge-mender",
+              "explanation": "You helped another traveler move a shared task forward, the same practical care a Hedge Mender brings to the road."
+            }
+          ],
           "default_species_id": "human",
           "default_origin_id": "wayside-inn",
           "species": [
@@ -17370,7 +17382,8 @@
               "detail": "adaptable, familiar, and hard to surprise twice",
               "title": "Human",
               "description": "A human traveler with practical hands and a face the road has not finished writing.",
-              "visual_prompt": "human traveler, expressive face, practical layered road clothes"
+              "visual_prompt": "human traveler, expressive face, practical layered road clothes",
+              "campaign_rule": "Story and portrait only: Human does not change available actions, ability checks, or modifiers."
             },
             {
               "id": "mouse",
@@ -17378,7 +17391,8 @@
               "detail": "small, quick, and attentive to overlooked things",
               "title": "Mouse",
               "description": "A small mouse traveler with bright eyes, careful paws, and an instinct for the useful edge of a room.",
-              "visual_prompt": "anthropomorphic mouse traveler, bright eyes, careful paws, small practical satchel"
+              "visual_prompt": "anthropomorphic mouse traveler, bright eyes, careful paws, small practical satchel",
+              "campaign_rule": "Story and portrait only: Mouse does not change available actions, ability checks, or modifiers."
             },
             {
               "id": "badger",
@@ -17386,7 +17400,8 @@
               "detail": "sturdy, patient, and difficult to hurry",
               "title": "Badger",
               "description": "A broad badger traveler with weathered fur, a patient stance, and room for one more burden.",
-              "visual_prompt": "anthropomorphic badger traveler, weathered fur, broad patient posture"
+              "visual_prompt": "anthropomorphic badger traveler, weathered fur, broad patient posture",
+              "campaign_rule": "Story and portrait only: Badger does not change available actions, ability checks, or modifiers."
             }
           ],
           "origins": [
@@ -17396,7 +17411,8 @@
               "detail": "you learned people by the state of their boots",
               "title": "the Wayside Inn",
               "description": "They grew up around kettle steam, wet cloaks, and stories told once the door was barred.",
-              "visual_prompt": "warm wayside inn details, kettle steam, patched travel cloak"
+              "visual_prompt": "warm wayside inn details, kettle steam, patched travel cloak",
+              "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
             },
             {
               "id": "open-road",
@@ -17404,7 +17420,8 @@
               "detail": "home was whichever milepost still had daylight",
               "title": "the Open Road",
               "description": "They learned to sleep lightly, mend straps in rain, and remember every honest milepost.",
-              "visual_prompt": "open road details, weathered map ribbon, rain-mended traveling gear"
+              "visual_prompt": "open road details, weathered map ribbon, rain-mended traveling gear",
+              "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
             },
             {
               "id": "old-chapel",
@@ -17412,7 +17429,8 @@
               "detail": "you know which old customs still keep people safe",
               "title": "the Old Chapel",
               "description": "They remember soot-black rafters, small bells, and rules whose reasons were never written down.",
-              "visual_prompt": "old roadside chapel details, small brass bell, soot-marked cloth"
+              "visual_prompt": "old roadside chapel details, small brass bell, soot-marked cloth",
+              "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
             }
           ],
           "choices": [
@@ -17423,7 +17441,8 @@
               "calling": "I keep a light burning when others lose the road.",
               "title": "Lantern Warden",
               "description": "A steady road-guard with a battered shield, a hooded lamp, and no habit of abandoning stragglers.",
-              "starting_skill_id": "steadiness"
+              "starting_skill_id": "steadiness",
+              "campaign_use": "Starts with Steadiness rank 1: +1 on Constitution checks, first useful when you endure danger or keep working under strain."
             },
             {
               "id": "mothwood-guide",
@@ -17432,7 +17451,8 @@
               "calling": "I find the path that still has living footprints on it.",
               "title": "Mothwood Guide",
               "description": "A weather-wise scout carrying chalk, twine, and a map corrected more often than it is folded.",
-              "starting_skill_id": "listening"
+              "starting_skill_id": "listening",
+              "campaign_use": "Starts with Listening rank 1: +1 on Wisdom checks, first useful when you listen, notice, or study the road ahead."
             },
             {
               "id": "hedge-mender",
@@ -17441,7 +17461,8 @@
               "calling": "I mend what the dark road tries to break.",
               "title": "Hedge Mender",
               "description": "A traveling fixer whose satchel holds bandages, wire, tea leaves, and exactly the wrong-sized screwdriver.",
-              "starting_skill_id": "kindness"
+              "starting_skill_id": "kindness",
+              "campaign_use": "Starts with Kindness rank 1: +1 on Charisma checks, first useful when you help, reassure, or win someone over."
             }
           ]
         }

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -792,7 +792,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:50205c5d58ef8e556744f5c383018ef1e2c440a7df2784ba013ecf75523d8f9f",
+  "bundle_hash": "sha256:9576956c1e4e526044e6bf67996d18ada8a52f140be77ea25d763b2f386dc790",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -2267,7 +2267,7 @@
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:bb4475d96fc6bd7c1b3e89a78a3927b6c5a7984da4f7a0472bbc1f46cfc43321"
+      "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141"
     },
     {
       "id": "cosyworld.the-holy-land",

--- a/v2/content/the-lantern-keeper/character_creation.json
+++ b/v2/content/the-lantern-keeper/character_creation.json
@@ -8,6 +8,18 @@
     "prompt": "What kind of traveler reaches the last light?",
     "class_prompt": "Which Lantern Keeper campaign path will you use?",
     "default_choice_id": "lantern-warden",
+    "class_recommendations": [
+      {
+        "offer_kind": "work",
+        "class_id": "lantern-warden",
+        "explanation": "You held to a shared task until it changed, the same steady practice a Lantern Warden brings to the road."
+      },
+      {
+        "offer_kind": "help",
+        "class_id": "hedge-mender",
+        "explanation": "You helped another traveler move a shared task forward, the same practical care a Hedge Mender brings to the road."
+      }
+    ],
     "default_species_id": "human",
     "default_origin_id": "wayside-inn",
     "species": [
@@ -17,7 +29,8 @@
         "detail": "adaptable, familiar, and hard to surprise twice",
         "title": "Human",
         "description": "A human traveler with practical hands and a face the road has not finished writing.",
-        "visual_prompt": "human traveler, expressive face, practical layered road clothes"
+        "visual_prompt": "human traveler, expressive face, practical layered road clothes",
+        "campaign_rule": "Story and portrait only: Human does not change available actions, ability checks, or modifiers."
       },
       {
         "id": "mouse",
@@ -25,7 +38,8 @@
         "detail": "small, quick, and attentive to overlooked things",
         "title": "Mouse",
         "description": "A small mouse traveler with bright eyes, careful paws, and an instinct for the useful edge of a room.",
-        "visual_prompt": "anthropomorphic mouse traveler, bright eyes, careful paws, small practical satchel"
+        "visual_prompt": "anthropomorphic mouse traveler, bright eyes, careful paws, small practical satchel",
+        "campaign_rule": "Story and portrait only: Mouse does not change available actions, ability checks, or modifiers."
       },
       {
         "id": "badger",
@@ -33,7 +47,8 @@
         "detail": "sturdy, patient, and difficult to hurry",
         "title": "Badger",
         "description": "A broad badger traveler with weathered fur, a patient stance, and room for one more burden.",
-        "visual_prompt": "anthropomorphic badger traveler, weathered fur, broad patient posture"
+        "visual_prompt": "anthropomorphic badger traveler, weathered fur, broad patient posture",
+        "campaign_rule": "Story and portrait only: Badger does not change available actions, ability checks, or modifiers."
       }
     ],
     "origins": [
@@ -43,7 +58,8 @@
         "detail": "you learned people by the state of their boots",
         "title": "the Wayside Inn",
         "description": "They grew up around kettle steam, wet cloaks, and stories told once the door was barred.",
-        "visual_prompt": "warm wayside inn details, kettle steam, patched travel cloak"
+        "visual_prompt": "warm wayside inn details, kettle steam, patched travel cloak",
+        "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
       },
       {
         "id": "open-road",
@@ -51,7 +67,8 @@
         "detail": "home was whichever milepost still had daylight",
         "title": "the Open Road",
         "description": "They learned to sleep lightly, mend straps in rain, and remember every honest milepost.",
-        "visual_prompt": "open road details, weathered map ribbon, rain-mended traveling gear"
+        "visual_prompt": "open road details, weathered map ribbon, rain-mended traveling gear",
+        "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
       },
       {
         "id": "old-chapel",
@@ -59,7 +76,8 @@
         "detail": "you know which old customs still keep people safe",
         "title": "the Old Chapel",
         "description": "They remember soot-black rafters, small bells, and rules whose reasons were never written down.",
-        "visual_prompt": "old roadside chapel details, small brass bell, soot-marked cloth"
+        "visual_prompt": "old roadside chapel details, small brass bell, soot-marked cloth",
+        "campaign_rule": "Story and portrait only: this Origin does not change available actions, ability checks, or modifiers."
       }
     ],
     "choices": [
@@ -70,7 +88,8 @@
         "calling": "I keep a light burning when others lose the road.",
         "title": "Lantern Warden",
         "description": "A steady road-guard with a battered shield, a hooded lamp, and no habit of abandoning stragglers.",
-        "starting_skill_id": "steadiness"
+        "starting_skill_id": "steadiness",
+        "campaign_use": "Starts with Steadiness rank 1: +1 on Constitution checks, first useful when you endure danger or keep working under strain."
       },
       {
         "id": "mothwood-guide",
@@ -79,7 +98,8 @@
         "calling": "I find the path that still has living footprints on it.",
         "title": "Mothwood Guide",
         "description": "A weather-wise scout carrying chalk, twine, and a map corrected more often than it is folded.",
-        "starting_skill_id": "listening"
+        "starting_skill_id": "listening",
+        "campaign_use": "Starts with Listening rank 1: +1 on Wisdom checks, first useful when you listen, notice, or study the road ahead."
       },
       {
         "id": "hedge-mender",
@@ -88,7 +108,8 @@
         "calling": "I mend what the dark road tries to break.",
         "title": "Hedge Mender",
         "description": "A traveling fixer whose satchel holds bandages, wire, tea leaves, and exactly the wrong-sized screwdriver.",
-        "starting_skill_id": "kindness"
+        "starting_skill_id": "kindness",
+        "campaign_use": "Starts with Kindness rank 1: +1 on Charisma checks, first useful when you help, reassure, or win someone over."
       }
     ]
   }

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.289"
+version = "0.0.290"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.289"
+version = "0.0.290"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_rules_facets.rs
+++ b/v2/orchestrator-rust/src/actor_rules_facets.rs
@@ -89,6 +89,190 @@ impl ActorRulesFacetState {
 }
 
 impl RuntimeWorld {
+    pub(super) fn apply_actor_creation_rpg_projection(
+        &mut self,
+        action: &CwAction,
+        events: &[EventView],
+        initial_calling: Option<&str>,
+        initial_skill: Option<&str>,
+        initial_character_profile_id: Option<&str>,
+        initial_species_id: Option<&str>,
+        initial_origin_id: Option<&str>,
+        initial_physical_description: Option<&str>,
+    ) -> Vec<EventView> {
+        if action.kind != CW_ACTION_CREATE_ACTOR || self.callings.contains_key(&action.actor_id) {
+            return Vec::new();
+        }
+        let Some(actor) = self.actor_by_id(action.actor_id) else {
+            return Vec::new();
+        };
+        if !Self::actor_can_act(actor) {
+            return Vec::new();
+        }
+        if let (Some(profile_id), Some(species_id), Some(origin_id)) = (
+            initial_character_profile_id,
+            initial_species_id,
+            initial_origin_id,
+        ) {
+            self.character_identities
+                .entry(action.actor_id)
+                .or_insert_with(|| AvatarIdentityState {
+                    actor_id: action.actor_id,
+                    profile_id: profile_id.to_string(),
+                    species_id: species_id.to_string(),
+                    origin_id: origin_id.to_string(),
+                    physical_description: initial_physical_description
+                        .map(compact_whitespace)
+                        .unwrap_or_default(),
+                    class_id: None,
+                    class_selection_ready: false,
+                    qualifying_world_actions: 0,
+                    class_source_event_seq: None,
+                    class_readiness_evidence: None,
+                });
+        }
+        let source_event_seq = events
+            .iter()
+            .find(|event| event.actor_id == Some(action.actor_id))
+            .map(|event| event.seq);
+        let calling = CallingState {
+            actor_id: action.actor_id,
+            statement: initial_calling
+                .and_then(normalize_calling_statement)
+                .unwrap_or_else(|| default_calling_statement().to_string()),
+            source_event_seq,
+        };
+        self.callings.insert(action.actor_id, calling.clone());
+        let reason = initial_calling
+            .and_then(normalize_calling_statement)
+            .map(|_| "chosen_calling")
+            .unwrap_or(CALLING_REASON_AVATAR_CREATED);
+        let mut projection_events =
+            vec![self.append_calling_event("calling.set", &calling, reason)];
+        if let Some(skill_id) = initial_skill.filter(|skill_id| skill_label(skill_id).is_some()) {
+            let id = skill_state_id(action.actor_id, skill_id);
+            if !self.skills.contains_key(&id) {
+                let skill = SkillState {
+                    actor_id: action.actor_id,
+                    skill_id: skill_id.to_string(),
+                    label: skill_label(skill_id).unwrap_or("Knack").to_string(),
+                    rank: 1,
+                    updated_event_seq: Some(self.world.next_event_seq),
+                };
+                self.skills.insert(id, skill.clone());
+                projection_events.push(self.append_skill_event(
+                    "skill.stepped",
+                    &skill,
+                    "character_creation",
+                ));
+            }
+        }
+        projection_events
+    }
+
+    pub(super) fn apply_class_readiness_projection(
+        &mut self,
+        record: &JournalRecord,
+        action: &CwAction,
+        committed_events: &[EventView],
+    ) -> Vec<EventView> {
+        if action.actor_id == 0
+            || action.kind == CW_ACTION_CREATE_ACTOR
+            || !matches!(
+                record.origin,
+                JournalOrigin::PlayerCard | JournalOrigin::Speech
+            )
+        {
+            return Vec::new();
+        }
+        if action.kind == CW_ACTION_NONE
+            && !record.projection_mutations.is_empty()
+            && record
+                .projection_mutations
+                .iter()
+                .all(|mutation| matches!(mutation, ProjectionMutation::ShuffleHand { .. }))
+        {
+            return Vec::new();
+        }
+        let Some((source_event_seq, trace)) = committed_events.iter().find_map(|event| {
+            (event.type_name == "job.contribution.resolved"
+                && event.actor_id == Some(action.actor_id))
+            .then(|| {
+                event
+                    .content
+                    .as_deref()
+                    .and_then(|content| serde_json::from_str::<JobContributionTrace>(content).ok())
+                    .filter(|trace| trace.total_progress > 0)
+                    .map(|trace| (event.seq, trace))
+            })
+            .flatten()
+        }) else {
+            return Vec::new();
+        };
+        let evidence = ClassReadinessEvidence {
+            offer_kind: trace.action_kind.clone(),
+            strategy_label: trace.strategy_label.clone(),
+            target: trace.target.clone(),
+            outcome: trace.outcome.clone(),
+            progress: trace.total_progress,
+            source_event_seq,
+        };
+        let became_ready = {
+            let Some(identity) = self.character_identities.get_mut(&action.actor_id) else {
+                return Vec::new();
+            };
+            if identity.class_id.is_some() || identity.class_selection_ready {
+                return Vec::new();
+            }
+            identity.qualifying_world_actions = identity.qualifying_world_actions.saturating_add(1);
+            identity
+                .class_readiness_evidence
+                .get_or_insert(evidence.clone());
+            identity.class_selection_ready = identity.qualifying_world_actions >= 1;
+            identity.class_selection_ready
+        };
+        if !became_ready {
+            return Vec::new();
+        }
+        let recommendation = self
+            .character_identities
+            .get(&action.actor_id)
+            .and_then(|identity| character_creation_profile(Some(&identity.profile_id)))
+            .and_then(|profile| {
+                let recommendation = profile
+                    .class_recommendations
+                    .iter()
+                    .find(|candidate| candidate.offer_kind == evidence.offer_kind)?;
+                profile
+                    .choices
+                    .iter()
+                    .find(|choice| choice.id == recommendation.class_id)
+                    .map(|choice| choice.label.clone())
+            });
+        let recommendation_copy = recommendation
+            .map(|label| {
+                format!(
+                    " {label} is recommended from that evidence; every Class remains selectable."
+                )
+            })
+            .unwrap_or_else(|| {
+                " That evidence does not point to one Class; every Class remains selectable."
+                    .to_string()
+            });
+        vec![self.append_async_job_event(
+            "class.selection_ready",
+            action.actor_id,
+            None,
+            Some(format!(
+                "{} changed {} by +{} progress. Optional campaign rules are now available.{}",
+                evidence.strategy_label,
+                evidence.target.label,
+                evidence.progress,
+                recommendation_copy
+            )),
+        )]
+    }
+
     fn actor_rules_facet_base_stats(&self, actor: CwActor) -> CwStatBlock {
         self.actor_rules_facets
             .get(&actor.id)
@@ -339,6 +523,131 @@ mod tests {
             .filter(|item| item.holder_actor_id == actor_id)
             .map(|item| (item.id, item.zone))
             .collect()
+    }
+
+    fn qualifying_contribution(actor_id: u64, action_kind: &str, seq: u64) -> EventView {
+        let trace = JobContributionTrace {
+            schema_version: 1,
+            job_id: "lantern-test".to_string(),
+            strategy_id: format!("{action_kind}-strategy"),
+            strategy_label: if action_kind == "work" {
+                "Hold the lantern line".to_string()
+            } else {
+                "Help mend the lantern".to_string()
+            },
+            narration_key: "test".to_string(),
+            action_kind: action_kind.to_string(),
+            rules_action: None,
+            operation: None,
+            target: ResolvedContributionTarget {
+                kind: "job".to_string(),
+                id: "lantern-test".to_string(),
+                label: "the last roadside lantern".to_string(),
+            },
+            resolution: "success".to_string(),
+            outcome: "progressed".to_string(),
+            baseline_progress: 1,
+            success_progress: 0,
+            prepared_bonus_progress: 0,
+            project_push_prepared: false,
+            project_evidence_count: 0,
+            project_location_count: 0,
+            total_progress: 1,
+            clock_id: "lantern-test.progress".to_string(),
+            claim_key: None,
+            requirement_source_event_seqs: Vec::new(),
+            source_event_seqs: Vec::new(),
+            rules_profile: "cosyworld.srd5/1".to_string(),
+            rules_pack_id: "cosyworld.rules-srd-5.1".to_string(),
+            rules_pack_version: "5.1".to_string(),
+            pack_id: "cosyworld.campaign.the-lantern-keeper".to_string(),
+            pack_version: "1.0.0".to_string(),
+        };
+        EventView {
+            seq,
+            type_name: "job.contribution.resolved".to_string(),
+            success: true,
+            actor_id: Some(actor_id),
+            content: Some(serde_json::to_string(&trace).expect("serialize contribution trace")),
+            ..EventView::default()
+        }
+    }
+
+    #[test]
+    fn first_positive_contribution_freezes_evidence_and_authored_class_recommendation() {
+        for (action_kind, expected_class) in [("work", "lantern-warden"), ("help", "hedge-mender")]
+        {
+            let mut runtime = RuntimeWorld::seeded();
+            runtime.character_identities.insert(
+                RATI_ACTOR_ID,
+                AvatarIdentityState {
+                    actor_id: RATI_ACTOR_ID,
+                    profile_id: "the-lantern-keeper".to_string(),
+                    species_id: "human".to_string(),
+                    origin_id: "wayside-inn".to_string(),
+                    physical_description: String::new(),
+                    class_id: None,
+                    class_selection_ready: false,
+                    qualifying_world_actions: 0,
+                    class_source_event_seq: None,
+                    class_readiness_evidence: None,
+                },
+            );
+            let action = CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: RATI_ACTOR_ID,
+                ..CwAction::default()
+            };
+            let record = JournalRecord::new(action, 1).into_player_card();
+            let readiness = runtime.apply_class_readiness_projection(
+                &record,
+                &action,
+                &[qualifying_contribution(RATI_ACTOR_ID, action_kind, 41)],
+            );
+            assert_eq!(readiness.len(), 1);
+            assert_eq!(readiness[0].type_name, "class.selection_ready");
+            let identity = runtime
+                .character_identities
+                .get(&RATI_ACTOR_ID)
+                .expect("campaign identity");
+            assert_eq!(
+                identity
+                    .class_readiness_evidence
+                    .as_ref()
+                    .map(|evidence| (evidence.offer_kind.as_str(), evidence.source_event_seq)),
+                Some((action_kind, 41))
+            );
+            let view = runtime
+                .character_identity_view(RATI_ACTOR_ID)
+                .expect("campaign identity view");
+            assert_eq!(
+                view.class_recommendation
+                    .as_ref()
+                    .map(|recommendation| recommendation.class_id.as_str()),
+                Some(expected_class)
+            );
+
+            let duplicate = runtime.apply_class_readiness_projection(
+                &record,
+                &action,
+                &[qualifying_contribution(RATI_ACTOR_ID, "help", 42)],
+            );
+            assert!(duplicate.is_empty());
+            assert_eq!(
+                runtime.character_identities[&RATI_ACTOR_ID]
+                    .class_readiness_evidence
+                    .as_ref()
+                    .map(|evidence| evidence.source_event_seq),
+                Some(41)
+            );
+            let restored = RuntimeSnapshot::from_runtime(&runtime)
+                .into_runtime()
+                .expect("evidence survives snapshot restore");
+            assert_eq!(
+                restored.character_identities[&RATI_ACTOR_ID].class_readiness_evidence,
+                runtime.character_identities[&RATI_ACTOR_ID].class_readiness_evidence
+            );
+        }
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -582,6 +582,8 @@ pub(super) struct SeedCharacterCreationProfile {
     pub(super) default_choice_id: String,
     pub(super) choices: Vec<SeedCharacterCreationChoice>,
     #[serde(default)]
+    pub(super) class_recommendations: Vec<SeedCharacterClassRecommendation>,
+    #[serde(default)]
     pub(super) class_prompt: Option<String>,
     #[serde(default)]
     pub(super) default_species_id: Option<String>,
@@ -602,6 +604,15 @@ pub(super) struct SeedCharacterCreationChoice {
     pub(super) title: String,
     pub(super) description: String,
     pub(super) starting_skill_id: String,
+    #[serde(default)]
+    pub(super) campaign_use: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct SeedCharacterClassRecommendation {
+    pub(super) offer_kind: String,
+    pub(super) class_id: String,
+    pub(super) explanation: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -612,6 +623,8 @@ pub(super) struct SeedCharacterCreationIdentityCard {
     pub(super) title: String,
     pub(super) description: String,
     pub(super) visual_prompt: String,
+    #[serde(default)]
+    pub(super) campaign_rule: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5115,9 +5115,18 @@
         if (creationProfile?.choices?.length) {
           const choices = creationProfile.choices.map((choice) => ({
             label: choice.label,
-            detail: choice.detail,
+            detail: [choice.detail, choice.campaign_use].filter(Boolean).join(". "),
             value: choice.id,
+            classChoice: choice,
           }));
+          const evidence = characterIdentity.class_readiness_evidence || null;
+          const recommendation = characterIdentity.class_recommendation || null;
+          const evidenceSummary = evidence
+            ? `${evidence.strategy_label} changed ${evidence.target?.label || "a shared task"} by +${evidence.progress} progress.`
+            : "A shared-world contribution made campaign Class rules available.";
+          const recommendationSummary = recommendation
+            ? `${recommendation.class_label} is recommended because ${lowerInitial(recommendation.explanation)}`
+            : "That evidence does not point to one Class.";
           const action = {
             handProvider: {
               kind: "campaign",
@@ -5134,10 +5143,14 @@
             card: cardForActor(actorId),
             shape: "avatar",
             modalTitle: creationProfile.class_prompt || "which campaign path will you use?",
-            modalSummary: `${characterIdentity.species_label} from ${characterIdentity.origin_label}: campaign class; practice stays emergent.`,
+            modalSummary: `${evidenceSummary} ${recommendationSummary} Every Class remains selectable.`,
             effect: "applies this campaign's level and starting-knack rules without changing universal verb permissions",
             choices,
-            selectedChoice: creationProfile.default_choice_id || choices[0].value,
+            selectedChoice: recommendation?.class_id
+              || creationProfile.default_choice_id
+              || choices[0].value,
+            creationProfile,
+            characterIdentity,
             busyLabel: "becoming",
             busyDetail: "your first path is settling into place…",
           };
@@ -10699,43 +10712,76 @@
       if (event.content === "notice") {
         const actor = event.actor_name || "Someone";
         const target = event.target_actor_name || "the other avatar";
+        const mechanics = abilityCheckMechanics(event);
         return success
           ? {
               label: "notice",
               symbol: "✦",
               title: `${actor} reads ${target}`,
-              detail: "What they carry and seek is now known.",
+              detail: `What they carry and seek is now known. ${mechanics}.`,
               result: "noticed",
-              story: `${actor} notices what ${target} carries and seeks.`,
+              story: `${actor} notices what ${target} carries and seeks. ${mechanics}.`,
             }
           : {
               label: "notice",
               symbol: "~",
               title: `${target} stays hard to read`,
-              detail: `${actor} learns nothing certain yet.`,
+              detail: `${actor} learns nothing certain yet. ${mechanics}.`,
               result: "unclear",
-              story: `${target} remains hard to read.`,
+              story: `${target} remains hard to read. ${mechanics}.`,
             };
       }
       const hint = listenHintForLocation(event.location_id, success);
       const actor = event.actor_name || "Someone";
+      const mechanics = abilityCheckMechanics(event);
       return success
         ? {
             label: "check",
             symbol: "✦",
             title: `${actor} checks carefully; the room answers`,
-            detail: hint,
+            detail: `${mechanics}. ${hint}`,
             result: "a clue appears",
-            story: `The room answers a careful check: ${hint}`,
+            story: `The room answers a careful check. ${mechanics}. ${hint}`,
           }
         : {
             label: "check",
             symbol: "~",
             title: `${actor} checks carefully; the room stays shy`,
-            detail: hint,
+            detail: `${mechanics}. ${hint}`,
             result: "try another way",
-            story: `A careful check leaves the room's secret tucked away.`,
+            story: `A careful check leaves the room's secret tucked away. ${mechanics}.`,
           };
+    }
+
+    function abilityCheckMechanics(event) {
+      const ability = abilityLabel(event?.ability, "Ability");
+      const raw = Number(event?.raw_roll);
+      const modifier = Number(event?.modifier);
+      const total = Number(event?.total);
+      const dc = Number(event?.dc);
+      const signed = Number.isFinite(modifier) ? `${modifier >= 0 ? "+" : "−"}${Math.abs(modifier)}` : "";
+      const roll = [Number.isFinite(raw) ? `d20 ${raw}` : "", signed].filter(Boolean).join(" ");
+      const equation = [
+        roll,
+        Number.isFinite(total) ? `= ${total}` : "",
+        Number.isFinite(dc) ? `vs DC ${dc}` : "",
+      ].filter(Boolean).join(" ");
+      const outcome = event?.success === true ? "success" : "failure";
+      const choice = authoredAbilityChoice(event?.ability);
+      const ownedCheck = Number(event?.actor_id || 0) === Number(actorId || 0);
+      const skill = choice && ownedCheck
+        ? (state?.skills || []).find((candidate) => candidate.skill_id === choice.id)
+        : null;
+      const identity = state?.character_identity || null;
+      const profile = (state?.character_creation || [])
+        .find((candidate) => candidate.id === identity?.profile_id);
+      const classChoice = (profile?.choices || [])
+        .find((candidate) => candidate.id === identity?.class_id);
+      const classSource = skill
+        && classChoice?.starting_skill_id === skill.skill_id
+        ? ` · Class skill: ${skill.label} +${Math.max(0, Number(skill.bonus || 0))} from ${classChoice.label}`
+        : "";
+      return `${ability} check · ${equation} · ${outcome}${classSource}`;
     }
 
     function eventAriaLabel(event, speaker, body) {
@@ -11070,19 +11116,20 @@
     }
 
     function abilityCheckEventText(event) {
+      const mechanics = abilityCheckMechanics(event);
       if (event.content === "notice") {
         const target = event.target_actor_name || "the other avatar";
         return event.success
-          ? `notices what ${target} carries and seeks.`
-          : `${target} remains hard to read.`;
+          ? `notices what ${target} carries and seeks. ${mechanics}.`
+          : `${target} remains hard to read. ${mechanics}.`;
       }
       if (event.content === "study") {
         return event.success
-          ? "studies the signs and understands their meaning."
-          : "studies the signs, but their meaning stays unclear.";
+          ? `studies the signs and understands their meaning. ${mechanics}.`
+          : `studies the signs, but their meaning stays unclear. ${mechanics}.`;
       }
       const hint = listenHintForLocation(event.location_id, event.success);
-      return `checks carefully: ${hint}`;
+      return `checks carefully: ${hint} ${mechanics}.`;
     }
 
     function listenHintForLocation(id, success) {
@@ -12125,10 +12172,22 @@
         ];
       }
       if (String(action?.kind || "") === "choose-class") {
+        const evidence = action?.characterIdentity?.class_readiness_evidence || null;
+        const recommendation = action?.characterIdentity?.class_recommendation || null;
+        const selected = (action?.creationProfile?.choices || [])
+          .find((choice) => choice.id === action.selectedChoice)
+          || action?.creationProfile?.choices?.[0]
+          || null;
         return [
-          ["Rules", "optional mounted campaign rules"],
-          ["Choose", "a campaign Class, separate from emergent practice"],
-          ["Then", "apply this campaign's level and starting-knack rules"],
+          evidence
+            ? ["First qualifying action", `${evidence.strategy_label} changed ${evidence.target?.label || "a shared task"} by +${evidence.progress} progress (${evidence.outcome})`]
+            : ["First qualifying action", "a contribution changed a shared task"],
+          recommendation
+            ? ["Recommendation", `${recommendation.class_label}: ${recommendation.explanation}`]
+            : ["Recommendation", "the evidence does not point to one Class"],
+          selected
+            ? ["Selected Class", `${selected.label} — ${selected.campaign_use}`]
+            : ["Choose", "one of this campaign's Classes"],
           ["Ordinary verbs", "remain available to every avatar"],
         ];
       }
@@ -12266,7 +12325,7 @@
     }
 
     function renderActionModalRows(action) {
-      const showConversationDetails = ["orb-chat", "advancement-bond"]
+      const showConversationDetails = ["orb-chat", "advancement-bond", "choose-class"]
         .includes(String(action?.kind || ""));
       const rows = (showConversationDetails ? actionModalRows(action) : [])
         .filter((row) => String(row?.[0] || "").trim() && String(row?.[1] || "").trim());
@@ -12437,7 +12496,7 @@
       if (stage === "species") {
         action.choices = (profile.species || []).map((choice) => ({
           label: choice.label,
-          detail: choice.detail,
+          detail: [choice.detail, choice.campaign_rule].filter(Boolean).join(". "),
           value: choice.id,
         }));
         action.selectedChoice = action.selectedSpeciesId
@@ -12449,7 +12508,7 @@
       }
       action.choices = (profile.origins || []).map((choice) => ({
         label: choice.label,
-        detail: choice.detail,
+        detail: [choice.detail, choice.campaign_rule].filter(Boolean).join(". "),
         value: choice.id,
       }));
       action.selectedChoice = action.selectedOriginId

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1272,6 +1272,18 @@ struct AvatarIdentityState {
     qualifying_world_actions: u8,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     class_source_event_seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    class_readiness_evidence: Option<ClassReadinessEvidence>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct ClassReadinessEvidence {
+    offer_kind: String,
+    strategy_label: String,
+    target: ResolvedContributionTarget,
+    outcome: String,
+    progress: u8,
+    source_event_seq: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2848,6 +2860,10 @@ struct CharacterCreationChoiceView {
     title: String,
     description: String,
     starting_skill_id: String,
+    starting_skill_label: String,
+    starting_ability: String,
+    starting_bonus: i16,
+    campaign_use: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -2858,6 +2874,14 @@ struct CharacterCreationIdentityCardView {
     title: String,
     description: String,
     visual_prompt: String,
+    campaign_rule: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct CharacterClassRecommendationView {
+    class_id: String,
+    class_label: String,
+    explanation: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -2871,6 +2895,8 @@ struct CharacterIdentityView {
     class_label: Option<String>,
     class_selection_ready: bool,
     qualifying_world_actions: u8,
+    class_readiness_evidence: Option<ClassReadinessEvidence>,
+    class_recommendation: Option<CharacterClassRecommendationView>,
     level: u8,
 }
 
@@ -4057,6 +4083,14 @@ fn character_creation_views() -> Vec<CharacterCreationProfileView> {
                             title: choice.title.clone(),
                             description: choice.description.clone(),
                             starting_skill_id: choice.starting_skill_id.clone(),
+                            starting_skill_label: skill_label(&choice.starting_skill_id)
+                                .unwrap_or("Knack")
+                                .to_string(),
+                            starting_ability: skill_ability_label(&choice.starting_skill_id)
+                                .unwrap_or("Ability")
+                                .to_string(),
+                            starting_bonus: 1,
+                            campaign_use: choice.campaign_use.clone(),
                         })
                         .collect(),
                     default_species_id: profile.default_species_id.clone(),
@@ -4086,6 +4120,7 @@ fn character_creation_identity_card_view(
         title: card.title.clone(),
         description: card.description.clone(),
         visual_prompt: card.visual_prompt.clone(),
+        campaign_rule: card.campaign_rule.clone(),
     }
 }
 
@@ -11632,149 +11667,6 @@ impl RuntimeWorld {
             ));
         }
         projected
-    }
-
-    fn apply_actor_creation_rpg_projection(
-        &mut self,
-        action: &CwAction,
-        events: &[EventView],
-        initial_calling: Option<&str>,
-        initial_skill: Option<&str>,
-        initial_character_profile_id: Option<&str>,
-        initial_species_id: Option<&str>,
-        initial_origin_id: Option<&str>,
-        initial_physical_description: Option<&str>,
-    ) -> Vec<EventView> {
-        if action.kind != CW_ACTION_CREATE_ACTOR || self.callings.contains_key(&action.actor_id) {
-            return Vec::new();
-        }
-        let Some(actor) = self.actor_by_id(action.actor_id) else {
-            return Vec::new();
-        };
-        if !Self::actor_can_act(actor) {
-            return Vec::new();
-        }
-        if let (Some(profile_id), Some(species_id), Some(origin_id)) = (
-            initial_character_profile_id,
-            initial_species_id,
-            initial_origin_id,
-        ) {
-            self.character_identities
-                .entry(action.actor_id)
-                .or_insert_with(|| AvatarIdentityState {
-                    actor_id: action.actor_id,
-                    profile_id: profile_id.to_string(),
-                    species_id: species_id.to_string(),
-                    origin_id: origin_id.to_string(),
-                    physical_description: initial_physical_description
-                        .map(compact_whitespace)
-                        .unwrap_or_default(),
-                    class_id: None,
-                    class_selection_ready: false,
-                    qualifying_world_actions: 0,
-                    class_source_event_seq: None,
-                });
-        }
-        let source_event_seq = events
-            .iter()
-            .find(|event| event.actor_id == Some(action.actor_id))
-            .map(|event| event.seq);
-        let calling = CallingState {
-            actor_id: action.actor_id,
-            statement: initial_calling
-                .and_then(normalize_calling_statement)
-                .unwrap_or_else(|| default_calling_statement().to_string()),
-            source_event_seq,
-        };
-        self.callings.insert(action.actor_id, calling.clone());
-        let reason = initial_calling
-            .and_then(normalize_calling_statement)
-            .map(|_| "chosen_calling")
-            .unwrap_or(CALLING_REASON_AVATAR_CREATED);
-        let mut projection_events =
-            vec![self.append_calling_event("calling.set", &calling, reason)];
-        if let Some(skill_id) = initial_skill.filter(|skill_id| skill_label(skill_id).is_some()) {
-            let id = skill_state_id(action.actor_id, skill_id);
-            if !self.skills.contains_key(&id) {
-                let skill = SkillState {
-                    actor_id: action.actor_id,
-                    skill_id: skill_id.to_string(),
-                    label: skill_label(skill_id).unwrap_or("Knack").to_string(),
-                    rank: 1,
-                    updated_event_seq: Some(self.world.next_event_seq),
-                };
-                self.skills.insert(id, skill.clone());
-                projection_events.push(self.append_skill_event(
-                    "skill.stepped",
-                    &skill,
-                    "character_creation",
-                ));
-            }
-        }
-        projection_events
-    }
-
-    fn apply_class_readiness_projection(
-        &mut self,
-        record: &JournalRecord,
-        action: &CwAction,
-        committed_events: &[EventView],
-    ) -> Vec<EventView> {
-        if action.actor_id == 0
-            || action.kind == CW_ACTION_CREATE_ACTOR
-            || !matches!(
-                record.origin,
-                JournalOrigin::PlayerCard | JournalOrigin::Speech
-            )
-        {
-            return Vec::new();
-        }
-        if action.kind == CW_ACTION_NONE
-            && !record.projection_mutations.is_empty()
-            && record
-                .projection_mutations
-                .iter()
-                .all(|mutation| matches!(mutation, ProjectionMutation::ShuffleHand { .. }))
-        {
-            return Vec::new();
-        }
-        let shared_world_contribution = committed_events.iter().any(|event| {
-            event.type_name == "job.contribution.resolved"
-                && event.actor_id == Some(action.actor_id)
-                && event
-                    .content
-                    .as_deref()
-                    .and_then(|content| serde_json::from_str::<JobContributionTrace>(content).ok())
-                    .is_some_and(|trace| trace.total_progress > 0)
-        });
-        if !shared_world_contribution {
-            return Vec::new();
-        }
-        let became_ready = {
-            let Some(identity) = self.character_identities.get_mut(&action.actor_id) else {
-                return Vec::new();
-            };
-            if identity.class_id.is_some() || identity.class_selection_ready {
-                return Vec::new();
-            }
-            identity.qualifying_world_actions = identity.qualifying_world_actions.saturating_add(1);
-            identity.class_selection_ready = identity.qualifying_world_actions >= 1;
-            identity.class_selection_ready
-        };
-        became_ready
-            .then(|| {
-                self.append_async_job_event(
-                    "class.selection_ready",
-                    action.actor_id,
-                    None,
-                    Some(
-                        "Your contribution changed the shared world. Optional campaign rules are now available."
-                            .to_string(),
-                    ),
-                )
-            })
-            .into_iter()
-            .collect()
     }
 
     fn apply_progress_contribution_ledger_projection(
@@ -37569,6 +37461,18 @@ fn skill_label(skill_id: &str) -> Option<&'static str> {
     }
 }
 
+fn skill_ability_label(skill_id: &str) -> Option<&'static str> {
+    match skill_id {
+        "lifting" => Some("Strength"),
+        "nimble_hands" => Some("Dexterity"),
+        "steadiness" => Some("Constitution"),
+        "lorecraft" => Some("Intelligence"),
+        "listening" => Some("Wisdom"),
+        "kindness" => Some("Charisma"),
+        _ => None,
+    }
+}
+
 fn skill_id_for_ability(ability: u8) -> Option<&'static str> {
     match ability {
         0 => Some("lifting"),
@@ -52588,9 +52492,43 @@ mod tests {
             assert!(identity.class_selection_ready);
             assert_eq!(identity.qualifying_world_actions, 1);
             assert_eq!(identity.class_id, None);
+            let evidence = identity
+                .class_readiness_evidence
+                .as_ref()
+                .expect("first qualifying action is retained");
+            assert_eq!(evidence.offer_kind, "work");
+            assert!(evidence.progress > 0);
+            assert_eq!(evidence.target.kind, "job");
+            let identity_view = runtime
+                .character_identity_view(actor.id)
+                .expect("identity view explains readiness");
+            assert_eq!(
+                identity_view
+                    .class_recommendation
+                    .as_ref()
+                    .map(|recommendation| recommendation.class_id.as_str()),
+                Some("lantern-warden")
+            );
         }
 
         let class_response = choose_avatar_class(
+            ConnectInfo("127.0.0.1:45110".parse().expect("client address")),
+            State(state.clone()),
+            Json(ChooseClassRequest {
+                actor_id: actor.id,
+                actor_session: Some(actor_session.clone()),
+                character_creation_id: "the-lantern-keeper".to_string(),
+                class_id: "mothwood-guide".to_string(),
+            }),
+        )
+        .await
+        .0;
+        assert!(class_response.ok, "{class_response:?}");
+        assert!(class_response
+            .events
+            .iter()
+            .any(|event| event.type_name == "class.chosen"));
+        let duplicate_response = choose_avatar_class(
             ConnectInfo("127.0.0.1:45110".parse().expect("client address")),
             State(state.clone()),
             Json(ChooseClassRequest {
@@ -52602,37 +52540,38 @@ mod tests {
         )
         .await
         .0;
-        assert!(class_response.ok, "{class_response:?}");
-        assert!(class_response
-            .events
-            .iter()
-            .any(|event| event.type_name == "class.chosen"));
+        assert!(!duplicate_response.ok);
+        assert!(duplicate_response.events.is_empty());
 
         let mut runtime = state.inner.lock().await;
         let actor = runtime.actor_view(runtime.actor_by_id(actor.id).expect("classed avatar"));
         assert_eq!(actor.stats.level, 1);
-        assert_eq!(actor.title, "Lantern Warden");
+        assert_eq!(actor.title, "Mothwood Guide");
         assert_eq!(
             runtime
                 .character_identities
                 .get(&actor.id)
                 .and_then(|identity| identity.class_id.as_deref()),
-            Some("lantern-warden")
+            Some("mothwood-guide")
         );
         assert_eq!(
             runtime
                 .callings
                 .get(&actor.id)
                 .map(|calling| calling.statement.as_str()),
-            Some("I keep a light burning when others lose the road.")
+            Some("I find the path that still has living footprints on it.")
         );
         assert_eq!(
             runtime
                 .skills
-                .get(&skill_state_id(actor.id, "steadiness"))
+                .get(&skill_state_id(actor.id, "listening"))
                 .map(|skill| skill.rank),
             Some(1)
         );
+        assert_eq!(runtime.skill_bonus_for_ability(actor.id, 4), 1);
+        assert!(!runtime
+            .skills
+            .contains_key(&skill_state_id(actor.id, "steadiness")));
         let item_count = runtime.world.item_count;
         let dawn_oil = runtime
             .world
@@ -52649,7 +52588,7 @@ mod tests {
             .expect("generated avatar can build a canonical art plan");
         assert!(art_plan.prompt.contains("species: Human"));
         assert!(art_plan.prompt.contains("origin: The Old Chapel"));
-        assert!(art_plan.prompt.contains("class: Lantern Warden"));
+        assert!(art_plan.prompt.contains("class: Mothwood Guide"));
         assert!(art_plan.prompt.contains("authoritative level 1"));
         assert!(art_plan.prompt.contains("stable physical description"));
         assert!(art_plan.prompt.contains("Dawn Oil (carried)"));
@@ -52663,7 +52602,7 @@ mod tests {
             .expect("restored composed identity");
         assert_eq!(
             restored_identity.class_id.as_deref(),
-            Some("lantern-warden")
+            Some("mothwood-guide")
         );
         assert_eq!(
             restored_identity.physical_description,
@@ -52681,9 +52620,16 @@ mod tests {
         assert_eq!(
             restored
                 .skills
-                .get(&skill_state_id(actor.id, "steadiness"))
+                .get(&skill_state_id(actor.id, "listening"))
                 .map(|skill| skill.rank),
             Some(1)
+        );
+        assert_eq!(
+            restored_identity
+                .class_readiness_evidence
+                .as_ref()
+                .map(|evidence| evidence.offer_kind.as_str()),
+            Some("work")
         );
     }
 

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -2699,7 +2699,7 @@ impl RuntimeWorld {
         }
     }
 
-    fn character_identity_view(&self, actor_id: u64) -> Option<CharacterIdentityView> {
+    pub(super) fn character_identity_view(&self, actor_id: u64) -> Option<CharacterIdentityView> {
         let identity = self.character_identities.get(&actor_id)?;
         let profile = character_creation_profile(Some(&identity.profile_id))?;
         let species_label = profile
@@ -2722,6 +2722,26 @@ impl RuntimeWorld {
                 .map(|choice| choice.label.clone())
                 .unwrap_or_else(|| class_id.clone())
         });
+        let class_recommendation = identity
+            .class_readiness_evidence
+            .as_ref()
+            .and_then(|evidence| {
+                profile
+                    .class_recommendations
+                    .iter()
+                    .find(|recommendation| recommendation.offer_kind == evidence.offer_kind)
+            })
+            .and_then(|recommendation| {
+                profile
+                    .choices
+                    .iter()
+                    .find(|choice| choice.id == recommendation.class_id)
+                    .map(|choice| CharacterClassRecommendationView {
+                        class_id: recommendation.class_id.clone(),
+                        class_label: choice.label.clone(),
+                        explanation: recommendation.explanation.clone(),
+                    })
+            });
         Some(CharacterIdentityView {
             profile_id: identity.profile_id.clone(),
             species_id: identity.species_id.clone(),
@@ -2732,6 +2752,8 @@ impl RuntimeWorld {
             class_label,
             class_selection_ready: identity.class_selection_ready,
             qualifying_world_actions: identity.qualifying_world_actions,
+            class_readiness_evidence: identity.class_readiness_evidence.clone(),
+            class_recommendation,
             level: self
                 .actor_by_id(actor_id)
                 .map(|actor| actor.stats.level)

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -1468,6 +1468,11 @@ for (const profile of characterCreationProfiles) {
       "default_species_id",
       "default_origin_id",
     ]);
+    for (const choice of choices) {
+      validateRequiredStrings(`staged character creation choice ${profile.id}`, choice, [
+        "campaign_use",
+      ]);
+    }
     for (const [slot, cards, defaultId] of [
       ["species", profile.species, profile.default_species_id],
       ["origin", profile.origins, profile.default_origin_id],
@@ -1487,7 +1492,33 @@ for (const profile of characterCreationProfiles) {
           "title",
           "description",
           "visual_prompt",
+          "campaign_rule",
         ]);
+      }
+    }
+    const recommendations = asArray(
+      `character creation profile ${profile.id} class_recommendations`,
+      profile.class_recommendations,
+    );
+    if (recommendations.length < 1 || recommendations.length > choices.length) {
+      fail(`character creation profile ${profile.id} must declare 1-${choices.length} class recommendations`);
+    }
+    const recommendationOffers = new Set();
+    for (const recommendation of recommendations) {
+      validateRequiredStrings(
+        `character creation recommendation ${profile.id}`,
+        recommendation,
+        ["offer_kind", "class_id", "explanation"],
+      );
+      if (!new Set(["work", "help"]).has(recommendation.offer_kind)) {
+        fail(`character creation recommendation ${profile.id} has invalid offer_kind ${recommendation.offer_kind}`);
+      }
+      if (recommendationOffers.has(recommendation.offer_kind)) {
+        fail(`character creation profile ${profile.id} repeats recommendation offer_kind ${recommendation.offer_kind}`);
+      }
+      recommendationOffers.add(recommendation.offer_kind);
+      if (!has(choiceIds, recommendation.class_id)) {
+        fail(`character creation recommendation ${profile.id} references missing class ${recommendation.class_id}`);
       }
     }
   }

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -136,4 +136,9 @@
 # submission and threshold resolution wiring at the root boundary.
 # 73653 -> 73647: issue #592 moves the shared ability parser into the existing
 # rules_context.rs seam while adding Hazard state and projection wiring.
-73423
+# 73423 -> 73369: issue #360 moves character-creation and Class-readiness
+# projections into actor_rules_facets.rs, where the frozen first-action evidence
+# and recommendation regressions now live. The root retains only persisted/view
+# types and the existing end-to-end campaign test. Its explicit non-combat check
+# disclosure supersedes #464's earlier product hold while combat stays narrative.
+73369

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -848,6 +848,7 @@ async function main() {
       try {
         const syntheticListenAction = { label: "notice", focusKey: "check", command: "listen" };
         const syntheticTakeAction = { label: "take", focusKey: "item:2001", command: "take Hearth Tonic" };
+        actorId = 5000;
         state = {
           location: { id: 1, name: "The Cosy Cottage" },
           economy: { listen_attempted_here: false },
@@ -4181,12 +4182,29 @@ async function main() {
         const trailTagHint = listenHintForLocation(3, true);
         state = { items: [] };
         const scienceFallbackHint = listenHintForLocation(10, true);
-        state = { items: [{ id: 2003, location_id: 3, holder_actor_id: 0 }] };
+        state = {
+          items: [{ id: 2003, location_id: 3, holder_actor_id: 0 }],
+          skills: [{ skill_id: "listening", label: "Listening", rank: 1, bonus: 1 }],
+          character_identity: {
+            profile_id: "the-lantern-keeper",
+            class_id: "mothwood-guide",
+          },
+          character_creation: [{
+            id: "the-lantern-keeper",
+            choices: [{
+              id: "mothwood-guide",
+              label: "Mothwood Guide",
+              starting_skill_id: "listening",
+            }],
+          }],
+        };
         const rollEvent = {
           type: "ability_check.rolled",
+          actor_id: 5000,
           actor_name: "Lantern Stitch",
           location_id: 3,
           location_name: "Moonlit Trail",
+          ability: "Wisdom",
           raw_roll: 9,
           modifier: 3,
           total: 12,
@@ -4196,6 +4214,60 @@ async function main() {
         const roll = rollMeta(rollEvent);
         const rollMarkup = rollHtml(rollEvent);
         const rollMemory = roomMemoryEntryForEvent(rollEvent);
+        const classProfile = {
+          id: "the-lantern-keeper",
+          name: "The Lantern Keeper",
+          class_prompt: "Which Lantern Keeper campaign path will you use?",
+          default_choice_id: "lantern-warden",
+          choices: [
+            {
+              id: "lantern-warden",
+              label: "Lantern Warden",
+              detail: "hold the line",
+              starting_skill_id: "steadiness",
+              campaign_use: "Starts with Steadiness rank 1: +1 on Constitution checks.",
+            },
+            {
+              id: "mothwood-guide",
+              label: "Mothwood Guide",
+              detail: "read the road",
+              starting_skill_id: "listening",
+              campaign_use: "Starts with Listening rank 1: +1 on Wisdom checks.",
+            },
+            {
+              id: "hedge-mender",
+              label: "Hedge Mender",
+              detail: "mend what breaks",
+              starting_skill_id: "kindness",
+              campaign_use: "Starts with Kindness rank 1: +1 on Charisma checks.",
+            },
+          ],
+        };
+        const classIdentity = {
+          profile_id: "the-lantern-keeper",
+          species_label: "Mouse",
+          origin_label: "The Open Road",
+          class_id: null,
+          class_selection_ready: true,
+          class_readiness_evidence: {
+            strategy_label: "Help mend the lantern",
+            target: { label: "the last roadside lantern" },
+            outcome: "progressed",
+            progress: 1,
+          },
+          class_recommendation: {
+            class_id: "hedge-mender",
+            class_label: "Hedge Mender",
+            explanation: "You helped another traveler move a shared task forward.",
+          },
+        };
+        state = { cards: { actors: {}, items: {}, locations: {} } };
+        const classAction = buildActions({
+          primary_action: { kind: "none" },
+          character_identity: classIdentity,
+          character_creation: [classProfile],
+        })[0];
+        const classRows = actionModalRows(classAction);
         const clashEvent = {
           type: "combat.attack.attempt",
           actor_name: "Lantern Stitch",
@@ -4280,6 +4352,10 @@ async function main() {
           rollResult: roll.result,
           rollMarkup,
           rollMemory,
+          classSelected: classAction.selectedChoice,
+          classChoices: classAction.choices.map((choice) => choice.value),
+          classSummary: classAction.modalSummary,
+          classRows,
           focusedListenHints,
           gardenBellHint,
           trailTagHint,
@@ -4390,7 +4466,7 @@ async function main() {
       }
     });
     assert(result.rollTitle === "Lantern Stitch checks carefully; the room answers", `Check feedback should name who found the clue: ${JSON.stringify(result)}`);
-    assert(result.rollDetail === "A small iron pawprint glints at the edge of the practice circle.", `Check feedback should offer one vivid lead instead of an inventory: ${JSON.stringify(result)}`);
+    assert(result.rollDetail === "Wisdom check · d20 9 +3 = 12 vs DC 10 · success · Class skill: Listening +1 from Mothwood Guide. A small iron pawprint glints at the edge of the practice circle.", `Check feedback should disclose the exact roll and Class skill source before one vivid lead: ${JSON.stringify(result)}`);
     assert(result.rollResult === "a clue appears", `Check feedback should end with a plain outcome: ${JSON.stringify(result)}`);
     assert(
       result.focusedListenHints.every((hint) => !/[,;]|\band\b/i.test(hint)),
@@ -4404,9 +4480,17 @@ async function main() {
       `Listen should rotate to one grounded room lead when earlier keepsakes are gone: ${JSON.stringify(result)}`,
     );
     assert(/class="roll-symbol"/.test(result.rollMarkup) && /class="roll-result"/.test(result.rollMarkup), `chance feedback should use the narrative card shape: ${JSON.stringify(result)}`);
-    assert(!/d20|modifier|total|\bdc\b|>9<|>12</i.test(result.rollMarkup), `chance feedback should not expose dice arithmetic: ${JSON.stringify(result)}`);
+    assert(/d20 9 \+3 = 12 vs DC 10/.test(result.rollMarkup) && /Listening \+1 from Mothwood Guide/.test(result.rollMarkup), `non-combat chance feedback should expose exact arithmetic and Class provenance: ${JSON.stringify(result)}`);
     assert(result.rollMemory?.label === "check" && /room answers a careful check/i.test(result.rollMemory?.text || ""), `room memory should preserve the story outcome: ${JSON.stringify(result)}`);
-    assert(!/d20|modifier|total|\bdc\b/i.test(JSON.stringify(result.rollMemory)), `room memory should not retain roll arithmetic: ${JSON.stringify(result)}`);
+    assert(/d20 9 \+3 = 12 vs DC 10/.test(JSON.stringify(result.rollMemory)), `room memory should retain legible non-combat check arithmetic: ${JSON.stringify(result)}`);
+    assert(
+      result.classSelected === "hedge-mender"
+        && result.classChoices.join(",") === "lantern-warden,mothwood-guide,hedge-mender"
+        && /Help mend the lantern changed the last roadside lantern by \+1 progress/.test(result.classSummary)
+        && /Every Class remains selectable/.test(result.classSummary)
+        && result.classRows.some(([label, detail]) => label === "Selected Class" && /Kindness rank 1: \+1 on Charisma/.test(detail)),
+      `Class revelation should explain its evidence, default to the recommendation, and preserve all choices: ${JSON.stringify(result)}`,
+    );
     assert(/Moonlit Echo slips clear/.test(result.clashMarkup) && /not this time/.test(result.clashMarkup), `combat chance feedback should read as a clash, not a calculation: ${JSON.stringify(result)}`);
     assert(result.clashMemory?.text === "Moonlit Echo slips clear of Lantern Stitch's Ashwood Practice Blade (Strength).", `room memory should preserve the authoritative combat method in story language: ${JSON.stringify(result)}`);
     assert(!/d20|modifier|total|\bdc\b|>4<|>6<|>13</i.test(result.clashMarkup), `combat chance feedback should hide dice arithmetic: ${JSON.stringify(result)}`);

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -167,7 +167,7 @@
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:bb4475d96fc6bd7c1b3e89a78a3927b6c5a7984da4f7a0472bbc1f46cfc43321",
+      "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141",
       "dependencies": [
         {
           "id": "cosyworld.core",


### PR DESCRIPTION
Closes #360

## Summary
- freeze the first positive shared-world contribution as durable Class-readiness evidence
- author Work and Help recommendations while keeping all three Classes selectable
- explain Species and Origin non-effects plus each Class skill, ability, bonus, and first campaign use
- show exact ability, roll, modifier, DC, result, and Class-skill provenance for non-combat checks
- release as 0.0.290

## Verification
- npm run check
- npm run v2:browser:check (deterministic and living-world stress)
- focused snapshot, recommendation, alternate-selection, and retry-safety tests