### PR TITLE
Harden community-art verdicts and location prompts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.298",
+  "version": "0.0.299",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.298",
+      "version": "0.0.299",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.298",
+  "version": "0.0.299",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.298"
+version = "0.0.299"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.298"
+version = "0.0.299"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -6,6 +6,9 @@ use super::{
     NaturalPotentialPolicy,
 };
 use crate::ai_voice_routing::VoiceRoutingConfig;
+use crate::media_recipes::media_verdict::{
+    bounded_visual_verdict_summary, MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT,
+};
 pub(crate) use registry::{
     CapabilityRegistrySnapshot, DataPolicyMode, ModelAttribution, ModelCapability,
     PinnedModelSelection, RegistryError, AI_CAPABILITY_MODELS_ENV, AI_REGISTRY_ENV,
@@ -691,7 +694,10 @@ pub(crate) async fn request_image_policy_decision(
                             ]
                         }
                     },
-                    "summary": { "type": "string", "maxLength": 240 }
+                    "summary": {
+                        "type": "string",
+                        "maxLength": MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT
+                    }
                 },
                 "required": ["allowed", "violations", "summary"]
             }
@@ -740,9 +746,8 @@ pub(crate) async fn request_image_policy_decision(
 fn parse_image_policy_decision(value: &str) -> Result<ImagePolicyDecision, String> {
     let raw: RawImagePolicyDecision = serde_json::from_str(value.trim())
         .map_err(|error| format!("image policy response was not valid strict JSON: {error}"))?;
-    let summary = raw.summary.split_whitespace().collect::<Vec<_>>().join(" ");
+    let summary = bounded_visual_verdict_summary(&raw.summary);
     if summary.is_empty()
-        || summary.chars().count() > 240
         || summary
             .chars()
             .any(|character| character.is_control() && !character.is_whitespace())
@@ -2352,6 +2357,22 @@ mod tests {
         assert!(message.contains("does not support image_url with json_schema"));
         assert!(!message.contains("dGVzdA=="));
         server.abort();
+    }
+
+    #[test]
+    fn image_policy_summary_is_bounded_by_utf8_bytes() {
+        let decision = parse_image_policy_decision(
+            &json!({
+                "allowed": true,
+                "violations": [],
+                "summary": format!("{} accepted", "landscape—".repeat(40))
+            })
+            .to_string(),
+        )
+        .expect("multi-byte policy summary should normalize without a storage failure");
+
+        assert!(decision.summary.len() <= MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT);
+        assert!(decision.summary.is_char_boundary(decision.summary.len()));
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -41,7 +41,7 @@ use crate::{
 
 pub(super) const MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS: u8 = 3;
 pub(super) const LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION: u8 = 1;
-pub(super) const LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION: u8 = 3;
+pub(super) const LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION: u8 = 4;
 pub(super) const LOCATION_LANDSCAPE_PROMPT_PREFIX: &str =
     "MRQ, cozy storybook landscape, wide environment establishing view";
 const COMMUNITY_ART_CANDIDATE_SCHEMA_VERSION: u8 = 1;
@@ -209,7 +209,7 @@ impl CommunityArtImagePolicy {
     pub(super) fn prompt(self) -> &'static str {
         match self {
             Self::LocationLandscape => {
-                "Landscape only. No people, human figures, humanoids, characters, animals, creatures, silhouettes, faces, body parts, statues, portraits, text, letters, numbers, logos, watermarks, UI, or card borders."
+                "Landscape only. Produce an uninhabited environment. No people, human figures, humanoids, characters, animals, creatures, silhouettes, faces, body parts, statues, or portraits. Do not generate text, letters, numbers, signatures, artist marks, logos, watermarks, UI, or card borders."
             }
         }
     }
@@ -217,7 +217,7 @@ impl CommunityArtImagePolicy {
     fn review(self) -> &'static str {
         match self {
             Self::LocationLandscape => {
-                "Publish only a landscape with no visible or implied people, human figures, humanoids, characters, animals, creatures, silhouettes, faces, body parts, statues, portraits, readable text, letters, numbers, logos, or watermarks."
+                "Publish only a landscape with no visible or implied people, human figures, humanoids, characters, animals, creatures, silhouettes, faces, body parts, statues, or portraits, and no readable text (including signatures or artist marks), letters, numbers, logos, or watermarks."
             }
         }
     }

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -678,6 +678,20 @@ fn location_generation_replaces_portrait_prompt_without_disabling_the_style_lora
 
     assert!(prompt.starts_with(LOCATION_LANDSCAPE_PROMPT_PREFIX));
     assert!(!prompt.contains("trading-card portrait"));
+    for publication_guardrail in [
+        "uninhabited environment",
+        "No people",
+        "animals",
+        "creatures",
+        "signatures",
+        "artist marks",
+        "watermarks",
+    ] {
+        assert!(
+            prompt.contains(publication_guardrail),
+            "missing {publication_guardrail}: {prompt}"
+        );
+    }
     for portrait_leak in [
         "Collectible card art",
         "titled",

--- a/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
+++ b/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
@@ -28,6 +28,11 @@ const MEDIA_VERDICT_DIR: &str = "media-verdicts/v1";
 /// must bound each constraint they build to this budget; `validate` rejects the
 /// whole brief otherwise.
 pub(crate) const MEDIA_BRIEF_CONSTRAINT_LIMIT: usize = 240;
+/// Maximum persisted UTF-8 byte length for a visual-review summary. The
+/// provider response parser and durable verdict builder both normalize through
+/// `bounded_visual_verdict_summary`, so multi-byte punctuation cannot pass one
+/// boundary and fail the next.
+pub(crate) const MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT: usize = 240;
 const MAX_CANDIDATES_PER_JOB: usize = 4;
 const MAX_REVIEW_FAILURES: u8 = 3;
 const PROVIDER_COOLDOWN_FAILURES: u8 = 3;
@@ -44,6 +49,10 @@ pub(crate) fn bounded_brief_constraints(values: impl IntoIterator<Item = String>
         .map(|value| crate::bounded_component(&value))
         .filter(|value| !value.trim().is_empty())
         .collect()
+}
+
+pub(crate) fn bounded_visual_verdict_summary(value: &str) -> String {
+    bounded_text(value, MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT)
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -597,7 +606,7 @@ pub(crate) fn make_visual_verdict(
         reviewer_version: reviewer_version.into(),
         approved,
         violations,
-        summary: bounded_text(&summary.into(), 240),
+        summary: bounded_visual_verdict_summary(&summary.into()),
         reference_digests: brief.approved_reference_digests.clone(),
         attempts,
         latency_ms,
@@ -921,21 +930,45 @@ fn validate_visual_verdict(
     record: &PersistedMediaVerdict,
     verdict: &MediaVisualVerdict,
 ) -> Result<(), String> {
-    if verdict.schema_version != MEDIA_VERDICT_SCHEMA_VERSION
-        || verdict.brief_digest != record.brief_digest
-        || verdict.reviewer.trim().is_empty()
-        || verdict.reviewer.len() > 120
-        || verdict.reviewer_version.trim().is_empty()
-        || verdict.reviewer_version.len() > 120
-        || verdict.summary.trim().is_empty()
-        || verdict.summary.len() > 240
-        || verdict.attempts == 0
-        || verdict.attempts > MAX_REVIEW_FAILURES
-        || verdict.approved != verdict.violations.is_empty()
-        || verdict.reference_digests != record.brief.approved_reference_digests
-    {
+    if verdict.schema_version != MEDIA_VERDICT_SCHEMA_VERSION {
+        return Err("visual reviewer verdict has an unsupported schema version".to_string());
+    }
+    if verdict.brief_digest != record.brief_digest {
         return Err(
-            "visual reviewer verdict is invalid or not bound to the frozen brief".to_string(),
+            "visual reviewer verdict brief digest does not match the frozen brief".to_string(),
+        );
+    }
+    if verdict.reviewer.trim().is_empty() {
+        return Err("visual reviewer verdict reviewer is empty".to_string());
+    }
+    if verdict.reviewer.len() > 120 {
+        return Err("visual reviewer verdict reviewer exceeds 120 UTF-8 bytes".to_string());
+    }
+    if verdict.reviewer_version.trim().is_empty() {
+        return Err("visual reviewer verdict reviewer version is empty".to_string());
+    }
+    if verdict.reviewer_version.len() > 120 {
+        return Err("visual reviewer verdict reviewer version exceeds 120 UTF-8 bytes".to_string());
+    }
+    if verdict.summary.trim().is_empty() {
+        return Err("visual reviewer verdict summary is empty".to_string());
+    }
+    if verdict.summary.len() > MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT {
+        return Err(format!(
+            "visual reviewer verdict summary exceeds {MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT} UTF-8 bytes"
+        ));
+    }
+    if verdict.attempts == 0 || verdict.attempts > MAX_REVIEW_FAILURES {
+        return Err(format!(
+            "visual reviewer verdict attempts must be between 1 and {MAX_REVIEW_FAILURES}"
+        ));
+    }
+    if verdict.approved != verdict.violations.is_empty() {
+        return Err("visual reviewer verdict approval contradicts its violation list".to_string());
+    }
+    if verdict.reference_digests != record.brief.approved_reference_digests {
+        return Err(
+            "visual reviewer verdict reference digests do not match the frozen brief".to_string(),
         );
     }
     if !record
@@ -1201,13 +1234,12 @@ fn tally_outcome(
 }
 
 fn bounded_text(value: &str, maximum: usize) -> String {
-    value
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .chars()
-        .take(maximum)
-        .collect()
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut end = compact.len().min(maximum);
+    while !compact.is_char_boundary(end) {
+        end -= 1;
+    }
+    compact[..end].to_string()
 }
 
 fn valid_digest(value: &str) -> bool {

--- a/v2/orchestrator-rust/src/media_verdict_tests.rs
+++ b/v2/orchestrator-rust/src/media_verdict_tests.rs
@@ -267,6 +267,86 @@ fn visual_verdict_is_versioned_bounded_and_covers_semantic_failure_taxonomy() {
 }
 
 #[test]
+fn multibyte_visual_summary_is_bounded_by_utf8_bytes_and_persists() {
+    let root = root("multibyte-summary");
+    let frozen = brief("multibyte-summary-job");
+    let candidate = image(patterned_png(16, 9, 9), "image/png", "multibyte-summary");
+    assert_eq!(
+        prepare(&root, frozen.clone(), &candidate, None, None),
+        MediaVerdictDisposition::ReviewPending
+    );
+    let verdict = make_visual_verdict(
+        &frozen,
+        sha256_hex(&candidate.bytes),
+        "fixture-reviewer",
+        "fixture-reviewer/1",
+        true,
+        Vec::new(),
+        format!("{} accepted", "landscape—".repeat(40)),
+        1,
+        1,
+        0,
+    )
+    .expect("build byte-bounded verdict");
+
+    assert!(verdict.summary.len() <= MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT);
+    assert!(verdict.summary.is_char_boundary(verdict.summary.len()));
+    assert_eq!(
+        record_media_visual_verdict(&root, "multibyte-summary-job", verdict),
+        Ok(MediaVerdictDisposition::Approved)
+    );
+}
+
+#[test]
+fn visual_verdict_binding_errors_name_the_invalid_field() {
+    let root = root("binding-errors");
+    let mut frozen = brief("binding-errors-job");
+    frozen.approved_reference_digests = vec!["a".repeat(64)];
+    let candidate = image(patterned_png(16, 9, 10), "image/png", "binding-errors");
+    assert_eq!(
+        prepare(&root, frozen.clone(), &candidate, None, None),
+        MediaVerdictDisposition::ReviewPending
+    );
+    let record = load_record_by_job(&root, "binding-errors-job").expect("load frozen record");
+    let valid = make_visual_verdict(
+        &frozen,
+        sha256_hex(&candidate.bytes),
+        "fixture-reviewer",
+        "fixture-reviewer/1",
+        true,
+        Vec::new(),
+        "The candidate matches the frozen brief.",
+        1,
+        1,
+        0,
+    )
+    .expect("build valid verdict");
+
+    let mut wrong_brief = valid.clone();
+    wrong_brief.brief_digest = "b".repeat(64);
+    assert_eq!(
+        validate_visual_verdict(&record, &wrong_brief),
+        Err("visual reviewer verdict brief digest does not match the frozen brief".to_string())
+    );
+
+    let mut wrong_references = valid.clone();
+    wrong_references.reference_digests = vec!["c".repeat(64)];
+    assert_eq!(
+        validate_visual_verdict(&record, &wrong_references),
+        Err("visual reviewer verdict reference digests do not match the frozen brief".to_string())
+    );
+
+    let mut oversized_summary = valid;
+    oversized_summary.summary = "🌲".repeat(61);
+    assert_eq!(
+        validate_visual_verdict(&record, &oversized_summary),
+        Err(format!(
+            "visual reviewer verdict summary exceeds {MEDIA_VISUAL_VERDICT_SUMMARY_LIMIT} UTF-8 bytes"
+        ))
+    );
+}
+
+#[test]
 fn approved_verdict_survives_restart_and_is_bound_to_brief_candidate_and_references() {
     let root = root("restart");
     let mut frozen = brief("restart-job");


### PR DESCRIPTION
## Summary
- bound image-policy summaries by UTF-8 bytes across parsing and durable verdict persistence
- return field-specific verdict binding errors
- make location generation explicitly forbid signatures, artist marks, watermarks, and incidental creatures
- advance the location generation profile so failed jobs can retry under the corrected prompt
- bump the release version to 0.0.299

## Validation
- `npm run check` (517 JS tests, 903 Rust tests, worldpack/proof/kernel, architecture/clippy, syntax)
- `npm run check:version`
- focused parser, verdict persistence/binding, and prompt regression tests

Closes #655