### PR TITLE
Align release entrypoint permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=build /app/v2/content /app/v2/content
 COPY deploy/lonelyforest /app/deploy/lonelyforest
 COPY deploy/entrypoint.sh /app/entrypoint.sh
 
-RUN chmod 0755 /app/deploy/entrypoint.sh /app/deploy/lonelyforest/run-multitenant.sh
+RUN chmod 0755 /app/entrypoint.sh /app/deploy/lonelyforest/run-multitenant.sh
 
 EXPOSE 3000
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.306",
+  "version": "0.0.307",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.306",
+      "version": "0.0.307",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.306",
+  "version": "0.0.307",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -120,6 +120,19 @@ describe('deploy workflow', () => {
     expect(dockerfile).toContain('ENTRYPOINT ["/app/entrypoint.sh"]');
   });
 
+  it('keeps the Docker entrypoint COPY, chmod, and ENTRYPOINT destinations aligned', () => {
+    const copies = [...dockerfile.matchAll(/^COPY\s+deploy\/entrypoint\.sh\s+(\S+)$/gm)];
+    expect(copies).toHaveLength(1);
+    const [, entrypointPath] = copies[0];
+    const normalizedDockerfile = dockerfile.replace(/\\\s*\n\s*/g, ' ');
+    const escapedEntrypointPath = entrypointPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    expect(normalizedDockerfile).toMatch(
+      new RegExp(`RUN\\s+chmod\\s+0755\\s+${escapedEntrypointPath}(?:\\s|$)`)
+    );
+    expect(dockerfile).toContain(`ENTRYPOINT ["${entrypointPath}"]`);
+    expect(dockerfile).not.toContain('/app/deploy/entrypoint.sh');
+  });
+
   it('blocks deployment on the real v2 gates before either Fly job runs', () => {
     const gate = job('production-gate', 'primary-fly');
     expect(gate).toContain('npm run v2:worldpack');

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.306"
+version = "0.0.307"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.306"
+version = "0.0.307"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- fix the release image build by chmodding the entrypoint at the path where Docker copies it
- add a Dockerfile contract that binds the COPY destination to both chmod and ENTRYPOINT, including line-continuation formatting
- bump the canonical release version to 0.0.307

## Deployment note

The main deployment for #671 created and verified rollback snapshot `vs_jJYAyRO3nxkZhjYwllD3b`, then failed before image replacement because Docker tried to chmod nonexistent `/app/deploy/entrypoint.sh`. Production remained healthy on 0.0.303. This PR repairs that build-only failure; the rollback backup gate remains mandatory.

## Validation

- `npx vitest run test/infrastructure/deploy-workflow.test.mjs` — 22/22 passed
- `npm run check:local` under Node 24 — 46 files / 530 Node tests passed, plus worldpack, kernel, Rust, architecture, syntax, composition, production, browser, and CLI gates
- pre-push `npm run check` under Node 24 — 530 Node tests and 918 Rust tests passed
- `npm run check:version`
- `git diff --check`

## Review checklist

- [x] minimal production-path correction
- [x] regression coverage added
- [x] canonical version files updated
- [x] no generated or runtime artifacts included
