### PR TITLE
fix: redesign mobile character cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.295",
+  "version": "0.0.296",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.295",
+      "version": "0.0.296",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.295",
+  "version": "0.0.296",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.295"
+version = "0.0.296"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.295"
+version = "0.0.296"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2152,6 +2152,15 @@
       padding: 18px;
       background: rgba(3, 5, 4, 0.76);
     }
+    .card-modal {
+      min-height: 100svh;
+      height: 100dvh;
+      padding:
+        max(12px, env(safe-area-inset-top))
+        max(12px, env(safe-area-inset-right))
+        max(12px, env(safe-area-inset-bottom))
+        max(12px, env(safe-area-inset-left));
+    }
     .card-modal[hidden],
     .all-actions-modal[hidden],
     .action-modal[hidden],
@@ -2179,6 +2188,16 @@
     }
     .card-dialog {
       position: relative;
+      max-height: calc(100dvh - 24px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+      overflow: hidden;
+      padding: 0;
+    }
+    .card-dialog-scroll {
+      width: 100%;
+      max-height: inherit;
+      overflow: auto;
+      overscroll-behavior: contain;
+      padding: 12px;
     }
     .card-close,
     .all-actions-close,
@@ -2548,6 +2567,46 @@
       object-fit: contain;
       display: block;
     }
+    .card-art-column {
+      min-width: 0;
+    }
+    .card-art-workshop {
+      display: grid;
+      gap: 6px;
+      margin-top: 8px;
+    }
+    .card-art-workshop:empty {
+      display: none;
+    }
+    .card-art-status {
+      min-width: 0;
+      display: grid;
+      gap: 2px;
+      border: 1px solid rgba(239, 201, 107, 0.24);
+      border-radius: 4px;
+      background: rgba(239, 201, 107, 0.06);
+      padding: 7px 8px;
+      line-height: 1.3;
+    }
+    .card-art-status span {
+      color: var(--dim);
+      font-size: 10px;
+      font-weight: 900;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .card-art-status strong {
+      color: var(--text);
+      font-size: 12px;
+      overflow-wrap: anywhere;
+    }
+    .card-art-status.error {
+      border-color: rgba(var(--type-danger-rgb), 0.34);
+      background: rgba(var(--type-danger-rgb), 0.08);
+    }
+    .card-art-workshop .account-button {
+      width: 100%;
+    }
     .card-copy {
       min-width: 0;
     }
@@ -2597,6 +2656,13 @@
       color: var(--amber);
       font-size: 11px;
       font-weight: 900;
+      text-transform: uppercase;
+    }
+    .card-section-label {
+      color: var(--amber);
+      font-size: 11px;
+      font-weight: 900;
+      letter-spacing: 0.04em;
       text-transform: uppercase;
     }
     .card-economy {
@@ -2649,6 +2715,50 @@
       color: var(--dim);
       font-weight: 900;
       text-transform: uppercase;
+    }
+    .card-current {
+      display: grid;
+      gap: 6px;
+      border: 1px solid rgba(239, 201, 107, 0.26);
+      border-radius: 5px;
+      background: rgba(239, 201, 107, 0.055);
+      padding: 8px;
+    }
+    .card-current .card-economy-row:first-of-type {
+      border-top: 0;
+      padding-top: 0;
+    }
+    .card-more {
+      border-top: 1px solid rgba(129, 255, 167, 0.18);
+      padding-top: 2px;
+    }
+    .card-more > summary {
+      min-height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      color: var(--dim);
+      font-size: 12px;
+      font-weight: 900;
+      list-style: none;
+      cursor: pointer;
+    }
+    .card-more > summary::-webkit-details-marker {
+      display: none;
+    }
+    .card-more > summary::after {
+      content: "+";
+      color: var(--amber);
+      font-size: 16px;
+    }
+    .card-more[open] > summary::after {
+      content: "−";
+    }
+    .card-more-body {
+      display: grid;
+      gap: 6px;
+      padding-bottom: 4px;
     }
     .avatar-controls {
       display: flex;
@@ -2803,15 +2913,25 @@
     @media (min-width: 701px) {
       .card-dialog.portrait-card {
         width: min(780px, calc(100vw - 36px));
+      }
+      .card-dialog.portrait-card .card-dialog-scroll {
         display: grid;
         grid-template-columns: minmax(260px, 0.94fr) minmax(300px, 1.06fr);
         gap: 16px;
         overflow: hidden;
       }
-      .card-dialog.portrait-card .card-art {
+      .card-dialog.portrait-card .card-art-column {
         min-height: 0;
         height: min(540px, calc(100vh - 60px));
         max-height: min(540px, calc(100vh - 60px));
+        display: grid;
+        grid-template-rows: minmax(0, 1fr) auto;
+        gap: 8px;
+      }
+      .card-dialog.portrait-card .card-art {
+        min-height: 0;
+        height: 100%;
+        max-height: none;
       }
       .card-dialog.portrait-card .card-art img {
         height: 100%;
@@ -2828,12 +2948,90 @@
       }
     }
     @media (max-width: 700px) {
+      .card-dialog.portrait-card .card-dialog-scroll {
+        display: grid;
+        grid-template-columns: minmax(96px, 31%) minmax(0, 1fr);
+        grid-template-rows: auto auto auto auto auto auto auto;
+        column-gap: 12px;
+        row-gap: 6px;
+        align-items: start;
+      }
+      .card-dialog.portrait-card .card-art-column,
+      .card-dialog.portrait-card .card-copy {
+        display: contents;
+      }
       .card-dialog.portrait-card .card-art {
-        min-height: 180px;
-        max-height: 44vh;
+        grid-column: 1;
+        grid-row: 1 / span 3;
+        width: 100%;
+        min-height: 0;
+        height: min(38vw, 156px);
+        max-height: 156px;
+        aspect-ratio: 3 / 4;
       }
       .card-dialog.portrait-card .card-art img {
-        max-height: 44vh;
+        width: 100%;
+        height: 100%;
+        max-height: none;
+        object-fit: contain;
+      }
+      .card-dialog.portrait-card .card-name {
+        grid-column: 2;
+        grid-row: 1;
+        align-self: end;
+        margin: 3px 0 0;
+        padding-right: 48px;
+        font-size: 19px;
+        line-height: 1.15;
+      }
+      .card-dialog.portrait-card .card-title {
+        grid-column: 2;
+        grid-row: 2;
+        margin-top: 0;
+        font-size: 14px;
+        line-height: 1.3;
+      }
+      .card-dialog.portrait-card .card-meta {
+        grid-column: 2;
+        grid-row: 3;
+        align-self: start;
+        margin-top: 2px;
+        gap: 4px;
+      }
+      .card-dialog.portrait-card .card-meta span {
+        padding: 2px 5px;
+        font-size: 11px;
+      }
+      .card-dialog.portrait-card .card-art-workshop {
+        grid-column: 1 / -1;
+        grid-row: 4;
+        margin-top: 2px;
+      }
+      .card-dialog.portrait-card .card-blurb {
+        grid-column: 1 / -1;
+        grid-row: 5;
+        margin-top: 4px;
+        font-size: 15px;
+        line-height: 1.45;
+      }
+      .card-dialog.portrait-card .card-keepsake {
+        grid-column: 1 / -1;
+        grid-row: 6;
+        font-size: 14px;
+        line-height: 1.45;
+      }
+      .card-dialog.portrait-card .card-economy {
+        grid-column: 1 / -1;
+        grid-row: 7;
+        margin-top: 2px;
+      }
+      .card-dialog.portrait-card .card-economy-row {
+        grid-template-columns: minmax(74px, 94px) minmax(0, 1fr);
+        font-size: 14px;
+        line-height: 1.4;
+      }
+      .card-dialog.portrait-card .card-current .card-economy-row {
+        grid-template-columns: minmax(58px, 76px) minmax(0, 1fr);
       }
     }
     [data-card-key] { cursor: zoom-in; }
@@ -4077,14 +4275,19 @@
   <div class="card-modal" id="card-modal" hidden>
     <section class="card-dialog" role="dialog" aria-modal="true" aria-labelledby="card-modal-name" tabindex="-1" data-player-concept="keepsake">
       <button class="card-close" type="button" data-card-close aria-label="Close keepsake details">x</button>
-      <div class="card-art"><img id="card-modal-image" alt="" /></div>
-      <div class="card-copy">
-        <h2 class="card-name" id="card-modal-name"></h2>
-        <div class="card-title" id="card-modal-title"></div>
-        <div class="card-blurb" id="card-modal-blurb"></div>
-        <div class="card-meta" id="card-modal-meta"></div>
-        <div class="card-keepsake" id="card-modal-keepsake"></div>
-        <div class="card-economy" id="card-modal-economy"></div>
+      <div class="card-dialog-scroll">
+        <div class="card-art-column">
+          <div class="card-art"><img id="card-modal-image" alt="" /></div>
+          <div class="card-art-workshop" id="card-modal-art-workshop" aria-live="polite" aria-atomic="true"></div>
+        </div>
+        <div class="card-copy">
+          <h2 class="card-name" id="card-modal-name"></h2>
+          <div class="card-title" id="card-modal-title"></div>
+          <div class="card-blurb" id="card-modal-blurb"></div>
+          <div class="card-meta" id="card-modal-meta"></div>
+          <div class="card-keepsake" id="card-modal-keepsake"></div>
+          <div class="card-economy" id="card-modal-economy"></div>
+        </div>
       </div>
     </section>
   </div>
@@ -11379,10 +11582,10 @@
       const retryableWithoutOrbs = Boolean(art.retryable_without_orbs);
       const viewerContributed = Boolean(art.viewer_contributed);
       if (clientState?.status === "starting") {
-        return `<div class="economy-row"><span>level ${level} image</span><strong>image workshop starting…</strong></div>`;
+        return `<div class="card-art-status"><span>level ${level} portrait</span> <strong>Image workshop starting…</strong></div>`;
       }
       if (status === "ready") {
-        return `<div class="economy-row"><span>community image</span><strong>level ${level} complete</strong></div><div class="economy-row"><span>next image</span><strong>unlocks at the next level</strong></div>`;
+        return `<div class="card-art-status"><span>community portrait</span> <strong>Level ${level} complete · next portrait unlocks at the next level.</strong></div>`;
       }
       const balance = Math.max(0, Number(state?.economy?.orbs || 0));
       const needsOrb = remaining > 0;
@@ -11419,9 +11622,9 @@
         ? `<button class="account-button" type="button" data-fund-community-image="${escapeAttr(subject.kind)}:${subject.id}">${escapeHtml(buttonLabel)}</button>`
         : "";
       const clientError = clientState?.status === "error"
-        ? `<div class="economy-row"><span>image update</span><strong>${escapeHtml(clientState.message)}</strong></div>`
+        ? `<div class="card-art-status error"><span>portrait update</span> <strong>${escapeHtml(clientState.message)}</strong></div>`
         : "";
-      return `<div class="economy-row"><span>level ${level} image</span><strong>${escapeHtml(detail)}</strong></div>${clientError}${action}`;
+      return `<div class="card-art-status"><span>level ${level} portrait</span> <strong>${escapeHtml(finishSentence(detail))}</strong></div>${clientError}${action}`;
     }
 
     function communityArtPlaceholderLabel(card) {
@@ -11582,12 +11785,42 @@
 
     function actorControlModeLabel(actor) {
       return {
-        direct_input: "player choice",
-        reactive_ai: "reactive inference",
-        local_ai: "local inference",
-        roaming_ai: "roaming inference",
-        delegated_ai: "delegated inference",
+        direct_input: Number(actor?.id || 0) === Number(actorId || 0) ? "you" : "another player",
+        reactive_ai: "a world character",
+        local_ai: "a world character",
+        roaming_ai: "a world character",
+        delegated_ai: "a delegated character",
       }[String(actor?.control_mode || "")] || "";
+    }
+
+    function practiceEvidenceTarget(evidence) {
+      const targetKind = cleanEconomyText(evidence?.target_kind).toLowerCase();
+      const targetId = Number(evidence?.target_id || 0);
+      if (targetKind === "location") {
+        const card = targetId ? cardForLocation(targetId) : null;
+        return cleanEconomyText(card?.display_name || card?.title) || "a hidden place";
+      }
+      if (targetKind === "actor" || targetKind === "avatar" || targetKind === "resident") {
+        const targetActor = targetId ? actorForId(targetId) : null;
+        return targetActor ? actorLabel(targetActor) : "someone in the shared world";
+      }
+      if (targetKind === "item") {
+        return targetId ? itemNameForId(targetId) : "a lasting keepsake";
+      }
+      return "the shared world";
+    }
+
+    function practiceEvidenceSummary(evidence) {
+      const target = practiceEvidenceTarget(evidence);
+      return {
+        exploration: `Discovered ${target}.`,
+        craft: `Made or transformed ${target}.`,
+        delivery: `Delivered a keepsake to ${target}.`,
+        stewardship: `Completed meaningful work for ${target}.`,
+        care: `Protected or restored ${target}.`,
+        mediation: `Helped resolve a strain involving ${target}.`,
+        lore: `Recovered knowledge connected to ${target}.`,
+      }[cleanEconomyText(evidence?.category).toLowerCase()] || `Left a lasting mark on ${target}.`;
     }
 
     function actorPracticePanelHtml(actor) {
@@ -11598,11 +11831,8 @@
           [practice.epithet, practice.known_for].filter(Boolean).join(" — ")
         )),
       ];
-      for (const [index, evidence] of (practice.evidence || []).slice(0, 2).entries()) {
-        const description = cleanEconomyText(evidence?.description);
-        if (description) {
-          rows.push(economyRowHtml(index === 0 ? "because" : "and", escapeHtml(description)));
-        }
+      for (const evidence of (practice.evidence || []).slice(0, 2)) {
+        rows.push(economyRowHtml("recently", escapeHtml(practiceEvidenceSummary(evidence))));
       }
       return rows.join("");
     }
@@ -11702,27 +11932,37 @@
 
     function actorEconomyPanelHtml(actor) {
       if (!actor) return "";
-      const rows = [];
+      const currentRows = [];
+      const detailRows = [];
       const practice = actorPracticePanelHtml(actor);
-      if (practice) rows.push(practice);
+      if (practice) detailRows.push(practice);
       const controller = actorControlModeLabel(actor);
-      if (controller) rows.push(economyRowHtml("controller", escapeHtml(controller)));
+      if (controller) detailRows.push(economyRowHtml("played by", escapeHtml(controller)));
       const economy = actor?.economy || null;
       if (!economy) {
         if (Number(actor.id || 0) !== Number(actorId || 0)) {
-          rows.push(economyRowHtml("today", "nothing known yet"));
+          currentRows.push(economyRowHtml("today", "Nothing known yet."));
         }
-        return `${rows.join("")}${actorSafetyPanelHtml(actor)}`;
+        const current = currentRows.length
+          ? `<section class="card-current" aria-label="Current character state"><div class="card-section-label">Now</div>${currentRows.join("")}</section>`
+          : "";
+        const details = detailRows.length
+          ? `<details class="card-more"><summary>History & details</summary><div class="card-more-body">${detailRows.join("")}</div></details>`
+          : "";
+        return `${current}${actorSafetyPanelHtml(actor)}${details}`;
       }
       const motive = economyMotiveSummary(actor, economy);
       if (motive && !economyMotiveRepeatsRows(actor, economy, motive)) {
-        rows.push(economyRowHtml("today", escapeHtml(motive)));
+        currentRows.push(economyRowHtml("today", escapeHtml(motive)));
       }
       const inventoryCount = Number(economy.inventory_count);
       const carriedWeight = Number(economy.carried_weight_tenths || 0);
       const carryingCapacity = Number(economy.carrying_capacity_tenths || 0);
       if (Number.isFinite(inventoryCount) && Number.isFinite(carryingCapacity) && carryingCapacity > 0) {
-        rows.push(economyRowHtml("carried deck", escapeHtml(`${inventoryCount} card${inventoryCount === 1 ? "" : "s"} · ${deckWeightLabel(carriedWeight)} / ${deckWeightLabel(carryingCapacity)}`)));
+        const carrying = inventoryCount === 0
+          ? "Nothing right now."
+          : `${inventoryCount} keepsake${inventoryCount === 1 ? "" : "s"} · ${deckWeightLabel(carriedWeight)} / ${deckWeightLabel(carryingCapacity)}`;
+        detailRows.push(economyRowHtml("carrying", escapeHtml(carrying)));
       }
       const sought = Array.isArray(economy.sought_items) ? economy.sought_items : [];
       const listedSoughtIds = new Set();
@@ -11730,20 +11970,26 @@
       if (request?.item_id) {
         const matchingSought = sought.find((soughtItem) => Number(soughtItem.item_id) === Number(request.item_id));
         const tags = soughtItemTags(matchingSought || {});
-        rows.push(economyRowHtml("wants", economyItemSummaryHtml(itemNameForId(request.item_id), tags)));
+        currentRows.push(economyRowHtml("wants", economyItemSummaryHtml(itemNameForId(request.item_id), tags)));
         listedSoughtIds.add(Number(request.item_id));
       }
       const trade = economy.trade_stance || economy.trade_offer || null;
       if (trade?.offered_item_id && trade?.requested_item_id) {
         const tradeText = `${itemNameForId(trade.offered_item_id)} for ${itemNameForId(trade.requested_item_id)}; ${trade.willingness || "willing"}`;
-        rows.push(economyRowHtml("trade", escapeHtml(trade.reason ? `${tradeText}. ${trade.reason}` : tradeText)));
+        currentRows.push(economyRowHtml("trade", escapeHtml(trade.reason ? `${tradeText}. ${trade.reason}` : tradeText)));
       }
       for (const soughtItem of sought) {
         if (listedSoughtIds.has(Number(soughtItem.item_id))) continue;
         const itemName = itemNameForId(soughtItem.item_id);
-        rows.push(economyRowHtml("seeks", economyItemSummaryHtml(itemName, soughtItemTags(soughtItem))));
+        currentRows.push(economyRowHtml("seeks", economyItemSummaryHtml(itemName, soughtItemTags(soughtItem))));
       }
-      return `${rows.join("")}${actorSafetyPanelHtml(actor)}`;
+      const current = currentRows.length
+        ? `<section class="card-current" aria-label="Current character state"><div class="card-section-label">Now</div>${currentRows.join("")}</section>`
+        : "";
+      const details = detailRows.length
+        ? `<details class="card-more"><summary>History & details</summary><div class="card-more-body">${detailRows.join("")}</div></details>`
+        : "";
+      return `${current}${actorSafetyPanelHtml(actor)}${details}`;
     }
 
     function nearbyLocationPanelHtml(card) {
@@ -11766,8 +12012,9 @@
       if (!card) return;
       const key = cardKey(card);
       const dialog = $("card-modal").querySelector(".card-dialog");
+      const scroller = dialog?.querySelector(".card-dialog-scroll");
       const copy = dialog?.querySelector(".card-copy");
-      const dialogScrollTop = preservePosition ? Number(dialog?.scrollTop || 0) : 0;
+      const dialogScrollTop = preservePosition ? Number(scroller?.scrollTop || 0) : 0;
       const copyScrollTop = preservePosition ? Number(copy?.scrollTop || 0) : 0;
       const image = cardImage(card) || fallbackCardImage(card);
       const actor = actorForCard(card);
@@ -11796,11 +12043,12 @@
       $("card-modal-meta").innerHTML = meta.map((value) => `<span>${escapeHtml(value)}</span>`).join("");
       const promise = keepsakePromise(card);
       $("card-modal-keepsake").innerHTML = promise
-        ? `<span>when kept close</span>${escapeHtml(promise)}`
+        ? `<span>companion art · cosmetic</span>${escapeHtml(promise)}`
         : "";
-      $("card-modal-economy").innerHTML = `${actorEconomyPanelHtml(actor)}${nearbyLocationPanelHtml(card)}${communityArtPanelHtml(card)}`;
+      $("card-modal-art-workshop").innerHTML = communityArtPanelHtml(card);
+      $("card-modal-economy").innerHTML = `${actorEconomyPanelHtml(actor)}${nearbyLocationPanelHtml(card)}`;
       openModal("card-modal", $("card-modal").querySelector(".card-close"), !preservePosition);
-      if (dialog) dialog.scrollTop = dialogScrollTop;
+      if (scroller) scroller.scrollTop = dialogScrollTop;
       if (copy) copy.scrollTop = copyScrollTop;
     }
 
@@ -11828,6 +12076,7 @@
       openCardModalKey = "";
       closeModal("card-modal");
       $("card-modal-image").removeAttribute("src");
+      $("card-modal-art-workshop").innerHTML = "";
       $("card-modal-keepsake").innerHTML = "";
       $("card-modal-economy").innerHTML = "";
     }

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2153,13 +2153,18 @@
       background: rgba(3, 5, 4, 0.76);
     }
     .card-modal {
+      --card-modal-available-height: calc(
+        100dvh
+        - max(12px, env(safe-area-inset-top, 0px))
+        - max(12px, env(safe-area-inset-bottom, 0px))
+      );
       min-height: 100svh;
       height: 100dvh;
       padding:
-        max(12px, env(safe-area-inset-top))
-        max(12px, env(safe-area-inset-right))
-        max(12px, env(safe-area-inset-bottom))
-        max(12px, env(safe-area-inset-left));
+        max(12px, env(safe-area-inset-top, 0px))
+        max(12px, env(safe-area-inset-right, 0px))
+        max(12px, env(safe-area-inset-bottom, 0px))
+        max(12px, env(safe-area-inset-left, 0px));
     }
     .card-modal[hidden],
     .all-actions-modal[hidden],
@@ -2188,13 +2193,15 @@
     }
     .card-dialog {
       position: relative;
-      max-height: calc(100dvh - 24px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+      width: min(420px, 100%);
+      max-width: 100%;
+      max-height: var(--card-modal-available-height);
       overflow: hidden;
       padding: 0;
     }
     .card-dialog-scroll {
       width: 100%;
-      max-height: inherit;
+      max-height: var(--card-modal-available-height);
       overflow: auto;
       overscroll-behavior: contain;
       padding: 12px;
@@ -2912,7 +2919,7 @@
     }
     @media (min-width: 701px) {
       .card-dialog.portrait-card {
-        width: min(780px, calc(100vw - 36px));
+        width: min(780px, 100%);
       }
       .card-dialog.portrait-card .card-dialog-scroll {
         display: grid;
@@ -3007,23 +3014,23 @@
         grid-row: 4;
         margin-top: 2px;
       }
-      .card-dialog.portrait-card .card-blurb {
+      .card-dialog.portrait-card .card-economy {
         grid-column: 1 / -1;
         grid-row: 5;
+        margin-top: 2px;
+      }
+      .card-dialog.portrait-card .card-blurb {
+        grid-column: 1 / -1;
+        grid-row: 6;
         margin-top: 4px;
         font-size: 15px;
         line-height: 1.45;
       }
       .card-dialog.portrait-card .card-keepsake {
         grid-column: 1 / -1;
-        grid-row: 6;
+        grid-row: 7;
         font-size: 14px;
         line-height: 1.45;
-      }
-      .card-dialog.portrait-card .card-economy {
-        grid-column: 1 / -1;
-        grid-row: 7;
-        margin-top: 2px;
       }
       .card-dialog.portrait-card .card-economy-row {
         grid-template-columns: minmax(74px, 94px) minmax(0, 1fr);
@@ -3921,6 +3928,35 @@
     body.large-text .account-row {
       font-size: 1rem;
     }
+    body.large-text .card-dialog {
+      font-size: 17px;
+    }
+    body.large-text .card-dialog .card-name {
+      font-size: 1.25em;
+    }
+    body.large-text .card-dialog :is(
+      .card-title,
+      .card-blurb,
+      .card-keepsake,
+      .card-economy-row,
+      .card-art-status strong,
+      .card-more > summary,
+      .avatar-item-detail strong,
+      .avatar-item-detail small,
+      .avatar-items-empty
+    ) {
+      font-size: 1em;
+    }
+    body.large-text .card-dialog :is(
+      .card-meta span,
+      .card-section-label,
+      .card-art-status span,
+      .avatar-items-label,
+      .nearby-keepsakes-label,
+      .avatar-icon-action.account-button
+    ) {
+      font-size: 0.85em;
+    }
     body.reduce-motion *,
     body.reduce-motion *::before,
     body.reduce-motion *::after {
@@ -4277,8 +4313,8 @@
       <button class="card-close" type="button" data-card-close aria-label="Close keepsake details">x</button>
       <div class="card-dialog-scroll">
         <div class="card-art-column">
-          <div class="card-art"><img id="card-modal-image" alt="" /></div>
-          <div class="card-art-workshop" id="card-modal-art-workshop" aria-live="polite" aria-atomic="true"></div>
+          <div class="card-art"><img id="card-modal-image" alt="" aria-describedby="card-modal-art-workshop" /></div>
+          <div class="card-art-workshop" id="card-modal-art-workshop" role="status" aria-live="polite" aria-atomic="true"></div>
         </div>
         <div class="card-copy">
           <h2 class="card-name" id="card-modal-name"></h2>
@@ -4605,7 +4641,7 @@
 
     function trapModalFocus(event, modal) {
       if (event.key !== "Tab" || !modal) return false;
-      const focusable = [...modal.querySelectorAll("button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])")]
+      const focusable = [...modal.querySelectorAll("button:not([disabled]), summary, [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])")]
         .filter((node) => !node.hidden && node.getAttribute("aria-hidden") !== "true" && node.getClientRects().length > 0);
       const dialog = modal.querySelector("[role='dialog']");
       if (!focusable.length) {
@@ -11823,6 +11859,18 @@
       }[cleanEconomyText(evidence?.category).toLowerCase()] || `Left a lasting mark on ${target}.`;
     }
 
+    function actorAvailabilityLabel(actor) {
+      const status = cleanEconomyText(actor?.status).toLowerCase();
+      if (status === "active") {
+        return Number(actor?.location_id || 0) === Number(state?.location?.id || 0)
+          ? "Here and available."
+          : "Active elsewhere in the world.";
+      }
+      if (status === "knocked_out") return "Knocked out and unable to act.";
+      if (status === "dead") return "Their tale has ended.";
+      return "Current availability is unknown.";
+    }
+
     function actorPracticePanelHtml(actor) {
       const practice = actor?.practice;
       if (!practice?.primary) return "";
@@ -11831,7 +11879,7 @@
           [practice.epithet, practice.known_for].filter(Boolean).join(" — ")
         )),
       ];
-      for (const evidence of (practice.evidence || []).slice(0, 2)) {
+      for (const evidence of (practice.evidence || [])) {
         rows.push(economyRowHtml("recently", escapeHtml(practiceEvidenceSummary(evidence))));
       }
       return rows.join("");
@@ -11932,7 +11980,9 @@
 
     function actorEconomyPanelHtml(actor) {
       if (!actor) return "";
-      const currentRows = [];
+      const currentRows = [
+        economyRowHtml("availability", escapeHtml(actorAvailabilityLabel(actor))),
+      ];
       const detailRows = [];
       const practice = actorPracticePanelHtml(actor);
       if (practice) detailRows.push(practice);

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -48680,12 +48680,15 @@ mod tests {
         assert!(INDEX_HTML.contains("economy.trade_stance"));
         assert!(INDEX_HTML.contains("function actorEconomyPanelHtml"));
         assert!(INDEX_HTML.contains("function practiceEvidenceSummary"));
+        assert!(INDEX_HTML.contains("function actorAvailabilityLabel"));
         assert!(INDEX_HTML.contains("function actorPracticePanelHtml"));
-        assert!(INDEX_HTML.contains("(practice.evidence || []).slice(0, 2)"));
+        assert!(INDEX_HTML.contains("for (const evidence of (practice.evidence || []))"));
         assert!(INDEX_HTML.contains("economyRowHtml(\"known for\""));
         assert!(INDEX_HTML.contains("function actorControlModeLabel"));
         assert!(INDEX_HTML.contains("played by\", escapeHtml(controller)"));
         assert!(INDEX_HTML.contains("card-modal-art-workshop"));
+        assert!(INDEX_HTML.contains("aria-describedby=\"card-modal-art-workshop\""));
+        assert!(INDEX_HTML.contains("button:not([disabled]), summary, [href]"));
         assert!(!INDEX_HTML.contains("room-avatar-more"));
         assert!(INDEX_HTML.contains("economy.inventory_count"));
         assert!(INDEX_HTML.contains("economy.carrying_capacity_tenths"));

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -42119,7 +42119,7 @@ mod tests {
     fn avatar_inspector_exposes_notice_transfer_and_safety_controls() {
         for contract in [
             "data-avatar-notice=",
-            "nothing known yet",
+            "Nothing known yet.",
             "data-avatar-transfer=\"give\"",
             "data-avatar-item-toggle=",
             "data-avatar-item-action=\"trade\"",
@@ -48679,13 +48679,13 @@ mod tests {
         assert!(INDEX_HTML.contains("target.economy?.trade_offer"));
         assert!(INDEX_HTML.contains("economy.trade_stance"));
         assert!(INDEX_HTML.contains("function actorEconomyPanelHtml"));
-        assert!(INDEX_HTML.contains("actor?.economy"));
+        assert!(INDEX_HTML.contains("function practiceEvidenceSummary"));
         assert!(INDEX_HTML.contains("function actorPracticePanelHtml"));
         assert!(INDEX_HTML.contains("(practice.evidence || []).slice(0, 2)"));
         assert!(INDEX_HTML.contains("economyRowHtml(\"known for\""));
         assert!(INDEX_HTML.contains("function actorControlModeLabel"));
-        assert!(INDEX_HTML.contains("controller\", escapeHtml(controller)"));
-        assert!(INDEX_HTML.contains("return actors.map((actor) =>"));
+        assert!(INDEX_HTML.contains("played by\", escapeHtml(controller)"));
+        assert!(INDEX_HTML.contains("card-modal-art-workshop"));
         assert!(!INDEX_HTML.contains("room-avatar-more"));
         assert!(INDEX_HTML.contains("economy.inventory_count"));
         assert!(INDEX_HTML.contains("economy.carrying_capacity_tenths"));
@@ -48693,7 +48693,7 @@ mod tests {
         assert!(INDEX_HTML.contains("economy.sought_items"));
         assert!(INDEX_HTML.contains("soughtItem?.world_status"));
         assert!(INDEX_HTML.contains("currently with ${worldHolderName}"));
-        assert!(INDEX_HTML.contains("card-modal-economy"));
+        assert!(!INDEX_HTML.contains("class=\"economy-row\""));
         assert!(INDEX_HTML.contains("class=\"account-card-open\""));
         assert!(INDEX_HTML.contains("class=\"account-asset-effect\""));
         assert!(INDEX_HTML.contains("class=\"keepsake-call\""));

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -141,4 +141,9 @@
 # and recommendation regressions now live. The root retains only persisted/view
 # types and the existing end-to-end campaign test. Its explicit non-combat check
 # disclosure supersedes #464's earlier product hold while combat stays narrative.
-73369
+# 73369 -> 73372: three net test-only lines pin the redesigned mobile
+# character card for issue #517 — the practice-evidence summary, the
+# availability label, the art-workshop describedby target, and the focus-trap
+# selector. The behaviour lives in index.html; main.rs only owns the
+# cross-surface INDEX_HTML contract beside it.
+73372

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4888,7 +4888,8 @@ async function main() {
           subject: button?.getAttribute("data-fund-community-image") || "",
           label: button?.textContent?.trim() || "",
           disabled: button?.disabled ?? true,
-          copy: document.querySelector("#card-modal-economy")?.textContent?.replace(/\s+/g, " ").trim() || "",
+          copy: document.querySelector("#card-modal-art-workshop")?.textContent?.replace(/\s+/g, " ").trim() || "",
+          live: document.querySelector("#card-modal-art-workshop")?.getAttribute("aria-live") || "",
         };
       } finally {
         closeCardModal();
@@ -4899,6 +4900,7 @@ async function main() {
       pathwayContract.subject === "location:990001"
         && pathwayContract.label === "add one Orb · 0/1"
         && pathwayContract.disabled === false
+        && pathwayContract.live === "polite"
         && pathwayContract.copy.includes("1 Orb still needed from the community"),
       `a revealed generated pathway keepsake should expose its Orb image contract: ${JSON.stringify(pathwayContract)}`,
     );
@@ -4977,7 +4979,7 @@ async function main() {
     );
     assert(
       communityArtStates.contributedPending.button === ""
-        && communityArtStates.contributedPending.copy.includes("your Orb is already helping")
+        && communityArtStates.contributedPending.copy.toLowerCase().includes("your orb is already helping")
         && communityArtStates.contributedPending.copy.includes("still needed from other players"),
       `a player who already contributed should see pending state instead of another invitation: ${JSON.stringify(communityArtStates)}`,
     );
@@ -4986,6 +4988,10 @@ async function main() {
         && communityArtStates.failed.copy.includes("no more provider credits will be used")
         && !/buy|purchase/i.test(JSON.stringify(communityArtStates)),
       `a terminal generation failure should be explicit and purchase-free: ${JSON.stringify(communityArtStates)}`,
+    );
+    assert(
+      Object.values(communityArtStates).every((entry) => /\bportrait\s+\S/.test(entry.copy)),
+      `community portrait labels and values should remain separated in text alternatives: ${JSON.stringify(communityArtStates)}`,
     );
 
     const communityArtRetryLifecycle = await page.evaluate(async () => {
@@ -5039,7 +5045,7 @@ async function main() {
       };
       const panelSnapshot = () => ({
         hidden: document.querySelector("#card-modal")?.hidden ?? true,
-        copy: document.querySelector("#card-modal-economy")?.textContent?.replace(/\s+/g, " ").trim() || "",
+        copy: document.querySelector("#card-modal-art-workshop")?.textContent?.replace(/\s+/g, " ").trim() || "",
         buttons: document.querySelectorAll("#card-modal [data-fund-community-image]").length,
       });
       try {
@@ -5148,7 +5154,7 @@ async function main() {
       communityArtRetryLifecycle.actionCalls === 1
         && communityArtRetryLifecycle.starting.hidden === false
         && communityArtRetryLifecycle.starting.buttons === 0
-        && communityArtRetryLifecycle.starting.copy.includes("image workshop starting"),
+        && communityArtRetryLifecycle.starting.copy.toLowerCase().includes("image workshop starting"),
       `a rapid repeated retry should coalesce and expose immediate starting state: ${JSON.stringify(communityArtRetryLifecycle)}`,
     );
     assert(
@@ -5217,7 +5223,7 @@ async function main() {
         missing: image?.dataset.artMissing || "",
         placeholder: image?.dataset.artPlaceholder || "",
         overlay: getComputedStyle(document.querySelector("#card-modal .card-art"), "::after").content,
-        panel: document.querySelector("#card-modal-economy")?.textContent?.replace(/\s+/g, " ").trim() || "",
+        panel: document.querySelector("#card-modal-art-workshop")?.textContent?.replace(/\s+/g, " ").trim() || "",
       };
     });
     assert(
@@ -5225,7 +5231,7 @@ async function main() {
         && brokenArtFallback.missing === "true"
         && brokenArtFallback.placeholder === "community image pending"
         && brokenArtFallback.overlay.includes("community image pending")
-        && brokenArtFallback.panel.includes("your Orb is already helping"),
+        && brokenArtFallback.panel.toLowerCase().includes("your orb is already helping"),
       `an unresolvable generated-art URL should render the authored, state-aware placeholder: ${JSON.stringify(brokenArtFallback)}`,
     );
     await page.evaluate(() => {
@@ -5287,28 +5293,86 @@ async function main() {
       await closeCardModal();
 
       const desktopViewport = page.viewportSize();
-      await page.setViewportSize({ width: 430, height: 860 });
-      await residentTargets.first().click();
-      await page.waitForSelector("#card-modal:not([hidden])");
-      const mobileCard = await page.evaluate(() => {
-        const dialog = document.querySelector("#card-modal .card-dialog");
-        const art = document.querySelector("#card-modal .card-art");
-        const copy = document.querySelector("#card-modal .card-copy");
-        const dialogRect = dialog?.getBoundingClientRect();
-        const artRect = art?.getBoundingClientRect();
-        const copyRect = copy?.getBoundingClientRect();
-        return {
-          dialogWidth: dialogRect?.width || 0,
-          artBottom: artRect?.bottom || 0,
-          copyTop: copyRect?.top || 0,
-          viewportWidth: window.innerWidth,
-          documentWidth: document.documentElement.scrollWidth,
-        };
-      });
-      assert(mobileCard.dialogWidth <= mobileCard.viewportWidth, `mobile cards should stay within the viewport: ${JSON.stringify(mobileCard)}`);
-      assert(mobileCard.artBottom <= mobileCard.copyTop + 1, `mobile portrait cards should stack copy beneath the art: ${JSON.stringify(mobileCard)}`);
-      assert(mobileCard.documentWidth <= mobileCard.viewportWidth, `mobile cards should not introduce horizontal scrolling: ${JSON.stringify(mobileCard)}`);
-      await closeCardModal();
+      for (const viewport of [{ width: 430, height: 860 }, { width: 375, height: 667 }]) {
+        await page.setViewportSize(viewport);
+        await residentTargets.first().click();
+        await page.waitForSelector("#card-modal:not([hidden])");
+        const mobileCard = await page.evaluate(() => {
+          const dialog = document.querySelector("#card-modal .card-dialog");
+          const scroller = document.querySelector("#card-modal .card-dialog-scroll");
+          const art = document.querySelector("#card-modal .card-art");
+          const name = document.querySelector("#card-modal-name");
+          const current = document.querySelector("#card-modal .card-current");
+          const actions = document.querySelector("#card-modal .avatar-action-strip");
+          const close = document.querySelector("#card-modal [data-card-close]");
+          const rect = (node) => node?.getBoundingClientRect().toJSON() || null;
+          const dialogRect = rect(dialog);
+          const artRect = rect(art);
+          const nameRect = rect(name);
+          const currentRect = rect(current);
+          const actionsRect = rect(actions);
+          const initialCloseRect = rect(close);
+          const usefulBottom = Math.max(
+            nameRect?.bottom || 0,
+            currentRect?.bottom || 0,
+            actionsRect?.bottom || 0,
+          );
+          if (scroller) scroller.scrollTop = scroller.scrollHeight;
+          const scrolledCloseRect = rect(close);
+          document.body.classList.add("large-text");
+          const largeTextDialogRect = rect(dialog);
+          const largeTextCloseRect = rect(close);
+          document.body.classList.remove("large-text");
+          return {
+            viewport: `${window.innerWidth}x${window.innerHeight}`,
+            dialog: dialogRect,
+            art: artRect,
+            name: nameRect,
+            current: currentRect,
+            actions: actionsRect,
+            initialClose: initialCloseRect,
+            scrolledClose: scrolledCloseRect,
+            largeTextDialog: largeTextDialogRect,
+            largeTextClose: largeTextCloseRect,
+            usefulBottom,
+            documentWidth: document.documentElement.scrollWidth,
+          };
+        });
+        assert(
+          mobileCard.dialog?.left >= 0
+            && mobileCard.dialog?.right <= viewport.width
+            && mobileCard.dialog?.top >= 0
+            && mobileCard.dialog?.bottom <= viewport.height,
+          `mobile cards should stay inside the visual viewport: ${JSON.stringify(mobileCard)}`,
+        );
+        assert(
+          mobileCard.art?.right <= mobileCard.name?.left + 1,
+          `mobile portrait cards should pair compact art with identity instead of leading with a poster: ${JSON.stringify(mobileCard)}`,
+        );
+        assert(
+          mobileCard.current && mobileCard.usefulBottom <= mobileCard.dialog.bottom + 1,
+          `mobile character identity and current state should be useful above the fold: ${JSON.stringify(mobileCard)}`,
+        );
+        for (const [stateLabel, closeRect] of [
+          ["initial", mobileCard.initialClose],
+          ["scrolled", mobileCard.scrolledClose],
+          ["large text", mobileCard.largeTextClose],
+        ]) {
+          assert(
+            closeRect?.width >= 44
+              && closeRect?.height >= 44
+              && closeRect?.top >= mobileCard.dialog.top
+              && closeRect?.right <= mobileCard.dialog.right + 1,
+            `${stateLabel} mobile card close control should remain visible and tappable: ${JSON.stringify(mobileCard)}`,
+          );
+        }
+        assert(
+          mobileCard.largeTextDialog?.right <= viewport.width
+            && mobileCard.documentWidth <= viewport.width,
+          `mobile cards should not introduce horizontal scrolling with larger text: ${JSON.stringify(mobileCard)}`,
+        );
+        await closeCardModal();
+      }
       if (desktopViewport) await page.setViewportSize(desktopViewport);
     }
 
@@ -5336,6 +5400,63 @@ async function main() {
     });
     assert(!economyCopy.repeated.includes(">today<") && !economyCopy.repeated.includes("Skull seeks"), `default motives should not repeat the wants rows: ${JSON.stringify(economyCopy)}`);
     assert(economyCopy.remembered.includes(">today<") && economyCopy.remembered.includes("remembers Watch Bell near Old Oak Tree"), `meaningful resident context should remain visible: ${JSON.stringify(economyCopy)}`);
+
+    const practiceCopy = await page.evaluate(() => {
+      const previousState = state;
+      try {
+        state = {
+          ...previousState,
+          cards: {
+            ...(previousState?.cards || {}),
+            locations: {
+              ...(previousState?.cards?.locations || {}),
+              1: {
+                card_id: "cosy-cottage",
+                display_name: "The Cosy Cottage",
+                role: "location",
+              },
+            },
+          },
+        };
+        const html = actorPracticePanelHtml({
+          practice: {
+            primary: "exploration",
+            epithet: "Explorer",
+            known_for: "finding and opening hidden ways",
+            evidence: [
+              {
+                category: "exploration",
+                target_kind: "location",
+                target_id: "1",
+                description: "Made the discovery at location 1 part of the shared world.",
+              },
+              {
+                category: "exploration",
+                target_kind: "location",
+                target_id: "712",
+                description: "Made the discovery at location 712 part of the shared world.",
+              },
+            ],
+          },
+        });
+        const host = document.createElement("div");
+        host.innerHTML = html;
+        return {
+          html,
+          text: host.textContent.replace(/\s+/g, " ").trim(),
+        };
+      } finally {
+        state = previousState;
+      }
+    });
+    assert(
+      practiceCopy.text.includes("Discovered The Cosy Cottage.")
+        && practiceCopy.text.includes("Discovered a hidden place.")
+        && !/\blocation\s+\d+\b/i.test(practiceCopy.text)
+        && !/>because</i.test(practiceCopy.html)
+        && !/>and</i.test(practiceCopy.html),
+      `practice history should use complete narrative evidence without database IDs: ${JSON.stringify(practiceCopy)}`,
+    );
   }
 
   async function assertRoomSummaryStaysFlatAndMechanical() {

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4933,9 +4933,21 @@ async function main() {
         const host = document.createElement("div");
         host.innerHTML = communityArtPanelHtml(card);
         const button = host.querySelector("[data-fund-community-image]");
+        const statuses = [...host.querySelectorAll(".card-art-status")].map((status) => {
+          const label = status.querySelector("span")?.textContent?.trim() || "";
+          const value = status.querySelector("strong")?.textContent?.trim() || "";
+          return {
+            label,
+            value,
+            text: status.textContent.replace(/\s+/g, " ").trim(),
+          };
+        });
         return {
           copy: host.textContent.replace(/\s+/g, " ").trim(),
           button: button?.textContent?.trim() || "",
+          statuses,
+          formatted: statuses.length > 0
+            && statuses.every(({ label, value, text }) => label && value && text === `${label} ${value}`),
         };
       };
       try {
@@ -4955,6 +4967,22 @@ async function main() {
             remaining_orbs: 1,
             viewer_contributed: true,
             status: "funding",
+          }, 4),
+          generating: renderPanel({
+            level: 2,
+            required_orbs: 2,
+            funded_orbs: 2,
+            remaining_orbs: 0,
+            viewer_contributed: true,
+            status: "generating",
+          }, 4),
+          ready: renderPanel({
+            level: 2,
+            required_orbs: 2,
+            funded_orbs: 2,
+            remaining_orbs: 0,
+            viewer_contributed: true,
+            status: "ready",
           }, 4),
           failed: renderPanel({
             level: 2,
@@ -4990,7 +5018,7 @@ async function main() {
       `a terminal generation failure should be explicit and purchase-free: ${JSON.stringify(communityArtStates)}`,
     );
     assert(
-      Object.values(communityArtStates).every((entry) => /\bportrait\s+\S/.test(entry.copy)),
+      Object.values(communityArtStates).every((entry) => entry.formatted),
       `community portrait labels and values should remain separated in text alternatives: ${JSON.stringify(communityArtStates)}`,
     );
 
@@ -5047,6 +5075,11 @@ async function main() {
         hidden: document.querySelector("#card-modal")?.hidden ?? true,
         copy: document.querySelector("#card-modal-art-workshop")?.textContent?.replace(/\s+/g, " ").trim() || "",
         buttons: document.querySelectorAll("#card-modal [data-fund-community-image]").length,
+        formatted: [...document.querySelectorAll("#card-modal .card-art-status")].every((status) => {
+          const label = status.querySelector("span")?.textContent?.trim() || "";
+          const value = status.querySelector("strong")?.textContent?.trim() || "";
+          return Boolean(label && value && status.textContent.replace(/\s+/g, " ").trim() === `${label} ${value}`);
+        }),
       });
       try {
         const lifecycleEvents = [
@@ -5154,12 +5187,14 @@ async function main() {
       communityArtRetryLifecycle.actionCalls === 1
         && communityArtRetryLifecycle.starting.hidden === false
         && communityArtRetryLifecycle.starting.buttons === 0
+        && communityArtRetryLifecycle.starting.formatted
         && communityArtRetryLifecycle.starting.copy.toLowerCase().includes("image workshop starting"),
       `a rapid repeated retry should coalesce and expose immediate starting state: ${JSON.stringify(communityArtRetryLifecycle)}`,
     );
     assert(
       communityArtRetryLifecycle.generating.hidden === false
         && communityArtRetryLifecycle.generating.buttons === 0
+        && communityArtRetryLifecycle.generating.formatted
         && communityArtRetryLifecycle.generating.copy.includes("saved job is still in progress"),
       `authoritative generation state should replace the starting latch without closing the modal: ${JSON.stringify(communityArtRetryLifecycle)}`,
     );
@@ -5261,8 +5296,12 @@ async function main() {
     const residentTargets = page.locator(".room-avatar-pfp[data-card-key^='resident:']");
     const residentTargetCount = await residentTargets.count();
     if (residentTargetCount > 0) {
+      await residentTargets.first().evaluate((trigger) => {
+        trigger.dataset.cardModalFocusReturnSmoke = "true";
+      });
       await residentTargets.first().click();
       await page.waitForSelector("#card-modal:not([hidden])");
+      await page.waitForFunction(() => document.activeElement?.matches?.("#card-modal [data-card-close]"));
       const residentCard = await page.evaluate(() => {
         const dialog = document.querySelector("#card-modal .card-dialog");
         const art = document.querySelector("#card-modal .card-art");
@@ -5279,6 +5318,10 @@ async function main() {
           copy: rect(copy),
           economyRect: rect(economy),
           copyFits: !copy || copy.scrollHeight <= copy.clientHeight + 1,
+          backgroundInert: document.querySelector(".shell")?.hasAttribute("inert") || false,
+          closeFocused: document.activeElement?.matches?.("#card-modal [data-card-close]") || false,
+          labelledBy: dialog?.getAttribute("aria-labelledby") || "",
+          describedBy: document.querySelector("#card-modal-image")?.getAttribute("aria-describedby") || "",
         };
       });
       assert(!/\blv\s*\d+/i.test(residentCard.meta), `resident cards should not expose level shorthand: ${JSON.stringify(residentCard)}`);
@@ -5286,11 +5329,38 @@ async function main() {
       assert(!/\bslots?\b/i.test(residentCard.economy), `resident cards should describe their hands without inventory slots: ${JSON.stringify(residentCard)}`);
       assert(!/\bwhy\b/i.test(residentCard.economy), `resident cards should not repeat their default wants as a why-row: ${JSON.stringify(residentCard)}`);
       assert(residentCard.portrait, `resident cards should opt into the portrait layout: ${JSON.stringify(residentCard)}`);
+      assert(
+        residentCard.backgroundInert
+          && residentCard.closeFocused
+          && residentCard.labelledBy === "card-modal-name"
+          && residentCard.describedBy === "card-modal-art-workshop",
+        `character cards should isolate, label, and focus the modal while associating portrait status: ${JSON.stringify(residentCard)}`,
+      );
       if (residentCard.viewportWidth > 700) {
         assert(residentCard.art?.right <= residentCard.copy?.left, `desktop portrait cards should place art beside character information: ${JSON.stringify(residentCard)}`);
         assert(residentCard.copyFits, `desktop portrait cards should keep their useful information above the fold: ${JSON.stringify(residentCard)}`);
       }
-      await closeCardModal();
+      await page.evaluate(() => {
+        const focusable = [...document.querySelectorAll("#card-modal button:not([disabled]), #card-modal summary, #card-modal [href], #card-modal input:not([disabled]), #card-modal select:not([disabled]), #card-modal textarea:not([disabled]), #card-modal [tabindex]:not([tabindex='-1'])")]
+          .filter((node) => !node.hidden && node.getAttribute("aria-hidden") !== "true" && node.getClientRects().length > 0);
+        focusable.at(-1)?.focus();
+      });
+      await page.keyboard.press("Tab");
+      assert(
+        await page.evaluate(() => document.activeElement?.matches?.("#card-modal [data-card-close]")),
+        "character card Tab should wrap from its last control to the persistent close control",
+      );
+      await page.keyboard.press("Shift+Tab");
+      assert(
+        await page.evaluate(() => document.activeElement?.matches?.("#card-modal summary, #card-modal button:not([data-card-close])")),
+        "character card Shift+Tab should wrap from close to its last disclosed control",
+      );
+      await page.keyboard.press("Escape");
+      await page.waitForFunction(() => (
+        document.querySelector("#card-modal")?.hidden === true
+        && !document.querySelector(".shell")?.hasAttribute("inert")
+        && document.activeElement?.dataset?.cardModalFocusReturnSmoke === "true"
+      ));
 
       const desktopViewport = page.viewportSize();
       for (const viewport of [{ width: 430, height: 860 }, { width: 375, height: 667 }]) {
@@ -5304,36 +5374,82 @@ async function main() {
           const name = document.querySelector("#card-modal-name");
           const current = document.querySelector("#card-modal .card-current");
           const actions = document.querySelector("#card-modal .avatar-action-strip");
+          const title = document.querySelector("#card-modal-title");
           const close = document.querySelector("#card-modal [data-card-close]");
+          const modal = document.querySelector("#card-modal");
           const rect = (node) => node?.getBoundingClientRect().toJSON() || null;
           const dialogRect = rect(dialog);
           const artRect = rect(art);
           const nameRect = rect(name);
+          const titleRect = rect(title);
           const currentRect = rect(current);
           const actionsRect = rect(actions);
           const initialCloseRect = rect(close);
+          const modalStyle = getComputedStyle(modal);
+          const normalEconomyFontSize = parseFloat(getComputedStyle(current).fontSize);
           const usefulBottom = Math.max(
             nameRect?.bottom || 0,
+            titleRect?.bottom || 0,
             currentRect?.bottom || 0,
             actionsRect?.bottom || 0,
           );
+          document.querySelectorAll("#card-modal details").forEach((details) => {
+            details.open = true;
+          });
+          const longCardProbe = document.createElement("div");
+          longCardProbe.dataset.longCardScrollProbe = "true";
+          longCardProbe.setAttribute("aria-hidden", "true");
+          longCardProbe.style.minHeight = "100dvh";
+          scroller?.append(longCardProbe);
           if (scroller) scroller.scrollTop = scroller.scrollHeight;
+          const scrolledDialogRect = rect(dialog);
           const scrolledCloseRect = rect(close);
+          const scrollTop = scroller?.scrollTop || 0;
+          const scrollRange = Math.max(0, (scroller?.scrollHeight || 0) - (scroller?.clientHeight || 0));
+          if (scroller) scroller.scrollTop = 0;
           document.body.classList.add("large-text");
           const largeTextDialogRect = rect(dialog);
           const largeTextCloseRect = rect(close);
+          const largeTextCurrentRect = rect(current);
+          const largeTextActionsRect = rect(actions);
+          const largeTextUsefulBottom = Math.max(
+            rect(name)?.bottom || 0,
+            rect(title)?.bottom || 0,
+            largeTextCurrentRect?.bottom || 0,
+            largeTextActionsRect?.bottom || 0,
+          );
+          const largeTextEconomyFontSize = parseFloat(getComputedStyle(current).fontSize);
+          const largeTextDocumentWidth = document.documentElement.scrollWidth;
+          longCardProbe.remove();
           document.body.classList.remove("large-text");
           return {
             viewport: `${window.innerWidth}x${window.innerHeight}`,
+            modal: rect(modal),
+            modalPadding: {
+              top: parseFloat(modalStyle.paddingTop),
+              right: parseFloat(modalStyle.paddingRight),
+              bottom: parseFloat(modalStyle.paddingBottom),
+              left: parseFloat(modalStyle.paddingLeft),
+            },
             dialog: dialogRect,
             art: artRect,
             name: nameRect,
+            title: titleRect,
             current: currentRect,
             actions: actionsRect,
             initialClose: initialCloseRect,
+            scrolledDialog: scrolledDialogRect,
             scrolledClose: scrolledCloseRect,
+            scrollTop,
+            scrollRange,
             largeTextDialog: largeTextDialogRect,
             largeTextClose: largeTextCloseRect,
+            largeTextCurrent: largeTextCurrentRect,
+            largeTextActions: largeTextActionsRect,
+            largeTextUsefulBottom,
+            normalEconomyFontSize,
+            largeTextEconomyFontSize,
+            largeTextDocumentWidth,
             usefulBottom,
             documentWidth: document.documentElement.scrollWidth,
           };
@@ -5346,33 +5462,74 @@ async function main() {
           `mobile cards should stay inside the visual viewport: ${JSON.stringify(mobileCard)}`,
         );
         assert(
+          mobileCard.dialog.left >= mobileCard.modal.left + mobileCard.modalPadding.left - 1
+            && mobileCard.dialog.right <= mobileCard.modal.right - mobileCard.modalPadding.right + 1
+            && mobileCard.dialog.top >= mobileCard.modal.top + mobileCard.modalPadding.top - 1
+            && mobileCard.dialog.bottom <= mobileCard.modal.bottom - mobileCard.modalPadding.bottom + 1,
+          `mobile cards should remain inside safe-area padding: ${JSON.stringify(mobileCard)}`,
+        );
+        assert(
           mobileCard.art?.right <= mobileCard.name?.left + 1,
           `mobile portrait cards should pair compact art with identity instead of leading with a poster: ${JSON.stringify(mobileCard)}`,
         );
         assert(
-          mobileCard.current && mobileCard.usefulBottom <= mobileCard.dialog.bottom + 1,
-          `mobile character identity and current state should be useful above the fold: ${JSON.stringify(mobileCard)}`,
+          mobileCard.name
+            && mobileCard.title
+            && mobileCard.current
+            && mobileCard.usefulBottom <= mobileCard.dialog.bottom + 1,
+          `mobile character identity, title, current state, and available actions should be useful above the fold: ${JSON.stringify(mobileCard)}`,
         );
-        for (const [stateLabel, closeRect] of [
-          ["initial", mobileCard.initialClose],
-          ["scrolled", mobileCard.scrolledClose],
-          ["large text", mobileCard.largeTextClose],
+        assert(
+          mobileCard.scrollRange > 0 && mobileCard.scrollTop >= mobileCard.scrollRange - 1,
+          `mobile card regression should exercise a genuinely long, bottom-scrolled card: ${JSON.stringify(mobileCard)}`,
+        );
+        for (const [stateLabel, closeRect, stateDialog] of [
+          ["initial", mobileCard.initialClose, mobileCard.dialog],
+          ["scrolled", mobileCard.scrolledClose, mobileCard.scrolledDialog],
+          ["large text", mobileCard.largeTextClose, mobileCard.largeTextDialog],
         ]) {
           assert(
             closeRect?.width >= 44
               && closeRect?.height >= 44
-              && closeRect?.top >= mobileCard.dialog.top
-              && closeRect?.right <= mobileCard.dialog.right + 1,
+              && closeRect?.top >= stateDialog.top
+              && closeRect?.right <= stateDialog.right + 1,
             `${stateLabel} mobile card close control should remain visible and tappable: ${JSON.stringify(mobileCard)}`,
           );
         }
         assert(
           mobileCard.largeTextDialog?.right <= viewport.width
+            && mobileCard.largeTextDialog?.bottom <= viewport.height
+            && mobileCard.largeTextEconomyFontSize > mobileCard.normalEconomyFontSize
+            && mobileCard.largeTextUsefulBottom <= mobileCard.largeTextDialog.bottom + 1
+            && mobileCard.largeTextDocumentWidth <= viewport.width
             && mobileCard.documentWidth <= viewport.width,
           `mobile cards should not introduce horizontal scrolling with larger text: ${JSON.stringify(mobileCard)}`,
         );
         await closeCardModal();
       }
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await residentTargets.first().click();
+      await page.waitForSelector("#card-modal:not([hidden])");
+      const desktopCard = await page.evaluate(() => {
+        const dialog = document.querySelector("#card-modal .card-dialog");
+        const art = document.querySelector("#card-modal .card-art");
+        const copy = document.querySelector("#card-modal .card-copy");
+        const rect = (node) => node?.getBoundingClientRect().toJSON() || null;
+        return {
+          dialog: rect(dialog),
+          art: rect(art),
+          copy: rect(copy),
+          copyScrollable: Boolean(copy && copy.scrollHeight > copy.clientHeight + 1),
+          closeVisible: document.querySelector("#card-modal [data-card-close]")?.getClientRects().length > 0,
+        };
+      });
+      assert(
+        desktopCard.dialog?.right <= 1280
+          && desktopCard.art?.right <= desktopCard.copy?.left
+          && desktopCard.closeVisible,
+        `desktop character cards should preserve the portrait split and close control: ${JSON.stringify(desktopCard)}`,
+      );
+      await closeCardModal();
       if (desktopViewport) await page.setViewportSize(desktopViewport);
     }
 
@@ -5436,6 +5593,12 @@ async function main() {
                 target_id: "712",
                 description: "Made the discovery at location 712 part of the shared world.",
               },
+              {
+                category: "lore",
+                target_kind: "location",
+                target_id: "404",
+                description: "Recovered lore at location 404.",
+              },
             ],
           },
         });
@@ -5452,6 +5615,7 @@ async function main() {
     assert(
       practiceCopy.text.includes("Discovered The Cosy Cottage.")
         && practiceCopy.text.includes("Discovered a hidden place.")
+        && practiceCopy.text.includes("Recovered knowledge connected to a hidden place.")
         && !/\blocation\s+\d+\b/i.test(practiceCopy.text)
         && !/>because</i.test(practiceCopy.html)
         && !/>and</i.test(practiceCopy.html),


### PR DESCRIPTION
Closes #517.

Rebases the local `fix/issue-517-card-modal-ux` work (2 commits) onto current `main` and lands it. Only the version files conflicted; all content applied unchanged.

## What this fixes

The mobile character card's hierarchy, dismissal, and community-art status, per #517 — a Lantern Keeper / Seventh Visit milestone issue, and one of the remaining 1.0 blockers.

- `index.html` — +385: card hierarchy, `practiceEvidenceSummary`, `actorAvailabilityLabel`, the art-workshop panel with its `aria-describedby` target, and a focus trap over `button:not([disabled]), summary, [href]`.
- `smoke-browser.mjs` — +325 of browser contract coverage for the new layout.
- `main.rs` — +15, entirely INDEX_HTML contract assertions pinning the above.

## Line ceiling

`main.rs` moves 73369 → 73372. The three net lines are test-only contract assertions; the behaviour lives in `index.html`. Recorded in `main-rs-line-ceiling.txt` with that reasoning, per the file's convention.

## Verification

`npm run v2:check` **exit 0** on the final SHA — required here because this is a UI change. Covers worldpack, kernel, ai-model, **892 Rust tests**, clippy 254 (unchanged), CLI, composition and production-profile smoke, and the live browser smoke where the new assertions execute.

## Note on the source branch

Supersedes the local `fix/issue-517-card-modal-ux`, which sat 3 commits behind. That branch can be deleted once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)