### PR TITLE
Preserve Lantern Keeper journal across the release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.302",
+  "version": "0.0.303",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.302",
+      "version": "0.0.303",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.302",
+  "version": "0.0.303",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/worldpack-bundle-gate.test.mjs
+++ b/test/v2/worldpack-bundle-gate.test.mjs
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -18,6 +18,10 @@ const compiledRegistryPath = path.join(
   repoRoot,
   "v2/content/official/registry.json",
 );
+const lanternRegistryPath = path.join(
+  repoRoot,
+  "v2/content/lantern-keeper/registry.json",
+);
 
 function digest(value) {
   return `sha256:${crypto.createHash("sha256").update(value).digest("hex")}`;
@@ -26,6 +30,8 @@ function digest(value) {
 const LIVE_HASH = digest("live-journal-bundle");
 const CANDIDATE_HASH = digest("candidate-bundle");
 const OLDER_HASH = digest("older-declared-bundle");
+const LANTERN_ACTIVE_HASH = "sha256:29db5ba3069c84dea79e90a5f707d0c1fc730c446f3948224f70539c91fe2bfb";
+const LANTERN_PERSISTED_HASH = "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586";
 
 function registry(overrides = {}) {
   return {
@@ -264,5 +270,17 @@ describe("worldpack deploy gate CLI", () => {
     );
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toMatch(/^sha256:[0-9a-f]{64} \d+$/);
+  });
+
+  it("accepts the exact deployed Lantern Keeper journal bundle migration", async () => {
+    const registry = JSON.parse(await readFile(lanternRegistryPath, "utf8"));
+    const candidate = candidateFromRegistry(registry);
+    expect(candidate.bundleHash).toBe(LANTERN_ACTIVE_HASH);
+    expect(candidate.replayCompatible).toContain(LANTERN_PERSISTED_HASH);
+    expect(evaluateWorldpackGate({
+      candidateHash: candidate.bundleHash,
+      candidateReplayCompatible: candidate.replayCompatible,
+      liveHash: LANTERN_PERSISTED_HASH,
+    })).toMatchObject({ ok: true, status: "declared_migration" });
   });
 });

--- a/v2/content/lantern-keeper/registry.json
+++ b/v2/content/lantern-keeper/registry.json
@@ -9,6 +9,12 @@
     "version": 1,
     "description": "A Lantern Keeper-first composition with the CosyWorld core mounted as its dependency.",
     "entry_location": "cosyworld.core:location/1",
+    "persistence_compatibility": {
+      "schema_version": 1,
+      "replay_compatible_bundle_hashes": [
+        "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586"
+      ]
+    },
     "pack_lifecycle": {
       "schema_version": 1,
       "unmount": [

--- a/v2/content/lantern-keeper/worldpack.json
+++ b/v2/content/lantern-keeper/worldpack.json
@@ -7,6 +7,12 @@
   "version": 1,
   "description": "A Lantern Keeper-first composition with the CosyWorld core mounted as its dependency.",
   "entry_location": "cosyworld.core:location/1",
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586"
+    ]
+  },
   "pack_lifecycle": {
     "schema_version": 1,
     "unmount": [

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.302"
+version = "0.0.303"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.302"
+version = "0.0.303"
 edition = "2021"
 publish = false
 

--- a/v2/worlds/lantern-keeper/world.json
+++ b/v2/worlds/lantern-keeper/world.json
@@ -19,6 +19,12 @@
       }
     ]
   },
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586"
+    ]
+  },
   "packs": [
     "cosyworld.core",
     "cosyworld.rules-srd-5.1",


### PR DESCRIPTION
## Summary

- declare the persisted standalone Lantern Keeper bundle `sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586` replay-compatible with the active `sha256:29db5ba3069c84dea79e90a5f707d0c1fc730c446f3948224f70539c91fe2bfb` bundle
- regenerate the standalone Lantern Keeper registry and worldpack without changing bundle identity
- add an exact production-hash compatibility regression
- bump the release version from 0.0.302 to 0.0.303

## Root cause

The v0.0.92 release changed the standalone Lantern composition after its journal had been compacted. The release deploy guard validated only the Lonely Forest root world, so the Lantern process discovered the undeclared bundle transition during boot and crash-looped while the other tenants remained healthy.

## Deployment and compatibility

This is an explicit forward replay declaration for the exact persisted Lantern snapshot hash observed in production. No state is reset or rewritten, and the active content bundle hash remains unchanged. A broader multitenant deploy-guard redesign is intentionally deferred because Lantern currently returns 502; adding a fail-closed live-host check in this recovery PR would block the release that restores it.

## Validation

- `npm run check` — 518 JavaScript tests, worldpack/proof checks, C kernel, 908 Rust tests, architecture/clippy ceilings, and syntax checks passed
- `npm run check:local` — 46 files / 518 tests and V2 smoke checks passed
- `npm exec vitest -- run test/v2/worldpack-bundle-gate.test.mjs` — 21 passed
- `npx eslint test/v2/worldpack-bundle-gate.test.mjs`
- `npm run check:version`
- `git diff --check`

## Review checklist

- [x] authored persistence policy and generated artifacts reviewed together
- [x] exact production hashes covered by a regression
- [x] no runtime database, secret, or unrelated worktree changes included
- [x] version and generated artifacts are current
