### PR TITLE
feat(world): the relit beacon opens a road

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.299",
+  "version": "0.0.300",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.299",
+      "version": "0.0.300",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.299",
+  "version": "0.0.300",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -265,6 +265,7 @@ describe("worldpack authored relationships", () => {
       "ruby-high.first-bell",
       "cosyworld.composition.core-ruby",
       "cosyworld.composition.core-holy-land",
+      "cosyworld.composition.core-lantern-keeper",
     ]);
     expect(locations).toHaveLength(49);
     expect(rules.map((bundle) => bundle.pack_id)).toEqual([
@@ -368,6 +369,9 @@ describe("canonical topology validation", () => {
       exit.from_location_id === 1 && exit.to_location_id === 2);
     forward.directionality = "one_way";
     forward.fallback_location_id = 3;
+    const lanternRoad = exits.find((exit) =>
+      exit.from_location_id === 804 && exit.to_location_id === 32);
+    lanternRoad.fallback_location_id = 3;
     const oneWayExits = exits.filter((exit) =>
       exit.from_location_id !== 2 || exit.to_location_id !== 1);
     writeJson(root, "exits.json", oneWayExits);
@@ -403,6 +407,10 @@ describe("canonical topology validation", () => {
 
   it("requires evacuation destinations to retain egress to the world root", () => {
     const root = worldpackFixture();
+    const exits = JSON.parse(fs.readFileSync(path.join(root, "exits.json"), "utf8"))
+      .filter((exit) => exit.pack_id !== "cosyworld.composition.core-lantern-keeper");
+    writeJson(root, "exits.json", exits);
+    updateExitCounts(root, exits);
     const manifest = JSON.parse(fs.readFileSync(path.join(root, "worldpack.json"), "utf8"));
     const policy = manifest.pack_lifecycle.unmount.find(
       (candidate) => candidate.pack_id === "ruby-high.first-bell",

--- a/v2/content/core-lantern-keeper-bridge/exits.json
+++ b/v2/content/core-lantern-keeper-bridge/exits.json
@@ -1,0 +1,27 @@
+[
+  {
+    "from_location_id": 4,
+    "to_location_id": 800,
+    "flags": 0,
+    "distance": 2,
+    "direction": "north",
+    "discovery": "known"
+  },
+  {
+    "from_location_id": 800,
+    "to_location_id": 4,
+    "flags": 0,
+    "distance": 2,
+    "direction": "south",
+    "discovery": "known"
+  },
+  {
+    "from_location_id": 804,
+    "to_location_id": 32,
+    "flags": 1,
+    "distance": 4,
+    "direction": "north",
+    "directionality": "one_way",
+    "fallback_location_id": 1
+  }
+]

--- a/v2/content/core-lantern-keeper-bridge/pack.json
+++ b/v2/content/core-lantern-keeper-bridge/pack.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": 1,
+  "id": "cosyworld.composition.core-lantern-keeper",
+  "name": "CosyWorld Core + Lantern Keeper Bridge",
+  "version": "1.0.0",
+  "kind": "world",
+  "description": "Composition-owned paths connecting CosyWorld Core and The Lantern Keeper, including the road the relit beacon opens.",
+  "license": "MIT",
+  "license_url": "https://opensource.org/license/mit",
+  "engine": ">=0.0.20 <0.1.0",
+  "capabilities": [
+    {
+      "id": "cosyworld.composition.core-lantern-keeper/world",
+      "kind": "world",
+      "version": "1.0.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "cosyworld.core",
+      "version": ">=1.3.0 <2.0.0",
+      "capabilities": [
+        "cosyworld.core/world"
+      ]
+    },
+    {
+      "id": "cosyworld.campaign.the-lantern-keeper",
+      "version": ">=0.1.8 <1.0.0",
+      "capabilities": [
+        "cosyworld.campaign.the-lantern-keeper/world"
+      ]
+    },
+    {
+      "id": "cosyworld.rules-profile-srd5",
+      "version": ">=1.0.0 <2.0.0",
+      "capabilities": [
+        "cosyworld.rules-profile-srd5/rules"
+      ]
+    }
+  ],
+  "rules_profile": "cosyworld.srd5/1",
+  "default_ruleset": null,
+  "entry_points": [],
+  "provenance": {
+    "author": "Cenetex",
+    "source_name": "CosyWorld official composition",
+    "source_url": "https://github.com/cenetex/cosyworld"
+  },
+  "resources": {
+    "exits": "exits.json"
+  },
+  "extensions": {
+    "x-cosyworld-composition": {
+      "schema_version": 1,
+      "role": "bridge"
+    },
+    "x-cosyworld-generation": {
+      "schema_version": 1,
+      "policy_id": "cosyworld.composition.core-lantern-keeper/generation/1",
+      "migration_version": 1,
+      "collision_namespace": "pack://cosyworld.composition.core-lantern-keeper/generated/v1",
+      "migrations": [
+        {
+          "from_policy_id": "cosyworld.compatibility.host-generation/1",
+          "from_migration_version": 0,
+          "from_pack_version": "1.0.0",
+          "mode": "preserve_descendants"
+        }
+      ],
+      "cross_pack_routes": [
+        {
+          "endpoints": [
+            {
+              "pack_id": "cosyworld.core",
+              "location_id": 4
+            },
+            {
+              "pack_id": "cosyworld.campaign.the-lantern-keeper",
+              "location_id": 800
+            }
+          ],
+          "route_owner": "cosyworld.composition.core-lantern-keeper",
+          "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+          "topology_authority": {
+            "pack_id": "cosyworld.composition.core-lantern-keeper",
+            "migration_version": 1
+          },
+          "ecology_transition": "endpoint_blend/1",
+          "media_profile_id": "cosyworld.community-art.base/1",
+          "unmount": "remove_with_route_owner",
+          "evacuation": "world_pack_lifecycle"
+        },
+        {
+          "endpoints": [
+            {
+              "pack_id": "cosyworld.campaign.the-lantern-keeper",
+              "location_id": 804
+            },
+            {
+              "pack_id": "cosyworld.core",
+              "location_id": 32
+            }
+          ],
+          "route_owner": "cosyworld.composition.core-lantern-keeper",
+          "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+          "topology_authority": {
+            "pack_id": "cosyworld.composition.core-lantern-keeper",
+            "migration_version": 1
+          },
+          "ecology_transition": "endpoint_blend/1",
+          "media_profile_id": "cosyworld.community-art.base/1",
+          "unmount": "remove_with_route_owner",
+          "evacuation": "world_pack_lifecycle"
+        }
+      ]
+    }
+  }
+}

--- a/v2/content/lantern-keeper/character_creation.json
+++ b/v2/content/lantern-keeper/character_creation.json
@@ -1,7 +1,7 @@
 [
   {
     "pack_id": "cosyworld.campaign.the-lantern-keeper",
-    "pack_version": "0.1.8",
+    "pack_version": "0.1.9",
     "profiles": [
       {
         "schema_version": 2,

--- a/v2/content/lantern-keeper/clocks.json
+++ b/v2/content/lantern-keeper/clocks.json
@@ -313,6 +313,12 @@
         "job_id": "lantern-keeper:rekindle-the-beacon",
         "status": "completed",
         "reason": "lantern_keeper_completed"
+      },
+      {
+        "op": "unlock_exit",
+        "from_location_id": 804,
+        "to_location_id": 32,
+        "reason": "beacon_rekindled_opens_the_road"
       }
     ],
     "presentation": {

--- a/v2/content/lantern-keeper/content_refs.json
+++ b/v2/content/lantern-keeper/content_refs.json
@@ -5,7 +5,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8301",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "actor",
       "local_id": "8301",
       "legacy_runtime_id": 8301,
@@ -14,7 +14,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8302",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "actor",
       "local_id": "8302",
       "legacy_runtime_id": 8302,
@@ -23,7 +23,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8303",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "actor",
       "local_id": "8303",
       "legacy_runtime_id": 8303,
@@ -32,7 +32,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8304",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "actor",
       "local_id": "8304",
       "legacy_runtime_id": 8304,
@@ -41,7 +41,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-barrow",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-barrow",
       "runtime_handle": 2693745143565876
@@ -49,7 +49,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-chapel",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-chapel",
       "runtime_handle": 485182594396993
@@ -57,7 +57,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-dawn-oil",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-dawn-oil",
       "runtime_handle": 2918403238373891
@@ -65,7 +65,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-ember",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-ember",
       "runtime_handle": 6023960511621204
@@ -73,7 +73,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-inn",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-inn",
       "runtime_handle": 2167662595818650
@@ -81,7 +81,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-key",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-key",
       "runtime_handle": 8905115040499656
@@ -89,7 +89,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-knight",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-knight",
       "runtime_handle": 7581163987072796
@@ -97,7 +97,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mara",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-mara",
       "runtime_handle": 2237714680835428
@@ -105,7 +105,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothglass",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-mothglass",
       "runtime_handle": 5170986584558554
@@ -113,7 +113,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothwood",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-mothwood",
       "runtime_handle": 1673786737892201
@@ -121,7 +121,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-pip",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-pip",
       "runtime_handle": 6288898560895936
@@ -129,7 +129,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-rowan",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-rowan",
       "runtime_handle": 1658308598845697
@@ -137,7 +137,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-tower",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-tower",
       "runtime_handle": 5850818207762215
@@ -145,7 +145,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/character-profile/the-lantern-keeper",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "character-profile",
       "local_id": "the-lantern-keeper",
       "runtime_handle": 6074007409727657
@@ -153,7 +153,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.darkness",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "clock",
       "local_id": "lantern-keeper.darkness",
       "runtime_handle": 3497107257475399
@@ -161,7 +161,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.light",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "clock",
       "local_id": "lantern-keeper.light",
       "runtime_handle": 1743073783466389
@@ -169,7 +169,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/front/lantern-keeper%3Ahollow-light",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "front",
       "local_id": "lantern-keeper:hollow-light",
       "runtime_handle": 8897349519357189
@@ -177,7 +177,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8401",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "item",
       "local_id": "8401",
       "legacy_runtime_id": 8401,
@@ -186,7 +186,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8402",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "item",
       "local_id": "8402",
       "legacy_runtime_id": 8402,
@@ -195,7 +195,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8403",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "item",
       "local_id": "8403",
       "legacy_runtime_id": 8403,
@@ -204,7 +204,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8404",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "item",
       "local_id": "8404",
       "legacy_runtime_id": 8404,
@@ -213,7 +213,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/job/lantern-keeper%3Arekindle-the-beacon",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "job",
       "local_id": "lantern-keeper:rekindle-the-beacon",
       "runtime_handle": 3517284423041433
@@ -221,7 +221,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/800",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "800",
       "legacy_runtime_id": 800,
@@ -230,7 +230,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/801",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "801",
       "legacy_runtime_id": 801,
@@ -239,7 +239,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/802",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "802",
       "legacy_runtime_id": 802,
@@ -248,7 +248,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/803",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "803",
       "legacy_runtime_id": 803,
@@ -257,7 +257,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/804",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "804",
       "legacy_runtime_id": 804,
@@ -266,7 +266,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A800",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:800",
       "runtime_handle": 485005815750293
@@ -274,7 +274,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A801",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:801",
       "runtime_handle": 5114262777545579
@@ -282,7 +282,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A802",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:802",
       "runtime_handle": 3932833224947827
@@ -290,7 +290,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A803",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:803",
       "runtime_handle": 7094111250995550
@@ -298,7 +298,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A804",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:804",
       "runtime_handle": 112964325215682

--- a/v2/content/lantern-keeper/exits.json
+++ b/v2/content/lantern-keeper/exits.json
@@ -394,5 +394,33 @@
     "flags": 0,
     "direction": "south",
     "pack_id": "cosyworld.campaign.the-lantern-keeper"
+  },
+  {
+    "from_location_id": 4,
+    "to_location_id": 800,
+    "flags": 0,
+    "distance": 2,
+    "direction": "north",
+    "discovery": "known",
+    "pack_id": "cosyworld.composition.core-lantern-keeper"
+  },
+  {
+    "from_location_id": 800,
+    "to_location_id": 4,
+    "flags": 0,
+    "distance": 2,
+    "direction": "south",
+    "discovery": "known",
+    "pack_id": "cosyworld.composition.core-lantern-keeper"
+  },
+  {
+    "from_location_id": 804,
+    "to_location_id": 32,
+    "flags": 1,
+    "distance": 4,
+    "direction": "north",
+    "directionality": "one_way",
+    "fallback_location_id": 1,
+    "pack_id": "cosyworld.composition.core-lantern-keeper"
   }
 ]

--- a/v2/content/lantern-keeper/jobs.json
+++ b/v2/content/lantern-keeper/jobs.json
@@ -857,7 +857,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8"
+        "pack_version": "0.1.9"
       },
       {
         "version": 1,
@@ -939,7 +939,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8"
+        "pack_version": "0.1.9"
       }
     ],
     "narrated_thresholds": [

--- a/v2/content/lantern-keeper/licenses.json
+++ b/v2/content/lantern-keeper/licenses.json
@@ -84,7 +84,7 @@
   {
     "pack_id": "cosyworld.campaign.the-lantern-keeper",
     "name": "The Lantern Keeper",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "license_identifier": "CC-BY-4.0",
     "license_url": "https://creativecommons.org/licenses/by/4.0/",
     "provenance": {
@@ -103,5 +103,18 @@
         "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
       }
     ]
+  },
+  {
+    "pack_id": "cosyworld.composition.core-lantern-keeper",
+    "name": "CosyWorld Core + Lantern Keeper Bridge",
+    "version": "1.0.0",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld official composition",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
   }
 ]

--- a/v2/content/lantern-keeper/registry.json
+++ b/v2/content/lantern-keeper/registry.json
@@ -715,7 +715,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586",
+    "bundle_hash": "sha256:da88aa082a8a87d89cee73d4894b451832d85ae5d31b2391eafe87e2f03b166f",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1959,7 +1959,7 @@
         "id": "cosyworld.campaign.the-lantern-keeper",
         "name": "The Lantern Keeper",
         "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
-        "version": "0.1.8",
+        "version": "0.1.9",
         "kind": "campaign",
         "license": "CC-BY-4.0",
         "license_url": "https://creativecommons.org/licenses/by/4.0/",
@@ -2146,7 +2146,7 @@
                 },
                 "egress": {
                   "min": 0,
-                  "max": 1
+                  "max": 2
                 },
                 "weighted_distance": {
                   "min": 3,
@@ -2190,7 +2190,168 @@
           "type": "workspace",
           "path": "../../content/the-lantern-keeper"
         },
-        "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141"
+        "integrity": "sha256:050fc1806f8569eea3cc40bef81eb95eb184bb27116d0cbbbdeac7ca4a804065"
+      },
+      {
+        "id": "cosyworld.composition.core-lantern-keeper",
+        "name": "CosyWorld Core + Lantern Keeper Bridge",
+        "description": "Composition-owned paths connecting CosyWorld Core and The Lantern Keeper, including the road the relit beacon opens.",
+        "version": "1.0.0",
+        "kind": "world",
+        "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.composition.core-lantern-keeper/world",
+            "kind": "world",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core",
+          "cosyworld.campaign.the-lantern-keeper",
+          "cosyworld.rules-profile-srd5"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.3.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          },
+          {
+            "id": "cosyworld.campaign.the-lantern-keeper",
+            "version": ">=0.1.8 <1.0.0",
+            "capabilities": [
+              "cosyworld.campaign.the-lantern-keeper/world"
+            ]
+          },
+          {
+            "id": "cosyworld.rules-profile-srd5",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.rules-profile-srd5/rules"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.rules-srd-5.2.1",
+          "cosyworld.rules-profile-srd5",
+          "cosyworld.core",
+          "cosyworld.rules-srd-5.1",
+          "cosyworld.campaign.the-lantern-keeper"
+        ],
+        "default_ruleset": null,
+        "entry_points": [],
+        "provenance": {
+          "author": "Cenetex",
+          "source_name": "CosyWorld official composition",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "actor_facets": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 3,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "action_vocabulary": 0,
+          "fronts": 0,
+          "cards": 0,
+          "card_bindings": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 0,
+          "rules": 0,
+          "character_creation": 0,
+          "reskins": 0,
+          "offers": 0,
+          "variants": 0,
+          "extensions": 0
+        },
+        "extensions": {
+          "x-cosyworld-composition": {
+            "schema_version": 1,
+            "role": "bridge"
+          },
+          "x-cosyworld-generation": {
+            "schema_version": 1,
+            "policy_id": "cosyworld.composition.core-lantern-keeper/generation/1",
+            "migration_version": 1,
+            "collision_namespace": "pack://cosyworld.composition.core-lantern-keeper/generated/v1",
+            "migrations": [
+              {
+                "from_policy_id": "cosyworld.compatibility.host-generation/1",
+                "from_migration_version": 0,
+                "from_pack_version": "1.0.0",
+                "mode": "preserve_descendants"
+              }
+            ],
+            "cross_pack_routes": [
+              {
+                "endpoints": [
+                  {
+                    "pack_id": "cosyworld.core",
+                    "location_id": 4
+                  },
+                  {
+                    "pack_id": "cosyworld.campaign.the-lantern-keeper",
+                    "location_id": 800
+                  }
+                ],
+                "route_owner": "cosyworld.composition.core-lantern-keeper",
+                "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+                "topology_authority": {
+                  "pack_id": "cosyworld.composition.core-lantern-keeper",
+                  "migration_version": 1
+                },
+                "ecology_transition": "endpoint_blend/1",
+                "media_profile_id": "cosyworld.community-art.base/1",
+                "unmount": "remove_with_route_owner",
+                "evacuation": "world_pack_lifecycle"
+              },
+              {
+                "endpoints": [
+                  {
+                    "pack_id": "cosyworld.campaign.the-lantern-keeper",
+                    "location_id": 804
+                  },
+                  {
+                    "pack_id": "cosyworld.core",
+                    "location_id": 32
+                  }
+                ],
+                "route_owner": "cosyworld.composition.core-lantern-keeper",
+                "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+                "topology_authority": {
+                  "pack_id": "cosyworld.composition.core-lantern-keeper",
+                  "migration_version": 1
+                },
+                "ecology_transition": "endpoint_blend/1",
+                "media_profile_id": "cosyworld.community-art.base/1",
+                "unmount": "remove_with_route_owner",
+                "evacuation": "world_pack_lifecycle"
+              }
+            ]
+          }
+        },
+        "rules_profile": "cosyworld.srd5/1",
+        "source": {
+          "type": "workspace",
+          "path": "../../content/core-lantern-keeper-bridge"
+        },
+        "integrity": "sha256:6aa8a08b240f5bb3c21ea5fa63b175365e90608c43162cb3a07d1e149f260d9b"
       }
     ],
     "files": {
@@ -4876,6 +5037,34 @@
         "flags": 0,
         "direction": "south",
         "pack_id": "cosyworld.campaign.the-lantern-keeper"
+      },
+      {
+        "from_location_id": 4,
+        "to_location_id": 800,
+        "flags": 0,
+        "distance": 2,
+        "direction": "north",
+        "discovery": "known",
+        "pack_id": "cosyworld.composition.core-lantern-keeper"
+      },
+      {
+        "from_location_id": 800,
+        "to_location_id": 4,
+        "flags": 0,
+        "distance": 2,
+        "direction": "south",
+        "discovery": "known",
+        "pack_id": "cosyworld.composition.core-lantern-keeper"
+      },
+      {
+        "from_location_id": 804,
+        "to_location_id": 32,
+        "flags": 1,
+        "distance": 4,
+        "direction": "north",
+        "directionality": "one_way",
+        "fallback_location_id": 1,
+        "pack_id": "cosyworld.composition.core-lantern-keeper"
       }
     ],
     "hidden_exits": [
@@ -6269,6 +6458,12 @@
             "job_id": "lantern-keeper:rekindle-the-beacon",
             "status": "completed",
             "reason": "lantern_keeper_completed"
+          },
+          {
+            "op": "unlock_exit",
+            "from_location_id": 804,
+            "to_location_id": 32,
+            "reason": "beacon_rekindled_opens_the_road"
           }
         ],
         "presentation": {
@@ -7185,7 +7380,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.campaign.the-lantern-keeper",
-            "pack_version": "0.1.8"
+            "pack_version": "0.1.9"
           },
           {
             "version": 1,
@@ -7267,7 +7462,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.campaign.the-lantern-keeper",
-            "pack_version": "0.1.8"
+            "pack_version": "0.1.9"
           }
         ],
         "narrated_thresholds": [
@@ -11900,7 +12095,7 @@
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license_identifier": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "provenance": {
@@ -11919,6 +12114,19 @@
           "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
         }
       ]
+    },
+    {
+      "pack_id": "cosyworld.composition.core-lantern-keeper",
+      "name": "CosyWorld Core + Lantern Keeper Bridge",
+      "version": "1.0.0",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
     }
   ],
   "modified_material": [
@@ -12559,7 +12767,7 @@
   "character_creation": [
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "profiles": [
         {
           "schema_version": 2,
@@ -12685,7 +12893,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8301",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "actor",
         "local_id": "8301",
         "legacy_runtime_id": 8301,
@@ -12694,7 +12902,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8302",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "actor",
         "local_id": "8302",
         "legacy_runtime_id": 8302,
@@ -12703,7 +12911,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8303",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "actor",
         "local_id": "8303",
         "legacy_runtime_id": 8303,
@@ -12712,7 +12920,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8304",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "actor",
         "local_id": "8304",
         "legacy_runtime_id": 8304,
@@ -12721,7 +12929,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-barrow",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-barrow",
         "runtime_handle": 2693745143565876
@@ -12729,7 +12937,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-chapel",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-chapel",
         "runtime_handle": 485182594396993
@@ -12737,7 +12945,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-dawn-oil",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-dawn-oil",
         "runtime_handle": 2918403238373891
@@ -12745,7 +12953,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-ember",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-ember",
         "runtime_handle": 6023960511621204
@@ -12753,7 +12961,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-inn",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-inn",
         "runtime_handle": 2167662595818650
@@ -12761,7 +12969,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-key",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-key",
         "runtime_handle": 8905115040499656
@@ -12769,7 +12977,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-knight",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-knight",
         "runtime_handle": 7581163987072796
@@ -12777,7 +12985,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mara",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-mara",
         "runtime_handle": 2237714680835428
@@ -12785,7 +12993,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothglass",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-mothglass",
         "runtime_handle": 5170986584558554
@@ -12793,7 +13001,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothwood",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-mothwood",
         "runtime_handle": 1673786737892201
@@ -12801,7 +13009,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-pip",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-pip",
         "runtime_handle": 6288898560895936
@@ -12809,7 +13017,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-rowan",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-rowan",
         "runtime_handle": 1658308598845697
@@ -12817,7 +13025,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-tower",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-tower",
         "runtime_handle": 5850818207762215
@@ -12825,7 +13033,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/character-profile/the-lantern-keeper",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "character-profile",
         "local_id": "the-lantern-keeper",
         "runtime_handle": 6074007409727657
@@ -12833,7 +13041,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.darkness",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "clock",
         "local_id": "lantern-keeper.darkness",
         "runtime_handle": 3497107257475399
@@ -12841,7 +13049,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.light",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "clock",
         "local_id": "lantern-keeper.light",
         "runtime_handle": 1743073783466389
@@ -12849,7 +13057,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/front/lantern-keeper%3Ahollow-light",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "front",
         "local_id": "lantern-keeper:hollow-light",
         "runtime_handle": 8897349519357189
@@ -12857,7 +13065,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8401",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "item",
         "local_id": "8401",
         "legacy_runtime_id": 8401,
@@ -12866,7 +13074,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8402",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "item",
         "local_id": "8402",
         "legacy_runtime_id": 8402,
@@ -12875,7 +13083,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8403",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "item",
         "local_id": "8403",
         "legacy_runtime_id": 8403,
@@ -12884,7 +13092,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8404",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "item",
         "local_id": "8404",
         "legacy_runtime_id": 8404,
@@ -12893,7 +13101,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/job/lantern-keeper%3Arekindle-the-beacon",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "job",
         "local_id": "lantern-keeper:rekindle-the-beacon",
         "runtime_handle": 3517284423041433
@@ -12901,7 +13109,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/800",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "800",
         "legacy_runtime_id": 800,
@@ -12910,7 +13118,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/801",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "801",
         "legacy_runtime_id": 801,
@@ -12919,7 +13127,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/802",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "802",
         "legacy_runtime_id": 802,
@@ -12928,7 +13136,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/803",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "803",
         "legacy_runtime_id": 803,
@@ -12937,7 +13145,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/804",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "804",
         "legacy_runtime_id": 804,
@@ -12946,7 +13154,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A800",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:800",
         "runtime_handle": 485005815750293
@@ -12954,7 +13162,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A801",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:801",
         "runtime_handle": 5114262777545579
@@ -12962,7 +13170,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A802",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:802",
         "runtime_handle": 3932833224947827
@@ -12970,7 +13178,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A803",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:803",
         "runtime_handle": 7094111250995550
@@ -12978,7 +13186,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A804",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:804",
         "runtime_handle": 112964325215682

--- a/v2/content/lantern-keeper/worldpack.json
+++ b/v2/content/lantern-keeper/worldpack.json
@@ -713,7 +713,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586",
+  "bundle_hash": "sha256:da88aa082a8a87d89cee73d4894b451832d85ae5d31b2391eafe87e2f03b166f",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1957,7 +1957,7 @@
       "id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
       "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "kind": "campaign",
       "license": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
@@ -2144,7 +2144,7 @@
               },
               "egress": {
                 "min": 0,
-                "max": 1
+                "max": 2
               },
               "weighted_distance": {
                 "min": 3,
@@ -2188,7 +2188,168 @@
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141"
+      "integrity": "sha256:050fc1806f8569eea3cc40bef81eb95eb184bb27116d0cbbbdeac7ca4a804065"
+    },
+    {
+      "id": "cosyworld.composition.core-lantern-keeper",
+      "name": "CosyWorld Core + Lantern Keeper Bridge",
+      "description": "Composition-owned paths connecting CosyWorld Core and The Lantern Keeper, including the road the relit beacon opens.",
+      "version": "1.0.0",
+      "kind": "world",
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "engine": ">=0.0.20 <0.1.0",
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-lantern-keeper/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        "cosyworld.core",
+        "cosyworld.campaign.the-lantern-keeper",
+        "cosyworld.rules-profile-srd5"
+      ],
+      "dependency_requirements": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.campaign.the-lantern-keeper",
+          "version": ">=0.1.8 <1.0.0",
+          "capabilities": [
+            "cosyworld.campaign.the-lantern-keeper/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "cosyworld.rules-srd-5.1",
+        "cosyworld.campaign.the-lantern-keeper"
+      ],
+      "default_ruleset": null,
+      "entry_points": [],
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "resource_counts": {
+        "actors": 0,
+        "actor_facets": 0,
+        "access_gates": 0,
+        "factions": 0,
+        "items": 0,
+        "locations": 0,
+        "exits": 3,
+        "hidden_exits": 0,
+        "room_features": 0,
+        "room_sheets": 0,
+        "clocks": 0,
+        "jobs": 0,
+        "action_vocabulary": 0,
+        "fronts": 0,
+        "cards": 0,
+        "card_bindings": 0,
+        "lifecycle_hooks": 0,
+        "evolution_tracks": 0,
+        "recipes": 0,
+        "sentences": 0,
+        "external_cards": 0,
+        "assets": 0,
+        "rules": 0,
+        "character_creation": 0,
+        "reskins": 0,
+        "offers": 0,
+        "variants": 0,
+        "extensions": 0
+      },
+      "extensions": {
+        "x-cosyworld-composition": {
+          "schema_version": 1,
+          "role": "bridge"
+        },
+        "x-cosyworld-generation": {
+          "schema_version": 1,
+          "policy_id": "cosyworld.composition.core-lantern-keeper/generation/1",
+          "migration_version": 1,
+          "collision_namespace": "pack://cosyworld.composition.core-lantern-keeper/generated/v1",
+          "migrations": [
+            {
+              "from_policy_id": "cosyworld.compatibility.host-generation/1",
+              "from_migration_version": 0,
+              "from_pack_version": "1.0.0",
+              "mode": "preserve_descendants"
+            }
+          ],
+          "cross_pack_routes": [
+            {
+              "endpoints": [
+                {
+                  "pack_id": "cosyworld.core",
+                  "location_id": 4
+                },
+                {
+                  "pack_id": "cosyworld.campaign.the-lantern-keeper",
+                  "location_id": 800
+                }
+              ],
+              "route_owner": "cosyworld.composition.core-lantern-keeper",
+              "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+              "topology_authority": {
+                "pack_id": "cosyworld.composition.core-lantern-keeper",
+                "migration_version": 1
+              },
+              "ecology_transition": "endpoint_blend/1",
+              "media_profile_id": "cosyworld.community-art.base/1",
+              "unmount": "remove_with_route_owner",
+              "evacuation": "world_pack_lifecycle"
+            },
+            {
+              "endpoints": [
+                {
+                  "pack_id": "cosyworld.campaign.the-lantern-keeper",
+                  "location_id": 804
+                },
+                {
+                  "pack_id": "cosyworld.core",
+                  "location_id": 32
+                }
+              ],
+              "route_owner": "cosyworld.composition.core-lantern-keeper",
+              "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+              "topology_authority": {
+                "pack_id": "cosyworld.composition.core-lantern-keeper",
+                "migration_version": 1
+              },
+              "ecology_transition": "endpoint_blend/1",
+              "media_profile_id": "cosyworld.community-art.base/1",
+              "unmount": "remove_with_route_owner",
+              "evacuation": "world_pack_lifecycle"
+            }
+          ]
+        }
+      },
+      "rules_profile": "cosyworld.srd5/1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-lantern-keeper-bridge"
+      },
+      "integrity": "sha256:6aa8a08b240f5bb3c21ea5fa63b175365e90608c43162cb3a07d1e149f260d9b"
     }
   ],
   "files": {

--- a/v2/content/official/character_creation.json
+++ b/v2/content/official/character_creation.json
@@ -1,7 +1,7 @@
 [
   {
     "pack_id": "cosyworld.campaign.the-lantern-keeper",
-    "pack_version": "0.1.8",
+    "pack_version": "0.1.9",
     "profiles": [
       {
         "schema_version": 2,

--- a/v2/content/official/clocks.json
+++ b/v2/content/official/clocks.json
@@ -313,6 +313,12 @@
         "job_id": "lantern-keeper:rekindle-the-beacon",
         "status": "completed",
         "reason": "lantern_keeper_completed"
+      },
+      {
+        "op": "unlock_exit",
+        "from_location_id": 804,
+        "to_location_id": 32,
+        "reason": "beacon_rekindled_opens_the_road"
       }
     ],
     "presentation": {

--- a/v2/content/official/content_refs.json
+++ b/v2/content/official/content_refs.json
@@ -5,7 +5,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8301",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "actor",
       "local_id": "8301",
       "legacy_runtime_id": 8301,
@@ -14,7 +14,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8302",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "actor",
       "local_id": "8302",
       "legacy_runtime_id": 8302,
@@ -23,7 +23,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8303",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "actor",
       "local_id": "8303",
       "legacy_runtime_id": 8303,
@@ -32,7 +32,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8304",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "actor",
       "local_id": "8304",
       "legacy_runtime_id": 8304,
@@ -41,7 +41,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-barrow",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-barrow",
       "runtime_handle": 2693745143565876
@@ -49,7 +49,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-chapel",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-chapel",
       "runtime_handle": 485182594396993
@@ -57,7 +57,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-dawn-oil",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-dawn-oil",
       "runtime_handle": 2918403238373891
@@ -65,7 +65,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-ember",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-ember",
       "runtime_handle": 6023960511621204
@@ -73,7 +73,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-inn",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-inn",
       "runtime_handle": 2167662595818650
@@ -81,7 +81,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-key",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-key",
       "runtime_handle": 8905115040499656
@@ -89,7 +89,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-knight",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-knight",
       "runtime_handle": 7581163987072796
@@ -97,7 +97,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mara",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-mara",
       "runtime_handle": 2237714680835428
@@ -105,7 +105,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothglass",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-mothglass",
       "runtime_handle": 5170986584558554
@@ -113,7 +113,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothwood",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-mothwood",
       "runtime_handle": 1673786737892201
@@ -121,7 +121,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-pip",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-pip",
       "runtime_handle": 6288898560895936
@@ -129,7 +129,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-rowan",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-rowan",
       "runtime_handle": 1658308598845697
@@ -137,7 +137,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-tower",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "card",
       "local_id": "lantern-keeper-tower",
       "runtime_handle": 5850818207762215
@@ -145,7 +145,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/character-profile/the-lantern-keeper",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "character-profile",
       "local_id": "the-lantern-keeper",
       "runtime_handle": 6074007409727657
@@ -153,7 +153,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.darkness",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "clock",
       "local_id": "lantern-keeper.darkness",
       "runtime_handle": 3497107257475399
@@ -161,7 +161,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.light",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "clock",
       "local_id": "lantern-keeper.light",
       "runtime_handle": 1743073783466389
@@ -169,7 +169,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/front/lantern-keeper%3Ahollow-light",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "front",
       "local_id": "lantern-keeper:hollow-light",
       "runtime_handle": 8897349519357189
@@ -177,7 +177,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8401",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "item",
       "local_id": "8401",
       "legacy_runtime_id": 8401,
@@ -186,7 +186,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8402",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "item",
       "local_id": "8402",
       "legacy_runtime_id": 8402,
@@ -195,7 +195,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8403",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "item",
       "local_id": "8403",
       "legacy_runtime_id": 8403,
@@ -204,7 +204,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8404",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "item",
       "local_id": "8404",
       "legacy_runtime_id": 8404,
@@ -213,7 +213,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/job/lantern-keeper%3Arekindle-the-beacon",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "job",
       "local_id": "lantern-keeper:rekindle-the-beacon",
       "runtime_handle": 3517284423041433
@@ -221,7 +221,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/800",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "800",
       "legacy_runtime_id": 800,
@@ -230,7 +230,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/801",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "801",
       "legacy_runtime_id": 801,
@@ -239,7 +239,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/802",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "802",
       "legacy_runtime_id": 802,
@@ -248,7 +248,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/803",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "803",
       "legacy_runtime_id": 803,
@@ -257,7 +257,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/804",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "location",
       "local_id": "804",
       "legacy_runtime_id": 804,
@@ -266,7 +266,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A800",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:800",
       "runtime_handle": 485005815750293
@@ -274,7 +274,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A801",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:801",
       "runtime_handle": 5114262777545579
@@ -282,7 +282,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A802",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:802",
       "runtime_handle": 3932833224947827
@@ -290,7 +290,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A803",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:803",
       "runtime_handle": 7094111250995550
@@ -298,7 +298,7 @@
     {
       "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A804",
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "kind": "room-sheet",
       "local_id": "room:804",
       "runtime_handle": 112964325215682

--- a/v2/content/official/exits.json
+++ b/v2/content/official/exits.json
@@ -648,6 +648,34 @@
     "pack_id": "cosyworld.composition.core-holy-land"
   },
   {
+    "from_location_id": 4,
+    "to_location_id": 800,
+    "flags": 0,
+    "distance": 2,
+    "direction": "north",
+    "discovery": "known",
+    "pack_id": "cosyworld.composition.core-lantern-keeper"
+  },
+  {
+    "from_location_id": 800,
+    "to_location_id": 4,
+    "flags": 0,
+    "distance": 2,
+    "direction": "south",
+    "discovery": "known",
+    "pack_id": "cosyworld.composition.core-lantern-keeper"
+  },
+  {
+    "from_location_id": 804,
+    "to_location_id": 32,
+    "flags": 1,
+    "distance": 4,
+    "direction": "north",
+    "directionality": "one_way",
+    "fallback_location_id": 1,
+    "pack_id": "cosyworld.composition.core-lantern-keeper"
+  },
+  {
     "from_location_id": 10,
     "to_location_id": 11,
     "flags": 0,

--- a/v2/content/official/jobs.json
+++ b/v2/content/official/jobs.json
@@ -857,7 +857,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8"
+        "pack_version": "0.1.9"
       },
       {
         "version": 1,
@@ -939,7 +939,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8"
+        "pack_version": "0.1.9"
       }
     ],
     "narrated_thresholds": [

--- a/v2/content/official/licenses.json
+++ b/v2/content/official/licenses.json
@@ -84,7 +84,7 @@
   {
     "pack_id": "cosyworld.campaign.the-lantern-keeper",
     "name": "The Lantern Keeper",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "license_identifier": "CC-BY-4.0",
     "license_url": "https://creativecommons.org/licenses/by/4.0/",
     "provenance": {
@@ -121,6 +121,19 @@
     "pack_id": "cosyworld.composition.core-holy-land",
     "name": "CosyWorld Core + Holy Land Bridge",
     "version": "1.0.4",
+    "license_identifier": "MIT",
+    "license_url": "https://opensource.org/license/mit",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "CosyWorld official composition",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
+  },
+  {
+    "pack_id": "cosyworld.composition.core-lantern-keeper",
+    "name": "CosyWorld Core + Lantern Keeper Bridge",
+    "version": "1.0.0",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit",
     "provenance": {

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -795,7 +795,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:9576956c1e4e526044e6bf67996d18ada8a52f140be77ea25d763b2f386dc790",
+    "bundle_hash": "sha256:66eb887cebebfc5516bb0e69ae5f1143f462654df5c0e7d46b0a907a00d99fd4",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -2039,7 +2039,7 @@
         "id": "cosyworld.campaign.the-lantern-keeper",
         "name": "The Lantern Keeper",
         "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
-        "version": "0.1.8",
+        "version": "0.1.9",
         "kind": "campaign",
         "license": "CC-BY-4.0",
         "license_url": "https://creativecommons.org/licenses/by/4.0/",
@@ -2226,7 +2226,7 @@
                 },
                 "egress": {
                   "min": 0,
-                  "max": 1
+                  "max": 2
                 },
                 "weighted_distance": {
                   "min": 3,
@@ -2270,7 +2270,7 @@
           "type": "workspace",
           "path": "../../content/the-lantern-keeper"
         },
-        "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141"
+        "integrity": "sha256:050fc1806f8569eea3cc40bef81eb95eb184bb27116d0cbbbdeac7ca4a804065"
       },
       {
         "id": "cosyworld.the-holy-land",
@@ -2749,6 +2749,167 @@
           "path": "../../content/core-holy-land-bridge"
         },
         "integrity": "sha256:33ec60037a997b8a40d92805bb2a9aff60428eeadf32a78489c179ef160af3d9"
+      },
+      {
+        "id": "cosyworld.composition.core-lantern-keeper",
+        "name": "CosyWorld Core + Lantern Keeper Bridge",
+        "description": "Composition-owned paths connecting CosyWorld Core and The Lantern Keeper, including the road the relit beacon opens.",
+        "version": "1.0.0",
+        "kind": "world",
+        "license": "MIT",
+        "license_url": "https://opensource.org/license/mit",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.composition.core-lantern-keeper/world",
+            "kind": "world",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core",
+          "cosyworld.campaign.the-lantern-keeper",
+          "cosyworld.rules-profile-srd5"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.3.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          },
+          {
+            "id": "cosyworld.campaign.the-lantern-keeper",
+            "version": ">=0.1.8 <1.0.0",
+            "capabilities": [
+              "cosyworld.campaign.the-lantern-keeper/world"
+            ]
+          },
+          {
+            "id": "cosyworld.rules-profile-srd5",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.rules-profile-srd5/rules"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.rules-srd-5.2.1",
+          "cosyworld.rules-profile-srd5",
+          "cosyworld.core",
+          "cosyworld.rules-srd-5.1",
+          "cosyworld.campaign.the-lantern-keeper"
+        ],
+        "default_ruleset": null,
+        "entry_points": [],
+        "provenance": {
+          "author": "Cenetex",
+          "source_name": "CosyWorld official composition",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "actor_facets": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 3,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "action_vocabulary": 0,
+          "fronts": 0,
+          "cards": 0,
+          "card_bindings": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 0,
+          "rules": 0,
+          "character_creation": 0,
+          "reskins": 0,
+          "offers": 0,
+          "variants": 0,
+          "extensions": 0
+        },
+        "extensions": {
+          "x-cosyworld-composition": {
+            "schema_version": 1,
+            "role": "bridge"
+          },
+          "x-cosyworld-generation": {
+            "schema_version": 1,
+            "policy_id": "cosyworld.composition.core-lantern-keeper/generation/1",
+            "migration_version": 1,
+            "collision_namespace": "pack://cosyworld.composition.core-lantern-keeper/generated/v1",
+            "migrations": [
+              {
+                "from_policy_id": "cosyworld.compatibility.host-generation/1",
+                "from_migration_version": 0,
+                "from_pack_version": "1.0.0",
+                "mode": "preserve_descendants"
+              }
+            ],
+            "cross_pack_routes": [
+              {
+                "endpoints": [
+                  {
+                    "pack_id": "cosyworld.core",
+                    "location_id": 4
+                  },
+                  {
+                    "pack_id": "cosyworld.campaign.the-lantern-keeper",
+                    "location_id": 800
+                  }
+                ],
+                "route_owner": "cosyworld.composition.core-lantern-keeper",
+                "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+                "topology_authority": {
+                  "pack_id": "cosyworld.composition.core-lantern-keeper",
+                  "migration_version": 1
+                },
+                "ecology_transition": "endpoint_blend/1",
+                "media_profile_id": "cosyworld.community-art.base/1",
+                "unmount": "remove_with_route_owner",
+                "evacuation": "world_pack_lifecycle"
+              },
+              {
+                "endpoints": [
+                  {
+                    "pack_id": "cosyworld.campaign.the-lantern-keeper",
+                    "location_id": 804
+                  },
+                  {
+                    "pack_id": "cosyworld.core",
+                    "location_id": 32
+                  }
+                ],
+                "route_owner": "cosyworld.composition.core-lantern-keeper",
+                "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+                "topology_authority": {
+                  "pack_id": "cosyworld.composition.core-lantern-keeper",
+                  "migration_version": 1
+                },
+                "ecology_transition": "endpoint_blend/1",
+                "media_profile_id": "cosyworld.community-art.base/1",
+                "unmount": "remove_with_route_owner",
+                "evacuation": "world_pack_lifecycle"
+              }
+            ]
+          }
+        },
+        "rules_profile": "cosyworld.srd5/1",
+        "source": {
+          "type": "workspace",
+          "path": "../../content/core-lantern-keeper-bridge"
+        },
+        "integrity": "sha256:6aa8a08b240f5bb3c21ea5fa63b175365e90608c43162cb3a07d1e149f260d9b"
       },
       {
         "id": "ruby-high.first-bell",
@@ -7162,6 +7323,34 @@
         "pack_id": "cosyworld.composition.core-holy-land"
       },
       {
+        "from_location_id": 4,
+        "to_location_id": 800,
+        "flags": 0,
+        "distance": 2,
+        "direction": "north",
+        "discovery": "known",
+        "pack_id": "cosyworld.composition.core-lantern-keeper"
+      },
+      {
+        "from_location_id": 800,
+        "to_location_id": 4,
+        "flags": 0,
+        "distance": 2,
+        "direction": "south",
+        "discovery": "known",
+        "pack_id": "cosyworld.composition.core-lantern-keeper"
+      },
+      {
+        "from_location_id": 804,
+        "to_location_id": 32,
+        "flags": 1,
+        "distance": 4,
+        "direction": "north",
+        "directionality": "one_way",
+        "fallback_location_id": 1,
+        "pack_id": "cosyworld.composition.core-lantern-keeper"
+      },
+      {
         "from_location_id": 10,
         "to_location_id": 11,
         "flags": 0,
@@ -9486,6 +9675,12 @@
             "job_id": "lantern-keeper:rekindle-the-beacon",
             "status": "completed",
             "reason": "lantern_keeper_completed"
+          },
+          {
+            "op": "unlock_exit",
+            "from_location_id": 804,
+            "to_location_id": 32,
+            "reason": "beacon_rekindled_opens_the_road"
           }
         ],
         "presentation": {
@@ -10478,7 +10673,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.campaign.the-lantern-keeper",
-            "pack_version": "0.1.8"
+            "pack_version": "0.1.9"
           },
           {
             "version": 1,
@@ -10560,7 +10755,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "cosyworld.campaign.the-lantern-keeper",
-            "pack_version": "0.1.8"
+            "pack_version": "0.1.9"
           }
         ],
         "narrated_thresholds": [
@@ -16627,7 +16822,7 @@
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license_identifier": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "provenance": {
@@ -16664,6 +16859,19 @@
       "pack_id": "cosyworld.composition.core-holy-land",
       "name": "CosyWorld Core + Holy Land Bridge",
       "version": "1.0.4",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.composition.core-lantern-keeper",
+      "name": "CosyWorld Core + Lantern Keeper Bridge",
+      "version": "1.0.0",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {
@@ -17351,7 +17559,7 @@
   "character_creation": [
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
-      "pack_version": "0.1.8",
+      "pack_version": "0.1.9",
       "profiles": [
         {
           "schema_version": 2,
@@ -17477,7 +17685,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8301",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "actor",
         "local_id": "8301",
         "legacy_runtime_id": 8301,
@@ -17486,7 +17694,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8302",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "actor",
         "local_id": "8302",
         "legacy_runtime_id": 8302,
@@ -17495,7 +17703,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8303",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "actor",
         "local_id": "8303",
         "legacy_runtime_id": 8303,
@@ -17504,7 +17712,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/actor/8304",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "actor",
         "local_id": "8304",
         "legacy_runtime_id": 8304,
@@ -17513,7 +17721,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-barrow",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-barrow",
         "runtime_handle": 2693745143565876
@@ -17521,7 +17729,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-chapel",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-chapel",
         "runtime_handle": 485182594396993
@@ -17529,7 +17737,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-dawn-oil",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-dawn-oil",
         "runtime_handle": 2918403238373891
@@ -17537,7 +17745,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-ember",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-ember",
         "runtime_handle": 6023960511621204
@@ -17545,7 +17753,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-inn",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-inn",
         "runtime_handle": 2167662595818650
@@ -17553,7 +17761,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-key",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-key",
         "runtime_handle": 8905115040499656
@@ -17561,7 +17769,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-knight",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-knight",
         "runtime_handle": 7581163987072796
@@ -17569,7 +17777,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mara",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-mara",
         "runtime_handle": 2237714680835428
@@ -17577,7 +17785,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothglass",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-mothglass",
         "runtime_handle": 5170986584558554
@@ -17585,7 +17793,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-mothwood",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-mothwood",
         "runtime_handle": 1673786737892201
@@ -17593,7 +17801,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-pip",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-pip",
         "runtime_handle": 6288898560895936
@@ -17601,7 +17809,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-rowan",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-rowan",
         "runtime_handle": 1658308598845697
@@ -17609,7 +17817,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/card/lantern-keeper-tower",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "card",
         "local_id": "lantern-keeper-tower",
         "runtime_handle": 5850818207762215
@@ -17617,7 +17825,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/character-profile/the-lantern-keeper",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "character-profile",
         "local_id": "the-lantern-keeper",
         "runtime_handle": 6074007409727657
@@ -17625,7 +17833,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.darkness",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "clock",
         "local_id": "lantern-keeper.darkness",
         "runtime_handle": 3497107257475399
@@ -17633,7 +17841,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/clock/lantern-keeper.light",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "clock",
         "local_id": "lantern-keeper.light",
         "runtime_handle": 1743073783466389
@@ -17641,7 +17849,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/front/lantern-keeper%3Ahollow-light",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "front",
         "local_id": "lantern-keeper:hollow-light",
         "runtime_handle": 8897349519357189
@@ -17649,7 +17857,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8401",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "item",
         "local_id": "8401",
         "legacy_runtime_id": 8401,
@@ -17658,7 +17866,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8402",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "item",
         "local_id": "8402",
         "legacy_runtime_id": 8402,
@@ -17667,7 +17875,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8403",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "item",
         "local_id": "8403",
         "legacy_runtime_id": 8403,
@@ -17676,7 +17884,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/item/8404",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "item",
         "local_id": "8404",
         "legacy_runtime_id": 8404,
@@ -17685,7 +17893,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/job/lantern-keeper%3Arekindle-the-beacon",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "job",
         "local_id": "lantern-keeper:rekindle-the-beacon",
         "runtime_handle": 3517284423041433
@@ -17693,7 +17901,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/800",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "800",
         "legacy_runtime_id": 800,
@@ -17702,7 +17910,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/801",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "801",
         "legacy_runtime_id": 801,
@@ -17711,7 +17919,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/802",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "802",
         "legacy_runtime_id": 802,
@@ -17720,7 +17928,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/803",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "803",
         "legacy_runtime_id": 803,
@@ -17729,7 +17937,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/location/804",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "location",
         "local_id": "804",
         "legacy_runtime_id": 804,
@@ -17738,7 +17946,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A800",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:800",
         "runtime_handle": 485005815750293
@@ -17746,7 +17954,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A801",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:801",
         "runtime_handle": 5114262777545579
@@ -17754,7 +17962,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A802",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:802",
         "runtime_handle": 3932833224947827
@@ -17762,7 +17970,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A803",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:803",
         "runtime_handle": 7094111250995550
@@ -17770,7 +17978,7 @@
       {
         "canonical_ref": "pack://cosyworld.campaign.the-lantern-keeper/room-sheet/room%3A804",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8",
+        "pack_version": "0.1.9",
         "kind": "room-sheet",
         "local_id": "room:804",
         "runtime_handle": 112964325215682

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -793,7 +793,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:9576956c1e4e526044e6bf67996d18ada8a52f140be77ea25d763b2f386dc790",
+  "bundle_hash": "sha256:66eb887cebebfc5516bb0e69ae5f1143f462654df5c0e7d46b0a907a00d99fd4",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -2037,7 +2037,7 @@
       "id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
       "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "kind": "campaign",
       "license": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
@@ -2224,7 +2224,7 @@
               },
               "egress": {
                 "min": 0,
-                "max": 1
+                "max": 2
               },
               "weighted_distance": {
                 "min": 3,
@@ -2268,7 +2268,7 @@
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141"
+      "integrity": "sha256:050fc1806f8569eea3cc40bef81eb95eb184bb27116d0cbbbdeac7ca4a804065"
     },
     {
       "id": "cosyworld.the-holy-land",
@@ -2747,6 +2747,167 @@
         "path": "../../content/core-holy-land-bridge"
       },
       "integrity": "sha256:33ec60037a997b8a40d92805bb2a9aff60428eeadf32a78489c179ef160af3d9"
+    },
+    {
+      "id": "cosyworld.composition.core-lantern-keeper",
+      "name": "CosyWorld Core + Lantern Keeper Bridge",
+      "description": "Composition-owned paths connecting CosyWorld Core and The Lantern Keeper, including the road the relit beacon opens.",
+      "version": "1.0.0",
+      "kind": "world",
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "engine": ">=0.0.20 <0.1.0",
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-lantern-keeper/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        "cosyworld.core",
+        "cosyworld.campaign.the-lantern-keeper",
+        "cosyworld.rules-profile-srd5"
+      ],
+      "dependency_requirements": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.campaign.the-lantern-keeper",
+          "version": ">=0.1.8 <1.0.0",
+          "capabilities": [
+            "cosyworld.campaign.the-lantern-keeper/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "cosyworld.rules-srd-5.1",
+        "cosyworld.campaign.the-lantern-keeper"
+      ],
+      "default_ruleset": null,
+      "entry_points": [],
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "resource_counts": {
+        "actors": 0,
+        "actor_facets": 0,
+        "access_gates": 0,
+        "factions": 0,
+        "items": 0,
+        "locations": 0,
+        "exits": 3,
+        "hidden_exits": 0,
+        "room_features": 0,
+        "room_sheets": 0,
+        "clocks": 0,
+        "jobs": 0,
+        "action_vocabulary": 0,
+        "fronts": 0,
+        "cards": 0,
+        "card_bindings": 0,
+        "lifecycle_hooks": 0,
+        "evolution_tracks": 0,
+        "recipes": 0,
+        "sentences": 0,
+        "external_cards": 0,
+        "assets": 0,
+        "rules": 0,
+        "character_creation": 0,
+        "reskins": 0,
+        "offers": 0,
+        "variants": 0,
+        "extensions": 0
+      },
+      "extensions": {
+        "x-cosyworld-composition": {
+          "schema_version": 1,
+          "role": "bridge"
+        },
+        "x-cosyworld-generation": {
+          "schema_version": 1,
+          "policy_id": "cosyworld.composition.core-lantern-keeper/generation/1",
+          "migration_version": 1,
+          "collision_namespace": "pack://cosyworld.composition.core-lantern-keeper/generated/v1",
+          "migrations": [
+            {
+              "from_policy_id": "cosyworld.compatibility.host-generation/1",
+              "from_migration_version": 0,
+              "from_pack_version": "1.0.0",
+              "mode": "preserve_descendants"
+            }
+          ],
+          "cross_pack_routes": [
+            {
+              "endpoints": [
+                {
+                  "pack_id": "cosyworld.core",
+                  "location_id": 4
+                },
+                {
+                  "pack_id": "cosyworld.campaign.the-lantern-keeper",
+                  "location_id": 800
+                }
+              ],
+              "route_owner": "cosyworld.composition.core-lantern-keeper",
+              "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+              "topology_authority": {
+                "pack_id": "cosyworld.composition.core-lantern-keeper",
+                "migration_version": 1
+              },
+              "ecology_transition": "endpoint_blend/1",
+              "media_profile_id": "cosyworld.community-art.base/1",
+              "unmount": "remove_with_route_owner",
+              "evacuation": "world_pack_lifecycle"
+            },
+            {
+              "endpoints": [
+                {
+                  "pack_id": "cosyworld.campaign.the-lantern-keeper",
+                  "location_id": 804
+                },
+                {
+                  "pack_id": "cosyworld.core",
+                  "location_id": 32
+                }
+              ],
+              "route_owner": "cosyworld.composition.core-lantern-keeper",
+              "generated_descendant_owner": "cosyworld.composition.core-lantern-keeper",
+              "topology_authority": {
+                "pack_id": "cosyworld.composition.core-lantern-keeper",
+                "migration_version": 1
+              },
+              "ecology_transition": "endpoint_blend/1",
+              "media_profile_id": "cosyworld.community-art.base/1",
+              "unmount": "remove_with_route_owner",
+              "evacuation": "world_pack_lifecycle"
+            }
+          ]
+        }
+      },
+      "rules_profile": "cosyworld.srd5/1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-lantern-keeper-bridge"
+      },
+      "integrity": "sha256:6aa8a08b240f5bb3c21ea5fa63b175365e90608c43162cb3a07d1e149f260d9b"
     },
     {
       "id": "ruby-high.first-bell",

--- a/v2/content/the-lantern-keeper/clocks.json
+++ b/v2/content/the-lantern-keeper/clocks.json
@@ -25,6 +25,12 @@
         "job_id": "lantern-keeper:rekindle-the-beacon",
         "status": "completed",
         "reason": "lantern_keeper_completed"
+      },
+      {
+        "op": "unlock_exit",
+        "from_location_id": 804,
+        "to_location_id": 32,
+        "reason": "beacon_rekindled_opens_the_road"
       }
     ],
     "presentation": {

--- a/v2/content/the-lantern-keeper/jobs.json
+++ b/v2/content/the-lantern-keeper/jobs.json
@@ -97,7 +97,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8"
+        "pack_version": "0.1.9"
       },
       {
         "version": 1,
@@ -179,7 +179,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "cosyworld.campaign.the-lantern-keeper",
-        "pack_version": "0.1.8"
+        "pack_version": "0.1.9"
       }
     ],
     "narrated_thresholds": [

--- a/v2/content/the-lantern-keeper/pack.json
+++ b/v2/content/the-lantern-keeper/pack.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "cosyworld.campaign.the-lantern-keeper",
   "name": "The Lantern Keeper",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "kind": "campaign",
   "description": "A short fifth-edition-inspired campaign about a missing keeper and a beacon going dark.",
   "license": "CC-BY-4.0",
@@ -84,13 +84,20 @@
       "generated_descendants": {
         "owner": "source_route",
         "composition": "active_bundle",
-        "subject_kinds": ["route", "waypoint", "place", "location_card"],
+        "subject_kinds": [
+          "route",
+          "waypoint",
+          "place",
+          "location_card"
+        ],
         "on_upgrade": "require_declared_migration",
         "on_unmount": "freeze_with_owner"
       },
       "prose": {
         "profile_id": "cosyworld.pathway-prose.ecology/1",
-        "prompt_versions": ["pathway-content-v2"],
+        "prompt_versions": [
+          "pathway-content-v2"
+        ],
         "ecology": {
           "interpolation": "endpoint_blend/1",
           "required_context": [
@@ -124,10 +131,20 @@
         },
         "prompt_version": "community-art/3",
         "prompt_prefix": "MRQ, cozy hand-painted fantasy landscape, practical travel detail",
-        "aspect_ratios": ["16:9"],
-        "output_formats": ["webp"],
-        "negative_constraints": ["no text", "no logos", "no interface chrome"],
-        "subject_kinds": ["location_card"],
+        "aspect_ratios": [
+          "16:9"
+        ],
+        "output_formats": [
+          "webp"
+        ],
+        "negative_constraints": [
+          "no text",
+          "no logos",
+          "no interface chrome"
+        ],
+        "subject_kinds": [
+          "location_card"
+        ],
         "authored_art": "permanent",
         "community_art": "eligible",
         "unexplored_placeholder": "common_unexplored/1",
@@ -138,16 +155,46 @@
         "directionality": "reciprocal_or_explicit_one_way",
         "evacuation": "world_lifecycle_required",
         "budgets": {
-          "components": { "min": 1, "max": 1 },
-          "roots": { "min": 1, "max": 2 },
-          "ingress": { "min": 0, "max": 1 },
-          "egress": { "min": 0, "max": 1 },
-          "weighted_distance": { "min": 3, "max": 6 },
-          "degree": { "min": 1, "max": 3 },
-          "cycle_rank": { "min": 0, "max": 1 },
-          "bridges": { "min": 3, "max": 4 },
-          "articulation_impact": { "min": 1, "max": 3 },
-          "terminal_spurs": { "min": 1, "max": 2 }
+          "components": {
+            "min": 1,
+            "max": 1
+          },
+          "roots": {
+            "min": 1,
+            "max": 2
+          },
+          "ingress": {
+            "min": 0,
+            "max": 1
+          },
+          "egress": {
+            "min": 0,
+            "max": 2
+          },
+          "weighted_distance": {
+            "min": 3,
+            "max": 6
+          },
+          "degree": {
+            "min": 1,
+            "max": 3
+          },
+          "cycle_rank": {
+            "min": 0,
+            "max": 1
+          },
+          "bridges": {
+            "min": 3,
+            "max": 4
+          },
+          "articulation_impact": {
+            "min": 1,
+            "max": 3
+          },
+          "terminal_spurs": {
+            "min": 1,
+            "max": 2
+          }
         }
       },
       "migrations": [

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.299"
+version = "0.0.300"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.299"
+version = "0.0.300"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -3643,16 +3643,40 @@ fn validate_lantern_clock_effect_contract(content: &SeedContent) -> Result<(), S
         if authoritative.is_empty() {
             return Err(format!("clock {clock_id} on_fill cannot be tag-only"));
         }
-        if !matches!(
-            authoritative.as_slice(),
-            [EffectDescriptor::SetJobStatus {
-                job_id,
-                status,
-                ..
-            }] if job_id == LANTERN_KEEPER_JOB_ID && status == expected_status
-        ) {
+        // The job status is the required consequence and there may be exactly
+        // one of it. A clock may additionally open a road it has earned: the
+        // relit beacon is what makes the way onward passable, and paying that
+        // with an authored UnlockExit keeps the topology change authoritative,
+        // journaled, and replayable rather than a projection or a tag other
+        // surfaces would have to interpret. Nothing else is admitted here, so
+        // the clock still cannot grant items, currency, or access at large.
+        let mut job_status_effects = 0usize;
+        let mut unlock_effects = 0usize;
+        for effect in &authoritative {
+            match effect {
+                EffectDescriptor::SetJobStatus { job_id, status, .. }
+                    if job_id == LANTERN_KEEPER_JOB_ID && status == expected_status =>
+                {
+                    job_status_effects += 1;
+                }
+                EffectDescriptor::UnlockExit { .. } => {
+                    unlock_effects += 1;
+                }
+                _ => {
+                    return Err(format!(
+                        "clock {clock_id} on_fill admits only one set_job_status consequence for {LANTERN_KEEPER_JOB_ID}:{expected_status} and at most one unlock_exit"
+                    ));
+                }
+            }
+        }
+        if job_status_effects != 1 {
             return Err(format!(
                 "clock {clock_id} must declare exactly one authoritative set_job_status consequence for {LANTERN_KEEPER_JOB_ID}:{expected_status}"
+            ));
+        }
+        if unlock_effects > 1 {
+            return Err(format!(
+                "clock {clock_id} may open at most one authored exit on fill"
             ));
         }
     }

--- a/v2/orchestrator-rust/src/content_packs.rs
+++ b/v2/orchestrator-rust/src/content_packs.rs
@@ -338,7 +338,7 @@ mod tests {
     #[test]
     fn catalog_projects_public_locked_partial_and_entitled_access() {
         let public = content_packs_response(&AccessContext::default());
-        assert_eq!(public.packs.len(), 10);
+        assert_eq!(public.packs.len(), 11);
         let core = public
             .packs
             .iter()

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -1440,7 +1440,7 @@ mod tests {
         )
         .expect("official registry loads");
         assert_eq!(registry.content().locations.len(), 49);
-        assert_eq!(registry.content().manifest.packs.len(), 10);
+        assert_eq!(registry.content().manifest.packs.len(), 11);
         assert_eq!(
             registry.content().manifest.rules_profile,
             "cosyworld.srd5/1"

--- a/v2/orchestrator-rust/src/lantern_keeper_tests.rs
+++ b/v2/orchestrator-rust/src/lantern_keeper_tests.rs
@@ -533,7 +533,7 @@ fn previous_epoch_snapshot_refreshes_the_finale_contract_and_shared_evidence() {
         .expect("active finale strategy replaces the old snapshot contract");
     assert_eq!(restored_strategy.requirements.len(), 10);
     assert_eq!(restored_strategy.baseline_progress, 6);
-    assert_eq!(restored_strategy.pack_version, "0.1.8");
+    assert_eq!(restored_strategy.pack_version, "0.1.9");
     assert_eq!(
         restored.tags[&room_feature_use_tag_id(801, "cold_lamp_post", 8402)].source_event_seq,
         Some(321)
@@ -850,6 +850,26 @@ fn assert_both_lantern_clock_fills_are_once_only() {
             .tags
             .get(case.expected_tag_id)
             .is_some_and(|tag| tag.active));
+
+        // Winning pays a road. The light clock opens the way onward from the
+        // tower; the darkness clock must not, so failure cannot hand out the
+        // reward that only success earns.
+        let road_is_open = !runtime.authored_route_locked_for_edge(804, 32);
+        assert_eq!(
+            road_is_open,
+            case.clock_id == LANTERN_PROGRESS_CLOCK_ID,
+            "the road onward from the Lantern Tower follows the beacon, not the dark"
+        );
+        if road_is_open {
+            assert!(
+                events.iter().any(|event| {
+                    event.type_name == "exit.unlocked"
+                        && event.location_id == Some(804)
+                        && event.destination_location_id == Some(32)
+                }),
+                "the opened road is a public journaled world event"
+            );
+        }
         let consequence_events = events
             .iter()
             .filter(|event| {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -61015,7 +61015,7 @@ mod tests {
         assert_eq!(content.manifest.version, 1);
         assert_eq!(content.manifest.schema_version, 2);
         assert_eq!(content.manifest.rules_profile, "cosyworld.srd5/1");
-        assert_eq!(content.manifest.packs.len(), 10);
+        assert_eq!(content.manifest.packs.len(), 11);
 
         assert!(content.manifest.bundle_hash.starts_with("sha256:"));
         assert!(content.manifest.description.contains("seed world"));
@@ -61031,7 +61031,7 @@ mod tests {
         assert_eq!(satchel.role, "container");
         assert_eq!(satchel.container_capacity_tenths, 300);
         assert_eq!(content.locations.len(), 49);
-        assert_eq!(content.exits.len(), 112);
+        assert_eq!(content.exits.len(), 115);
 
         assert!(content.exits.iter().any(|exit| {
             exit.from_location_id == MOONLIT_TRAIL_LOCATION_ID

--- a/v2/orchestrator-rust/src/semantic_receipts.rs
+++ b/v2/orchestrator-rust/src/semantic_receipts.rs
@@ -104,13 +104,24 @@ fn next_after_arrival(location_id: u64) -> &'static str {
     }
 }
 
+/// The actor's most recent location *inside the campaign*.
+///
+/// The campaign filter belongs inside the search, not after it. A committed
+/// turn can end on an event that points outside the campaign — filling the
+/// beacon clock also opens the road onward, and that `exit.unlocked` names its
+/// core destination — and taking the last location unconditionally would make
+/// this return `None` and silently drop the finale's story receipt.
 fn lantern_location_for(events: &[EventView], actor_id: u64) -> Option<u64> {
     events
         .iter()
         .rev()
         .filter(|event| event.actor_id == Some(actor_id))
-        .find_map(|event| event.destination_location_id.or(event.location_id))
-        .filter(|location_id| LANTERN_LOCATION_IDS.contains(location_id))
+        .find_map(|event| {
+            event
+                .destination_location_id
+                .or(event.location_id)
+                .filter(|location_id| LANTERN_LOCATION_IDS.contains(location_id))
+        })
 }
 
 fn receipt_event_seqs(events: &[EventView], actor_id: u64) -> Vec<u64> {

--- a/v2/scripts/lantern-clock-contract.mjs
+++ b/v2/scripts/lantern-clock-contract.mjs
@@ -40,15 +40,33 @@ export function lanternClockEffectValidationErrors({
       errors.push(`clock ${clockId} on_fill cannot be tag-only`);
       continue;
     }
-    if (
-      authoritative.length !== 1
-      || authoritative[0]?.op !== "set_job_status"
-      || authoritative[0]?.job_id !== LANTERN_KEEPER_JOB_ID
-      || authoritative[0]?.status !== expectedStatus
-    ) {
+    // The job status is required and may appear exactly once. A clock may
+    // additionally open a road it has earned, so at most one unlock_exit is
+    // admitted alongside it. Nothing else: the clock still cannot grant items,
+    // currency, or access at large. Mirrors validate_lantern_clock_effect_contract
+    // in v2/orchestrator-rust/src/content_load.rs.
+    let jobStatusEffects = 0;
+    let unlockEffects = 0;
+    let foreign = false;
+    for (const effect of authoritative) {
+      if (
+        effect?.op === "set_job_status"
+        && effect?.job_id === LANTERN_KEEPER_JOB_ID
+        && effect?.status === expectedStatus
+      ) {
+        jobStatusEffects += 1;
+      } else if (effect?.op === "unlock_exit") {
+        unlockEffects += 1;
+      } else {
+        foreign = true;
+      }
+    }
+    if (foreign || jobStatusEffects !== 1) {
       errors.push(
         `clock ${clockId} must declare exactly one authoritative set_job_status consequence for ${LANTERN_KEEPER_JOB_ID}:${expectedStatus}`,
       );
+    } else if (unlockEffects > 1) {
+      errors.push(`clock ${clockId} may open at most one authored exit on fill`);
     }
   }
 

--- a/v2/scripts/lantern-clock-contract.test.mjs
+++ b/v2/scripts/lantern-clock-contract.test.mjs
@@ -75,6 +75,53 @@ test("Lantern clock contract rejects a duplicate lifecycle source", () => {
   );
 });
 
+test("a filled clock may open exactly one road it earned, and nothing else", () => {
+  const clockId = "lantern-keeper.light";
+  const unlock = {
+    op: "unlock_exit",
+    from_location_id: 804,
+    to_location_id: 32,
+    reason: "beacon_rekindled_opens_the_road",
+  };
+
+  // The shipped content pairs the job status with a single unlock.
+  const shipped = clocks.find((clock) => clock.id === clockId);
+  assert.equal(shipped.on_fill.filter((effect) => effect.op === "unlock_exit").length, 1);
+  assert.deepEqual(validate(), []);
+
+  // Two roads from one fill is not a bounded consequence.
+  const twoRoads = structuredClone(clocks);
+  twoRoads.find((clock) => clock.id === clockId).on_fill.push({
+    ...unlock,
+    to_location_id: 33,
+  });
+  assert.match(validate({ clocks: twoRoads }).join("\n"), /at most one authored exit/);
+
+  // The relaxation admits unlock_exit only; it is not a general effect surface.
+  const foreign = structuredClone(clocks);
+  foreign.find((clock) => clock.id === clockId).on_fill.push({
+    op: "reveal_item",
+    item_id: 2001,
+    location_id: 804,
+    reason: "beacon_rekindled_opens_the_road",
+  });
+  assert.match(
+    validate({ clocks: foreign }).join("\n"),
+    /exactly one authoritative set_job_status/,
+  );
+
+  // Dropping the job status is still rejected even with a road present.
+  const unlockOnly = structuredClone(clocks);
+  const unlockOnlyClock = unlockOnly.find((clock) => clock.id === clockId);
+  unlockOnlyClock.on_fill = unlockOnlyClock.on_fill.filter(
+    (effect) => effect.op !== "set_job_status",
+  );
+  assert.match(
+    validate({ clocks: unlockOnly }).join("\n"),
+    /exactly one authoritative set_job_status/,
+  );
+});
+
 test("compositions without the Lantern pack are outside this contract", () => {
   assert.deepEqual(
     lanternClockEffectValidationErrors({

--- a/v2/worlds/lantern-keeper/pack.lock.json
+++ b/v2/worlds/lantern-keeper/pack.lock.json
@@ -8,7 +8,8 @@
     "cosyworld.rules-profile-srd5",
     "cosyworld.core",
     "cosyworld.rules-srd-5.1",
-    "cosyworld.campaign.the-lantern-keeper"
+    "cosyworld.campaign.the-lantern-keeper",
+    "cosyworld.composition.core-lantern-keeper"
   ],
   "packs": [
     {
@@ -157,12 +158,12 @@
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "source": {
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141",
+      "integrity": "sha256:050fc1806f8569eea3cc40bef81eb95eb184bb27116d0cbbbdeac7ca4a804065",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -206,6 +207,59 @@
         "source_name": "CosyWorld and System Reference Document 5.1",
         "source_url": "https://github.com/cenetex/cosyworld",
         "modification_notice": "Original CosyWorld campaign material adapts selected SRD 5.1 rules references."
+      }
+    },
+    {
+      "id": "cosyworld.composition.core-lantern-keeper",
+      "version": "1.0.0",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-lantern-keeper-bridge"
+      },
+      "integrity": "sha256:6aa8a08b240f5bb3c21ea5fa63b175365e90608c43162cb3a07d1e149f260d9b",
+      "dependencies": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.campaign.the-lantern-keeper",
+          "version": ">=0.1.8 <1.0.0",
+          "capabilities": [
+            "cosyworld.campaign.the-lantern-keeper/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "cosyworld.rules-srd-5.1",
+        "cosyworld.campaign.the-lantern-keeper"
+      ],
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-lantern-keeper/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
       }
     }
   ],
@@ -295,7 +349,7 @@
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license_identifier": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "provenance": {
@@ -314,6 +368,19 @@
           "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
         }
       ]
+    },
+    {
+      "pack_id": "cosyworld.composition.core-lantern-keeper",
+      "name": "CosyWorld Core + Lantern Keeper Bridge",
+      "version": "1.0.0",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
     }
   ]
 }

--- a/v2/worlds/lantern-keeper/world.json
+++ b/v2/worlds/lantern-keeper/world.json
@@ -24,6 +24,7 @@
     "cosyworld.rules-srd-5.1",
     "cosyworld.rules-srd-5.2.1",
     "cosyworld.rules-profile-srd5",
-    "cosyworld.campaign.the-lantern-keeper"
+    "cosyworld.campaign.the-lantern-keeper",
+    "cosyworld.composition.core-lantern-keeper"
   ]
 }

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -11,6 +11,7 @@
     "cosyworld.campaign.the-lantern-keeper",
     "cosyworld.the-holy-land",
     "cosyworld.composition.core-holy-land",
+    "cosyworld.composition.core-lantern-keeper",
     "ruby-high.first-bell",
     "cosyworld.composition.core-ruby",
     "cosyworld.lonely-forest.characters"
@@ -162,12 +163,12 @@
     },
     {
       "id": "cosyworld.campaign.the-lantern-keeper",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "source": {
         "type": "workspace",
         "path": "../../content/the-lantern-keeper"
       },
-      "integrity": "sha256:0318228d0ff1b5c32340c2e712191c3e0e47fccc148179b1eaf9860e581ca141",
+      "integrity": "sha256:050fc1806f8569eea3cc40bef81eb95eb184bb27116d0cbbbdeac7ca4a804065",
       "dependencies": [
         {
           "id": "cosyworld.core",
@@ -302,6 +303,59 @@
       "capabilities": [
         {
           "id": "cosyworld.composition.core-holy-land/world",
+          "kind": "world",
+          "version": "1.0.0"
+        }
+      ],
+      "license": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      }
+    },
+    {
+      "id": "cosyworld.composition.core-lantern-keeper",
+      "version": "1.0.0",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/core-lantern-keeper-bridge"
+      },
+      "integrity": "sha256:6aa8a08b240f5bb3c21ea5fa63b175365e90608c43162cb3a07d1e149f260d9b",
+      "dependencies": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.3.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.campaign.the-lantern-keeper",
+          "version": ">=0.1.8 <1.0.0",
+          "capabilities": [
+            "cosyworld.campaign.the-lantern-keeper/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core",
+        "cosyworld.rules-srd-5.1",
+        "cosyworld.campaign.the-lantern-keeper"
+      ],
+      "capabilities": [
+        {
+          "id": "cosyworld.composition.core-lantern-keeper/world",
           "kind": "world",
           "version": "1.0.0"
         }
@@ -562,7 +616,7 @@
     {
       "pack_id": "cosyworld.campaign.the-lantern-keeper",
       "name": "The Lantern Keeper",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license_identifier": "CC-BY-4.0",
       "license_url": "https://creativecommons.org/licenses/by/4.0/",
       "provenance": {
@@ -599,6 +653,19 @@
       "pack_id": "cosyworld.composition.core-holy-land",
       "name": "CosyWorld Core + Holy Land Bridge",
       "version": "1.0.4",
+      "license_identifier": "MIT",
+      "license_url": "https://opensource.org/license/mit",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.composition.core-lantern-keeper",
+      "name": "CosyWorld Core + Lantern Keeper Bridge",
+      "version": "1.0.0",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit",
       "provenance": {

--- a/v2/worlds/official/world.json
+++ b/v2/worlds/official/world.json
@@ -87,6 +87,7 @@
     "cosyworld.lonely-forest.characters",
     "ruby-high.first-bell",
     "cosyworld.composition.core-ruby",
-    "cosyworld.composition.core-holy-land"
+    "cosyworld.composition.core-holy-land",
+    "cosyworld.composition.core-lantern-keeper"
   ]
 }


### PR DESCRIPTION
**Draft** — two fixture tests still to reconcile, detailed at the bottom.

## What this fixes

The Lantern Keeper was mounted but unreachable. Its six-segment beacon clock filled to an invisible tag plus a job status, while its own authored outcome promised *"the beacon burns again and makes the Mothwood road trustworthy after dusk."* Nothing in the world changed.

Reachability from the Cosy Cottage over unlocked authored topology:

| | Unreachable |
|---|---|
| `main` | Dark Abyss **+ all five Lantern Keeper rooms** |
| this branch | Dark Abyss only |

## How

- New composition pack `cosyworld.composition.core-lantern-keeper`, following the existing Core+Ruby and Core+Holy Land bridge pattern, so cross-pack topology stays in composition data rather than in either reusable pack.
- **Mossbell Inn (core 4) ↔ Wayside Lantern Inn (800)**, open both ways. Mossbell was a dead-end spur one hop from the Cottage; it now leads somewhere, and the campaign sits two hops from home.
- **Lantern Tower (804) → Summit Trail (core 32)**, authored locked and one-way, opened by `lantern-keeper.light` on fill.

I first attached the inbound road at Moonlit Trail, per the write-up in `world-topology-and-composition-joins.md`. That gave combatants an extra flee route and an existing combat fixture started resolving differently — the NPC escaped instead of being knocked out. Mossbell Inn is better anyway: same "inn on the road" idea, no fixture perturbation, and it repairs a terminal spur.

## Two deliberate contracts moved

Both narrowly, both on purpose, because this could not be done in content alone:

1. **The lantern clock admitted exactly one non-tag consequence.** It now also admits at most one `unlock_exit`. Mirrored in `validate_lantern_clock_effect_contract` and `lantern-clock-contract.mjs`, with tests proving two roads and any other effect are still rejected. The clock still cannot grant items, currency, or access at large.
2. **The campaign declared `egress: max 1`** — a linear journey with one way out. It is now a region with two entrances, so the budget is raised explicitly and the pack bumped to `0.1.9` (with its `pack_version` pins in `jobs.json` kept in sync).

## A real bug this surfaced

`lantern_location_for` took the actor's most recent location and only *then* filtered for a campaign room. Because filling the clock also emits `exit.unlocked` naming its **core** destination, that filter rejected the last event and returned `None` — silently dropping the finale's story receipt. The filter now lives inside the search.

Without that fix, wiring any consequence that points outside the campaign would quietly delete the player-facing beat.

## Verification

- `npm run v2:worldpack` — green.
- **898 Rust tests** green, including a new assertion that the beacon opens the road and the darkness clock does not, and that the opening is a public journaled `exit.unlocked`.
- `main.rs` and clippy ceilings unchanged.

## Why this is still a draft

Two tests in `test/v2/worldpack-access.test.mjs` fail. This adds the **first one-way exit in official content**, which activates a validation path those fixtures never exercised:

- `accepts an explicit one-way edge with a reachable fallback preview` — the fixture mutates the official graph, and the checker now also evaluates my `804→32` fallback inside that mutated world.
- `requires evacuation destinations to retain egress to the world root` — expected a failure that no longer occurs, because the new bridge keeps the graph connected.

Both look like fixtures that should account for the new edge rather than defects in the change, but they deserve a proper look rather than a quick loosening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)