### PR TITLE
Guard every Lonely Forest tenant before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,11 @@ on:
           - both
           - primary
           - lonelyforest
+      lonelyforest_recovery_capture:
+        description: Reviewed committed tenant=path capture, only when that tenant's live /meta is unavailable
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: deploy-${{ github.repository }}
@@ -139,8 +144,15 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
 
-      - name: Guard Lonely Forest worldpack bundle compatibility
-        run: node v2/scripts/check-deploy-worldpack.mjs https://lonelyforest.com
+      - name: Guard every Lonely Forest tenant worldpack bundle compatibility
+        run: |
+          if [ -n "$COSYWORLD_LONELYFOREST_RECOVERY_CAPTURE" ]; then
+            node v2/scripts/check-lonelyforest-worldpacks.mjs --recovery-capture "$COSYWORLD_LONELYFOREST_RECOVERY_CAPTURE"
+          else
+            node v2/scripts/check-lonelyforest-worldpacks.mjs
+          fi
+        env:
+          COSYWORLD_LONELYFOREST_RECOVERY_CAPTURE: ${{ inputs.lonelyforest_recovery_capture }}
 
       - name: Validate Lonely Forest multitenant contract
         run: npm run v2:lonelyforest:contract

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV RUST_LOG=cosyworld_orchestrator=info,tower_http=warn
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates gosu nginx \
+  && apt-get install -y --no-install-recommends ca-certificates curl gosu nginx \
   && rm -rf /var/lib/apt/lists/* \
   && groupadd --system cosyworld \
   && useradd --system --no-create-home --gid cosyworld --groups www-data --shell /usr/sbin/nologin cosyworld \
@@ -54,7 +54,10 @@ COPY --from=build /app/v2/content /app/v2/content
 COPY deploy/lonelyforest /app/deploy/lonelyforest
 COPY deploy/entrypoint.sh /app/entrypoint.sh
 
-RUN chmod 0755 /app/entrypoint.sh /app/deploy/lonelyforest/run-multitenant.sh
+RUN chmod 0755 \
+  /app/entrypoint.sh \
+  /app/deploy/lonelyforest/check-required-health.sh \
+  /app/deploy/lonelyforest/run-multitenant.sh
 
 EXPOSE 3000
 

--- a/deploy/lonelyforest/check-required-health.sh
+++ b/deploy/lonelyforest/check-required-health.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+tenant_config="${1:?tenant configuration path is required}"
+supervisor_pid="${2:?supervisor pid is required}"
+startup_grace_secs="${3:?startup grace seconds are required}"
+interval_secs="${4:?health interval seconds are required}"
+
+log() {
+  printf '[lonelyforest-required-health] %s\n' "$*"
+}
+
+case "$startup_grace_secs:$interval_secs" in
+  *[!0-9:]*|:*|*:) log "health timing must be integer seconds"; exit 2 ;;
+esac
+
+# All processes are given time to validate their registry and replay their
+# persisted journal before a composite readiness failure is actionable. Once
+# that grace is over, every required tenant must answer its private readiness
+# endpoint; this catches a hung/unready process as well as an exited child.
+sleep "$startup_grace_secs"
+while :; do
+  while IFS='|' read -r slug requirement hosts upstream port registry entry_location snapshot_path event_db_path generated_asset_dir extra_origins; do
+    case "$slug" in
+      ""|\#*) continue ;;
+    esac
+    [ "$requirement" = "required" ] || continue
+    if ! curl --noproxy '*' --fail --silent --show-error --max-time 3 "http://127.0.0.1:$port/health" >/dev/null; then
+      log "required tenant $slug failed private /health on 127.0.0.1:$port; failing supervisor $supervisor_pid"
+      kill -USR1 "$supervisor_pid" 2>/dev/null || true
+      exit 1
+    fi
+  done < "$tenant_config"
+  sleep "$interval_secs"
+done

--- a/deploy/lonelyforest/run-multitenant.sh
+++ b/deploy/lonelyforest/run-multitenant.sh
@@ -4,15 +4,16 @@ set -eu
 orchestrator="${COSYWORLD_ORCHESTRATOR_BINARY:-/app/cosyworld-orchestrator}"
 nginx_config="${COSYWORLD_MULTITENANT_NGINX_CONFIG:-/app/deploy/lonelyforest/nginx.conf}"
 tenant_data_root="${COSYWORLD_MULTITENANT_DATA_ROOT:-/data/worldpacks}"
+tenant_config="${COSYWORLD_MULTITENANT_TENANTS_CONFIG:-/app/deploy/lonelyforest/tenants.tsv}"
+health_monitor="${COSYWORLD_MULTITENANT_HEALTH_MONITOR:-/app/deploy/lonelyforest/check-required-health.sh}"
+health_startup_grace_secs="${COSYWORLD_MULTITENANT_HEALTH_STARTUP_GRACE_SECS:-45}"
+health_interval_secs="${COSYWORLD_MULTITENANT_HEALTH_INTERVAL_SECS:-5}"
 restart_delay="${COSYWORLD_MULTITENANT_RESTART_DELAY_SECS:-2}"
+supervisor_pid="$$"
 workers=""
 nginx_pid=""
-elysium_registry="/app/v2/content/elysium-only/registry.json"
-required_health_urls="http://127.0.0.1:3107/health,http://127.0.0.1:3189/health,http://127.0.0.1:3180/health"
-
-if [ -r "$elysium_registry" ]; then
-  required_health_urls="$required_health_urls,http://127.0.0.1:3101/health"
-fi
+health_monitor_pid=""
+required_health_urls=""
 
 log() {
   printf '[lonelyforest-multitenant] %s\n' "$*"
@@ -28,6 +29,8 @@ run_world() {
   event_db_path="$7"
   generated_asset_dir="$8"
   extra_origins="$9"
+  requirement="${10}"
+  supervisor_pid="${11}"
   active_child=""
 
   # Invoked indirectly by the signal trap below.
@@ -60,7 +63,7 @@ run_world() {
         COSYWORLD_WEBAUTHN_EXTRA_ORIGINS="$extra_origins" \
         "$orchestrator" &
     else
-      env \
+      env -u COSYWORLD_REQUIRED_HEALTH_URLS \
         COSYWORLD_V2_ADDR="127.0.0.1:$port" \
         COSYWORLD_PROCESS_ID="lonelyforest-$slug" \
         COSYWORLD_V2_SHARD_ID="lonelyforest-$slug" \
@@ -82,19 +85,51 @@ run_world() {
     fi
     active_child=""
     log "$slug exited with status $status; restarting in ${restart_delay}s"
+    # A required tenant's process is part of this Fly Machine's readiness.
+    # Do not leave nginx serving root health while another required world
+    # crash-loops behind its hostname. Terminating the supervisor makes the
+    # machine fail its health check and restart as one deploy boundary.
+    if [ "$requirement" = "required" ]; then
+      log "$slug is required; failing supervisor $supervisor_pid so Fly marks the Machine unhealthy"
+      kill -USR1 "$supervisor_pid" 2>/dev/null || true
+      exit 1
+    fi
     sleep "$restart_delay"
   done
 }
 
 start_world() {
-  run_world "$@" &
+  run_world "$@" "$supervisor_pid" &
   workers="$workers $!"
 }
 
+tenant_data_path() {
+  case "$1" in
+    /data/worldpacks/*) printf '%s/%s\n' "$tenant_data_root" "${1#/data/worldpacks/}" ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+
+monitor_required_tenants() {
+  if "$health_monitor" "$tenant_config" "$supervisor_pid" "$health_startup_grace_secs" "$health_interval_secs"; then
+    status=0
+  else
+    status="$?"
+  fi
+  # The monitor is a required readiness component. Its own unexpected exit
+  # must not leave nginx serving only the root health endpoint indefinitely.
+  log "required tenant health monitor exited with status $status; failing supervisor $supervisor_pid"
+  kill -USR1 "$supervisor_pid" 2>/dev/null || true
+  exit "$status"
+}
+
 stop_all() {
-  trap - TERM INT HUP
+  trap - TERM INT HUP USR1
   if [ -n "$nginx_pid" ]; then
     kill -TERM "$nginx_pid" 2>/dev/null || true
+  fi
+  if [ -n "$health_monitor_pid" ]; then
+    kill -TERM "$health_monitor_pid" 2>/dev/null || true
   fi
   for worker in $workers; do
     kill -TERM "$worker" 2>/dev/null || true
@@ -102,78 +137,79 @@ stop_all() {
   if [ -n "$nginx_pid" ]; then
     wait "$nginx_pid" 2>/dev/null || true
   fi
+  if [ -n "$health_monitor_pid" ]; then
+    wait "$health_monitor_pid" 2>/dev/null || true
+  fi
   for worker in $workers; do
     wait "$worker" 2>/dev/null || true
   done
 }
 
 trap 'stop_all; exit 0' TERM INT HUP
+trap 'stop_all; exit 1' USR1
 
 mkdir -p \
   /tmp/cosyworld-nginx/client-body \
   /tmp/cosyworld-nginx/proxy \
   "$tenant_data_root"
 
-# Preserve the established Lonely Forest journal paths exactly. The new
-# worldpack processes receive their own directories on the same volume.
-start_world \
-  "root" \
-  "3100" \
-  "/app/v2/content/official/registry.json" \
-  "-" \
-  "https://lonelyforest.com" \
-  "/data/cosyworld-v2-snapshot.json" \
-  "/data/cosyworld-v2-events.sqlite" \
-  "/data/generated" \
-  "https://www.lonelyforest.com"
-
-start_world \
-  "7" \
-  "3107" \
-  "/app/v2/content/bethlehem/registry.json" \
-  "700" \
-  "https://7.lonelyforest.com" \
-  "$tenant_data_root/7/snapshot.json" \
-  "$tenant_data_root/7/events.sqlite" \
-  "$tenant_data_root/7/generated" \
-  ""
-
-start_world \
-  "89" \
-  "3189" \
-  "/app/v2/content/project89/registry.json" \
-  "8900" \
-  "https://89.lonelyforest.com" \
-  "$tenant_data_root/89/snapshot.json" \
-  "$tenant_data_root/89/events.sqlite" \
-  "$tenant_data_root/89/generated" \
-  ""
-
-start_world \
-  "lantern" \
-  "3180" \
-  "/app/v2/content/lantern-keeper/registry.json" \
-  "800" \
-  "https://lantern.lonelyforest.com" \
-  "$tenant_data_root/lantern/snapshot.json" \
-  "$tenant_data_root/lantern/events.sqlite" \
-  "$tenant_data_root/lantern/generated" \
-  ""
-
-if [ -r "$elysium_registry" ]; then
-  start_world \
-    "0" \
-    "3101" \
-    "$elysium_registry" \
-    "652000" \
-    "https://0.lonelyforest.com" \
-    "$tenant_data_root/0/snapshot.json" \
-    "$tenant_data_root/0/events.sqlite" \
-    "$tenant_data_root/0/generated" \
-    ""
-else
-  log "Elysium registry is absent; 0.lonelyforest.com will return HTTP 503"
+# tenants.tsv is the committed source of truth for hostname, registry, port,
+# and persistence identity. The deploy guard validates every required row
+# before Fly replaces this image. Elysium is explicitly optional: a release
+# without its registry leaves only 0.lonelyforest.com unavailable (HTTP 503).
+if [ ! -r "$tenant_config" ]; then
+  log "tenant configuration is unreadable: $tenant_config"
+  exit 1
 fi
+if [ ! -x "$health_monitor" ]; then
+  log "required tenant health monitor is not executable: $health_monitor"
+  exit 1
+fi
+# Preserve current-main's root readiness contract: every installed sibling,
+# including optional Elysium when present, is checked by root /health. Build
+# this manifest-derived list before root starts so it cannot race later rows.
+while IFS='|' read -r slug requirement hosts upstream port registry entry_location snapshot_path event_db_path generated_asset_dir extra_origins; do
+  case "$slug" in
+    ""|\#*) continue ;;
+  esac
+  if [ ! -r "$registry" ]; then
+    [ "$requirement" = "optional" ] && continue
+    log "required tenant $slug registry is unreadable: $registry"
+    exit 1
+  fi
+  [ "$slug" = "root" ] && continue
+  health_url="http://127.0.0.1:$port/health"
+  if [ -n "$required_health_urls" ]; then
+    required_health_urls="$required_health_urls,$health_url"
+  else
+    required_health_urls="$health_url"
+  fi
+done < "$tenant_config"
+while IFS='|' read -r slug requirement hosts upstream port registry entry_location snapshot_path event_db_path generated_asset_dir extra_origins; do
+  case "$slug" in
+    ""|\#*) continue ;;
+  esac
+  case "$requirement" in
+    required|optional) ;;
+    *) log "tenant $slug has invalid requirement '$requirement'"; exit 1 ;;
+  esac
+  if [ ! -r "$registry" ]; then
+    if [ "$requirement" = "optional" ]; then
+      log "optional tenant $slug registry is absent; ${hosts%%,*} will return HTTP 503"
+      continue
+    fi
+    log "required tenant $slug registry is unreadable: $registry"
+    exit 1
+  fi
+  origin="https://${hosts%%,*}"
+  snapshot_path="$(tenant_data_path "$snapshot_path")"
+  event_db_path="$(tenant_data_path "$event_db_path")"
+  generated_asset_dir="$(tenant_data_path "$generated_asset_dir")"
+  start_world \
+    "$slug" "$port" "$registry" "$entry_location" "$origin" \
+    "$snapshot_path" "$event_db_path" "$generated_asset_dir" "$extra_origins" \
+    "$requirement"
+done < "$tenant_config"
 
 if ! nginx -t -c "$nginx_config"; then
   log "hostname router configuration is invalid"
@@ -183,6 +219,9 @@ fi
 nginx -c "$nginx_config" -g "daemon off;" &
 nginx_pid="$!"
 log "hostname router listening on 0.0.0.0:3000"
+monitor_required_tenants &
+health_monitor_pid="$!"
+log "required tenant health monitor started after ${health_startup_grace_secs}s grace"
 
 if wait "$nginx_pid"; then
   status=0

--- a/deploy/lonelyforest/tenants.tsv
+++ b/deploy/lonelyforest/tenants.tsv
@@ -1,0 +1,6 @@
+# slug|required|public_hosts|nginx_upstream|port|registry|entry_location|snapshot_path|event_db_path|generated_asset_dir|extra_origins
+root|required|lonelyforest.com,www.lonelyforest.com|lonelyforest_root|3100|/app/v2/content/official/registry.json|-|/data/cosyworld-v2-snapshot.json|/data/cosyworld-v2-events.sqlite|/data/generated|https://www.lonelyforest.com
+0|optional|0.lonelyforest.com|elysium|3101|/app/v2/content/elysium-only/registry.json|652000|/data/worldpacks/0/snapshot.json|/data/worldpacks/0/events.sqlite|/data/worldpacks/0/generated|
+7|required|7.lonelyforest.com|bethlehem|3107|/app/v2/content/bethlehem/registry.json|700|/data/worldpacks/7/snapshot.json|/data/worldpacks/7/events.sqlite|/data/worldpacks/7/generated|
+89|required|89.lonelyforest.com|project89|3189|/app/v2/content/project89/registry.json|8900|/data/worldpacks/89/snapshot.json|/data/worldpacks/89/events.sqlite|/data/worldpacks/89/generated|
+lantern|required|lantern.lonelyforest.com|lantern_keeper|3180|/app/v2/content/lantern-keeper/registry.json|800|/data/worldpacks/lantern/snapshot.json|/data/worldpacks/lantern/events.sqlite|/data/worldpacks/lantern/generated|

--- a/docs/deployment/lonelyforest-fly.md
+++ b/docs/deployment/lonelyforest-fly.md
@@ -14,8 +14,13 @@ processes; each worldpack has its own SQLite journal directory on that volume.
 
 The orchestrator remains one authoritative world per process and is not allowed
 to select a journal from an untrusted `Host` or `X-Forwarded-Host` header.
-Adding a tenant requires an explicit process, data directory, and nginx hostname
-mapping in the committed release.
+`deploy/lonelyforest/tenants.tsv` is the committed tenant identity manifest. It
+is the source of truth for the slug, public hostname, registry, loopback port,
+entry location, and every persistence path. The supervisor starts processes
+from that file; the contract test cross-validates nginx routing and Fly health
+behavior against every row. Adding a tenant therefore requires an intentional
+manifest change plus matching nginx routing, not an ad hoc process or volume
+path.
 
 Accounts, avatars, sessions, world events, snapshots, and generated assets stay
 isolated between processes even though all passkeys use the parent RP ID
@@ -72,6 +77,64 @@ attached volume, requests an on-demand Fly snapshot, and waits for that
 specific snapshot to reach `created`. The script is fail-closed and does not
 detach, replace, or destroy a volume. The resulting snapshot ID is printed in
 the workflow log for the rollback operator.
+Before Fly replaces the image, the Lonely Forest job runs
+`v2/scripts/check-lonelyforest-worldpacks.mjs`. It reads every
+required tenant's live `https://<host>/meta` identity and compares it with the
+candidate registry using the same exact-match or explicitly declared
+replay-compatible migration rule as the primary deploy guard. Missing,
+malformed, unreachable, or undeclared identities stop the release; the output
+names the tenant, live hash, candidate hash, and remediation. This proves both
+forward deploys and rollbacks: an older image cannot normally declare a
+snapshot hash created by a newer image.
+
+Required tenants are `root`, `7`, `89`, and `lantern`. Their supervisor exits
+the Machine immediately when a child exits, and the required-tenant health
+monitor probes every required process's private `/health` after a 45-second
+startup grace, then every five seconds. A hung or unready tenant therefore
+terminates the Machine even if nginx could still proxy root `/health`; Fly
+observes failed health and restarts the single deployment boundary. Elysium
+(`0`) is explicitly optional: its registry may be absent from a release, in
+which case only its hostname returns the documented `503`; when present, it is
+still continuity checked like every other candidate registry. The supervisor
+also treats an unexpected health-monitor exit as fatal, so monitoring cannot
+silently disappear while nginx remains available. Internal required-tenant
+failures use a nonzero supervisor exit; normal operator `TERM`/`INT`/`HUP`
+shutdown remains clean.
+
+### Recovery when a tenant is already unavailable
+
+Do not bypass the guard and do not blindly redeploy the previous image. A
+successful forward boot may have written a snapshot under the new bundle hash;
+the older image will then fail its own bundle-identity check and can crash-loop
+before it serves recovery traffic.
+
+1. Leave the mounted volume attached and obtain the unavailable tenant's
+   persisted identity from its snapshot on that volume. If volume access is
+   unavailable, a reviewed operator may save the last observed `/meta` response
+   in a committed capture file. Never infer the hash from the candidate image.
+2. Store a capture with this exact shape and review it with the recovery change:
+
+   ```json
+   {
+     "schema_version": 1,
+     "tenant": "lantern",
+     "source": "tenant-volume",
+     "captured_at": "2026-08-01T12:34:56Z",
+     "meta": { "worldpack": { "bundle_hash": "sha256:<64 lowercase hex>" } }
+   }
+   ```
+
+   `source` may instead be `operator-capture`, but it must still contain the
+   unmodified observed `/meta` identity and a reviewable timestamp.
+3. Run the guard explicitly with
+   `node v2/scripts/check-lonelyforest-worldpacks.mjs --recovery-capture lantern=path/to/capture.json`.
+   It records a GitHub Actions warning with the capture path, source, and time,
+   then applies the normal exact/declaration comparison. It never silently
+   skips the unavailable tenant. A mismatch means author the tenant's explicit
+   replay-compatible migration or restore the matching image; do not edit a
+   persisted bundle hash.
+4. Preserve the workflow log and capture with the incident record, then verify
+   every hostname's `/meta` after recovery before creating the next release.
 
 The workflow requires two GitHub Actions secrets:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.307",
+  "version": "0.0.308",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.307",
+      "version": "0.0.308",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.307",
+  "version": "0.0.308",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,
@@ -52,7 +52,7 @@
     "v2:media:evolution": "node v2/scripts/report-media-evolution.mjs",
     "v2:proof-world": "node v2/scripts/check-proof-world.mjs",
     "v2:spike:deck-gated": "node v2/scripts/spike-deck-gated-actions.mjs",
-    "v2:syntax": "node --check v2/scripts/actor-model-binding-schema.mjs && node --check v2/scripts/generate-elysium-cast.mjs && node --check v2/scripts/discovery-authority-schema.mjs && node --check v2/scripts/threshold-descriptor-schema.mjs && node --check v2/scripts/progression-safety-schema.mjs && node --check v2/scripts/smoke-browser.mjs && node --check v2/scripts/smoke-production-profile.mjs && node --check v2/scripts/smoke-deployed-ruby-high.mjs && node --check v2/scripts/smoke-standalone-compositions.mjs && node --check v2/scripts/smoke-core-ruby-composition.mjs && node --check v2/scripts/smoke-lonelyforest-multitenant.mjs && node --check v2/scripts/inspect-action-journal.mjs && node --check v2/scripts/check-deploy-worldpack.mjs && node --check v2/scripts/check-fly-oom.mjs && node --check v2/scripts/report-media-evolution.mjs && python3 -m py_compile v2/cli/cosy_cli.py",
+    "v2:syntax": "node --check v2/scripts/actor-model-binding-schema.mjs && node --check v2/scripts/generate-elysium-cast.mjs && node --check v2/scripts/discovery-authority-schema.mjs && node --check v2/scripts/threshold-descriptor-schema.mjs && node --check v2/scripts/progression-safety-schema.mjs && node --check v2/scripts/smoke-browser.mjs && node --check v2/scripts/smoke-production-profile.mjs && node --check v2/scripts/smoke-deployed-ruby-high.mjs && node --check v2/scripts/smoke-standalone-compositions.mjs && node --check v2/scripts/smoke-core-ruby-composition.mjs && node --check v2/scripts/smoke-lonelyforest-multitenant.mjs && node --check v2/scripts/inspect-action-journal.mjs && node --check v2/scripts/check-deploy-worldpack.mjs && node --check v2/scripts/check-lonelyforest-worldpacks.mjs && node --check v2/scripts/lonelyforest-tenants.mjs && node --check v2/scripts/check-fly-oom.mjs && node --check v2/scripts/report-media-evolution.mjs && python3 -m py_compile v2/cli/cosy_cli.py",
     "reset-setup": "node scripts/reset-setup.mjs",
     "build": "npm run clean && npm run build:js && npm run docs",
     "clean": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\"",

--- a/v2/content/bethlehem/registry.json
+++ b/v2/content/bethlehem/registry.json
@@ -9,6 +9,12 @@
     "version": 1,
     "description": "A Bethlehem-first composition of the CosyWorld core and Holy Land worldpacks.",
     "entry_location": "cosyworld.core:location/1",
+    "persistence_compatibility": {
+      "schema_version": 1,
+      "replay_compatible_bundle_hashes": [
+        "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df"
+      ]
+    },
     "pack_lifecycle": {
       "schema_version": 1,
       "unmount": [

--- a/v2/content/bethlehem/worldpack.json
+++ b/v2/content/bethlehem/worldpack.json
@@ -7,6 +7,12 @@
   "version": 1,
   "description": "A Bethlehem-first composition of the CosyWorld core and Holy Land worldpacks.",
   "entry_location": "cosyworld.core:location/1",
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df"
+    ]
+  },
   "pack_lifecycle": {
     "schema_version": 1,
     "unmount": [

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -343,6 +343,13 @@ older bundle cannot declare a newer hash. The gate never mutates the journal,
 the snapshot, or the recorded hashes; the remedy for a blocked deploy is the
 declared migration path above, never a hand-edited hash.
 
+Lonely Forest is one Fly Machine containing several isolated world processes.
+Its release gate applies this same proof to every required tenant registry and
+public `/meta` identity, rather than treating the root host as evidence for
+every journal. See [the Lonely Forest deployment procedure](../../docs/deployment/lonelyforest-fly.md#recovery-when-a-tenant-is-already-unavailable)
+for required-tenant health behavior and the narrow captured-identity recovery
+path when a crashed tenant cannot serve `/meta`.
+
 Pack content has a canonical, version-independent identity of the form
 `pack://<pack-id>/<kind>/<local-id>`. For example,
 `pack://five-e-commons/creature/goblin-warrior` and

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.307"
+version = "0.0.308"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.307"
+version = "0.0.308"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/check-lonelyforest-worldpacks.mjs
+++ b/v2/scripts/check-lonelyforest-worldpacks.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Pre-deploy continuity gate for every Lonely Forest world process.
+ *
+ * This intentionally calls the same bundle compatibility evaluation as the
+ * single-world gate. A Fly Machine shares a deploy boundary, but each tenant
+ * owns a distinct journal and snapshot, so checking only the root hostname is
+ * not sufficient evidence that replacing the image is safe.
+ *
+ * A normal deploy reads every live tenant's public /meta. If a tenant is
+ * already unavailable, an operator may pass an explicit captured identity:
+ *
+ *   --recovery-capture lantern=ops/lantern-meta-capture.json
+ *
+ * Captures must record the tenant, source, timestamp, and unmodified /meta
+ * response. This is an audited recovery path, not a bypass: the captured hash
+ * is evaluated against the candidate registry exactly like a live identity.
+ */
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  candidateFromRegistry,
+  evaluateWorldpackGate,
+  fetchLiveWorldpackHash,
+} from "./check-deploy-worldpack.mjs";
+import {
+  TenantConfigError,
+  candidateRegistryPath,
+  readLonelyForestTenants,
+  repoRoot,
+} from "./lonelyforest-tenants.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const DEFAULT_TIMEOUT_MS = 15_000;
+const CAPTURE_SOURCES = new Set(["tenant-volume", "operator-capture"]);
+
+export class LonelyForestGateError extends Error {}
+
+function fail(message) {
+  throw new LonelyForestGateError(message);
+}
+
+function parseCaptureArgument(value) {
+  const separator = value.indexOf("=");
+  if (separator < 1 || separator === value.length - 1) {
+    fail("--recovery-capture must be tenant=path/to/captured-meta.json");
+  }
+  return [value.slice(0, separator), value.slice(separator + 1)];
+}
+
+export function recoveryCapturesFromArgs(args, root = repoRoot) {
+  const captures = new Map();
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] !== "--recovery-capture") continue;
+    const value = args[index + 1];
+    if (!value) fail("--recovery-capture requires tenant=path");
+    const [slug, capturePath] = parseCaptureArgument(value);
+    if (captures.has(slug)) fail(`duplicate recovery capture for tenant '${slug}'`);
+    let capture;
+    try {
+      capture = JSON.parse(fs.readFileSync(path.resolve(root, capturePath), "utf8"));
+    } catch (error) {
+      fail(`cannot read recovery capture for ${slug} at ${capturePath}: ${error.message}`);
+    }
+    if (capture?.schema_version !== 1 || capture?.tenant !== slug
+      || !CAPTURE_SOURCES.has(capture?.source)
+      || typeof capture?.captured_at !== "string" || Number.isNaN(Date.parse(capture.captured_at))) {
+      fail(`recovery capture for ${slug} must contain schema_version: 1, matching tenant, source ('tenant-volume' or 'operator-capture'), and captured_at`);
+    }
+    const liveHash = capture?.meta?.worldpack?.bundle_hash;
+    if (typeof liveHash !== "string") {
+      fail(`recovery capture for ${slug} has no meta.worldpack.bundle_hash`);
+    }
+    captures.set(slug, {
+      path: capturePath,
+      absolutePath: path.resolve(root, capturePath),
+      source: capture.source,
+      capturedAt: capture.captured_at,
+      liveHash,
+    });
+  }
+  return captures;
+}
+
+function requireTrackedRecoveryCaptures(captures) {
+  for (const [slug, capture] of captures) {
+    const relativePath = path.relative(repoRoot, capture.absolutePath);
+    if (!relativePath || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+      fail(`recovery capture for ${slug} must be a reviewed file inside the committed checkout, got ${capture.path}`);
+    }
+    const result = spawnSync("git", ["ls-files", "--error-unmatch", "--", relativePath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      fail(`recovery capture for ${slug} must be committed and reviewable at ${relativePath} before a production deploy`);
+    }
+  }
+}
+
+function registryForTenant(tenant, root) {
+  const registryPath = candidateRegistryPath(tenant, root);
+  try {
+    return candidateFromRegistry(JSON.parse(fs.readFileSync(registryPath, "utf8")));
+  } catch (error) {
+    if (error instanceof TenantConfigError) throw error;
+    fail(`tenant=${tenant.slug} cannot read candidate registry ${registryPath}: ${error.message}`);
+  }
+}
+
+export async function verifyLonelyForestTenants({
+  tenants = readLonelyForestTenants(),
+  root = repoRoot,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  recoveryCaptures = new Map(),
+  fetchImpl = fetch,
+  log = console.log,
+}) {
+  const results = [];
+  const usedRecoveryCaptures = new Set();
+  for (const tenant of tenants) {
+    const registryPath = candidateRegistryPath(tenant, root);
+    if (!fs.existsSync(registryPath)) {
+      if (!tenant.required) {
+        log(`::notice::tenant=${tenant.slug} policy=optional candidate registry absent; it is intentionally not installed in this release`);
+        results.push({ tenant, status: "optional_absent", ok: true });
+        continue;
+      }
+      fail(`tenant=${tenant.slug} required candidate registry is missing: ${registryPath}`);
+    }
+    const candidate = registryForTenant(tenant, root);
+    const baseUrl = `https://${tenant.hosts[0]}`;
+    let liveHash;
+    let identitySource = "live /meta";
+    try {
+      liveHash = await fetchLiveWorldpackHash({ baseUrl, timeoutMs, fetchImpl });
+    } catch (error) {
+      const capture = recoveryCaptures.get(tenant.slug);
+      if (!capture) {
+        fail(`tenant=${tenant.slug} host=${tenant.hosts[0]} candidate=${candidate.bundleHash} could not read live /meta (${error.message}). Refusing to replace the image without this tenant's persisted bundle identity. Restore the tenant or pass an explicit reviewed --recovery-capture ${tenant.slug}=path from its volume.`);
+      }
+      liveHash = capture.liveHash;
+      usedRecoveryCaptures.add(tenant.slug);
+      identitySource = `recovery capture ${capture.path} source=${capture.source} captured_at=${capture.capturedAt}`;
+      log(`::warning::tenant=${tenant.slug} live /meta unavailable; using ${identitySource}`);
+    }
+    const decision = evaluateWorldpackGate({
+      candidateHash: candidate.bundleHash,
+      candidateReplayCompatible: candidate.replayCompatible,
+      liveHash,
+    });
+    log(`Lonely Forest worldpack gate: tenant=${tenant.slug} host=${tenant.hosts[0]} status=${decision.status}\n`
+      + `  identity source:         ${identitySource}\n`
+      + `  live journal worldpack: ${liveHash || "(none reported)"}\n`
+      + `  candidate worldpack:    ${candidate.bundleHash}`);
+    if (!decision.ok) {
+      fail(`tenant=${tenant.slug} host=${tenant.hosts[0]} live=${liveHash || "(none reported)"} candidate=${candidate.bundleHash}: ${decision.reason}. Author an explicit replay compatibility migration for this tenant or deploy the bundle its persisted journal requires; an older rollback image is unsafe after a forward snapshot migration.`);
+    }
+    results.push({ tenant, status: decision.status, ok: true, liveHash, candidateHash: candidate.bundleHash, identitySource });
+  }
+  for (const slug of recoveryCaptures.keys()) {
+    if (!tenants.some((tenant) => tenant.slug === slug)) fail(`recovery capture names unknown tenant '${slug}'`);
+    if (!usedRecoveryCaptures.has(slug)) {
+      fail(`recovery capture for ${slug} was supplied but live /meta was available; remove it so recovery use remains explicit and auditable`);
+    }
+  }
+  return results;
+}
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  return index < 0 ? undefined : args[index + 1];
+}
+
+async function main(args) {
+  const timeoutOption = option(args, "--timeout-ms");
+  const timeoutMs = timeoutOption === undefined ? DEFAULT_TIMEOUT_MS : Number(timeoutOption);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 120_000) {
+    fail("--timeout-ms must be an integer from 1000 through 120000");
+  }
+  const captures = recoveryCapturesFromArgs(args);
+  requireTrackedRecoveryCaptures(captures);
+  return verifyLonelyForestTenants({ timeoutMs, recoveryCaptures: captures });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(scriptPath)) {
+  main(process.argv.slice(2))
+    .then(() => process.exit(0))
+    .catch((error) => {
+      const prefix = error instanceof TenantConfigError || error instanceof LonelyForestGateError
+        ? "Lonely Forest worldpack deploy gate failed"
+        : "Lonely Forest worldpack deploy gate crashed";
+      console.error(`::error::${prefix}: ${error.message}`);
+      console.error("usage: check-lonelyforest-worldpacks.mjs [--timeout-ms N] [--recovery-capture tenant=path/to/captured-meta.json]");
+      process.exit(1);
+    });
+}

--- a/v2/scripts/holy-land-worldpack.test.mjs
+++ b/v2/scripts/holy-land-worldpack.test.mjs
@@ -19,6 +19,9 @@ const bridgePack = readJson("core-holy-land-bridge", "pack.json");
 const officialWorld = JSON.parse(
   fs.readFileSync(path.resolve(scriptDir, "../worlds/official/world.json"), "utf8"),
 );
+const bethlehemWorld = JSON.parse(
+  fs.readFileSync(path.resolve(scriptDir, "../worlds/bethlehem/world.json"), "utf8"),
+);
 
 test("the Twelve search for Christ for twelve distinct reasons", () => {
   const disciples = actors.filter(({ id }) => id >= 7002 && id <= 7013);
@@ -125,4 +128,15 @@ test("the official world accepts replay from prior Holy Land bundles", () => {
       "sha256:fea970b0cdbb1266e4fd20bbec60ed2ff48bb8feb36a799ebd558700a7f83028",
     ),
   );
+});
+
+test("Bethlehem accepts the pre-context-dominant prompt bundle", () => {
+  // #669 changed only authored voice text and prompt presentation: the world,
+  // resource identities, rules profile, pack versions, and persisted-state
+  // interpretation remain stable across this boundary.
+  const compatible = bethlehemWorld.persistence_compatibility
+    .replay_compatible_bundle_hashes;
+  assert.deepEqual(compatible, [
+    "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
+  ]);
 });

--- a/v2/scripts/lonelyforest-multitenant-contract.test.mjs
+++ b/v2/scripts/lonelyforest-multitenant-contract.test.mjs
@@ -1,147 +1,310 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { spawn, spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
+import { candidateFromRegistry } from "./check-deploy-worldpack.mjs";
+import {
+  recoveryCapturesFromArgs,
+  verifyLonelyForestTenants,
+} from "./check-lonelyforest-worldpacks.mjs";
+import {
+  candidateRegistryPath,
+  readLonelyForestTenants,
+} from "./lonelyforest-tenants.mjs";
+
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "../..");
 const deploymentRoot = resolve(repoRoot, "deploy/lonelyforest");
-
-const expected = [
-  {
-    slug: "root",
-    host: "lonelyforest.com",
-    upstream: "lonelyforest_root",
-    port: "3100",
-    registry: "/app/v2/content/official/registry.json",
-    entry: "-",
-    eventDb: "/data/cosyworld-v2-events.sqlite",
-  },
-  {
-    slug: "0",
-    host: "0.lonelyforest.com",
-    upstream: "elysium",
-    port: "3101",
-    registry: "$elysium_registry",
-    entry: "652000",
-    eventDb: "$tenant_data_root/0/events.sqlite",
-  },
-  {
-    slug: "7",
-    host: "7.lonelyforest.com",
-    upstream: "bethlehem",
-    port: "3107",
-    registry: "/app/v2/content/bethlehem/registry.json",
-    entry: "700",
-    eventDb: "$tenant_data_root/7/events.sqlite",
-  },
-  {
-    slug: "89",
-    host: "89.lonelyforest.com",
-    upstream: "project89",
-    port: "3189",
-    registry: "/app/v2/content/project89/registry.json",
-    entry: "8900",
-    eventDb: "$tenant_data_root/89/events.sqlite",
-  },
-  {
-    slug: "lantern",
-    host: "lantern.lonelyforest.com",
-    upstream: "lantern_keeper",
-    port: "3180",
-    registry: "/app/v2/content/lantern-keeper/registry.json",
-    entry: "800",
-    eventDb: "$tenant_data_root/lantern/events.sqlite",
-  },
-];
+const tenants = readLonelyForestTenants();
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function startWorldArguments(script, slug) {
-  const blockPattern = new RegExp(
-    `start_world[\\s\\\\]+\\n\\s+"${escapeRegExp(slug)}"([\\s\\S]*?)(?:\\n\\s*\\n|\\n(?:else|fi)$)`,
-    "m",
-  );
-  const block = script.match(blockPattern)?.[0];
-  assert.ok(block, `missing start_world block for ${slug}`);
-  return [...block.matchAll(/"([^"]*)"/g)].map((match) => match[1]);
+async function candidateHashes() {
+  return new Map(await Promise.all(tenants.map(async (tenant) => {
+    const registry = JSON.parse(await readFile(candidateRegistryPath(tenant), "utf8"));
+    return [tenant.hosts[0], candidateFromRegistry(registry).bundleHash];
+  })));
 }
 
-test("Lonely Forest routes fixed hosts to isolated fixed world processes", async () => {
-  const [nginx, supervisor, fly, dockerfile, entrypoint] = await Promise.all([
+test("Lonely Forest tenant manifest strictly covers supervisor, nginx, Fly health, and deployment", async () => {
+  const [nginx, supervisor, healthMonitor, fly, workflow, dockerfile, entrypoint] = await Promise.all([
     readFile(resolve(deploymentRoot, "nginx.conf"), "utf8"),
     readFile(resolve(deploymentRoot, "run-multitenant.sh"), "utf8"),
+    readFile(resolve(deploymentRoot, "check-required-health.sh"), "utf8"),
     readFile(resolve(repoRoot, "fly.lonelyforest.toml"), "utf8"),
+    readFile(resolve(repoRoot, ".github/workflows/deploy.yml"), "utf8"),
     readFile(resolve(repoRoot, "Dockerfile"), "utf8"),
     readFile(resolve(repoRoot, "deploy/entrypoint.sh"), "utf8"),
   ]);
 
-  const eventDbs = new Set();
-  for (const tenant of expected) {
-    assert.match(
-      nginx,
-      new RegExp(
-        `upstream\\s+${escapeRegExp(tenant.upstream)}\\s*\\{\\s*server\\s+127\\.0\\.0\\.1:${tenant.port};`,
-      ),
-      `${tenant.upstream} must stay on its fixed loopback port`,
-    );
-    assert.match(
-      nginx,
-      new RegExp(
-        `server_name[^;]*${escapeRegExp(tenant.host)}[^;]*;[\\s\\S]*?proxy_pass\\s+http://${escapeRegExp(tenant.upstream)};`,
-      ),
-      `${tenant.host} must route only to ${tenant.upstream}`,
-    );
+  assert.match(supervisor, /tenant_config="\$\{COSYWORLD_MULTITENANT_TENANTS_CONFIG:-\/app\/deploy\/lonelyforest\/tenants\.tsv\}"/);
+  assert.match(supervisor, /while IFS='\|' read -r slug requirement hosts upstream port registry entry_location snapshot_path event_db_path generated_asset_dir extra_origins;/);
+  assert.match(supervisor, /trap 'stop_all; exit 1' USR1/);
+  assert.match(supervisor, /trap 'stop_all; exit 0' TERM INT HUP/);
+  assert.match(supervisor, /trap - TERM INT HUP USR1/);
+  assert.match(supervisor, /if \[ "\$requirement" = "required" \]; then[\s\S]*?failing supervisor/);
+  assert.match(supervisor, /kill -USR1 "\$supervisor_pid"/);
+  assert.match(supervisor, /health_startup_grace_secs="\$\{COSYWORLD_MULTITENANT_HEALTH_STARTUP_GRACE_SECS:-45\}"/);
+  assert.match(supervisor, /supervisor_pid="\$\$"/);
+  assert.match(supervisor, /run_world "\$@" "\$supervisor_pid"/);
+  assert.match(supervisor, /"\$health_monitor" "\$tenant_config" "\$supervisor_pid" "\$health_startup_grace_secs" "\$health_interval_secs"/);
+  assert.match(supervisor, /required tenant health monitor exited with status \$status; failing supervisor \$supervisor_pid/);
+  assert.match(healthMonitor, /sleep "\$startup_grace_secs"/);
+  assert.match(healthMonitor, /\[ "\$requirement" = "required" \] \|\| continue/);
+  assert.match(healthMonitor, /curl --noproxy '\*' --fail --silent --show-error --max-time 3 "http:\/\/127\.0\.0\.1:\$port\/health"/);
+  assert.match(healthMonitor, /required tenant \$slug failed private \/health[\s\S]*?kill -USR1 "\$supervisor_pid"/);
 
-    const args = startWorldArguments(supervisor, tenant.slug);
-    assert.equal(args[0], tenant.slug);
-    assert.equal(args[1], tenant.port);
-    assert.equal(args[2], tenant.registry);
-    assert.equal(args[3], tenant.entry);
-    assert.equal(args[6], tenant.eventDb);
-    assert.ok(!eventDbs.has(tenant.eventDb), `${tenant.eventDb} is reused`);
-    eventDbs.add(tenant.eventDb);
+  for (const tenant of tenants) {
+    assert.match(
+      nginx,
+      new RegExp(`upstream\\s+${escapeRegExp(tenant.upstream)}\\s*\\{\\s*server\\s+127\\.0\\.0\\.1:${tenant.port};`),
+      `${tenant.slug} upstream must stay on its manifest port`,
+    );
+    for (const host of tenant.hosts) {
+      assert.match(
+        nginx,
+        new RegExp(`server_name[^;]*${escapeRegExp(host)}[^;]*;[\\s\\S]*?proxy_pass\\s+http://${escapeRegExp(tenant.upstream)};`),
+        `${host} must route only to ${tenant.upstream}`,
+      );
+    }
   }
-
-  assert.match(
-    supervisor,
-    /if \[ -r "\$elysium_registry" \]; then/,
-    "Elysium must be optional until its compiled registry lands",
+  assert.deepEqual(tenants.filter((tenant) => tenant.required).map((tenant) => tenant.slug), ["root", "7", "89", "lantern"]);
+  assert.deepEqual(tenants.filter((tenant) => !tenant.required).map((tenant) => tenant.slug), ["0"]);
+  assert.match(supervisor, /optional tenant \$slug registry is absent/);
+  assert.match(nginx, /return 503 '\{"ok":false,"error":"Elysium is not installed in this release"\}'/);
+  assert.match(nginx, /listen 0\.0\.0\.0:3000 default_server;[\s\S]*?location = \/health[\s\S]*?lonelyforest_root/);
+  assert.equal((fly.match(/\[\[http_service\.checks\]\]/g) ?? []).length, 1);
+  assert.match(fly, /path = "\/health"/);
+  assert.match(workflow, /node v2\/scripts\/check-lonelyforest-worldpacks\.mjs/);
+  assert.match(workflow, /check-lonelyforest-worldpacks\.mjs[\s\S]*?npm run v2:lonelyforest:contract[\s\S]*?flyctl deploy/);
+  assert.match(supervisor, /health_url="http:\/\/127\.0\.0\.1:\$port\/health"/);
+  assert.match(supervisor, /COSYWORLD_REQUIRED_HEALTH_URLS="\$required_health_urls"/);
+  assert.equal(
+    (supervisor.match(/COSYWORLD_REQUIRED_HEALTH_URLS="\$required_health_urls"/g) ?? []).length,
+    1,
+    "only root readiness may receive the sibling health list",
   );
   assert.match(
     supervisor,
-    /elysium_registry="\/app\/v2\/content\/elysium-only\/registry\.json"/,
-  );
-  assert.match(
-    supervisor,
-    /required_health_urls="http:\/\/127\.0\.0\.1:3107\/health,http:\/\/127\.0\.0\.1:3189\/health,http:\/\/127\.0\.0\.1:3180\/health"/,
-  );
-  assert.match(
-    supervisor,
-    /required_health_urls="\$required_health_urls,http:\/\/127\.0\.0\.1:3101\/health"/,
-    "Elysium must join readiness only when its registry is installed",
-  );
-  assert.match(
-    supervisor,
-    /COSYWORLD_REQUIRED_HEALTH_URLS="\$required_health_urls"/,
-    "root readiness must include every installed tenant",
-  );
-  assert.match(
-    nginx,
-    /return 503 '\{"ok":false,"error":"Elysium is not installed in this release"\}'/,
+    /if \[ "\$entry_location_id" = "-" \]; then[\s\S]*?COSYWORLD_REQUIRED_HEALTH_URLS="\$required_health_urls"[\s\S]*?else\n      env -u COSYWORLD_REQUIRED_HEALTH_URLS/,
+    "non-root workers must not recursively probe the sibling health list",
   );
   assert.match(nginx, /location = \/health\/live/);
   assert.match(nginx, /listen 0\.0\.0\.0:3000 default_server;[\s\S]*?return 421;/);
   assert.equal((fly.match(/\[\[mounts\]\]/g) ?? []).length, 1);
   assert.match(fly, /source = "lonelyforest_data"/);
   assert.match(fly, /app = "\/app\/deploy\/lonelyforest\/run-multitenant\.sh"/);
-  assert.match(dockerfile, /apt-get install[^\\\n]*ca-certificates gosu nginx/);
+  assert.match(dockerfile, /apt-get install[^\\\n]*ca-certificates curl gosu nginx/);
   assert.match(dockerfile, /COPY deploy\/lonelyforest \/app\/deploy\/lonelyforest/);
   assert.match(dockerfile, /COPY deploy\/entrypoint\.sh \/app\/entrypoint\.sh/);
   assert.match(dockerfile, /ENTRYPOINT \["\/app\/entrypoint\.sh"\]/);
+  assert.match(dockerfile, /check-required-health\.sh/);
   assert.match(entrypoint, /chown -R cosyworld:cosyworld \/data/);
   assert.match(entrypoint, /exec gosu cosyworld/);
+});
+
+test("tenant manifest rejects path traversal and overlapping persistence identities", async () => {
+  const tempRoot = await mkdtemp(resolve(tmpdir(), "cosyworld-tenant-config-"));
+  const valid = [
+    "root|required|root.example|root|3100|/app/v2/content/root/registry.json|-|/data/root/snapshot.json|/data/root/events.sqlite|/data/root/generated|",
+    "tenant|required|tenant.example|tenant_world|3101|/app/v2/content/tenant/registry.json|1|/data/tenant/snapshot.json|/data/tenant/events.sqlite|/data/tenant/generated|",
+  ].join("\n");
+  try {
+    const cases = [
+      [
+        "registry traversal",
+        valid.replace("/app/v2/content/tenant/registry.json", "/app/v2/content/tenant/../other/registry.json"),
+        /registry must be a canonical path/,
+      ],
+      [
+        "persistence normalization alias",
+        valid.replace("/data/tenant/snapshot.json", "/data/tenant//snapshot.json"),
+        /snapshot path must be a canonical path/,
+      ],
+      [
+        "duplicate event database",
+        valid.replace("/data/tenant/events.sqlite", "/data/root/events.sqlite"),
+        /overlaps root event database path/,
+      ],
+      [
+        "generated directory overlapping another tenant snapshot",
+        valid.replace("/data/tenant/generated", "/data/root"),
+        /overlaps root snapshot path/,
+      ],
+    ];
+    for (const [name, source, expected] of cases) {
+      const configPath = resolve(tempRoot, `${name.replaceAll(" ", "-")}.tsv`);
+      await writeFile(configPath, source);
+      assert.throws(() => readLonelyForestTenants(configPath), expected, name);
+    }
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("Lonely Forest deploy gate proves every configured tenant before image replacement", async () => {
+  const hashes = await candidateHashes();
+  const requests = [];
+  const results = await verifyLonelyForestTenants({
+    fetchImpl: async (url) => {
+      requests.push(url);
+      const host = new URL(url).host;
+      return new Response(JSON.stringify({ worldpack: { bundle_hash: hashes.get(host) } }), { status: 200 });
+    },
+    log: () => {},
+  });
+  assert.deepEqual(requests, tenants.map((tenant) => `https://${tenant.hosts[0]}/meta`));
+  assert.deepEqual(results.map((result) => result.tenant.slug), tenants.map((tenant) => tenant.slug));
+  assert.ok(results.every((result) => result.ok));
+});
+
+test("Lantern-style tenant mismatch blocks the release before Fly deployment", async () => {
+  const hashes = await candidateHashes();
+  const mismatch = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  await assert.rejects(
+    verifyLonelyForestTenants({
+      fetchImpl: async (url) => {
+        const host = new URL(url).host;
+        return new Response(JSON.stringify({
+          worldpack: { bundle_hash: host === "lantern.lonelyforest.com" ? mismatch : hashes.get(host) },
+        }), { status: 200 });
+      },
+      log: () => {},
+    }),
+    (error) => error.message.includes("tenant=lantern")
+      && error.message.includes(mismatch)
+      && error.message.includes("candidate="),
+  );
+});
+
+test("an unavailable tenant needs an explicit audited captured identity, never a skip", async () => {
+  const hashes = await candidateHashes();
+  const unavailableLantern = async (url) => {
+    const host = new URL(url).host;
+    if (host === "lantern.lonelyforest.com") throw new Error("connection refused");
+    return new Response(JSON.stringify({ worldpack: { bundle_hash: hashes.get(host) } }), { status: 200 });
+  };
+  await assert.rejects(
+    verifyLonelyForestTenants({ fetchImpl: unavailableLantern, log: () => {} }),
+    /tenant=lantern.*Refusing to replace the image/,
+  );
+
+  const tempRoot = await mkdtemp(resolve(tmpdir(), "cosyworld-lantern-capture-"));
+  try {
+    const capturePath = resolve(tempRoot, "lantern.json");
+    await writeFile(capturePath, JSON.stringify({
+      schema_version: 1,
+      tenant: "lantern",
+      source: "tenant-volume",
+      captured_at: "2026-08-01T12:34:56Z",
+      meta: { worldpack: { bundle_hash: hashes.get("lantern.lonelyforest.com") } },
+    }));
+    const captures = recoveryCapturesFromArgs(["--recovery-capture", `lantern=${capturePath}`], "/");
+    const results = await verifyLonelyForestTenants({
+      fetchImpl: unavailableLantern,
+      recoveryCaptures: captures,
+      log: () => {},
+    });
+    assert.equal(results.find((result) => result.tenant.slug === "lantern")?.identitySource.includes("recovery capture"), true);
+    const cli = spawnSync(
+      process.execPath,
+      [resolve(scriptDir, "check-lonelyforest-worldpacks.mjs"), "--recovery-capture", `lantern=${capturePath}`],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    assert.equal(cli.status, 1);
+    assert.match(`${cli.stdout}\n${cli.stderr}`, /reviewed file inside the committed checkout/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("required-tenant health monitor fails the Machine after startup grace when any required process is unready", async () => {
+  const tempRoot = await mkdtemp(resolve(tmpdir(), "cosyworld-required-health-"));
+  try {
+    const binDir = resolve(tempRoot, "bin");
+    const curlLog = resolve(tempRoot, "curl.log");
+    const fakeCurl = resolve(binDir, "curl");
+    const tenantConfig = resolve(deploymentRoot, "tenants.tsv");
+    await mkdir(binDir);
+    await writeFile(fakeCurl, "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$FAKE_CURL_LOG\"\ncase \"$*\" in *:3180*) exit 1 ;; *) exit 0 ;; esac\n");
+    await chmod(fakeCurl, 0o755);
+    const result = await new Promise((resolveResult, reject) => {
+      const child = spawn(
+        "sh",
+        [resolve(deploymentRoot, "check-required-health.sh"), tenantConfig, "999999", "0", "1"],
+        {
+          env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, FAKE_CURL_LOG: curlLog },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      let output = "";
+      child.stdout.on("data", (chunk) => { output += chunk; });
+      child.stderr.on("data", (chunk) => { output += chunk; });
+      child.once("error", reject);
+      child.once("close", (code) => resolveResult({ code, output }));
+    });
+    assert.equal(result.code, 1, result.output);
+    assert.match(result.output, /required tenant lantern failed private \/health/);
+    const requests = await readFile(curlLog, "utf8");
+    for (const port of ["3100", "3107", "3189", "3180"]) {
+      assert.match(requests, new RegExp(`127\\.0\\.0\\.1:${port}/health`));
+    }
+    assert.doesNotMatch(requests, /127\.0\.0\.1:3101\/health/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("a required child crash exits the supervisor nonzero", async () => {
+  const tempRoot = await mkdtemp(resolve(tmpdir(), "cosyworld-supervisor-exit-"));
+  try {
+    const binDir = resolve(tempRoot, "bin");
+    const registry = resolve(tempRoot, "registry.json");
+    const tenantConfig = resolve(tempRoot, "tenants.tsv");
+    const snapshot = resolve(tempRoot, "snapshot.json");
+    const eventDb = resolve(tempRoot, "events.sqlite");
+    const generated = resolve(tempRoot, "generated");
+    await mkdir(binDir);
+    await writeFile(registry, "{}");
+    await writeFile(tenantConfig, `root|required|root.example|root|3100|${registry}|-|${snapshot}|${eventDb}|${generated}|\n`);
+    const scripts = {
+      chown: "#!/bin/sh\nexit 0\n",
+      nginx: "#!/bin/sh\nif [ \"$1\" = \"-t\" ]; then exit 0; fi\nexec sleep 300\n",
+      orchestrator: "#!/bin/sh\nexit 1\n",
+      monitor: "#!/bin/sh\nexec sleep 300\n",
+    };
+    await Promise.all(Object.entries(scripts).map(async ([name, content]) => {
+      const script = resolve(binDir, name);
+      await writeFile(script, content);
+      await chmod(script, 0o755);
+    }));
+    const startedAt = Date.now();
+    const result = await new Promise((resolveResult, reject) => {
+      const child = spawn("sh", [resolve(deploymentRoot, "run-multitenant.sh")], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          COSYWORLD_ORCHESTRATOR_BINARY: resolve(binDir, "orchestrator"),
+          COSYWORLD_MULTITENANT_TENANTS_CONFIG: tenantConfig,
+          COSYWORLD_MULTITENANT_HEALTH_MONITOR: resolve(binDir, "monitor"),
+          COSYWORLD_MULTITENANT_NGINX_CONFIG: resolve(tempRoot, "nginx.conf"),
+          COSYWORLD_MULTITENANT_DATA_ROOT: resolve(tempRoot, "worldpacks"),
+          COSYWORLD_MULTITENANT_HEALTH_STARTUP_GRACE_SECS: "60",
+        },
+        stdio: "ignore",
+      });
+      child.once("error", reject);
+      child.once("exit", (code) => resolveResult({ code }));
+    });
+    assert.equal(result.code, 1);
+    assert.ok(Date.now() - startedAt < 3_000, "required child crash must fail the supervisor immediately");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });

--- a/v2/scripts/lonelyforest-tenants.mjs
+++ b/v2/scripts/lonelyforest-tenants.mjs
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+export const repoRoot = path.resolve(path.dirname(scriptPath), "../..");
+export const TENANTS_PATH = path.join(repoRoot, "deploy/lonelyforest/tenants.tsv");
+const REQUIRED_COLUMNS = 11;
+const VALID_SLUG = /^[a-z0-9][a-z0-9-]*$/;
+const VALID_UPSTREAM = /^[a-z_][a-z0-9_]*$/;
+const VALID_PORT = /^[1-9][0-9]{3,4}$/;
+const VALID_HOST = /^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/;
+
+export class TenantConfigError extends Error {}
+
+function configError(message) {
+  throw new TenantConfigError(`Lonely Forest tenant configuration: ${message}`);
+}
+
+function canonicalContainerPath(value, root, label) {
+  if (typeof value !== "string" || !value.startsWith(`${root}/`)) {
+    configError(`${label} must be an absolute path below ${root}`);
+  }
+  const normalized = path.posix.normalize(value);
+  if (normalized !== value || value.includes("//") || value.endsWith("/")) {
+    configError(`${label} must be a canonical path without traversal or normalization aliases: ${value}`);
+  }
+  return value;
+}
+
+function overlappingPath(a, b) {
+  return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+}
+
+export function candidateRegistryPath(tenant, root = repoRoot) {
+  if (!tenant.registry.startsWith("/app/")) {
+    configError(`${tenant.slug} registry must be rooted at /app/, got ${tenant.registry}`);
+  }
+  return path.join(root, tenant.registry.slice("/app/".length));
+}
+
+export function readLonelyForestTenants(file = TENANTS_PATH) {
+  let source;
+  try {
+    source = fs.readFileSync(file, "utf8");
+  } catch (error) {
+    configError(`cannot read ${file}: ${error.message}`);
+  }
+  const tenants = [];
+  const slugs = new Set();
+  const hosts = new Set();
+  const ports = new Set();
+  const upstreams = new Set();
+  const persistenceTargets = [];
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    if (!line || line.startsWith("#")) continue;
+    const columns = line.split("|");
+    if (columns.length !== REQUIRED_COLUMNS) {
+      configError(`line ${index + 1} must have ${REQUIRED_COLUMNS} pipe-separated columns`);
+    }
+    const [slug, requirement, hostList, upstream, port, registry, entryLocation,
+      snapshotPath, eventDbPath, generatedAssetDir, extraOrigins] = columns;
+    if (!VALID_SLUG.test(slug) || slugs.has(slug)) configError(`invalid or duplicate slug '${slug}'`);
+    if (!new Set(["required", "optional"]).has(requirement)) {
+      configError(`${slug} must be required or optional`);
+    }
+    const hostsForTenant = hostList.split(",");
+    if (hostsForTenant.length === 0 || hostsForTenant.some((host) => !VALID_HOST.test(host) || hosts.has(host))) {
+      configError(`${slug} has an invalid or duplicate public host`);
+    }
+    if (!VALID_UPSTREAM.test(upstream) || upstreams.has(upstream)) configError(`${slug} has an invalid or duplicate nginx upstream`);
+    if (!VALID_PORT.test(port) || ports.has(port)) configError(`${slug} has an invalid or duplicate port`);
+    canonicalContainerPath(registry, "/app/v2/content", `${slug} registry`);
+    if (!registry.endsWith("/registry.json")) configError(`${slug} registry must name registry.json`);
+    for (const [field, target] of [
+      ["snapshot path", snapshotPath],
+      ["event database path", eventDbPath],
+      ["generated asset directory", generatedAssetDir],
+    ]) {
+      canonicalContainerPath(target, "/data", `${slug} ${field}`);
+      const existing = persistenceTargets.find((entry) => overlappingPath(entry.target, target));
+      if (existing) {
+        configError(`${slug} ${field} ${target} overlaps ${existing.slug} ${existing.field} ${existing.target}`);
+      }
+      persistenceTargets.push({ slug, field, target });
+    }
+    if (entryLocation !== "-" && !/^[1-9][0-9]*$/.test(entryLocation)) configError(`${slug} has an invalid entry location`);
+    slugs.add(slug);
+    hostsForTenant.forEach((host) => hosts.add(host));
+    ports.add(port);
+    upstreams.add(upstream);
+    tenants.push({
+      slug,
+      requirement,
+      required: requirement === "required",
+      hosts: hostsForTenant,
+      upstream,
+      port,
+      registry,
+      entryLocation,
+      snapshotPath,
+      eventDbPath,
+      generatedAssetDir,
+      extraOrigins: extraOrigins ? extraOrigins.split(",") : [],
+    });
+  }
+  if (tenants.length === 0 || tenants[0]?.slug !== "root" || !tenants[0].required) {
+    configError("must begin with the required root tenant");
+  }
+  return tenants;
+}

--- a/v2/worlds/bethlehem/world.json
+++ b/v2/worlds/bethlehem/world.json
@@ -19,6 +19,12 @@
       }
     ]
   },
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df"
+    ]
+  },
   "packs": [
     "cosyworld.core",
     "cosyworld.rules-srd-5.2.1",


### PR DESCRIPTION
## Summary

- define every Lonely Forest process, hostname, registry, port, entry location, and persistence target in one validated tenant manifest
- fail the deploy before image replacement unless every installed tenant's live bundle is exact or explicitly replay-compatible with its candidate registry
- make required child exits, readiness failures, and health-monitor exits fail the shared Fly Machine; retain an explicit optional policy for Elysium
- provide a reviewed, committed-capture recovery path when a tenant cannot serve `/meta`
- declare the exact pre-context-dominant Bethlehem bundle replay-compatible after verifying #669 changed prompt/voice presentation only

Closes #667

## Persistence and recovery

The guard checks root, Elysium when installed, Bethlehem, Project 89, and Lantern independently. It never treats root health or root `/meta` as evidence for sibling journals. Recovery captures must be committed inside the checkout, identify the tenant/source/time, and still pass the normal exact/declaration rule; no skip or hash rewrite is permitted.

Bethlehem's only declared migration is:

`sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df` → `sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3`

The boundary changes authored actor voice/prompt fields and consequent bundle integrity only; resource IDs, topology, rules, pack versions, entry location, and persisted-state interpretation are unchanged.

## Validation

- tenant multitenant contract — 7/7 passed
- Holy Land/Bethlehem migration contract — 7/7 passed
- deploy workflow contract — 22/22 passed
- all five live tenant guards — green:
  - root: declared migration
  - Elysium: exact
  - Bethlehem: declared migration
  - Project 89: exact
  - Lantern: declared migration
- `npm run check:local` under Node 24 — 46 files / 530 Node tests plus full V2 production, browser, CLI, and 918 Rust tests
- Node-24 pre-push `npm run check` — 530 Node / 918 Rust passed
- `npm run v2:architecture`
- `npm run v2:syntax`
- shell syntax for both deployment scripts
- `npm run check:version`
- `git diff --check`

## Deployment note

Version 0.0.308. After merge, publish a new immutable release tag so both the primary app and Lonely Forest run the guarded deployment path and GitHub creates the release.

## Review checklist

- [x] every acceptance criterion has direct contract evidence
- [x] persistence paths are canonical, non-overlapping, and process-isolated
- [x] required and optional health policies are explicit
- [x] recovery remains fail-closed and auditable
- [x] generated Bethlehem artifacts match the owning source world
- [x] no secret, runtime database, snapshot, or local artifact is included
