### PR TITLE
fix: normalize duplicate Fly snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.305",
+  "version": "0.0.306",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.305",
+      "version": "0.0.306",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.305",
+  "version": "0.0.306",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/scripts/backup-fly-v2.sh
+++ b/scripts/backup-fly-v2.sh
@@ -57,17 +57,22 @@ snapshots = value.get("snapshots", []) if isinstance(value, dict) else value
 if not isinstance(snapshots, list):
     raise SystemExit("flyctl snapshot JSON did not contain a snapshot list")
 
-ids = []
+ids = set()
 for snapshot in snapshots:
     if not isinstance(snapshot, dict):
         raise SystemExit("flyctl snapshot JSON contained a non-object snapshot")
     snapshot_id = snapshot.get("id")
     if not isinstance(snapshot_id, str) or not snapshot_id.startswith("vs_"):
         raise SystemExit("flyctl snapshot JSON contained an unverifiable snapshot id")
-    ids.append(snapshot_id)
-if len(set(ids)) != len(ids):
-    raise SystemExit("flyctl snapshot JSON contained duplicate snapshot ids")
-print(json.dumps(ids))
+    status = snapshot.get("status", "")
+    if not isinstance(status, str):
+        raise SystemExit("flyctl snapshot JSON contained an unverifiable snapshot status")
+    ids.add(snapshot_id)
+
+# The before-set is identity-only. After every list record has passed schema
+# validation, duplicate statuses or incidental metadata cannot make an old id
+# appear new, so one copy of each id is sufficient.
+print(json.dumps(sorted(ids)))
 PY
 }
 
@@ -223,9 +228,25 @@ for snapshot in snapshots:
     candidate_id = snapshot.get("id")
     if not isinstance(candidate_id, str) or not candidate_id.startswith("vs_"):
         raise SystemExit("flyctl snapshot JSON contained an unverifiable snapshot id")
-    if candidate_id in by_id:
-        raise SystemExit("flyctl snapshot JSON contained duplicate snapshot ids")
-    by_id[candidate_id] = snapshot
+    status = snapshot.get("status", "")
+    if not isinstance(status, str):
+        raise SystemExit("flyctl snapshot JSON contained an unverifiable snapshot status")
+    by_id.setdefault(candidate_id, []).append(snapshot)
+
+normalized = {}
+terminal_statuses = {"failed", "error", "destroyed"}
+for candidate_id, records in by_id.items():
+    statuses = {record.get("status", "").strip().lower() for record in records}
+    terminal = sorted({
+        status for status in statuses if status in terminal_statuses
+    })
+    if terminal:
+        # A terminal failure always wins over a duplicate stale success; never
+        # claim a backup was created while Fly reports any terminal failure.
+        normalized[candidate_id] = terminal[0]
+        continue
+    normalized[candidate_id] = next(iter(statuses)) if len(statuses) == 1 else "conflicting"
+by_id = normalized
 
 snapshot_id = os.environ.get("SNAPSHOT_ID", "")
 if not snapshot_id:
@@ -241,7 +262,7 @@ if not snapshot_id:
 if not snapshot_id:
     print("|pending")
 elif snapshot_id in by_id:
-    print(f"{snapshot_id}|{by_id[snapshot_id].get('status', '')}")
+    print(f"{snapshot_id}|{by_id[snapshot_id]}")
 else:
     print(f"{snapshot_id}|missing")
 PY

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -76,7 +76,7 @@ const runVolumeGuard = (fakeFlyctl) => {
   }
 };
 
-const runBackup = (fakeFlyctl, profile = 'primary') => {
+const runBackup = (fakeFlyctl, profile = 'primary', timeoutSecs = '1') => {
   const directory = mkdtempSync(join(tmpdir(), 'cosyworld-fly-backup-'));
   const flyctlPath = join(directory, 'flyctl');
   writeFileSync(flyctlPath, `#!/usr/bin/env bash\n${fakeFlyctl}\n`);
@@ -90,7 +90,7 @@ const runBackup = (fakeFlyctl, profile = 'primary') => {
         env: {
           ...process.env,
           PATH: `${directory}${delimiter}${process.env.PATH}`,
-          COSYWORLD_FLY_SNAPSHOT_TIMEOUT_SECS: '1',
+          COSYWORLD_FLY_SNAPSHOT_TIMEOUT_SECS: timeoutSecs,
           COSYWORLD_FLY_SNAPSHOT_POLL_SECS: '1'
         }
       }
@@ -277,6 +277,103 @@ describe('deploy workflow', () => {
     expect(result.stdout).toContain('returned no JSON snapshot id');
     expect(result.stdout).not.toContain('snapshot created');
     expect(result.stdout).toContain('Verified Fly volume snapshot vs_new');
+  });
+
+  it('collapses identical and same-status Fly snapshot duplicates', () => {
+    const result = runBackup(
+      `case "$*" in
+        *"volumes list"*) echo '[{"id":"vol_123","name":"cosyworld_data","state":"created","attached_machine_id":"machine_123"}]' ;;
+        *"snapshots create"*) echo 'snapshot created' ;;
+        *"snapshots list"*)
+          state_file="$(dirname "$0")/snapshot-list-count"
+          if [ -f "$state_file" ]; then
+            echo '[{"id":"vs_existing","status":"created","size_gb":1},{"id":"vs_existing","status":"created","size_gb":2},{"id":"vs_identical","status":"created"},{"id":"vs_identical","status":"created"},{"id":"vs_new","status":"created","region":"yyz"},{"id":"vs_new","status":"created","region":"sea"}]'
+          else
+            touch "$state_file"
+            echo '[{"id":"vs_existing","status":"created","size_gb":1},{"id":"vs_existing","status":"created","size_gb":2},{"id":"vs_identical","status":"created"},{"id":"vs_identical","status":"created"}]'
+          fi ;;
+        *) exit 1 ;;
+      esac`
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Verified Fly volume snapshot vs_new');
+  });
+
+  it('waits for conflicting duplicate Fly snapshot statuses to converge', () => {
+    const result = runBackup(
+      `case "$*" in
+        *"volumes list"*) echo '[{"id":"vol_123","name":"cosyworld_data","state":"created","attached_machine_id":"machine_123"}]' ;;
+        *"snapshots create"*) echo '{"id":"vs_new","status":"running"}' ;;
+        *"snapshots list"*)
+          state_file="$(dirname "$0")/snapshot-list-count"
+          count=0
+          if [ -f "$state_file" ]; then count="$(cat "$state_file")"; fi
+          count=$((count + 1))
+          echo "$count" > "$state_file"
+          if [ "$count" -eq 1 ]; then
+            echo '[]'
+          elif [ "$count" -eq 2 ]; then
+            echo '[{"id":"vs_new","status":"created"},{"id":"vs_new","status":"running"}]'
+          else
+            echo '[{"id":"vs_new","status":"created","region":"yyz"},{"id":"vs_new","status":"created","region":"sea"}]'
+          fi ;;
+        *) exit 1 ;;
+      esac`,
+      'primary',
+      '3'
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Waiting for Fly volume snapshot vs_new: conflicting');
+    expect(result.stdout).toContain('Verified Fly volume snapshot vs_new');
+  });
+
+  it('fails closed when conflicting duplicate Fly snapshot statuses do not converge', () => {
+    const result = runBackup(
+      `case "$*" in
+        *"volumes list"*) echo '[{"id":"vol_123","name":"cosyworld_data","state":"created","attached_machine_id":"machine_123"}]' ;;
+        *"snapshots create"*) echo '{"id":"vs_new","status":"running"}' ;;
+        *"snapshots list"*)
+          state_file="$(dirname "$0")/snapshot-list-count"
+          if [ -f "$state_file" ]; then
+            echo '[{"id":"vs_new","status":"created"},{"id":"vs_new","status":"running"}]'
+          else
+            touch "$state_file"
+            echo '[]'
+          fi ;;
+        *) exit 1 ;;
+      esac`,
+      'primary',
+      '2'
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('Waiting for Fly volume snapshot vs_new: conflicting');
+    expect(result.stderr).toContain('timed out waiting for Fly volume snapshot vs_new');
+    expect(result.stdout).not.toContain('Verified Fly volume snapshot');
+  });
+
+  it('fails closed when a duplicate Fly snapshot record reports a terminal failure', () => {
+    const result = runBackup(
+      `case "$*" in
+        *"volumes list"*) echo '[{"id":"vol_123","name":"cosyworld_data","state":"created","attached_machine_id":"machine_123"}]' ;;
+        *"snapshots create"*) echo '{"id":"vs_new","status":"running"}' ;;
+        *"snapshots list"*)
+          state_file="$(dirname "$0")/snapshot-list-count"
+          if [ -f "$state_file" ]; then
+            echo '[{"id":"vs_new","status":"created"},{"id":"vs_new","status":"failed"}]'
+          else
+            touch "$state_file"
+            echo '[]'
+          fi ;;
+        *) exit 1 ;;
+      esac`
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("terminal state 'failed'");
+    expect(result.stdout).not.toContain('Verified Fly volume snapshot');
   });
 
   it('fails closed when the configured volume is ambiguous', () => {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.305"
+version = "0.0.306"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.305"
+version = "0.0.306"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- normalize Fly snapshot-list duplicates by verified snapshot ID and normalized status
- collapse same-status duplicates even when incidental metadata differs
- wait for nonterminal duplicate status disagreement to converge instead of accepting a premature completion
- make any terminal duplicate status win and fail the backup
- preserve exact single-new-ID discovery and ambiguity rejection
- bump the release version to `0.0.306`

## Production evidence

Post-merge deploy run `30706742034` proved the non-JSON create fallback finds the exact new snapshot, then Fly returned duplicate rows for that ID during polling. The deployment stopped before image replacement.

## Validation

- `npm run check` (529 Node tests, 918 Rust tests, worldpack/kernel/architecture/syntax)
- focused deploy-workflow suite: 21/21
- duplicate coverage: same-status/different metadata, conflict then convergence, persistent conflict timeout, terminal conflict failure
- `npm run check:version`
- `git diff --check`
