### PR TITLE
Size the kernel world for every authored pack

### DIFF
--- a/ENG.md
+++ b/ENG.md
@@ -198,7 +198,7 @@ Standing rules for new work:
 
 ## Deployment and Scale
 
-`COSYWORLD_DEPLOY_PROFILE=production` refuses to boot without the protected remote ownership feed + bearer, the SQLite event store, a moderation token, a shard id, and with any dev shortcut enabled. Kernel capacities are compiled (512 actors, 1024 items, 256 locations, 1024 exits) and exposed with live counters on `/meta`; approaching them is a sharding conversation, not a hot patch. Track live-item growth against authored faucet bounds and content-ratio validation; raise a capacity or retention decision before the item counter approaches its compiled cap.
+`COSYWORLD_DEPLOY_PROFILE=production` refuses to boot without the protected remote ownership feed + bearer, the SQLite event store, a moderation token, a shard id, and with any dev shortcut enabled. Kernel capacities are compiled (1024 actors, 1024 items, 2048 locations, 4096 exits) and exposed with live counters on `/meta`; approaching them is a sharding conversation, not a hot patch. Locations and exits are sized so a single world can mount every authored pack at once — that union currently seeds 555 locations and 1151 exits — with room for generated pathway descendants. Actors and items are not: the same union seeds 565 actors and 540 items, which leaves under half of each cap for live play. Track live-item growth against authored faucet bounds and content-ratio validation; raise a capacity or retention decision before the item counter approaches its compiled cap.
 
 Scale model: one shard per process, isolated stores, route players to their shard at a layer above. Revisit only when a single world's concurrency actually demands it.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.310",
+  "version": "0.0.311",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.310",
+      "version": "0.0.311",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.310",
+  "version": "0.0.311",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/core-c/include/cosy_kernel.h
+++ b/v2/core-c/include/cosy_kernel.h
@@ -9,12 +9,18 @@ extern "C" {
 #endif
 
 /* Version 9 is reserved by #411 for project-push ABI state. */
-#define CW_KERNEL_VERSION 13u
+/* Version 14 widens the location and exit arrays; sizeof(cw_world) changed. */
+#define CW_KERNEL_VERSION 14u
 
+/* Capacities are compiled into cw_world as fixed arrays, so raising one is an
+ * ABI change that must be mirrored in the Rust bindings. Locations and exits
+ * are sized for a single world that mounts every authored pack at once: the
+ * current union is 555 locations and 1151 exits, and generated pathway
+ * descendants grow both at runtime. */
 #define CW_MAX_ACTORS 1024u
 #define CW_MAX_ITEMS 1024u
-#define CW_MAX_LOCATIONS 512u
-#define CW_MAX_EXITS 1024u
+#define CW_MAX_LOCATIONS 2048u
+#define CW_MAX_EXITS 4096u
 #define CW_MAX_EVOLUTION_TRACKS 128u
 #define CW_MAX_EVOLUTION_REQUIREMENTS 4u
 #define CW_MAX_EVENTS 256u

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -39,13 +39,18 @@ static cw_gate *test_find_gate(cw_world *world, cw_id gate_id) {
 static void test_kernel_capacities_are_runtime_sized(void) {
   assert(CW_MAX_ACTORS >= 1024u);
   assert(CW_MAX_ITEMS >= 1024u);
-  assert(CW_MAX_LOCATIONS >= 256u);
-  assert(CW_MAX_EXITS >= 1024u);
+  /* A world mounting every authored pack seeds 555 locations and 1151 exits,
+   * and generated pathway descendants grow both while the world is live. */
+  assert(CW_MAX_LOCATIONS >= 1110u);
+  assert(CW_MAX_EXITS >= 2302u);
+  assert(CW_MAX_EXITS >= CW_MAX_LOCATIONS);
   assert(CW_MAX_EVENTS >= 128u);
   assert(CW_MAX_EVOLUTION_TRACKS >= 128u);
   assert(CW_MAX_GATES >= 32u);
   assert(CW_MAX_GATE_CLAIMS >= 128u);
-  assert(sizeof(cw_world) <= 190000u);
+  /* The world is one flat struct handed across the ABI. Keep it small enough
+   * to stay comfortable on a 2 MB worker stack even when built unoptimized. */
+  assert(sizeof(cw_world) <= 320000u);
 }
 
 static void test_seed_and_chat(void) {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.310"
+version = "0.0.311"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.310"
+version = "0.0.311"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/cards.rs
+++ b/v2/orchestrator-rust/src/cards.rs
@@ -311,7 +311,7 @@ impl RuntimeWorld {
 
     pub(super) fn set_item_zone(&mut self, item_id: u64, zone: u8, container_item_id: u64) -> bool {
         unsafe {
-            cw_world_set_item_zone(&mut self.world, item_id, zone, container_item_id) == CW_OK
+            cw_world_set_item_zone(&mut *self.world, item_id, zone, container_item_id) == CW_OK
         }
     }
 

--- a/v2/orchestrator-rust/src/crafting.rs
+++ b/v2/orchestrator-rust/src/crafting.rs
@@ -1089,7 +1089,7 @@ mod tests {
         }
         let mut kernel_offers = CwActionOffers::default();
         assert_eq!(
-            unsafe { cw_get_action_offers(&runtime.world, RATI_ACTOR_ID, &mut kernel_offers) },
+            unsafe { cw_get_action_offers(&*runtime.world, RATI_ACTOR_ID, &mut kernel_offers) },
             CW_OK
         );
         assert_eq!(kernel_offers.option_flags & CW_OFFER_CRAFT, 0);

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -9,10 +9,12 @@ use serde::{Deserialize, Serialize};
 mod rejections;
 pub(crate) use rejections::*;
 
+// These mirror the compiled capacities in core-c/include/cosy_kernel.h. They
+// are part of the cw_world layout, so the two files must move together.
 pub const CW_MAX_ACTORS: usize = 1024;
 pub const CW_MAX_ITEMS: usize = 1024;
-pub const CW_MAX_LOCATIONS: usize = 512;
-pub const CW_MAX_EXITS: usize = 1024;
+pub const CW_MAX_LOCATIONS: usize = 2048;
+pub const CW_MAX_EXITS: usize = 4096;
 pub const CW_MAX_EVENTS: usize = 256;
 pub const CW_MAX_EVOLUTION_TRACKS: usize = 128;
 pub const CW_MAX_EVOLUTION_REQUIREMENTS: usize = 4;
@@ -29,7 +31,8 @@ pub const CW_MAX_GATE_CLAIMS: usize = 128;
 pub const CW_ITEM_DEFAULT_WEIGHT_TENTHS: u16 = 10;
 
 // Kernel version 9 is reserved by #411 for project-push ABI state.
-pub const CW_KERNEL_VERSION: u32 = 13;
+// Version 14 widens the location and exit arrays; sizeof(cw_world) changed.
+pub const CW_KERNEL_VERSION: u32 = 14;
 
 pub const CW_OK: u32 = 0;
 pub const CW_ERR_INVALID: u32 = 1;
@@ -923,5 +926,49 @@ mod tests {
         assert_eq!(action.kind, CW_ACTION_REST);
         assert_eq!(action.rest.requested_grade, CW_REST_GRADE_HEARTH);
         assert_eq!(action.rest.entitled_grade, CW_REST_GRADE_CAMP);
+    }
+
+    /// One world that mounts every authored pack at once currently seeds 555
+    /// locations and 1151 exits, which both exceeded the pre-version-14
+    /// capacities. This pins the headroom the topology actually needs rather
+    /// than each number in isolation, and proves the far end of each widened
+    /// array is addressable through the shared struct.
+    #[test]
+    fn capacity_holds_every_authored_pack_in_one_world() {
+        const UNIFIED_SEED_LOCATIONS: usize = 555;
+        const UNIFIED_SEED_EXITS: usize = 1151;
+        const ELYSIUM_LAST_LOCATION_ID: u64 = 652_484;
+
+        // One world needs room for generated pathway descendants beyond its
+        // seed, and every location must be able to carry at least one exit.
+        const {
+            assert!(CW_MAX_LOCATIONS >= UNIFIED_SEED_LOCATIONS * 2);
+            assert!(CW_MAX_EXITS >= UNIFIED_SEED_EXITS * 2);
+            assert!(CW_MAX_EXITS >= CW_MAX_LOCATIONS);
+        }
+
+        let mut world = CwWorld {
+            location_count: CW_MAX_LOCATIONS,
+            exit_count: CW_MAX_EXITS,
+            ..CwWorld::default()
+        };
+        world.locations[CW_MAX_LOCATIONS - 1] = CwLocation {
+            id: ELYSIUM_LAST_LOCATION_ID,
+            ..CwLocation::default()
+        };
+        world.exits[CW_MAX_EXITS - 1] = CwExit {
+            from_location_id: ELYSIUM_LAST_LOCATION_ID,
+            to_location_id: 1,
+            ..CwExit::default()
+        };
+
+        assert_eq!(
+            world.locations[CW_MAX_LOCATIONS - 1].id,
+            ELYSIUM_LAST_LOCATION_ID
+        );
+        assert_eq!(
+            world.exits[CW_MAX_EXITS - 1].from_location_id,
+            ELYSIUM_LAST_LOCATION_ID
+        );
     }
 }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1706,7 +1706,11 @@ enum SearchRevealCandidate {
 
 #[derive(Clone, Debug)]
 struct RuntimeWorld {
-    world: CwWorld,
+    // Boxed so `RuntimeWorld` stays small enough to move cheaply. The kernel
+    // world is a flat 285 KB struct; keeping it inline put several copies in
+    // the bootstrap match and its async state machine, which overflowed the
+    // main thread stack in unoptimized builds.
+    world: Box<CwWorld>,
     canonical_identities: CanonicalIdentityState,
     command_receipts: CommandReceiptCache,
     ai_publications: BTreeMap<String, AiPublicationReceipt>,
@@ -6520,7 +6524,7 @@ impl RuntimeSnapshot {
             }
         }
 
-        let mut world = CwWorld {
+        let mut world = Box::new(CwWorld {
             version: self.world_version,
             tick: self.tick,
             next_event_seq: self.next_event_seq,
@@ -6531,11 +6535,11 @@ impl RuntimeSnapshot {
             evolution_track_count: self.world_evolution_tracks.len(),
             combat_encounter_count: self.world_combat_encounters.len(),
             ..CwWorld::default()
-        };
+        });
 
         if world.version == 0 {
             unsafe {
-                cw_world_init(&mut world);
+                cw_world_init(&mut *world);
             }
             world.actor_count = self.world_actors.len();
             world.item_count = self.world_items.len();
@@ -7037,10 +7041,10 @@ impl RuntimeWorld {
     }
 
     fn seeded() -> Self {
-        let mut world = CwWorld::default();
+        let mut world = Box::new(CwWorld::default());
 
         unsafe {
-            cw_world_init(&mut world);
+            cw_world_init(&mut *world);
         }
 
         let mut runtime = RuntimeWorld {
@@ -8429,7 +8433,7 @@ impl RuntimeWorld {
             };
             let status = unsafe {
                 cw_world_set_item_profile(
-                    &mut self.world,
+                    &mut *self.world,
                     item.id,
                     item.weight_tenths.max(1),
                     size_class,
@@ -8441,7 +8445,7 @@ impl RuntimeWorld {
             let (max_charges, recovery, ready_zone) = seed_item_recovery_profile(item);
             let recovery_status = unsafe {
                 cw_world_set_item_recovery_profile(
-                    &mut self.world,
+                    &mut *self.world,
                     item.id,
                     max_charges,
                     recovery,
@@ -8483,7 +8487,7 @@ impl RuntimeWorld {
             }
             let status = unsafe {
                 cw_world_set_evolution_track(
-                    &mut self.world,
+                    &mut *self.world,
                     track.actor_id,
                     requirements.as_ptr(),
                     track.requirements.len(),
@@ -13479,7 +13483,7 @@ impl RuntimeWorld {
         let mut events = CwEventBuffer::default();
         let status = unsafe {
             cw_world_apply_with_tick(
-                &mut self.world,
+                &mut *self.world,
                 &action,
                 seed,
                 u8::from(advances_world_tick),
@@ -16375,7 +16379,7 @@ The relationship statement they are preserving is: {statement}"
             _ => return false,
         };
         let mut offers = CwActionOffers::default();
-        (unsafe { cw_get_action_offers(&self.world, action.actor_id, &mut offers) }) == CW_OK
+        (unsafe { cw_get_action_offers(&*self.world, action.actor_id, &mut offers) }) == CW_OK
             && offers.option_flags & required_offer != 0
     }
 
@@ -19136,7 +19140,7 @@ The relationship statement they are preserving is: {statement}"
         }
 
         let mut offers = CwActionOffers::default();
-        let status = unsafe { cw_get_action_offers(&self.world, actor_id, &mut offers) };
+        let status = unsafe { cw_get_action_offers(&*self.world, actor_id, &mut offers) };
         let has_authored_contribution = !self
             .job_contribution_intents(actor_id, None, None, None, None)
             .is_empty();
@@ -45917,11 +45921,28 @@ mod tests {
     fn rust_ffi_kernel_capacities_are_runtime_sized() {
         assert_eq!(CW_MAX_ACTORS, 1024);
         assert_eq!(CW_MAX_ITEMS, 1024);
-        assert_eq!(CW_MAX_LOCATIONS, 512);
-        assert_eq!(CW_MAX_EXITS, 1024);
+        assert_eq!(CW_MAX_LOCATIONS, 2048);
+        assert_eq!(CW_MAX_EXITS, 4096);
         assert_eq!(CW_MAX_EVENTS, 256);
         assert!(CW_MAX_EVENTS >= CW_MAX_EVOLUTION_TRACKS + 2);
         assert_eq!(CW_MAX_EVOLUTION_TRACKS, 128);
+    }
+
+    #[test]
+    fn legacy_kernel_layout_snapshot_rehydrates_into_the_current_world_abi() {
+        let mut snapshot = RuntimeSnapshot::from_runtime(&RuntimeWorld::seeded());
+        snapshot.world_version = CW_KERNEL_VERSION - 1;
+
+        let restored = snapshot
+            .into_runtime()
+            .expect("vector-backed legacy snapshot rehydrates");
+
+        // Snapshots persist active entries as vectors, not the fixed-array
+        // cw_world memory layout. Rehydration therefore upgrades an older
+        // layout safely into the currently compiled kernel ABI.
+        assert_eq!(restored.world.version, CW_KERNEL_VERSION);
+        assert!(restored.world.location_count <= CW_MAX_LOCATIONS);
+        assert!(restored.world.exit_count <= CW_MAX_EXITS);
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/threshold_descriptors.rs
+++ b/v2/orchestrator-rust/src/threshold_descriptors.rs
@@ -2072,7 +2072,7 @@ impl RuntimeWorld {
             && record.action.kind == CW_ACTION_NONE
             && !record.projection_mutations.is_empty()
         {
-            unsafe { cw_world_access_changed(&mut self.world) };
+            unsafe { cw_world_access_changed(&mut *self.world) };
         }
     }
 
@@ -2158,7 +2158,7 @@ impl RuntimeWorld {
             }
         }
         if !events.is_empty() {
-            unsafe { cw_world_access_changed(&mut self.world) };
+            unsafe { cw_world_access_changed(&mut *self.world) };
         }
         events
     }
@@ -2324,7 +2324,7 @@ impl RuntimeWorld {
                 }
             }
         }
-        unsafe { cw_world_access_changed(&mut self.world) };
+        unsafe { cw_world_access_changed(&mut *self.world) };
         events
     }
 
@@ -2702,7 +2702,7 @@ impl RuntimeWorld {
                         ..CwGate::default()
                     };
                     let status = unsafe {
-                        cw_world_set_gate(&mut self.world, &gate, methods.as_ptr(), methods.len())
+                        cw_world_set_gate(&mut *self.world, &gate, methods.as_ptr(), methods.len())
                     };
                     assert_eq!(
                         status, CW_OK,
@@ -2734,7 +2734,7 @@ impl RuntimeWorld {
         let mut gate_state = CwGateDecision::default();
         if unsafe {
             cw_gate_evaluate(
-                &self.world,
+                &*self.world,
                 gate.id,
                 actor_id,
                 std::ptr::null(),
@@ -2759,7 +2759,7 @@ impl RuntimeWorld {
                 let mut decision = CwGateDecision::default();
                 if unsafe {
                     cw_gate_evaluate(
-                        &self.world,
+                        &*self.world,
                         gate.id,
                         actor_id,
                         facts.as_ptr(),
@@ -3212,7 +3212,7 @@ mod tests {
             ..CwGatePredicate::default()
         };
         assert_eq!(
-            unsafe { cw_world_set_gate(&mut runtime.world, &gate, &method, 1) },
+            unsafe { cw_world_set_gate(&mut *runtime.world, &gate, &method, 1) },
             CW_OK
         );
         runtime.threshold_gate_sources.insert(
@@ -3366,7 +3366,7 @@ mod tests {
         let methods = [key_method, tool_method];
         assert_eq!(
             unsafe {
-                cw_world_set_gate(&mut runtime.world, &gate, methods.as_ptr(), methods.len())
+                cw_world_set_gate(&mut *runtime.world, &gate, methods.as_ptr(), methods.len())
             },
             CW_OK
         );
@@ -3442,7 +3442,7 @@ mod tests {
         assert_eq!(
             unsafe {
                 cw_gate_evaluate(
-                    &runtime.world,
+                    &*runtime.world,
                     gate_id,
                     action.actor_id,
                     std::ptr::null(),
@@ -3536,7 +3536,7 @@ mod tests {
             ..CwGatePredicate::default()
         };
         assert_eq!(
-            unsafe { cw_world_set_gate(&mut runtime.world, &gate, &method, 1) },
+            unsafe { cw_world_set_gate(&mut *runtime.world, &gate, &method, 1) },
             CW_OK
         );
         runtime.threshold_gate_sources.insert(
@@ -3660,7 +3660,7 @@ mod tests {
             .expect("projection route binding");
         projection_route.threshold = Some(projection_offer);
         runtime.tags.get_mut(&tag_id).expect("threshold tag").active = false;
-        unsafe { cw_world_access_changed(&mut runtime.world) };
+        unsafe { cw_world_access_changed(&mut *runtime.world) };
         assert!(!runtime.route_binding_is_current(&projection_route));
         assert!(!runtime.threshold_action_is_current_and_allowed(&projected_move));
         assert!(
@@ -3676,7 +3676,7 @@ mod tests {
         );
         runtime.tags.get_mut(&tag_id).expect("threshold tag").active = true;
         runtime.jobs.get_mut(&job_id).expect("threshold job").status = "changed".to_string();
-        unsafe { cw_world_access_changed(&mut runtime.world) };
+        unsafe { cw_world_access_changed(&mut *runtime.world) };
         assert!(
             !runtime
                 .threshold_offer_binding_for_exit_with_access(

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -2006,7 +2006,7 @@ impl RuntimeWorld {
         let mut open_decision = CwGateDecision::default();
         if unsafe {
             cw_gate_evaluate(
-                &self.world,
+                &*self.world,
                 gate.id,
                 actor_id,
                 std::ptr::null(),
@@ -2029,7 +2029,7 @@ impl RuntimeWorld {
                 let mut decision = CwGateDecision::default();
                 if unsafe {
                     cw_gate_evaluate(
-                        &self.world,
+                        &*self.world,
                         gate.id,
                         actor_id,
                         facts.as_ptr(),
@@ -2134,7 +2134,7 @@ impl RuntimeWorld {
         let mut decision = CwGateDecision::default();
         let status = unsafe {
             cw_gate_evaluate(
-                &self.world,
+                &*self.world,
                 threshold.gate_id,
                 threshold.actor_id,
                 threshold.facts.as_ptr(),
@@ -2158,7 +2158,7 @@ impl RuntimeWorld {
         let mut decision = CwGateDecision::default();
         (unsafe {
             cw_gate_evaluate(
-                &self.world,
+                &*self.world,
                 threshold.gate_id,
                 action.actor_id,
                 threshold.facts.as_ptr(),

--- a/v2/scripts/generate-elysium-cast.mjs
+++ b/v2/scripts/generate-elysium-cast.mjs
@@ -255,8 +255,8 @@ async function main() {
     bindings.every((binding) => binding.actor_id === actorId(binding.id)),
     "Elysium actor ids do not match the stable model-id mapping",
   );
-  assert(resources.locations.length <= 512, "Elysium exceeds the location capacity");
-  assert(resources.exits.length <= 1024, "Elysium exceeds the exit capacity");
+  assert(resources.locations.length <= 2048, "Elysium exceeds the location capacity");
+  assert(resources.exits.length <= 4096, "Elysium exceeds the exit capacity");
   assert(resources.items.length <= 1024, "Elysium exceeds the item capacity");
   assert(
     new Set(resources.actors.map((actor) => actor.location_id)).size === bindings.length,

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -159,4 +159,9 @@
 # machine ready. The deployment boundary remains in main.rs because it owns
 # AppState and the existing HTTP health route; this is a reviewed operational
 # integration exception, with focused health regressions.
-73775
+# 73775 -> 73796: Kernel version 14 widened the location and exit arrays. The
+# RuntimeWorld Box keeps the resulting 285 KB C world off bootstrap and async
+# state-machine stacks; the remaining added lines are its FFI wiring plus the
+# legacy vector-backed snapshot rehydration contract. This is existing runtime
+# and persistence compatibility wiring, not a new subsystem.
+73796

--- a/v2/scripts/progression-safety-schema.mjs
+++ b/v2/scripts/progression-safety-schema.mjs
@@ -410,10 +410,10 @@ export function progressionSafetyValidationErrors(config, label = "progression s
     errors.push(`${label} entry_location_id must be positive`);
   }
   if (
-    !boundedUnique(config.required_location_ids, 1, 512)
+    !boundedUnique(config.required_location_ids, 1, 2048)
     || config.required_location_ids.some((id) => !positiveInteger(id))
   ) {
-    errors.push(`${label} required_location_ids must be 1-512 unique positive ids`);
+    errors.push(`${label} required_location_ids must be 1-2048 unique positive ids`);
   }
   if (!boundedUnique(config.optional_content, 0, 128, (entry) => `${entry?.kind}:${entry?.id}`)) {
     errors.push(`${label} optional_content must be a bounded unique list`);

--- a/v2/scripts/project89-worldpack.test.mjs
+++ b/v2/scripts/project89-worldpack.test.mjs
@@ -238,7 +238,7 @@ test("Project 89 Ring 3 is a populated longhaul circuit within kernel capacity",
   const ring3Waypoints = [...ring3Edges.values()]
     .reduce((total, exit) => total + exit.distance - 1, 0);
   assert.equal(authoredLocations + ring2Waypoints + ring3Waypoints, 406);
-  assert.ok(authoredLocations + ring2Waypoints + ring3Waypoints <= 512);
+  assert.ok(authoredLocations + ring2Waypoints + ring3Waypoints <= 2048);
 });
 
 test("Project 89 generated-place terminology never falls back to cairns", () => {


### PR DESCRIPTION
Raises the compiled location and exit capacities so one world can hold every authored pack, and fixes the latent stack overflow that widening the world struct exposed.

This revision is rebased directly onto the v0.0.96 main commit `898062aae40f88ceee9aaa769fbe18776de7e939` and bumps the application to `0.0.311`.

## Why

Every authored pack already shares one coordinated ID space. The checked union has zero collisions across 1,588 location, actor, and item IDs, but mounting every authored pack in one world seeds **555 locations and 1,151 exits**, above the old 512/1,024 limits.

## Capacity and ABI

Kernel ABI version 13 → 14:

| | Before | After | Unified seed |
|---|---:|---:|---:|
| Locations | 512 | 2,048 | 555 |
| Exits | 1,024 | 4,096 | 1,151 |

Both capacities leave at least 2× seed headroom for generated pathway descendants. The C header, Rust FFI layout, C floor assertions, content guards, and public engineering documentation move together.

Actors and items remain at 1,024. The same union seeds 565 actors and 540 items, so those capacities still require an explicit faucet/retention decision before future growth.

## Stack-safety fix

The widened `cw_world` is about 285 KB. Keeping it inline in `RuntimeWorld` caused debug bootstrap and async state machines to overflow the main thread stack. `RuntimeWorld` now owns `Box<CwWorld>`, with explicit dereferences only at FFI boundaries.

Snapshots persist active entries as vectors rather than raw C struct bytes. Restore reconstructs the current layout and stamps ABI v14; the focused legacy snapshot rehydration test passes. Journals contain logical records, so no raw-layout migration is required.

## Verification

- Node 24 full local gate: exit 0
- Vitest: 46 files / 530 tests
- Rust orchestrator: 920 passed
- AI model: 8 passed
- Focused capacity test: passed
- Focused legacy snapshot rehydration test: passed
- Lonely Forest tenant/SNI contract: 11 passed
- Worldpack, kernel, composition, production-profile, browser, CLI, health, architecture, syntax, version, and `git diff --check`: passed
- `main.rs`: 73,796 lines with a reviewed 73,796 ceiling
- Clippy warning baseline unchanged at 254

After merge, the main workflow will prove primary snapshot rehydration first. The release tag will deploy the same artifact to every Lonely Forest tenant behind the guarded backup and compatibility checks.