### PR TITLE
fix: align Lonely Forest smoke TLS with tenant hosts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.309",
+  "version": "0.0.310",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.309",
+      "version": "0.0.310",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.309",
+  "version": "0.0.310",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,
@@ -22,7 +22,7 @@
     "v2:smoke": "./v2/mvp.sh smoke",
     "v2:browser:check": "./v2/mvp.sh browser-check",
     "v2:smoke:ruby-high-deploy": "node v2/scripts/smoke-deployed-ruby-high.mjs",
-    "v2:lonelyforest:contract": "node --test v2/scripts/lonelyforest-multitenant-contract.test.mjs",
+    "v2:lonelyforest:contract": "node --test v2/scripts/lonelyforest-multitenant-contract.test.mjs v2/scripts/smoke-lonelyforest-multitenant.test.mjs",
     "v2:lonelyforest:smoke": "node v2/scripts/smoke-lonelyforest-multitenant.mjs",
     "v2:check": "./v2/mvp.sh check",
     "v2:stop": "./v2/mvp.sh stop",

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.309"
+version = "0.0.310"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.309"
+version = "0.0.310"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-lonelyforest-multitenant.mjs
+++ b/v2/scripts/smoke-lonelyforest-multitenant.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import http from "node:http";
 import https from "node:https";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const args = process.argv.slice(2);
 const baseUrl = new URL(
@@ -10,6 +12,7 @@ const baseUrl = new URL(
 const expectElysium = args.includes("--expect-elysium");
 const allowRemoteMutations = args.includes("--allow-remote-mutations");
 const loopbackHosts = new Set(["127.0.0.1", "localhost", "::1"]);
+const scriptPath = fileURLToPath(import.meta.url);
 
 if (!loopbackHosts.has(baseUrl.hostname) && !allowRemoteMutations) {
   throw new Error(
@@ -40,19 +43,43 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function request(host, path, { method = "GET", body } = {}) {
+export function requestTarget(base, host, { routerProbe = false } = {}) {
+  // Local router tests deliberately exercise nginx's Host dispatch through one
+  // loopback listener. A remote smoke must instead connect to the hostname it
+  // advertises, so DNS and TLS SNI agree with Host.
+  const connectToBase = loopbackHosts.has(base.hostname) || routerProbe;
+  const hostname = connectToBase ? base.hostname : host;
+  return {
+    hostname,
+    port: base.port || undefined,
+    hostHeader: host,
+    // Node otherwise derives SNI from Host. Router probes intentionally send
+    // an untrusted Host through the base certificate, so pin SNI separately.
+    servername: base.protocol === "https:" ? hostname : undefined,
+  };
+}
+
+export function requestContext({ method, host, path, target }) {
+  const authority = target.port ? `${target.hostname}:${target.port}` : target.hostname;
+  return `${method} host=${host} path=${path} connect=${authority}`;
+}
+
+export function request(host, path, { method = "GET", body, routerProbe = false } = {}, base = baseUrl) {
   const payload = body === undefined ? null : JSON.stringify(body);
-  const transport = baseUrl.protocol === "https:" ? https : http;
+  const transport = base.protocol === "https:" ? https : http;
+  const target = requestTarget(base, host, { routerProbe });
+  const context = requestContext({ method, host, path, target });
   return new Promise((resolveRequest, rejectRequest) => {
     const req = transport.request(
       {
-        protocol: baseUrl.protocol,
-        hostname: baseUrl.hostname,
-        port: baseUrl.port || undefined,
+        protocol: base.protocol,
+        hostname: target.hostname,
+        port: target.port,
+        ...(target.servername ? { servername: target.servername } : {}),
         method,
         path,
         headers: {
-          host,
+          host: target.hostHeader,
           accept: "application/json",
           ...(payload === null
             ? {}
@@ -80,8 +107,10 @@ function request(host, path, { method = "GET", body } = {}) {
         });
       },
     );
-    req.on("error", rejectRequest);
-    req.on("timeout", () => req.destroy(new Error(`timed out requesting ${host}${path}`)));
+    req.on("error", (error) => {
+      rejectRequest(new Error(`${context}: ${error.message}`, { cause: error }));
+    });
+    req.on("timeout", () => req.destroy(new Error(`${context}: timed out after 10000ms`)));
     if (payload !== null) req.write(payload);
     req.end();
   });
@@ -187,7 +216,9 @@ async function main() {
     );
   }
 
-  const unknown = await request("untrusted.lonelyforest.com", "/");
+  // This is intentionally a router probe rather than a tenant request: there
+  // is no public DNS/TLS identity for the untrusted host.
+  const unknown = await request("untrusted.lonelyforest.com", "/", { routerProbe: true }, baseUrl);
   assert(unknown.status === 421, `unknown host returned HTTP ${unknown.status}`);
 
   console.log(JSON.stringify({
@@ -199,7 +230,9 @@ async function main() {
   }, null, 2));
 }
 
-main().catch((error) => {
-  console.error(error.stack || error.message || String(error));
-  process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  main().catch((error) => {
+    console.error(error.stack || error.message || String(error));
+    process.exit(1);
+  });
+}

--- a/v2/scripts/smoke-lonelyforest-multitenant.test.mjs
+++ b/v2/scripts/smoke-lonelyforest-multitenant.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import { request, requestContext, requestTarget } from "./smoke-lonelyforest-multitenant.mjs";
+
+test("remote Lonely Forest tenant smokes connect and negotiate TLS with the tenant hostname", () => {
+  const target = requestTarget(new URL("https://lonelyforest.com"), "7.lonelyforest.com");
+  assert.deepEqual(target, {
+    hostname: "7.lonelyforest.com",
+    port: undefined,
+    hostHeader: "7.lonelyforest.com",
+    servername: "7.lonelyforest.com",
+  });
+  assert.match(
+    requestContext({ method: "GET", host: "7.lonelyforest.com", path: "/meta", target }),
+    /GET host=7\.lonelyforest\.com path=\/meta connect=7\.lonelyforest\.com/,
+  );
+});
+
+test("loopback Lonely Forest router smokes retain one transport target and vary Host", () => {
+  const target = requestTarget(new URL("http://127.0.0.1:3000"), "lantern.lonelyforest.com");
+  assert.deepEqual(target, {
+    hostname: "127.0.0.1",
+    port: "3000",
+    hostHeader: "lantern.lonelyforest.com",
+    servername: undefined,
+  });
+});
+
+test("remote unknown-host router probes retain the configured public transport", () => {
+  const target = requestTarget(
+    new URL("https://lonelyforest.com"),
+    "untrusted.lonelyforest.com",
+    { routerProbe: true },
+  );
+  assert.deepEqual(target, {
+    hostname: "lonelyforest.com",
+    port: undefined,
+    hostHeader: "untrusted.lonelyforest.com",
+    servername: "lonelyforest.com",
+  });
+});
+
+test("failed smoke requests name the method, Host, path, and transport without retrying a POST", async () => {
+  let attempts = 0;
+  const server = http.createServer((incoming) => {
+    attempts += 1;
+    incoming.socket.destroy();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  try {
+    await assert.rejects(
+      request(
+        "lantern.lonelyforest.com",
+        "/avatar",
+        { method: "POST", body: { name: "Smoke" } },
+        new URL(`http://127.0.0.1:${port}`),
+      ),
+      /POST host=lantern\.lonelyforest\.com path=\/avatar connect=127\.0\.0\.1:/,
+    );
+    assert.equal(attempts, 1, "a mutating smoke request must not receive a blind transport retry");
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});


### PR DESCRIPTION
## Summary
- connect remote smoke requests to each tenant's actual DNS/TLS hostname so SNI, certificate, and HTTP `Host` agree
- preserve loopback `Host`-routing probes through one local listener
- pin the base SNI explicitly for the deliberately untrusted-host 421 probe
- include method, host, path, and transport target in failures without retrying mutating POSTs
- add focused transport tests to the deploy-gated Lonely Forest contract
- bump the canonical runtime version to `0.0.310`

## Release incident
The v0.0.95 image deployed successfully and is healthy in production, but GitHub withheld its release object because the post-deploy smoke client disconnected during TLS. Direct per-host probes proved all five public hosts healthy. The old client connected to `lonelyforest.com` while varying only `Host`; Node derives SNI from that header, which also broke the final deliberately untrusted-host probe.

## Validation
- corrected production smoke passed end-to-end against v0.0.309: four durable tenant avatar mutations, correct entry locations/worldpacks, Elysium ready, unknown host HTTP 421
- focused transport tests: 4
- full Lonely Forest contract: 11
- deploy contract: 22
- Node 24 pre-push: 46 files / 530 tests
- Rust: 918 tests
- kernel, worldpack, architecture, syntax, version, and diff checks

After merge, publish `v0.0.96`; keep failed-but-immutable `v0.0.95` as audit history.