### PR TITLE
docs: define quest grammar and traveler pact

### DIFF
--- a/docs/backlog/quest-grammar-and-return.md
+++ b/docs/backlog/quest-grammar-and-return.md
@@ -1,0 +1,349 @@
+# Quest Grammar And Return
+
+**Outcome**: compose deterministic, replayable tales from Hearth, Sign,
+Venture, Challenge, Discover, and Return across avatars, items, and locations
+without adding a second action system or handing authority to AI.
+
+**Status**: Groomed and filed (2026-07-30). The linked issues are the source of
+truth for implementation state.
+
+**Execution backlog**: epic
+[#639](https://github.com/cenetex/cosyworld/issues/639).
+
+## Diagnosis
+
+CosyWorld has most of the rules needed to resolve a good quest, but no
+authoritative structure that says what role those resolutions played in a
+tale.
+
+The runtime can move and place actors and items, reveal and unlock routes,
+resolve checks, apply closed effects, advance Job clocks, allocate loot, form
+Bonds, record discoveries, and preserve replay. The focused discovery
+procedures now share one authority and frozen receipt, but discovery remains
+disconnected from Jobs, routes, cross-system relation deltas, and Return at the
+quest level. Nothing binds those subsystem receipts into one typed, versioned
+causal arc.
+
+The gap is therefore not “add quests to the kernel.” It is:
+
+> Add a deterministic semantic layer that compiles authored quest functions
+> into existing legal actions, records the evidence and world delta of each
+> resolution, and makes Return settle that delta into shared play.
+
+This is the next major windfall because it joins work that otherwise risks
+becoming several parallel discovery, traversal, Job, and Journal systems.
+
+## Existing Foundations
+
+| Foundation | Current evidence | What it already gives the grammar |
+| --- | --- | --- |
+| Append-only concrete actions | `cw_action_kind` in `v2/core-c/include/cosy_kernel.h` | Stable authority for physical actions, kernel Gate transitions, and versioned discovery-procedure commits. |
+| Small deterministic world state | `cw_world` in `v2/core-c/include/cosy_kernel.h` | Canonical actors, items, locations, exits, evolution, and encounters. |
+| Three card subject kinds | seed-card validation in `v2/orchestrator-rust/src/content_load.rs` | The avatar/item/location focus axis already exists. |
+| Jobs and clocks | `JobState` in `v2/orchestrator-rust/src/jobs.rs` | Premise, stakes, participants, places, progress, danger, reward, consequence, and completion memory. |
+| Named contribution methods | `JobContributionStrategy` and `JobContributionTrace` in `v2/orchestrator-rust/src/main.rs` | Versioned methods, requirements, checks, effects, claims, and causal receipts. |
+| Closed world changes | `EffectDescriptor` in `v2/orchestrator-rust/src/rpg/effects.rs` and `ProjectionMutation` in `main.rs` | A fail-closed compiler seam for authoritative and projected effects. |
+| Threshold authority | `ThresholdDescriptorCatalog`, `ThresholdPredicate`, `AcceptedThresholdIntent`, and kernel Gate state | Versioned Leads, Gates, Hazards, Pressure, Anchors, holder/actor/expedition/world scopes, exact methods, and conditional transitions. |
+| Discovery authority | `DiscoveryAuthorityCatalog`, `DiscoveryRollReceipt`, `DiscoveryClaimState`, and `discovery-procedure-v2` | Fixed and weighted stocking plus event/presentation tables, typed tells/phases/claim scopes, and one frozen procedure across focused Notice, Search, Study, and Scout. |
+| Route truth and provenance | `RouteRecordState` in `v2/orchestrator-rust/src/topology.rs` | Separate topology, lifecycle, discovery, unlock history, and route version. |
+| Concrete local leads | `LocalLeadState` in `v2/orchestrator-rust/src/local_leads.rs` | A source, origin, destination, hint, consumption, settlement, and forgetting state. |
+| Frozen loot draws | `LootAllocationState` in `v2/orchestrator-rust/src/quest_loot.rs` | Table and pack versions, replay algorithm, roll seed and input, selected entries, materialized IDs, and destination. |
+| Focused scenes | `FocusedEncounterView` in `v2/orchestrator-rust/src/turns.rs` | Existing nodes, relations, conditions, completion, stop, and retreat fields for Challenge presentation. |
+| Shared discovery memory | Search, Study, hidden-exit, avatar, item, and Visit Ledger projections | Evidence-backed discoveries with witnesses and replay. |
+| Evidence-based identity | player-authored Calling state plus deed/practice records in `v2/orchestrator-rust/src/actor_practice.rs` | A foundation for becoming through witnessed action rather than inferred personality. |
+| Player-facing chronicle | semantic Journal and Visit Ledger | A place to present resolved differences without exposing event grammar. |
+| Voice/authority boundary | `PRD.md`, `AI.md`, and the AI gateway | AI can render selected facts but cannot choose rules, topology, or rewards. |
+
+## Code-To-Vision Gaps
+
+| Vision | Current code | Gap |
+| --- | --- | --- |
+| Six reusable quest functions | Concrete C actions and Job contribution kinds | There is no `QuestPattern`, quest node, transition graph, or function binding. |
+| Avatar/item/location as typed focal roles | Card subjects validate those three kinds | Contribution targets also admit stringly `job`, `room`, and `feature`; there is no canonical quest entity reference or role. |
+| A tale may branch, loop, retreat, and resume | Jobs expose two clocks and a status | Jobs have no authored beat graph, entry nodes, failure edges, return vector, or resume contract. |
+| Venture follows a Lead from an Anchor | Legacy generated-route Scout and slot-bound `scout_v2` are replay-compatible and do not move the actor | Anchor qualification, active-foray state, Lead and return-chain validation, track loss, fatigue binding, and quest Venture/Return integration remain outside the shipped procedures. |
+| Signs arise from evidence and may retain plural readings | Discovery Slots carry typed tells, phases, claim scope, and one frozen receipt across Notice, Search, Study, and Scout; local Leads cite concrete sources | There is no quest Sign record, `trace | symbol` contract, motif recurrence, plural interpretation policy, or adapter joining legacy Leads to the receipt. |
+| Discovery changes a relation or capacity | Reveal, unlock, placement, Bond, tag, clock, and memory mutations exist | Their effects have no common typed delta that says what the resulting assemblage can now do. |
+| Challenge can hold two legitimate claims in contact | Progress/danger clocks and multiple contribution strategies exist; focused scenes expose graph-shaped fields | There is no authored tension or per-pole engagement, and current focused work/combat scenes leave local nodes, relations, and conditions empty. |
+| Return reintegrates the venture's difference | `apply_frontier_return_ledger_projection` marks a successful flee from frontier to non-frontier | This is a narrow spatial ledger mark, not a departure snapshot, return vector, witnessed settlement, or durable quest closure. |
+| One causal receipt joins action, evidence, roll, delta, and next state | Each subsystem has its own trace or projection mutation | There is no unified frozen `quest.phase.resolved` receipt for replay, Journal, tests, and AI narration. |
+| Original OSR-style tables select bounded facts | Discovery authority ships fixed and weighted stocking plus event/presentation schemas in `DiscoveryRollReceipt`; Job loot has its own frozen receipt | Physical item/location materialization and quest-role composition for motifs, encounters, complications, and return hooks remain unbound. |
+| Quest capacities arise from relations | Threshold predicates cover exact and installed items, charges, capabilities, tags, clocks, Jobs, standing, Bonds, grants, claims, scopes, and kernel Gate decisions | Official authored catalogs are absent, Open offers project exits only, item-capability content is limited, and no quest-level typed relation/capacity delta joins the owning systems. |
+| Identity can be complicated through play | Calling is a statement with keyword/exact relevance; faction truth, failure mode, verbs, and motifs are mostly content; deeds are durable evidence | Quest outcomes cannot yet support, contradict, or invite revision of a Calling through an authored tension without inferring a psyche. |
+| Symbolic acts remain concrete and safe | Items, placements, features, Jobs, and Bonds can express them | There is no recipe vocabulary or safety rule preventing diagnosis, coercion, or real-world prescription. |
+
+## Design Decision
+
+The six words are **quest functions**, not new player buttons and not new C
+action codes:
+
+| Function | Authoritative meaning |
+| --- | --- |
+| **Hearth** | Establish or strengthen an anchor and a return vector. |
+| **Sign** | Bind observable evidence to an open question, Lead, motif, or tension. |
+| **Venture** | Cross or create an edge and expose part of the current arrangement to risk. |
+| **Challenge** | Alter a relationship, threshold, obligation, or clock under resistance. |
+| **Discover** | Add usable knowledge, a capacity, or a relation that did not exist in this arrangement before. |
+| **Return** | Settle the venture's difference into an anchor as durable world state and memory. |
+
+Travel, Inspect/Search, Study, Work, Help, Give, Use, Rest, Flee, and the other
+concrete verbs remain the actions a player commits. A quest node names which
+function one of those actions may resolve and the evidence required to prove
+it.
+
+The canonical six-function walk is useful:
+
+`Hearth → Sign → Venture → Challenge → Discover → Return`
+
+It is not mandatory. A pattern may have several entry points, loop, retreat,
+skip a function, make a new Hearth, or remain unresolved. The world graph is
+globally centerless; a quest gives one live subgraph a temporary center.
+
+## The Eighteen Focal Operations
+
+|  | Avatar | Item | Location |
+| --- | --- | --- | --- |
+| **Hearth** | host, trust, accompany, or make a promise | entrust, prepare, cache, keep, or install | shelter, camp, raise a cairn, or maintain a landmark |
+| **Sign** | witness an appeal, contradiction, gesture, or changed deed | inspect damage, residue, provenance, absence, or unusual use | notice a track, threshold, weather change, or disturbed feature |
+| **Venture** | follow, escort, seek, separate, or invite | carry, send, risk, or deploy | scout, cross, descend, climb, or open a route |
+| **Challenge** | bargain, refuse, confront, question, or aid under pressure | test, repair, break, combine, sacrifice, or use against resistance | endure a hazard, negotiate a boundary, or alter terrain |
+| **Discover** | form a reciprocal capacity or authored understanding | reveal a contextual use, provenance, or relationship | reveal a path, site, resource, feature, or condition |
+| **Return** | escort, reconcile, reintroduce, answer, or report | restore, give, offer, bury, display, or install | revisit, reconnect, mark, secure, or deliberately abandon |
+
+These are authoring slots, not an exhaustive verb list. A quest should involve
+at least two focal kinds and create, alter, or resolve at least one cross-kind
+relationship.
+
+`Discover avatar` never authorizes the game to reveal a hidden psyche. It can
+only recognize something the avatar's player authored, something the avatar
+did, or something another actor reciprocally disclosed.
+
+## Design Lineage Without Doctrine
+
+- **The hero's journey** supplies a readable local rhythm. It does not make one
+  protagonist, one sequence, separation, victory, or homecoming universal.
+- **Jung** contributes recurring motifs, compensation for one-sided action,
+  tension between legitimate poles, and integration through a changed Return.
+  Archetype names, universal symbol dictionaries, and psychological diagnoses
+  stay out of authoritative state.
+- **Deleuze and Guattari** contribute assemblages, capacities produced by
+  relations, many entrances, rerouting after rupture, provisional territories,
+  and becoming rather than revealed essence. Hearth makes Venture possible; it
+  is not the opposite of freedom.
+- **Jodorowsky** contributes the possibility of a concrete symbolic act whose
+  physical arrangement carries meaning. CosyWorld confines this to consensual
+  fictional action with authored effects. It is never therapy, diagnosis,
+  humiliation, self-harm, coercion, or a real-world instruction.
+
+The synthesis is architectural:
+
+> Use Jung for local recurrence and accountability, Deleuze and Guattari for a
+> relational and centerless world, Jodorowsky for bounded material action, and
+> the hero's journey as one rhythm rather than a railway.
+
+### Mechanical translations
+
+- **Constellation is an evidence threshold.** A worldpack may make a motif
+  eligible as a Sign after it recurs across two focal kinds or several
+  causally distinct events. The exact threshold is authored and frozen; the
+  runtime does not scan prose for secret meaning.
+- **Compensation is authored counterpressure.** Repeated one-sided methods may
+  make an excluded claim or capacity newly actionable. It is neither a random
+  punishment nor a diagnosis of the player.
+- **Tension is two tracked claims.** Challenge records effective engagement
+  with each pole. A third arrangement is an authored capacity unlocked only
+  after both have affected play.
+- **Assemblage is a typed relation set.** A bell is not inherently a key. The
+  bell, its holder, an installed place, a route condition, and a learned
+  practice may together grant one contextual capacity.
+- **The refrain is Hearth–Venture–Return.** Hearth establishes enough
+  continuity to leave; Venture opens the arrangement to change; Return
+  establishes continuity again with a recorded difference.
+- **Becoming is a changed capability, not a revealed essence.** Deeds and quest
+  receipts may let a player affirm, complicate, or revise a Calling. The
+  player chooses the statement.
+- **A symbolic act is material.** Its meaning comes from an optional in-world
+  arrangement of actors, items, and places with ordinary legal actions and
+  bounded effects.
+
+## Authoritative Contract
+
+A versioned quest pattern needs, at minimum:
+
+```text
+QuestPattern
+  id, version, source pack
+  entry nodes
+  nodes
+    function
+    focal entity reference or predicate
+    required evidence
+    allowed concrete methods
+    resolution policy
+    success, consequence, retreat, and rupture edges
+  motifs
+  optional authored tensions
+  anchor rules and return vectors
+  completion and continuation policy
+```
+
+A quest instance freezes the chosen pattern version, bound entity references,
+departure revision, active node set, evidence, relation/capacity baseline,
+table results, resolved nodes, return state, and unresolved threads.
+
+Reference the proven `DiscoveryRollReceipt` and `LootAllocationState` through a
+closed quest evidence-reference type. Do not reroll, rewrite, or replace either
+implementation with a third roller. Generalize the focused-scene graph for
+Challenge presentation; do not add another encounter protocol beside it.
+
+Every resolved function emits one shared causal receipt containing:
+
+- quest, pattern, version, instance, and node identity;
+- function and focal actor/item/location reference;
+- committed action and source event sequence;
+- cited evidence and frozen table roll, when any;
+- resolution policy and outcome;
+- typed before/after relation or capacity delta;
+- opened, closed, or rerouted nodes;
+- anchor and return-vector changes;
+- idempotency key and provenance.
+
+The receipt summarizes authoritative facts. It does not let Rust or AI
+contradict a physical C-kernel result. If a new physical invariant cannot be
+derived from existing actions, it receives a new append-only action/event
+meaning; historical action `0` and existing event meanings are never
+reinterpreted.
+
+## Invariants
+
+1. Quest functions never become a second legal-action surface.
+2. The same world state, pattern version, table version, seed, and action
+   produce the same result and receipt.
+3. AI cannot choose eligibility, a table row, a check, a transition, topology,
+   custody, access, reward, or effect.
+4. Every Sign cites observable evidence. Symbolic signs preserve at least two
+   authored viable readings until play settles one.
+5. Every resolved node names an actor, item, or location focus.
+6. Every quest changes or resolves at least one cross-kind relation.
+7. Discover adds actionable knowledge, a capacity, a relationship, or an edge;
+   prose alone cannot satisfy it.
+8. A third arrangement in Challenge requires effective engagement with both
+   authored poles.
+9. Losing an actor, item, or location may reroute or fail a node but never
+   erases causal history.
+10. Quest-level Return requires a difference from the departure snapshot and
+    writes that difference into shared state or memory.
+11. Spatial revisit semantics reserved by
+    [#93](https://github.com/cenetex/cosyworld/issues/93) are not reused for
+    quest settlement. Use a distinct versioned namespace.
+12. Retreat, refusal, rescue, and unresolved Return remain representable
+    outcomes.
+13. A symbolic act is optional, fictional, consent-aware, and selected from
+    an authored closed vocabulary.
+14. Browser, terminal, direct API, and inference controllers see the same
+    legal actions and consequences.
+15. Mounted quest situations become actionable through Hearth or Sign
+    conditions and exact legal offers. Legacy quest acceptance remains a
+    replay no-op; no quest-log Accept button returns.
+
+## Integration Boundaries
+
+This backlog does not duplicate:
+
+- [#586](https://github.com/cenetex/cosyworld/issues/586), which owns the
+  strict-referee primitives for Leads, Gates, Hazards, Pressure, and evidence;
+- [ADR 0005](../decisions/0005-thresholds-trails-and-strict-referee.md),
+  [#589](https://github.com/cenetex/cosyworld/issues/589), and
+  [#601](https://github.com/cenetex/cosyworld/issues/601), which established
+  kernel Gate transitions and the unified v2 discovery procedure;
+- [#594](https://github.com/cenetex/cosyworld/issues/594), which owns anchored
+  Scout forays and perishable geographic Leads;
+- [#602](https://github.com/cenetex/cosyworld/issues/602), which owns bounded
+  materialization of item and location discoveries;
+- [#157](https://github.com/cenetex/cosyworld/issues/157), which established
+  authoritative Job clocks and contribution strategies;
+- [#158](https://github.com/cenetex/cosyworld/issues/158), which established
+  deterministic physical Job loot;
+- [#289](https://github.com/cenetex/cosyworld/issues/289), which owns the
+  distinction between route existence, discovery, and knowledge;
+- [#292](https://github.com/cenetex/cosyworld/issues/292), which owns arrival
+  presentation and derived pact context;
+- [#357](https://github.com/cenetex/cosyworld/issues/357), whose Lantern Keeper
+  campaign is the preferred player-facing proof surface.
+
+Quest grammar consumes those facts and emits typed narrative function
+receipts. THR remains authoritative for how evidence, routes, thresholds, and
+pressure work. Jobs remain authoritative for contribution methods and clocks.
+The kernel remains authoritative for physical mutation.
+
+## Execution Backlog
+
+| Slice | State | Outcome | Depends on |
+| --- | --- | --- | --- |
+| [QST-0 — quest-function contract](https://github.com/cenetex/cosyworld/issues/640) | P1 / next / ready | Record the grammar, namespace, authority, migration, and safety decision. | Existing foundations |
+| [QST-1 — pattern schema and compiler](https://github.com/cenetex/cosyworld/issues/641) | P1 / next / blocked | Validate versioned graphs, typed focal references, transitions, motifs, tensions, and anchors. | QST-0 |
+| [QST-2 — phase receipt and replay](https://github.com/cenetex/cosyworld/issues/642) | P1 / next / blocked | Persist quest instances and emit one frozen causal receipt per resolved function. | QST-1 |
+| [QST-3 — relation and capacity deltas](https://github.com/cenetex/cosyworld/issues/643) | P1 / next / blocked | Adapt existing threshold, custody, placement, Bond, route, and Anchor facts into typed quest deltas. | QST-2 |
+| [QST-4 — evidence-led Signs and tables](https://github.com/cenetex/cosyworld/issues/644) | P1 / next / blocked | Bind existing discovery/loot receipts to plural symbolic Signs and quest evidence. | QST-2, QST-3, THR-D2 |
+| [QST-5 — two-pole Challenges](https://github.com/cenetex/cosyworld/issues/645) | P1 / next / blocked | Reuse focused scenes, contribution methods, and pressure for authored tension, retreat, and third arrangements. | QST-2, QST-3, THR-6 |
+| [QST-6 — Return settlement](https://github.com/cenetex/cosyworld/issues/646) | P1 / next / blocked | Compare departure and return, settle a durable delta, and open an honest continuation. | QST-2, QST-3 |
+| [QST-7 — symbolic-act recipes](https://github.com/cenetex/cosyworld/issues/647) | P2 / later / blocked | Add safe, concrete, pack-authored arrangements and narration guardrails. | QST-4, QST-5, QST-6 |
+| [QST-8 — vertical proof](https://github.com/cenetex/cosyworld/issues/648) | P1 / later / blocked | Prove branching, retreat, replay, offline play, and Return across all three focal kinds. | QST-4 through QST-7, THR-7/D2 |
+
+```mermaid
+flowchart LR
+  Q0["QST-0<br/>contract"] --> Q1["QST-1<br/>schema"]
+  Q1 --> Q2["QST-2<br/>receipt"]
+  Q2 --> Q3["QST-3<br/>typed deltas"]
+  Q2 --> Q4["QST-4<br/>Signs + tables"]
+  Q3 --> Q4
+  Q2 --> Q5["QST-5<br/>Challenges"]
+  Q3 --> Q5
+  Q2 --> Q6["QST-6<br/>Return"]
+  Q3 --> Q6
+  Q4 --> Q7["QST-7<br/>symbolic acts"]
+  Q5 --> Q7
+  Q6 --> Q7
+  Q4 --> Q8["QST-8<br/>vertical proof"]
+  Q5 --> Q8
+  Q6 --> Q8
+  Q7 --> Q8
+```
+
+## First Vertical Proof
+
+Use one compact authored situation rather than a generated epic:
+
+- a Hearth at a known shared place;
+- a damaged or displaced item that provides a Sign;
+- an exact frontier Lead and anchored Venture;
+- a Challenge between two legitimate uses of a location;
+- at least three concrete methods, including Help and withdrawal;
+- a Discover result that changes a route or installed capacity;
+- a Return that settles the item, relationship, and public memory;
+- one unresolved thread that can become the next Sign.
+
+The proof passes only when:
+
+- the pattern compiles from a worldpack with no bespoke runtime IDs;
+- direct play, terminal play, and provider-offline play produce the same
+  legality and authoritative receipts;
+- each supported branch and retreat path replays across restart;
+- actor, item, and location each serve as a focal node;
+- the Journal renders concrete outcomes without machine vocabulary;
+- AI narration cannot add a route, reward, meaning, or effect;
+- a simple spatial revisit cannot claim quest Return;
+- a second traveler can enter through a different node and still act on the
+  shared result.
+
+## Non-Goals
+
+- A universal story generator.
+- Six mandatory stages or six new UI buttons.
+- A generic graph language that can mutate arbitrary state.
+- Fixed archetypes, a symbol dictionary, personality scoring, or player
+  diagnosis.
+- AI-authored legality or dynamically improvised rewards.
+- Replacing Jobs, clocks, strict-referee primitives, the action hand, the
+  Journal, or the C kernel.
+- Treating every errand, conversation, or revisit as a quest.

--- a/docs/cosyworld-pact.md
+++ b/docs/cosyworld-pact.md
@@ -1,0 +1,140 @@
+# The CosyWorld Pact
+
+CosyWorld is a shared world that remembers what people do. This Pact is the
+promise the game makes to every traveler, regardless of who controls their
+avatar, which worldpack they entered through, or whether AI is available.
+
+It is product law. It is not an in-world faction, a membership gate, or the
+[Cottage Pact proof world](../v2/docs/pact-proof-world.md).
+
+## One World, One Truth
+
+Everyone in a place shares the same people, items, exits, conversation, and
+consequences. A resident does not give each player a private version of events.
+Ownership may open a shared place, but it never creates a private copy of that
+place.
+
+The server decides what is legal and records what happened. A client, a
+language model, or a vivid description cannot make an unearned change true.
+
+## Home Holds
+
+Home is a real sanctuary. It does not decay while people are away. Combat and
+uninvited pressure do not enter it. Rest there is free and complete.
+
+The frontier may contain danger, loss, and unfinished trouble, but only after a
+traveler chooses to go there. Time moves through played turns, not a clock on
+the wall.
+
+## Every Choice Is Honest
+
+Before a traveler commits, an action names its target, cost, and known risk.
+The complete legal set remains reachable even when the hand shows only two
+suggestions. Looking through that set is free; committing an action spends the
+turn.
+
+If an action is certain, the world does not roll. If the outcome is uncertain
+and consequential, the referee resolves it from declared rules and recorded
+state. A failed check changes the situation or closes that approach; it is not
+an invitation to press the same empty button again.
+
+## Identity Comes From Play
+
+A Calling belongs to its player. The game does not diagnose a hidden self or
+assign a destiny. Friends, rivalries, debts, promises, skills, and public deeds
+give an avatar shape over time.
+
+The Journal records meaningful outcomes, not flattering inventions. Other
+people can witness those outcomes, answer them, and depend on them.
+
+## Things Matter Because Of Their Relations
+
+An item is not only a bonus. It can be carried, entrusted, installed, broken,
+repaired, offered, or returned. A location is not only a backdrop. It can
+shelter, divide, reveal, connect, or become a home. A person is never only a
+quest marker.
+
+Keys, permissions, promises, placements, and completed work open only the
+thresholds they actually fit. Moving one of them can remove that capacity.
+Shared state, not story convenience, decides who may pass.
+
+## Discovery Begins With Evidence
+
+A track, absence, damaged tool, repeated gesture, or changed room can become a
+sign because it is present in the world. Some signs have one factual answer.
+Others can sustain more than one honest reading.
+
+The game may invite interpretation, but it does not declare what a symbol
+means inside the player. AI may describe evidence already chosen by the rules;
+it may not invent a route, item, person, reward, or conclusion and call it a
+discovery.
+
+## Leaving Is Not A Promise To Win
+
+Retreat, refusal, rescue, compromise, and return with an unanswered question
+are valid outcomes. The game must not spend a traveler's last strength while
+removing every path to shelter, aid, or home.
+
+Care is a real action. So are giving something up, keeping watch, repairing a
+route, witnessing another person's deed, and bringing useful knowledge back.
+
+## Return Makes The Difference Public
+
+A venture is more than movement away from home. Its discoveries alter what
+people can know, do, reach, trust, carry, or remember.
+
+Returning is more than crossing an old doorway. A return settles something
+from the venture into a hearth, relationship, route, item, obligation, or
+shared memory. If nothing has changed, it is simply another visit.
+
+## AI Has A Voice, Not Authority
+
+AI may speak for a resident, propose narration, or illustrate an earned
+moment. It never chooses legality, odds, access, topology, rewards, custody, or
+consequences.
+
+Core play remains available without AI. If requested dialogue cannot be
+generated, it fails plainly and without charge. The game does not put invented
+words into a character's mouth as a fallback.
+
+## Progress Is Earned, Never Bought
+
+Ordinary play, friendship, travel, discovery, safety, and growth always have a
+zero-Orb path. Orbs support shared images. They do not buy success, power,
+access, conversation, or a better roll.
+
+Gifts and trades preserve provenance. Paying for or holding a keepsake or pass
+does not grant rules authority over another player.
+
+## Every Traveler Keeps Their Boundaries
+
+Speech and trade are subject to consent and moderation. Travelers can mute,
+block, decline, withdraw, and report. A symbolic or ceremonial act is always a
+fictional world action chosen by its participants, never treatment, diagnosis,
+humiliation, or an instruction for real life.
+
+## The Shape Of A Tale
+
+CosyWorld authors may compose a tale from six recurring functions:
+
+1. **Hearth** — establish something worth returning to.
+2. **Sign** — encounter evidence that makes a question concrete.
+3. **Venture** — cross a boundary and place something at risk.
+4. **Challenge** — meet resistance or hold two real claims in contact.
+5. **Discover** — reveal or create a usable relationship, capacity, or path.
+6. **Return** — bring the difference into shared life.
+
+These are not six buttons and not a mandatory order. A tale may begin with a
+Sign, retreat to a Hearth, loop through several Challenges, or make a new
+Hearth far from the old one. The world remains open; the tale gives one part of
+it a temporary center.
+
+Shared truth, sanctuary, action authority, the AI boundary, the zero-Orb core,
+and moderation are live product law. Typed Gate authority, descriptor
+validation, exact threshold methods, telegraphed Hazards, no-null discovery
+procedures, and frozen Discovery Slot tables are shipped foundations. Official
+pack adoption, item and location materialization, Pressure scenes, anchored
+and perishable scouting, generalized relation deltas, and the six-function
+quest grammar remain backlog work. The future fatigue cadence is still
+undecided. Until those pieces land, this Pact is the standard against which
+their design and implementation are judged.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,12 @@ do not define V2 behavior.
 
 ## Product and design
 
+- **[The CosyWorld Pact](cosyworld-pact.md)** — the promises CosyWorld makes
+  about shared truth, sanctuary, honest choices, discovery, return, AI
+  authority, progression, and player boundaries.
+- **[A Traveler's Guide To CosyWorld](travelers-guide.md)** — the concise
+  player guide to the action hand, Callings, Friends, discovery, scouting,
+  thresholds, rest, the six-function tale rhythm, and what is still direction.
 - **[How to Design a Worldpack](worldpacks/how-to-design-a-worldpack.md)** —
   tentative design method for authored boundaries, world graphs, characters,
   factions, economies, special items, dynamic evolution, and validation.
@@ -90,6 +96,10 @@ do not define V2 behavior.
 - **[Thresholds, Trails, and the Strict Referee](backlog/thresholds-trails-and-strict-referee.md)** —
   dependency-ordered Discovery Slot, Lead, Gate, Hazard, Pressure, trail, and
   recovery work following ADR 0005.
+- **[Quest Grammar and Return](backlog/quest-grammar-and-return.md)** —
+  the code-to-vision diagnosis and dependency-ordered foundation for Hearth,
+  Sign, Venture, Challenge, Discover, and Return across avatars, items, and
+  locations.
 
 GitHub Issues are the live execution backlog. These local backlogs carry the
 long-form contracts and acceptance gates that do not fit cleanly in an issue.

--- a/docs/systems/09-cosyworld-rpg-system.md
+++ b/docs/systems/09-cosyworld-rpg-system.md
@@ -13,9 +13,10 @@ authoritative Collection/Carried/Equipped/Spell deck/Exhausted/Contained/World/
 Escrow zones, weight and size, equipped non-recursive containers, bracelet
 slots, possession-bound skill charms, weapon profiles, executable spell cards,
 idempotent collection materialization, theft, and provenance. Deterministic
-scene composition produces the complete legal offer set and a ranked
-three-card hand for browser and terminal clients. Legacy skill ranks, action
-codes, combat/2 and combat/3 rows remain replay-readable. Covenant contribution
+scene composition produces the complete legal offer set, two ranked
+suggestions, and a complete chooser for browser and terminal clients. Legacy
+skill ranks, action codes, combat/2 and combat/3 rows remain replay-readable.
+Covenant contribution
 and additional advancement choices remain future RPG breadth; they are not
 gaps in the SRD action-card foundation.
 

--- a/docs/travelers-guide.md
+++ b/docs/travelers-guide.md
@@ -1,0 +1,292 @@
+# A Traveler's Guide To CosyWorld
+
+CosyWorld is a shared fantasy world played one meaningful action at a time.
+You do not need to learn a command language or optimize a character sheet. Read
+the room, choose what matters, and let the world remember the result.
+
+This guide distinguishes the game you can play now from mechanics that are
+being prepared. The [CosyWorld Pact](cosyworld-pact.md) is the promise both must
+keep.
+
+## Your First Visit
+
+1. Make an avatar and enter the shared world.
+2. Read the place, the people present, and the two suggested actions.
+3. Open **all actions** if neither suggestion interests you. Browsing or
+   redealing does not spend a turn.
+4. Open an action to see its target, cost, known risk, and expected effect.
+5. Commit one action. Everyone present sees the same result.
+6. Choose a Calling when the world asks what draws you.
+7. Before leaving, read the Journal. It keeps the deeds and relationships that
+   can become growth.
+
+Speech and emotes do not consume the room's action turn. In a shared room,
+people otherwise take turns so one player cannot silently act over another.
+
+## The Things To Know
+
+| Word | What it means |
+| --- | --- |
+| **You** | Your avatar, condition, carried items, and equipped tools. |
+| **Home** | The sanctuary that holds while you are away. |
+| **Calling** | A short statement, written by you, about what draws your avatar. |
+| **Friends** | Bonds with residents and other travelers, including trust, rivalry, and debt. |
+| **Journal** | What happened, what remains open, and the deeds available to settle into growth. |
+| **Orbs** | An optional contribution to shared images, never a price on play or power. |
+
+An **action** is a legal choice you can make now. It is not owned or collected.
+An **item** is a physical thing in the shared world. A **keepsake** is an
+actor, item, or location represented in your collection; owning it does not
+replace or privately own the shared subject. A **pass** explains access to a
+gated place. A **bundle** is a one-time collection reveal from a Box. A
+**world pack** is mounted experience content.
+
+Jobs, clocks, tags, rules profiles, and claim keys exist behind the surface.
+You should not need those terms to decide what to do.
+
+## Reading An Action
+
+Every legal action comes from the server. The two suggestions in the hand come
+from that same set; they are not a limit on what you may do.
+
+- **Target** says exactly which person, item, feature, or place the action
+  concerns.
+- **Cost** says what committing spends: usually the turn, and sometimes an
+  item use, position, or exposure.
+- **Risk** states a known consequence before commitment. Hidden discoveries
+  remain hidden, but the fact that an approach is dangerous does not.
+- **Effect** says what success can actually change.
+
+A certain action simply happens. A check is used only when uncertainty and a
+meaningful consequence are both present. The referee rolls from frozen rules;
+AI may narrate the result but cannot improve it.
+
+## Common Ways To Act
+
+Exact offers depend on the place, the people and things present, your
+equipment, and what has already happened.
+
+| Intention | Use it when |
+| --- | --- |
+| **Notice** | You spend one turn on one unresolved broad sensory Lead or safety result. |
+| **Search** | You exhaustively examine one named physical target. |
+| **Inspect** | An offer uses this alternate label while binding to Search or Study. |
+| **Study** | You interpret an already perceived target. |
+| **Scout** | You resolve one offered geographic discovery without moving. |
+| **Travel** | A known, accessible route leads where you want to go. |
+| **Take, Give, Trade, or Use** | Custody, placement, or the use of a physical item matters. |
+| **Prepare** | You ready an item, skill, spell, or approach before pressure arrives. |
+| **Work or Help** | You advance a concrete shared need alone or beside someone. |
+| **Rest** | The current place and your gear permit a specific kind of recovery. |
+| **Defend, Flee, or Attack** | A frontier conflict is active. Leaving alive is a valid result. |
+
+If an offered action does not name the thing it affects, do not guess what the
+button means. Open its detail or choose another action.
+
+## The Shape Of A Tale
+
+Not every story is a quest, and not every quest follows a straight line.
+CosyWorld uses six functions to help authors and the referee keep a tale
+coherent:
+
+| Function | What the traveler experiences |
+| --- | --- |
+| **Hearth** | You establish a person, item, or place that can orient and receive the journey. |
+| **Sign** | Concrete evidence gives you a question worth following. |
+| **Venture** | You cross a boundary and expose a relationship, possession, or route to change. |
+| **Challenge** | Resistance forces a choice, test, negotiation, sacrifice, or withdrawal. |
+| **Discover** | The journey reveals or creates something the world can now use. |
+| **Return** | You carry that difference back into shared memory and future play. |
+
+Think of these as a rhythm, not a checklist. A Sign can send you back to
+prepare. A Challenge can create a new Hearth. A Return can expose the next
+Sign. Different travelers can enter the same situation through different
+people, items, and places.
+
+The full six-function quest grammar is being built. Current Jobs already
+provide premises, stakes, contribution choices, progress, danger, rewards, and
+completion memories; the missing layer is a durable record of how those pieces
+form and transform a tale.
+
+You do not accept a tale from a quest log. A situation becomes actionable when
+its evidence, people, things, places, and exact legal actions are present.
+
+## Signs, Tracks, And Discovery
+
+Evidence comes before interpretation.
+
+- A **trace** has a factual referent: prints leave the road, a seal is broken,
+  a bell bears river clay.
+- A **sign** connects observed facts to an open question. It can admit several
+  readings until later play settles one.
+- A **Lead** names a concrete thing that can be pursued: a destination, person,
+  item, feature, or event.
+- A **discovery** changes what the shared world knows or can do. Flavor text
+  alone is not enough.
+
+Obvious room facts appear automatically and cost no turn. **Notice** spends one
+turn on one unresolved broad sensory Lead or safety result. **Search**
+exhaustively examines one named physical target; **Inspect** is alternate copy
+only when bound to Search or Study. **Study** interprets an already perceived
+target.
+
+CosyWorld now has a validated Discovery Slot catalog and one replay-safe
+receipt shared by Notice, Search, Study, and Scout. It freezes the slot, table
+version, eligible server facts, seed, selected row, and claim once. The current
+procedure records a Lead or reveal only; it does not yet materialize an item or
+location, move, Open, Take, or award the selected result. Official packs still
+rely mainly on older discovery paths. General materialization and quest-level
+Sign and Return tables remain backlog work.
+
+Quest work will cite those existing receipts as Signs and discoveries rather
+than inventing another roller. AI may give the selected result a voice or
+visual description; it cannot roll again, add a reward, or change the map.
+
+## Routes, Anchors, And Cairns
+
+Two Scout paths are replay-compatible today. Generated-route Scout reveals one
+adjacent edge without moving. The newer slot-bound Scout resolves one frozen
+authored geographic result and also does not move. Travel remains separate.
+Neither path yet enforces the full Anchor, active-foray, return-chain, or
+track-loss contract.
+
+The strengthened frontier rule is:
+
+- a new Lead or independent branch begins at a place or fixture explicitly
+  authored as an **Anchor**; sanctuary, lodging, shelter, and rest grade do not
+  imply that role;
+- one exact Lead is chosen when the foray begins;
+- continuing that Lead does not require building a cairn on every step;
+- leaving the Lead to open a new branch requires another Anchor;
+- a cairn makes a hard-won place usable as a later start, retreat, or
+  rendezvous point;
+- pressure can distort, exhaust, or expire a Lead, but it cannot silently move
+  the route or invent a replacement.
+
+This makes cairns meaningful infrastructure rather than a breadcrumb tax. The
+Anchor, return-chain, and cairn contract is accepted, and the descriptor
+foundation exists. Perishable Leads and full foray enforcement remain backlog
+work rather than current long-range Scout behavior.
+
+## Doors, Keys, And Thresholds
+
+A threshold can be a door, chest, bridge, boundary, custom, vow, or guarded
+route. Its requirement must be exact and testable. Examples include:
+
+- a particular key is carried;
+- an item remains installed at the threshold;
+- a seal may be broken once;
+- every traveler must hold a token;
+- one holder opens the way for everyone present;
+- a resident has granted permission;
+- a Job, placement, or relationship has changed the access state.
+
+Passing does not necessarily destroy or consume the key. The author declares
+custody, placement, charges, one-shot behavior, who benefits, and what happens
+when the enabling thing is removed.
+
+Typed threshold descriptors, kernel-owned Gate decisions and claims, exact
+method offers, recovery validation, and telegraphed Hazard receipts are shipped
+foundations. The schema and kernel can represent exit and container Gates, but
+current Open offers are projected only for exits, and official worldpacks do
+not yet mount threshold catalogs. Container interaction, Pressure scenes,
+anchored forays, and wider authored adoption remain dependency-ordered in
+[Thresholds, Trails, and the Strict Referee](backlog/thresholds-trails-and-strict-referee.md).
+
+## Items And Loot
+
+Items are shared physical facts. They have custody and location; many also
+have size, weight, charges, a card zone, or an installed use. Giving away a
+key can change which path you can open. Installing a bell can give a place a
+new capacity.
+
+Finding an item and taking it are separate acts. A discovery may make an item
+known or reachable without placing it in your hand. Capacity and access still
+apply.
+
+Job loot already uses authored candidates, deterministic selection, frozen
+provenance, and one materialization receipt. General physical discoveries will
+retain the owning discovery or loot receipt when materialization lands. There
+is no invisible AI treasure faucet.
+
+## Rest, Fatigue, And Coming Home
+
+The shipped rest ladder is tied to fiction:
+
+- **Camp** requires an equipped `camp_shelter`. It clears `tired`, refreshes one
+  exhausted spell, and advances one active frontier danger clock.
+- **Lodged** currently requires an authored lodging feature with the only
+  supported gate, `open`. Bond, Job, and room-resource lodging gates are future
+  work.
+- **Hearth** clears expedition depth and refreshes eligible spells, charms, and
+  relics.
+
+Cairns do not count as shelter. Rest may advance authored frontier pressure
+when the action says so.
+
+Short-rest limits and additional fatigue states remain undecided in
+[#603](https://github.com/cenetex/cosyworld/issues/603). Three short rests and
+Fresh/Winded/Weary/Spent are one playtest candidate, not live product law. The
+decision remains tracked in
+[Rest, Travel, and Weariness](backlog/rest-travel-and-weariness.md).
+
+## Challenge Without A Forced Answer
+
+A strong Challenge often places two legitimate claims in contact: shelter and
+freedom, loyalty and truth, memory and renewal. Work, Help, a relevant item,
+negotiation, risk, refusal, or retreat may each be valid methods.
+
+Sometimes engaging both claims can unlock a third arrangement that neither
+side offered at the start. That result must be authored and earned by effective
+actions on both sides. It is not a reward for choosing a dialogue option that
+sounds balanced.
+
+The game never stores psychological labels about a player. Symbolic acts are
+concrete, fictional changes—return the bell, bury the counterfeit key, leave
+the repaired chair at the threshold—not diagnoses or real-world prescriptions.
+
+## What Counts As Return
+
+Crossing back into a familiar room is ordinary travel. A tale's Return occurs
+when something from the venture is settled:
+
+- useful knowledge becomes a public Lead;
+- an item is restored, offered, displayed, buried, or installed;
+- a relationship, promise, or debt changes;
+- a route becomes known, marked, secured, or deliberately abandoned;
+- a place receives a repair or a new capacity;
+- the Journal records an earned difference and an honest unfinished thread.
+
+Return does not require victory. Escaping danger with evidence, keeping a
+promise at a cost, or reporting that a route cannot yet be crossed may all
+change the world.
+
+Quest-level Return settlement is part of the new grammar. The current Visit
+Ledger already recognizes some frontier returns, discoveries, help, Callings,
+and Bonds, but it does not yet unify them into one quest receipt.
+
+## Other Travelers And Residents
+
+Everyone present sees the same committed events. Residents follow the same
+legal action surface as human-controlled avatars; a different controller does
+not receive a private rules advantage.
+
+You may speak freely within moderation, but direct Chat that asks AI for a
+resident response is separate from deterministic action. When inference is
+unavailable, the world remains playable and no substitute character speech is
+invented.
+
+You can decline trades and requests. Mute and block prevent unwanted social
+contact; report sends an auditable record to an operator.
+
+## When You Are Unsure
+
+1. Read the current place and newest Journal entry.
+2. Open **all actions** and inspect the exact targets.
+3. Use Notice for one unresolved broad sensory Lead or safety result.
+4. Use Search or Study only when you can name the thing receiving your
+   attention.
+5. Check whether the route says Scout or Travel.
+6. If pressure is rising, prepare, help, rest, retreat, or return home.
+7. If the surface promises an effect it cannot explain, report it. That is a
+   rules or presentation bug, not a riddle you are expected to solve.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.289",
+  "version": "0.0.292",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.289",
+      "version": "0.0.292",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.291",
+  "version": "0.0.292",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary

- add the CosyWorld Pact and Traveler's Guide, separating live product law, shipped deterministic foundations, and backlog direction
- add the quest-grammar/code-gap contract for HEARTH, SIGN, VENTURE, CHALLENGE, DISCOVER, and RETURN, linked to epic #639 and QST-0 through QST-8
- align the documentation index and replace the stale three-card-hand description with two suggestions plus the complete chooser

## Why

CosyWorld already has strong threshold, discovery, Job, route, loot, and replay authorities, but no quest-level semantic aggregate or Return settlement. These documents name that gap without duplicating the kernel or handing authority to AI.

## Impact

Documentation and backlog only. No runtime behavior changes.

## Validation

- `npm run check:version`
- `git diff --check`
- local Markdown-link audit: 49 changed-doc targets resolved

The repository-wide `npm run check` was not run for this docs-only change. The first pre-push attempt stopped because the isolated publication worktree has no installed `vitest`; the repository's documented `COSYWORLD_SKIP_PREPUSH=1` path was then used after the required docs checks passed.

Tracks #639.
