### PR TITLE
fix: give every d20 one disclosure rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.293",
+  "version": "0.0.294",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.293",
+      "version": "0.0.294",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.293",
+  "version": "0.0.294",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/writing-style.md
+++ b/v2/docs/writing-style.md
@@ -126,6 +126,38 @@ in `v2/content/core/sentences.json`.
 - "As if" and "seems to" remain authorially banned even though this collection
   is exempt from ordinary world-prose lint.
 
+### 8. Chance feedback (every d20 the kernel resolves)
+
+**One disclosure rule for every roll.** Where the kernel resolves a d20, the
+result is shown as a story beat *and* the arithmetic that produced it. Chance
+is legible because the referee is deterministic and has nothing to hide; a
+player who missed is owed the reason.
+
+The card carries a title, the mechanics, and a plain outcome:
+
+```
+Lantern Stitch finds an opening
+Ashwood Practice Blade · Strength attack · d20 14 +3 = 17 vs AC 13
+it lands
+```
+
+- Attacks read `<Ability> attack · … vs AC <n>`; ordinary checks read
+  `<Ability> check · … vs DC <n> · <outcome>`. Both come from one formatter
+  (`abilityCheckMechanics`) so the two surfaces cannot drift apart.
+- The outcome line stays plain language — "it lands", "not this time", "a clue
+  appears". Arithmetic explains the outcome; it never replaces it.
+- Damage, HP, and recovery keep their existing prose treatment. This section
+  governs the roll, not its consequences: "Gust looks steadier" is still right,
+  and zero-HP language is still banned.
+- The same roll may appear in both the transcript and the Log. That is
+  deliberate: the transcript carries the beat you read, the Log the row you
+  scan. They render from `detail` and `story` on the same event.
+
+This reverses an earlier stance under which combat hid its arithmetic while
+ordinary checks exposed theirs — the same kernel roll with two opposite rules.
+Both browser assertions in `v2/scripts/smoke-browser.mjs` now pin exact
+arithmetic. See issue #464.
+
 ## Review checklist
 
 - [ ] Could this sentence appear on a button a player reads 200 times?

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.293"
+version = "0.0.294"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.293"
+version = "0.0.294"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -10690,23 +10690,23 @@
         const actor = event.actor_name || "Someone";
         const target = event.target_actor_name || "their opponent";
         const method = event.combat_method || event.item_name || "Unarmed strike";
-        const ability = event.ability || "Strength";
+        const mechanics = combatAttackMechanics(event);
         return success
           ? {
               label: "clash",
               symbol: "✦",
               title: `${actor} finds an opening`,
-              detail: `${method} · ${ability}. ${target} is caught off guard.`,
+              detail: `${method} · ${mechanics}. ${target} is caught off guard.`,
               result: "it lands",
-              story: `${actor} finds an opening against ${target} with ${method} (${ability}).`,
+              story: `${actor} finds an opening against ${target} with ${method}. ${mechanics}.`,
             }
           : {
               label: "clash",
               symbol: "·",
               title: `${target} slips clear`,
-              detail: `${method} · ${ability}. ${actor}'s swing meets empty air.`,
+              detail: `${method} · ${mechanics}. ${actor}'s swing meets empty air.`,
               result: "not this time",
-              story: `${target} slips clear of ${actor}'s ${method} (${ability}).`,
+              story: `${target} slips clear of ${actor}'s ${method}. ${mechanics}.`,
             };
       }
       if (event.content === "notice") {
@@ -10753,7 +10753,17 @@
           };
     }
 
-    function abilityCheckMechanics(event) {
+    // One formatter for every d20 the kernel resolves, so an attack and an
+    // ordinary check cannot disagree about how chance reads. Attacks say
+    // "attack ... vs AC" and let the card's result line carry the outcome;
+    // checks say "check ... vs DC" and spell the outcome out. See issue #464.
+    function abilityCheckMechanics(event, options = {}) {
+      const {
+        kind = "check",
+        threshold = "DC",
+        includeOutcome = true,
+        includeClassSource = true,
+      } = options;
       const ability = abilityLabel(event?.ability, "Ability");
       const raw = Number(event?.raw_roll);
       const modifier = Number(event?.modifier);
@@ -10764,10 +10774,13 @@
       const equation = [
         roll,
         Number.isFinite(total) ? `= ${total}` : "",
-        Number.isFinite(dc) ? `vs DC ${dc}` : "",
+        Number.isFinite(dc) ? `vs ${threshold} ${dc}` : "",
       ].filter(Boolean).join(" ");
+      if (!includeOutcome) {
+        return `${ability} ${kind} · ${equation}`;
+      }
       const outcome = event?.success === true ? "success" : "failure";
-      const choice = authoredAbilityChoice(event?.ability);
+      const choice = includeClassSource ? authoredAbilityChoice(event?.ability) : null;
       const ownedCheck = Number(event?.actor_id || 0) === Number(actorId || 0);
       const skill = choice && ownedCheck
         ? (state?.skills || []).find((candidate) => candidate.skill_id === choice.id)
@@ -10781,7 +10794,16 @@
         && classChoice?.starting_skill_id === skill.skill_id
         ? ` · Class skill: ${skill.label} +${Math.max(0, Number(skill.bonus || 0))} from ${classChoice.label}`
         : "";
-      return `${ability} check · ${equation} · ${outcome}${classSource}`;
+      return `${ability} ${kind} · ${equation} · ${outcome}${classSource}`;
+    }
+
+    function combatAttackMechanics(event) {
+      return abilityCheckMechanics(event, {
+        kind: "attack",
+        threshold: "AC",
+        includeOutcome: false,
+        includeClassSource: false,
+      });
     }
 
     function eventAriaLabel(event, speaker, body) {

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4492,8 +4492,13 @@ async function main() {
       `Class revelation should explain its evidence, default to the recommendation, and preserve all choices: ${JSON.stringify(result)}`,
     );
     assert(/Moonlit Echo slips clear/.test(result.clashMarkup) && /not this time/.test(result.clashMarkup), `combat chance feedback should read as a clash, not a calculation: ${JSON.stringify(result)}`);
-    assert(result.clashMemory?.text === "Moonlit Echo slips clear of Lantern Stitch's Ashwood Practice Blade (Strength).", `room memory should preserve the authoritative combat method in story language: ${JSON.stringify(result)}`);
-    assert(!/d20|modifier|total|\bdc\b|>4<|>6<|>13</i.test(result.clashMarkup), `combat chance feedback should hide dice arithmetic: ${JSON.stringify(result)}`);
+    assert(result.clashMemory?.text === "Moonlit Echo slips clear of Lantern Stitch's Ashwood Practice Blade. Strength attack · d20 4 +2 = 6 vs AC 13.", `room memory should preserve the authoritative combat method in story language: ${JSON.stringify(result)}`);
+    // One disclosure rule for every d20 the kernel resolves. An attack and an
+    // ordinary check must not disagree about whether chance is legible, so the
+    // attack exposes the same arithmetic the non-combat assertion above pins,
+    // against AC rather than DC. See issue #464.
+    assert(/Strength attack · d20 4 \+2 = 6 vs AC 13/.test(result.clashMarkup), `combat chance feedback should expose the same exact arithmetic as a non-combat check: ${JSON.stringify(result)}`);
+    assert(!/\bDC\b/.test(result.clashMarkup), `an attack resolves against AC, never a DC: ${JSON.stringify(result)}`);
     assert(result.combatHitText === "Ashwood Practice Blade breaks through Moonlit Echo's guard.", `combat hits should preserve the authoritative method without damage accounting: ${JSON.stringify(result)}`);
     assert(result.knockoutText === "Ashwood Practice Blade leaves Moonlit Echo's light quiet for now.", `knockouts should preserve the method and avoid zero-HP language: ${JSON.stringify(result)}`);
    assert(result.bankedText === "lets what happened shape what comes next.", `historical settlement should land as a simple story beat instead of exposing memory marks: ${JSON.stringify(result)}`);


### PR DESCRIPTION
Closes #464.

## The issue's premise was stale

#464 says the fate tag is forbidden by a browser rule. That was true when the comment was written; it isn't now. On `main` today:

- `abilityCheckMechanics()` (`index.html:10756`) already builds the tag and renders it into the transcript for ordinary checks — `d20 9 +3 = 12 vs DC 10`.
- The blanket assertion is gone. What remained guarded only `clashMarkup`, i.e. **combat**.
- There is no composition gating anywhere in the roll path, so this is global — Ruby High shows dice because every composition does.

## The actual defect

Combat and checks disagreed about the same kernel roll:

| | Today | |
|---|---|---|
| Search a room | `d20 9 +3 = 12 vs DC 10` | arithmetic shown |
| Attack someone | `it lands` | arithmetic suppressed, test-enforced |

Same d20, two opposite disclosure rules — and combat is the outlier, a narrow assertion on top of otherwise-global behavior. Combat is also precisely where *"why did I miss?"* is the question players most want answered.

## The change

Attacks now read `<Ability> attack · d20 N ±M = T vs AC <n>`, with the card's result line still carrying the plain outcome. Checks keep `<Ability> check · … vs DC <n> · <outcome>`. Both come from one formatter, so the two surfaces cannot drift apart again.

```
Lantern Stitch finds an opening
Ashwood Practice Blade · Strength attack · d20 14 +3 = 17 vs AC 13
it lands
```

**No projection or kernel change needed.** `raw_roll`, `modifier`, `total`, `dc`, and `ability` already reach the client for attacks (`main.rs:13697`). This is client copy plus its contract.

## Contract updates

- `smoke-browser.mjs`: the assertion hiding combat arithmetic is replaced by one pinning the exact tag, plus one proving an attack resolves against **AC**, never a DC.
- `writing-style.md`: new §8 *Chance feedback*, recording the reversal — the prior stance was documented product law and shouldn't change silently.

## On the transcript/Log duplication

The roll stays in both, and that's now written down rather than incidental: the transcript carries the beat you read (`detail`), the Log the row you scan (`story`), both projected from one event. Ability-check rolls are the only event rendered to both surfaces; the two renderings differ in form and serve different reading modes.

## Verification

`npm run v2:check` **exit 0** on the final SHA — worldpack, kernel, ai-model, **892 Rust tests**, `main.rs` ceiling 73369 (unchanged), clippy 254 (unchanged), CLI, composition smoke, production-profile smoke, and the live browser smoke (`check_all` → `run_smoke` → `smoke-browser.mjs`) where the new assertions execute.

Two concurrency tests (`divergent_capacity_processes_converge_without_affinity`, `hot_room_and_regional_chaos_preserve_one_committed_world`) flaked on earlier local runs with `503 Canonical write authority is unavailable`, each passing in isolation and both green on the verifying run. This branch changes no Rust, but the flake may be worth its own look — it resembles the lock contention in #544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)