### PR TITLE
fix: restore main deployment gates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.304",
+  "version": "0.0.305",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.304",
+      "version": "0.0.305",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.304",
+  "version": "0.0.305",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/scripts/backup-fly-v2.sh
+++ b/scripts/backup-fly-v2.sh
@@ -43,6 +43,34 @@ json_value() {
   python3 - "$@"
 }
 
+snapshot_ids() {
+  SNAPSHOTS_JSON="$1" json_value <<'PY'
+import json
+import os
+
+try:
+    value = json.loads(os.environ["SNAPSHOTS_JSON"])
+except (KeyError, json.JSONDecodeError) as error:
+    raise SystemExit(f"invalid flyctl snapshot-list JSON: {error}")
+
+snapshots = value.get("snapshots", []) if isinstance(value, dict) else value
+if not isinstance(snapshots, list):
+    raise SystemExit("flyctl snapshot JSON did not contain a snapshot list")
+
+ids = []
+for snapshot in snapshots:
+    if not isinstance(snapshot, dict):
+        raise SystemExit("flyctl snapshot JSON contained a non-object snapshot")
+    snapshot_id = snapshot.get("id")
+    if not isinstance(snapshot_id, str) or not snapshot_id.startswith("vs_"):
+        raise SystemExit("flyctl snapshot JSON contained an unverifiable snapshot id")
+    ids.append(snapshot_id)
+if len(set(ids)) != len(ids):
+    raise SystemExit("flyctl snapshot JSON contained duplicate snapshot ids")
+print(json.dumps(ids))
+PY
+}
+
 if ! volumes_json="$(flyctl volumes list --app "$APP" --json 2>&1)"; then
   volumes_json="${volumes_json//$'\n'/ }"
   echo "::error::could not list volumes for $APP: $volumes_json" >&2
@@ -90,6 +118,16 @@ PY
 
 echo "Resolved $APP/$VOLUME_NAME to $volume_id"
 
+if ! snapshots_before_json="$(flyctl volumes snapshots list "$volume_id" --app "$APP" --json 2>&1)"; then
+  snapshots_before_json="${snapshots_before_json//$'\n'/ }"
+  echo "::error::could not list existing snapshots for $APP/$VOLUME_NAME: $snapshots_before_json" >&2
+  exit 1
+fi
+if ! snapshot_ids_before="$(snapshot_ids "$snapshots_before_json")"; then
+  echo "::error::could not parse existing snapshots for $APP/$VOLUME_NAME" >&2
+  exit 1
+fi
+
 if ! create_json="$(flyctl volumes snapshots create "$volume_id" --app "$APP" --json 2>&1)"; then
   create_json="${create_json//$'\n'/ }"
   echo "::error::could not create snapshot for $volume_id: $create_json" >&2
@@ -99,12 +137,14 @@ fi
 snapshot_id="$(CREATE_JSON="$create_json" json_value <<'PY'
 import json
 import os
-import sys
 
+raw = os.environ.get("CREATE_JSON", "").strip()
+if not raw:
+    raise SystemExit(0)
 try:
-    value = json.loads(os.environ["CREATE_JSON"])
-except (KeyError, json.JSONDecodeError) as error:
-    raise SystemExit(f"invalid flyctl snapshot JSON: {error}")
+    value = json.loads(raw)
+except json.JSONDecodeError:
+    raise SystemExit(0)
 
 def find_snapshot_id(candidate):
     if isinstance(candidate, dict):
@@ -124,14 +164,16 @@ def find_snapshot_id(candidate):
     return None
 
 snapshot_id = find_snapshot_id(value)
-if not snapshot_id:
-    raise SystemExit("flyctl did not return a verifiable snapshot id")
-print(snapshot_id)
+if snapshot_id:
+    print(snapshot_id)
 PY
 )" || {
-  echo "::error::snapshot request for $volume_id returned no verifiable snapshot id" >&2
+  echo "::error::could not inspect snapshot creation response for $volume_id" >&2
   exit 1
 }
+if [ -z "$snapshot_id" ]; then
+  echo "::notice::flyctl snapshot create returned no JSON snapshot id; resolving the exact new snapshot from the verified list"
+fi
 
 timeout_secs="${COSYWORLD_FLY_SNAPSHOT_TIMEOUT_SECS:-180}"
 poll_secs="${COSYWORLD_FLY_SNAPSHOT_POLL_SECS:-5}"
@@ -152,12 +194,14 @@ while [ "$SECONDS" -lt "$deadline" ]; do
     exit 1
   fi
 
-  snapshot_status="$(SNAPSHOTS_JSON="$snapshots_json" json_value "$snapshot_id" <<'PY'
+  snapshot_state="$(
+    SNAPSHOTS_JSON="$snapshots_json" \
+      SNAPSHOT_ID="$snapshot_id" \
+      SNAPSHOT_IDS_BEFORE="$snapshot_ids_before" \
+      json_value <<'PY'
 import json
 import os
-import sys
 
-snapshot_id = sys.argv[1]
 try:
     value = json.loads(os.environ["SNAPSHOTS_JSON"])
 except (KeyError, json.JSONDecodeError) as error:
@@ -167,17 +211,47 @@ snapshots = value.get("snapshots", []) if isinstance(value, dict) else value
 if not isinstance(snapshots, list):
     raise SystemExit("flyctl snapshot JSON did not contain a snapshot list")
 
+try:
+    before = set(json.loads(os.environ["SNAPSHOT_IDS_BEFORE"]))
+except (KeyError, json.JSONDecodeError) as error:
+    raise SystemExit(f"invalid saved Fly snapshot identity set: {error}")
+
+by_id = {}
 for snapshot in snapshots:
-    if isinstance(snapshot, dict) and snapshot.get("id") == snapshot_id:
-        print(snapshot.get("status", ""))
-        break
+    if not isinstance(snapshot, dict):
+        raise SystemExit("flyctl snapshot JSON contained a non-object snapshot")
+    candidate_id = snapshot.get("id")
+    if not isinstance(candidate_id, str) or not candidate_id.startswith("vs_"):
+        raise SystemExit("flyctl snapshot JSON contained an unverifiable snapshot id")
+    if candidate_id in by_id:
+        raise SystemExit("flyctl snapshot JSON contained duplicate snapshot ids")
+    by_id[candidate_id] = snapshot
+
+snapshot_id = os.environ.get("SNAPSHOT_ID", "")
+if not snapshot_id:
+    fresh = sorted(set(by_id).difference(before))
+    if len(fresh) > 1:
+        raise SystemExit(
+            "could not identify exactly one new snapshot after a successful create request: "
+            + ", ".join(fresh)
+        )
+    if len(fresh) == 1:
+        snapshot_id = fresh[0]
+
+if not snapshot_id:
+    print("|pending")
+elif snapshot_id in by_id:
+    print(f"{snapshot_id}|{by_id[snapshot_id].get('status', '')}")
 else:
-    print("missing")
+    print(f"{snapshot_id}|missing")
 PY
-)" || {
-    echo "::error::could not parse snapshot verification response for $snapshot_id" >&2
+  )" || {
+    echo "::error::could not parse snapshot verification response for ${snapshot_id:-new snapshot}" >&2
     exit 1
   }
+
+  snapshot_id="${snapshot_state%%|*}"
+  snapshot_status="${snapshot_state#*|}"
 
   case "$snapshot_status" in
     created)
@@ -190,6 +264,9 @@ PY
       ;;
     missing)
       echo "Waiting for Fly volume snapshot $snapshot_id to appear"
+      ;;
+    pending)
+      echo "Waiting for Fly volume snapshot creation to appear"
       ;;
     *)
       echo "Waiting for Fly volume snapshot $snapshot_id: ${snapshot_status:-unknown}"

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -198,12 +198,84 @@ describe('deploy workflow', () => {
       `case "$*" in
         *"volumes list"*) echo '[{"id":"vol_123","name":"cosyworld_data","state":"created","attached_machine_id":"machine_123"}]' ;;
         *"snapshots create"*) echo '{"id":"vs_new","status":"running"}' ;;
-        *"snapshots list"*) echo '[{"id":"vs_new","status":"created"}]' ;;
+        *"snapshots list"*)
+          state_file="$(dirname "$0")/snapshot-list-count"
+          if [ -f "$state_file" ]; then
+            echo '[{"id":"vs_new","status":"created"}]'
+          else
+            touch "$state_file"
+            echo '[]'
+          fi ;;
         *) exit 1 ;;
       esac`
     );
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Verified Fly volume snapshot vs_new');
+  });
+
+  it('recovers a verifiable new snapshot when flyctl create returns an empty successful response', () => {
+    const result = runBackup(
+      `case "$*" in
+        *"volumes list"*) echo '[{"id":"vol_123","name":"cosyworld_data","state":"created","attached_machine_id":"machine_123"}]' ;;
+        *"snapshots create"*) : ;;
+        *"snapshots list"*)
+          state_file="$(dirname "$0")/snapshot-list-count"
+          if [ -f "$state_file" ]; then
+            echo '[{"id":"vs_existing","status":"created"},{"id":"vs_new","status":"created"}]'
+          else
+            touch "$state_file"
+            echo '[{"id":"vs_existing","status":"created"}]'
+          fi ;;
+        *) exit 1 ;;
+      esac`
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Verified Fly volume snapshot vs_new');
+  });
+
+  it('fails closed when an empty successful create response exposes multiple new snapshots', () => {
+    const result = runBackup(
+      `case "$*" in
+        *"volumes list"*) echo '[{"id":"vol_123","name":"cosyworld_data","state":"created","attached_machine_id":"machine_123"}]' ;;
+        *"snapshots create"*) : ;;
+        *"snapshots list"*)
+          state_file="$(dirname "$0")/snapshot-list-count"
+          if [ -f "$state_file" ]; then
+            echo '[{"id":"vs_existing","status":"created"},{"id":"vs_one","status":"created"},{"id":"vs_two","status":"created"}]'
+          else
+            touch "$state_file"
+            echo '[{"id":"vs_existing","status":"created"}]'
+          fi ;;
+        *) exit 1 ;;
+      esac`
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('could not identify exactly one new snapshot');
+  });
+
+  it('recovers the exact new snapshot when Fly emits non-JSON create diagnostics', () => {
+    const result = runBackup(
+      `case "$*" in
+        *"volumes list"*) echo '[{"id":"vol_123","name":"cosyworld_data","state":"created","attached_machine_id":"machine_123"}]' ;;
+        *"snapshots list"*)
+          state_file="$(dirname "$0")/snapshot-list-count"
+          if [ -f "$state_file" ]; then
+            echo '[{"id":"vs_new","status":"created"}]'
+          else
+            touch "$state_file"
+            echo '[]'
+          fi ;;
+        *"snapshots create"*) echo 'snapshot created' ;;
+        *) exit 1 ;;
+      esac`
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('returned no JSON snapshot id');
+    expect(result.stdout).not.toContain('snapshot created');
     expect(result.stdout).toContain('Verified Fly volume snapshot vs_new');
   });
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.304"
+version = "0.0.305"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.304"
+version = "0.0.305"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -9460,7 +9460,27 @@ async function main() {
       return actor ? { id: Number(actor.id), name: actor.name || "" } : null;
     });
     assert(nearbyActor?.id && nearbyActor?.name, "avatar report smoke needs a nearby resident before the room starts moving");
+    async function refreshReportSubmissionState() {
+      const synchronized = await page.evaluate(async (targetActorId) => {
+        await queueRefresh();
+        while (refreshInFlight) await refreshInFlight;
+        const target = actorForId(targetActorId);
+        const reporter = actorForId(actorId);
+        return {
+          targetName: target?.name || "",
+          reporterVersion: Number(reporter?.entity_version || 0),
+        };
+      }, nearbyActor.id);
+      assert(
+        synchronized.targetName === nearbyActor.name && synchronized.reporterVersion > 0,
+        `avatar report submission should refresh the visible reporter and target: ${JSON.stringify(synchronized)}`,
+      );
+    }
     const submitReport = async () => {
+      // The envelope binds the reporter's observed actor version. Refresh
+      // through the browser's normal state path immediately before building
+      // this form, since world activity may advance it between smoke steps.
+      await refreshReportSubmissionState();
       await page.evaluate((targetActorId) => {
         const card = cardForActor(targetActorId);
         if (card) openCardModal(card);

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -63,6 +63,37 @@ async function postJson(url, body) {
   });
 }
 
+async function postJsonExpectingStatus(url, body, expectedStatus) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(5_000),
+  });
+  const text = await response.text();
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${url} returned HTTP ${response.status} with invalid JSON: ${text.slice(0, 400)} (${error.message})`,
+    );
+  }
+  assert(
+    response.status === expectedStatus,
+    `${url} returned HTTP ${response.status}, expected ${expectedStatus}: ${text.slice(0, 400)}`,
+  );
+  assert(
+    parsed && typeof parsed === "object" && !Array.isArray(parsed),
+    `${url} returned HTTP ${response.status} with a non-object JSON response: ${text.slice(0, 400)}`,
+  );
+  assert(
+    parsed.status === expectedStatus,
+    `${url} returned JSON status ${parsed.status}, expected ${expectedStatus}: ${text.slice(0, 400)}`,
+  );
+  return parsed;
+}
+
 async function waitForMeta(baseUrl, proc, output) {
   const deadline = Date.now() + 10_000;
   let lastError = null;
@@ -258,8 +289,15 @@ async function move(baseUrl, actorId, actorSession, destinationLocationId) {
   return result;
 }
 
-async function submitOffer(baseUrl, offer, path, payload, compositionId = offer.composition_id) {
-  return postJson(`${baseUrl}/actions/submit`, {
+async function submitOffer(
+  baseUrl,
+  offer,
+  path,
+  payload,
+  compositionId = offer.composition_id,
+  expectedStatus,
+) {
+  const body = {
     path,
     offer_id: offer.offer_id,
     composition_id: compositionId,
@@ -272,7 +310,10 @@ async function submitOffer(baseUrl, offer, path, payload, compositionId = offer.
     target: offer.target,
     cost: offer.cost,
     payload,
-  });
+  };
+  return expectedStatus === undefined
+    ? postJson(`${baseUrl}/actions/submit`, body)
+    : postJsonExpectingStatus(`${baseUrl}/actions/submit`, body, expectedStatus);
 }
 
 async function discoverExit(baseUrl, actorId, actorSession, destinationLocationId) {
@@ -452,6 +493,7 @@ async function main() {
       "/actions/move",
       travelPayload,
       `sha256:${"0".repeat(64)}`,
+      409,
     );
     assert(
       rejectedTravel.ok === false

--- a/v2/scripts/smoke-standalone-compositions.mjs
+++ b/v2/scripts/smoke-standalone-compositions.mjs
@@ -190,6 +190,37 @@ async function postJson(url, body, timeoutMs) {
   }, timeoutMs);
 }
 
+async function postJsonExpectingStatus(url, body, expectedStatus, timeoutMs) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs ?? 5_000),
+  });
+  const text = await response.text();
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${url} returned HTTP ${response.status} with invalid JSON: ${text.slice(0, 400)} (${error.message})`,
+    );
+  }
+  assert(
+    response.status === expectedStatus,
+    `${url} returned HTTP ${response.status}, expected ${expectedStatus}: ${text.slice(0, 400)}`,
+  );
+  assert(
+    parsed && typeof parsed === "object" && !Array.isArray(parsed),
+    `${url} returned HTTP ${response.status} with a non-object JSON response: ${text.slice(0, 400)}`,
+  );
+  assert(
+    parsed.status === expectedStatus,
+    `${url} returned JSON status ${parsed.status}, expected ${expectedStatus}: ${text.slice(0, 400)}`,
+  );
+  return parsed;
+}
+
 async function waitForMeta(baseUrl, proc, output) {
   const deadline = Date.now() + 10_000;
   let lastError = null;
@@ -383,12 +414,12 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     chosen.ok === true && chosen.events?.filter((event) => event.type === "class.chosen").length === 1,
     `Lantern Keeper Class selection did not commit exactly once: ${JSON.stringify(chosen)}`,
   );
-  const duplicate = await postJson(`${baseUrl}/avatar/class`, {
+  const duplicate = await postJsonExpectingStatus(`${baseUrl}/avatar/class`, {
     actor_id: actorId,
     actor_session: actorSession,
     character_creation_id: "the-lantern-keeper",
     class_id: "lantern-warden",
-  });
+  }, 409);
   assert(
     duplicate.ok === false && duplicate.status === 409,
     `Lantern Keeper allowed Class selection to be replayed: ${JSON.stringify(duplicate)}`,
@@ -480,12 +511,12 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
         matchesProjectOffer(offer, "lantern-keeper:rekindle-the-beacon")),
     `Lantern Keeper did not reach Saint Orra with the shortcut still closed: ${JSON.stringify(lanternJourneySummary(saintOrra))}`,
   );
-  const shortcut = await postJson(`${baseUrl}/commands`, {
+  const shortcut = await postJsonExpectingStatus(`${baseUrl}/commands`, {
     actor_id: actorId,
     actor_session: actorSession,
     wallet_address: walletAddress,
     command: "work",
-  });
+  }, 409);
   assert(
     shortcut.ok === false && shortcut.events?.length === 0,
     `Lantern Keeper accepted the Saint Orra finale shortcut: ${JSON.stringify(shortcut)}`,
@@ -579,13 +610,13 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   );
   traceLantern("lantern Tower ready", towerReady);
 
-  const tamperedOffer = await postJson(`${baseUrl}/commands`, {
+  const tamperedOffer = await postJsonExpectingStatus(`${baseUrl}/commands`, {
     actor_id: actorId,
     actor_session: actorSession,
     wallet_address: walletAddress,
     offer_id: `${initialWorkOffer.offer_id}:tampered`,
     command: initialWorkOffer.command,
-  });
+  }, 404);
   assert(
     tamperedOffer.ok === false
       && tamperedOffer.status === 404
@@ -595,13 +626,13 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   );
 
   const firstTowerListen = await command(baseUrl, actorId, actorSession, "listen");
-  const staleOffer = await postJson(`${baseUrl}/commands`, {
+  const staleOffer = await postJsonExpectingStatus(`${baseUrl}/commands`, {
     actor_id: actorId,
     actor_session: actorSession,
     wallet_address: walletAddress,
     offer_id: initialWorkOffer.offer_id,
     command: initialWorkOffer.command,
-  });
+  }, 409);
   assert(
     staleOffer.ok === false
       && staleOffer.status === 409
@@ -674,10 +705,10 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     JSON.stringify(retriedFinale) === JSON.stringify(finale),
     `Lantern Keeper finale retry was not idempotent: ${JSON.stringify({ finale, retriedFinale })}`,
   );
-  const conflictingRetry = await postJson(`${baseUrl}/commands`, {
+  const conflictingRetry = await postJsonExpectingStatus(`${baseUrl}/commands`, {
     ...finalePayload,
     offer_id: `${freshWorkOffer.offer_id}:tampered-retry`,
-  });
+  }, 409);
   assert(
     conflictingRetry.ok === false
       && conflictingRetry.status === 409
@@ -986,12 +1017,12 @@ async function runWorldLoop(spec) {
           offers: discovered.action_offers?.map(({ kind, target }) => ({ kind, target })),
         })}`,
       );
-      const repeated = await postJson(`${first.baseUrl}/commands`, {
+      const repeated = await postJsonExpectingStatus(`${first.baseUrl}/commands`, {
         actor_id: actorId,
         actor_session: actorSession,
         wallet_address: walletAddress,
         command: `scout ${spec.scoutDestination}`,
-      });
+      }, 404);
       assert(
         repeated.ok === false,
         `${spec.label} allowed its already-discovered route to be scouted again`,
@@ -1147,10 +1178,10 @@ async function assertServicesContract(server, expectedPackIds) {
         pack.notices?.some((notice) => notice.text.includes("System Reference Document 5.2.1"))),
     `services-only licenses are incomplete: ${JSON.stringify(licenses)}`,
   );
-  const rejected = await postJson(`${server.baseUrl}/avatar`, {
+  const rejected = await postJsonExpectingStatus(`${server.baseUrl}/avatar`, {
     name: "No World Walker",
     wallet_address: walletAddress,
-  });
+  }, 503);
   assert(
     rejected.ok === false
       && rejected.status === 503


### PR DESCRIPTION
## Summary

- preserve intentional non-2xx runtime responses in composition smoke tests by asserting both HTTP and JSON status
- make Fly snapshot backup verification tolerate successful non-JSON create output by identifying exactly one new snapshot from before/after lists
- fail closed when snapshot identity is missing or ambiguous, without logging raw create diagnostics
- synchronize the fresh-seed browser report control with the canonical reporter version while preserving stale-write rejection
- bump the release version to `0.0.305`

## Validation

- `npm run check` (525 Node tests, 918 Rust tests, worldpack/kernel/architecture/syntax)
- `npm run v2:composition:smoke`
- `npm run v2:browser:check` (two consecutive local passes after synchronization fix)
- `npx vitest run test/infrastructure/deploy-workflow.test.mjs`
- `npm run check:version`
- `git diff --check`
