### PR TITLE
docs: fold parked backlog design into the doc set

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -471,6 +471,171 @@ Pipeline:
 
 The running server may load new content packs. It must never let the swarm rewrite the C kernel, Rust orchestrator, wallet verification, or economy ledger logic in production.
 
+## A Diverse Model Cast Behind Per-Generation Gates
+
+Groomed 2026-07-26; folded here 2026-07-30 from issues
+[#388](https://github.com/cenetex/cosyworld/issues/388),
+[#393](https://github.com/cenetex/cosyworld/issues/393), and
+[#394](https://github.com/cenetex/cosyworld/issues/394). The registry
+([#389](https://github.com/cenetex/cosyworld/issues/389)), publication gate
+([#390](https://github.com/cenetex/cosyworld/issues/390)), weighted exploration
+([#391](https://github.com/cenetex/cosyworld/issues/391)), and voice/intent
+separation ([#392](https://github.com/cenetex/cosyworld/issues/392)) have
+shipped; Fly evaluation and the adversarial corpus remain direction.
+
+Make model diversity a first-class feature: a broad cast of tiny and unusual
+language models may attempt public character speech, while every individual
+generation is buffered and deterministically qualified before entering the
+shared world.
+
+**The system certifies outputs, not models.** A model that fails one line may
+still participate later at a lower sampling weight. Conversation-only models
+provide voice; a smaller independently qualified planner pool may propose
+bounded intent; the kernel remains the only authority for world actions.
+
+### Product principles
+
+- Diversity of model voice is an intended property, not only a provider
+  fallback mechanism. Any operational text model may attempt voice generation,
+  including 1B/4B models.
+- No model is trusted: every completed output passes the same publication gate.
+- Failed outputs are private, recorded as evaluation evidence, and never
+  streamed or committed.
+- Content failure lowers selection weight but never permanently suspends a
+  model. Provider/transport health and output quality are measured separately.
+- Character identity and durable continuity live in world data; backend model
+  choice is an execution detail.
+- Conversation and intent planning are separate capabilities. A model may
+  qualify for one without the other.
+- Provider-offline play remains mechanically and narratively truthful.
+
+### Architectural contract
+
+```text
+world event
+  -> freeze public generation context
+  -> choose untrusted voice candidate(s)
+  -> generate privately
+  -> deterministic publication gate
+       pass -> commit exactly one visible line
+       fail -> discard, record, and try another candidate
+  -> bounded attempts exhausted -> explicit authored/unavailable outcome
+
+decision-required event
+  -> enumerate authoritative legal candidates
+  -> optional planner proposes one typed intent
+  -> validate against exact candidates and kernel rules
+  -> voice model expresses proposed/committed state truthfully
+```
+
+No diverse live rollout begins before the publication gate and resolved-model
+attribution are present.
+
+### Fly evaluation and resolved-model telemetry
+
+Exercise diverse candidates against production-shaped contexts, record every
+attempt accurately, and use the same evidence for live routing without letting
+shadow output affect the world. Per-generation gating is the live safety
+boundary; shadow evaluation supplies additional traffic and evidence for
+rare or new candidates. It does **not** create a binary trusted-model promotion
+system.
+
+- Enqueue bounded asynchronous shadow jobs from frozen copies of public
+  generation contexts. Shadow responses are never published, charged as
+  successful gameplay, fed into later prompts, or allowed to mutate state.
+- Run the evaluator inside the existing single-writer orchestrator or through a
+  control API preserving one SQLite writer. **Do not attach a second
+  uncoordinated process to the event volume.**
+- Bound concurrency, sample rate, timeouts, daily spend, per-model spend, and
+  queue depth. Live generation and world turns take priority.
+- Apply the exact same adapters and deterministic publication gate used by live
+  dialogue.
+
+Record for every live and shadow attempt: durable generation/job identity and
+feature; requested candidate and **actual resolved model/provider**; registry,
+adapter, prompt, and gate versions; frozen context hash and output hash; every
+gate check and failure code; transport status, attempts, latency, token usage,
+provider-reported cost; live/shadow disposition and whether the line committed;
+selected-candidate evidence and cooldown changes.
+
+Usage attribution based only on the configured `AiConfig.model` is insufficient
+once provider/model fallback exists.
+
+**Operational controls.** Content failure changes sampling evidence only. Rate
+limits, outages, and timeouts affect provider health and cooldown. Runaway
+spend, a permanently malformed endpoint, or repeated infrastructure abuse may
+open a temporary circuit breaker. No raw API key, private provider body, or
+unredacted player-sensitive prompt enters logs or model reports.
+
+### Adversarial corpus
+
+A permanent corpus and integration matrix proving diverse, unreliable models
+may attempt speech without any failed generation becoming public or
+authoritative. Cover at minimum: concise grounded prose, emoji-only, and emote
+speech; crowded rooms with multiple named actors; empty and long-but-bounded
+context; direct action reaction, gift/trade, relationship, danger, ordinary
+banter; prompt injection and requests to expose system/policy/tool/model text;
+multiple-speaker transcripts and invented labels; looping tokens, repeated
+n-grams, unfinished quotes/lists/JSON, length exhaustion; wrong speech mode and
+inaccessible emoji; subject drift and absent scene anchors; exact, normalized,
+and near-duplicate recent lines; proposal-versus-commit truthfulness; valid and
+invalid bounded intent schemas; stale candidate IDs, illegal targets, and
+provider-offline behaviour; multilingual/Unicode punctuation without permitting
+hidden control characters or leakage.
+
+Use deterministic fake OpenAI-compatible providers returning exact
+hostile/successful payloads, finish reasons, resolved model IDs, delays,
+errors, and races. Real-provider evidence supplements but never replaces
+hermetic regression tests.
+
+**Required journeys**: one tiny model fails the gate, a second passes, exactly
+one line commits; two passing hedged candidates race and only one commits;
+every candidate fails and the authored/unavailable result closes the beat; a
+provider errors while the same model succeeds through another provider; a
+conversation-only model is never selected for intent planning; a planner emits
+valid JSON for an illegal action and the kernel rejects it without mutation;
+retry, reconnect, restart, snapshot, and full replay reproduce one committed
+world result; browser and CLI expose the same accepted line or failure outcome
+without rejected-text leakage.
+
+### Definition of done
+
+- [ ] At least three materially different model families, including tiny
+      models, produce accepted public speech in a production-like run.
+- [ ] Every visible generated line has a recorded generation identity, resolved
+      model/provider, gate result, prompt adapter/version, latency, and usage.
+- [ ] An output violating any hard gate is never visible, even under retry,
+      reconnect, race, or provider fallback.
+- [ ] A failing model remains eligible for bounded future exploration without
+      being able to publish a failing output.
+- [ ] Bounded retries and authored fallback prevent a low-quality pool from
+      stalling a world turn.
+- [ ] Voice selection is diverse but character continuity remains stable and
+      inspectable.
+- [ ] Conversation-only models are never asked to execute tools or acquire
+      mechanical authority.
+- [ ] Planner proposals match an exact current legal action/target or fail
+      closed without mutation.
+- [ ] Provider outages, rate limits, content failures, and safety failures have
+      distinct metrics and recovery behaviour.
+- [ ] Snapshot and full journal replay reproduce committed world state without
+      re-running inference.
+- [ ] Provider-offline browser and CLI journeys remain complete and truthful.
+- [ ] Property/fuzz tests cannot make rejected text enter an event, SSE frame,
+      room-memory chapter, later prompt, or visible error.
+- [ ] Statistical tests show exploration remains nonzero, budgets stay bounded,
+      and consistently passing models receive more attempts without total
+      monopoly.
+
+### Out of scope
+
+Letting a model invent verbs, targets, costs, rewards, topology, or world
+truth. Publishing partial or streamed output before validation. Running
+hundreds of models for every line. Treating benchmark rank or parameter count
+as sufficient qualification. Requiring generated speech for authoritative
+campaign correctness. Declaring any third-party model permanently good or bad.
+Requiring network access for the core regression suite.
+
 ## Data Model Additions
 
 ```sql

--- a/docs/backlog/avatar-lifecycle-and-rescue.md
+++ b/docs/backlog/avatar-lifecycle-and-rescue.md
@@ -1,0 +1,481 @@
+# Avatar Lifecycle And The Rescue Run — Backlog
+
+**Epic**: Give every avatar one controller-neutral lifecycle from presence
+through Death or Return, and make a knockout the start of a rescue rather than
+the end of a tale.
+
+> Absence changes the controller. Knockout changes the body. Only Death or
+> Return ends the avatar.
+
+**Status**: Groomed 2026-07-26, amended with the rescue-run decisions
+2026-07-28, folded into this document 2026-07-30. Direction, not committed
+scope — nothing here is in a 1.0 milestone.
+
+**Prior execution backlog**: epic
+[#380](https://github.com/cenetex/cosyworld/issues/380) and children
+[#382](https://github.com/cenetex/cosyworld/issues/382),
+[#383](https://github.com/cenetex/cosyworld/issues/383),
+[#384](https://github.com/cenetex/cosyworld/issues/384),
+[#385](https://github.com/cenetex/cosyworld/issues/385),
+[#492](https://github.com/cenetex/cosyworld/issues/492),
+[#493](https://github.com/cenetex/cosyworld/issues/493), closed into this
+document. [#491](https://github.com/cenetex/cosyworld/issues/491) — renewable
+potion supply — shipped separately as a standalone bug.
+
+| Ticket | Prior issue | Priority |
+| --- | --- | --- |
+| LC-0 — preserve identity through Knockout and revival | [#385](https://github.com/cenetex/cosyworld/issues/385) | P1, load-bearing |
+| LC-1 — collapse downed bodies into a targetable rescue row | [#382](https://github.com/cenetex/cosyworld/issues/382) | P1 |
+| LC-2 — carry downed bodies; pause Fading in sanctuary | [#492](https://github.com/cenetex/cosyworld/issues/492) | P1 |
+| LC-3 — the rescue run: birth draught, revival, independence release | [#493](https://github.com/cenetex/cosyworld/issues/493) | P1 |
+| LC-4 — presence lease and atomic handback to temporary AI | [#384](https://github.com/cenetex/cosyworld/issues/384) | P2 |
+| LC-5 — Fading, Death, and Return as bounded population sinks | [#383](https://github.com/cenetex/cosyworld/issues/383) | P2 |
+
+**Related architecture**:
+
+- [The CosyWorld Pact](../cosyworld-pact.md) — "Home Holds" and "Leaving Is Not
+  A Promise To Win" are the product law this backlog implements.
+- [CosyWorld RPG System Bible](../systems/09-cosyworld-rpg-system.md)
+- [Thresholds, Trails, And The Strict Referee](thresholds-trails-and-strict-referee.md)
+  — owns Anchors, retreat reachability, and the fatigue restrictions that must
+  never remove a rescue path.
+- [Rest, Travel, and Weariness](rest-travel-and-weariness.md) — owns the
+  recovery reachability invariant at Spent.
+
+---
+
+## Why now
+
+The current runtime treats Knockout as the end of a tale: the browser clears
+the active session, offers Begin Again, creates a replacement actor, and leaves
+the former actor `KNOCKED_OUT` holding its items and identity. In a shared
+persistent room this produces an unreadable crowd of downed and replacement
+avatars.
+
+Production evidence, 2026-07-27, Flooded Barrow:
+
+- Ten full-size portraits occupied the primary avatar rail while the linked
+  traveler was inactive.
+- The account stayed in the room and rendered `cannot act right now. Return
+  when your traveler is active.` — but the action hand still showed a single
+  `Notice` card, which then failed with the stale-choice receipt `That choice
+  changed while you were deciding.`
+
+That is internally contradictory. An inactive linked traveler should receive an
+explicit Knockout observer/rescue surface, not an ordinary action it can never
+commit. Both observations need production-shaped regressions that assert the
+**authoritative actor status**, not the UI's inference of it.
+
+---
+
+## Product decision: the rescue run
+
+Distilled from the 2026-07-28 design discussion. This is the decided shape of
+the loop, superseding the earlier "full ghost vs. diminished ghost" question.
+
+### The blocking discovery
+
+There was exactly one usable potion in the world: Hearth Tonic (2001), one
+charge, in the Cosy Cottage. Dawn Oil (8403) is a campaign puzzle item already
+consumed by the beacon. One instance with charges in a shared persistent world
+means the first player to pick it up owns the only rescue in the game, and the
+first use spends it. Any rescue loop deadlocks on turn one and "oldest fades"
+becomes the only outcome — rescue degenerates into a slow attrition timer.
+
+This was a live bug independent of the rest of this epic:
+`resident_healing_target` already heals downed actors with potions and could be
+stranded. Fixed separately as #491.
+
+### The birth draught
+
+After a knockout, the account's next avatar is born carrying a draught —
+granted **because** there is a body to deliver it to, never at a first-ever
+birth. Supply therefore scales exactly with rescue demand and is unfarmable:
+you cannot mint rescue potions without first being knocked out. It rides the
+existing claim-keyed starter-grant path on `CREATE_ACTOR`, alongside
+`STARTING_ORBS`.
+
+### The choice is the mechanic
+
+Delivering is optional. Not delivering is a legitimate reroll whose cost is
+everything the old body carries and is — gear stays on the body, keepsakes stay
+with it. Abandonment needs no designed penalty because its cost is intrinsic.
+
+### Revival is a swap, not an accumulation
+
+On delivery the body wakes, the player chooses which of the two to inhabit, and
+the other **unlinks from the account and becomes an independent resident** —
+keeping name, gear, keepsakes, and history, and joining the same bounded
+autonomy pool as lapsed avatars (LC-4). Your failed hero is not deleted; they
+stay in the world and you can walk past them.
+
+**Max two avatars per account, by construction.** The second body exists only
+transiently during the rescue window. No persistent character-select, no
+per-avatar session juggling, no swap-at-will — which is what keeps losing a
+body expensive.
+
+### The cascade, pinned
+
+> A unconscious + B unconscious → A (oldest) Dies, spawn C.
+> Result: B unconscious + C active.
+
+The invariant: at most two bodies per account, exactly one playable. Never
+stuck, never accumulating, always rescuing something. Repeated failure costs
+your longest-lived character one at a time — a real, legible stake with no dead
+end. It also gives Death a player-caused route alongside the Fading clock,
+which is better drama than a timer.
+
+### The account bargain
+
+No linked account → one avatar, no rescue; it transfers to temporary AI when it
+drops. Linked account → the two-body rescue loop. The account buys you the
+right to go get your character back. The Knockout screen's job changes
+accordingly: not *"this tale has ended"* but *"your avatar is down — link an
+account and go get them."*
+
+---
+
+## The controller/body state model
+
+Controller state and body state are orthogonal.
+
+```mermaid
+stateDiagram-v2
+    Direct --> Grace: presence lease lapses
+    Grace --> Direct: player returns
+    Grace --> TemporaryAI: grace expires
+    TemporaryAI --> Direct: atomic handback
+
+    Active --> Unconscious: defeated
+    Unconscious --> Active: Recovery fills or remedy revives
+    Unconscious --> Dead: Fading fills
+    TemporaryAI --> Returned: safe Return completes
+```
+
+---
+
+## Principles (acceptance gate for every ticket)
+
+1. One actor ID survives direct control, absence, temporary AI, Knockout, and
+   revival. Knockout never creates a replacement actor.
+2. Begin Again is unavailable until an authoritative terminal state: Death,
+   Return, retirement, or release.
+3. Lack of chosen actions is not abandonment. A player may be reading or
+   watching; only a lapsed **presence lease** transfers control.
+4. An Unconscious actor never acts merely because its presence lease expired.
+5. Fading advances through committed play, never because real-world minutes
+   passed. No real-time-only expiry can kill or retire an avatar.
+6. **Fading must not advance in sanctuary.** Per the Pact, sanctuary cannot
+   receive irreversible loss. Sanctuary pauses the clock; it does not heal,
+   restore, or reset it, and it never rewinds.
+7. Every temporarily autonomous avatar has a bounded terminal path — Death in
+   genuinely mortal play, or a safe authored Return. Temporary autonomy must
+   not ship before its sink exists.
+8. Controller transitions and terminal transitions are journaled, snapshot-safe,
+   replay-safe, and exactly once.
+9. Direct and inference controllers receive the same legal action set once
+   active; only controller ownership differs.
+10. Dead and Returned avatars leave active rosters, offers, initiative,
+    presence leases, and autonomy scheduling — but remain in account history,
+    Journal evidence, provenance, and replay.
+11. Items can never remain trapped on an unreachable terminal actor.
+
+### Out of scope
+
+- **Ghost conversion.** It can follow after rescue, Death, and Return exist. A
+  ghost must consume an explicit bounded population budget and must not
+  substitute for a real terminal lifecycle.
+- **Making Knockout cheaper.** Scarce recovery is part of the campaign's
+  stakes.
+
+---
+
+## LC-0 — Preserve actor and account identity through Knockout and revival
+
+**Priority**: P1 — load-bearing; every other slice depends on it
+**Scope**: Rust lifecycle state + browser session + migration
+
+### What to do
+
+Knockout pauses an avatar; it does not end that avatar or create a replacement
+identity. Recovery returns the same actor with the same history, inventory,
+relationships, and account ownership.
+
+- An account remains linked to its Knocked Out actor.
+- Refresh or reconnect returns an observer/rescue view for that actor rather
+  than character creation.
+- The actor cannot submit ordinary actions while Unconscious — and no card that
+  would deterministically reject on that basis may be displayed.
+- A legal remedy or filled Recovery clock changes that same actor from
+  `KNOCKED_OUT` to `ACTIVE`; it never clones or relinks.
+- If the account has active presence at revival, direct control resumes. If it
+  is absent and temporary autonomy is enabled, the same actor resumes under
+  temporary AI.
+- Carried items, Calling, Bonds, practices, Journal evidence, campaign claims,
+  and provenance remain attached throughout.
+
+### Acceptance
+
+- [ ] Actor ID and account link are unchanged across Knockout, refresh,
+      snapshot, replay, remedy, and revival.
+- [ ] Knockout refresh cannot enter character creation or mint a replacement.
+- [ ] A present owner observes while Knocked Out and regains control exactly
+      once on revival.
+- [ ] An absent owner does not block another co-located actor from committing
+      legal care.
+- [ ] Revival clears only the conditions named by the remedy/rules profile.
+- [ ] Duplicate remedy submissions and replay cannot reward, heal, or
+      reactivate twice.
+- [ ] Begin Again fails closed while the linked actor is Active or Knocked Out.
+- [ ] Existing snapshots containing a Knocked Out actor migrate without
+      inventing a replacement.
+- [ ] A production-shaped fixture covers refresh/reconnect while Knocked Out
+      and asserts the authoritative actor status: the account stays linked,
+      ordinary action cards are absent, and the visible state names
+      Knockout/Unconscious rather than generic inactivity.
+
+### Tests
+
+Protect direct-input and inference-controlled rescuers, present and absent
+owners, reconnect races, snapshot restore, stale action offers, and replay from
+before Knockout through revival.
+
+---
+
+## LC-1 — Collapse downed bodies into a targetable rescue row
+
+**Priority**: P1
+**Scope**: projection + browser rail
+**Depends on**: LC-0, and one shared roster/offer visibility predicate
+
+### What to do
+
+The main room rail communicates who can act. Knocked-out bodies remain present
+and consequential without turning the room heading into a wall of portraits.
+
+- The existing portrait rail contains active, visible avatars only.
+- Every co-located Unconscious avatar appears beneath it as one compact rescue
+  indicator.
+- Indicator colour communicates medical urgency — Stable, Fading, Critical —
+  but colour is never the only signal; every indicator has an accessible name
+  and state.
+- A compact summary stays legible at crowd size (`3 knocked out`), with bounded
+  individual dots and a `+N` overflow.
+- Selecting an indicator opens that avatar's keepsake/rescue sheet: identity,
+  medical state, Recovery and Fading clocks, and legal care actions.
+- A potion, First Aid, Carry, or other authored remedy targets the selected
+  downed actor directly. The server still validates co-location, charges,
+  conditions, and replay identity.
+- Downed avatars do not appear as ordinary Chat, gift, friendship, combat, or
+  work targets.
+
+### Acceptance
+
+- [ ] Active portraits and downed indicators derive from one visibility
+      predicate.
+- [ ] A room containing active, Stable, Fading, and Critical avatars renders
+      each in the correct surface.
+- [ ] The rescue summary is understandable without colour and is
+      keyboard/screen-reader operable.
+- [ ] A legal potion committed from the selected indicator revives exactly the
+      selected actor.
+- [ ] Stale, duplicate, remote, and forged targets fail closed without
+      consuming the remedy.
+- [ ] Refresh and snapshot restore reproduce the same rail, indicators, target,
+      and clocks.
+- [ ] A bounded browser fixture protects empty, one-Knockout, and crowded
+      layouts — including the production-shaped ten-actor case from Flooded
+      Barrow, where multiple downed avatars must keep active participants
+      legible.
+
+### Out of scope
+
+Controller takeover, Death, and Begin Again. This slice exposes the medical
+state and legal care the server already owns.
+
+---
+
+## LC-2 — Carry downed bodies and pause Fading in sanctuary
+
+**Priority**: P1
+**Scope**: kernel-validated move + clock suspension
+**Depends on**: LC-1 (bodies are targetable), LC-5 (Fading owns the clock)
+
+### What to do
+
+A downed body is a physical thing allies can move. Carrying it to sanctuary
+stops its Fading clock, which makes sanctuary meaningful to the death loop and
+gives allies something to do with a dot in the rescue row besides heal it. The
+rescue run becomes an actual run.
+
+- Fading must not advance in sanctuary. A body delivered there is safe.
+  Sanctuary pauses the clock — it does not heal, restore, or reset it.
+- Carrying is a journaled move of the unconscious actor through the normal
+  validated path, with a claim key. The rescue row reflects the body's location
+  as it travels.
+- Setting a body down outside sanctuary resumes Fading from where it paused. No
+  pause-and-reset exploit; the clock only ever freezes, never rewinds.
+- Carrying is deliberately unglamorous: it occupies hands/capacity like any
+  heavy load, so the carry is a commitment, not a free taxi for downed friends.
+- The carrier need not be the body's owner. Any ally — or a resident — can make
+  the delivery, which is what turns a dot on the row into a cooperative errand.
+
+### Acceptance
+
+- [ ] An unconscious actor can be picked up, moved, and set down by another
+      actor, all journaled and replayable.
+- [ ] Fading does not advance for any clock whose actor is inside a sanctuary
+      location; it resumes at the same value on exit.
+- [ ] Replay and snapshot round trips reproduce carried state and paused clocks
+      exactly.
+- [ ] The rescue row and room presentation distinguish a body being carried
+      from a body lying in a room.
+- [ ] No sanctuary loss path: nothing in the carry/deliver flow can kill,
+      strip, or transfer a body against its owner's account.
+
+---
+
+## LC-3 — The rescue run: birth draught, revival, and independence release
+
+**Priority**: P1
+**Scope**: new action code + claim-keyed grant + ownership transfer
+**Depends on**: LC-0; interacts with LC-2 and LC-5
+
+### What to do
+
+Implement the decided rescue loop above.
+
+- The draught is granted at avatar creation **only when the account has a
+  downed body** — never at a first-ever birth — on the existing claim-keyed
+  starter-grant path on `CREATE_ACTOR`.
+- Player-caused revival uses the normal item-use path already exercised by
+  `resident_healing_target`, extended to a validated player action on a downed
+  actor.
+- Revive + inhabit choice + unlink is a single journaled, terminal-class action
+  with a claim key — a **new action code**, never a reinterpretation of an
+  existing one — and must survive journal replay and snapshot round trips.
+- The double-Knockout cascade applies during the rescue window. That death is a
+  journaled `combat.death`-class event with a claim key, never implicit
+  cleanup, so replay reproduces which avatar died.
+
+### Acceptance
+
+- [ ] Account with a downed body → next created avatar carries the draught;
+      first-ever avatar → no draught.
+- [ ] Revival, inhabit choice, and unlink replay exactly once; a snapshot round
+      trip preserves the ownership transfer.
+- [ ] The released avatar appears in the world as an independent resident with
+      its prior identity, gear, and keepsakes.
+- [ ] Double-Knockout during the rescue window kills the oldest body and spawns
+      a replacement avatar, journaled and replayable.
+- [ ] The Knockout screen copy changes from "this tale has ended" to "your
+      avatar is down — link an account and go get them," in register per
+      `v2/docs/writing-style.md`.
+- [ ] Unauthenticated players keep the single-avatar path: no rescue run, and
+      the avatar transfers to temporary AI when it drops.
+
+---
+
+## LC-4 — Presence lease and atomic handback to temporary AI
+
+**Priority**: P2
+**Scope**: presence lease state machine + controller epoch
+**Depends on**: LC-0. **Must not ship before LC-5.**
+
+### What to do
+
+A player avatar can keep participating when its human controller truly leaves,
+then return to that human without changing actor identity or creating
+controller-specific rules.
+
+- The server owns a renewable presence lease for every directly controlled
+  active avatar, renewed by client heartbeats.
+- Lease expiry enters a configurable grace state. Grace expiry journals a
+  controller transition to temporary AI.
+- Temporary AI receives the same server-authored legal offers and authoritative
+  validation as a human controller.
+- Reconnection atomically increments a controller epoch, returns control to
+  direct input, and invalidates any inference submission prepared under the old
+  epoch.
+- Only one controller may commit for an actor at a time. A late heartbeat,
+  inference response, retry, or replay cannot create a double turn.
+- The room communicates temporary autonomy quietly but unambiguously; it does
+  not pretend the human is speaking.
+
+### Acceptance
+
+- [ ] Lease, grace, takeover, and handback are explicit server states with
+      configurable durations.
+- [ ] Takeover and handback are journaled exactly once and survive
+      snapshot/replay.
+- [ ] A valid heartbeat during grace prevents takeover.
+- [ ] Disconnecting eventually enables temporary AI without creating a new
+      actor; an idle but connected client retains control.
+- [ ] Reconnect wins before the next autonomous commit; stale AI work fails
+      closed by controller epoch.
+- [ ] Human and temporary-AI controllers see the same action identifiers,
+      costs, consent rules, and results.
+- [ ] Knocked Out, Dead, Returned, retired, and released actors cannot acquire
+      an actionable AI lease.
+- [ ] Metrics expose lease expiry, takeover, handback, stale-controller
+      rejection, and autonomous lifetime.
+
+---
+
+## LC-5 — Fading, Death, and Return as bounded population sinks
+
+**Priority**: P2
+**Scope**: kernel terminal states + cleanup + item disposition
+**Depends on**: LC-0
+
+### What to do
+
+Every player-created avatar needs an explicit, replayable terminal path. Danger
+can end in Death; ordinary abandonment can end in a safe Return. Neither
+outcome silently erases the life that happened. The kernel already defines
+`DEAD`, but current combat sets only `KNOCKED_OUT`, and abandoned temporary
+actors would otherwise accumulate forever.
+
+**Medical sink**
+
+- Knockout creates public three-segment Recovery and Fading clocks.
+- Fading advances on deterministic committed danger beats.
+- Stable prevents ordinary Fading; care advances Recovery per the remedy.
+- Recovery 3/3 revives the same actor. Fading 3/3 commits one atomic Death
+  event. Mortal stakes, method capability, and mortality profile must all
+  permit Death.
+
+**Abandonment sink**
+
+- Temporary AI receives a bounded, visible Return obligation rather than
+  roaming forever.
+- Return advances through committed autonomous play toward an authored safe
+  destination; it is not a hidden wall-clock deletion.
+- Reclaiming the actor cancels or pauses Return according to one explicit rule.
+- Completing Return retires the actor from active world participation without
+  calling the outcome Death.
+- A temporarily autonomous avatar remains subject to ordinary mortal danger and
+  may die before returning.
+
+**Terminal cleanup**
+
+- Dead and Returned actors leave active rosters, action offers, initiative,
+  presence leases, and autonomy scheduling.
+- Carried items move atomically to the authored death/return destination or
+  cache with provenance intact.
+- Account history and Journal retain identity, Calling, Bonds, deeds, and
+  terminal cause.
+- Begin Again unlocks only after the terminal event is durable.
+
+### Acceptance
+
+- [ ] Recovery/Fading clocks, Stable, Critical, Death, and Return have one
+      authoritative state model.
+- [ ] Death and Return each emit a distinct versioned event and cannot be
+      conflated with Knockout.
+- [ ] No real-time-only expiry can kill or retire an avatar.
+- [ ] No terminal actor can receive offers or autonomous turns.
+- [ ] Items cannot remain trapped on an unreachable terminal actor.
+- [ ] Begin Again cannot race terminal cleanup or duplicate account rewards.
+- [ ] Population remains bounded under repeated disconnect, temporary-AI,
+      Knockout, revival, Death, and Return cycles.

--- a/docs/backlog/card-composed-character-creation.md
+++ b/docs/backlog/card-composed-character-creation.md
@@ -1,7 +1,8 @@
 # Card-Composed Character Creation
 
 Status: staged-creation vertical slice implemented, broader account collection
-proposed, 2026-07-22.
+proposed (2026-07-22), with the Avatar/Home/Keepsake world-allocation follow-on
+groomed locally (2026-07-30).
 
 ## Decision
 
@@ -80,6 +81,12 @@ revised.
 The compiler accepts references to validated rules profiles, traits, hooks,
 items, and charms. It does not accept arbitrary stat blocks or prose-defined
 effects.
+
+The selected Origin and the avatar's unique runtime Home are separate facts.
+Origin is a reusable account card and can name a culture, remembered place, or
+tradition. Home is one canonical location allocated for this particular
+avatar. Creating Home must not move the campaign entry room, bypass a Gate, or
+make the selected Origin a private instance.
 
 ### Suggested Lantern Keeper starter set
 
@@ -383,6 +390,268 @@ The compiler must reject:
 - species or class text that promises unsupported mechanics; and
 - a campaign with no fully deterministic creation path.
 
+## Follow-On Epic: Avatar, Home, And Signature Keepsake
+
+Every new tale should add a small authored triptych to the canonical world:
+
+1. one **Avatar**;
+2. one unique **Home** location; and
+3. one physical **Signature Keepsake** allocated somewhere in the world.
+
+The three identities are allocated together, but they need not all be loaded
+into the active simulation or have generated media before the avatar can play.
+“Authored” means the location and item have stable canonical identity,
+validated mechanical facts, provenance, and presentation inputs. It does not
+mean AI controls their rules, topology, placement, or access.
+
+This is a follow-on to staged card creation, not a blocker for the existing
+Species/Origin/Class slice.
+
+**Current capacity note (reviewed 2026-07-30)**:
+`v2/core-c/include/cosy_kernel.h` currently bounds one loaded `cw_world` at
+512 actors, 512 locations, 1,024 items, and 1,024 directed exits. A reciprocal
+Home ingress normally consumes two exit rows. One permanent Home and item per
+avatar therefore cannot scale to the actor ceiling while all authored and
+historical entities remain loaded. AVH-4 deliberately proves the game below
+those bounds; AVH-5 is required before removing the cohort ceiling.
+
+| Ticket | Queue | Depends on |
+| --- | --- | --- |
+| AVH-0 — record the Avatar/Home/Keepsake contract | P1 / proposed | staged creation contract, THR-0 |
+| AVH-1 — allocate the triptych atomically | P1 / proposed | AVH-0, THR-D0 |
+| AVH-2 — place homes through bounded route slots | P1 / proposed | AVH-1, THR-7, THR-7G |
+| AVH-3 — decorate the triptych asynchronously | P1 / proposed | AVH-1 |
+| AVH-4 — prove a bounded living-world cohort | P1 / proposed | AVH-1 through AVH-3 |
+| AVH-5 — hydrate cold canonical homes by partition | P1 / later / proposed | AVH-4, ADR 0003 |
+| AVH-6 — remove the bounded-cohort production gate | P1 / later / blocked | AVH-5 |
+
+The AVH rows are issue-ready local proposals and are not yet filed.
+
+### AVH-0 — Record The Avatar/Home/Keepsake Contract
+
+**Scope**: identity, ownership, privacy, lifecycle, access, and compatibility
+
+#### What to decide
+
+- Allocate stable identities for the actor, Home, Signature Keepsake,
+  discovery placement, and initial Home ingress in one versioned bundle.
+- Home is unique to the avatar but remains part of the one canonical shared
+  world. It is not a private shard, campaign copy, or client-owned room.
+- Origin remains a reusable creation card. It may influence Home presentation
+  inputs but does not select topology, grant access, or substitute for Home.
+- The campaign profile remains authoritative for the avatar's initial room.
+  Creation grants the owner truthful private knowledge of Home and one
+  geographically contextual way to seek it; it does not teleport the actor
+  there or globally map the route.
+- The Keepsake is a physical world item, not the identity card and not a
+  guaranteed starting possession. Its frozen discovery placement may be at
+  Home or in another eligible bounded Slot, but retry cannot move or duplicate
+  it.
+- Define what retirement, release, archive, account unlinking, pack upgrade,
+  and owner absence do. Recommended: Home and Keepsake remain canonical world
+  history; access and stewardship may change through authored rules, but the
+  bundle is not silently deleted.
+- Define the minimum mechanical fallback for all three subjects so creation
+  succeeds and remains understandable while AI services are unavailable.
+
+#### Acceptance
+
+- One contract distinguishes Origin, Home, Signature Keepsake, identity card,
+  starter equipment, campaign entry, ownership, stewardship, and access.
+- No lifecycle state implicitly deletes a canonical Home or item.
+- The owner can truthfully know Home without every actor learning it or every
+  route to it.
+- AI and wallet availability are outside the authoritative creation
+  preconditions.
+
+### AVH-1 — Allocate The Triptych Atomically
+
+**Scope**: allocator receipt, idempotency, bounded materialization, and replay
+
+#### What to do
+
+- Keep the allocator as the live authoritative procedure. On creation it
+  selects and reserves, from validated bounded candidates:
+  - actor, Home, and Signature Keepsake IDs;
+  - a typed Home location template and rules profile;
+  - one eligible Home ingress/route Slot;
+  - one eligible item Discovery Slot;
+  - allocation seed, table versions, inputs, and pack hashes.
+- Commit one idempotent allocation receipt before exposing success. A retry
+  returns the same bundle and cannot consume another route or discovery Slot.
+- Validate all kernel and projection capacity needed for the bounded slice
+  before commit. Reject cleanly if the bundle cannot fit; never create the
+  actor while dropping Home, item, or route reservation.
+- Allow Home and Keepsake to remain cold canonical allocations until revealed
+  or approached. Their IDs and receipts exist even if their active kernel
+  rows, prose, or media do not.
+- Extend `actor.created` provenance with the bundle identity without placing
+  private Home coordinates or item truth in the public room transcript.
+
+#### Acceptance
+
+- Repeating the same creation request produces one actor, one Home, one
+  Signature Keepsake, one ingress reservation, and one item placement.
+- A crash after the receipt but before presentation reconstructs the same
+  bundle.
+- An allocation failure creates none of the three canonical subjects and
+  consumes no capacity.
+- Replay with AI disabled reconstructs the same rules, identities, placement,
+  and private knowledge.
+
+### AVH-2 — Place Homes Through Bounded Route Slots
+
+**Scope**: route eligibility, connection capacity, private Home Leads, gossip,
+and access
+
+#### What to do
+
+- Replace “choose a random location with fewer than five exits” with authored
+  typed `home_route_slots`. An eligible source declares region/biome,
+  directionality, Home kinds, privacy/access policy, and an available
+  connection-capacity slot.
+- Count unique neighbor connections, not two reciprocal exit rows. Reserve one
+  slot at Home and one at its selected source before the private Lead is
+  offered.
+- Allocate exactly one initial hidden ingress. Additional approaches are
+  earned later through scouting and infrastructure if both endpoints have
+  capacity; creation does not randomly make a Home a hub.
+- Grant the owner Home knowledge and an actionable Lead tied to the selected
+  source Anchor. Other avatars learn the place by visiting, receiving gossip,
+  or discovering a compatible bounded Sign.
+- Separate knowledge, route legibility, and entry access. Knowing a cottage
+  exists or reaching its doorstep does not bypass its hospitality, lock,
+  invitation, or stewardship rules.
+- Use THR-7's Scout/cairn development ladder for the approach. Do not add a
+  Home-only navigation system.
+
+#### Acceptance
+
+- A Home can only be allocated where both endpoints have compatible free
+  capacity.
+- Two simultaneous creations cannot claim the same single-capacity route Slot.
+- A Home has exactly one initial ingress and stable placement after retry.
+- The owner can Scout toward Home from the frozen source context; another
+  avatar without knowledge receives no omniscient Home offer.
+- Gossip can teach the Home's existence without opening its route or door.
+
+### AVH-3 — Decorate The Triptych Asynchronously
+
+**Scope**: AI workshop jobs, deterministic fallback, subject consistency, and
+media replacement
+
+#### What to do
+
+- After the authoritative bundle commits, enqueue linked Avatar, Home, and
+  Signature Keepsake presentation jobs.
+- Give the workshop only certified mechanical facts, pack style, identity-card
+  fragments, safe relationship context, and allocated subject IDs.
+- Generate names, descriptions, composition text, and media as replaceable
+  presentation. Do not allow generated output to add exits, capabilities,
+  item effects, access, rarity, occupants, loot, or history.
+- Require an authored deterministic fallback card and image treatment for all
+  three subjects. The avatar can enter play immediately using those fallbacks.
+- Keep the three subjects visually and narratively related without forcing the
+  Keepsake to spawn at Home or making Origin and Home identical.
+- Bind every job and result to the stable subject identity and allocation
+  receipt so retry or model change cannot create a fourth subject.
+
+#### Acceptance
+
+- Creation completes and is playable when the model, image workshop, or job
+  queue is offline.
+- Late media replaces fallback presentation without changing rules, topology,
+  placement, or knowledge.
+- Retried jobs update the same three subjects and never allocate new ones.
+- The player can recognize a coherent Avatar/Home/Keepsake relationship
+  without generated prose promising unsupported mechanics.
+
+### AVH-4 — Prove A Bounded Living-World Cohort
+
+**Scope**: small-cohort gameplay proof before partitioned scaling
+
+#### What to do
+
+- Set an explicit test cohort, recommended at 16 first and 32 as the stretch
+  gate, within the current fixed-capacity kernel.
+- Create the cohort under deterministic seeds and prove:
+  - unique triptych identities and receipts;
+  - collision-free Home route reservations;
+  - exactly one initial ingress per Home;
+  - owner-only initial knowledge;
+  - scouting, loss, cairn marking, gossip, and access at one Home;
+  - discovery and recovery of one Signature Keepsake;
+  - restart, snapshot, replay, AI-offline, and pack-upgrade behavior.
+- Report remaining actor, location, item, and unique-connection headroom. The
+  test must count reciprocal exit rows correctly in the kernel capacity
+  budget.
+
+#### Acceptance
+
+- The full cohort creates without duplicate subjects, half-committed bundles,
+  capacity overrun, or route collision.
+- Every bundle replays byte-for-byte in authoritative identity and placement.
+- At least one other avatar learns of and reaches a Home through gossip and
+  Scout without receiving owner access automatically.
+- This proof does not require a new database product or partition loader.
+
+### AVH-5 — Hydrate Cold Canonical Homes By Partition
+
+**Scope**: durable canonical registry, active-world hydration, ownership
+fencing, and capacity release
+
+**Depends on**: [ADR 0003](../decisions/0003-one-canonical-world.md)
+
+#### What to do
+
+- Preserve the allocator/runtime boundary:
+  - the allocator commits the authoritative bundle and immutable receipt;
+  - durable storage retains cold canonical identity, placement, and history;
+  - the C kernel hydrates only active partitions and their bounded neighbors;
+  - approaching a cold Home loads the same place rather than allocating it.
+- Begin with the existing journal/snapshot/SQLite persistence where practical.
+  This ticket requires a canonical storage and hydration contract, not a
+  premature database-product migration.
+- Define partition contents for a Home, its occupants/floor state, local
+  fixtures, items, discovery Slots, and adjacent route stubs.
+- Use ADR 0003 lease epochs and fenced single-writer commits for movement and
+  other actions that cross partitions.
+- Prove eviction and rehydration preserve IDs, receipts, knowledge, access,
+  route state, items, and generated presentation.
+
+#### Acceptance
+
+- A dormant Home and Keepsake remain canonical without occupying permanent
+  rows in every live `cw_world`.
+- Loading, evicting, and reloading a Home cannot duplicate it or change its
+  topology.
+- Cross-partition arrival commits once under the canonical event history.
+- The bounded AVH-4 gameplay remains unchanged when the storage boundary is
+  introduced.
+
+### AVH-6 — Remove The Bounded-Cohort Production Gate
+
+**Scope**: rollout limits, capacity telemetry, failure behavior, and migration
+
+#### What to do
+
+- Keep public creation capped at the proven bounded cohort until AVH-5 passes.
+  Increasing C array constants alone is not the production scaling design.
+- Add capacity and hydration telemetry for actors, hot/cold locations, items,
+  route Slots, partition loads, allocation failures, and orphan checks.
+- Migrate already allocated bounded-cohort bundles into the cold canonical
+  registry without changing IDs or receipts.
+- Fail creation before commit when canonical storage or route allocation is
+  unavailable. Never create an actor without the promised Home and Keepsake.
+
+#### Acceptance
+
+- Public creation no longer depends on all historical avatars, Homes, items,
+  and exits fitting simultaneously in one fixed-capacity kernel instance.
+- Capacity exhaustion is observable, bounded, and mutation-free.
+- Migration preserves every AVH-4 identity, placement, knowledge, and replay
+  result.
+
 ## Persistence and events
 
 Suggested durable records:
@@ -414,6 +683,11 @@ idempotent transaction that:
 5. links the account to the new active actor;
 6. writes the arrival events; and
 7. returns the same result on retry.
+
+When the AVH follow-on is enabled, AVH-1 extends this transaction with one
+precommitted triptych allocation receipt. The actor commit must not succeed
+without its promised Home, Signature Keepsake, ingress, and placement
+reservations; asynchronous AVH-3 presentation remains outside the transaction.
 
 The first qualifying player card or speech event records
 `class.selection_ready`. Class selection is then a separate replay-safe system

--- a/docs/backlog/combat-encounters-and-range.md
+++ b/docs/backlog/combat-encounters-and-range.md
@@ -1,0 +1,201 @@
+# Combat, Encounters, And Range — Backlog
+
+**Epic**: Make combat read as a continuation of the shared room conversation,
+with compact status in the avatar rail and a deterministic server-owned rules
+model. The card hand remains for player choices; timing and status chrome must
+not crowd it out.
+
+**Status**: Groomed 2026-07-27, folded into this document 2026-07-30. The
+chat-first half has largely shipped; the three-band spatial layer is direction,
+not committed scope.
+
+**Prior execution backlog**: epic
+[#460](https://github.com/cenetex/cosyworld/issues/460) and children
+[#467](https://github.com/cenetex/cosyworld/issues/467),
+[#468](https://github.com/cenetex/cosyworld/issues/468), closed into this
+document.
+
+| Ticket | Prior issue | State |
+| --- | --- | --- |
+| Timing/status banner above the hand | [#461](https://github.com/cenetex/cosyworld/issues/461) | ✅ shipped |
+| Keep the shared transcript mounted | [#463](https://github.com/cenetex/cosyworld/issues/463) | ✅ shipped |
+| Authoritative equipped attack method | [#462](https://github.com/cenetex/cosyworld/issues/462) | ✅ shipped |
+| CB-1 — truthful avatar-rail combat tracker | [#465](https://github.com/cenetex/cosyworld/issues/465) | **open issue** |
+| CB-2 — pace automated actions one per reply beat | [#466](https://github.com/cenetex/cosyworld/issues/466) | **open issue**, partially shipped |
+| CB-3 — one-line fate tags for RPG checks | [#464](https://github.com/cenetex/cosyworld/issues/464) | **open decision** |
+| CB-4 — authoritative three-band range protocol | [#467](https://github.com/cenetex/cosyworld/issues/467) | direction |
+| CB-5 — render and operate three zones in the rail | [#468](https://github.com/cenetex/cosyworld/issues/468) | direction |
+
+Knockout presentation and identity moved to
+[Avatar Lifecycle And The Rescue Run](avatar-lifecycle-and-rescue.md) — LC-0
+and LC-1 own what #385 and #382 previously covered.
+
+**Related architecture**:
+
+- [CosyWorld RPG System Bible](../systems/09-cosyworld-rpg-system.md)
+- [Combat system contract](../../v2/docs/combat-system.md)
+- [Writing style](../../v2/docs/writing-style.md) — governs how chance reads in
+  the transcript, which is the crux of CB-3.
+
+---
+
+## Product contract
+
+- The shared room transcript stays mounted throughout combat.
+- Ordered-combat timing is a clean red-accent banner above the card hand, never
+  a wide pseudo-card.
+- The avatar rail becomes the encounter tracker: current actor, target/status
+  affordances, and compact Knockout/rescue representation.
+- A knocked-out linked traveler is observably distinct from a generic inactive
+  actor and does not receive ordinary actions that cannot commit.
+- Attacks resolve from an authoritative equipped method supplied by the server.
+- Automated combat advances one public action per room-reply beat so the
+  transcript stays legible.
+- RPG checks use compact one-line fate tags — **pending the CB-3 decision.**
+- The later spatial layer has exactly three authoritative range bands and
+  replays deterministically.
+
+### Epic acceptance
+
+A deterministic combat fixture can be refreshed and reconnected without
+changing actor identity, available actions, timing state, attack method,
+Knockout/rescue representation, or replay result. The transcript remains
+readable, and neither the timer nor knocked-out avatars displace the actionable
+card hand.
+
+### Production evidence (2026-07-27)
+
+At Flooded Barrow the linked traveler was reported unable to act while one
+`Notice` choice remained visible and ten full-size portraits filled the rail, a
+stale-choice rejection also visible. That screenshot establishes a
+truthful-state and priority problem, but does **not** by itself prove every
+other actor was knocked out. The lifecycle regressions must assert
+authoritative lifecycle state, never infer it from the UI.
+
+---
+
+## CB-3 — The fate-tag decision (unresolved, blocking)
+
+Recorded here because it is a live contradiction between two landed decisions,
+and the implementation work has already been written and reverted once.
+
+The contract as originally written wants `🎲 6 + 3 − 1 · Heart = 8` in the
+transcript. A landed browser rule forbids exactly that:
+
+```js
+// v2/scripts/smoke-browser.mjs:4402
+assert(!/d20|modifier|total|\bdc\b|>9<|>12</i.test(result.rollMarkup),
+  `chance feedback should not expose dice arithmetic: ${JSON.stringify(result)}`);
+```
+
+It is not incidental. Neighbouring assertions say the same thing from other
+angles: *"Check feedback should end with a plain outcome"*, *"chance feedback
+should use the narrative card shape"*, *"Check feedback should offer one vivid
+lead instead of an inventory"*.
+
+An implementation attempt tripped the guard verbatim (`🎲 9 + 3 = 12 vs 10`) and
+was reverted rather than deleting the assertion, since deleting it would
+silently reverse a deliberate product decision about how chance reads in this
+game.
+
+**Three options; one must be chosen before any code:**
+
+1. **Reverse the rule** — dice arithmetic becomes visible, `smoke-browser.mjs:4402`
+   is removed or narrowed, and `writing-style.md` records the new stance.
+2. **Keep the rule, move the tag** — arithmetic lives only in the
+   developer-facing Log and the transcript stays prose-only. *Most consistent
+   with the existing design, and the smaller change.*
+3. **Close as won't-do** — the qualitative cards are the intended feel.
+
+### Prerequisites, independent of the choice
+
+- **Landed:** `apply_ability_check` never set `event->ability`, so every
+  projected ability check reported Strength regardless of what was rolled.
+  Fixed; the projection now sends the resolved attribute for ordinary checks,
+  with a regression proving a Wisdom check is not mislabeled Strength.
+- **Outstanding:** `roll_mode` exists on `cw_action` (`kernel.rs:389`) but is
+  **not on `cw_event` at all**. The kernel rolls twice and reports only the
+  surviving `raw_roll`, so advantage/disadvantage is not derivable from the
+  emitted event. Any requirement that roll mode come from authoritative state
+  needs `roll_mode` appended to `cw_event` and a `CW_KERNEL_VERSION` bump,
+  populated in `apply_ability_check` and the combat attack path.
+
+---
+
+## CB-4 — Authoritative three-band combat range
+
+**Priority**: P2 — direction
+**Scope**: C kernel + ABI + persistence + offers
+**Depends on**: CB-2
+
+Add a minimal versioned spatial combat contract with exactly three stable
+bands: `side_one_range`, `close`, and `side_two_range`. Historical
+`cosyworld.combat/5` remains non-spatial.
+
+### Rules
+
+- Melee requires attacker and target in `close`.
+- Ranged attacks may cross zero or one band; opposite outer ranges cannot
+  attack directly.
+- Move travels between a participant's own outer range and `close` and consumes
+  the one-action activation.
+- Support, recovery, items, and Magic gain no new range rule unless their
+  authored method declares one.
+
+### Contract
+
+- Persist authoritative zone per active participant.
+- Put legal target IDs and movement destinations into offers and views.
+- Emit append-only `combat.zone.changed` events.
+- Validate stale offers after movement.
+- Authored encounters choose starting bands; the compatibility fallback is
+  explicit.
+- **Never synthesize zones into `combat/5` replay.**
+
+### Acceptance
+
+- [ ] The kernel rejects illegal opposite-range and melee-out-of-`close`
+      attacks.
+- [ ] Move changes the persisted band, consumes activation, emits once, and
+      advances initiative.
+- [ ] Restart, snapshot, and replay preserve zones and movement.
+- [ ] Late join, Knockout, encounter resolution, stale offer, and every range
+      pair are covered.
+- [ ] `combat/5` fixtures remain byte-for-byte compatible.
+
+---
+
+## CB-5 — Render and operate three zones in the avatar rail
+
+**Priority**: P2 — direction
+**Scope**: browser rail
+**Depends on**: CB-1, CB-4
+
+Render authoritative three-band combat in the existing top rail as
+`Left Range | Close | Right Range`, without introducing a second roster or a
+full-screen board.
+
+### Contract
+
+- Place portraits solely from the authoritative zone field.
+- Preserve health, current-turn, urgent-condition, legal-target,
+  selected-target, and rescue-row behaviour.
+- Attack emphasizes only server-offered legal targets; illegal actors remain
+  visible with a reason.
+- Move exposes the one legal destination without drag-and-drop and commits
+  through the normal confirmation flow.
+- Animate only after authoritative state arrives, and respect reduced motion.
+- Narrow layouts collapse spacing and labels, never participants.
+
+### Acceptance
+
+- [ ] Zones and portraits remain correct after refresh, reconnect, movement,
+      join, Knockout, and resolution.
+- [ ] Opposite-range illegality is visible before confirmation and still
+      enforced on forged requests.
+- [ ] Keyboard and screen-reader users can discover zone, HP, status, current
+      actor, targets, and movement.
+- [ ] Desktop and mobile fixtures keep the transcript dominant and the tracker
+      contained in the existing rail.
+- [ ] Leaving combat restores the ordinary room rail with no stale zone
+      decoration.

--- a/docs/backlog/community-art-evolution.md
+++ b/docs/backlog/community-art-evolution.md
@@ -2,6 +2,17 @@
 
 Status: first vertical slice shipped in the Rust/browser implementation; production hardening remains.
 
+The follow-on epic — [Reference-Composed World
+Scenes](#follow-on-epic-reference-composed-world-scenes) — was groomed
+2026-07-26 and folded into this document 2026-07-30 from issues
+[#396](https://github.com/cenetex/cosyworld/issues/396),
+[#399](https://github.com/cenetex/cosyworld/issues/399),
+[#400](https://github.com/cenetex/cosyworld/issues/400),
+[#401](https://github.com/cenetex/cosyworld/issues/401),
+[#402](https://github.com/cenetex/cosyworld/issues/402), and
+[#335](https://github.com/cenetex/cosyworld/issues/335). It is direction, not
+committed scope.
+
 ## Product decision
 
 Orbs exist to help the community make shared images. They do not pay for Chat or any other world verb.
@@ -62,3 +73,360 @@ The generated image belongs to the public card. Its prompt uses the card identit
 5. The prompt is derived only from committed public history through a recorded sequence.
 6. A ready image changes presentation only; mechanics and ownership are byte-for-byte unaffected.
 7. Reaching level `L+1` creates a fresh pool of `L+1` Orbs while preserving the prior level's provenance.
+
+---
+
+## Follow-On Epic: Reference-Composed World Scenes
+
+**Outcome**: treat every approved avatar, item, and location image as a
+reusable, immutable reference asset, then compose bounded world scenes from
+those references instead of regenerating from prompts alone.
+
+| Ticket | Prior issue | Priority |
+| --- | --- | --- |
+| Version-pinned provider/reference capability registry | [#398](https://github.com/cenetex/cosyworld/issues/398) | ✅ shipped |
+| CA-1 — immutable reference asset graph | [#399](https://github.com/cenetex/cosyworld/issues/399) | P2 |
+| CA-2 — canary FLUX.2 single-reference evolution | [#400](https://github.com/cenetex/cosyworld/issues/400) | P2 |
+| CA-3 — bounded scene composition | [#401](https://github.com/cenetex/cosyworld/issues/401) | P2 |
+| CA-4 — per-generation visual publication gate | [#402](https://github.com/cenetex/cosyworld/issues/402) | P2 |
+| CA-5 — worldpack-scoped unexplored art lifecycle | [#335](https://github.com/cenetex/cosyworld/issues/335) | P2 |
+
+### Problem
+
+CosyWorld generates avatar, item, and location bases through Replicate FLUX.1
+LoRA recipes. Those images are useful final assets today, but they are not a
+durable visual vocabulary that later generations can reference. As the world
+begins to illustrate encounters and shared scenes, prompt-only regeneration
+will drift identities, invent absent actors, omit authoritative items, and lose
+worldpack art direction.
+
+FLUX.2 adds reference-image generation and editing, but changing the default
+model everywhere would mix four separate decisions: base quality, identity
+preservation, scene composition, and provider migration. Keep them separate.
+
+### Architecture
+
+> Authoritative world snapshot + approved immutable reference assets + frozen
+> versioned media recipe → stored candidate image → visual publication gate →
+> approved asset, or withheld for audit.
+
+**Reference images are evidence for appearance, never authority for world
+facts.** The journal/world projection decides who and what is present.
+Generated media changes presentation only.
+
+### Migration stages
+
+- **A — Preserve the current base layer.** Keep FLUX.1 LoRA recipes available
+  for base generation. Promote approved outputs to immutable, hashed reference
+  assets with provenance. Do not re-render existing canonical art merely to
+  change providers.
+- **B — Reference-preserving evolution.** Add a version-pinned FLUX.2
+  capability for one-reference edit/evolution, using the prior approved level
+  as the primary identity reference.
+- **C — Bounded scene composition.** Compose location + actor(s) + item from
+  indexed references and an authoritative scene snapshot. Freeze reference
+  order/roles; reject jobs exceeding a model version's declared limits. Never
+  silently drop a subject.
+- **D — Re-evaluate base generation.** Run FLUX.2 base generation against the
+  incumbent per media profile. Migrate a profile only when evidence shows a win
+  and rollback remains possible.
+
+### Invariants
+
+- Every request pins provider, model/version, capability, prompt version, seed,
+  input asset hashes, reference roles/order, subject/event boundary, and
+  worldpack media profile.
+- Provider reference limits are capabilities of a pinned model version, not
+  hard-coded assumptions.
+- No candidate becomes public before approval.
+- A failed or misleading image cannot mutate actors, inventory, topology,
+  history, funding, or ownership.
+- Retry is idempotent and never recollects Orbs; policy-service failure retains
+  the candidate instead of buying another generation.
+- Secrets and arbitrary provider request bodies remain host-owned; packs select
+  only allowlisted media profiles.
+- Authored/on-chain art is never converted into a model input unless its
+  rights/provenance policy permits it.
+
+### Delivery order
+
+1. Capability recipes (#398, shipped) establish the provider boundary.
+2. CA-1 makes current approved FLUX.1 art reusable without regeneration.
+3. CA-4 may proceed beside CA-1, but **no new media intent publishes before it
+   lands.**
+4. CA-2 runs shadow evaluation and canary first.
+5. CA-3 starts with one location, up to two actors, and one item.
+6. FLUX.2 base generation is evaluated only after these slices expose real
+   quality, cost, latency, and rollback data.
+
+---
+
+### CA-1 — Make approved art an immutable reference asset graph
+
+Approved card art is currently treated mainly as a display result. Reference-based
+generation needs stable, permissioned inputs whose identity survives cache keys,
+replacement, provider retries, pack upgrades, and later scene composition. **A
+mutable URL is not sufficient provenance.**
+
+**Asset and lineage contract.** Record: immutable asset ID, content digest,
+dimensions, MIME type, stable object-storage location, creation time; subject
+kind/ID, level/revision, pack provenance, approval/moderation state; source kind
+(authored, on-chain, imported, generated, derived); whether reference reuse is
+permitted and its rights basis; provider/model/version, prompt version, seed,
+prediction ID, source event boundary; parent asset IDs plus reference slot,
+order, crop/mask, and transformation for each derived asset; supersession
+without mutating or deleting historical lineage.
+
+**Deterministic resolution.** Given an authoritative media intent and world
+snapshot, resolve required typed slots in a stable order, preferring the
+currently approved canonical revision. If a required asset is missing,
+unapproved, inaccessible, or unlicensed for derivation, the job is ineligible —
+never fall back to an unrelated visual. When a scene exceeds the recipe's
+reference budget, return an explicit composition-plan requirement.
+
+**Acceptance**
+
+- [ ] Existing approved FLUX.1 LoRA outputs backfill as immutable reference
+      assets without re-generation.
+- [ ] Replacing public art preserves the old asset and lineage while moving the
+      canonical pointer to a new approved revision.
+- [ ] References resolve deterministically across restart, replay, pack mount
+      order, and cache eviction.
+- [ ] Every derived asset exposes complete parent/reference lineage by digest
+      and role.
+- [ ] Authored/on-chain/imported assets default to non-derivable until policy
+      explicitly permits use.
+- [ ] Unapproved, rejected, private, deleted, or rights-ineligible images cannot
+      enter provider requests.
+- [ ] Over-budget and missing-reference fixtures fail without provider spend.
+- [ ] No asset mutation changes subject ownership, level, inventory, location,
+      or journal state.
+
+---
+
+### CA-2 — Canary FLUX.2 single-reference art evolution
+
+Later-level community art should reflect new history while remaining
+recognizably the same avatar, item, or place. Prompt-only generation cannot
+reliably preserve identity; switching all base generation to FLUX.2 before
+measuring it risks degrading established pack styles or raising cost and
+latency.
+
+**The evolution brief** freezes: subject identity and persisted visual
+description; the prior approved asset digest as a required `prior_level`
+reference; the public history delta since that asset plus the committed cutoff
+sequence; stable traits that must not change and a bounded list of requested
+changes; worldpack media profile, target level/revision, aspect/crop, negative
+constraints; the exact resolved recipe and lineage fields. The prompt may
+describe appearance and public events. It cannot infer mechanics, possessions,
+relationships, or location beyond the authoritative snapshot.
+
+**Evaluation gate.** Build a reviewed corpus spanning avatars, items, locations,
+multiple pack profiles, dark/light subjects, and small/large history deltas.
+Compare incumbent and candidate on subject recognizability, stable-trait
+retention, requested-change accuracy, pack fidelity, absence of invented
+actors/items/text/logos, composition usability, safety pass rate, cost,
+latency, provider error rate, and retry spend. Store blind human preferences
+alongside automated signals. Choose thresholds per media intent and profile —
+one global score must not hide a weak subject class.
+
+**Rollout.** Shadow-only, then canary a small percentage of eligible level
+evolutions. Keep the prior approved image public until the new candidate passes
+review. Rollback changes routing only; it does not mutate funding or lineage.
+
+**Acceptance**
+
+- [ ] A prior approved asset is required and frozen into the job by digest.
+- [ ] History prompts use only the committed public delta and preserve declared
+      stable traits.
+- [ ] A reviewed incumbent-vs-candidate corpus reports quality, safety, cost,
+      latency, and error metrics per subject kind and profile.
+- [ ] Canary thresholds and an automatic disable/rollback condition are
+      explicit.
+- [ ] A rejected or failed evolution leaves the prior approved asset public and
+      charges no additional Orbs.
+- [ ] At least one avatar, item, and location fixture preserves recognizability
+      while incorporating a legitimate later-level change.
+- [ ] Base generation remains on its existing recipe until its own
+      profile-specific comparison wins.
+
+---
+
+### CA-3 — Compose bounded scenes from authoritative references
+
+A composed image can imply world facts more strongly than prose: an absent
+person, missing carried item, wrong location, or invented relationship becomes
+visible canon to players. Passing several references to a model is not enough —
+the composition request must be a truthful, replayable projection of one
+committed scene boundary.
+
+**First supported template**: exactly one authoritative location plate; one or
+two present actors; zero or one selected important item; one committed
+scene/event boundary; one resolved worldpack media profile. The model
+illustrates this scene but cannot choose its cast, inventory, location,
+outcome, or relationship facts.
+
+**The frozen scene brief** records room identity and committed projection
+sequence; ordered actor IDs with approved reference digests, poses/attention
+only when grounded by the event; selected item ID, owner/holder, and digest;
+location reference digest and environmental facts; the public beat to
+illustrate; intended media use, aspect/crop/safe areas, payer policy,
+visibility; forbidden subjects/facts and pack constraints; typed indexed
+reference order and exact resolved recipe.
+
+The **scene projector, not the image model, resolves the cast.** A prompt phrase
+such as "image 1 is the location; image 2 is actor A" is generated from typed
+slots and covered by adapter tests.
+
+**Reference budgeting.** Resolve all required subjects before generation. If the
+model version cannot accept the full set: select another compatible allowlisted
+recipe; or create an explicit, separately reviewable multi-pass composition
+plan; or leave the scene unillustrated. Never silently drop, merge, or replace a
+required subject. Multi-pass outputs retain full intermediate lineage.
+
+**Acceptance**
+
+- [ ] A fixture composes a location, two distinct actors, and one held item
+      from immutable references.
+- [ ] The job is byte-for-byte traceable to a committed scene projection and
+      exact reference order.
+- [ ] Removing an actor or item from the authoritative snapshot removes it from
+      the required composition set; provider output cannot add it back to state.
+- [ ] Missing, rejected, or rights-ineligible references make the job
+      explicitly ineligible before provider spend.
+- [ ] Over-budget reference sets use a declared fallback or remain
+      unillustrated; no subject is silently omitted.
+- [ ] Replays and retries reuse the same logical job and do not publish
+      duplicate scene assets.
+- [ ] The existing location image or deterministic fallback remains public
+      until the candidate passes review.
+- [ ] Tests cover swapped reference order, duplicate actors, absent item, stale
+      snapshot, pack boundary, and provider timeout.
+- [ ] Arbitrary crowds and unconstrained combat tableaux are explicitly out of
+      scope for this slice.
+
+---
+
+### CA-4 — Gate every generated image before publication
+
+Reference-capable models can still drift identity, duplicate or omit subjects,
+invent people, render text, or violate safety constraints. A model-level
+allowlist alone cannot make a particular image truthful. Conversely, one bad
+output should not permanently exclude a useful model.
+
+CosyWorld already withholds misleading generated location art. Scene
+composition needs that rule generalized to every candidate and every media
+intent.
+
+Every provider output is stored as an **untrusted candidate** and evaluated
+against its frozen brief before any public pointer changes:
+
+- **pass** — approve and atomically publish the candidate revision;
+- **content fail** — retain the candidate and reasons for audit, leave the
+  previous truthful asset visible, retry only under bounded policy;
+- **reviewer/infrastructure unavailable** — keep the candidate pending and
+  retry review without buying another generation;
+- **repeated operational provider failures** — cooldown or reroute the recipe
+  without mutating world state.
+
+A failed candidate informs routing quality but does not permanently ban the
+model family.
+
+**Gate checks**, cheap deterministic first, then bounded visual review:
+decodable image and expected format/dimensions/aspect; safety and moderation
+policy; no prohibited text, logos, watermarks, prompt leakage, or UI artifacts;
+expected subject count and no extra people or creatures; identity/reference
+similarity per subject within intent-specific thresholds; required item presence
+and ownership when visually asserted; location match; crop usability;
+near-duplicate detection against recent revisions; pack-specific negative
+constraints.
+
+The reviewer receives the frozen brief and approved reference thumbnails — not
+secrets or raw provider payloads. Its verdict is structured, versioned, and
+bounded; **it cannot publish or mutate state directly.**
+
+**Retry and routing.** Bound attempts and total spend per logical job. Never
+debit or recollect Orbs on moderation or provider retry. Prefer review retry
+over generation retry when review fails operationally. Record pass/fail by model
+version, profile, intent, and failure reason. Use canary weights and cooldowns
+to favour reliable recipes while continuing bounded exploration. Escalate
+terminal or ambiguous candidates to moderator review, preserving the truthful
+fallback.
+
+**Acceptance**
+
+- [ ] No provider response can update a public asset URL before a persisted
+      passing verdict.
+- [ ] The gate generalizes the existing location-art truthfulness contract
+      without regressing it.
+- [ ] A fixture catches an extra actor, missing required actor, wrong item,
+      identity drift, text/logo, blank image, unsafe content, and
+      near-duplicate.
+- [ ] Policy or reviewer outage retains one candidate and retries review
+      without another provider prediction.
+- [ ] Retry budgets are durable and idempotent across process restart and
+      replay.
+- [ ] Every verdict records checker versions, signals, reasons, references,
+      candidate digest, and final disposition.
+- [ ] Dashboards expose pass rate, failure taxonomy, cost per approved asset,
+      review latency, retry spend, and model/profile/intent slices.
+- [ ] Operators can inspect, approve, reject, replace, or disable a recipe
+      without charging contributors or changing mechanics.
+- [ ] A rejected candidate never becomes a reference input for later
+      generations.
+
+---
+
+### CA-5 — Worldpack-scoped unexplored art lifecycle (Holy Land first)
+
+The 31 authored Holy Land cards have a pack-specific art pipeline pinned to
+`ratimics/b43l` with trigger `B43L`, but Orb-funded runtime art does not inherit
+that profile. The live `cosyworld` Fly configuration routes every community-art
+subject through the global `black-forest-labs/flux-dev-lora` +
+`immanencer/mirquo` profile and prefixes prompts with `MRQ`.
+
+Generated pathway locations also reveal a deterministic scene SVG before
+community art exists. That is mechanically safe, but it weakens the feeling that
+a newly discovered place is still visually unexplored.
+
+**Lifecycle**: `hidden` → `discovered_unillustrated` → `funding` → `generating`
+→ `ready`, where `generating` may transition to `failed` with a free retry while
+the funding threshold remains satisfied.
+
+**Contract**
+
+- The 31 authored Holy Land WebPs are permanent base art and never require Orb
+  funding.
+- A hidden generated location leaks no card or bespoke scene art.
+- A discovered but unillustrated location projects a stable, nonrepresentational
+  **Unexplored** placeholder plus its level-1 Orb image contract.
+- Funding and generation keep the placeholder visible; a committed ready event
+  atomically swaps in the shared generated image.
+- Failed or restarted jobs return to a recoverable state without a broken image.
+- Worldpacks may declare a bounded media profile: provider/model identifier and
+  pinned version, trigger/prompt prefix, aspect policy, negative constraints.
+- A generated location inherits its media profile from the canonical
+  route/worldpack that owns it. Cross-pack routes use an explicit resolver and
+  deterministic host fallback; they never silently borrow an endpoint style.
+- Holy Land generated location prompts use `ratimics/b43l` version
+  `2846199bda89a44676dc5da00bd02faa3f5183b1c1d3e124c966d656874f141f` and begin
+  with `B43L`, not `MRQ`.
+- The model creates visual prose only; authoritative ecology, actors, topology,
+  access, rewards, and rules remain server-owned.
+
+**Acceptance**
+
+- [ ] A newly discovered Holy Land waypoint displays the common Unexplored
+      placeholder, not its generated pathway SVG.
+- [ ] Its modal exposes the level-1 Orb contract.
+- [ ] A captured provider request for that waypoint uses the pinned B43L
+      model/version and a prompt beginning with `B43L`.
+- [ ] Core and default generated art continue using the configured default
+      profile.
+- [ ] Authored Holy Land base cards continue loading their existing 31 WebPs.
+- [ ] Pending, failed, restarted, and ready transitions have projection and
+      replay coverage.
+- [ ] The placeholder never depicts people, structures, or biome facts not yet
+      revealed.
+- [ ] Pack validation rejects incomplete or unsafe media profiles.
+- [ ] Browser coverage proves no broken-image or premature-scene-art state.

--- a/docs/backlog/quest-grammar-and-return.md
+++ b/docs/backlog/quest-grammar-and-return.md
@@ -1,0 +1,349 @@
+# Quest Grammar And Return
+
+**Outcome**: compose deterministic, replayable tales from Hearth, Sign,
+Venture, Challenge, Discover, and Return across avatars, items, and locations
+without adding a second action system or handing authority to AI.
+
+**Status**: Groomed and filed (2026-07-30). The linked issues are the source of
+truth for implementation state.
+
+**Execution backlog**: epic
+[#639](https://github.com/cenetex/cosyworld/issues/639).
+
+## Diagnosis
+
+CosyWorld has most of the rules needed to resolve a good quest, but no
+authoritative structure that says what role those resolutions played in a
+tale.
+
+The runtime can move and place actors and items, reveal and unlock routes,
+resolve checks, apply closed effects, advance Job clocks, allocate loot, form
+Bonds, record discoveries, and preserve replay. Those systems are strong
+foundations. They currently meet in ad hoc projections: a Search receipt, a
+route discovery, a local Lead, a Job contribution, a loot allocation, a Visit
+Ledger mark, or a frontier-return mark. Nothing binds them into one typed,
+versioned causal arc.
+
+The gap is therefore not “add quests to the kernel.” It is:
+
+> Add a deterministic semantic layer that compiles authored quest functions
+> into existing legal actions, records the evidence and world delta of each
+> resolution, and makes Return settle that delta into shared play.
+
+This is the next major windfall because it joins work that otherwise risks
+becoming several parallel discovery, traversal, Job, and Journal systems.
+
+## Existing Foundations
+
+| Foundation | Current evidence | What it already gives the grammar |
+| --- | --- | --- |
+| Append-only concrete actions | `cw_action_kind` in `v2/core-c/include/cosy_kernel.h` | Stable authority for physical actions, kernel Gate transitions, and versioned discovery-procedure commits. |
+| Small deterministic world state | `cw_world` in `v2/core-c/include/cosy_kernel.h` | Canonical actors, items, locations, exits, evolution, and encounters. |
+| Three card subject kinds | seed-card validation in `v2/orchestrator-rust/src/content_load.rs` | The avatar/item/location focus axis already exists. |
+| Jobs and clocks | `JobState` in `v2/orchestrator-rust/src/jobs.rs` | Premise, stakes, participants, places, progress, danger, reward, consequence, and completion memory. |
+| Named contribution methods | `JobContributionStrategy` and `JobContributionTrace` in `v2/orchestrator-rust/src/main.rs` | Versioned methods, requirements, checks, effects, claims, and causal receipts. |
+| Closed world changes | `EffectDescriptor` in `v2/orchestrator-rust/src/rpg/effects.rs` and `ProjectionMutation` in `main.rs` | A fail-closed compiler seam for authoritative and projected effects. |
+| Threshold authority | `ThresholdPredicate`, `AcceptedThresholdIntent`, and kernel Gate state | Versioned Leads, Gates, Hazards, Anchors, holder/actor/expedition/world scopes, exact methods, and conditional transitions. |
+| Discovery authority | `DiscoveryRollReceipt` and `DiscoveryClaimState` | Versioned stocking/event/presentation tables and one frozen procedure across focused Notice, Search, Study, and Scout. |
+| Route truth and provenance | `RouteRecordState` in `v2/orchestrator-rust/src/topology.rs` | Separate topology, lifecycle, discovery, unlock history, and route version. |
+| Concrete local leads | `LocalLeadState` in `v2/orchestrator-rust/src/local_leads.rs` | A source, origin, destination, hint, consumption, settlement, and forgetting state. |
+| Frozen loot draws | `LootAllocationState` in `v2/orchestrator-rust/src/quest_loot.rs` | Table and pack versions, replay algorithm, roll seed and input, selected entries, materialized IDs, and destination. |
+| Focused scenes | `FocusedEncounterView` in `v2/orchestrator-rust/src/turns.rs` | Existing nodes, relations, conditions, completion, stop, and retreat fields for Challenge presentation. |
+| Shared discovery memory | Search, Study, hidden-exit, avatar, item, and Visit Ledger projections | Evidence-backed discoveries with witnesses and replay. |
+| Evidence-based identity | player-authored Calling state plus deed/practice records in `v2/orchestrator-rust/src/actor_practice.rs` | A foundation for becoming through witnessed action rather than inferred personality. |
+| Player-facing chronicle | semantic Journal and Visit Ledger | A place to present resolved differences without exposing event grammar. |
+| Voice/authority boundary | `PRD.md`, `AI.md`, and the AI gateway | AI can render selected facts but cannot choose rules, topology, or rewards. |
+
+## Code-To-Vision Gaps
+
+| Vision | Current code | Gap |
+| --- | --- | --- |
+| Six reusable quest functions | Concrete C actions and Job contribution kinds | There is no `QuestPattern`, quest node, transition graph, or function binding. |
+| Avatar/item/location as typed focal roles | Card subjects validate those three kinds | Contribution targets also admit stringly `job`, `room`, and `feature`; there is no canonical quest entity reference or role. |
+| A tale may branch, loop, retreat, and resume | Jobs expose two clocks and a status | Jobs have no authored beat graph, entry nodes, failure edges, return vector, or resume contract. |
+| Venture follows a Lead from an Anchor | Legacy `scout_v1` remains replay-readable; `scout_v2` now commits through a frozen Discovery Slot, while Anchor/Lead descriptors can declare return chains and branch authority | Perishable active-foray state, track loss, fatigue binding, and quest Venture/Return-vector integration remain outside the shipped procedure. |
+| Signs arise from evidence and may retain plural readings | The v2 discovery procedure now shares a frozen receipt across focused Notice, Search, Study, and Scout; local Leads cite concrete sources | There is no quest Sign record binding that evidence to a node, recurring motif, authored tension, or plural interpretation policy. |
+| Discovery changes a relation or capacity | Reveal, unlock, placement, Bond, tag, clock, and memory mutations exist | Their effects have no common typed delta that says what the resulting assemblage can now do. |
+| Challenge can hold two legitimate claims in contact | Progress/danger clocks and multiple contribution strategies exist; focused scenes expose graph-shaped fields | There is no authored tension or per-pole engagement, and current focused work/combat scenes leave local nodes, relations, and conditions empty. |
+| Return reintegrates the venture's difference | `apply_frontier_return_ledger_projection` marks a successful flee from frontier to non-frontier | This is a narrow spatial ledger mark, not a departure snapshot, return vector, witnessed settlement, or durable quest closure. |
+| One causal receipt joins action, evidence, roll, delta, and next state | Each subsystem has its own trace or projection mutation | There is no unified frozen `quest.phase.resolved` receipt for replay, Journal, tests, and AI narration. |
+| Original OSR-style tables select bounded facts | Discovery and Job loot each freeze table/version/algorithm/input/selection in durable but distinct receipts | Quest nodes cannot yet cite both receipt families through one evidence contract, and motif, encounter, or return-hook use has no quest binding. |
+| Quest capacities arise from relations | Threshold descriptors already express exact items, installed items, charges, tags, Jobs, Bonds, grants, claims, holder scope, and kernel-owned Gate transitions | Those facts remain threshold-specific; there is no cross-domain quest delta that joins custody, placement, Bond, Anchor, route, obligation, and memory without duplicating their existing authorities. |
+| Identity can be complicated through play | Calling is a statement with keyword/exact relevance; faction truth, failure mode, verbs, and motifs are mostly content; deeds are durable evidence | Quest outcomes cannot yet support, contradict, or invite revision of a Calling through an authored tension without inferring a psyche. |
+| Symbolic acts remain concrete and safe | Items, placements, features, Jobs, and Bonds can express them | There is no recipe vocabulary or safety rule preventing diagnosis, coercion, or real-world prescription. |
+
+## Design Decision
+
+The six words are **quest functions**, not new player buttons and not new C
+action codes:
+
+| Function | Authoritative meaning |
+| --- | --- |
+| **Hearth** | Establish or strengthen an anchor and a return vector. |
+| **Sign** | Bind observable evidence to an open question, Lead, motif, or tension. |
+| **Venture** | Cross or create an edge and expose part of the current arrangement to risk. |
+| **Challenge** | Alter a relationship, threshold, obligation, or clock under resistance. |
+| **Discover** | Add usable knowledge, a capacity, or a relation that did not exist in this arrangement before. |
+| **Return** | Settle the venture's difference into an anchor as durable world state and memory. |
+
+Travel, Inspect/Search, Study, Work, Help, Give, Use, Rest, Flee, and the other
+concrete verbs remain the actions a player commits. A quest node names which
+function one of those actions may resolve and the evidence required to prove
+it.
+
+The canonical six-function walk is useful:
+
+`Hearth → Sign → Venture → Challenge → Discover → Return`
+
+It is not mandatory. A pattern may have several entry points, loop, retreat,
+skip a function, make a new Hearth, or remain unresolved. The world graph is
+globally centerless; a quest gives one live subgraph a temporary center.
+
+## The Eighteen Focal Operations
+
+|  | Avatar | Item | Location |
+| --- | --- | --- | --- |
+| **Hearth** | host, trust, accompany, or make a promise | entrust, prepare, cache, keep, or install | shelter, camp, raise a cairn, or maintain a landmark |
+| **Sign** | witness an appeal, contradiction, gesture, or changed deed | inspect damage, residue, provenance, absence, or unusual use | notice a track, threshold, weather change, or disturbed feature |
+| **Venture** | follow, escort, seek, separate, or invite | carry, send, risk, or deploy | scout, cross, descend, climb, or open a route |
+| **Challenge** | bargain, refuse, confront, question, or aid under pressure | test, repair, break, combine, sacrifice, or use against resistance | endure a hazard, negotiate a boundary, or alter terrain |
+| **Discover** | form a reciprocal capacity or authored understanding | reveal a contextual use, provenance, or relationship | reveal a path, site, resource, feature, or condition |
+| **Return** | escort, reconcile, reintroduce, answer, or report | restore, give, offer, bury, display, or install | revisit, reconnect, mark, secure, or deliberately abandon |
+
+These are authoring slots, not an exhaustive verb list. A quest should involve
+at least two focal kinds and create, alter, or resolve at least one cross-kind
+relationship.
+
+`Discover avatar` never authorizes the game to reveal a hidden psyche. It can
+only recognize something the avatar's player authored, something the avatar
+did, or something another actor reciprocally disclosed.
+
+## Design Lineage Without Doctrine
+
+- **The hero's journey** supplies a readable local rhythm. It does not make one
+  protagonist, one sequence, separation, victory, or homecoming universal.
+- **Jung** contributes recurring motifs, compensation for one-sided action,
+  tension between legitimate poles, and integration through a changed Return.
+  Archetype names, universal symbol dictionaries, and psychological diagnoses
+  stay out of authoritative state.
+- **Deleuze and Guattari** contribute assemblages, capacities produced by
+  relations, many entrances, rerouting after rupture, provisional territories,
+  and becoming rather than revealed essence. Hearth makes Venture possible; it
+  is not the opposite of freedom.
+- **Jodorowsky** contributes the possibility of a concrete symbolic act whose
+  physical arrangement carries meaning. CosyWorld confines this to consensual
+  fictional action with authored effects. It is never therapy, diagnosis,
+  humiliation, self-harm, coercion, or a real-world instruction.
+
+The synthesis is architectural:
+
+> Use Jung for local recurrence and accountability, Deleuze and Guattari for a
+> relational and centerless world, Jodorowsky for bounded material action, and
+> the hero's journey as one rhythm rather than a railway.
+
+### Mechanical translations
+
+- **Constellation is an evidence threshold.** A worldpack may make a motif
+  eligible as a Sign after it recurs across two focal kinds or several
+  causally distinct events. The exact threshold is authored and frozen; the
+  runtime does not scan prose for secret meaning.
+- **Compensation is authored counterpressure.** Repeated one-sided methods may
+  make an excluded claim or capacity newly actionable. It is neither a random
+  punishment nor a diagnosis of the player.
+- **Tension is two tracked claims.** Challenge records effective engagement
+  with each pole. A third arrangement is an authored capacity unlocked only
+  after both have affected play.
+- **Assemblage is a typed relation set.** A bell is not inherently a key. The
+  bell, its holder, an installed place, a route condition, and a learned
+  practice may together grant one contextual capacity.
+- **The refrain is Hearth–Venture–Return.** Hearth establishes enough
+  continuity to leave; Venture opens the arrangement to change; Return
+  establishes continuity again with a recorded difference.
+- **Becoming is a changed capability, not a revealed essence.** Deeds and quest
+  receipts may let a player affirm, complicate, or revise a Calling. The
+  player chooses the statement.
+- **A symbolic act is material.** Its meaning comes from an optional in-world
+  arrangement of actors, items, and places with ordinary legal actions and
+  bounded effects.
+
+## Authoritative Contract
+
+A versioned quest pattern needs, at minimum:
+
+```text
+QuestPattern
+  id, version, source pack
+  entry nodes
+  nodes
+    function
+    focal entity reference or predicate
+    required evidence
+    allowed concrete methods
+    resolution policy
+    success, consequence, retreat, and rupture edges
+  motifs
+  optional authored tensions
+  anchor rules and return vectors
+  completion and continuation policy
+```
+
+A quest instance freezes the chosen pattern version, bound entity references,
+departure revision, active node set, evidence, relation/capacity baseline,
+table results, resolved nodes, return state, and unresolved threads.
+
+Reference the proven `DiscoveryRollReceipt` and `LootAllocationState` through a
+closed quest evidence-reference type. Do not reroll, rewrite, or replace either
+implementation with a third roller. Generalize the focused-scene graph for
+Challenge presentation; do not add another encounter protocol beside it.
+
+Every resolved function emits one shared causal receipt containing:
+
+- quest, pattern, version, instance, and node identity;
+- function and focal actor/item/location reference;
+- committed action and source event sequence;
+- cited evidence and frozen table roll, when any;
+- resolution policy and outcome;
+- typed before/after relation or capacity delta;
+- opened, closed, or rerouted nodes;
+- anchor and return-vector changes;
+- idempotency key and provenance.
+
+The receipt summarizes authoritative facts. It does not let Rust or AI
+contradict a physical C-kernel result. If a new physical invariant cannot be
+derived from existing actions, it receives a new append-only action/event
+meaning; historical action `0` and existing event meanings are never
+reinterpreted.
+
+## Invariants
+
+1. Quest functions never become a second legal-action surface.
+2. The same world state, pattern version, table version, seed, and action
+   produce the same result and receipt.
+3. AI cannot choose eligibility, a table row, a check, a transition, topology,
+   custody, access, reward, or effect.
+4. Every Sign cites observable evidence. Symbolic signs preserve at least two
+   authored viable readings until play settles one.
+5. Every resolved node names an actor, item, or location focus.
+6. Every quest changes or resolves at least one cross-kind relation.
+7. Discover adds actionable knowledge, a capacity, a relationship, or an edge;
+   prose alone cannot satisfy it.
+8. A third arrangement in Challenge requires effective engagement with both
+   authored poles.
+9. Losing an actor, item, or location may reroute or fail a node but never
+   erases causal history.
+10. Quest-level Return requires a difference from the departure snapshot and
+    writes that difference into shared state or memory.
+11. Spatial revisit semantics reserved by
+    [#93](https://github.com/cenetex/cosyworld/issues/93) are not reused for
+    quest settlement. Use a distinct versioned namespace.
+12. Retreat, refusal, rescue, and unresolved Return remain representable
+    outcomes.
+13. A symbolic act is optional, fictional, consent-aware, and selected from
+    an authored closed vocabulary.
+14. Browser, terminal, direct API, and inference controllers see the same
+    legal actions and consequences.
+15. Mounted quest situations become actionable through Hearth or Sign
+    conditions and exact legal offers. Legacy quest acceptance remains a
+    replay no-op; no quest-log Accept button returns.
+
+## Integration Boundaries
+
+This backlog does not duplicate:
+
+- [#586](https://github.com/cenetex/cosyworld/issues/586), which owns the
+  strict-referee primitives for Leads, Gates, Hazards, Pressure, and evidence;
+- [ADR 0005](../decisions/0005-thresholds-trails-and-strict-referee.md),
+  [#589](https://github.com/cenetex/cosyworld/issues/589), and
+  [#601](https://github.com/cenetex/cosyworld/issues/601), which established
+  kernel Gate transitions and the unified v2 discovery procedure;
+- [#594](https://github.com/cenetex/cosyworld/issues/594), which owns anchored
+  Scout forays and perishable geographic Leads;
+- [#602](https://github.com/cenetex/cosyworld/issues/602), which owns bounded
+  materialization of item and location discoveries;
+- [#157](https://github.com/cenetex/cosyworld/issues/157), which established
+  authoritative Job clocks and contribution strategies;
+- [#158](https://github.com/cenetex/cosyworld/issues/158), which established
+  deterministic physical Job loot;
+- [#289](https://github.com/cenetex/cosyworld/issues/289), which owns the
+  distinction between route existence, discovery, and knowledge;
+- [#292](https://github.com/cenetex/cosyworld/issues/292), which owns arrival
+  presentation and derived pact context;
+- [#357](https://github.com/cenetex/cosyworld/issues/357), whose Lantern Keeper
+  campaign is the preferred player-facing proof surface.
+
+Quest grammar consumes those facts and emits typed narrative function
+receipts. THR remains authoritative for how evidence, routes, thresholds, and
+pressure work. Jobs remain authoritative for contribution methods and clocks.
+The kernel remains authoritative for physical mutation.
+
+## Execution Backlog
+
+| Slice | State | Outcome | Depends on |
+| --- | --- | --- | --- |
+| [QST-0 — quest-function contract](https://github.com/cenetex/cosyworld/issues/640) | P1 / next / ready | Record the grammar, namespace, authority, migration, and safety decision. | Existing foundations |
+| [QST-1 — pattern schema and compiler](https://github.com/cenetex/cosyworld/issues/641) | P1 / next / blocked | Validate versioned graphs, typed focal references, transitions, motifs, tensions, and anchors. | QST-0 |
+| [QST-2 — phase receipt and replay](https://github.com/cenetex/cosyworld/issues/642) | P1 / next / blocked | Persist quest instances and emit one frozen causal receipt per resolved function. | QST-1 |
+| [QST-3 — relation and capacity deltas](https://github.com/cenetex/cosyworld/issues/643) | P1 / next / blocked | Adapt existing threshold, custody, placement, Bond, route, and Anchor facts into typed quest deltas. | QST-2 |
+| [QST-4 — evidence-led Signs and tables](https://github.com/cenetex/cosyworld/issues/644) | P1 / next / blocked | Bind existing discovery/loot receipts to plural symbolic Signs and quest evidence. | QST-2, QST-3, THR-D2 |
+| [QST-5 — two-pole Challenges](https://github.com/cenetex/cosyworld/issues/645) | P1 / next / blocked | Reuse focused scenes, contribution methods, and pressure for authored tension, retreat, and third arrangements. | QST-2, QST-3, THR-6 |
+| [QST-6 — Return settlement](https://github.com/cenetex/cosyworld/issues/646) | P1 / next / blocked | Compare departure and return, settle a durable delta, and open an honest continuation. | QST-2, QST-3 |
+| [QST-7 — symbolic-act recipes](https://github.com/cenetex/cosyworld/issues/647) | P2 / later / blocked | Add safe, concrete, pack-authored arrangements and narration guardrails. | QST-4, QST-5, QST-6 |
+| [QST-8 — vertical proof](https://github.com/cenetex/cosyworld/issues/648) | P1 / later / blocked | Prove branching, retreat, replay, offline play, and Return across all three focal kinds. | QST-4 through QST-7, THR-7/D2 |
+
+```mermaid
+flowchart LR
+  Q0["QST-0<br/>contract"] --> Q1["QST-1<br/>schema"]
+  Q1 --> Q2["QST-2<br/>receipt"]
+  Q2 --> Q3["QST-3<br/>typed deltas"]
+  Q2 --> Q4["QST-4<br/>Signs + tables"]
+  Q3 --> Q4
+  Q2 --> Q5["QST-5<br/>Challenges"]
+  Q3 --> Q5
+  Q2 --> Q6["QST-6<br/>Return"]
+  Q3 --> Q6
+  Q4 --> Q7["QST-7<br/>symbolic acts"]
+  Q5 --> Q7
+  Q6 --> Q7
+  Q4 --> Q8["QST-8<br/>vertical proof"]
+  Q5 --> Q8
+  Q6 --> Q8
+  Q7 --> Q8
+```
+
+## First Vertical Proof
+
+Use one compact authored situation rather than a generated epic:
+
+- a Hearth at a known shared place;
+- a damaged or displaced item that provides a Sign;
+- an exact frontier Lead and anchored Venture;
+- a Challenge between two legitimate uses of a location;
+- at least three concrete methods, including Help and withdrawal;
+- a Discover result that changes a route or installed capacity;
+- a Return that settles the item, relationship, and public memory;
+- one unresolved thread that can become the next Sign.
+
+The proof passes only when:
+
+- the pattern compiles from a worldpack with no bespoke runtime IDs;
+- direct play, terminal play, and provider-offline play produce the same
+  legality and authoritative receipts;
+- each supported branch and retreat path replays across restart;
+- actor, item, and location each serve as a focal node;
+- the Journal renders concrete outcomes without machine vocabulary;
+- AI narration cannot add a route, reward, meaning, or effect;
+- a simple spatial revisit cannot claim quest Return;
+- a second traveler can enter through a different node and still act on the
+  shared result.
+
+## Non-Goals
+
+- A universal story generator.
+- Six mandatory stages or six new UI buttons.
+- A generic graph language that can mutate arbitrary state.
+- Fixed archetypes, a symbol dictionary, personality scoring, or player
+  diagnosis.
+- AI-authored legality or dynamically improvised rewards.
+- Replacing Jobs, clocks, strict-referee primitives, the action hand, the
+  Journal, or the C kernel.
+- Treating every errand, conversation, or revisit as a quest.

--- a/docs/backlog/rest-travel-and-weariness.md
+++ b/docs/backlog/rest-travel-and-weariness.md
@@ -4,8 +4,11 @@
 by place and carried gear, refreshing exhausted cards through the kernel, with
 expedition depth visible as an unlabeled ring rather than a stamina number.
 
-**Status**: Groomed and filed (2026-07-26); delivery is in progress. The linked
-issues are the source of truth for each slice's implementation state.
+**Status**: Groomed and filed (2026-07-26); delivery is in progress. The
+short-rest/Fatigue follow-on (RT-8, RT-9) was groomed 2026-07-29 and the
+prepared-frontier-camp follow-on (RT-10) proposed 2026-07-30; all three were
+folded in from their issues 2026-07-30. RT-0 through RT-7 track live issues;
+RT-8 onward is direction.
 
 **Execution backlog**: epic [#356](https://github.com/cenetex/cosyworld/issues/356).
 
@@ -19,6 +22,9 @@ issues are the source of truth for each slice's implementation state.
 | RT-5 — the expedition ring | [#353](https://github.com/cenetex/cosyworld/issues/353) | P1 |
 | RT-6 — action reachability decision | [#354](https://github.com/cenetex/cosyworld/issues/354), amended by [#529](https://github.com/cenetex/cosyworld/issues/529) | P0 decision, resolved |
 | RT-7 — lodging pays in fiction | [#355](https://github.com/cenetex/cosyworld/issues/355) | P2 |
+| RT-8 — decide three short rests and the Spent hand | [#603](https://github.com/cenetex/cosyworld/issues/603), folded here | P1, direction |
+| RT-9 — implement long-rest epochs and Spent recovery | [#604](https://github.com/cenetex/cosyworld/issues/604), folded here | P1, direction |
+| RT-10 — require a prepared frontier camp | not filed | P1, proposed |
 
 **Related architecture**:
 
@@ -27,10 +33,13 @@ issues are the source of truth for each slice's implementation state.
 - [ADR 0002: the action hand is authoritative state](../decisions/0002-action-hand-is-authoritative-state.md)
 - [ADR 0005: thresholds, trails, and the strict referee](../decisions/0005-thresholds-trails-and-strict-referee.md)
 
-**Related backlog**: [Action Verbs And Economy](action-verbs-and-economy.md).
+**Related backlog**: [Action Verbs And Economy](action-verbs-and-economy.md)
+and [Thresholds, Trails, And The Strict Referee](thresholds-trails-and-strict-referee.md).
 AVE owns the verb lexicon, per-offer cost/risk presentation, and complete legal
-reachability. This backlog owns what rest *does* and where it is legal. Where
-they touch — the cost surface a rest offer renders into, and the Recover
+reachability. THR owns Anchors, Scout forays, cairns, and traversal recovery
+proof, and consumes the Fatigue restrictions decided here rather than inventing
+a second rest system. This backlog owns what rest *does* and where it is legal.
+Where they touch — the cost surface a rest offer renders into, and the Recover
 intention group — AVE is authoritative and RT consumes it.
 
 ## Why now
@@ -365,6 +374,147 @@ collapse same-kind target offers before the redeal cycle.
 
 ---
 
+## RT-8 — Decide Three Short Rests And The Spent Survival Hand
+
+**Priority**: P1 / later / parked (decision before implementation)
+
+**Scope**: Superseding ADR, migration law, player-facing action contract
+
+**Depends on**: original rest ladder decisions; coordinates with THR-0/THR-7
+
+### Candidate rule to decide
+
+- A long-rest epoch grants three short-rest uses.
+- Fatigue has four states: Fresh, Winded, Weary, and Spent.
+- A short rest costs one turn and one use, clears one Fatigue plus transient
+  `tired`, and may refresh one eligible limited resource. Unsafe short rests
+  can trigger pressure; they do not reset the expedition.
+- Camp, Lodged, and Hearth consume a full watch and begin a new epoch, with
+  distinct place/gear costs and refresh contracts. Camp remains in the
+  expedition and can attract frontier pressure; Hearth closes it.
+- At Spent, disallow new outward scouting, searching, studying, working,
+  forcing, and route branching. Preserve the survival hand: retreat to the
+  last secure Anchor, short rest if a use and opportunity remain, Camp, accept
+  aid, defend/flee, or call for rescue.
+- No action may transition the character to Spent unless retreat, Camp, aid,
+  or rescue remains reachable.
+- Cairns are navigation/recovery Anchors and never satisfy shelter.
+
+### Decisions required
+
+- Confirm or replace three uses, four Fatigue states, and one step recovered.
+- Decide whether a short rest refreshes a chosen resource, an archetype-fixed
+  resource, or no resource beyond Fatigue/tags.
+- Map the complete action taxonomy into allowed and disallowed Spent groups.
+- Reconcile and supersede conflicting parts of ADR 0004 and RT-0 without
+  changing historical event meanings.
+- Fix player-facing copy without exposing system words or hidden pressure.
+
+### Acceptance
+
+- One ADR owns the cadence, Spent hand, migration, and exact superseded text.
+- The rule prevents short-rest spam without creating a recovery soft-lock.
+- Cairn, Camp, Lodged, and Hearth have non-overlapping meanings.
+- Every Spent state has at least one understandable legal recovery route.
+
+---
+
+## RT-9 — Implement Long-Rest Epochs And Spent Recovery
+
+**Priority**: P1 / later / blocked
+
+**Scope**: Kernel/rest state, offers, replay, traversal reachability
+
+**Depends on**: RT-2, RT-4, RT-5, RT-8
+
+### What to do
+
+- Persist remaining short rests and long-rest epoch in authoritative state.
+- Apply the accepted Fatigue thresholds, recovery, time costs, rest-grade
+  reset, card refresh, and pressure hooks.
+- At Spent, filter the complete legal surface to the accepted survival hand;
+  do not merely hide actions from the two-card spotlight.
+- Reject an unavailable rest without spending time, a rest use, or any partial
+  mutation.
+- Project remaining capacity and honest disabled reasons without exposing
+  hidden table/pressure state.
+- Preserve snapshots, reconnects, replay, and historical rest records.
+- Extend worldpack reachability validation so an authored route cannot enter
+  Spent with no retreat, Camp, aid, or rescue edge.
+
+### Acceptance
+
+- Exactly the accepted number of short rests succeeds in one epoch; the next
+  is rejected without mutation.
+- A valid long rest resets the epoch and applies its grade-specific effects.
+- Spent exposes the survival hand across browser, terminal, API, and inference
+  controllers.
+- Direct and inferred intents have identical legality and consequences.
+- Golden replay preserves Fatigue, rest count, offered recovery, time, and
+  pressure results.
+- No legal authored traversal can strand the party.
+
+---
+
+## RT-10 — Require A Prepared Frontier Camp
+
+**Priority**: P1 / later / proposed
+
+**Scope**: frontier Camp eligibility, durable site preparation, fixture
+composition, and migration from the gear-only rule
+
+**Depends on**: RT-2, THR-7S; coordinates with RT-8 and RT-9
+
+### Candidate rule to decide
+
+- Hearth and Lodged retain their existing place rights.
+- Frontier Camp requires both:
+  - a durable prepared navigation site such as a cairn, Signal Anchor, or
+    pack-equivalent fixture; and
+  - equipped Shelter capability.
+- An established fire ring is a separate higher development tier. It grants
+  the authored third connection slot and can host a fire, but a ring alone
+  supplies no fuel, light, warmth, or rest grade.
+- A lit fire consumes fuel and may improve a Camp or prevent an authored cold
+  or dark consequence. It is not durable connection capacity.
+- Packs without cairn stone provide a mechanically equivalent installed
+  marker made from suitable local or carried materials. The capacity and rest
+  contract stay the same even when vocabulary changes.
+
+### What to do
+
+- Record whether the prepared-site requirement supersedes the current
+  `frontier + equipped camp_shelter` Camp derivation or is introduced only for
+  newly authored expedition regions. Recommended: supersede it with an
+  explicit compatibility projection for historical saves.
+- Reuse THR-7S construction receipts and fixtures; Rest must not create cairns,
+  fire rings, fuel, or shelter implicitly.
+- Project honest separate disabled reasons: no prepared site, no Shelter,
+  missing required fuel, unsafe pressure, or Spent restriction.
+- Ensure the first outbound leg always has a reachable authored preparation,
+  retreat, lodging, sanctuary, aid, or rescue path before the actor can become
+  unable to continue.
+- Give successful preparation, lighting, extinguishing, and Camp semantic
+  Journal beats without exposing internal capability nouns.
+
+### Acceptance
+
+- Carrying a tent into arbitrary wilderness is no longer sufficient for Camp
+  under the accepted new-content rule.
+- A cairn plus equipped Shelter permits Camp without pretending the cairn is a
+  bed.
+- A fire ring without fuel is durable infrastructure but not a lit fire; a
+  transient campfire without the installed ring does not grant connection
+  capacity.
+- Sanctuary and lodging remain usable without cairns.
+- Direct input, inference, reconnect, replay, and AI-offline fallback derive
+  identical Camp eligibility and disabled reasons.
+- No route can force a tired or Spent actor into an unrecoverable state.
+
+---
+
+---
+
 ## Open questions
 
 - **Ring direction.** Fills (depth travelled) or drains (supplies left)?
@@ -378,3 +528,6 @@ collapse same-kind target offers before the redeal cycle.
   is graded and gear-gated, tiring a player inside sanctuary may strand nothing
   but still feel punitive. Confirm during RT-4 whether Work should tire only on
   the frontier.
+- **Short-rest refresh.** RT-8 must decide whether the limited-resource refresh
+  is player-selected, archetype-fixed, or omitted. Do not bury that product
+  decision in RT-9 implementation.

--- a/docs/backlog/thresholds-trails-and-strict-referee.md
+++ b/docs/backlog/thresholds-trails-and-strict-referee.md
@@ -8,7 +8,9 @@ Discovery authority v1 is specified by
 [`discovery-authority-v1.schema.json`](../../v2/schemas/discovery-authority-v1.schema.json);
 the shared Lead/Gate/Hazard/Pressure contract is specified by
 [`threshold-descriptors-v1.schema.json`](../../v2/schemas/threshold-descriptors-v1.schema.json).
-Player procedures and runtime enforcement remain dependency-ordered below.
+Player procedures and runtime enforcement remain dependency-ordered below, and
+the unshipped slices carry their scope and acceptance in
+[Open slice detail](#open-slice-detail).
 
 ## Shared model
 
@@ -94,6 +96,690 @@ New work uses append-only procedure and descriptor versions. A migration may
 project old state into the new inspector, but must not reroll hidden truth,
 re-award a claim, add a consequence, change topology, or newly authorize
 access. The complete field-by-field inventory is normative in ADR 0005.
+
+## Open slice detail
+
+The delivery table above is the index; ADR 0005 is the normative contract.
+The sections below carry the per-slice scope and acceptance for the slices
+that have not shipped, folded in from their issues on 2026-07-30 so the
+criteria survive outside the issue tracker. THR-7G, THR-7C, THR-7S, and
+THR-7L are proposed extensions with no filed issue.
+
+---
+
+## THR-6 — Add Bounded Pressure Scenes For Layered Obstacles
+
+**Priority**: P1 / later / blocked
+
+**Scope**: Persistent scene state, progress/danger clocks, concurrency
+
+**Depends on**: THR-2, THR-4, THR-D0
+
+### What to do
+
+- Add a bounded Pressure scene that can represent:
+  - a pursuer closing during a chase;
+  - a patrol arriving while a lock is opened;
+  - weather erasing a track;
+  - rising water, spreading fire, or a collapsing passage.
+- Reuse authoritative progress and danger clocks. Name clocks for the obstacle
+  or impending truth, not for one prescribed method.
+- Keep simple obstacles outside Pressure. Authoring a scene requires at least
+  two meaningful beats, strategies with different tradeoffs, and a terminal
+  consequence.
+- Define participants, controller eligibility, target conflicts, turn order,
+  joining/leaving, and stale-offer behavior under the scene concurrency policy.
+- Give each strategy explicit position/risk, effect, cost, and clock movement.
+  `Hurry`, `Proceed carefully`, `Investigate`, `Help`, `Mark the way`, and
+  `Withdraw` are pack vocabulary over certified operations, not free-form AI
+  choices.
+- Separate soft and hard consequences. A soft consequence exposes an
+  approaching threat or cost and creates a response window. A hard consequence
+  applies only when committed resolution, an ignored warning, or a filled
+  danger clock authorizes it.
+- Define terminal results for progress first, danger first, simultaneous fill,
+  voluntary withdrawal, loss of all participants, and snapshot recovery.
+- Advance scenes only through relevant committed turns; never through wall
+  time or unrelated room actions.
+- On an authored trigger, select a versioned contextual event row. The common
+  OSR-shaped categories are `Encounter`, `Sign`, `Environment`, `Loss`,
+  `Exhaustion`, and `Discovery`; worldpacks may weight or replace them within
+  the closed result vocabulary.
+- Event rolls happen after committed time/noise, entering a new zone, hurrying,
+  unsafe rest, or another authored trigger. They are not stocking rolls and
+  cannot mint unauthorized topology, loot, or actors.
+- If a `Sign` or `Discovery` row advances hidden truth, it must name an
+  existing compatible Discovery Slot or a bounded typed follow-up table.
+- Record table/version/inputs/seed/row and effects for replay. An authored
+  quiet interval is a real safe interval or opportunity, never a null result.
+
+### Acceptance
+
+- One scene schema expresses a chase, patrol-vs-lock, and fading-track example.
+- Every strategy changes progress, danger, information, position, resources,
+  or scene status.
+- The same scene never both completes and silently discards its filled danger
+  consequence; simultaneous fill has an authored result.
+- Co-present actors cannot double-apply one scene beat through concurrent
+  submissions.
+- Leaving, reconnecting, restoring a snapshot, or handing control between
+  direct input and inference does not lose or duplicate scene state.
+- Sanctuary and unrelated players cannot advance a frontier Pressure scene.
+
+---
+
+## THR-D2 — Materialize Bounded Item And Location Discoveries
+
+**Priority**: P1 / later / blocked
+
+**Scope**: Worldpack stocking tables and bounded runtime materialization
+
+**Depends on**: THR-3, THR-D0, THR-D1
+
+### What to do
+
+- Author discovery sources for containers, room features, wilderness
+  discoveries, hidden caches, resolved encounters, resource sites, and Hazard
+  aftermaths.
+- A location Slot declares its parent route/region, allowed point-of-interest
+  kinds, maximum topology and directionality, biome/terrain, danger band,
+  entrance/return rules, required/optional status, Sign budget, and referenced
+  encounter/loot tables.
+- An item Slot declares quantity, placement/reveal policy, tell, uniqueness,
+  fallback, capacity implications, claim state, and provenance.
+- Freeze the selection before materialization; the result may remain hidden
+  until the discovery procedure reveals it.
+- Instantiate a bounded dungeon's hidden graph once and reveal it
+  incrementally. Event rows may choose a compatible typed follow-up but may
+  not exceed the Slot.
+- Keep Open/Take/Travel as separate access and movement operations after
+  Reveal.
+
+### Acceptance
+
+- One hidden item and one ruin share receipt, claim, reveal, and replay code.
+- The table cannot exceed an authored quantity or topology bound.
+- Required content has a finite completion proof; optional content may be
+  explicitly missable.
+- Core and Project 89 provide mechanically identical examples with distinct
+  presentation vocabulary.
+- AI may name and describe the selected result but cannot choose or materialize
+  it.
+
+---
+
+## THR-7 — Make Frontier Scouting Pursue Perishable Leads
+
+**Priority**: P1 / later / blocked (distinctive exploration payoff)
+
+**Scope**: Scout/Travel contract, route legibility, connection capacity,
+cairns, and lost-track recovery
+
+**Depends on**: THR-1 through THR-3, THR-D0 through THR-D1
+
+**First proof**: the frozen Bethlehem–Jerusalem pathway with one substantial
+midpoint location
+
+### What to do
+
+- Freeze the full bounded route and all destination identities once. Generated
+  pathway allocation remains the live authoritative procedure; replay stores
+  its inputs, seed, topology, identity allocations, and content version.
+- Replace new-content Scout's current “reveal without moving” meaning with
+  pursuit of one exact geographically valid Lead:
+  - while the Lead is legible, Scout is offered once and cannot be farmed;
+  - completing it enters the already allocated destination;
+  - a lost Lead may be reacquired by Scouting toward that same destination;
+  - reacquisition never chooses a different waypoint or rerolls its content.
+- Keep historical Scout events replay-readable under their legacy meaning.
+- Make Travel movement over a durable known accessible connection. Moving over
+  a perishable trail, including returning from a newly scouted place, remains
+  Scout toward a known place and may expose a named lost-track consequence.
+- Give every substantial connectable location a bounded
+  `connection_capacity` and count unique neighbors rather than reciprocal exit
+  records:
+  - **Scouted — 1**: the perishable return Lead occupies the only slot;
+  - **Cairn / Signal Anchor — 2**: the return becomes durable and a forward
+    or branch slot becomes available;
+  - **Established fire ring / field station — 3**: a third connection becomes
+    available;
+  - later settlement tiers may grant more only through authored data.
+- Reserve capacity at both endpoints before exposing a Lead. A failed
+  reservation creates no half-edge, dangling return, or duplicate exit.
+- Treat a capacity tier as location development, not a number derived from
+  how many directed exit rows happen to exist. Tiers upgrade monotonically;
+  constructing a fire ring cannot skip the cairn/Anchor tier.
+- Let `Build a cairn` install a fixture in the already scouted location,
+  promote only the traversed return connection to durable Travel, and grant
+  the second connection slot. Do not create a second “cairn location.”
+- Once marked, present the same stable waypoint as an authored ordinary
+  location. A pack may name it “Bethlehem–Jerusalem Trail Cairn,” but its
+  identity does not change when its art, name, description, or fixture state
+  arrives.
+- Define bounded lost-track outcomes such as delay plus Fatigue, retreat to
+  the departure Anchor, resource loss, or displacement to an authored adjacent
+  node. Loss always changes state and never creates arbitrary topology.
+- Keep route familiarity and place settlement as separate later cooperative
+  progress. Capacity and a cairn do not make a place familiar, settled,
+  sheltered, or sanctuary.
+- Give first entry, loss, reacquisition, cairn construction, and durable
+  traversal semantic Journal beats.
+
+### Acceptance
+
+- A traveler Scouts once from Bethlehem toward a frozen midpoint and enters
+  it. Repeating Scout cannot produce another midpoint.
+- Before construction, the midpoint has one occupied connection slot and its
+  return is a fallible Scout toward Bethlehem, not ordinary Travel.
+- Building its cairn consumes no new topology, makes the Bethlehem return
+  durable, and grants exactly one free slot for the next Lead.
+- After the Jerusalem Lead is discovered, the cairned midpoint has exactly two
+  unique neighbors; each reciprocal exit pair counts once.
+- A scouted one-slot location cannot accept another Lead. Rejection is
+  mutation-free and explains which endpoint lacks capacity.
+- A lost Lead leaves canonical topology, route ownership, waypoint identity,
+  generated media identity, and allocation receipt unchanged.
+- Reacquisition targets the same place, and a mapped route uses ordinary
+  Travel without replaying discovery.
+- A cairn never reveals the route ahead, settles the location, supplies
+  shelter, lights a fire, or changes sanctuary state.
+- Holy Land cairn and Project 89 Signal Anchor vocabulary preserve the same
+  capacity, target, construction cost, effects, and persistence.
+- Direct input, inference, reconnect, snapshot restore, and replay expose the
+  same capacity and route state.
+
+---
+
+## THR-7G — Make Place Knowledge Travel As Gossip
+
+**Priority**: P1 / later / proposed
+
+**Scope**: actor-scoped place knowledge, truthful rumors, Sign discovery, and
+conversation transfer
+
+**Depends on**: THR-7; integrates with the shared conversation and Journal
+contracts
+
+### What to do
+
+- Represent canonical place existence, actor knowledge of the place, and route
+  knowledge as separate facts.
+- Record actor-scoped knowledge at least as:
+  - target place identity;
+  - `signed`, `rumored`, or `visited` state;
+  - source event and, when applicable, the actor who told it;
+  - a source Anchor, region, direction, or other authored geographic context;
+  - confidence/provenance for presentation, not for rerolling truth.
+- On first entry, grant `visited` knowledge to participating witnesses.
+  Building a cairn changes route state; it does not broadcast omniscience.
+- Let authored dialogue and explicit actions such as `Ask`, `Tell`, or
+  `Share directions` transfer eligible knowledge. Do not infer that every
+  co-present avatar automatically exchanges every known location.
+- Offer Scout toward a rumored place only where the rumor's geographic context
+  and an available connection slot make it actionable.
+- Let broad frontier investigation find a truthful bounded Sign selected from
+  already allocated compatible destinations. The random result is which Sign
+  becomes available, never whether the destination is recreated.
+- Give required destinations a deterministic or finite-budget Sign path.
+  Optional rumors may remain missable.
+- Start with truthful but incomplete rumors. False destinations, deliberate
+  lies, confidence decay, and contested testimony are later social-system
+  work, not part of the first gossip slice.
+
+### Acceptance
+
+- Two avatars in the same world may legitimately have different maps and
+  Scout offers without disagreeing about canonical topology.
+- Visiting a hidden cottage teaches its identity to the visitor but does not
+  reveal it globally.
+- Telling another avatar about the cottage creates a replayable rumor with
+  provenance; the listener still needs a geographically valid Lead.
+- Hearing of Jerusalem in one region does not permit Scouting toward it from
+  every wilderness location.
+- Repeated frontier investigation cannot mint a second cottage or replace its
+  frozen route.
+- AI may phrase a rumor but cannot select its target, origin context, truth
+  status, or recipients.
+
+---
+
+## THR-7C — Let Cairns Fall, Be Rebuilt, And Be Rumoured
+
+**Priority**: P2 / later / proposed
+
+**Scope**: cairn condition state, rebuild contribution, belief publication
+
+**Depends on**: THR-7, THR-7G; place-establishment method resolution
+([#471](https://github.com/cenetex/cosyworld/issues/471))
+
+Folded from [#472](https://github.com/cenetex/cosyworld/issues/472) and
+[#473](https://github.com/cenetex/cosyworld/issues/473), 2026-07-30.
+
+### Maintenance, not monument
+
+A cairn can fall and be rebuilt without the place it anchors ever becoming less
+real. That is the difference between a monument system and a maintenance
+system, and it should be chosen deliberately. **The proposal is maintenance:**
+stones scatter, the road stops being guided, and someone who comes later can
+set them back up.
+
+**The invariant this must not break.** Anchoring is a ratchet. A fallen cairn
+changes what the place *communicates*, never whether it *exists*.
+
+- The place stays anchored. Its location, exits, clocks, and jobs are
+  untouched.
+- Forgetting cannot close or recreate a route; Anchored is a derived view over
+  durable facts, not an independently mutable stage.
+- No cairn state may delete a location, exit, or route. Location deletion is
+  the one direction that breaks journal replay, and nothing here should reach
+  it.
+
+**Cause, not timer.** A cairn falls because of represented play, never because
+a background tick elapsed.
+
+- Falling is driven by a relevant danger clock filling — for example The Road
+  Goes Fully Dark taking the Mothwood road — not by a decay interval.
+- Sanctuary cairns never fall. Sanctuary cannot receive offscreen danger or
+  irreversible loss from background simulation.
+- The fall is journaled as a world event naming the clock that caused it, so a
+  returning player can read why.
+
+**Rebuilding.**
+
+- Rebuilding is a normal contribution action available to any actor, not only
+  the original builder.
+- The rebuilt cairn retains the original builder's provenance and reason and
+  adds the rebuilder's. **A cairn accumulates its keepers rather than
+  overwriting them.**
+- Rebuilding is claim-keyed so a repeated submission cannot double-credit.
+
+### Rumoured and rediscovered
+
+A cairn can be rumoured, half-remembered, and gone looking for — without the
+world ever forgetting that it is there. This costs almost nothing new: the
+separation already exists and is already tested by
+`discovered_routes_survive_memory_decay_for_later_actors_and_replay`
+(`topology.rs:2017`), which establishes that world facts are durable while
+beliefs decay. Cairns publish into that same belief substrate rather than
+inventing a second forgetting rule.
+
+`BELIEF_TUNING` already distinguishes firsthand from secondhand and has an
+action floor:
+
+| Belief | Behaviour |
+| --- | --- |
+| "I raised this cairn" / "I stood at it" | firsthand confidence and salience; durable |
+| "Someone said there is a cairn past the barrow" | gossip decay rates; can fall below `minimum_action_confidence` |
+
+Belief storage is `capacity` bounded, so cairn beliefs are evictable like any
+other. The result is a rumoured cairn: residents stop acting on it, a player
+hears it mentioned without knowing where, and going to look becomes a real
+errand. The cairn itself never moves and is never destroyed.
+
+**What must not happen.** Belief decay must never affect whether the cairn, its
+place, or its routes exist — knowledge is never topology authority. A decayed
+belief must not re-close a discovered route or re-hide a discovered exit.
+Replay must reproduce identical beliefs and identical world facts,
+independently.
+
+Publish cairn existence and provenance on the same path as other firsthand and
+secondhand knowledge, and use the unified belief storage rather than a parallel
+cairn-belief store.
+
+### Acceptance
+
+- A cairn has a legible standing/fallen condition in the room projection.
+- Only a named clock outcome can fell a cairn; no elapsed-time path exists.
+- A cairn in a sanctuary zone cannot fall.
+- Felling a cairn leaves the place anchored, and its location, exits, routes,
+  clocks, and jobs unchanged.
+- Rebuilding preserves original provenance and appends the rebuilder, and is
+  idempotent under a claim key.
+- Replay of a fall-and-rebuild sequence reproduces identical state and
+  identical accumulated provenance.
+- Raising or visiting a cairn records a firsthand belief; hearing of one
+  records a secondhand belief with gossip decay.
+- A fully decayed or evicted cairn belief leaves the cairn, its place, and its
+  routes unchanged.
+- A rediscovered cairn restores firsthand confidence without creating a
+  duplicate world fact.
+- Residents do not assert a cairn below `minimum_action_confidence`.
+
+---
+
+## THR-7S — Make Field Supplies And Infrastructure Physical
+
+**Priority**: P1 / later / proposed
+
+**Scope**: wilderness gathering, carried expedition capabilities, installed
+route/camp fixtures, and construction authority
+
+**Depends on**: THR-7, RT-2; coordinates with crafting and natural affordances
+
+### What to do
+
+- Add a small physical expedition capability vocabulary before adding
+  continuous survival meters:
+  - **Waymark** — material and tools for route infrastructure;
+  - **Shelter** — equipment that can satisfy the existing Camp gear gate;
+  - **Light** — carried charges/fuel for authored dark beats;
+  - **Water** — carried charges for authored dry/deep beats.
+- Use existing item weight, size, charge, container, and zone rules so carrying
+  stone, water, fuel, or loot creates an understandable choice.
+- Let free Scene Notice expose obvious material facts. Focused Notice or Search
+  resolves a bounded gathering opportunity such as loose cairn stone, dry
+  sticks, clean water, or usable salvage.
+- Make gathering eligibility biome- and feature-authored. Not every biome
+  supplies stone, fuel, clean water, or suitable marker material.
+- Materialize a finite physical bundle or resource-site charge. After
+  construction exhausts the opportunity, stop offering Gather; do not erase
+  the location's geology or imply all stones vanished.
+- Unify generated-place `Work` and physical crafting behind one authoritative
+  construction receipt. Building a cairn cannot be both free progress and an
+  item-consuming recipe.
+- Treat the established fire ring as the persistent capacity-three fixture.
+  Lighting it is a separate action that consumes compatible fuel and creates
+  transient light/warmth/pressure state.
+- Keep the rest contract compositional: a prepared site or cairn may be
+  required for frontier Camp, but the site still needs equipped Shelter, and a
+  fire ring still needs fuel where authored. Sanctuary and lodging retain
+  their existing rest rights.
+- Consume Light and Water only on declared exploration beats such as entering
+  a dark zone, completing a watch, or crossing a dry depth. Never drain them
+  by wall time.
+
+### Acceptance
+
+- A stony wilderness location can reveal and yield a heavy cairn-stone bundle;
+  an incompatible biome cannot.
+- Installing the bundle creates one persistent cairn fixture, exhausts the
+  relevant opportunity, and cannot also complete through a free parallel
+  Work path.
+- The same bundle cannot be installed twice after retry, reconnect, or replay.
+- An established fire ring grants the authored third connection slot while
+  an ordinary lit campfire does not.
+- A fire ring cannot be installed as a shortcut around the cairn/Anchor tier.
+- An unlit fire ring provides no free light, warmth, or fuel.
+- Cairn, shelter, fire ring, lit fire, lodging, and sanctuary remain distinct
+  facts with distinct offers.
+- Exhausting Light or Water changes an authored consequence or blocks a named
+  method; it never silently ticks down while the player is away.
+
+---
+
+## THR-7L — Explore Bounded Labyrinths Through The Same Procedure
+
+**Priority**: P1 / later / proposed
+
+**Scope**: dungeon graph allocation, incremental reveal, doors, chests,
+darkness, supplies, and presentation templates
+
+**Depends on**: THR-2, THR-5 through THR-7, THR-D2
+
+### What to do
+
+- Treat a labyrinth as a bounded hidden graph allocated once:
+  - entrance and substantial rooms are Locations;
+  - unexplored passages are Leads;
+  - doors and seals are Gates;
+  - traps are Hazards;
+  - chests and room contents are Discovery Slots;
+  - darkness, pursuit, flooding, or collapse are Pressure.
+- Freeze room count, adjacency, return rules, required route, optional branches,
+  contents, hazards, and receipts before the first reveal. AI may not extend
+  the graph because the party kept walking.
+- Use hallway, doorway, chamber, and chest templates as presentation inputs to
+  the image workshop. Generated text and images decorate certified room state;
+  they do not create exits, contents, or mechanics.
+- Apply location connection capacity to substantial branching rooms and
+  entrances, not to every decorative corridor segment. A hallway template may
+  be part of an edge rather than a development node.
+- Let the same Scout-toward-a-place procedure reveal and enter the next
+  chamber. Use setting-appropriate return fixtures—chalk marks, rope, lamps,
+  sconces, cairns, signal repeaters—through the same Waymark capability.
+- Bind Light, Water, Shelter, and other supplies only where the authored
+  labyrinth declares relevant beats and consequences.
+- First prove one deterministic five-room dark labyrinth with one locked door,
+  one telegraphed Hazard, one chest, one optional branch, one return mark, and
+  one finite light budget.
+
+### Acceptance
+
+- The five-room graph, door, Hazard, chest result, and optional branch are
+  identical after replay and cannot grow beyond their authored bounds.
+- Scouting a known chamber twice cannot replace it or reroll its contents.
+- Losing the return trail changes expedition state without deleting rooms.
+- Door, chest, trap, route, and darkness use the shared descriptor and supply
+  rules rather than labyrinth-only handlers.
+- Running out of Light has an authored stateful consequence and preserves a
+  retreat, aid, or rescue path.
+- The browser can render each certified chamber through an image-workshop
+  template while remaining fully playable with AI disabled.
+
+---
+
+## THR-8 — Give AI A Fail-Closed Referee Presentation Packet
+
+**Priority**: P1 / later / blocked
+
+**Scope**: AI context, narration gate, deterministic fallback, audit trace
+
+**Depends on**: THR-4 through THR-7, THR-7G, THR-D0 through THR-D2
+
+### What to do
+
+- Build one versioned scene packet containing:
+  - perceivable sensory truth;
+  - hidden truth excluded from player output;
+  - certified targets and methods;
+  - visible requirements and disabled reasons;
+  - named costs and consequences;
+  - current Lead, Gate, Hazard, and Pressure presentation state;
+  - player-visible Discovery Slot state and committed receipt result, excluding
+    seeds, unused rows, latent identities, and hidden topology;
+  - the exact committed outcome when narrating resolution; and
+  - allowed nouns, voice anchors, and pack vocabulary.
+- Separate situation narration from outcome narration. The former cannot imply
+  an uncommitted result; the latter cannot contradict committed events.
+- Let AI choose wording only. If free-form player input is supported later, AI
+  may propose a mapping to an existing certified method but cannot submit or
+  mutate it without the ordinary confirmation and stale-offer checks.
+- Compile a bounded referee move vocabulary for presentation:
+  show a sign, warn of an approaching threat, state a requirement, offer a
+  certified opportunity with its cost, or narrate an authorized consequence.
+  The resolver chooses the legal move and facts; the model realizes them.
+- Reject narration that invents an exit, item, route, trap, affected actor,
+  requirement, consequence, reward, historical fact, table row, or mechanical
+  state.
+- Preserve deterministic authored fallback prose for model absence, timeout,
+  invalid output, moderation rejection, and failed grounding.
+- Store prompt version, input fact hashes, provider/model attribution,
+  validation outcome, and published event references without storing secrets.
+
+### Acceptance
+
+- Turning AI off leaves every threshold and frontier procedure mechanically
+  complete and understandable.
+- An ungrounded narration cannot create or imply a legal method or state
+  transition that the action surface does not contain.
+- Hidden mechanism and topology facts do not leak before their reveal evidence.
+- Notice, Search, Study, and Scout narration cannot imply a discovery outside
+  the selected Slot or committed receipt.
+- Model failure publishes deterministic prose and never rolls back a committed
+  action.
+- Direct-input and inference-controlled actors receive identical rules; only
+  controller selection and prose source differ.
+- Audit tooling can explain which facts authorized every published sentence
+  and committed consequence.
+
+---
+
+## THR-9 — Add Worldpack Validation And Threshold Inspection
+
+**Priority**: P1 / later / blocked
+
+**Scope**: Compiler checks, fixtures, developer inspector, author guidance
+
+**Depends on**: THR-1, THR-3, THR-5, THR-7, THR-7G, THR-7S, THR-7L,
+THR-D0, THR-D2; coordinates with RT-9 and RT-10
+
+### What to do
+
+- Add schema and semantic validation for all descriptors, Discovery Slots,
+  table/version references, methods, predicates, effects, scope, transitions,
+  tells, finite budgets, fallbacks, and recovery references.
+- Extend reachability checks with gate transitions and unique-key custody
+  states from THR-3.
+- Reject:
+  - Hazards with no tell;
+  - rolls with no named consequence;
+  - methods with no state change;
+  - Pressure scenes with no terminal result;
+  - actor-scoped gates presented as world-open transitions;
+  - critical unique keys with no recovery;
+  - required discoveries with no finite completion/fallback;
+  - table rows incompatible with a Slot or exceeding its topology;
+  - Leads whose endpoints lack compatible connection capacity;
+  - reciprocal exits that are double-counted as two unique neighbors;
+  - rumors with no stable target or geographic source context;
+  - cairns or anchors that create topology;
+  - a fire-ring tier that skips its required Anchor tier;
+  - construction paths that can install the same fixture without its physical
+    material receipt;
+  - bounded labyrinths with unbounded expansion or no reachable return,
+    retreat, aid, or rescue;
+  - generated prose bound to an authoritative descriptor.
+- Add a developer-only inspector that shows:
+  - canonical topology;
+  - player-visible Lead state by scope;
+  - current Gate predicates and satisfied evidence;
+  - hidden and revealed Hazard facts;
+  - Pressure participants, strategies, clocks, and terminal rules;
+  - key lifecycle and recovery path;
+  - Discovery Slot, claim, receipt, materialized IDs, Anchor, connection
+    capacity/reservations, perishable return Lead, and actor-scoped rumor
+    provenance;
+  - construction materials, installed fixture tier, fire/fuel state, and
+    (when RT-9/RT-10 land) Fatigue/rest capacity;
+  - descriptor versions and source pack.
+- Clearly separate “player currently perceives” from “authoritative hidden
+  truth.” Raw details never appear in the production Journal.
+- Publish author examples for a mundane door, holder-only seal, trapped chest,
+  installed relic gate, fading trail, geographic rumor, capacity-tiered
+  location, prepared camp, bounded labyrinth, and simple chase.
+- Add a content-ratio report showing which keys, gates, Hazards, and Leads have
+  reachable uses and recovery.
+
+### Acceptance
+
+- A content author can diagnose why a method is disabled and why a route would
+  deadlock without reading Rust or C.
+- The compiler fails closed with actionable messages for every rejected case
+  above.
+- Inspector state agrees with kernel offers and journal evidence after item
+  movement, gate transitions, hazard triggers, Lead promotion/loss, and table
+  claims.
+- Replaying a receipt explains why one result was chosen and proves that it
+  cannot be rerolled.
+- Production player surfaces cannot expose hidden truth or developer nouns
+  through inspector APIs.
+- Core and one official expansion compile with representative fixtures before
+  broader content migration begins.
+
+---
+
+## THR-10 — Prove Discovery, Thresholds, And Traversal End To End
+
+**Priority**: P1 / later / blocked (release proof for the substrate)
+
+**Scope**: Core/Holy Land content, browser, terminal, inference parity, replay
+
+**Depends on**: THR-2 through THR-9, THR-D0 through THR-D2,
+THR-7G/THR-7S/THR-7L, RT-8 through RT-10
+
+### What to do
+
+Ship five deliberately different examples using no bespoke resolver. The
+Bethlehem–Jerusalem route-capacity proof in THR-7 lands earlier; this ticket is
+the broader release proof.
+
+1. **Mundane door**
+   - obvious material and signs beyond it;
+   - exact retained key;
+   - quiet tool method with time;
+   - force method with noise and inability to relock;
+   - reciprocal return and visible disabled reasons.
+2. **Trapped chest and hidden item**
+   - sensory tell;
+   - exact key bypass;
+   - Search/Study reveal path;
+   - tool method that risks the named Hazard;
+   - force method with a different cost;
+   - a frozen item-table receipt and no reroll on repeat;
+   - Reveal, Open, Take, and capacity as separate transitions;
+   - opened, disarmed, triggered, and spent replay states.
+3. **Frontier trail and bounded location**
+   - begin from an Anchor with a truthful geographically bounded rumor;
+   - Scout once toward an exact frozen midpoint and enter it;
+   - one-slot scouted state with a fallible Scout return;
+   - fading-track Pressure scene;
+   - careful, hurry, investigate, reacquire, and withdraw strategies;
+   - one contextual event receipt and one bounded location-table receipt;
+   - physical cairn construction that makes the return durable and grants a
+     second connection slot without becoming shelter;
+   - discovery of the second neighbor only after capacity exists;
+   - established fire ring granting a third slot separately from lit fuel;
+   - lost-track recovery without topology loss;
+   - actor-scoped visit and gossip transfer; and
+   - later ordinary Travel on the mapped return route.
+4. **Bounded labyrinth**
+   - one frozen five-room dark graph;
+   - incremental chamber reveal through Scout;
+   - one door, one chest, one telegraphed Hazard, and one optional branch;
+   - a finite Light capability and a marked return;
+   - image-workshop room presentation with deterministic fallback.
+5. **Fatigue and rest**
+   - accrue Fatigue through the foray;
+   - spend the accepted number of short rests;
+   - expose the Spent survival hand; and
+   - prove retreat or Camp reaches recovery.
+
+- Exercise all examples through browser buttons, terminal commands, API
+  envelopes, and one inference-controlled avatar.
+- Cover action-hand reachability, stale offers, concurrent attempts, reconnect,
+  snapshot restore, journal replay, model-disabled fallback, and pack-version
+  migration.
+- Render semantic Journal beats for discovery, warning, chosen method,
+  consequence, gate transition, lost/recovered Lead, and durable mark.
+- Add golden state and transcript fixtures with no raw internal type, predicate,
+  descriptor, clock fraction, or claim-key vocabulary.
+
+### Acceptance
+
+- The five examples share descriptor evaluation, action projection, journal
+  evidence, and referee presentation code; content labels and target facts are
+  their meaningful differences.
+- No example can enter an unchanged retry loop.
+- The door, chest, item, trail, and labyrinth remain fully playable without
+  AI.
+- Item and location selections freeze once and replay identically.
+- A one-slot scouted place cannot grow forward until development supplies
+  another connection slot.
+- Gossip changes actor knowledge without changing topology or globally
+  revealing the route.
+- Physical cairn, shelter, fire-ring, fuel, Light, and Water facts do not
+  collapse into one generic prepared flag.
+- Fatigue can restrict outward actions but never removes the recovery hand.
+- Losing the frontier trail is consequential and recoverable; it does not
+  delete or reroll the route.
+- Direct and inference controllers produce identical legal surfaces and
+  mechanical results from identical state.
+- Golden replay from before each interaction reconstructs the same final
+  topology, access, item, Hazard, Lead, Pressure, and Journal state.
+- The worldpack checker proves key recovery and route/recovery reachability for
+  all five examples.
+
+---
 
 ## Definition of ready for downstream issues
 

--- a/docs/backlog/world-topology-and-composition-joins.md
+++ b/docs/backlog/world-topology-and-composition-joins.md
@@ -1,0 +1,687 @@
+# World Topology And Composition Joins — Backlog
+
+**Epic**: Give composition data a way to attach one pack's geography to
+another's, so every mounted room belongs to one walkable world and a campaign
+ending can open a road instead of terminating.
+
+**Status**: Groomed 2026-07-26 and 2026-07-27. This document was cited as
+`docs/backlog/world-topology-and-composition-joins.md` by the WT tickets from
+the day they were filed but was never actually written; it is reconstructed
+here from those issues and their playtest evidence, 2026-07-30. Direction, not
+committed scope.
+
+**Prior execution backlog**: epics
+[#371](https://github.com/cenetex/cosyworld/issues/371),
+[#289](https://github.com/cenetex/cosyworld/issues/289),
+[#339](https://github.com/cenetex/cosyworld/issues/339) and children
+[#372](https://github.com/cenetex/cosyworld/issues/372)–[#379](https://github.com/cenetex/cosyworld/issues/379),
+[#336](https://github.com/cenetex/cosyworld/issues/336), closed into this
+document.
+
+| Ticket | Prior issue | Priority |
+| --- | --- | --- |
+| WT-0 — `routes` in `world.json`, compiled to `exits.json` | [#372](https://github.com/cenetex/cosyworld/issues/372) | P1, foundation |
+| WT-1 — pack gateways; routes restricted to them | [#373](https://github.com/cenetex/cosyworld/issues/373) | P1 |
+| WT-2 — `open` / `gated` / `earned` access | [#374](https://github.com/cenetex/cosyworld/issues/374) | P1 |
+| WT-3 — reachability, sink, and seam-target gates | [#377](https://github.com/cenetex/cosyworld/issues/377) | P1, lands last |
+| WT-4 — join the Lantern Keeper; pay the win with a road | [#376](https://github.com/cenetex/cosyworld/issues/376) | P1 |
+| WT-5 — give Dark Abyss a way out | [#375](https://github.com/cenetex/cosyworld/issues/375) | P1 |
+| WT-6 — know your own doorstep at spawn | [#378](https://github.com/cenetex/cosyworld/issues/378) | P2, independent |
+| WT-7 — weight Scout by distance and open seams | [#379](https://github.com/cenetex/cosyworld/issues/379) | P2, independent |
+| WT-8 — pack-native generated descendants | [#339](https://github.com/cenetex/cosyworld/issues/339) | P2 |
+| WT-9 — Holy Land as a regional pilgrimage mesh | [#336](https://github.com/cenetex/cosyworld/issues/336) | P2, reference fixture |
+
+**Still an open issue**: [#337](https://github.com/cenetex/cosyworld/issues/337)
+— declare generation and topology policy in worldpack manifests. It is
+`state:ready` and stays in the live queue; WT-8 and WT-9 consume it.
+
+**Related architecture**:
+
+- [The CosyWorld Pact](../cosyworld-pact.md) — "One World, One Truth" and
+  "Home Holds" constrain what a join may do.
+- [How to Design a Worldpack](../worldpacks/how-to-design-a-worldpack.md)
+- [Thresholds, Trails, And The Strict Referee](thresholds-trails-and-strict-referee.md)
+  — owns Leads, Gates, Anchors, and Scout forays over this topology.
+- `CLAUDE.md`: *"Cross-pack topology belongs in composition data rather than
+  either reusable pack."*
+
+---
+
+## Why now
+
+### The missing primitive
+
+`worlds/official/world.json` selects packs and names one `entry_location`. It
+**cannot express an edge between two packs**. Intra-pack exits are authored by
+the pack owning both endpoints, which is correct — and it means a campaign pack
+can only ever be an island unless some pack reaches into another's interior,
+which the contributor guide forbids.
+
+The seam is named in `CLAUDE.md` and absent from the schema.
+
+### Measured state
+
+Against `v2/content/official/` at `0.0.196` — 48 locations across 4 packs, 110
+authored exits:
+
+| | |
+| --- | --- |
+| Reachable from `entry_location` | 42 of 48 |
+| Unreachable | `800`–`804` (all of `cosyworld.campaign.the-lantern-keeper`), `65` Dark Abyss |
+| Sinks | `65` Dark Abyss |
+
+`ruby-high.first-bell` and `cosyworld.the-holy-land` are correctly wired. The
+Lantern Keeper is the only disconnected component. Both defects shipped to
+production and were found by walking the world by hand.
+
+The live `/world` projection is knowledge-filtered — an actor sees 15 of the 42
+reachable rooms — so **undiscovered is not unreachable**, and topology must
+never be diagnosed from that projection.
+
+### Not the Cottage
+
+Rejected: The Cosy Cottage as the nexus every region hangs off.
+
+Sanctuary law says home never takes danger or offscreen pressure, and "your
+home is exactly as you left it" is a weaker promise when home is also the
+transit hall. A star graph is also a level-select screen wearing a room —
+distance stops meaning anything and every new pack edits the same room.
+
+Core already has a real map. Regions attach at different nodes of the existing
+ring.
+
+---
+
+## The four-layer model
+
+Topology, legibility, and knowledge are separate state. Keep four independent
+layers; this is the contract the shipped route work (#316, #317, #318) already
+established and everything below preserves.
+
+1. **Authored anchor graph** — locations, cards, ecology, entry points, and
+   editorially reviewed places.
+2. **Canonical weighted routes** — stable directional edge records, distances,
+   ownership, lifecycle, traffic, and ecology transition. Durable shared state.
+3. **Generated descendants** — waypoint chains and place prose/media that
+   subdivide an authorized route edge, inheriting explicit pack provenance and
+   policy. They never invent graph authority.
+4. **Actor knowledge** — fog, Leads, and memory. **Never topology authority.**
+
+Corollaries:
+
+- Journeys progress against canonical route IDs and versions.
+- Kernel exits are projections of canonical route records.
+- Unknown meaningful stretches offer Scout; known open stretches offer Travel.
+- Forgetting cannot close or recreate a route.
+- Traffic and descriptive evolution never reallocate route identity.
+
+---
+
+## Principles (acceptance gate for every ticket)
+
+1. Cross-pack topology lives in composition data. A reusable pack never reaches
+   into another pack's interior.
+2. A composition route may attach only at a **declared gateway**.
+3. Access kinds come from a closed vocabulary: `open`, `gated`, `earned`.
+4. An opened `earned` seam is **world state, not per-actor state**. Once opened
+   it is open for everyone, consistent with Scout revealing shared geography.
+5. Seam openings are journaled and replayable. A replayed journal reopens the
+   seam at the same point in history. No snapshot is required to know a road is
+   open, and no client-supplied claim can open one.
+6. Generated entities always retain owning pack/composition, parent route,
+   prompt version, ecology provenance, and migration version.
+7. LLMs propose names, prose, and media prompts only. They cannot create
+   topology, access, rewards, economy mutations, or rules.
+8. Generated pathways are excluded from reachability checks, so an undiscovered
+   authored room is never mistaken for an unreachable one.
+9. Packs stay independently mountable. `core-only` and `ruby-high-only` must
+   keep booting and must pass every new gate.
+10. Bundle identity changes go through the documented persistence path, never by
+    erasing a mismatched hash.
+11. Legacy packs preserve behaviour until they opt into a versioned policy.
+
+---
+
+## Delivery order
+
+1. WT-0 — the `routes` primitive.
+2. WT-1 — gateways.
+3. WT-2 — access kinds; `earned` shares the `unlock_exit` seam.
+4. WT-5 — give Dark Abyss a way out.
+5. WT-4 — join the Lantern Keeper.
+6. WT-3 — turn on the gates.
+
+**WT-3 lands last on purpose.** Its rules fail against the world as it stands,
+so WT-5 and WT-4 must merge first or the build goes red on arrival.
+
+WT-6 and WT-7 are independent playtest findings from the same session and block
+nothing.
+
+---
+
+## WT-0 — Add a routes array to world.json and compile cross-pack edges
+
+**Priority**: P1 — foundation for every ticket below
+**Scope**: world schema + `scripts/compile-worldpack.mjs`
+
+### What to do
+
+- Add a `routes` array to the world schema. Endpoints use the canonical
+  `pack:location/N` refs that `entry_location` already uses.
+- Fields: `id`, `from`, `to`, `direction` (`one_way` | `two_way`), `distance`,
+  `access`.
+- `compile-worldpack.mjs` resolves refs and emits composition routes into the
+  existing `exits.json`, tagged with the composition as `pack_id`.
+- Fail closed on an unresolvable endpoint, a duplicate route id, or a route
+  whose endpoints are in the same pack — that belongs in the pack, not the
+  composition.
+- **No runtime change.** The host keeps reading one `exits.json` and learns no
+  second edge concept.
+
+### Acceptance
+
+- [ ] A composition route between two packs compiles into `exits.json` and is
+      walkable at runtime with no orchestrator change.
+- [ ] An unresolvable ref, duplicate id, or same-pack route fails the compile
+      with an actionable message.
+- [ ] Bundle identity changes are handled through the documented persistence
+      path.
+
+---
+
+## WT-1 — Declare pack gateways and restrict routes to them
+
+**Priority**: P1
+**Depends on**: WT-0
+
+### What to do
+
+Give every pack a declared front door, and stop compositions wiring themselves
+into a pack's interior.
+
+- A pack contributing locations declares one or more `gateways` in `pack.json`.
+- A composition route may attach only at a declared gateway; attaching
+  elsewhere fails the compile.
+- The declaration survives a pack moving to its own repository, per the
+  documented pack-extraction path.
+- Declare gateways for the four current world/campaign packs.
+  `ruby-high.first-bell` should gate at Courtyard (`15`) rather than an
+  interior classroom; `cosyworld.campaign.the-lantern-keeper` at Wayside
+  Lantern Inn (`800`) and Lantern Tower (`804`).
+
+### Acceptance
+
+- [ ] Every pack contributing locations declares at least one gateway, or
+      composition fails closed.
+- [ ] A route targeting a non-gateway location is rejected, with the gateway
+      list in the message.
+- [ ] `core-only` and `ruby-high-only` still boot.
+
+---
+
+## WT-2 — Implement open, gated, and earned route access
+
+**Priority**: P1
+**Depends on**: WT-0, WT-1
+
+### What to do
+
+Three ways a route can be closed, drawn from a closed vocabulary.
+
+| Kind | Opens when | Reuses |
+| --- | --- | --- |
+| `open` | always | — |
+| `gated` | the actor holds a named grant or card | existing `required_grant_id` / `required_card_id` on exits |
+| `earned` | a named clock fills, or a journaled world event fires | the clock on-fill effect seam |
+
+- `open` and `gated` are presentation and access checks over machinery that
+  already exists on exits.
+- `earned` needs the authoritative `unlock_exit` op fired from a clock fill.
+  This is the **same seam** the clock on-fill work defines — coordinate rather
+  than building a parallel path.
+- Reject a route naming a clock or grant that does not exist in the
+  composition.
+
+### Acceptance
+
+- [ ] A `gated` route is impassable without the grant and passable with it,
+      with an actionable reason when refused.
+- [ ] Filling the named clock opens an `earned` route as a public, journaled
+      world event.
+- [ ] Replay reconstructs seam state exactly.
+- [ ] No client-supplied claim can open a seam.
+
+---
+
+## WT-3 — Gate composition on reachability, sinks, and seam targets
+
+**Priority**: P1 — **lands last**
+**Depends on**: WT-5, WT-4
+
+### What to do
+
+Make an unreachable room a compile error instead of a production discovery.
+
+Four rules in `v2/scripts/check-worldpack.mjs`, run **per composition** so
+`core-only` and `ruby-high-only` are covered:
+
+1. **No unreachable component** from `entry_location` across authored plus
+   composition edges, ignoring generated pathways.
+2. **No sink** — every location can reach the entry component.
+3. **Gateway required** for any pack contributing locations.
+4. **Seam targets resolve** — a `gated` route names a real grant, an `earned`
+   route names a real clock.
+
+Report failures as a room list with pack ids, not a count.
+
+### Ordering
+
+Rules 1 and 2 fail against the world as it stands today. This ticket cannot
+land before the defects it catches are fixed.
+
+### Acceptance
+
+- [ ] `npm run v2:worldpack` fails closed on an unreachable component, a sink,
+      a missing gateway, or an unresolvable seam target.
+- [ ] Each failure names the offending rooms and packs.
+- [ ] Generated pathways are excluded from reachability.
+- [ ] `core-only` and `ruby-high-only` pass the new gates.
+
+---
+
+## WT-4 — Join the Lantern Keeper and pay the win with a road
+
+**Priority**: P1 — first consumer of the routes primitive
+**Depends on**: WT-0, WT-1, WT-2
+
+### The two routes
+
+| | From | To | Access |
+| --- | --- | --- | --- |
+| in | `cosyworld.core:location/3` Moonlit Trail | `…the-lantern-keeper:location/800` Wayside Lantern Inn | `open`, two-way |
+| out | `…the-lantern-keeper:location/804` Lantern Tower | `cosyworld.core:location/35` Circle of the Moon | `earned` on `lantern-keeper.light`, one-way |
+
+A wayside inn belongs on a road, and Moonlit Trail is the road one step past
+the garden.
+
+The outbound seam deliberately does **not** return to Moonlit Trail. You arrive
+at the Inn from home, finish the campaign, and the relit lantern shows you a
+road further out that you could not see before. **The reward for winning is a
+new road.**
+
+### Why this shape
+
+It makes the campaign a *region with two entrances* rather than a mode you
+leave. Spawning at the Inn stays a fast start; finding it by road is the
+open-world path. Same rooms, no mode concept, and the "which game am I in"
+question stops needing an answer.
+
+### Scope
+
+- Land both routes in `world.json`.
+- Define the `lantern-keeper.light` on-fill effect as the `unlock_exit` that
+  opens the outbound road, coordinating with the clock on-fill seam rather than
+  adding a second effect path.
+- Confirm campaign archetypes survive outside the campaign before the outbound
+  seam opens — `mothwood-guide` and `lantern-warden` are level-one archetypes
+  balanced against five authored rooms.
+- Regenerate the worldpack and commit the bundle with the lock.
+
+### Acceptance
+
+- [ ] A player can walk from The Cosy Cottage to the Wayside Lantern Inn
+      without a campaign spawn.
+- [ ] Filling `lantern-keeper.light` opens the Lantern Tower road as a public,
+      journaled, replayable event.
+- [ ] A campaign-born avatar can walk out into core and keep its archetype,
+      Calling, and practice.
+- [ ] The composition passes the reachability gate with no remaining
+      unreachable component.
+
+---
+
+## WT-5 — Give Dark Abyss a way out
+
+**Priority**: P1 — blocks WT-3
+**Depends on**: WT-0, WT-1
+
+Dark Abyss (`65`, `cosyworld.core`) is the world's only sink. It has no
+outgoing exit: a player who enters cannot leave by travel.
+
+Pick one and record which:
+
+- Give it an exit, or
+- Declare it a deliberate one-way place with a documented escape — Flee, rescue
+  by another player, or a claimed return — so it is a designed trap rather than
+  an accident.
+
+Whichever is chosen must satisfy the no-sink rule in WT-3.
+
+### Acceptance
+
+- [ ] Dark Abyss either reaches the entry component by travel, or its escape is
+      authored, journaled, and documented.
+- [ ] The no-sink check passes with no exemption list.
+
+---
+
+## WT-6 — Know your own doorstep at spawn
+
+**Priority**: P2 — independent, blocks nothing
+
+A new player should not have to Scout to find the road out of their own house.
+
+### The problem
+
+Found by playing the live world. At The Cosy Cottage — the world's declared
+`entry_location` — a fresh avatar's only visible exit is `Homeroom`,
+`accessible: false`, needing a Ruby High pass. The authored road east to
+Rain-Soft Garden exists in `exits.json` but is hidden behind Scout, so the
+entry room reads as a dead end with one locked door.
+
+**The topology is correct. The discovery filter is what makes it look broken.**
+
+### Scope
+
+- The entry location's authored exits are known at spawn.
+- Everything past the first ring stays earned through Scout — this is a
+  doorstep exemption, not a change to the discovery model.
+- Check the same first impression on any composition's entry location, not just
+  Core's.
+
+### Acceptance
+
+- [ ] A newly created avatar at the entry location sees at least one accessible
+      authored exit before taking any action.
+- [ ] Scout still governs discovery everywhere beyond the entry location's own
+      exits.
+- [ ] The first-session arc no longer opens on a locked expansion door.
+
+---
+
+## WT-7 — Weight Scout proposals by distance and open seams
+
+**Priority**: P2 — independent, blocks nothing
+
+### The problem
+
+Found by playing the live world. Standing in The Cosy Cottage, the offered
+pathway action was **"Scout toward Bethlehem"** — a `cosyworld.the-holy-land`
+room, across the map, from a cottage garden. The generator is reaching without
+regard to graph distance.
+
+### Scope
+
+- Weight scout proposals by graph distance from the actor.
+- Never propose a destination across a composition seam that has not opened for
+  that actor.
+- Keep proposals deterministic and server-owned; this changes ranking, not
+  legality.
+
+### Acceptance
+
+- [ ] Scout proposals are drawn from the actor's neighbourhood, and distance is
+      inspectable in the offer trace.
+- [ ] No proposal crosses an unopened `gated` or `earned` seam.
+- [ ] Two clients with the same authoritative state receive the same proposals.
+
+---
+
+## WT-8 — Make generated descendants native to their worldpack
+
+**Priority**: P2
+**Depends on**: [#337](https://github.com/cenetex/cosyworld/issues/337)
+
+A worldpack owns not only its authored locations and cards, but also the
+routes, waypoints, places, ecology, prompts, and media generated from them.
+Generated content remains deterministic, replayable, pack-styled, and
+mechanically bounded. The worldpack declares bounded policy; the host owns
+credentials, execution, persistence, safety, economy, and authoritative
+mechanics.
+
+### Scope
+
+- Consume the versioned generation, media, topology, and cross-pack policy
+  declared in manifests (#337).
+- Add a generic graph report to worldpack validation: components, degree
+  distribution, cycle rank, bridges, articulation impact, weighted diameter,
+  ingress/egress, and evacuation.
+- Provide a legacy compatibility profile and an explicit pack-policy migration.
+
+### Acceptance
+
+- [ ] Two worldpacks with different topology and media profiles mount together
+      safely.
+- [ ] Each pack's generated descendants inherit the correct identity, ecology,
+      route, placeholder, and media profile.
+- [ ] A cross-pack journey cannot silently default generated content to Core.
+- [ ] Discovery, funding, generation, failure, restart, ready, pack upgrade,
+      and pack removal are covered by replay fixtures.
+- [ ] Topology validation applies profile-appropriate constraints rather than
+      imposing one map shape on every pack.
+- [ ] Provider credentials and arbitrary external requests never come from
+      untrusted pack data.
+- [ ] Cross-pack routes explicitly resolve ownership, ecology, style, unmount,
+      and evacuation.
+- [ ] Full replay and mount-order fixtures produce identical IDs, ownership,
+      route state, and media state.
+
+---
+
+## WT-9 — Expand Holy Land as a resilient regional pilgrimage mesh
+
+**Priority**: P2 — the end-to-end reference fixture
+**Depends on**: WT-8, #337
+
+### Current graph
+
+The Holy Land pack authors 15 internal location vertices and 15 undirected
+route edges (32 directed exit records including the two-way Cosy Cottage ↔
+Bethlehem gateway). As an undirected weighted graph:
+
+| Measure | Value |
+| --- | --- |
+| Connected components | 1 |
+| Average degree | 2.0 |
+| Independent cycle rank `E − V + 1` | 1 |
+| Bridges | 11 of 15 edges |
+| Articulation vertices | 8 |
+| Weighted diameter | 27 stretches, Caesarea Philippi ↔ Road to Emmaus |
+
+The only substantial loop is Nazareth → Jordan River Crossing → Jericho →
+Sychar Well → Nazareth. This is mostly a tree with one four-cycle. Jerusalem is
+a useful degree-4 hub, but pure hub-and-spoke expansion would produce
+repetitive backtracking and make too much of the map depend on a few
+articulation points.
+
+### Target topology constraints
+
+- 24–30 authored anchors in the first expansion.
+- Typical anchor degree 2–4; curated hubs may reach 5.
+- Major regional hubs have at least two edge-disjoint routes to the backbone.
+- Add 6–10 independent cycles rather than one giant ring.
+- Bridges reserved for intentional destinations, retreats, and dramatic
+  terminal spurs; target no more than 25% of internal edges.
+- Removing one ordinary hub must not orphan a large region.
+- Weighted shortest paths stay geographically plausible — no teleport-like
+  cross-region shortcuts.
+- Every loop offers a meaningful distinction (biome, traffic class, story
+  function, safety, season, resource), not merely duplicate distance.
+- Every new anchor participates in at least two systems or story loops. Density
+  matters more than raw map size.
+
+### Regional clusters
+
+Galilee lake mesh · Lower Galilee / Nazareth · Samaria and Jordan corridor ·
+Jericho / Judean wilderness · Jerusalem / Mount of Olives local mesh · optional
+northern/coastal or Decapolis expansions.
+
+### Suggested motifs
+
+- **Lake ring:** Capernaum ↔ Chorazin ↔ Bethsaida ↔ eastern shore/Decapolis ↔
+  Magdala/Sea Shore ↔ Capernaum.
+- **Lower Galilee loop:** Nazareth ↔ Cana ↔ Capernaum/Magdala ↔ Nain ↔
+  Nazareth.
+- **Jordan–Judea loop:** Jordan Crossing ↔ Jericho ↔ Judean Wilderness ↔
+  Jerusalem/Bethany ↔ Sychar/Samaria ↔ Jordan Crossing.
+- **Jerusalem local ring:** Jerusalem ↔ Mount of Olives ↔ Bethany ↔ Gethsemane
+  ↔ Jerusalem.
+- Keep Caesarea Philippi, Emmaus, Tyre/Sidon, and selected retreat places as
+  purposeful spurs only where the story benefits from a terminus.
+
+### Candidate additions for editorial review
+
+Graph-role candidates, not final historical claims: Magdala, Chorazin, Nain, an
+eastern-shore/Decapolis place; Tyre and Sidon as a later optional corridor; a
+Samaritan village or road anchor and a Judean-wilderness anchor; Mount of
+Olives connecting Jerusalem, Bethany, and Gethsemane; the Emmaus destination
+settlement so the existing Road to Emmaus becomes an edge/waypoint identity
+rather than a terminal road-shaped location. Traditional or uncertain sites
+such as Mount Tabor only with explicit provenance and confidence metadata.
+
+### Acceptance
+
+- [ ] Extend the worldpack schema/content with reviewed locations, ecology,
+      route distances, and direction pairs.
+- [ ] Preserve the Cosy Cottage ↔ Bethlehem gateway and deterministic replay.
+- [ ] Add a topology report to worldpack validation.
+- [ ] Meet agreed degree, cycle, bridge, and resilience budgets, or declare
+      reviewed exceptions.
+- [ ] Generated waypoint chains inherit the owning route's pack, ecology
+      transition, art profile, and canonical identity.
+- [ ] Browser/journey fixtures prove two genuinely different loop choices and
+      successful return travel.
+- [ ] Editorial metadata distinguishes textual association, later tradition,
+      and geographic uncertainty without presenting disputed identifications as
+      certainty.
+
+---
+
+## Appendix: playtest evidence
+
+Recorded from live sessions on lonelyforest.com, 2026-07-25 and 2026-07-26,
+against `origin/main` @ `5c9b637` (v0.0.180). These findings motivated the
+tickets above and are preserved because they describe *why* route work matters.
+
+### The world is broad and thin
+
+| Measure | Value |
+| --- | ---: |
+| Locations | 48 |
+| Exit records | 110 (~2.3 per room, mostly one-way pairs) |
+| Items placed in the world | 17 → 0.35 per room |
+| Actors | 56 → ~1.2 per room |
+
+Reachability from The Cosy Cottage:
+
+```
+hop 1:  3    hop 5:  5    hop  9: 2
+hop 2:  7    hop 6:  3    hop 10: 1
+hop 3:  9    hop 7:  1    hop 11: 1
+hop 4:  8    hop 8:  1
+```
+
+A bulge of 27 rooms in the first four hops, then a corridor one to three rooms
+wide for the remaining seven. Almost no loops anywhere.
+
+That shape matters directly: **you cannot get lost in a tree, but you also
+cannot learn your way around one.** Familiarity needs redundant paths. Every
+journey is currently out-and-back along the same line, which is why the far
+half reads as a corridor rather than a place. If route discovery is going to
+carry the exploration feel, the near graph probably needs loops before it needs
+more destinations.
+
+### Three doors, three tonal worlds, one hop out
+
+From the cottage the immediate choices are Rain-Soft Garden, Homeroom (a high
+school), and Bethlehem. No gradient, no sense that the trail gets wilder —
+three unrelated registers hanging off one hallway.
+
+### A correction on the job count
+
+An earlier pass reported "six jobs for forty-eight rooms." That counted
+**authored** jobs in `v2/content/official/jobs.json` only; the live world also
+creates jobs at runtime that appear in no content file. Standing in Rain-Soft
+Garden, `/state` returns two live generated jobs and four clocks. The
+generative machinery is working and the world is less content-starved than that
+figure implied.
+
+What survives the correction: **the Cosy Cottage itself returns `jobs: none`.**
+The starting room, the best-authored room in the world, has nothing to work on
+— only Take, Search, Notice, and Ask.
+
+### The shared-question structure is very good
+
+The strongest content shape observed in the codebase, worth preserving as a
+model:
+
+```
+"Can we make the washed garden path trustworthy before the next visitor?"
+  situation  Rain has hidden the first stepping stones and left the drain
+             carrying water across the path.
+  stakes     Someone following the blurred edge could lose the safe way toward
+             the river.
+  outcome    The first stones show clearly again and leave a trustworthy lead
+             toward the riverside.
+  next       "The first stone shows through the wash, giving the next visitor
+             one honest footing."
+  strategies inspect the stones (check) · clear the drain (work) ·
+             lift the stones together (help)
+```
+
+The third strategy is correctly marked unavailable — *"Its target is not
+reachable from here yet"* — because it needs another traveller. That is the
+co-presence design working, stated in fiction, with an honest reason. Note that
+the outcome text already promises a **lead** as its payoff.
+
+### `Ask for a local lead` resolves and produces no lead
+
+The offer is fully authored: contextual offer
+`cosyworld.core:cottage-ask-local-lead`, resolver `influence_v1`, target Rati,
+claim key `influence:{actor}:1001:local-lead`, with a declared effect — *"asks
+Rati to share one useful local lead; allowed outcomes are cooperates or
+declines."*
+
+Invoking it succeeds:
+
+```
+POST /actions/influence {target_actor_id: 1001}  → ok
+event: "Rati cooperates: the authored request was to share one useful local lead."
+```
+
+And then nothing. No exit revealed, no offer added, no room memory, no route
+knowledge. Offers before and after are byte-identical. **Rati cooperates and
+tells you nothing.**
+
+Treat the lead verb as *existing and empty* rather than as something to design
+from scratch.
+
+### Clocks that fill to an invisible tag
+
+```json
+{ "id": "lantern-keeper.light", "scope": "room", "scope_id": 804,
+  "zone": "frontier", "label": "Rekindle the Beacon", "segments": 6 }
+```
+
+Six segments of contribution, and its only effect in `lifecycle_hooks.json` is
+`set_tag → room:804:beacon_rekindled`. An invisible tag. This is not specific to
+the beacon: **all 12 clocks in the official world set tags and do nothing
+else**, while `UnlockExit` and `RevealItem` landed as authoritative on-fill ops
+with no content consumer.
+
+Room 804 sits inside the unreachable Lantern Keeper component, which is what
+makes the beacon the natural first vertical slice for WT-4: the beacon is the
+lead, lighting it is the reach, and `unlock_exit` is the arrival.
+
+A competing `lantern-keeper.darkness` clock on the same room fills to
+`set_tag → room:804:black_beacon`. Light versus dark is already contested on
+room 804 — it simply has no stakes on either side. **Constraint on that half:**
+decay must advance on played ticks, never wall clock. A beacon that dims while
+nobody is playing would be offline pressure, which sanctuary law forbids.
+
+### The command parser does not reach advertised commands
+
+`ask for a local lead` via `/commands` returns **404**, even though the offer
+advertises `"command": "ask for a local lead"`. The direct `/actions/influence`
+route works. Worth checking whether other advertised command strings are
+similarly unroutable.

--- a/docs/cosyworld-pact.md
+++ b/docs/cosyworld-pact.md
@@ -1,0 +1,138 @@
+# The CosyWorld Pact
+
+CosyWorld is a shared world that remembers what people do. This Pact is the
+promise the game makes to every traveler, regardless of who controls their
+avatar, which worldpack they entered through, or whether AI is available.
+
+It is product law. It is not an in-world faction, a membership gate, or the
+[Cottage Pact proof world](../v2/docs/pact-proof-world.md).
+
+## One World, One Truth
+
+Everyone in a place shares the same people, items, exits, conversation, and
+consequences. A resident does not give each player a private version of events.
+Ownership may open a shared place, but it never creates a private copy of that
+place.
+
+The server decides what is legal and records what happened. A client, a
+language model, or a vivid description cannot make an unearned change true.
+
+## Home Holds
+
+Home is a real sanctuary. It does not decay while people are away. Combat and
+uninvited pressure do not enter it. Rest there is free and complete.
+
+The frontier may contain danger, loss, and unfinished trouble, but only after a
+traveler chooses to go there. Time moves through played turns, not a clock on
+the wall.
+
+## Every Choice Is Honest
+
+Before a traveler commits, an action names its target, cost, and known risk.
+The complete legal set remains reachable even when the hand shows only two
+suggestions. Looking through that set is free; committing an action spends the
+turn.
+
+If an action is certain, the world does not roll. If the outcome is uncertain
+and consequential, the referee resolves it from declared rules and recorded
+state. A failed check changes the situation or closes that approach; it is not
+an invitation to press the same empty button again.
+
+## Identity Comes From Play
+
+A Calling belongs to its player. The game does not diagnose a hidden self or
+assign a destiny. Friends, rivalries, debts, promises, skills, and public deeds
+give an avatar shape over time.
+
+The Journal records meaningful outcomes, not flattering inventions. Other
+people can witness those outcomes, answer them, and depend on them.
+
+## Things Matter Because Of Their Relations
+
+An item is not only a bonus. It can be carried, entrusted, installed, broken,
+repaired, offered, or returned. A location is not only a backdrop. It can
+shelter, divide, reveal, connect, or become a home. A person is never only a
+quest marker.
+
+Keys, permissions, promises, placements, and completed work open only the
+thresholds they actually fit. Moving one of them can remove that capacity.
+Shared state, not story convenience, decides who may pass.
+
+## Discovery Begins With Evidence
+
+A track, absence, damaged tool, repeated gesture, or changed room can become a
+sign because it is present in the world. Some signs have one factual answer.
+Others can sustain more than one honest reading.
+
+The game may invite interpretation, but it does not declare what a symbol
+means inside the player. AI may describe evidence already chosen by the rules;
+it may not invent a route, item, person, reward, or conclusion and call it a
+discovery.
+
+## Leaving Is Not A Promise To Win
+
+Retreat, refusal, rescue, compromise, and return with an unanswered question
+are valid outcomes. The game must not spend a traveler's last strength while
+removing every path to shelter, aid, or home.
+
+Care is a real action. So are giving something up, keeping watch, repairing a
+route, witnessing another person's deed, and bringing useful knowledge back.
+
+## Return Makes The Difference Public
+
+A venture is more than movement away from home. Its discoveries alter what
+people can know, do, reach, trust, carry, or remember.
+
+Returning is more than crossing an old doorway. A return settles something
+from the venture into a hearth, relationship, route, item, obligation, or
+shared memory. If nothing has changed, it is simply another visit.
+
+## AI Has A Voice, Not Authority
+
+AI may speak for a resident, propose narration, or illustrate an earned
+moment. It never chooses legality, odds, access, topology, rewards, custody, or
+consequences.
+
+Core play remains available without AI. If requested dialogue cannot be
+generated, it fails plainly and without charge. The game does not put invented
+words into a character's mouth as a fallback.
+
+## Progress Is Earned, Never Bought
+
+Ordinary play, friendship, travel, discovery, safety, and growth always have a
+zero-Orb path. Orbs support shared images. They do not buy success, power,
+access, conversation, or a better roll.
+
+Gifts and trades preserve provenance. Paying for or holding a keepsake or pass
+does not grant rules authority over another player.
+
+## Every Traveler Keeps Their Boundaries
+
+Speech and trade are subject to consent and moderation. Travelers can mute,
+block, decline, withdraw, and report. A symbolic or ceremonial act is always a
+fictional world action chosen by its participants, never treatment, diagnosis,
+humiliation, or an instruction for real life.
+
+## The Shape Of A Tale
+
+CosyWorld authors may compose a tale from six recurring functions:
+
+1. **Hearth** — establish something worth returning to.
+2. **Sign** — encounter evidence that makes a question concrete.
+3. **Venture** — cross a boundary and place something at risk.
+4. **Challenge** — meet resistance or hold two real claims in contact.
+5. **Discover** — reveal or create a usable relationship, capacity, or path.
+6. **Return** — bring the difference into shared life.
+
+These are not six buttons and not a mandatory order. A tale may begin with a
+Sign, retreat to a Hearth, loop through several Challenges, or make a new
+Hearth far from the old one. The world remains open; the tale gives one part of
+it a temporary center.
+
+Shared truth, sanctuary, action authority, the AI boundary, the zero-Orb core,
+moderation, strict discovery receipts, and kernel-owned Gate transitions are
+live foundations. Perishable frontier forays and fatigue, cross-system
+relation/capacity deltas, quest-level table evidence, and the six-function
+grammar with Return settlement remain accepted direction. Until they land,
+this Pact is the standard against which their design and implementation are
+judged.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,12 @@ do not define V2 behavior.
 
 ## Product and design
 
+- **[The CosyWorld Pact](cosyworld-pact.md)** — the promises CosyWorld makes
+  about shared truth, sanctuary, honest choices, discovery, return, AI
+  authority, progression, and player boundaries.
+- **[A Traveler's Guide To CosyWorld](travelers-guide.md)** — the concise
+  player guide to the action hand, Callings, Friends, discovery, scouting,
+  thresholds, rest, the six-function tale rhythm, and what is still direction.
 - **[How to Design a Worldpack](worldpacks/how-to-design-a-worldpack.md)** —
   tentative design method for authored boundaries, world graphs, characters,
   factions, economies, special items, dynamic evolution, and validation.
@@ -89,10 +95,45 @@ do not define V2 behavior.
   direct-avatar continuity boundaries found in the first end-to-end journey.
 - **[Thresholds, Trails, and the Strict Referee](backlog/thresholds-trails-and-strict-referee.md)** —
   dependency-ordered Discovery Slot, Lead, Gate, Hazard, Pressure, trail, and
-  recovery work following ADR 0005.
+  recovery work following ADR 0005, with per-slice scope and acceptance for
+  everything that has not shipped.
+- **[Rest, Travel, and Weariness](backlog/rest-travel-and-weariness.md)** —
+  graded recovery, expedition Fatigue, short-rest cadence and the Spent
+  survival hand, prepared frontier camps, and recovery reachability.
+- **[Quest Grammar and Return](backlog/quest-grammar-and-return.md)** —
+  the code-to-vision diagnosis and dependency-ordered foundation for Hearth,
+  Sign, Venture, Challenge, Discover, and Return across avatars, items, and
+  locations.
+- **[World Topology and Composition Joins](backlog/world-topology-and-composition-joins.md)** —
+  the cross-pack `routes` primitive, pack gateways, open/gated/earned access,
+  reachability and sink gates, pack-native generated descendants, the Holy Land
+  regional mesh, and the playtest evidence that motivated them.
+- **[Avatar Lifecycle and the Rescue Run](backlog/avatar-lifecycle-and-rescue.md)** —
+  controller-neutral lifecycle from presence through Death or Return, the birth
+  draught, the two-body cascade, carrying downed bodies, and Fading paused in
+  sanctuary.
+- **[Combat, Encounters, and Range](backlog/combat-encounters-and-range.md)** —
+  chat-first combat, the avatar-rail encounter tracker, the unresolved fate-tag
+  decision, and the three-band range protocol.
+- **[Community Art Evolution](backlog/community-art-evolution.md)** — pooled
+  Orb funding, immutable reference assets, bounded scene composition, the
+  per-generation publication gate, and the unexplored art lifecycle.
 
-GitHub Issues are the live execution backlog. These local backlogs carry the
-long-form contracts and acceptance gates that do not fit cleanly in an issue.
+## How design and execution are split
+
+**Design lives in markdown. GitHub Issues are only what we are actively
+doing.**
+
+- A contract, a rule, an invariant, an acceptance gate, or a shape we have
+  argued ourselves into belongs in one of the documents above — where it can be
+  read whole, revised in a diff, and linked to.
+- An issue is a unit of work someone could pick up this week. It carries a
+  milestone or it does not exist.
+- `state:parked` and `horizon:later` are not a filing system for design. If work
+  is not being done, its thinking belongs in a backlog document and the issue
+  should close with a pointer to that section.
+- Closing an issue into a document is not cancellation. The design survives; the
+  queue stops pretending it is scheduled.
 
 ## Legacy service archive
 

--- a/docs/systems/09-cosyworld-rpg-system.md
+++ b/docs/systems/09-cosyworld-rpg-system.md
@@ -13,9 +13,10 @@ authoritative Collection/Carried/Equipped/Spell deck/Exhausted/Contained/World/
 Escrow zones, weight and size, equipped non-recursive containers, bracelet
 slots, possession-bound skill charms, weapon profiles, executable spell cards,
 idempotent collection materialization, theft, and provenance. Deterministic
-scene composition produces the complete legal offer set and a ranked
-three-card hand for browser and terminal clients. Legacy skill ranks, action
-codes, combat/2 and combat/3 rows remain replay-readable. Covenant contribution
+scene composition produces the complete legal offer set, two ranked
+suggestions, and a complete chooser for browser and terminal clients. Legacy
+skill ranks, action codes, combat/2 and combat/3 rows remain replay-readable.
+Covenant contribution
 and additional advancement choices remain future RPG breadth; they are not
 gaps in the SRD action-card foundation.
 

--- a/docs/travelers-guide.md
+++ b/docs/travelers-guide.md
@@ -1,0 +1,284 @@
+# A Traveler's Guide To CosyWorld
+
+CosyWorld is a shared fantasy world played one meaningful action at a time.
+You do not need to learn a command language or optimize a character sheet. Read
+the room, choose what matters, and let the world remember the result.
+
+This guide distinguishes the game you can play now from mechanics that are
+being prepared. The [CosyWorld Pact](cosyworld-pact.md) is the promise both must
+keep.
+
+## Your First Visit
+
+1. Make an avatar and enter the shared world.
+2. Read the place, the people present, and the two suggested actions.
+3. Open **all actions** if neither suggestion interests you. Browsing or
+   redealing does not spend a turn.
+4. Open an action to see its target, cost, known risk, and expected effect.
+5. Commit one action. Everyone present sees the same result.
+6. Choose a Calling when the world asks what draws you.
+7. Before leaving, read the Journal. It keeps the deeds and relationships that
+   can become growth.
+
+Speech and emotes do not consume the room's action turn. In a shared room,
+people otherwise take turns so one player cannot silently act over another.
+
+## The Things To Know
+
+| Word | What it means |
+| --- | --- |
+| **You** | Your avatar, condition, carried items, and equipped tools. |
+| **Home** | The sanctuary that holds while you are away. |
+| **Calling** | A short statement, written by you, about what draws your avatar. |
+| **Friends** | Bonds with residents and other travelers, including trust, rivalry, and debt. |
+| **Journal** | What happened, what remains open, and the deeds available to settle into growth. |
+| **Orbs** | An optional contribution to shared images, never a price on play or power. |
+
+An **action** is a legal choice you can make now. It is not owned or collected.
+An **item** is a physical thing in the shared world. A **keepsake** is an
+actor, item, or location represented in your collection; owning it does not
+replace or privately own the shared subject. A **pass** explains access to a
+gated place. A **bundle** is a one-time collection reveal from a Box. A
+**world pack** is mounted experience content.
+
+Jobs, clocks, tags, rules profiles, and claim keys exist behind the surface.
+You should not need those terms to decide what to do.
+
+## Reading An Action
+
+Every legal action comes from the server. The two suggestions in the hand come
+from that same set; they are not a limit on what you may do.
+
+- **Target** says exactly which person, item, feature, or place the action
+  concerns.
+- **Cost** says what committing spends: usually the turn, and sometimes an
+  item use, position, or exposure.
+- **Risk** states a known consequence before commitment. Hidden discoveries
+  remain hidden, but the fact that an approach is dangerous does not.
+- **Effect** says what success can actually change.
+
+A certain action simply happens. A check is used only when uncertainty and a
+meaningful consequence are both present. The referee rolls from frozen rules;
+AI may narrate the result but cannot improve it.
+
+## Common Ways To Act
+
+Exact offers depend on the place, the people and things present, your
+equipment, and what has already happened.
+
+| Intention | Use it when |
+| --- | --- |
+| **Notice** | You want the immediate, openly available situation. |
+| **Inspect** | You commit to finding something concealed in a named place, item, or feature. |
+| **Study** | You spend attention on meaning, provenance, or a difficult detail. |
+| **Scout** | You have an offered unrevealed route to investigate. |
+| **Travel** | A known, accessible route leads where you want to go. |
+| **Take, Give, Trade, or Use** | Custody, placement, or the use of a physical item matters. |
+| **Prepare** | You ready an item, skill, spell, or approach before pressure arrives. |
+| **Work or Help** | You advance a concrete shared need alone or beside someone. |
+| **Rest** | The current place and your gear permit a specific kind of recovery. |
+| **Defend, Flee, or Attack** | A frontier conflict is active. Leaving alive is a valid result. |
+
+If an offered action does not name the thing it affects, do not guess what the
+button means. Open its detail or choose another action.
+
+## The Shape Of A Tale
+
+Not every story is a quest, and not every quest follows a straight line.
+CosyWorld uses six functions to help authors and the referee keep a tale
+coherent:
+
+| Function | What the traveler experiences |
+| --- | --- |
+| **Hearth** | You establish a person, item, or place that can orient and receive the journey. |
+| **Sign** | Concrete evidence gives you a question worth following. |
+| **Venture** | You cross a boundary and expose a relationship, possession, or route to change. |
+| **Challenge** | Resistance forces a choice, test, negotiation, sacrifice, or withdrawal. |
+| **Discover** | The journey reveals or creates something the world can now use. |
+| **Return** | You carry that difference back into shared memory and future play. |
+
+Think of these as a rhythm, not a checklist. A Sign can send you back to
+prepare. A Challenge can create a new Hearth. A Return can expose the next
+Sign. Different travelers can enter the same situation through different
+people, items, and places.
+
+The full six-function quest grammar is being built. Current Jobs already
+provide premises, stakes, contribution choices, progress, danger, rewards, and
+completion memories; the missing layer is a durable record of how those pieces
+form and transform a tale.
+
+You do not accept a tale from a quest log. A situation becomes actionable when
+its evidence, people, things, places, and exact legal actions are present.
+
+## Signs, Tracks, And Discovery
+
+Evidence comes before interpretation.
+
+- A **trace** has a factual referent: prints leave the road, a seal is broken,
+  a bell bears river clay.
+- A **sign** connects observed facts to an open question. It can admit several
+  readings until later play settles one.
+- A **Lead** names a concrete thing that can be pursued: a destination, person,
+  item, feature, or event.
+- A **discovery** changes what the shared world knows or can do. Flavor text
+  alone is not enough.
+
+Notice should expose what is immediately available. Inspect and Study commit
+time to a specific target. Scout is geographic. Repeating an exhausted
+approach should not produce a blank invitation to repeat it again.
+
+Worldpacks already use original, versioned tables to stock bounded discovery
+slots in the style of old-school referee tools. The chosen row, table version,
+and eligible context are frozen before reveal, so reconnecting or repeating an
+action cannot reroll the hidden truth. Focused Notice, Search, Study, and Scout
+share that procedure; Job loot has its own proven receipt.
+
+Quest work will cite those existing receipts as Signs and discoveries rather
+than inventing another roller. AI may give the selected result a voice or
+visual description; it cannot roll again, add a reward, or change the map.
+Bounded materialization of new item and location results remains backlog work.
+
+## Routes, Anchors, And Cairns
+
+Today, Scout binds to one exact offered route. It reveals the next adjacent
+stretch without moving you. Travel follows a revealed and accessible stretch.
+A generated long route may contain several hidden waypoints, encountered one
+at a time.
+
+The strengthened frontier rule is:
+
+- a new scouting foray begins at a sanctuary, lodging, trailhead, durable
+  cairn, or other authored **Anchor**;
+- one exact Lead is chosen when the foray begins;
+- continuing that Lead does not require building a cairn on every step;
+- leaving the Lead to open a new branch requires another Anchor;
+- a cairn makes a hard-won place usable as a later start, retreat, or
+  rendezvous point;
+- pressure can distort, exhaust, or expire a Lead, but it cannot silently move
+  the route or invent a replacement.
+
+This makes cairns meaningful infrastructure rather than a breadcrumb tax. The
+Anchor, return-chain, and cairn contract is accepted, and the descriptor
+foundation exists. Perishable Leads and full foray enforcement remain backlog
+work rather than current long-range Scout behavior.
+
+## Doors, Keys, And Thresholds
+
+A threshold can be a door, chest, bridge, boundary, custom, vow, or guarded
+route. Its requirement must be exact and testable. Examples include:
+
+- a particular key is carried;
+- an item remains installed at the threshold;
+- a seal may be broken once;
+- every traveler must hold a token;
+- one holder opens the way for everyone present;
+- a resident has granted permission;
+- a Job, placement, or relationship has changed the access state.
+
+Passing does not necessarily destroy or consume the key. The author declares
+custody, placement, charges, one-shot behavior, who benefits, and what happens
+when the enabling thing is removed.
+
+Versioned Lead, Gate, Hazard, Pressure, and Anchor descriptors now exist, and
+the kernel owns conditional Gate transitions. Broader player procedures,
+Pressure scenes, materialized discoveries, author inspection, and content
+proof remain dependency-ordered in
+[Thresholds, Trails, and the Strict Referee](backlog/thresholds-trails-and-strict-referee.md).
+
+## Items And Loot
+
+Items are shared physical facts. They have custody and location; many also
+have size, weight, charges, a card zone, or an installed use. Giving away a
+key can change which path you can open. Installing a bell can give a place a
+new capacity.
+
+Finding an item and taking it are separate acts. A discovery may make an item
+known or reachable without placing it in your hand. Capacity and access still
+apply.
+
+Job loot already uses authored candidates, deterministic selection, frozen
+provenance, and one materialization receipt. General location and item tables
+will reuse that contract. There is no invisible AI treasure faucet.
+
+## Rest, Fatigue, And Coming Home
+
+The shipped rest ladder is tied to fiction:
+
+- **Camp** is limited frontier recovery and requires suitable shelter.
+- **Lodged** rest is broader recovery earned through a place, resource,
+  relationship, or completed work.
+- **Hearth** rest is complete sanctuary recovery and closes the expedition.
+
+Cairns do not count as shelter. Rest may advance authored frontier pressure
+when the action says so.
+
+The playtest direction adds three short-rest uses to each long-rest epoch and
+four readable fatigue states: Fresh, Winded, Weary, and Spent. A short rest
+would cost a turn and one use, ease one fatigue step, and never reset the
+expedition. At Spent, outward exertion would close while a survival hand
+remains: retreat to an Anchor, rest if possible, Camp, accept aid, defend,
+flee, or call for rescue.
+
+The exact short-rest refresh and cadence remain a decision in
+[Rest, Travel, and Weariness](backlog/rest-travel-and-weariness.md). Do not
+assume the playtest rule is live until that decision and its migration ship.
+
+## Challenge Without A Forced Answer
+
+A strong Challenge often places two legitimate claims in contact: shelter and
+freedom, loyalty and truth, memory and renewal. Work, Help, a relevant item,
+negotiation, risk, refusal, or retreat may each be valid methods.
+
+Sometimes engaging both claims can unlock a third arrangement that neither
+side offered at the start. That result must be authored and earned by effective
+actions on both sides. It is not a reward for choosing a dialogue option that
+sounds balanced.
+
+The game never stores psychological labels about a player. Symbolic acts are
+concrete, fictional changes—return the bell, bury the counterfeit key, leave
+the repaired chair at the threshold—not diagnoses or real-world prescriptions.
+
+## What Counts As Return
+
+Crossing back into a familiar room is ordinary travel. A tale's Return occurs
+when something from the venture is settled:
+
+- useful knowledge becomes a public Lead;
+- an item is restored, offered, displayed, buried, or installed;
+- a relationship, promise, or debt changes;
+- a route becomes known, marked, secured, or deliberately abandoned;
+- a place receives a repair or a new capacity;
+- the Journal records an earned difference and an honest unfinished thread.
+
+Return does not require victory. Escaping danger with evidence, keeping a
+promise at a cost, or reporting that a route cannot yet be crossed may all
+change the world.
+
+Quest-level Return settlement is part of the new grammar. The current Visit
+Ledger already recognizes some frontier returns, discoveries, help, Callings,
+and Bonds, but it does not yet unify them into one quest receipt.
+
+## Other Travelers And Residents
+
+Everyone present sees the same committed events. Residents follow the same
+legal action surface as human-controlled avatars; a different controller does
+not receive a private rules advantage.
+
+You may speak freely within moderation, but direct Chat that asks AI for a
+resident response is separate from deterministic action. When inference is
+unavailable, the world remains playable and no substitute character speech is
+invented.
+
+You can decline trades and requests. Mute and block prevent unwanted social
+contact; report sends an auditable record to an operator.
+
+## When You Are Unsure
+
+1. Read the current place and newest Journal entry.
+2. Open **all actions** and inspect the exact targets.
+3. Notice for openly available context.
+4. Inspect or Study only when you can name the thing receiving your attention.
+5. Check whether the route says Scout or Travel.
+6. If pressure is rising, prepare, help, rest, retreat, or return home.
+7. If the surface promises an effect it cannot explain, report it. That is a
+   rules or presentation bug, not a riddle you are expected to solve.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.289",
+  "version": "0.0.292",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.289",
+      "version": "0.0.292",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.291",
+  "version": "0.0.292",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.291"
+version = "0.0.292"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.291"
+version = "0.0.292"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Why

Design belongs in markdown; GitHub Issues should only carry work we are actively doing.

The backlog is 90 open issues, **78% of them `state:parked` or `state:blocked`**, against 17 `state:ready`. Over the last 14 days it took on 307 new issues and closed 232 — net +75. Meanwhile the `Ship Cosyworld 1.0` contract (#533) is seven issues from its own definition of done, and 83 open issues carry no milestone at all.

This PR lands the design corpus so ~69 parked and blocked issues can close **without losing their contracts**.

## New documents

- `docs/cosyworld-pact.md`, `docs/travelers-guide.md` — the product promises and the concise player guide.
- `docs/backlog/quest-grammar-and-return.md` — QST-0..QST-8.
- `docs/backlog/world-topology-and-composition-joins.md` — WT-0..WT-9. **This path was cited by #372–#379 from the day they were filed but had never been written in any commit.** Reconstructed from those issues, including the lonelyforest.com playtest evidence (the 48-room graph shape, `Ask for a local lead` resolving to nothing, the twelve clocks that fill to an invisible tag).
- `docs/backlog/avatar-lifecycle-and-rescue.md` — LC-0..LC-5. The birth draught, the two-body cascade, and Fading paused in sanctuary existed **only as a comment on #380**.
- `docs/backlog/combat-encounters-and-range.md` — CB-3..CB-5, including the unresolved fate-tag decision and its conflict with the landed no-dice-arithmetic rule at `v2/scripts/smoke-browser.mjs:4402`.

## Expanded

- `thresholds-trails-and-strict-referee.md` keeps ADR 0005 as the normative contract and the delivery table as the index, and gains **Open slice detail** carrying per-slice scope and acceptance for everything unshipped. (The working copy this came from was the pre-THR-0 monolith; main's split is preserved rather than reverted.)
- `rest-travel-and-weariness.md` gains RT-8, RT-9, RT-10.
- `community-art-evolution.md` gains CA-1..CA-5.
- `AI.md` gains the diverse model cast, Fly evaluation, and adversarial corpus contract.
- `docs/index.md` records how design and execution are split.

## Not runtime

No runtime, content, or schema changes. The `Cargo.toml`/`Cargo.lock` edits are only the version alignment that `content_registry::tests::official_registry_exposes_pack_aware_indexes` requires against the root bump.

## Verification

`npm run check` passes on the final SHA, including the Vitest suite, 892 Rust tests, `check-main-size.sh` (73369 = ceiling, unchanged), clippy (254 = ceiling, unchanged), and `check:version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)