### PR TITLE
fix: make Lonely Forest nginx runtime non-root safe

### DIFF
--- a/deploy/lonelyforest/nginx.conf
+++ b/deploy/lonelyforest/nginx.conf
@@ -1,17 +1,19 @@
-user cosyworld;
 worker_processes auto;
 pid /tmp/cosyworld-nginx/nginx.pid;
-error_log /dev/stderr notice;
+error_log /tmp/cosyworld-nginx/error.log notice;
 
 events {
   worker_connections 2048;
 }
 
 http {
-  access_log /dev/stdout combined;
+  access_log /tmp/cosyworld-nginx/access.log combined;
   client_max_body_size 25m;
   client_body_temp_path /tmp/cosyworld-nginx/client-body;
   proxy_temp_path /tmp/cosyworld-nginx/proxy;
+  fastcgi_temp_path /tmp/cosyworld-nginx/fastcgi;
+  uwsgi_temp_path /tmp/cosyworld-nginx/uwsgi;
+  scgi_temp_path /tmp/cosyworld-nginx/scgi;
 
   map $http_upgrade $connection_upgrade {
     default upgrade;

--- a/deploy/lonelyforest/run-multitenant.sh
+++ b/deploy/lonelyforest/run-multitenant.sh
@@ -149,8 +149,12 @@ trap 'stop_all; exit 0' TERM INT HUP
 trap 'stop_all; exit 1' USR1
 
 mkdir -p \
+  /tmp/cosyworld-nginx \
   /tmp/cosyworld-nginx/client-body \
   /tmp/cosyworld-nginx/proxy \
+  /tmp/cosyworld-nginx/fastcgi \
+  /tmp/cosyworld-nginx/uwsgi \
+  /tmp/cosyworld-nginx/scgi \
   "$tenant_data_root"
 
 # tenants.tsv is the committed source of truth for hostname, registry, port,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.308",
+  "version": "0.0.309",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.308",
+      "version": "0.0.309",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.308",
+  "version": "0.0.309",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.308"
+version = "0.0.309"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.308"
+version = "0.0.309"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/lonelyforest-multitenant-contract.test.mjs
+++ b/v2/scripts/lonelyforest-multitenant-contract.test.mjs
@@ -97,6 +97,30 @@ test("Lonely Forest tenant manifest strictly covers supervisor, nginx, Fly healt
   );
   assert.match(nginx, /location = \/health\/live/);
   assert.match(nginx, /listen 0\.0\.0\.0:3000 default_server;[\s\S]*?return 421;/);
+  assert.doesNotMatch(nginx, /^user\s+/m, "nginx runs as the non-root entrypoint user");
+  assert.doesNotMatch(nginx, /\/dev\/(?:stdout|stderr)/, "non-root nginx must not open container-owned standard streams");
+  assert.doesNotMatch(nginx, /\/var\/lib\/nginx/, "non-root nginx must not retain default temp paths");
+  assert.match(nginx, /^error_log \/tmp\/cosyworld-nginx\/error\.log notice;$/m);
+  assert.match(nginx, /^\s*access_log \/tmp\/cosyworld-nginx\/access\.log combined;$/m);
+  assert.match(supervisor, /mkdir -p[\s\S]*?\/tmp\/cosyworld-nginx \\/);
+  for (const [directive, directory] of [
+    ["client_body_temp_path", "/tmp/cosyworld-nginx/client-body"],
+    ["proxy_temp_path", "/tmp/cosyworld-nginx/proxy"],
+    ["fastcgi_temp_path", "/tmp/cosyworld-nginx/fastcgi"],
+    ["uwsgi_temp_path", "/tmp/cosyworld-nginx/uwsgi"],
+    ["scgi_temp_path", "/tmp/cosyworld-nginx/scgi"],
+  ]) {
+    assert.match(nginx, new RegExp(`\\b${directive}\\s+${escapeRegExp(directory)};`));
+    assert.match(
+      supervisor,
+      new RegExp(`mkdir -p[\\s\\S]*?${escapeRegExp(directory)}`),
+      `${directive} directory must exist before non-root nginx -t`,
+    );
+  }
+  assert.ok(
+    supervisor.indexOf("/tmp/cosyworld-nginx/scgi") < supervisor.indexOf('if ! nginx -t -c "$nginx_config"'),
+    "all nginx temp directories must be created before nginx validates its config",
+  );
   assert.equal((fly.match(/\[\[mounts\]\]/g) ?? []).length, 1);
   assert.match(fly, /source = "lonelyforest_data"/);
   assert.match(fly, /app = "\/app\/deploy\/lonelyforest\/run-multitenant\.sh"/);


### PR DESCRIPTION
## Summary
- route every nginx temp directory through the writable `/tmp/cosyworld-nginx` runtime tree
- write nginx access/error logs under the same non-root-owned tree instead of reopening container-owned standard streams
- remove the ineffective `user` directive and create all runtime directories before `nginx -t`
- add a regression contract for all five temp directives, both log paths, and startup ordering
- bump the canonical runtime version to `0.0.309`

## Production incident
The v0.0.94 Lonely Forest image stopped after Debian nginx attempted to create `/var/lib/nginx/fastcgi` as the unprivileged `cosyworld` user. A live config probe then exposed the same restriction when nginx attempted to reopen `/dev/stderr`. The reviewed config has been injected temporarily into the existing Machine; all five tenant health endpoints are back to HTTP 200. This PR makes that bridge permanent in the image.

## Validation
- Node 24 pre-push gate: 46 files / 530 tests
- Rust: 918 tests
- tenant contract: 7 tests
- deploy contract: 22 tests
- kernel, worldpack, architecture, syntax, version, and diff checks
- production runtime probe: nginx config accepted and all five tenant health endpoints returned HTTP 200

After merge, publish `v0.0.95`; do not move the immutable failed `v0.0.94` tag.