### PR TITLE
Fix repeat Notice browser identity check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.313",
+  "version": "0.0.314",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.313",
+      "version": "0.0.314",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.313",
+  "version": "0.0.314",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.313"
+version = "0.0.314"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.313"
+version = "0.0.314"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -9702,7 +9702,7 @@ async function main() {
     });
     assert(
       noticeBefore.actorId > 0
-        && noticeBefore.focused?.label === "notice"
+        && noticeBefore.focused?.intention === "notice"
         && noticeBefore.focused?.isCertified === true,
       `Notice must remain an exact currently dealt hand action before it is played: ${JSON.stringify(noticeBefore)}`,
     );


### PR DESCRIPTION
## Summary
- identify current-room Notice by its stable semantic intention
- accept the valid repeat-play display copy “notice again”
- retain the exact dealt-offer certificate and actor/room-memory assertions
- bump synchronized package versions to 0.0.314

## Validation
- two fresh full browser gates on the identical corrected tree (deterministic, living-world stress, CLI)
- 530 Node tests
- 950 Rust tests
- content, kernel, architecture, lint, and syntax gates

This is the CI-only follow-up to #668, which was merged while its final one-line amendment was in flight.