### PR TITLE
Document model evaluation leaderboard and hearts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.315",
+  "version": "0.0.316",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.315",
+      "version": "0.0.316",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.315",
+  "version": "0.0.316",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/model-evaluations-leaderboard-and-hearts.md
+++ b/v2/docs/model-evaluations-leaderboard-and-hearts.md
@@ -1,0 +1,1138 @@
+# Model evaluations, `/leaderboard`, and `<3` feedback
+
+Status: design proposal; no runtime or UI implementation is included here.
+
+This design turns CosyWorld's existing per-generation publication evidence into
+capability-specific model scorecards, exposes aggregate results at
+`/leaderboard`, and adds one lightweight `<3` message reaction that people and
+AI-controlled residents can use. It preserves the core rule from `AI.md`: the
+system certifies each output, never a model. A high-ranked model receives no
+gate bypass or world authority.
+
+## Decisions
+
+1. Every OpenRouter catalog model is represented, but only comparable,
+   policy-eligible models are ranked. An unseen or incompatible model displays
+   a reason, not a fabricated zero.
+2. Models are compared within a capability and gate profile. Prose voice, raw
+   voice, planner JSON, world content, and images are not one leaderboard.
+3. The highlighted live voice score is **`<3` Heart Score**: account-browser
+   hearts per 100 eligible closed-window presentations, ranked by a conservative
+   adjusted lower bound. Show the raw heart total beside it, but never let raw
+   traffic alone determine rank.
+4. Objective accuracy is shown only where an independent fixture labels the
+   correct or acceptable answer. Merely producing a legal planner candidate is
+   a legal-output rate, and merely compiling world content is validity or
+   constraint satisfaction. Gate quality itself is audited separately against
+   blinded human labels.
+5. Reliability, latency, cost, and preference remain separate dimensions.
+   They do not buy back a safety or authority failure.
+6. Gate performance is primarily shown as an attempt funnel under one fixed
+   three-attempt policy: **approved 1st**, **approved 2nd**, **approved 3rd**,
+   and **failed after 3**. Cosy Gate Score remains the conservative lab
+   compliance statistic behind the funnel.
+7. Direct-input and server-AI hearts are never merged. Authenticated-account,
+   browser direct-input hearts are the primary weak RLF signal; guest, CLI/agent,
+   organic-resident AI, and off-world AI-jury evidence remain separate cohorts.
+8. A `<3` is visible, durable social state but no mechanical authority. It
+   changes no turn, tick, Orb, advancement, Bond, continuity, memory, prompt,
+   dialogue heartbeat, selection weight, or reward.
+9. V1 hearts target only committed `message.created` events. Image reactions
+   can later reuse the same target contract.
+
+## Existing foundation and instrumentation gaps
+
+CosyWorld already has most of the difficult evidence path:
+
+- `ai_registry.rs` pins an immutable registry snapshot and distinguishes the
+  requested model from the provider-resolved model and revision. It also holds
+  provider, family, modality, capability, privacy, adapter, sampling, observed
+  price, p50 latency, availability, and historical gate facts.
+- `ai_publication.rs` produces a receipt with generation, candidate and
+  publication identities; prompt and context hashes; output hash; resolved
+  attribution; finish reason; tokens; attempts; latency; and every gate check.
+- The current voice gate checks envelope integrity, emptiness, word budget,
+  terminal finish, repetition, multiple speakers, instruction leakage, speech
+  mode, scene anchors, recent duplication, cozy/public safety, false action
+  claims, and object agency.
+- `ai_voice_routing.rs` correctly keeps content pass/fail evidence separate
+  from endpoint health and preserves selection decisions, resampling,
+  certified hedge losers, provider failures, cooldown, cost estimates, and the
+  exploration propensity inputs.
+- `AI.md` already requires production-shaped shadow jobs, the same production
+  adapter and gate, resolved attribution, bounded budgets, and an adversarial
+  corpus.
+
+The public leaderboard must wait for these gaps to close:
+
+| Gap | Required change |
+| --- | --- |
+| No explicit gate version on a publication receipt | Add `gate_id` and `gate_version`; include them in every evidence key. |
+| Content evidence can mix prompt changes | Key normalized evidence by prompt ID/version as well as adapter, feature, and speech mode. |
+| Provider errors do not have a common attempt row | Persist assigned, started, canceled, provider-failed, completed, gate-failed, and gate-passed dispositions. |
+| Cost is currently estimated from catalog rates | Capture provider-reported cost or label an amount explicitly as estimated. |
+| No eval suite/run/case identity | Add immutable campaign, corpus, case, scenario bucket, repeat, and source IDs. |
+| No assignment probability | Persist the pre-outcome routing propensity for any live analysis. |
+| No message-to-publication link | Bind accepted `publication_id` and `candidate_id` to `(world_id, world_epoch, message_event_seq)` when speech commits. |
+| Message origin is inferred from mutable actor state in the browser | Project immutable target origin from the AI publication receipt; never infer it later from actor kind or current control mode. |
+| No visible-message denominator | Add idempotent foreground presentation receipts for humans and bounded observation receipts for AI. |
+| Generic AI usage rows can name the configured rather than resolved model | Build scores from normalized attempts/publication receipts, not the generic usage ledger. |
+
+The legacy model list and its price-derived rarity are not evaluation inputs.
+The V2 immutable catalog/registry snapshot is the source of comparison facts.
+
+## The evaluation funnel
+
+Every provider attempt has exactly one terminal disposition. A case may contain
+multiple policy-declared attempts, such as a first failure followed by a retry,
+and therefore has its own aggregate outcome. Provider failure is not silently
+counted as a content failure, and a certified hedge loser remains a content
+pass even though it did not win publication.
+
+```mermaid
+flowchart LR
+  A["Catalog model"] --> B{"Capability and policy eligible?"}
+  B -- "no" --> X["Visible, unranked status"]
+  B -- "yes" --> C["Assigned eval case"]
+  C --> D{"Provider returned a terminal candidate?"}
+  D -- "no" --> E["Reliability failure"]
+  D -- "yes" --> F{"Every applicable gate check passed?"}
+  F -- "no" --> G["Private rejection evidence"]
+  F -- "yes" --> H["Certified output"]
+  H --> I{"Published to a real room?"}
+  I -- "lab or hedge loser" --> J["Content-pass evidence only"]
+  I -- "yes" --> K["Visible message + publication link"]
+  K --> L["Direct-input presentations and AI observations"]
+  L --> M["Direct-input and AI hearts, kept separate"]
+```
+
+### Attempt dispositions
+
+Use a closed, append-only vocabulary:
+
+- `not_started`
+- `provider_failure`
+- `canceled_hedge`
+- `gate_failed`
+- `gate_passed`
+- `certified_loser`
+- `published`
+
+`gate_passed`, `certified_loser`, and `published` are content passes.
+`provider_failure` and `canceled_hedge` do not enter the gate-pass denominator.
+Cases use a separate closed outcome vocabulary: `not_started`, `passed_first`,
+`passed_after_retry`, `exhausted_content`, `exhausted_provider`, and
+`exhausted_mixed`. Content retry salvage is `passed_after_retry / all cases`
+whose designated sample-one attempt returned a candidate that failed the gate,
+under one fixed retry policy. Provider recovery is the analogous rate among
+cases whose sample-one attempt had a provider failure. The two estimands are
+never pooled.
+
+Direct lab evaluation uses one isolated model assignment so hedging and
+first-winner censoring cannot bias model comparison. Router-level `pass@K` and
+time-to-first-certified remain separate system metrics.
+
+## Comparison identity
+
+The leaderboard has two different identities and must not collapse them:
+
+- `catalog_entry_id = (catalog_snapshot_version, requested_model_id)` answers
+  whether every OpenRouter catalog entry is searchable and why it is or is not
+  eligible; and
+- `evaluation_profile_id` identifies the comparable execution profile below
+  and owns scorecards.
+
+A versioned alias-resolution record links one catalog entry to zero or more
+resolved evaluation profiles. An unevaluated or policy-blocked catalog entry
+still exists even though it has no profile evidence.
+
+A comparable score slice is identified by:
+
+```text
+capability
++ resolved model ID and revision
++ provider/endpoint policy
++ prompt adapter ID and version
++ prompt ID and version
++ gate ID and version
++ speech mode
++ feature
++ sampling profile
++ corpus/suite version
+```
+
+Requested aliases are useful selection metadata, but results are credited to
+the concrete model the provider reports. If an alias resolves to a new model,
+the new identity starts a new score history. The UI may group related revisions
+without pooling their evidence.
+
+Because adapters and sampling affect results, the row is technically an
+execution profile, not an abstract model in isolation. The model is the primary
+label; the exact profile is always visible in row details.
+
+## Capability tracks
+
+| Track | Eligible population | Hard outcome | Independent accuracy/quality |
+| --- | --- | --- | --- |
+| World voice / prose | Text-output models declared for `voice` | Existing full speech publication gate | No exact target string; use blinded rubric and pairwise preference after gate certification. |
+| Raw voice | Exact-bound raw text models | Thin raw envelope, length, finish, repetition, duplicate, and safety gate | Keep separate from prose because grounding, character voice, and model-language checks deliberately do not apply. |
+| Planner JSON | Models declared for `intent_json` | Strict schema and exact current candidate validation | Legal-output rate for any current candidate; accuracy only when a fixture independently labels the acceptable/correct candidate set. Stale/illegal action rate must remain zero. |
+| World content | Models declared for `world_content` | Schema, compiler, reachability, duplication, safety, and dry-run checks | Validity/constraint satisfaction from the compiler; accuracy only for independently labelled fixture facts. |
+| Images | Text-to-image candidates | Decode/dimension checks and visible-pixel publication policy | Blinded human preference, policy false-accept audit, latency, and cost. |
+| Full catalog | Every immutable catalog entry | None | Status and capability coverage only; never a cross-modality rank. |
+
+## Metrics
+
+### Model metrics
+
+| Metric | Definition | Interpretation |
+| --- | --- | --- |
+| Gate approval funnel | Mutually exclusive shares certified first on attempt 1, 2, or 3, plus no certification within three / `included_cases` | Primary gate display; the four shares sum to 100% under one fixed attempt policy and analysis set. |
+| Cumulative approval@N | Cases certified within attempts 1..N / `included_cases` | `approval@1`, `approval@2`, and `approval@3`; includes reliability as experienced by the system. |
+| Cosy Gate Score | `100 × gate_rate_p05`, the conservative lower bound of the macro gate-rate posterior | Lab compliance statistic behind the attempt funnel; not the live Heart Score, median pass estimate, or semantic accuracy. |
+| End-to-end publishable yield | Certified outputs / all isolated assigned cases, including provider failure | Probability an assignment produces a usable line. |
+| Retry salvage | Cases whose sample-one candidate gate-failed and later passed within the declared retry budget / all cases whose sample-one candidate gate-failed under that fixed policy | Value and cost of retries. |
+| Provider recovery | Cases whose sample-one provider attempt failed and later produced a certified output / all cases whose sample-one provider attempt failed under that fixed policy | Operational recovery, not content improvement. |
+| Per-check failure rate | Failures for one stable gate code / provider-completed candidates | Diagnostic; hard checks do not award partial credit. |
+| Legal/constraint validity | Current legal candidate or compiler-valid proposal / provider-completed candidates | Does not imply the choice/content was independently correct. |
+| Task accuracy | Correct typed result / independently labelled cases | Shown only for fixtures with a specified correct/acceptable target. |
+| Endpoint reliability | Valid candidate-bearing completions / started provider requests | Terminal HTTP/provider errors are failures, not completions. |
+| Latency | Candidate p50/p95, certified-within-deadline yield, and censored time-to-usable | Conditional latency is always paired with yield so fail-fast models do not look best. P99 requires a suite minimum sample. |
+| Cost | Actual or labelled-estimated cost/request and cost/certified output | Cost/human-approved output appears only for fully reviewed or randomly sampled, inclusion-weighted audits. Rejects and hedges remain in cost. |
+| Stability | Within-context variance over repeated samples | Repeats are clustered under one context, not treated as independent cases. |
+| `<3` Heart Score | `100 × heart_rate_p05` from the named account-browser live estimator | Highlighted live voice score; raw hearts and eligible presentations are always shown beside it. |
+| Account browser-direct heart action rate | Eligible account-browser principal/message opportunities whose withdrawal-adjusted heart is active at the aggregation cutoff / eligible account-browser presentation opportunities | Primary observed RLF cohort; an authenticated direct-input route does not prove an unaided human judgement. |
+| Guest browser-direct heart action rate | Eligible guest-browser principal/message opportunities whose withdrawal-adjusted heart is active at the aggregation cutoff / eligible guest-browser presentation opportunities | Visible but separated from account and automated-direct-input cohorts. |
+| Organic AI conditional heart action rate | `completed_heart / (completed_heart + completed_none)` among eligible decisions | Character/attention-policy preference conditional on a usable evaluator decision. |
+| Organic AI end-to-end heart yield | `completed_heart / all eligible scheduled observation opportunities` | Includes provider failure/cancellation; always paired with decision reliability. |
+| AI jury preference | Votes from a fixed/common or explicitly calibrated blinded evaluator panel | Controlled teacher/judge metric, separate from organic residents and direct-input hearts. |
+| Withdrawal rate | Removed hearts / ever-added hearts | Detects accidental clicks and later regret. |
+| Coverage/freshness | Required buckets completed, contexts, repeats, unique raters, last run, suite version | Determines ranking status. |
+
+Raw heart count is not a quality metric; it mostly measures traffic. A public
+message returned by `/state`, hidden behind Menu, or mounted in a background
+tab is not an impression. The browser records a presentation only after the
+message is actually visible in a foreground document. The server accepts an
+idempotent presentation receipt bound to scoped principal, exact
+world/epoch/message/hash, server-derived credential/transport class,
+visibility-contract version, and time. Browser, CLI, and agent classes require
+distinct server-issued credential capabilities; a client cannot claim its class
+with a payload enum.
+
+Browser, CLI/agent direct-input, guest, organic-AI, and jury observations are
+distinct cohorts. Presentation endpoints are themselves rate-limited and
+anomaly-filtered so an attacker cannot cheaply poison the denominator.
+
+The scoring denominator contains at most one eligible opportunity for each
+scoped principal and message within the versioned reaction window; refreshes
+and repeated renders may update `last_seen_at` but never inflate exposure. V1
+uses seven days from the first eligible presentation. At an analysis cutoff,
+both numerator and denominator include only opportunities whose seven-day
+window has closed; open windows are right-censored and do not advance evidence
+maturity. A future survival estimator must be separately named and versioned.
+A counted heart requires the accepted presentation-receipt ID, and numerator
+and denominator apply identical moderation, principal, target, transport,
+time-window, and attribution exclusions. Intervals cluster by both principal
+and target message and remain provisional below the declared minimum unique
+principals, messages, and closed opportunities. The initial V1 display threshold
+is 30 distinct target messages, 30 distinct account principals, and 100 eligible
+principal-message opportunities; a suite may raise, but never silently lower,
+these thresholds.
+
+### Gate health metrics
+
+The deterministic gate needs its own scorecard against independently labelled
+candidate outputs. Treat human-publishable as the positive label and gate-pass
+as the positive prediction:
+
+| | Human publishable | Human unpublishable |
+| --- | --- | --- |
+| Gate passed | true positive (`TP`) | false positive (`FP`) |
+| Gate failed | false negative (`FN`) | true negative (`TN`) |
+
+Report publishable precision `TP / (TP + FP)`, unsafe-pass share
+`FP / (TP + FP)`, false-accept rate `FP / (FP + TN)`, publishable recall
+`TP / (TP + FN)`, and overblock rate `FN / (TP + FN)`, each with its exact
+denominator and interval. Report the same confusion matrix by stable check code
+and severity, plus reviewer agreement, adjudication rate, and calibration of
+the router's pre-outcome pass probability on the next non-overlapping window
+using Brier score, log loss, and reliability bins.
+
+Reviewers are blinded to model identity and gate verdict. Exploratory audits may
+be balanced or enriched for suspected failures, but population rates are valid
+only when every stratum's pre-outcome inclusion probability is persisted and
+all four confusion cells and intervals are design-weighted. An enriched sample
+without those probabilities reports stratum diagnostics only.
+
+Before a gate version can support a public model comparison, a separate IID
+confirmatory holdout from the declared target distribution—or a predeclared
+probability sample with valid design weights—must contain no critical safety or
+authority escape, and the 95% upper confidence bound on the critical
+false-accept rate must be below the suite threshold (proposed V1: 1%). A failed
+gate audit blocks publication of model rankings; a model's high pass rate never
+repairs the gate.
+
+This is how CosyWorld can say whether the gate is accurate. A model's gate pass
+rate alone cannot answer that question.
+
+### Human quality rubric
+
+Open-ended voice has many good answers and no exact reference string. A
+versioned blinded audit uses two independent reviewers plus adjudication and a
+1–5 rubric for:
+
+- grounding and relevance;
+- character/voice fidelity;
+- coherence and finish;
+- conversational affordance; and
+- charm, wit, or cleverness.
+
+Pairwise "which line is better?" judgements can produce a Bradley-Terry model
+score. The target post-MVP headline can become the conservative lower bound of
+**quality-adjusted yield**: normalized human quality for acceptable outputs and
+zero for unavailable or rejected assignments. Until review coverage is broad
+enough, reviewed quality remains provisional beside the live Heart Score and
+lab gate funnel.
+
+## Statistics and ranking
+
+### Highlighted `<3` Heart Score
+
+For live voice, the primary highlighted model score is not the raw number of
+hearts. Display all three facts together:
+
+```text
+<3 Heart Score = 100 × heart_rate_p05
+observed rate   = active eligible account-browser hearts
+                  / eligible closed-window account-browser presentations
+raw popularity  = active eligible account-browser heart count
+```
+
+A heart is attributed to a model only when its target has an immutable
+`server_ai_publication` receipt. Credit goes to that receipt's resolved model,
+revision, and evaluation profile; current actor control and requested aliases
+cannot move it. Account, guest, and organic-resident raw heart totals are shown
+separately, and hearts on direct-input-authored messages never enter a model
+score.
+
+`heart-score-v1` standardizes the live account-browser cohort to a declared
+reference mix of pre-outcome context, character, room-activity, surface/position,
+and time buckets. It uses logged assignment/exposure probabilities, predeclared
+weight clipping, common-support checks, and a minimum effective sample size.
+Two-way principal/message cluster resampling produces `heart_rate_p05`,
+`heart_rate_p50`, and `heart_rate_p95`; the public `<3` Heart Score is the
+conservative p05 rate per 100 eligible presentations.
+
+The score becomes rankable only when the existing closed-window minimums and
+the estimator's overlap/weight/ESS gates pass. Until then, highlight the raw
+heart count and observed rate as provisional but show no ordinal heart rank.
+Guest, CLI/agent, organic-AI, and AI-jury reactions never enter this score; they
+remain adjacent, explicitly labelled signals.
+
+### Three-attempt gate approval funnel
+
+V1 pins `max_attempts = 3` for every compared profile. Define `included_cases`
+once in the suite manifest: policy-eligible cases with a valid model assignment
+whose three-attempt policy either reached its budget or ended early on a gate
+pass. An attempt is one validly started generation request; a provider-side
+failure after that start consumes the attempt, a gate pass ends the case, and
+the prompt/repair, timeout, sampling, and retry policy are versioned.
+
+Harness/operator cancellations and `not_started` assignments are excluded from
+`included_cases`, retained as campaign data-quality evidence, and rerun under
+the same pre-outcome rule for every model. They never silently enter
+`failed_after_3`. Provider failures on validly started attempts do enter the
+funnel and its provider/mixed failure breakdown.
+
+Every included case lands in exactly one public bucket:
+
+```text
+approved_on_1 = first certified output arrived on attempt 1 / included cases
+approved_on_2 = first certified output arrived on attempt 2 / included cases
+approved_on_3 = first certified output arrived on attempt 3 / included cases
+failed_after_3 = no certified output within the three-attempt budget
+                 / included cases
+```
+
+The four exact-attempt shares sum to 100%. Also expose cumulative
+`approval_at_1`, `approval_at_2`, and `approval_at_3`, where each cumulative rate
+adds the earlier success buckets. Expand `failed_after_3` into gate/content,
+provider, and mixed exhaustion so a model is not diagnosed as unsafe merely
+because an endpoint was unavailable. The compact UI is a stacked bar such as:
+
+```text
+1st 71%  |  2nd 13%  |  3rd 5%  |  fail 11%
+```
+
+`approval_at_1` is an end-to-end case rate and can be lower than the conditional
+sample-one gate-pass rate used by Cosy Gate Score because its denominator keeps
+validly started provider failures.
+
+### Cosy Gate Score
+
+Exactly one predeclared sample-one attempt per independent fixture context is
+eligible for Cosy Gate Score. If it returns a valid candidate, that candidate
+contributes one pass or failure; a provider failure contributes to reliability
+and end-to-end yield but supplies no conditional gate observation. A retry may
+salvage the case but cannot replace sample one in this score. Repeats are used
+only for stability, and neither repeats nor retries are treated as additional
+independent score observations.
+
+For each fixture-declared scenario bucket, use the existing `Beta(1,1)`
+convention:
+
+```text
+posterior mean = (passes + 1) / (passes + failures + 2)
+```
+
+Display the posterior median, a 90% interval, completed-candidate count, and
+bucket coverage. The track rate is the macro-average across required buckets so
+easy or high-volume contexts cannot dominate. API fields are
+`gate_rate_p05`, `gate_rate_p50`, and `gate_rate_p95`; the named numeric
+`cosy_gate_score` is exactly `100 × gate_rate_p05`. Within the Lab gate view,
+ordering uses `cosy_gate_score`, then stable resolved model ID.
+
+`cosy-gate-score-v1` computes the macro interval explicitly: for each required
+bucket, draw from `Beta(passes + 1, failures + 1)`; equal-weight the bucket
+draws into one macro-average; use the 5th, 50th, and 95th percentiles; and rank
+by the 5th percentile. The suite pins the estimator version, deterministic RNG
+seed, required buckets, and draw count so rebuilds are byte-for-byte stable.
+Wilson intervals may describe other simple binary rates, but never replace the
+declared ranking estimator inside one release.
+
+Human quality, cost, latency, and paired model differences use a cluster
+bootstrap over whole contexts/episodes. Bootstrap p95 latency rather than
+assuming a normal distribution.
+
+### State axes, not false precision
+
+A single ladder is misleading because eligibility, evidence maturity,
+qualification, freshness, and catalog lifecycle are independent. Persist the
+axes on the identity that actually owns them:
+
+| Axis | Owner | Values |
+| --- | --- | --- |
+| Eligibility | `catalog_entry_id` under a policy/capability version | `eligible`, `capability_ineligible`, `policy_blocked` |
+| Catalog state | `catalog_entry_id` | `current`, `retired` |
+| Maturity | profile + source + estimator scorecard | `not_evaluated`, `smoke`, `provisional`, `ranked`, `high_confidence` |
+| Qualification | profile + source + estimator scorecard | `unknown`, `qualified`, `uncertain`, `below_gate` |
+| Freshness | profile + source + estimator scorecard | `current`, `stale` |
+
+The lab suite manifest owns gate thresholds. `provisional` means some balanced evidence
+but fewer than 100 independent contexts or incomplete scenario coverage.
+`ranked` requires every bucket, at least 20 independent completed sample-one
+contexts in every required bucket, and at least 100 in total. These are proposed
+V1 floors; a suite can require more. `high_confidence` begins around 400
+independent contexts and also has suite-declared per-bucket floors. `below_gate`
+means the upper interval is below the suite's qualification floor; `uncertain`
+means the interval crosses it.
+
+Heart Score has an independent live scorecard and maturity state using closed
+presentation windows, unique-principal/message floors, common support, weight
+stability, and effective sample size. A model may therefore have a ranked gate
+funnel while its Heart Score remains provisional, or vice versa.
+
+The Full Catalog view returns one row per catalog entry. Comparable track views
+return one row per unique evaluation profile with `requested_aliases[]`, so
+aliases never duplicate a rank. The UI may derive one concise badge using a
+documented row-type-specific priority order, while details and the API expose
+every applicable axis. A retired catalog alias may therefore link to a profile
+whose scorecard remains high-confidence, below-gate, and stale without assigning
+catalog lifecycle to the profile itself.
+
+Repeated generations of one context measure stability but do not pretend to be
+independent contexts. Rank bands come from paired, context-level difference
+intervals (or versioned posterior rank probabilities) on the shared cases and
+a predeclared practical-equivalence margin; simple overlap of two marginal
+intervals is not a significance test. A public winner claim across many models
+also requires a confirmatory holdout and versioned multiple-comparison control,
+such as a simultaneous cluster bootstrap or Holm-adjusted paired tests.
+
+### Lab versus live
+
+Never pool these sources:
+
+- **Lab**: every model sees the same frozen cases, randomized order, declared
+  sampling, direct assignment, and budget. This is the public comparison.
+- **Shadow**: production-shaped frozen public contexts, never published or
+  allowed to mutate the world. Use balanced/random assignment.
+- **Live**: operational evidence from routed world traffic. It is selected by
+  prior gate evidence, affinity, novelty, endpoint health, cost, and latency.
+  `<3` Heart Score is the highlighted live voice rank only while
+  `heart-score-v1` (or a successor named in the response) is active. There is no
+  official live "Best gate" sort, and no other comparative winner badge unless
+  its own named, versioned propensity-adjusted estimator is active.
+  Activation requires randomized traffic or demonstrated common support,
+  bounded/stable weights, and a declared effective-sample-size floor; merely
+  logging propensity is insufficient. Otherwise show live data as descriptive
+  per-model observability only.
+
+## Evaluation corpus and campaign
+
+The permanent corpus described in `AI.md` becomes an immutable suite manifest.
+At minimum it covers:
+
+- concise grounded prose, emoji-only, emote-only, and raw speech;
+- empty, ordinary, crowded, and long-but-bounded contexts;
+- direct reaction, gift/trade, relationship, danger, and banter;
+- prompt injection and requests for system, policy, tool, or model text;
+- invented speakers, looping tokens, repeated n-grams, unfinished output,
+  length exhaustion, wrong speech mode, and inaccessible emoji;
+- absent anchors, subject drift, exact/near-duplicate recent lines, false
+  action claims, and scenery agency;
+- multilingual text, Unicode punctuation, and hidden control characters;
+- valid/invalid planner schemas, stale candidates, illegal targets, and
+  provider-offline behavior; and
+- counterfactual grounding cases so a model cannot pass merely by front-loading
+  a room or actor name.
+
+Keep whole room/episode/context clusters in one split. Publish a development
+set, keep a rotating adversarial holdout private, and prevent leaderboard
+holdouts from entering training exports.
+
+Every campaign pins:
+
+- catalog and operator registry snapshots;
+- capability and feature;
+- corpus/suite and case versions;
+- prompt, adapter, gate, and sampling versions;
+- contexts, repeats, randomization, timeout, retry, and concurrency policy;
+- spend ceiling and cost source;
+- eligibility rules and qualification thresholds; and
+- retention and human-review policy.
+
+The evaluator uses the production gateway and exact production gate inside the
+existing single-writer architecture. Production turns always outrank shadow
+work. A separate uncoordinated SQLite writer is not allowed.
+
+Rejected production bytes currently retain only hashes and receipts. They
+cannot later be human-adjudicated. Gate false-accept/false-reject audits
+therefore use a dedicated access-controlled eval harness with short-lived,
+sealed candidate storage; after review, retain labels and hashes, not rejected
+text. Never place a player-sensitive production context in that review corpus.
+
+## `/leaderboard` product design
+
+`/leaderboard` is a public, standalone V2 meta page, following the same static
+HTML + Axum pattern as `/moderation`. It is not part of the in-world transcript
+and does not expose a model badge on each message.
+
+Keep the implementation boundary explicit: `leaderboard.rs` owns handlers,
+query types, aggregate reads, and cache metadata; `leaderboard.html` owns the
+standalone page; `routes.rs` only registers the routes. Do not add aggregation
+or page handlers to the already oversized `main.rs`.
+
+### Header and controls
+
+- Title: **OpenRouter models in CosyWorld**
+- Catalog snapshot, eval suite, prompt/adapter profile, gate version, and last
+  aggregation time
+- Track tabs: `World voice`, `Raw voice`, `Planner JSON`, `World content`,
+  `Images`, `Full catalog`
+- Source toggle: `Overview`, `Lab evals`, and `Live world`; voice defaults to
+  Overview, which places labelled live hearts beside labelled lab gate evidence
+  without pooling them into one number
+- Candidate sorts, exposed only when valid for the active track/source:
+  `Best <3 Heart Score`, `Best 1st try`, `Best within 3`, `Lowest fail`,
+  `Most reliable`, `Fastest`, `Cheapest pass`, `Most tested`
+- Search and filters for publisher/family, status, feature, speech mode,
+  capability, minimum sample, privacy/ZDR eligibility, modality, structured
+  output, price, active/retired snapshot, adapter, prompt, and gate version
+
+Controls are track/source-aware rather than universal:
+
+| View | Official comparison | Preference columns | Disabled examples |
+| --- | --- | --- | --- |
+| Voice/raw overview | `<3` Heart Score when its live estimator is rankable; lab 1st/2nd/3rd/fail funnel beside it | Direct-input and organic-AI signals remain separate | Raw-heart ranking and live "Best gate" |
+| Lab voice/raw | 1st/2nd/3rd/fail gate funnel, Cosy Gate Score, and reviewed quality | Blinded review only, unless the lab explicitly collected reactions | Natural-world hearts and live-window filters |
+| Live voice/raw | `<3` Heart Score only while a named valid estimator is active; otherwise no ordinal rank | Direct-input and organic-AI hearts, opportunity-normalized and separated | "Best gate" always; Heart Score sort while the estimator is provisional/inactive |
+| Lab planner/content | Task accuracy, gate score, reliability, cost | None by default | `<3` Heart Score |
+| Lab images | Image gate, blinded preference, reliability, cost | Dedicated image review only | Message-heart metrics in V1 |
+| Full catalog | Coverage/search only | None | Rank, gate, cost/pass, and Heart Score sorts |
+
+Invalid columns, filters, and sorts are hidden or disabled with an explanation.
+The default table stays compact; failure histograms and advanced profile facts
+live in the expandable row/detail view.
+`Best <3 Heart Score` orders by `heart_score`, never raw heart count. Gate sorts
+use the declared exact or cumulative attempt fields, not a visually inferred
+stacked-bar width.
+
+### Main table/card
+
+Every row has a small common shell; track/source schemas supply the performance
+fields rather than forcing voice columns onto every capability.
+
+| Column | Content |
+| --- | --- |
+| Rank/state | Ordinal only inside one comparable track; otherwise a provisional/block reason. |
+| Model | Requested identity, concrete resolved identity/revision, provider, family. |
+| Primary result | Track-specific score/rate with interval, denominator, and coverage. |
+| Gate attempts | Approved 1st/2nd/3rd/fail stacked bar on generation tracks, with cumulative approval@1/@2/@3 in details. |
+| Failure note | Dominant stable rejection code and link to the full histogram. |
+| Reliability | Completion, timeout, rate-limit, and invalid-response rates. |
+| Speed | Candidate and time-to-certified p50/p95. |
+| Cost | Actual/estimated badge plus cost per request and the track's named usable outcome. |
+| Preference | Only the valid reviewed/direct-input/organic-AI/jury fields for this view, never a merged rate. |
+| Freshness | Last evaluated, profile/suite version, contexts and repeats. |
+
+The concrete schemas and allowed performance sorts are:
+
+| View | Primary/supporting fields | Allowed performance sorts |
+| --- | --- | --- |
+| Voice/raw overview | Live `<3` Heart Score, raw eligible heart/presentation counts, lab 1st/2nd/3rd/fail gate funnel | Heart Score when rankable, reliability, cost/certified, tested; never raw hearts |
+| Lab voice/raw | 1st/2nd/3rd/fail gate funnel, cumulative approval@1/@2/@3, `cosy_gate_score`, p50/p95, reviewed quality, failure histogram | Approval@1 or @3, gate score, reviewed quality when mature, reliability, latency, cost/certified, tested |
+| Lab planner | 1st/2nd/3rd/fail valid-output funnel; independently labelled task accuracy when available; legal/stale/illegal diagnostics | Approval@1/@3, task accuracy only on labelled suites, legal-output rate, reliability, latency, cost/legal or cost/correct, tested |
+| Lab content | 1st/2nd/3rd/fail compiler-valid funnel, independently labelled fact accuracy when available, gate diagnostics | Approval@1/@3, validity, task accuracy only on labelled suites, reliability, latency, cost/valid, tested |
+| Lab images | 1st/2nd/3rd/fail image-gate funnel, blinded preference, policy-audit status | Approval@1/@3, blinded preference when mature, reliability, latency, cost/certified, tested |
+| Live voice/raw | `<3` Heart Score plus raw eligible count/denominator, descriptive certified/published yield, reliability, latency/cost, guest direct-input and organic-AI rates | Heart Score only while its named estimator is active; other fields require their own estimator |
+| Full catalog | Entry eligibility/reasons, lifecycle, modalities/capabilities, privacy policy, catalog price facts | Model/publisher, catalog facts, or freshness only; never performance/cost-per-success |
+
+A compact row might read:
+
+```text
+<3 Heart Score 6.8  ·  observed 8.1/100  ·  ♥147 / 1,810 views
+Gate: 1st 71%  |  2nd 13%  |  3rd 5%  |  fail 11%
+```
+
+The model detail view shows score history, scenario heatmap, per-check
+histogram, reliability funnel, latency/cost distributions, direct-input versus AI
+preference, sample coverage, and full attribution/version facts. It never
+exposes rejected output, hidden prompts, API error bodies, reactor identity, or
+player-sensitive context.
+
+### Public API
+
+Recommended read surfaces:
+
+```text
+GET /leaderboard
+GET /leaderboard/data?track=voice_prose&source=overview&sort=heart_score&direction=desc&limit=50&cursor=...
+GET /leaderboard/data?track=voice_prose&source=lab&sort=approval_at_1&direction=desc&limit=50&cursor=...
+GET /leaderboard/model?catalog_entry_id=...&evaluation_profile_id=...
+```
+
+Public reads use cached, paginated scorecards, not live scans of JSON receipts.
+Raw run control, adjudication, excluded-heart audit, and attempt inspection
+remain protected moderation/operator surfaces.
+
+The data query uses closed enums and supports `q`, state-axis filters, catalog
+snapshot, scorecard/aggregation version, cursor, and a bounded `limit`.
+Responses declare `row_population: catalog_entry | evaluation_profile` and
+include totals and disjoint coverage counts for exactly that population,
+`next_cursor`, catalog/profile/scorecard versions, aggregation time, active
+estimator, and source/track-valid sorts. `catalog_total` is additionally
+reported as snapshot metadata but is never confused with the number of unique
+ranked profiles. Profile rows include `requested_aliases[]`; catalog-entry rows
+include zero or more linked profile IDs. Score payloads expose the estimator's
+named fields, including `gate_rate_p05`, `gate_rate_p50`, `gate_rate_p95`, and
+`cosy_gate_score` when applicable. Voice overview rows contain separately
+versioned `heart_scorecard` and `gate_scorecard` objects. The former exposes
+`heart_score`, `heart_rate_p05/p50/p95`, `active_heart_count`, and
+`eligible_closed_presentation_count`; the latter exposes
+`approved_on_1/2/3_rate`, `approval_at_1/2/3`, `failed_after_3_rate`, and the
+content/provider/mixed failure breakdown. The four exact attempt shares must sum
+to one within deterministic rounding tolerance.
+
+Stable `ETag`/`If-None-Match` semantics key the full query and aggregate version.
+Model history uses stable catalog entry, evaluation profile, and scorecard
+identities; an unevaluated entry never needs an operator run ID merely to have a
+detail page.
+
+## `<3` message hearts
+
+Internally name the feature `message_heart`. CosyWorld already uses "card
+reaction" for generated follow-up speech, so a generic `reaction` name would be
+ambiguous.
+
+### Attribution has two independent axes
+
+For every heart, preserve both:
+
+1. **Target origin**: `direct_input_publication` or `server_ai_publication`. The
+   decisive AI link is the target's immutable `AiPublicationReceipt`, not actor
+   kind or current control mode. AI proxy speech may be emitted for an otherwise
+   directly controlled avatar.
+2. **Reactor origin**: `direct_input_account`, `direct_input_guest`, or
+   `server_ai_organic`. Record the reactor's control mode and transport at
+   reaction time as additional provenance, but never accept origin from a
+   client payload. Off-world jury votes are eval records, not social hearts.
+
+Controller modes can change. Snapshot the target control mode at publication
+and reactor control mode at reaction time; do not derive either from current
+actor state during aggregation. These labels describe observable authenticated
+routes. Actor-session ownership, an account cookie, or a passkey cannot prove
+that a unique unaided human made the judgement; the UI may say “people,” but
+methodology and exports use the precise cohort names.
+
+### UX
+
+- Render a subtle outline heart/`<3` button beneath every eligible committed
+  message. Filled state means the current viewer has hearted it.
+- Show a compact total such as `♥ 4`. Accessible detail says, for example,
+  "3 people and 1 resident hearted this message."
+- Use a real button with `aria-pressed`, keyboard focus, and dynamic
+  "Heart this message" / "Remove heart" labels.
+- Keep the zero-count button discoverable on touch devices; it cannot be
+  hover-only.
+- Optimistically set the requested active state and roll back if validation
+  rejects it. The request says `active: true|false`; it is never a non-idempotent
+  toggle.
+- Do not show account/wallet identities or a reactor-name list. Avoid heart
+  notifications, achievements, streaks, or popularity treatment.
+- Exact duplicate model outputs with distinct event/publication identities
+  remain separately reactable. The browser must not collapse them into one
+  mutable row once hearts ship.
+
+### Eligibility and permissions
+
+Direct-input heart requests require the same actor-session ownership boundary
+as direct speech. Account identity and the server-issued browser/CLI/agent
+credential class are authenticated independently from actor ownership; neither
+origin nor transport is accepted from the payload.
+
+For `active: true`, the server validates:
+
+- active, unsuspended direct control for the direct-input route;
+- a successful supported `message.created` target in the same world/epoch;
+- an accepted presentation receipt for that exact target/hash, principal,
+  transport, and reaction window in the reactor's allowed room context;
+- no self-heart by either actor identity or publication-time scoped account
+  principal, preventing same-account reactions through a second avatar;
+- no block or moderation restriction between actors;
+- one active heart per scoped principal and target; and
+- idempotency and rate limits across retries, tabs, avatars, IP, and account.
+
+For `active: false`, the stored canonical principal (or its authorized erasure
+workflow) needs only the exact target and authentication. Removal remains
+available after leaving the room, window expiry, a later block, or suspension;
+it never requires a fresh presentation receipt. The metric uses the eligible
+original opportunity and withdrawal-adjusted state at its aggregation cutoff,
+so a later removal actually withdraws the label.
+
+Guest players may use the friendly interaction. Their hearts are displayed and
+reported separately; account principals are deduplicated across avatars, and
+browser-direct evidence is not pooled with CLI/agent automation. Current-state
+uniqueness is enforced by both canonical principal and reactor-actor binding.
+When a guest becomes an authenticated account, one transaction appends a
+principal-merge adjudication and merges/reclassifies any guest heart on the same
+actor/target; it cannot produce a second count, and later removal resolves the
+old guest alias to the canonical account subject.
+
+AI hearts never use the public direct-input endpoint. A bounded durable actor
+job may ask at most one eligible, co-present inference-controlled resident per
+message for the strict result:
+
+```json
+{ "reaction": "heart" }
+```
+
+or:
+
+```json
+{ "reaction": "none" }
+```
+
+Every scheduled organic-AI decision gets a durable row, including `scheduled`,
+`started`, `completed_heart`, `completed_none`, `provider_failed`, `canceled`,
+or `excluded`. The row binds its observation receipt, evaluator and producer
+attribution/family, prompt/adapter/schema versions, hashes, and eligibility.
+Only eligible completed-heart and completed-none decisions form the organic-AI
+conditional rate. The end-to-end yield retains every eligible scheduled
+opportunity, including failures/cancellations, and decision reliability is
+reported separately.
+
+The job uses stable rotation/attention and daily spend limits, cannot choose
+the target's author, cannot schedule another heart job, and stores the deciding
+model's resolved attribution. No free-form rationale becomes public. A
+separate blinded AI-jury source sees public scene context and message text but
+not the producer model; same-model and same-family votes are excluded from the
+peer metric. Public jury comparisons use a fixed common panel where possible.
+If producer-family exclusion changes the panel, a versioned judge-effect model
+must be calibrated on overlapping assignments; withhold the comparison when
+the overlap graph is too sparse. Jury votes never enter visible resident counts
+or `message_heart_state`. V1 jury processing is limited to server-AI-produced
+targets and the target plus sanitized, non-user-authored world facts. If any
+direct-input text would enter the target or scene context, evaluation through
+extra providers requires an explicit disclosure/consent policy and pinned
+privacy/ZDR-eligible endpoints.
+
+### Persistence and replay
+
+Hearts use a world/epoch-scoped, append-only **social log** with its own
+monotonic `reaction_seq`, written by the same canonical orchestrator/SQLite
+writer. They do not use `JournalRecord` or `world_events`. A world event would
+advance `world.next_event_seq`, churn global `state_revision`, rebind offers,
+move canonical cursors, and affect event-distance diagnostics even without
+advancing `world.tick`; that is not gameplay-neutral.
+
+An actual active-state transition appends one immutable social event and updates
+the current-state projection in one transaction. Asking for the already-current
+state is a successful no-op even with a new idempotency key and appends nothing.
+A dedicated `reaction` SSE message carries `reaction_seq` in its data without
+consuming the canonical world-event SSE ID.
+
+Initial load and reconnect first fetch an authenticated batch snapshot of every
+authorized visible target, aggregate counts, this principal's active states, and
+`through_reaction_seq`. The client then opens the separate reaction stream with
+`after_reaction_seq=through_reaction_seq`; the server replays every authorized
+delta after that cursor before live fanout. The stream may use `reaction_seq` as
+its own SSE `id` without consuming the canonical world-event SSE ID. If the
+cursor predates the social compaction floor, the server returns
+`snapshot_required` and the client restarts from a fresh snapshot.
+
+Both replay and live fanout apply the same current target/location authorization
+per connection. A shared delta contains only authorized aggregate counts and its
+monotonic `reaction_seq`; viewer-specific active state appears only in the
+authenticated snapshot and action response. Sequence jumps are valid because
+unauthorized deltas are filtered. After replay, an empty `replay_complete`
+watermark advances the opaque authenticated cursor without revealing filtered
+targets; clients ignore older/duplicate deltas and treat only an explicit
+`snapshot_required` response as a compaction gap. This closes the
+snapshot/subscribe race without leaking gated or off-room reaction content.
+
+Conceptual append-only record:
+
+```text
+message_heart_events
+- reaction_seq, event_id, and idempotency_key
+- world_id, world_epoch
+- target_message_event_seq, target_content_id, target_output_hash
+- target_actor_id, target_control_mode_at_publish
+- target_author_principal_ref nullable
+- target_origin: direct_input_publication | server_ai_publication
+- target_publication_id, target_candidate_id nullable
+- reactor_actor_ref, reactor_control_mode_at_reaction, reactor_transport
+- reactor_origin: direct_input_account | direct_input_guest | server_ai_organic
+- reactor_principal_ref
+- presentation_or_observation_receipt_id nullable; required for add
+- origin_ai_decision_id nullable
+- operation: add | remove
+- observed_through_seq, location_id
+- created_at_ms
+```
+
+Maintain `message_heart_state` keyed by world/epoch/target/canonical subject for
+fast current counts, with an additional unique target/reactor-actor binding and
+versioned guest-to-account alias resolution. An immutable
+`message_reaction_targets` index covers every
+eligible committed message and contains its publication-time author binding;
+for server-AI targets it also holds publication/candidate IDs and resolved
+producer attribution. Store scoped pseudonyms, hashes, and IDs, not another
+copy of message prose or prompts.
+
+The social write path never enters prose transcripts, room memory, resident
+observations/prompts, story metrics, relationship logic, world clocks, action
+journal, or rewards. The AI actor job may propose a heart, but only the bounded
+server validator can append the social event.
+
+The canonical writer records the target-index outbox fact with every eligible
+message commit; its durable projection is required before world-journal
+compaction can advance past that message. The journal alone is not a permanent
+rebuild source because CosyWorld compacts checkpointed prefixes. The social log
+therefore has its own durable snapshot and compaction floor, and compaction
+requires both the target index and heart-state projection to be caught up. A
+downstream scorecard failure never blocks gameplay; affected evidence stays
+excluded until deterministic repair catches up.
+
+Suggested write surfaces:
+
+```text
+PUT  /messages/{event_seq}/heart  { "world_id": "...", "world_epoch": 1,
+                                    "observed_through_seq": 123,
+                                    "presentation_receipt_id": "...",
+                                    "active": true|false,
+                                    "idempotency_key": "..." }
+POST /messages/presentations      batched visible-message receipts
+GET  /message-hearts/state?world_id=...&world_epoch=...
+                                 authenticated visible-target snapshot
+GET  /message-hearts/stream?world_id=...&world_epoch=...
+                                 &after_reaction_seq=...
+                                 authorized replay then live SSE
+```
+
+`presentation_receipt_id` is required for `active: true` and omitted for an
+authorized `active: false` withdrawal.
+
+The authenticated snapshot/action response may contain:
+
+```json
+{
+  "reaction_seq": 45,
+  "message_event_seq": 123,
+  "account_direct_count": 2,
+  "guest_direct_count": 1,
+  "organic_ai_count": 1,
+  "viewer_active": true
+}
+```
+
+The authorized SSE delta uses the same fields except `viewer_active`. AI-jury
+votes and deterministic system judgements never appear in these social counts.
+
+### Privacy, moderation, and erasure
+
+Social and evaluation tables use purpose-scoped, one-way principal and actor
+references. Raw account, wallet, session, cookie, IP, and passkey material lives
+only in the existing access-controlled identity/abuse systems under a shorter
+retention policy; it is never copied into the social log or public scorecard.
+The reaction/eval policy version pins retention for presentation receipts,
+social events, AI decisions, adjudications, and aggregates, with no indefinite
+default.
+
+Later suspension, brigade detection, target invalidation, consent withdrawal,
+or erasure is represented by an append-only `message_heart_adjudications` event
+with an effective version, rather than mutating the original heart. It removes
+affected rows from current social counts and model aggregates on rebuild. Any
+adjudication or principal merge that changes visible projection state also
+advances `reaction_seq` and fans out the resulting aggregate delta. Target
+deletion removes all of that target's visible hearts; a reactor's withdrawal or
+erasure removes that reactor's active hearts. A pairwise block prevents future
+reactions but does not retroactively reveal or rewrite which past heart caused a
+count. Subject-link deletion or cryptographic unlinking makes retained audit
+facts no longer resolvable to an account, and every prior export receives a
+deletion manifest/tombstone.
+
+Counts are social disclosure, not anonymity: in a tiny room, another resident
+may infer who reacted even without a name list. The UI and policy must say this
+plainly; any product promise of anonymity requires delayed or k-thresholded
+counts rather than exact realtime totals.
+
+### Abuse resistance
+
+- One active heart per principal/message and no author self-heart.
+- Add/remove is idempotent; a removed heart withdraws the label.
+- Cap additions per actor/account/minute/day. For model metrics, preselect
+  eligible opportunities before observing the outcome or apply the same
+  normalized principal/day weight to numerator and denominator; never discard
+  only a later heart because another producer model happened to be seen first.
+- Detect bursts, brigades, reciprocal rings, explicit heart solicitation, and
+  anomalous actor/model pairs. Apply rate limits and anomaly checks to accepted
+  presentation receipts as well as heart writes.
+- Exclude suspended principals, deleted/moderation-invalidated targets, test
+  worlds, and policy-invalid rows from scoring while retaining reason-coded
+  audit evidence.
+- Use scoped pseudonymous principal references; never expose account, wallet,
+  IP, or reactor lists on the leaderboard.
+- Direct-input and AI cohorts remain separate. AI hearts cannot raise the
+  primary account-browser direct-input rate or Cosy Gate Score.
+- Hearts confer no player/model reward and do not affect live model routing in
+  V1. A later routing experiment must be explicit, versioned, randomized, and
+  reversible.
+
+## RLF semantics and export
+
+A heart means "this visible line delighted me"—clever, warm, funny, apt, or
+otherwise good. It does not mean the line is factually accurate, gate-safe, or
+better than an unseen alternative.
+
+Report at least:
+
+```text
+account browser-direct heart action rate
+    = eligible closed-window principal-message opportunities whose
+      withdrawal-adjusted heart is active at the aggregation cutoff
+      / eligible closed-window presentation opportunities
+      among gate-passing displayed outputs
+```
+
+Natural-world hearts are confounded by character, prompt, room, position,
+traffic, and router selection. They support product diagnostics and weak
+positive labels, not an unqualified causal claim about the base model.
+Likewise, do not multiply lab publishable yield by a live heart rate and label
+the product "end-to-end delight": the factors come from different target
+distributions. Estimate an end-to-end heart yield directly in one randomized
+target population, or standardize/reweight both factors to the same declared
+context and exposure distribution. Without that support, show the product only
+as a non-comparable descriptive hybrid.
+
+Training/export rules:
+
+- account browser-direct hearts on server-AI publications are the primary
+  weak-positive label, while acknowledging residual automation;
+- direct-input hearts on direct-input publications remain community UX, not
+  model-training examples;
+- organic-AI hearts and AI-jury votes are teacher/judge telemetry and are never
+  silently mixed with direct-input evidence;
+- no-heart is censored, not a negative;
+- a removed heart withdraws the label;
+- construct a preference pair only when the same eligible rater actually saw
+  comparable alternatives and selected one;
+- keep leaderboard holdouts out of training;
+- include dataset, consent/disclosure, sanitization, deletion, provenance, and
+  retention versions in every export manifest; and
+- default to aggregate evaluation until an explicit training-data policy is
+  approved.
+
+## Storage and aggregation model
+
+Normalized tables should make public reads cheap without turning aggregates
+into authority:
+
+```text
+model_catalog_snapshots
+model_catalog_entries
+model_alias_resolutions
+model_eval_suites
+model_eval_runs
+model_eval_cases
+model_eval_attempts
+model_scorecards
+message_reaction_targets
+message_presentation_receipts
+message_heart_events
+message_heart_adjudications
+message_heart_state
+message_ai_heart_decisions
+social_log_snapshots
+```
+
+`model_catalog_entries` is keyed by catalog snapshot and requested model ID. It
+stores normalized modalities/capabilities, policy eligibility and reason codes,
+price facts, and current/retired state. `model_alias_resolutions` links each
+entry to the concrete profile identities observed during a versioned run. This
+host-level catalog import is immutable and does not depend on a particular
+worldpack being mounted.
+
+`model_eval_attempts` stores run/suite/case/source, requested and resolved
+identity, catalog snapshot, capability/feature/mode, adapter/prompt/gate
+versions, provider and gate dispositions, check codes, assignment propensity,
+queue/candidate/total latency, attempts, tokens, actual/estimated cost, output
+hash, and cancellation/censoring reason. It can reference the existing
+publication `candidate_id` instead of duplicating a receipt.
+
+`model_scorecards` is a versioned materialized aggregate. Rebuild it whenever
+an attempt, adjudication, valid presentation, active heart, exclusion, or suite
+status changes. `message_ai_heart_decisions` retains both positive and none/error
+outcomes so organic-AI preference and evaluator reliability have auditable
+denominators. Public requests never join raw journal JSON on demand.
+
+Imported registry `gate_history` must carry immutable source IDs. Do not add an
+imported count to local evidence again after restart or catalog refresh.
+
+## Delivery phases
+
+### Phase 0 — evidence integrity
+
+- Add gate/prompt versioning to receipts and normalized evidence.
+- Add provider result, actual/estimated cost, assignment propensity, and eval
+  campaign/case identities.
+- Add immutable message-publication linkage and producer-origin projection.
+- Build deterministic backfill and aggregate-rebuild commands.
+
+### Phase 1 — lab scorecards
+
+- Freeze `voice-prose-v1`, its identical three-attempt retry policy, and the
+  first private adversarial holdout.
+- Fill each new catalog snapshot progressively under strict global/per-model
+  budgets: capability/policy audit with no call; a small balanced transport and
+  gate smoke; a 40-context provisional run; then the per-bucket/100-context
+  ranked and high-confidence thresholds in fair round-robin batches.
+- Refresh changed/new profiles first without making completion of the entire
+  catalog an atomic launch dependency. Honest `not_evaluated`, `smoke`, and
+  `provisional` rows remain public while the queue fills.
+- Validate score/interval/coverage calculations and the mutually exclusive
+  1st/2nd/3rd/fail funnel against hand-built fixtures.
+- Keep the page operator-only until breadth and data-quality checks pass.
+
+### Phase 2 — public `/leaderboard`
+
+- Ship the standalone page, cached JSON, full-catalog statuses, track/source
+  isolation, labelled Overview, gate funnel, row details, interval bands, and
+  methodology copy. Heart Score remains `collecting` until Phase 3 evidence is
+  mature.
+- Publish no raw prompts, rejected candidates, provider bodies, or personal
+  context.
+
+### Phase 3 — direct-input `<3`
+
+- Add publication mapping, set-active social-log write, replay-safe projection,
+  accessible browser/CLI/agent controls, authenticated snapshots, multi-client
+  fanout, and direct-input/resident count split.
+- Add server-accepted foreground presentation receipts before showing a heart
+  rate, and keep browser, guest, and CLI/agent cohorts separate.
+- Build `heart-score-v1`; show raw hearts immediately, but enable Heart Score
+  rank only after closed-window, common-support, weight, and ESS gates pass.
+
+### Phase 4 — AI `<3` and RLF export
+
+- Add the bounded organic resident job and blinded multi-family AI jury.
+- Persist every AI decision disposition and prove self/same-family exclusions,
+  jury/social separation, and strict attribution.
+- Add consented, versioned, deletion-aware aggregate/dataset export.
+- Keep preference out of routing until a separate controlled experiment.
+
+## Acceptance gates
+
+### Evaluation and leaderboard
+
+- Every current catalog model is searchable with its catalog-owned axes; every
+  linked scorecard exposes its profile-owned axes and one row-appropriate badge.
+- Full Catalog has one row per catalog entry; ranked tracks have one row per
+  evaluation profile with aliases attached, never duplicate ranks.
+- Every ranked row is scoped to one comparable, fully versioned profile.
+- Provider failure never becomes content failure; certified hedge losers count
+  as content passes.
+- Requested aliases are credited to the actual resolved model/revision.
+- Required scenario macro-averaging, intervals, rank bands, and sample counts
+  match deterministic fixtures; `cosy_gate_score` equals `100 × gate_rate_p05`.
+- Each gate case appears exactly once in approved-on-1st, 2nd, 3rd, or
+  failed-after-3; shares sum to 100%, cumulative approval is monotonic, and
+  failure detail preserves content/provider/mixed causes.
+- `<3` Heart Score equals `100 × heart_rate_p05`, is always accompanied by raw
+  eligible hearts/presentations, and raw heart count is never the rank key.
+- Each track/source exposes only its declared columns and sorts, with the named
+  usable outcome in every cost denominator.
+- Lab, shadow, and live evidence are never silently pooled.
+- Live Heart Score receives an ordinal rank only when the response names an
+  active versioned heart estimator that passes support/ESS gates. Live gate
+  traffic receives no official comparative winner without its own estimator.
+- Raw and prose gates are never pooled.
+- Gate failures receive no partial score and can never publish because a model
+  ranks highly.
+- No public endpoint leaks rejected bytes, hidden prompts, provider bodies,
+  player-sensitive context, or reactor identities.
+- Removal, new model revision, prompt/adapter/gate change, and catalog refresh
+  produce stale/new scorecards rather than rewriting history.
+
+### Message hearts
+
+- A heart binds to exact `(world_id, world_epoch, message_event_seq,
+  output_hash)` and, for AI targets, the immutable publication receipt.
+- Controller handoff and AI proxy speech cannot change historical target or
+  reactor attribution.
+- Direct-input add/remove requests are idempotent across retry and two browser
+  tabs; a requested state that is already current appends no event.
+- Social-log compaction/replay, restart, reconnect, and SSE converge on one
+  active state and correct direct-input/organic-AI counts. Snapshot responses
+  include viewer state; broadcast deltas do not.
+- An actual add/remove transition leaves world tick, `world.next_event_seq`,
+  global `state_revision`, action-journal sequence, offer identities, canonical
+  SSE cursor, and gameplay RNG seed unchanged; only `reaction_seq` advances. An
+  idempotent no-op advances nothing.
+- Off-room, unseen, blocked, suspended, self, deleted, stale-world, and
+  unsupported targets fail with stable codes.
+- Same-account self-hearts fail across avatars using publication-time ownership.
+- Server AI cannot impersonate a direct-input route, heart its own output, or
+  generate a heart cascade; organic `none` and failures remain auditable.
+- AI-jury votes never alter visible message counts, and direct-input speech is
+  not sent to an off-world jury without explicit disclosure/consent policy.
+- Erasure/adjudication removes evidence from current counts, scorecards, and
+  deletion-aware exports without rewriting the append-only source event.
+- Duplicate text with distinct publication identities remains separately
+  reactable.
+- The control is keyboard/touch accessible and exposes `aria-pressed`.
+- Property tests prove hearts change no tick, turn, Orb, advancement, Bond,
+  memory, prompt, dialogue scheduling, selection evidence, game reward, or
+  story/retention player score.
+
+## Explicit non-goals
+
+- Trusting or permanently promoting a model past per-output gates.
+- One universal score across incompatible capabilities or gate profiles.
+- Ranking players, avatars, authors, or heart givers.
+- Paying, rewarding, or progressing anyone for hearts.
+- Treating an unviewed or unhearted line as disliked.
+- Training on natural-world hearts without disclosure, consent, provenance,
+  deletion, and bias controls.
+- Showing the generating model beside every in-world message.
+- Letting leaderboard or reaction analytics become kernel authority.

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.315"
+version = "0.0.316"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.315"
+version = "0.0.316"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -89,6 +89,7 @@ pub(crate) struct SpeechGateContext {
     pub(crate) generation_key: String,
     pub(crate) speaker_actor_id: u64,
     pub(crate) speaker_name: String,
+    pub(crate) other_speaker_names: Vec<String>,
     pub(crate) mode: SpeechMode,
     pub(crate) max_words: usize,
     pub(crate) anchors: Vec<String>,
@@ -190,7 +191,7 @@ pub(crate) fn certify_speech(
     candidate_text: &str,
     context: SpeechGateContext,
 ) -> Result<CertifiedSpeech, Box<PublicationRejection>> {
-    let text = bounded_normalize(candidate_text);
+    let text = bounded_normalize(candidate_text, &context);
     let candidate_hash = sha256_hex(completion.text.as_bytes());
     let output_hash = sha256_hex(text.as_bytes());
     let generation_id = publication_generation_id(&context, &completion.prompt_version);
@@ -203,7 +204,7 @@ pub(crate) fn certify_speech(
     );
     let publication_id = sha256_hex(format!("{}\0{}", generation_id, output_hash).as_bytes());
 
-    let checks = evaluate_checks(&text, &completion.finish_reason, &context);
+    let checks = evaluate_checks(&text, candidate_text, &completion.finish_reason, &context);
     let prompt_adapter_id = completion
         .model_attribution
         .as_ref()
@@ -283,6 +284,7 @@ pub(crate) fn certified_test_speech(
         generation_key: format!("test:{speaker_actor_id}"),
         speaker_actor_id,
         speaker_name: speaker_name.to_string(),
+        other_speaker_names: Vec::new(),
         mode: SpeechMode::Prose,
         max_words: 80,
         anchors: vec!["Keeper Brass Key".to_string()],
@@ -474,6 +476,7 @@ impl crate::RuntimeWorld {
 
 fn evaluate_checks(
     text: &str,
+    candidate_text: &str,
     finish_reason: &str,
     context: &SpeechGateContext,
 ) -> Vec<PublicationCheck> {
@@ -507,7 +510,7 @@ fn evaluate_checks(
         ),
         (
             PublicationCheckCode::VoiceMultipleSpeakers,
-            raw || !has_multiple_speakers(text, &context.speaker_name),
+            raw || !has_multiple_speakers(candidate_text, context),
         ),
         (
             PublicationCheckCode::VoiceInstructionLeakage,
@@ -577,23 +580,114 @@ fn has_clean_terminal_structure(value: &str) -> bool {
     delimiters.is_empty() && !straight_quote_open && !curly_quote_open
 }
 
-fn bounded_normalize(value: &str) -> String {
-    let trimmed = value.trim();
-    if trimmed.len() >= 2 {
-        let first = trimmed.chars().next();
-        let last = trimmed.chars().last();
+fn bounded_normalize(value: &str, context: &SpeechGateContext) -> String {
+    let normalized = strip_outer_quote_pair(value.trim());
+    if context.mode == SpeechMode::Raw {
+        return normalized;
+    }
+    normalized
+        .lines()
+        .map(str::trim)
+        .map(|line| strip_own_speaker_label(line, &context.speaker_name))
+        .map(|line| strip_outer_quote_pair(line.trim()))
+        .filter(|line| !line.is_empty())
+        .flat_map(|line| {
+            line.split_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn strip_outer_quote_pair(value: &str) -> String {
+    if value.len() >= 2 {
+        let first = value.chars().next();
+        let last = value.chars().last();
         if matches!(
             (first, last),
             (Some('"'), Some('"')) | (Some('“'), Some('”'))
         ) {
-            return trimmed
+            return value
                 .chars()
                 .skip(1)
-                .take(trimmed.chars().count().saturating_sub(2))
-                .collect::<String>();
+                .take(value.chars().count().saturating_sub(2))
+                .collect();
         }
     }
-    trimmed.to_string()
+    value.to_string()
+}
+
+fn strip_own_speaker_label(value: &str, speaker_name: &str) -> String {
+    // Model-backed residents can carry provider-qualified display names such
+    // as `Anthropic: Claude Fable Latest`. Match that exact name before the
+    // generic first-colon parser so punctuation inside the name is harmless.
+    if let Some(rest) = value.strip_prefix(speaker_name) {
+        let rest = strip_leading_speaker_annotation(rest.trim_start());
+        if let Some(speech) = rest.strip_prefix(':') {
+            return speech.trim_start().to_string();
+        }
+    }
+    let Some((label, speech)) = value.split_once(':') else {
+        return value.to_string();
+    };
+    let label = speaker_label_without_annotation(label);
+    if label.contains('\n')
+        || label.contains('\r')
+        || canonical_speaker_label(label) != canonical_speaker_label(speaker_name)
+    {
+        return value.to_string();
+    }
+    speech.trim_start().to_string()
+}
+
+fn strip_leading_speaker_annotation(value: &str) -> &str {
+    let mut value = value.trim_start();
+    loop {
+        let mut after_annotation = None;
+        for (open, close) in [('(', ')'), ('[', ']')] {
+            if let Some(rest) = value.strip_prefix(open) {
+                if let Some((_, after)) = rest.split_once(close) {
+                    after_annotation = Some(after.trim_start());
+                    break;
+                }
+            }
+        }
+        let Some(after) = after_annotation else {
+            return value;
+        };
+        value = after;
+    }
+}
+
+fn speaker_label_without_annotation(value: &str) -> &str {
+    let mut value = value.trim();
+    loop {
+        let mut undecorated = None;
+        for (open, close) in [('(', ')'), ('[', ']')] {
+            if let Some(without_close) = value.strip_suffix(close) {
+                if let Some((label, _)) = without_close.rsplit_once(open) {
+                    let label = label.trim_end();
+                    if !label.is_empty() {
+                        undecorated = Some(label);
+                        break;
+                    }
+                }
+            }
+        }
+        let Some(label) = undecorated else {
+            return value;
+        };
+        value = label;
+    }
+}
+
+fn canonical_speaker_label(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| character.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 fn normalized_words(value: &str) -> Vec<String> {
@@ -646,19 +740,136 @@ fn shares_recent_speaker_phrase(value: &str, recent_shingle_hashes: &[u64]) -> b
         .any(|hash| recent.contains(&hash))
 }
 
-fn has_multiple_speakers(value: &str, speaker_name: &str) -> bool {
-    if value.lines().count() > 1 {
+fn has_multiple_speakers(value: &str, context: &SpeechGateContext) -> bool {
+    let nonempty_lines = value
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let marked_turns = nonempty_lines
+        .iter()
+        .filter(|line| {
+            line.chars()
+                .next()
+                .is_some_and(|character| matches!(character, '"' | '“' | '—' | '–'))
+                || line
+                    .strip_prefix('-')
+                    .is_some_and(|rest| rest.chars().next().is_some_and(char::is_whitespace))
+        })
+        .count();
+    if marked_turns > 1 {
         return true;
     }
-    let _ = speaker_name;
-    value.split_whitespace().any(|token| {
-        let label = token.trim_matches(['"', '\'', '“', '”']);
-        label.ends_with(':')
-            && label
-                .trim_end_matches(':')
-                .chars()
-                .all(|character| character.is_alphanumeric() || character == '_')
-    })
+
+    let speaker = canonical_speaker_label(&context.speaker_name);
+    let other_speakers = context
+        .other_speaker_names
+        .iter()
+        .map(|name| canonical_speaker_label(name))
+        .filter(|name| !name.is_empty() && *name != speaker)
+        .collect::<BTreeSet<_>>();
+    // Remove the one harmless label we know exactly before scanning turn
+    // boundaries. This matters for punctuated names such as `Dr. Rati`: the
+    // period is otherwise indistinguishable from a sentence boundary. A
+    // second same-line label remains in the scan and is rejected below.
+    let label_scan = value
+        .lines()
+        .map(str::trim)
+        .map(|line| strip_own_speaker_label(line, &context.speaker_name))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut own_label_lines = BTreeSet::new();
+    for label in dialogue_boundary_labels(&label_scan) {
+        if label.canonical == speaker {
+            if !label.at_line_start || !own_label_lines.insert(label.line_index) {
+                return true;
+            }
+            continue;
+        }
+        if other_speakers.contains(&label.canonical)
+            || label.name_shaped
+            || matches!(
+                label.canonical.as_str(),
+                "system" | "user" | "assistant" | "narrator" | "developer"
+            )
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[derive(Debug)]
+struct DialogueBoundaryLabel {
+    canonical: String,
+    name_shaped: bool,
+    line_index: usize,
+    at_line_start: bool,
+}
+
+fn dialogue_boundary_labels(value: &str) -> Vec<DialogueBoundaryLabel> {
+    let mut labels = Vec::new();
+    for (colon, character) in value.char_indices() {
+        if character != ':' {
+            continue;
+        }
+        let before = &value[..colon];
+        let start = before
+            .char_indices()
+            .rev()
+            .find_map(|(index, character)| {
+                matches!(
+                    character,
+                    '\n' | '\r' | '.' | '!' | '?' | ';' | '/' | '|' | '—' | '–'
+                )
+                .then_some(index + character.len_utf8())
+            })
+            .unwrap_or(0);
+        let raw_label = before[start..].trim();
+        let speaker_label = speaker_label_without_annotation(raw_label);
+        let canonical = canonical_speaker_label(speaker_label);
+        if !canonical.is_empty() {
+            let line_start = before
+                .char_indices()
+                .rev()
+                .find_map(|(index, character)| {
+                    matches!(character, '\n' | '\r').then_some(index + character.len_utf8())
+                })
+                .unwrap_or(0);
+            labels.push(DialogueBoundaryLabel {
+                canonical,
+                name_shaped: looks_like_speaker_label(speaker_label),
+                line_index: before[..line_start]
+                    .bytes()
+                    .filter(|byte| *byte == b'\n')
+                    .count(),
+                at_line_start: start == line_start,
+            });
+        }
+    }
+    labels
+}
+
+fn looks_like_speaker_label(value: &str) -> bool {
+    // A leading ASCII dash is a common dialogue bullet, not part of the name.
+    // Keep internal hyphens intact for names such as Anne-Marie.
+    let value = value.trim();
+    let value = value
+        .strip_prefix('-')
+        .map(str::trim_start)
+        .unwrap_or(value);
+    let value = value.trim_matches(|character: char| {
+        !character.is_alphanumeric() && !matches!(character, ' ' | '_' | '-' | '\'' | '’')
+    });
+    let words = value.split_whitespace().collect::<Vec<_>>();
+    !words.is_empty()
+        && words.len() <= 4
+        && words.iter().all(|word| {
+            word.chars().next().is_some_and(char::is_uppercase)
+                && word.chars().all(|character| {
+                    character.is_alphanumeric() || matches!(character, '_' | '-' | '\'' | '’')
+                })
+        })
 }
 
 fn contains_instruction_leakage(value: &str) -> bool {
@@ -1044,6 +1255,7 @@ mod tests {
             generation_key: "test-beat-1".to_string(),
             speaker_actor_id: 42,
             speaker_name: "Rati".to_string(),
+            other_speaker_names: vec!["Gust".to_string()],
             mode: SpeechMode::Prose,
             max_words: 8,
             anchors: anchors.to_vec(),
@@ -1274,6 +1486,112 @@ mod tests {
     }
 
     #[test]
+    fn own_speaker_label_and_harmless_wrap_are_normalized() {
+        let raw = "Rati:\nTeapot ready.\nRati: \"I'll pour.\"";
+        let published = "Teapot ready. I'll pour.";
+        let speech = certify_speech(
+            None,
+            completion(raw),
+            raw,
+            context(&["teapot".to_string()], &[]),
+        )
+        .expect("one speaker's harmless formatting certifies");
+
+        assert_eq!(speech.text(), published);
+        assert_eq!(speech.receipt().candidate_hash, sha256_hex(raw.as_bytes()));
+        assert_eq!(
+            speech.receipt().output_hash,
+            sha256_hex(published.as_bytes())
+        );
+    }
+
+    #[test]
+    fn own_speaker_label_with_stage_direction_is_normalized() {
+        let raw = "Rati (smiling): Teapot ready.";
+        let speech = certify_speech(
+            None,
+            completion(raw),
+            raw,
+            context(&["teapot".to_string()], &[]),
+        )
+        .expect("one speaker's stage direction is harmless label formatting");
+
+        assert_eq!(speech.text(), "Teapot ready.");
+    }
+
+    #[test]
+    fn punctuated_own_speaker_label_is_normalized() {
+        let raw = "Dr. Rati: Teapot ready.";
+        let mut gate = context(&["teapot".to_string()], &[]);
+        gate.speaker_name = "Dr. Rati".to_string();
+        let speech = certify_speech(None, completion(raw), raw, gate)
+            .expect("the exact punctuated speaker label is harmless formatting");
+
+        assert_eq!(speech.text(), "Teapot ready.");
+    }
+
+    #[test]
+    fn colon_qualified_own_speaker_label_is_normalized() {
+        let raw = "Anthropic: Claude Fable Latest: Teapot ready.";
+        let mut gate = context(&["teapot".to_string()], &[]);
+        gate.speaker_name = "Anthropic: Claude Fable Latest".to_string();
+        let speech = certify_speech(None, completion(raw), raw, gate)
+            .expect("the exact provider-qualified speaker label is harmless formatting");
+
+        assert_eq!(speech.text(), "Teapot ready.");
+    }
+
+    #[test]
+    fn natural_colon_and_wrapping_do_not_invent_a_second_speaker() {
+        for (raw, published) in [
+            (
+                "One thing: teapot first.\nBiscuits follow.",
+                "One thing: teapot first. Biscuits follow.",
+            ),
+            (
+                "I asked Gust: teapot or biscuits?",
+                "I asked Gust: teapot or biscuits?",
+            ),
+        ] {
+            let speech = certify_speech(
+                None,
+                completion(raw),
+                raw,
+                context(&["teapot".to_string()], &[]),
+            )
+            .expect("ordinary punctuation and wrapping certify");
+            assert_eq!(speech.text(), published);
+        }
+    }
+
+    #[test]
+    fn foreign_labels_and_alternating_turns_still_fail_closed() {
+        let anchors = vec!["teapot".to_string()];
+        for raw in [
+            "Rati: Teapot ready.\nGust: Not yet.",
+            "Teapot ready. Gust: Not yet.",
+            "Rati: Teapot ready; Gust: Not yet.",
+            "Rati: Teapot ready / Gust: Not yet.",
+            "Rati: Teapot ready; Dr. Gust: Not yet.",
+            "Rati: Teapot ready.\nGust (smiling): Not yet.",
+            "Rati: Teapot ready; Gust [quietly]: Not yet.",
+            "Bob (smiling): Teapot ready.",
+            "Bob: Teapot ready.",
+            "- Bob: Teapot ready.",
+            "Rati: Teapot ready; Rati: I'll pour.",
+            "—Teapot ready.\n—Not yet.",
+            "Narrator: Teapot ready.",
+        ] {
+            assert_check_failed(
+                raw,
+                completion(raw),
+                context(&anchors, &[]),
+                PublicationCheckCode::VoiceMultipleSpeakers,
+            );
+        }
+    }
+
+    #[test]
     fn voice_instruction_leakage_check_is_deterministic() {
         let anchors = vec!["teapot".to_string()];
         assert_eq!(
@@ -1410,6 +1728,7 @@ mod tests {
             },
         )
         .expect("raw model identity speech certifies");
+        assert_eq!(speech.text(), text, "raw output keeps its formatting");
         for code in [
             PublicationCheckCode::VoiceMultipleSpeakers,
             PublicationCheckCode::VoiceInstructionLeakage,
@@ -1464,7 +1783,7 @@ mod tests {
     }
 
     #[test]
-    fn normalization_only_removes_outer_space_and_one_quote_pair() {
+    fn normalization_removes_outer_space_and_one_quote_pair() {
         let anchors = vec!["teapot".to_string()];
         let recent = Vec::new();
         let certified = certify_speech(
@@ -1592,6 +1911,7 @@ mod tests {
                 generation_key: "privacy-beat-1".to_string(),
                 speaker_actor_id: 1001,
                 speaker_name: "Rati".to_string(),
+                other_speaker_names: Vec::new(),
                 mode: SpeechMode::Prose,
                 max_words: 20,
                 anchors: vec!["teapot".to_string()],
@@ -1653,6 +1973,7 @@ mod tests {
                 generation_key: format!("replay-beat-{content_id}"),
                 speaker_actor_id: actor_id,
                 speaker_name: "Rati".to_string(),
+                other_speaker_names: Vec::new(),
                 mode: SpeechMode::Prose,
                 max_words: 12,
                 anchors: vec!["teapot".to_string()],

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -1,18 +1,21 @@
 use crate::{
-    ai_context::{PromptBudgetTelemetry, PromptEnvelope},
+    ai_context::{PromptBudgetTelemetry, PromptEnvelope, PromptSegmentKind},
     ai_gateway::{
         request_chat_completion_with_selection, AiCompletion, AiConfig, AiGatewayError,
         ChatCompletionRequest, ModelCapability, PinnedModelSelection,
     },
     ai_publication::{
         append_ai_publication_attempt, certify_speech, publication_generation_id,
-        AiPublicationReceipt, CertifiedSpeech, PublicationRejection, SpeechGateContext,
+        AiPublicationReceipt, CertifiedSpeech, PublicationCheckCode, PublicationRejection,
+        SpeechGateContext, SpeechMode,
     },
 };
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{future::Future, io, path::Path, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeSet, future::Future, io, path::Path, pin::Pin, sync::Arc, time::Duration,
+};
 use tokio::{task::JoinSet, time::Instant};
 
 pub(crate) const VOICE_MAX_ATTEMPTS_ENV: &str = "COSYWORLD_AI_VOICE_MAX_ATTEMPTS";
@@ -26,6 +29,7 @@ pub(crate) const VOICE_EXPLORATION_FLOOR_BPS_ENV: &str = "COSYWORLD_AI_VOICE_EXP
 
 const MAX_VOICE_ATTEMPTS: u8 = 3;
 const MAX_JOB_LEASE_RETRIES: u32 = 1;
+const VOICE_RETRY_FEEDBACK_RESERVE_TOKENS: u32 = 96;
 
 #[derive(Clone, Debug)]
 pub(crate) struct VoiceRoutingConfig {
@@ -192,6 +196,7 @@ pub(crate) struct VoiceSelectionDecision {
 struct PlannedCandidate {
     selection: PinnedModelSelection,
     decision: VoiceSelectionDecision,
+    retry_feedback_cost_microdollars: u64,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -339,7 +344,24 @@ async fn route_certified_voice_with(
     let started = Instant::now();
     let mut rejections = Vec::new();
     let mut provider_failures = 0usize;
-    for batch in planned.chunks(config.voice_routing.hedge_width as usize) {
+    let mut next_candidate = 0usize;
+    let mut first_batch = true;
+    while next_candidate < planned.len() {
+        let remaining_candidates = planned.len() - next_candidate;
+        // Hedges are peers, not retries. Keep one bounded attempt in reserve so
+        // every multi-attempt configuration can act on a publication-gate verdict.
+        let available_to_batch = if first_batch && remaining_candidates > 1 {
+            remaining_candidates - 1
+        } else {
+            remaining_candidates
+        };
+        let batch_width = (config.voice_routing.hedge_width as usize)
+            .min(available_to_batch)
+            .max(1);
+        let batch_end = next_candidate + batch_width;
+        let batch = &planned[next_candidate..batch_end];
+        next_candidate = batch_end;
+        first_batch = false;
         let elapsed = started.elapsed();
         let Some(remaining) = config.voice_routing.latency_ceiling.checked_sub(elapsed) else {
             mark_timed_out_batch(store_path, &generation_id, batch);
@@ -350,7 +372,7 @@ async fn route_certified_voice_with(
         let mut attempts = JoinSet::new();
         for candidate in batch.iter().cloned() {
             let backend = Arc::clone(&backend);
-            let request = request.clone();
+            let request = request_with_retry_feedback(&request, &rejections, &gate);
             attempts.spawn(async move {
                 let result = backend
                     .attempt(candidate.selection.clone(), request, remaining)
@@ -495,6 +517,106 @@ async fn route_certified_voice_with(
     Err(routing_error(code, rejections))
 }
 
+fn request_with_retry_feedback(
+    request: &VoiceAttemptRequest,
+    rejections: &[PublicationRejection],
+    gate: &SpeechGateContext,
+) -> VoiceAttemptRequest {
+    let mut request = request.clone();
+    if let Some(instruction) = retry_instruction(rejections, gate, request.max_tokens) {
+        request.prompt = if gate.mode == SpeechMode::Raw {
+            request
+                .prompt
+                .user(instruction, PromptSegmentKind::Envelope, u8::MAX, true)
+        } else {
+            request.prompt.system(instruction)
+        };
+    }
+    request
+}
+
+fn retry_instruction(
+    rejections: &[PublicationRejection],
+    gate: &SpeechGateContext,
+    max_tokens: u32,
+) -> Option<String> {
+    let failed = rejections
+        .iter()
+        .flat_map(|rejection| rejection.receipt.checks.iter())
+        .filter_map(|check| (!check.passed).then_some(check.code))
+        .collect::<BTreeSet<_>>();
+    if failed.is_empty()
+        || failed
+            .iter()
+            .all(|code| *code == PublicationCheckCode::VoiceEnvelopeInvalid)
+    {
+        return None;
+    }
+
+    let mut clauses = Vec::new();
+    let needs_complete_shape = failed.iter().any(|code| {
+        matches!(
+            code,
+            PublicationCheckCode::VoiceEmpty
+                | PublicationCheckCode::VoiceBudgetExceeded
+                | PublicationCheckCode::VoiceFinishIncomplete
+        )
+    });
+    if needs_complete_shape {
+        clauses.push(match gate.mode {
+            SpeechMode::Prose => {
+                format!("one short complete line · at most {} words", gate.max_words)
+            }
+            SpeechMode::EmojiOnly => "3–6 emoji only".to_string(),
+            SpeechMode::EmoteOnly => {
+                format!("one complete *emote* · at most {} words", gate.max_words)
+            }
+            SpeechMode::Raw => {
+                let conservative_words = gate.max_words.min((max_tokens as usize / 2).clamp(8, 64));
+                format!("one complete response · at most {conservative_words} words")
+            }
+        });
+    }
+    if failed.iter().any(|code| {
+        matches!(
+            code,
+            PublicationCheckCode::VoiceRepeatedNgram | PublicationCheckCode::VoiceRecentDuplicate
+        )
+    }) {
+        clauses.push("fresh wording · no repeated phrase".to_string());
+    }
+    if failed.contains(&PublicationCheckCode::VoiceMultipleSpeakers) {
+        clauses.push("one voice · no speaker labels".to_string());
+    }
+    if failed.contains(&PublicationCheckCode::VoiceInstructionLeakage) {
+        clauses.push("spoken words only · no meta".to_string());
+    }
+    if failed.contains(&PublicationCheckCode::VoiceModeMismatch) && !needs_complete_shape {
+        clauses.push(
+            match gate.mode {
+                SpeechMode::Prose => "spoken prose only",
+                SpeechMode::EmojiOnly => "emoji only",
+                SpeechMode::EmoteOnly => "one emote only",
+                SpeechMode::Raw => "plain response only",
+            }
+            .to_string(),
+        );
+    }
+    if failed.contains(&PublicationCheckCode::VoiceAnchorMissing) {
+        clauses.push("touch something already present".to_string());
+    }
+    if failed.contains(&PublicationCheckCode::VoiceUnsafeTone) {
+        clauses.push("keep it gentle".to_string());
+    }
+    if failed.contains(&PublicationCheckCode::VoiceProposedActionClaim) {
+        clauses.push("intention, not completed action".to_string());
+    }
+    if failed.contains(&PublicationCheckCode::VoiceObjectAgency) {
+        clauses.push("objects don't think or choose".to_string());
+    }
+    (!clauses.is_empty()).then(|| format!("again · {}", clauses.join(" · ")))
+}
+
 fn routing_error(code: &'static str, rejections: Vec<PublicationRejection>) -> VoiceRoutingError {
     VoiceRoutingError { code, rejections }
 }
@@ -633,20 +755,26 @@ fn build_voice_plan(
 
     let mut planned = Vec::new();
     let mut all = Vec::with_capacity(decisions.len());
-    let mut spent = 0u64;
     for (selection, mut decision) in decisions {
         if decision.excluded_reason.is_none() && planned.len() < config.max_attempts as usize {
-            if spent.saturating_add(decision.estimated_cost_microdollars)
+            decision.selected = true;
+            decision.ordinal = planned.len() as u8 + 1;
+            let candidate = PlannedCandidate {
+                retry_feedback_cost_microdollars: estimated_retry_feedback_cost(
+                    selection.candidate().observations().input_cost_per_million,
+                ),
+                selection,
+                decision: decision.clone(),
+            };
+            let mut prospective = planned.clone();
+            prospective.push(candidate.clone());
+            if planned_spend_microdollars(&prospective, config.hedge_width)
                 <= config.spend_ceiling_microdollars
             {
-                spent = spent.saturating_add(decision.estimated_cost_microdollars);
-                decision.selected = true;
-                decision.ordinal = planned.len() as u8 + 1;
-                planned.push(PlannedCandidate {
-                    selection,
-                    decision: decision.clone(),
-                });
+                planned.push(candidate);
             } else {
+                decision.selected = false;
+                decision.ordinal = 0;
                 decision.excluded_reason = Some("spend_ceiling".to_string());
             }
         } else if decision.excluded_reason.is_none() {
@@ -667,20 +795,24 @@ fn build_voice_plan(
         let mut ordinal = planned.len() as u8;
         while planned.len() < config.max_attempts as usize {
             let source = planned[0].clone();
-            let cost = source.decision.estimated_cost_microdollars;
-            if spent.saturating_add(cost) > config.spend_ceiling_microdollars {
-                break;
-            }
-            spent = spent.saturating_add(cost);
             ordinal += 1;
             let mut decision = source.decision.clone();
             decision.selected = true;
             decision.ordinal = ordinal;
             decision.resampled = true;
-            planned.push(PlannedCandidate {
+            let candidate = PlannedCandidate {
                 selection: source.selection.clone(),
                 decision: decision.clone(),
-            });
+                retry_feedback_cost_microdollars: source.retry_feedback_cost_microdollars,
+            };
+            let mut prospective = planned.clone();
+            prospective.push(candidate.clone());
+            if planned_spend_microdollars(&prospective, config.hedge_width)
+                > config.spend_ceiling_microdollars
+            {
+                break;
+            }
+            planned.push(candidate);
             all.push(decision);
         }
     }
@@ -702,6 +834,37 @@ fn estimated_cost(
     (input_rate * input_tokens as f64 + output_rate * request.max_tokens as f64)
         .ceil()
         .max(1.0) as u64
+}
+
+fn estimated_retry_feedback_cost(input_rate: Option<f64>) -> u64 {
+    input_rate
+        .map(|rate| {
+            (rate * VOICE_RETRY_FEEDBACK_RESERVE_TOKENS as f64)
+                .ceil()
+                .max(0.0) as u64
+        })
+        .unwrap_or_default()
+}
+
+fn planned_spend_microdollars(planned: &[PlannedCandidate], hedge_width: u8) -> u64 {
+    let first_batch_width = match planned.len() {
+        0 => 0,
+        1 => 1,
+        len => (hedge_width as usize).min(len - 1).max(1),
+    };
+    planned
+        .iter()
+        .enumerate()
+        .fold(0u64, |spent, (index, candidate)| {
+            let feedback_cost = if index < first_batch_width {
+                0
+            } else {
+                candidate.retry_feedback_cost_microdollars
+            };
+            spent
+                .saturating_add(candidate.decision.estimated_cost_microdollars)
+                .saturating_add(feedback_cost)
+        })
 }
 
 fn stable_affinity(actor_id: u64, family: &str) -> f64 {
@@ -1269,12 +1432,15 @@ mod tests {
     struct MockOutput {
         text: String,
         delay: Duration,
+        finish_reason: String,
     }
 
     #[derive(Clone, Default)]
     struct MockBackend {
         outputs: Arc<StdMutex<BTreeMap<String, VecDeque<MockOutput>>>>,
         calls: Arc<StdMutex<Vec<String>>>,
+        systems: Arc<StdMutex<Vec<String>>>,
+        users: Arc<StdMutex<Vec<String>>>,
     }
 
     impl MockBackend {
@@ -1290,6 +1456,26 @@ mod tests {
                     .push_back(MockOutput {
                         text: text.to_string(),
                         delay: Duration::from_millis(delay_ms),
+                        finish_reason: "stop".to_string(),
+                    });
+            }
+            drop(configured);
+            backend
+        }
+
+        fn with_finished_outputs(
+            outputs: impl IntoIterator<Item = (&'static str, &'static str, &'static str, u64)>,
+        ) -> Self {
+            let backend = Self::default();
+            let mut configured = backend.outputs.lock().unwrap();
+            for (model, text, finish_reason, delay_ms) in outputs {
+                configured
+                    .entry(model.to_string())
+                    .or_default()
+                    .push_back(MockOutput {
+                        text: text.to_string(),
+                        delay: Duration::from_millis(delay_ms),
+                        finish_reason: finish_reason.to_string(),
                     });
             }
             drop(configured);
@@ -1298,6 +1484,13 @@ mod tests {
 
         fn call_count(&self) -> usize {
             self.calls.lock().unwrap().len()
+        }
+
+        fn rendered_prompts(&self) -> (Vec<String>, Vec<String>) {
+            (
+                self.systems.lock().unwrap().clone(),
+                self.users.lock().unwrap().clone(),
+            )
         }
     }
 
@@ -1310,6 +1503,9 @@ mod tests {
         ) -> VoiceAttemptFuture {
             let model = selection.requested_model_id().to_string();
             self.calls.lock().unwrap().push(model.clone());
+            let rendered = request.prompt.render_for_test();
+            self.systems.lock().unwrap().push(rendered.system);
+            self.users.lock().unwrap().push(rendered.user);
             let output = self
                 .outputs
                 .lock()
@@ -1319,6 +1515,7 @@ mod tests {
                 .unwrap_or(MockOutput {
                     text: "Teapot ready.".to_string(),
                     delay: Duration::ZERO,
+                    finish_reason: "stop".to_string(),
                 });
             Box::pin(async move {
                 tokio::time::sleep(output.delay).await;
@@ -1330,7 +1527,7 @@ mod tests {
                     attempts: 1,
                     latency: output.delay,
                     model_attribution: Some(model_attribution),
-                    finish_reason: "stop".to_string(),
+                    finish_reason: output.finish_reason,
                     usage: AiTokenUsage {
                         prompt_tokens: Some(20),
                         completion_tokens: Some(6),
@@ -1376,6 +1573,18 @@ mod tests {
                 }
             }
         })
+    }
+
+    fn priced_candidate(
+        requested: &str,
+        provider: &str,
+        input_cost_per_million: f64,
+        output_cost_per_million: f64,
+    ) -> Value {
+        let mut value = candidate(requested, provider, requested, requested, "r1", true);
+        value["observations"]["input_cost_per_million"] = json!(input_cost_per_million);
+        value["observations"]["output_cost_per_million"] = json!(output_cost_per_million);
+        value
     }
 
     fn config(values: Vec<Value>, routing: VoiceRoutingConfig) -> AiConfig {
@@ -1457,6 +1666,7 @@ mod tests {
             generation_key: key.to_string(),
             speaker_actor_id: 5_000,
             speaker_name: "Tiny Tester".to_string(),
+            other_speaker_names: vec!["Gust".to_string()],
             mode: crate::ai_publication::SpeechMode::Prose,
             max_words: 20,
             anchors: vec!["teapot".to_string()],
@@ -1768,12 +1978,307 @@ mod tests {
             .any(|value| value.excluded_reason.as_deref() == Some("spend_ceiling")));
     }
 
+    #[test]
+    fn retry_feedback_cost_is_bounded() {
+        let prompt_budget = PromptBudgetTelemetry {
+            estimated_prompt_tokens: 10,
+            ..PromptBudgetTelemetry::default()
+        };
+        let request = request("dialogue_avatar");
+        assert_eq!(
+            estimated_cost(Some(1.0), Some(1.0), &request, &prompt_budget, 250),
+            80,
+        );
+        assert_eq!(
+            estimated_retry_feedback_cost(Some(1.0)),
+            VOICE_RETRY_FEEDBACK_RESERVE_TOKENS as u64,
+        );
+        assert_eq!(estimated_retry_feedback_cost(None), 0);
+    }
+
+    #[test]
+    fn sequential_retries_each_fit_their_own_feedback_cost() {
+        let generous = config(
+            vec![priced_candidate(
+                "provider/cheap",
+                "provider-cheap",
+                1.0,
+                0.0,
+            )],
+            VoiceRoutingConfig {
+                max_attempts: 3,
+                hedge_width: 1,
+                spend_ceiling_microdollars: u64::MAX,
+                ..VoiceRoutingConfig::default()
+            },
+        );
+        let request = request("dialogue_avatar");
+        let (generous_plan, _) = build_voice_plan(
+            None,
+            "sequential-retry-cost-baseline",
+            5_000,
+            "prose",
+            &request,
+            &generous.voice_routing,
+            generous.pin_models(ModelCapability::Voice).unwrap(),
+        )
+        .unwrap();
+        let base_cost = generous_plan[0].decision.estimated_cost_microdollars;
+        let feedback_cost = estimated_retry_feedback_cost(Some(1.0));
+        let ceiling_with_only_one_feedback =
+            base_cost.saturating_mul(3).saturating_add(feedback_cost);
+        let bounded = config(
+            vec![priced_candidate(
+                "provider/cheap",
+                "provider-cheap",
+                1.0,
+                0.0,
+            )],
+            VoiceRoutingConfig {
+                max_attempts: 3,
+                hedge_width: 1,
+                spend_ceiling_microdollars: ceiling_with_only_one_feedback,
+                ..VoiceRoutingConfig::default()
+            },
+        );
+        let (planned, _) = build_voice_plan(
+            None,
+            "sequential-retry-cost-bounded",
+            5_000,
+            "prose",
+            &request,
+            &bounded.voice_routing,
+            bounded.pin_models(ModelCapability::Voice).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(planned.len(), 2);
+        assert_eq!(
+            planned_spend_microdollars(&planned, 1),
+            base_cost.saturating_mul(2).saturating_add(feedback_cost)
+        );
+    }
+
+    #[test]
+    fn unused_expensive_candidate_does_not_tax_a_cheap_retry() {
+        let path = test_path("candidate-specific-retry-cost");
+        let _ = fs::remove_file(&path);
+        crate::init_event_store(&path).unwrap();
+        let routing = VoiceRoutingConfig {
+            max_attempts: 2,
+            hedge_width: 1,
+            spend_ceiling_microdollars: 50,
+            ..VoiceRoutingConfig::default()
+        };
+        let config = config(
+            vec![
+                priced_candidate("provider/cheap", "provider-cheap", 0.1, 0.0),
+                priced_candidate("provider/expensive", "provider-expensive", 100.0, 0.0),
+            ],
+            routing,
+        );
+        record_provider_failure(
+            Some(&path),
+            "provider-expensive",
+            "provider/expensive",
+            "inference_provider_error",
+        );
+        let (planned, decisions) = build_voice_plan(
+            Some(&path),
+            "candidate-specific-retry-cost",
+            5_000,
+            "prose",
+            &request("dialogue_avatar"),
+            &config.voice_routing,
+            config.pin_models(ModelCapability::Voice).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(planned.len(), 2, "the cheap model can still be retried");
+        assert!(planned
+            .iter()
+            .all(|candidate| candidate.decision.requested_model_id == "provider/cheap"));
+        assert_eq!(
+            decisions
+                .iter()
+                .find(|decision| decision.requested_model_id == "provider/expensive")
+                .and_then(|decision| decision.excluded_reason.as_deref()),
+            Some("provider_cooldown")
+        );
+        assert!(planned_spend_microdollars(&planned, 1) <= 50);
+        let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn rejection_feedback_reaches_only_later_attempts() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 2,
+            hedge_width: 2,
+            ..VoiceRoutingConfig::default()
+        });
+        let rejected = "Gust: Teapot plan:";
+        let backend = MockBackend::with_outputs([
+            ("provider/tiny-a", rejected, 0),
+            ("provider/tiny-a", "Teapot ready.", 0),
+        ]);
+
+        let certified = route_certified_voice_with(
+            &config,
+            None,
+            request("dialogue_avatar"),
+            gate("feedback-beat"),
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect("the corrected retry certifies");
+
+        assert_eq!(certified.text(), "Teapot ready.");
+        assert_eq!(certified.prior_rejections().len(), 1);
+        assert_eq!(
+            certified.prior_rejections()[0].failure_code,
+            PublicationCheckCode::VoiceFinishIncomplete,
+            "the receipt keeps the first failed check even when feedback covers every failed check",
+        );
+        let (systems, users) = backend.rendered_prompts();
+        assert_eq!(systems.len(), 2);
+        assert_eq!(systems[0], "Write one short anchored line.");
+        assert_eq!(
+            systems[1],
+            "Write one short anchored line.\nagain · one short complete line · at most 20 words · one voice · no speaker labels",
+        );
+        assert_eq!(users, vec!["The teapot rattled."; 2]);
+        assert!(systems
+            .iter()
+            .chain(&users)
+            .all(|prompt| !prompt.contains(rejected)));
+    }
+
+    #[tokio::test]
+    async fn raw_retry_keeps_feedback_in_the_single_user_envelope() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 2,
+            hedge_width: 2,
+            ..VoiceRoutingConfig::default()
+        });
+        let backend = MockBackend::with_outputs([
+            (
+                "provider/tiny-a",
+                "teapot rattles and teapot rattles and",
+                0,
+            ),
+            ("provider/tiny-a", "A clean answer.", 0),
+        ]);
+        let mut raw_request = request("dialogue_resident_raw");
+        raw_request.prompt = PromptEnvelope::default().user(
+            "raw scene",
+            PromptSegmentKind::UniqueEvidence,
+            100,
+            true,
+        );
+        let mut raw_gate = gate("raw-feedback-beat");
+        raw_gate.mode = SpeechMode::Raw;
+        raw_gate.anchors.clear();
+
+        let certified = route_certified_voice_with(
+            &config,
+            None,
+            raw_request,
+            raw_gate,
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect("the raw retry certifies");
+
+        assert_eq!(certified.text(), "A clean answer.");
+        let (systems, users) = backend.rendered_prompts();
+        assert_eq!(systems, vec![""; 2]);
+        assert_eq!(users[0], "raw scene");
+        assert_eq!(
+            users[1],
+            "raw scene\nagain · fresh wording · no repeated phrase"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_length_retry_uses_a_conservative_word_cap() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 2,
+            hedge_width: 2,
+            ..VoiceRoutingConfig::default()
+        });
+        let backend = MockBackend::with_finished_outputs([
+            ("provider/tiny-a", "still going", "length", 0),
+            ("provider/tiny-a", "A complete answer.", "stop", 0),
+        ]);
+        let mut raw_request = request("dialogue_resident_raw");
+        raw_request.max_tokens = 160;
+        raw_request.prompt = PromptEnvelope::default().user(
+            "raw scene",
+            PromptSegmentKind::UniqueEvidence,
+            100,
+            true,
+        );
+        let mut raw_gate = gate("raw-length-feedback-beat");
+        raw_gate.mode = SpeechMode::Raw;
+        raw_gate.max_words = 400;
+        raw_gate.anchors.clear();
+
+        route_certified_voice_with(
+            &config,
+            None,
+            raw_request,
+            raw_gate,
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect("the length-corrected raw retry certifies");
+
+        let (systems, users) = backend.rendered_prompts();
+        assert_eq!(systems, vec![""; 2]);
+        assert_eq!(users[0], "raw scene");
+        assert_eq!(
+            users[1],
+            "raw scene\nagain · one complete response · at most 64 words"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_shape_feedback_respects_emoji_mode() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 2,
+            hedge_width: 2,
+            ..VoiceRoutingConfig::default()
+        });
+        let backend = MockBackend::with_outputs([
+            ("provider/tiny-a", "unfinished:", 0),
+            ("provider/tiny-a", "☕🌧️😤", 0),
+        ]);
+        let mut emoji_gate = gate("emoji-feedback-beat");
+        emoji_gate.mode = SpeechMode::EmojiOnly;
+
+        route_certified_voice_with(
+            &config,
+            None,
+            request("dialogue_avatar"),
+            emoji_gate,
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect("the emoji retry certifies");
+
+        let (systems, _) = backend.rendered_prompts();
+        assert_eq!(
+            systems[1],
+            "Write one short anchored line.\nagain · 3–6 emoji only · touch something already present"
+        );
+    }
+
     #[tokio::test]
     async fn hedge_race_accepts_once_and_duplicate_reuses_the_durable_job() {
         let path = test_path("race");
         let _ = fs::remove_file(&path);
         let config = three_candidates(VoiceRoutingConfig {
-            max_attempts: 2,
+            max_attempts: 3,
             hedge_width: 2,
             ..VoiceRoutingConfig::default()
         });

--- a/v2/orchestrator-rust/src/prompts.rs
+++ b/v2/orchestrator-rust/src/prompts.rs
@@ -357,9 +357,9 @@ async fn request_ai_avatar_chat(
                 "dialogue_avatar"
             },
             prompt_version: if followup {
-                "dialogue-avatar-followup-v4"
+                "dialogue-avatar-followup-v5"
             } else {
-                "dialogue-avatar-v4"
+                "dialogue-avatar-v5"
             },
             prompt: avatar_chat_prompt(plan, followup),
             temperature: 0.8,
@@ -571,7 +571,7 @@ pub(super) async fn request_ai_avatar_intent(
             store_path,
             VoiceAttemptRequest {
                 feature: "dialogue_resident_raw",
-                prompt_version: "dialogue-resident-raw-v1",
+                prompt_version: "dialogue-resident-raw-v2",
                 prompt: PromptEnvelope::default().user(
                     plan.user_text.clone(),
                     PromptSegmentKind::UniqueEvidence,
@@ -619,7 +619,7 @@ pub(super) async fn request_ai_avatar_intent(
         store_path,
         VoiceAttemptRequest {
             feature: "dialogue_resident",
-            prompt_version: "dialogue-resident-voice-v4",
+            prompt_version: "dialogue-resident-voice-v5",
             prompt,
             temperature: 0.75,
             max_tokens: 120,
@@ -860,6 +860,15 @@ fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGate
     // present, which made announcing it the cheapest way to pass the gate. See
     // issue #553.
     anchors.extend(plan.cast.iter().cloned());
+    let other_speaker_names = std::iter::once(plan.target_actor_name.clone())
+        .chain(plan.cast.iter().cloned())
+        .chain(
+            plan.exchange_turns
+                .iter()
+                .flat_map(|turn| [turn.speaker_name.clone(), turn.recipient_name.clone()]),
+        )
+        .filter(|name| !name.eq_ignore_ascii_case(&plan.actor_name))
+        .collect();
     SpeechGateContext {
         feature: if followup {
             "dialogue_avatar_followup"
@@ -873,6 +882,7 @@ fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGate
         ),
         speaker_actor_id: plan.actor_id,
         speaker_name: plan.actor_name.clone(),
+        other_speaker_names,
         mode: SpeechMode::Prose,
         max_words: if followup { 28 } else { 34 },
         anchors,
@@ -910,6 +920,17 @@ fn resident_gate_context(plan: &AvatarReplyPlan, has_proposed_action: bool) -> S
     // guaranteed way through the gate. See issue #553.
     anchors.extend(plan.cast.iter().cloned());
     anchors.extend(plan.goals.iter().cloned());
+    let other_speaker_names = plan
+        .cast
+        .iter()
+        .cloned()
+        .chain(
+            plan.incoming_turn
+                .iter()
+                .flat_map(|turn| [turn.speaker_name.clone(), turn.recipient_name.clone()]),
+        )
+        .filter(|name| !name.eq_ignore_ascii_case(&plan.speaker_name))
+        .collect();
     SpeechGateContext {
         feature: if plan.speech_mode == "raw" {
             "dialogue_resident_raw"
@@ -923,6 +944,7 @@ fn resident_gate_context(plan: &AvatarReplyPlan, has_proposed_action: bool) -> S
         ),
         speaker_actor_id: plan.speaker_actor_id,
         speaker_name: plan.speaker_name.clone(),
+        other_speaker_names,
         mode: SpeechMode::from_name(&plan.speech_mode),
         max_words: resident_word_budget(plan),
         anchors,

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -533,6 +533,43 @@ async function main() {
   await assertModerationCanSuspendActor(moderationProbeAvatar);
   let chatPendingChecked = false;
   let useFocusedActionOnNextClick = false;
+  let focusedSelectionIdentity = null;
+  const livingItemEvidence = [];
+  const playerSpeechEvidence = new Set();
+  const observedBranchEventReceipts = [];
+  const branchReceiptAudits = new Set();
+  let moonlitProjectObservedCompleted = false;
+  const recordLivingItemEvidence = (evidence) => {
+    if (!runLivingWorldStress) return;
+    if (livingItemEvidence.some((existing) => (
+      existing.type === evidence.type
+        && existing.resident === evidence.resident
+        && existing.item === evidence.item
+    ))) return;
+    livingItemEvidence.push(evidence);
+  };
+  page.on("response", (response) => {
+    const request = response.request();
+    const pathname = new URL(response.url()).pathname;
+    if (
+      request.method() !== "POST"
+        || (pathname !== "/commands" && !pathname.startsWith("/actions/"))
+    ) return;
+    const audit = response.json()
+      .then((body) => {
+        for (const event of body?.events || []) {
+          if (!String(event?.type || "").startsWith("branch.")) continue;
+          if (observedBranchEventReceipts.some((existing) => (
+            Number(existing.seq || 0) === Number(event.seq || 0)
+              && existing.type === event.type
+          ))) continue;
+          observedBranchEventReceipts.push({ seq: Number(event.seq || 0), type: event.type });
+        }
+      })
+      .catch(() => {});
+    branchReceiptAudits.add(audit);
+    audit.finally(() => branchReceiptAudits.delete(audit));
+  });
 
   async function primaryText() {
     return page.locator("#primary").evaluate((node) => {
@@ -8503,6 +8540,9 @@ async function main() {
       if (stopWhen && await stopWhen()) return null;
       candidates = await page.evaluate(() => actionBarActions().map((action) => ({
         index: action.actionIndex,
+        handKey: actionHandKey(action),
+        offerIds: (action.offerIds || []).map(String),
+        generation: Number(state?.action_hand?.generation || 0),
         text: [compactActionLabel(action), friendlyActionText(action?.detail), action?.command]
           .filter(Boolean).join(" "),
       })));
@@ -8512,12 +8552,16 @@ async function main() {
           focusIndex = index;
           focusedKey = actionHandKey(actions[index]);
         }, match.index);
+        focusedSelectionIdentity = {
+          handKey: match.handKey,
+          offerIds: match.offerIds,
+          generation: match.generation,
+        };
         useFocusedActionOnNextClick = true;
         return match.text;
       }
       if (draw + 1 < Math.min(attempts, deckSize)) {
-        await page.locator("#shuffle").click();
-        await page.waitForFunction(() => actionBusy === false && refreshInFlight === null && document.querySelector("#shuffle")?.disabled === false);
+        await passCertifiedHandForDraw(`${label} draw ${draw + 1}`);
       }
     }
     throw new Error(`${label} was not dealt within one full hand rotation: ${JSON.stringify(candidates)}`);
@@ -8527,7 +8571,7 @@ async function main() {
     return focusPrimaryMatching(label, predicate, Math.max(64, shuffles), stopWhen);
   }
 
-  async function drawPrimaryMatching(label, needles) {
+  async function drawPrimaryMatching(label, needles, stopWhen = null) {
     await page.waitForFunction(() => (
       actionBusy === false
         && refreshInFlight === null
@@ -8537,6 +8581,7 @@ async function main() {
     const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
     let result = null;
     for (let draw = 0; draw < deckSize; draw += 1) {
+      if (stopWhen && await stopWhen()) return null;
       result = await page.evaluate((terms) => {
       const actionText = (action) => [
         action?.label,
@@ -8572,14 +8617,16 @@ async function main() {
       return {
         ok: true,
         index: action.actionIndex,
+        handKey: actionHandKey(action),
+        offerIds: (action.offerIds || []).map(String),
+        generation: Number(state?.action_hand?.generation || 0),
         choiceMatched: Boolean(selectedChoice),
         text: actionText(action),
       };
     }, normalizedNeedles);
       if (result.ok) break;
       if (draw + 1 < deckSize) {
-        await page.locator("#shuffle").click();
-        await page.waitForFunction(() => actionBusy === false && refreshInFlight === null && document.querySelector("#shuffle")?.disabled === false);
+        await passCertifiedHandForDraw(`${label} draw ${draw + 1}`);
       }
     }
     assert(result.ok, `${label} card was not drawable from actions: ${JSON.stringify(result)}`);
@@ -8587,6 +8634,11 @@ async function main() {
       focusIndex = index;
       focusedKey = actionHandKey(actions[index]);
     }, result.index);
+    focusedSelectionIdentity = {
+      handKey: result.handKey,
+      offerIds: result.offerIds,
+      generation: result.generation,
+    };
     useFocusedActionOnNextClick = true;
     await assertNoVisibleOverflow();
     assert(
@@ -8596,60 +8648,112 @@ async function main() {
     return result.text;
   }
 
-  async function drawRoomSearch(label, extraNeedles = []) {
+  async function drawRoomSearch(label, extraNeedles = [], stopWhen = null) {
     const needles = extraNeedles.map((needle) => needle.toLowerCase());
     return focusPrimaryMatchingAcrossShuffles(label, (text) => (
       text.startsWith("inspect ")
         && needles.every((needle) => text.includes(needle))
-    ));
+    ), 8, stopWhen);
   }
 
   async function passCertifiedHandForDraw(label) {
-    const before = await page.evaluate(() => {
-      const pass = state?.action_hand?.pass || null;
-      const control = document.querySelector("#shuffle");
-      return {
-        offerId: String(pass?.offer_id || ""),
-        generation: Number(state?.action_hand?.generation || 0),
-        controlId: control?.id || "",
-        visible: Boolean(control && getComputedStyle(control).display !== "none"),
-        disabled: Boolean(control?.disabled),
-        ariaLabel: control?.getAttribute("aria-label") || "",
-      };
-    });
-    assert(
-      before.offerId
-        && before.controlId === "shuffle"
-        && before.visible
-        && !before.disabled
-        && /commit a pass/i.test(before.ariaLabel),
-      `${label} hand rotation must start from the certified Pass (Think) control: ${JSON.stringify(before)}`,
+    let lastRejection = null;
+    const currentPassState = () => page.evaluate(() => ({
+      offerId: String(state?.action_hand?.pass?.offer_id || ""),
+      generation: Number(state?.action_hand?.generation || 0),
+    }));
+    const reconciledAsOneHandAdvance = (before, after) => (
+      after.offerId
+        && after.offerId !== before.offerId
+        && after.generation === before.generation + 1
     );
-    const responsePromise = page.waitForResponse((response) => (
-      response.request().method() === "POST"
-        && new URL(response.url()).pathname === "/commands"
-        && String(response.request().postData() || "").includes("\"command\":\"pass\"")
-    ));
-    await page.locator("#shuffle").click();
-    const response = await responsePromise;
-    const receipt = await response.json();
-    const request = response.request().postDataJSON();
-    const shuffleEvent = (receipt.events || []).find((event) => event.type === "hand.shuffled");
-    assert(
-      receipt.ok === true
-        && request?.command === "pass"
-        && request?.offer_id === before.offerId
-        && Number(shuffleEvent?.seq || 0) > 0,
-      `${label} hand rotation must commit the exact certified Pass, never an undealt action: ${JSON.stringify({ before, request, receipt })}`,
-    );
-    await page.waitForFunction(() => (
-      actionBusy === false
-        && refreshInFlight === null
-        && document.querySelector("#shuffle")?.disabled === false
-    ));
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      await page.waitForFunction(() => (
+        actionBusy === false
+          && refreshInFlight === null
+          && document.querySelector("#shuffle")?.disabled === false
+      ));
+      const before = await page.evaluate(() => {
+        const pass = state?.action_hand?.pass || null;
+        const control = document.querySelector("#shuffle");
+        return {
+          offerId: String(pass?.offer_id || ""),
+          generation: Number(state?.action_hand?.generation || 0),
+          controlId: control?.id || "",
+          visible: Boolean(control && getComputedStyle(control).display !== "none"),
+          disabled: Boolean(control?.disabled),
+          ariaLabel: control?.getAttribute("aria-label") || "",
+        };
+      });
+      assert(
+        before.offerId
+          && before.controlId === "shuffle"
+          && before.visible
+          && !before.disabled
+          && /commit a pass/i.test(before.ariaLabel),
+        `${label} hand rotation must start from the certified Pass (Think) control: ${JSON.stringify(before)}`,
+      );
+      let response;
+      try {
+        [response] = await Promise.all([
+          page.waitForResponse((candidate) => (
+            candidate.request().method() === "POST"
+              && new URL(candidate.url()).pathname === "/commands"
+              && String(candidate.request().postData() || "").includes("\"command\":\"pass\"")
+          ), { timeout: 10_000 }),
+          page.locator("#shuffle").click(),
+        ]);
+      } catch (error) {
+        lastRejection = { before, error: String(error?.message || error) };
+        await page.evaluate(() => refresh());
+        const after = await currentPassState();
+        if (reconciledAsOneHandAdvance(before, after)) return;
+        assert(
+          after.offerId === before.offerId && after.generation === before.generation,
+          `${label} Pass outcome was ambiguous across multiple hand generations: ${JSON.stringify({ before, after, error: lastRejection.error })}`,
+        );
+        throw new Error(`${label} Pass response was not observed; refusing an ambiguous retry: ${lastRejection.error}`);
+      }
+      const receipt = await response.json();
+      const request = response.request().postDataJSON();
+      const shuffleEvent = (receipt.events || []).find((event) => event.type === "hand.shuffled");
+      if (receipt.ok === true) {
+        assert(
+          request?.command === "pass"
+            && String(request?.offer_id || "") === before.offerId
+            && Number(shuffleEvent?.seq || 0) > 0,
+          `${label} hand rotation must commit the exact certified Pass, never an undealt action: ${JSON.stringify({ before, request, receipt })}`,
+        );
+        await page.waitForFunction(() => (
+          actionBusy === false
+            && refreshInFlight === null
+            && document.querySelector("#shuffle")?.disabled === false
+        ));
+        const after = await currentPassState();
+        assert(
+          reconciledAsOneHandAdvance(before, after),
+          `${label} successful Pass should advance exactly one hand generation: ${JSON.stringify({ before, request, after, receipt })}`,
+        );
+        return;
+      }
+      lastRejection = { before, request, receipt, httpStatus: response.status() };
+      assert(
+        Number(receipt.status || response.status()) === 409,
+        `${label} Pass failed without a definitive stale certificate: ${JSON.stringify(lastRejection)}`,
+      );
+      await page.waitForFunction(() => actionBusy === false && refreshInFlight === null);
+      await page.evaluate(() => refresh());
+      const after = await currentPassState();
+      if (reconciledAsOneHandAdvance(before, after)) return;
+      assert(
+        after.generation === before.generation,
+        `${label} stale Pass crossed multiple hand generations: ${JSON.stringify({ before, after, lastRejection })}`,
+      );
+    }
+    throw new Error(`${label} could not obtain a fresh certified Pass after three stale scenes: ${JSON.stringify(lastRejection)}`);
   }
 
-  async function drawCertifiedGardenInspect(label) {
+  async function drawCertifiedGardenInspect(label, stopWhen = null) {
     const inspectIsLegal = await page.evaluate(() => (
       state?.search_available === true
         || actions.some((action) => (
@@ -8660,9 +8764,18 @@ async function main() {
     if (!inspectIsLegal) return null;
 
     const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
-    const drawLimit = Math.min(deckSize, 24);
+    const drawLimit = deckSize;
     let lastHand = [];
     for (let draw = 0; draw < drawLimit; draw += 1) {
+      if (stopWhen && await stopWhen()) return false;
+      const inspectStillLegal = await page.evaluate(() => (
+        state?.search_available === true
+          || actions.some((action) => (
+            String(action?.intention || "").toLowerCase() === "inspect"
+              || String(action?.label || "").toLowerCase() === "inspect"
+          ))
+      ));
+      if (!inspectStillLegal) return false;
       const dealt = await page.evaluate(() => {
         const certifiedSearchOfferIds = new Set((state?.action_hand?.entries || [])
           .filter((entry) => String(entry?.kind || "") === "search")
@@ -8687,6 +8800,8 @@ async function main() {
         return {
           ok: true,
           index: action.actionIndex,
+          handKey: actionHandKey(action),
+          generation: Number(state?.action_hand?.generation || 0),
           text: [compactActionLabel(action), friendlyActionText(action?.detail), action?.command]
             .filter(Boolean)
             .join(" "),
@@ -8704,6 +8819,11 @@ async function main() {
           focusIndex = index;
           focusedKey = actionHandKey(actions[index]);
         }, dealt.index);
+        focusedSelectionIdentity = {
+          handKey: dealt.handKey,
+          offerIds: dealt.offerIds.map(String),
+          generation: dealt.generation,
+        };
         useFocusedActionOnNextClick = true;
         await assertNoVisibleOverflow();
         return dealt.text;
@@ -8732,7 +8852,7 @@ async function main() {
     const needle = text.toLowerCase();
     const focus = async () => page.evaluate((destination) => {
       const visible = actionBarActions();
-      const action = visible.find((action) => {
+      const visibleAction = visible.find((action) => {
         const intention = String(action?.intention || "").toLowerCase();
         const label = String(action?.label || "").toLowerCase();
         if (!["move", "travel", "scout", "flee"].includes(intention) && label !== "flee") return false;
@@ -8749,7 +8869,7 @@ async function main() {
           `${choice.label || ""} ${choice.detail || ""}`.toLowerCase().includes(destination)
         ));
       });
-      if (!action) {
+      if (!visibleAction) {
         return {
           ok: false,
           location: state?.location?.name || "",
@@ -8767,16 +8887,21 @@ async function main() {
             .map((action) => `${action.label} ${action.detail || action.command || ""} ${(action.choices || []).map((choice) => choice.label).join(" ")}`),
         };
       }
-      const route = action;
+      const route = actions[visibleAction.actionIndex];
       const choice = (route.choices || []).find((candidate) => (
         `${candidate.label || ""} ${candidate.detail || ""}`.toLowerCase().includes(destination)
       ));
       if (choice) route.selectedChoice = choice.value;
-      focusIndex = route.actionIndex;
+      focusIndex = visibleAction.actionIndex;
       focusedKey = choice ? `exit:${choice.value}` : actionHandKey(route);
       return {
         ok: true,
-        index: route.actionIndex,
+        index: visibleAction.actionIndex,
+        handKey: actionHandKey(route),
+        offerIds: (route.offerIds || []).map(String),
+        generation: Number(state?.action_hand?.generation || 0),
+        routeIdentity: choice ? String(choice.value || "") : "",
+        destinationLocationId: Number(route.selectedPayload?.()?.destination_location_id || 0),
         choice: choice?.label || "",
         intention: String(route?.intention || "").toLowerCase(),
         text: [route?.label, route?.detail, route?.command, choice?.label, choice?.detail]
@@ -8800,14 +8925,20 @@ async function main() {
         || primary.toLowerCase().startsWith("search")
         || primary.toLowerCase().includes("search pathway");
       if (result.ok && routeVisible) {
+        focusedSelectionIdentity = {
+          handKey: result.handKey,
+          offerIds: result.offerIds,
+          generation: result.generation,
+          routeIdentity: result.routeIdentity,
+          destinationLocationId: result.destinationLocationId,
+        };
         useFocusedActionOnNextClick = true;
         await assertNoVisibleOverflow();
         return primary;
       }
       last = { result, primary };
       if (attempt < deckSize) {
-        await page.locator("#shuffle").click();
-        await page.waitForFunction(() => actionBusy === false && refreshInFlight === null && document.querySelector("#shuffle")?.disabled === false);
+        await passCertifiedHandForDraw(`route ${text} draw ${attempt}`);
       }
     }
     if (
@@ -8821,73 +8952,38 @@ async function main() {
 
   async function confirmRouteTo(name, label, focusBeforeConfirm = () => focusRoute(name)) {
     let lastResult = null;
+    let stableDestinationId = 0;
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       const focused = await focusBeforeConfirm();
+      if (focused?.replan === true) return focused;
       assert(focused !== false, `${label} route card should remain focusable`);
-      const responsePromise = page.waitForResponse((response) => (
-        response.request().method() === "POST"
-          && ["/actions/submit", "/actions/move", "/actions/flee", "/actions/explore-path"]
-            .includes(new URL(response.url()).pathname)
-      ));
-      const routeClick = await page.evaluate(() => {
-        const action = actions[focusIndex];
-        const intention = String(action?.intention || "").toLowerCase();
-        const routeLike = ["move", "travel", "scout", "flee"].includes(intention)
-          || String(action?.label || "").toLowerCase() === "flee";
-        if (!routeLike) return { clicked: false, focusedKey: String(focusedKey || "") };
-        const key = String(focusedKey || "");
-        openActionModal(action);
-        return {
-          clicked: true,
-          focusedKey: key,
-          routeIdentity: key.startsWith("exit:") ? key.slice("exit:".length) : "",
+      if (focused && typeof focused === "object") {
+        focusedSelectionIdentity = {
+          handKey: focused.handKey,
+          offerIds: focused.offerIds,
+          generation: focused.generation,
+          routeIdentity: focused.routeIdentity || "",
+          destinationLocationId: Number(focused.destinationLocationId || 0),
         };
-      });
-      if (!routeClick.clicked) {
-        responsePromise.catch(() => {});
-        await page.evaluate(() => refresh());
-        continue;
       }
-      const focusedRouteIdentity = routeClick.routeIdentity;
-      await page.waitForSelector("#action-modal:not([hidden])");
-      const choices = page.locator("#action-modal-choices .action-choice");
-      const choiceCount = await choices.count();
-      if (choiceCount > 0) {
-        const modalChoices = await choices.evaluateAll((nodes) => nodes.map((node, index) => ({
-          index,
-          label: node.textContent?.trim().replace(/\s+/g, " ") || "",
-          value: node.querySelector("input")?.value || "",
-          checked: Boolean(node.querySelector("input")?.checked),
-        })));
-        const destinationChoices = modalChoices.filter((choice) => (
-          choice.value === focusedRouteIdentity
-        ));
-        assert(
-          destinationChoices.length === 1
-            && destinationChoices[0].label.toLowerCase().includes(name.toLowerCase()),
-          `${name} should resolve to one stable route identity even when generated places share a display name: ${JSON.stringify({ focusedRouteIdentity, modalChoices })}`,
-        );
-        await choices.nth(destinationChoices[0].index).click();
-      }
-      await page.locator("#action-modal-confirm").click();
-      const response = await responsePromise;
-      lastResult = {
-        httpStatus: response.status(),
-        path: new URL(response.url()).pathname,
-        request: response.request().postDataJSON(),
-        body: await response.json(),
-      };
-      await page.waitForFunction(() => actionBusy === false && refreshInFlight === null);
-      if (lastResult.body?.ok === true) {
-        await assertNoVisibleOverflow();
-        steps.push({ label, primary: await primaryText(), location: await page.locator("#location-name").innerText() });
-        return lastResult.body;
-      }
+      const expectedRoute = focusedSelectionIdentity;
       assert(
-        Number(lastResult.body?.status || lastResult.httpStatus) === 409,
-        `${label} should commit or reject only as a stale concurrent offer: ${JSON.stringify(lastResult)}`,
+        expectedRoute?.handKey
+          && expectedRoute?.offerIds?.length === 1
+          && expectedRoute.destinationLocationId > 0,
+        `${label} should retain one exact certified route and destination: ${JSON.stringify(expectedRoute)}`,
       );
-      await page.evaluate(() => refresh());
+      if (!stableDestinationId) stableDestinationId = expectedRoute.destinationLocationId;
+      assert(
+        expectedRoute.destinationLocationId === stableDestinationId,
+        `${label} stale retry should not switch to another same-named destination: ${JSON.stringify({ stableDestinationId, expectedRoute })}`,
+      );
+      lastResult = await commitFocusedCertifiedAction(label, {
+        choiceText: expectedRoute.routeIdentity ? name : "",
+        choiceValue: expectedRoute.routeIdentity,
+        expectedDestinationId: expectedRoute.destinationLocationId,
+      });
+      if (lastResult.ok) return lastResult.body;
     }
     throw new Error(`${label} stayed stale after three fresh offers: ${JSON.stringify(lastResult)}`);
   }
@@ -8944,82 +9040,270 @@ async function main() {
     return true;
   }
 
-  async function clickPrimary(label) {
-    if (useFocusedActionOnNextClick) {
-      await page.evaluate(() => openActionModal(focusedAction()));
-      useFocusedActionOnNextClick = false;
-    } else {
-      await page.locator("#primary").click({ force: true });
+  async function clickPrimary(label, { allowStale = false } = {}) {
+    if (useFocusedActionOnNextClick && focusedSelectionIdentity) {
+      const result = await commitFocusedCertifiedAction(label);
+      if (!result.ok && !allowStale) {
+        throw new Error(`${label} exact selected certificate became stale before commit`);
+      }
+      return result;
     }
+    focusedSelectionIdentity = null;
+    useFocusedActionOnNextClick = false;
+    await page.locator("#primary").click({ force: true });
     await confirmActionModalIfOpen();
     await page.waitForTimeout(200);
     await assertNoVisibleOverflow();
     steps.push({ label, primary: await primaryText(), location: await page.locator("#location-name").innerText() });
   }
 
-  async function clickActionMatching(label, needles) {
-    return clickDealtActionMatching(label, needles);
-
-    const normalizedNeedles = needles.map((needle) => needle.toLowerCase());
-    let lastResult = null;
-    for (let attempt = 1; attempt <= 3; attempt += 1) {
-      await page.waitForFunction(() => (
-        actionBusy === false
-          && refreshInFlight === null
-          && document.querySelector("#action-modal")?.hidden === true
-      ), null, { timeout: 35_000 });
-      const selected = await page.evaluate((terms) => {
-        const actionText = (action) => [
-          compactActionLabel(action),
-          action?.detail,
-          action?.command,
-          action?.cost,
-          action?.risk,
-          action?.effect,
-        ].filter(Boolean).join(" ").toLowerCase();
-        const index = actions.findIndex((action) => terms.every((term) => actionText(action).includes(term)));
-        if (index < 0) return { ok: false, actions: actions.map(actionText) };
-        focusIndex = index;
-        focusedKey = actionHandKey(actions[index]);
-        openActionModal(actions[index]);
-        return { ok: true, action: actionText(actions[index]) };
-      }, normalizedNeedles);
-      assert(selected.ok, `${label} card was not atomically selectable: ${JSON.stringify(selected)}`);
-      const responsePromise = page.waitForResponse((response) => (
-        response.request().method() === "POST"
-          && new URL(response.url()).pathname.startsWith("/actions/")
+  async function commitFocusedCertifiedAction(label, options = {}) {
+    const {
+      choiceText = "",
+      choiceValue = "",
+      transferTarget = "",
+      expectedDestinationId = 0,
+      expectedProjectId = "",
+      expectedStrategyId,
+      expectedItemId = 0,
+      expectedLocationId = 0,
+    } = options;
+    const expectedSelection = focusedSelectionIdentity;
+    focusedSelectionIdentity = null;
+    useFocusedActionOnNextClick = false;
+    assert(expectedSelection, `${label} should retain the exact selected hand identity before commit`);
+    const selectionStaleness = (expected) => page.evaluate((selection) => {
+      const handOfferIds = new Set((state?.action_hand?.entries || [])
+        .map((entry) => String(entry?.offer_id || ""))
+        .filter(Boolean));
+      return {
+        generation: Number(state?.action_hand?.generation || 0),
+        expectedGeneration: Number(selection.generation || 0),
+        missingOfferIds: (selection.offerIds || []).filter((offerId) => (
+          !handOfferIds.has(String(offerId))
+        )),
+      };
+    }, expected);
+    const opened = await page.evaluate((expected) => {
+      if (Number(state?.action_hand?.generation || 0) !== Number(expected.generation)) return false;
+      const sameOffers = (action) => {
+        const actual = (action.offerIds || []).map(String).sort();
+        const wanted = (expected.offerIds || []).map(String).sort();
+        return actual.length === wanted.length && actual.every((offerId, index) => offerId === wanted[index]);
+      };
+      const visibleAction = actionBarActions().find((candidate) => (
+        actionHandKey(candidate) === expected.handKey && sameOffers(candidate)
       ));
-      await confirmActionModalIfOpen();
-      const response = await responsePromise;
-      const body = await response.json();
-      lastResult = { httpStatus: response.status(), body };
-      await page.waitForFunction(() => (
-        actionBusy === false
-          && refreshInFlight === null
-          && document.querySelector("#action-modal")?.hidden === true
-      ), null, { timeout: 35_000 });
-      if (body?.ok === true) {
-        await assertNoVisibleOverflow();
-        steps.push({ label, primary: await primaryText(), location: await page.locator("#location-name").innerText() });
-        return lastResult;
-      }
-      const staleOffer = Number(body?.status || response.status()) === 409
-        && (body?.events || []).some((event) => String(event.content || "").includes("offer_id"));
+      const action = visibleAction ? actions[visibleAction.actionIndex] : null;
+      if (action && (!sameOffers(action) || actionHandKey(action) !== expected.handKey)) return false;
+      if (!action) return false;
+      focusIndex = visibleAction.actionIndex;
+      focusedKey = actionHandKey(action);
+      openActionModal(action);
+      return true;
+    }, expectedSelection);
+    if (!opened) {
+      const staleness = await selectionStaleness(expectedSelection);
       assert(
-        staleOffer,
-        `${label} should commit or reject only as a stale concurrent offer: ${JSON.stringify(lastResult)}`,
+        staleness.generation !== staleness.expectedGeneration
+          || staleness.missingOfferIds.length > 0,
+        `${label} exact current certificate disappeared only from the rendered action model: ${JSON.stringify(staleness)}`,
       );
       await page.evaluate(() => refresh());
+      return { ok: false, stale: true, submission: null };
     }
-    throw new Error(`${label} stayed stale after three fresh offers: ${JSON.stringify(lastResult)}`);
+    await page.waitForSelector("#action-modal:not([hidden])");
+    if (choiceText || choiceValue) {
+      const choices = page.locator("#action-modal-choices .action-choice");
+      if (await choices.count() > 0) {
+        const modalChoices = await choices.evaluateAll((nodes) => nodes.map((node, index) => ({
+          index,
+          label: node.textContent?.trim().replace(/\s+/g, " ") || "",
+          value: node.querySelector("input")?.value || "",
+        })));
+        const matchingChoices = modalChoices.filter((choice) => (
+          (!choiceValue || choice.value === choiceValue)
+            && (!choiceText || choice.label.toLowerCase().includes(choiceText.toLowerCase()))
+        ));
+        assert(matchingChoices.length === 1, `${choiceText || choiceValue} should appear once in the ${label} choices`);
+        await choices.nth(matchingChoices[0].index).click();
+      }
+    }
+    const submission = await page.evaluate((expected) => {
+      const aggregate = actionConfirmAction;
+      const selected = aggregate?.selectedMode?.()?.source || aggregate;
+      const offerIds = (selected?.offerIds || []).map(String);
+      const handOfferIds = new Set((state?.action_hand?.entries || []).map((entry) => String(entry.offer_id || "")));
+      const focusKey = String(selected?.focusKey || "");
+      const selectedPayload = selected?.selectedPayload?.() || null;
+      const intention = String(selected?.intention || "").toLowerCase();
+      const [kind, itemId, targetActorId, targetItemId] = focusKey.split(":");
+      const featureParts = kind === "use-feature" ? focusKey.split(":") : [];
+      const featureItemId = Number(featureParts.at(-1) || 0);
+      const featureKey = kind === "use-feature" ? featureParts.slice(1, -1).join(":") : "";
+      const expectedPath = kind === "give"
+        ? "/actions/give-item"
+        : (kind === "trade" ? "/actions/trade-item" : "");
+      const target = (state?.actors || []).find((actor) => Number(actor.id || 0) === Number(targetActorId));
+      return {
+        offerIds,
+        focusKey,
+        command: String(selected?.command || ""),
+        projectId: String(selected?.project?.id || ""),
+        strategyId: String(selected?.project?.strategy_id || ""),
+        expectedPath,
+        itemId: Number(itemId || 0),
+        targetActorId: Number(targetActorId || 0),
+        targetItemId: Number(targetItemId || 0),
+        targetName: target?.name || "",
+        destinationLocationId: Number(selectedPayload?.destination_location_id || 0),
+        payloadItemId: Number(selectedPayload?.item_id || featureItemId || 0),
+        payloadLocationId: Number(
+          selectedPayload?.location_id
+            || (kind === "use-feature" ? state?.location?.id : 0)
+            || 0,
+        ),
+        featureKey: String(selectedPayload?.feature_key || featureKey),
+        routePath: intention === "scout"
+          ? "/actions/explore-path"
+          : (intention === "flee"
+            ? "/actions/flee"
+            : (intention === "travel"
+              ? "/actions/move"
+              : (kind === "use-feature" ? "/actions/use-item" : ""))),
+        selectionMatches: offerIds.every((offerId) => (expected.offerIds || []).includes(offerId)),
+        certified: offerIds.length === 1
+          && handOfferIds.has(offerIds[0])
+          && offerIds.every((offerId) => (expected.offerIds || []).includes(offerId)),
+      };
+    }, expectedSelection);
+    if (transferTarget) {
+      assert(
+        submission.expectedPath
+          && submission.itemId > 0
+          && submission.targetActorId > 0
+          && submission.targetName === transferTarget,
+        `${transferTarget} choice should resolve one exact transfer target: ${JSON.stringify(submission)}`,
+      );
+    }
+    if (expectedDestinationId) {
+      assert(
+        submission.destinationLocationId === Number(expectedDestinationId),
+        `${label} should retain destination ${expectedDestinationId}: ${JSON.stringify(submission)}`,
+      );
+    }
+    if (expectedProjectId || expectedStrategyId !== undefined) {
+      assert(
+        (!expectedProjectId || submission.projectId === expectedProjectId)
+          && (expectedStrategyId === undefined
+            || submission.strategyId === String(expectedStrategyId || "")),
+        `${label} should retain its exact authored project strategy: ${JSON.stringify({ expectedProjectId, expectedStrategyId, submission })}`,
+      );
+    }
+    if (expectedItemId || expectedLocationId) {
+      assert(
+        (!expectedItemId || submission.payloadItemId === Number(expectedItemId))
+          && (!expectedLocationId || submission.payloadLocationId === Number(expectedLocationId)),
+        `${label} should retain its exact authored item use: ${JSON.stringify({ expectedItemId, expectedLocationId, submission })}`,
+      );
+    }
+    if (!submission.certified) {
+      const staleness = await selectionStaleness(expectedSelection);
+      assert(
+        staleness.generation !== staleness.expectedGeneration
+          || staleness.missingOfferIds.length > 0,
+        `${label} exact current certificate resolved to an uncertified modal action: ${JSON.stringify({ staleness, submission })}`,
+      );
+      await page.evaluate(() => {
+        closeActionModal();
+        return refresh();
+      });
+      return { ok: false, stale: true, submission };
+    }
+    const responsePromise = page.waitForResponse((response) => {
+      if (response.request().method() !== "POST") return false;
+      const responsePath = new URL(response.url()).pathname;
+      const request = response.request().postDataJSON();
+      if (responsePath === "/commands") {
+        return submission.offerIds.includes(String(request?.offer_id || ""))
+          && request?.command === submission.command;
+      }
+      if (responsePath !== "/actions/submit") return false;
+      return submission.offerIds.includes(String(request?.offer_id || ""))
+        && (!submission.routePath || request?.path === submission.routePath)
+        && (!submission.expectedPath || (
+          request?.path === submission.expectedPath
+            && Number(request?.payload?.item_id || 0) === submission.itemId
+            && Number(request?.payload?.target_actor_id || 0) === submission.targetActorId
+            && (
+              submission.targetItemId === 0
+                || Number(request?.payload?.target_item_id || 0) === submission.targetItemId
+            )
+        ))
+        && (!expectedDestinationId
+          || Number(request?.payload?.destination_location_id || 0) === Number(expectedDestinationId))
+        && (!expectedItemId || Number(request?.payload?.item_id || 0) === Number(expectedItemId))
+        && (!expectedLocationId || Number(request?.payload?.location_id || 0) === Number(expectedLocationId))
+        && (!submission.featureKey || request?.payload?.feature_key === submission.featureKey);
+    }, { timeout: 10_000 }).then((response) => ({ response }));
+    const localRejectionPromise = page.waitForFunction(() => (
+      actionBusy === false
+        && document.querySelector("#action-modal")?.hidden === true
+        && /no longer in your hand/i.test(document.querySelector("#error")?.textContent || "")
+    ), null, { timeout: 10_000 }).then(() => ({ localRejection: true }));
+    await page.locator("#action-modal-confirm").click();
+    const outcome = await Promise.race([responsePromise, localRejectionPromise]);
+    if (outcome.localRejection) {
+      responsePromise.catch(() => {});
+      await page.evaluate(() => refresh());
+      return { ok: false, stale: true, submission };
+    }
+    const response = outcome.response;
+    const body = await response.json();
+    await page.waitForFunction(() => (
+      actionBusy === false
+        && refreshInFlight === null
+        && document.querySelector("#action-modal")?.hidden === true
+    ), null, { timeout: 35_000 });
+    if (body?.ok !== true) {
+      const responsePath = new URL(response.url()).pathname;
+      const retryableConflict = Number(body?.status || response.status()) === 409
+        && (
+          (body?.events || []).some((event) => (
+            ["action.offer_rejected", "action.conflict"].includes(String(event?.type || ""))
+          ))
+            || (responsePath === "/commands" && body?.error_kind === "stale_offer")
+        );
+      assert(
+        retryableConflict,
+        `${label} should commit or reject only with exact stale-offer evidence: ${JSON.stringify(body)}`,
+      );
+      await page.evaluate(() => refresh());
+      return { ok: false, stale: true, submission, body };
+    }
+    await assertNoVisibleOverflow();
+    steps.push({ label, primary: await primaryText(), location: await page.locator("#location-name").innerText() });
+    return {
+      ok: true,
+      stale: false,
+      submission,
+      body,
+      request: response.request().postDataJSON(),
+    };
+  }
+
+  async function clickActionMatching(label, needles) {
+    const body = await clickDealtActionMatching(label, needles);
+    return { httpStatus: Number(body?.status || 200), body };
   }
 
   async function clickDealtActionMatching(label, needles) {
     const normalizedNeedles = needles.map((needle) => needle.toLowerCase());
     let lastHand = [];
     let lastScene = {};
+    let staleAttempts = 0;
     const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 8)));
-    for (let draw = 0; draw < deckSize; draw += 1) {
+    for (let draw = 0; draw < deckSize;) {
       await page.waitForFunction(() => (
         actionBusy === false
           && refreshInFlight === null
@@ -9050,8 +9334,13 @@ async function main() {
         }
         focusIndex = action.actionIndex;
         focusedKey = actionHandKey(action);
-        openActionModal(action);
-        return { ok: true, action: actionText(action) };
+        return {
+          ok: true,
+          action: actionText(action),
+          handKey: actionHandKey(action),
+          offerIds: (action.offerIds || []).map(String),
+          generation: Number(state?.action_hand?.generation || 0),
+        };
       }, normalizedNeedles);
       lastHand = selected.hand || lastHand;
       lastScene = {
@@ -9059,33 +9348,51 @@ async function main() {
         items: selected.items || lastScene.items || [],
       };
       if (selected.ok) {
-        const responsePromise = page.waitForResponse((response) => (
-          response.request().method() === "POST"
-            && new URL(response.url()).pathname.startsWith("/actions/")
-        ));
-        await confirmActionModalIfOpen();
-        const response = await responsePromise;
-        const body = await response.json();
-        await page.waitForFunction(() => (
-          actionBusy === false
-            && refreshInFlight === null
-            && document.querySelector("#action-modal")?.hidden === true
-        ), null, { timeout: 35_000 });
-        if (body?.ok === true) return body;
-        const staleOffer = Number(body?.status || response.status()) === 409
-          && (body?.events || []).some((event) => String(event.content || "").includes("offer_id"));
-        assert(staleOffer, `${label} should commit or reject only as a stale dealt offer: ${JSON.stringify(body)}`);
+        focusedSelectionIdentity = {
+          handKey: selected.handKey,
+          offerIds: selected.offerIds,
+          generation: selected.generation,
+        };
+        useFocusedActionOnNextClick = true;
+        const result = await commitFocusedCertifiedAction(label);
+        if (result.ok) return result.body;
+        staleAttempts += 1;
+        assert(staleAttempts < 3, `${label} stayed stale after three fresh offers`);
+        continue;
       }
-      await page.locator("#shuffle").click();
+      if (draw + 1 < deckSize) {
+        await passCertifiedHandForDraw(`${label} draw ${draw + 1}`);
+      }
+      draw += 1;
     }
     throw new Error(`${label} was not dealt within one complete hand rotation: ${JSON.stringify({ lastHand, ...lastScene })}`);
   }
 
   async function clickPrimaryAndAssertPending(label) {
-    if (useFocusedActionOnNextClick) {
-      await page.evaluate(() => openActionModal(focusedAction()));
+    if (useFocusedActionOnNextClick && focusedSelectionIdentity) {
+      const expectedSelection = focusedSelectionIdentity;
+      const opened = await page.evaluate((expected) => {
+        if (Number(state?.action_hand?.generation || 0) !== Number(expected.generation)) return false;
+        const wanted = (expected.offerIds || []).map(String).sort();
+        const visible = actionBarActions().find((candidate) => {
+          const actual = (candidate.offerIds || []).map(String).sort();
+          return actionHandKey(candidate) === expected.handKey
+            && actual.length === wanted.length
+            && actual.every((offerId, index) => offerId === wanted[index]);
+        });
+        const action = visible ? actions[visible.actionIndex] : null;
+        if (!action) return false;
+        focusIndex = visible.actionIndex;
+        focusedKey = actionHandKey(action);
+        openActionModal(action);
+        return true;
+      }, expectedSelection);
+      assert(opened, `${label} pending lifecycle should open its exact current Chat certificate`);
+      focusedSelectionIdentity = null;
       useFocusedActionOnNextClick = false;
     } else {
+      focusedSelectionIdentity = null;
+      useFocusedActionOnNextClick = false;
       await page.locator("#primary").click();
     }
     await confirmActionModalIfOpen();
@@ -9175,7 +9482,11 @@ async function main() {
 
   async function clickSearchAndAssertProgress(label) {
     const before = visibleDiscoveryKeys(await fetchCurrentState());
-    await clickPrimary(label);
+    const result = await clickPrimary(label, { allowStale: true });
+    if (result?.stale) {
+      steps.push({ label: `${label} replanned`, outcome: "the exact Inspect certificate changed" });
+      return false;
+    }
     await page.waitForFunction(
       () => !document.querySelector("#primary")?.disabled,
       null,
@@ -9184,6 +9495,7 @@ async function main() {
     const after = visibleDiscoveryKeys(await fetchCurrentState());
     const additions = after.filter((key) => !before.includes(key));
     steps.push({ label: `${label} discovery`, additions, outcome: additions.length ? "revealed" : "no new lead" });
+    return true;
   }
 
   async function waitForLocation(name) {
@@ -9234,22 +9546,43 @@ async function main() {
     }, name);
     await confirmRouteTo(name, `${route.includes("flee") ? "flee" : (searchingPathway ? "search" : "travel")} ${name}`);
     await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
-    const segmentedJourney = Boolean((await fetchCurrentState()).journey);
+    const journeyAtStart = await fetchCurrentState();
+    const segmentedJourney = Boolean(journeyAtStart.journey);
+    const journeyDestinationId = Number(journeyAtStart.journey?.destination_location_id || 0);
     let pathwayActions = 0;
-    while (segmentedJourney && (await fetchCurrentState()).journey) {
-      pathwayActions += 1;
-      assert(pathwayActions <= 12, `segmented route to ${name} should finish without looping`);
+    let pathwayPlans = 0;
+    while (segmentedJourney) {
       const current = await fetchCurrentState();
+      if (!current.journey) break;
+      pathwayPlans += 1;
+      assert(pathwayPlans <= 36, `segmented route to ${name} should replan without looping`);
+      assert(
+        Number(current.journey?.destination_location_id || 0) === journeyDestinationId,
+        `segmented route to ${name} should retain its original destination: ${JSON.stringify({ journeyDestinationId, journey: current.journey })}`,
+      );
       const nextName = String(current.journey?.next_location_name || name);
       const beforeLocation = String(current.location?.name || "");
-      const focusJourneyStep = () => page.evaluate(({ nextLocationId, destinationId, currentStep }) => {
+      const focusJourneyStep = () => page.evaluate((expected) => {
+        const actual = {
+          locationId: Number(state?.location?.id || 0),
+          nextLocationId: Number(state?.journey?.next_location_id || 0),
+          destinationId: Number(state?.journey?.destination_location_id || 0),
+          currentStep: Number(state?.journey?.current_step || 0),
+        };
+        if (
+          actual.locationId !== expected.locationId
+            || actual.nextLocationId !== expected.nextLocationId
+            || actual.destinationId !== expected.destinationId
+            || actual.currentStep !== expected.currentStep
+        ) return { replan: true, actual, expected };
+        const { nextLocationId, destinationId, currentStep } = expected;
         const exitKey = `exit:${nextLocationId}`;
         const searchKey = `journey-search:${destinationId}:${currentStep}`;
-        const index = actions.findIndex((action) => (
-          actionMatchesFocusKey(action, exitKey) || actionMatchesFocusKey(action, searchKey)
+        const visibleAction = actionBarActions().find((candidate) => (
+          actionMatchesFocusKey(candidate, exitKey) || actionMatchesFocusKey(candidate, searchKey)
         ));
-        if (index < 0) return false;
-        const action = actions[index];
+        if (!visibleAction) return false;
+        const action = actions[visibleAction.actionIndex];
         const journeyChoice = (action.choices || []).find((choice) => {
           const value = String(choice.value || "");
           return value.includes(searchKey)
@@ -9257,8 +9590,13 @@ async function main() {
             || value === String(nextLocationId);
         });
         if (journeyChoice) action.selectedChoice = journeyChoice.value;
-        focusAction(index, actionMatchesFocusKey(action, exitKey) ? exitKey : searchKey);
+        focusAction(visibleAction.actionIndex, actionMatchesFocusKey(action, exitKey) ? exitKey : searchKey);
         return {
+          handKey: actionHandKey(action),
+          offerIds: (action.offerIds || []).map(String),
+          generation: Number(state?.action_hand?.generation || 0),
+          routeIdentity: String(journeyChoice?.value || ""),
+          destinationLocationId: Number(action.selectedPayload?.()?.destination_location_id || 0),
           intention: String(action.intention || "").toLowerCase(),
           text: [action.label, action.detail, journeyChoice?.label, journeyChoice?.detail]
             .filter(Boolean)
@@ -9266,11 +9604,27 @@ async function main() {
             .toLowerCase(),
         };
       }, {
+        locationId: Number(current.location?.id || 0),
         nextLocationId: Number(current.journey?.next_location_id || 0),
         destinationId: Number(current.journey?.destination_location_id || 0),
         currentStep: Number(current.journey?.current_step || 0),
       });
-      const focusedJourneyStep = await focusJourneyStep();
+      let focusedJourneyStep = await focusJourneyStep();
+      if (focusedJourneyStep?.replan) {
+        await page.evaluate(() => refresh());
+        continue;
+      }
+      const journeyDeckSize = await page.evaluate(() => (
+        Math.max(1, Number(state?.action_hand?.deck_size || 1))
+      ));
+      for (let draw = 1; !focusedJourneyStep && draw < journeyDeckSize; draw += 1) {
+        await passCertifiedHandForDraw(`continue journey toward ${nextName}`);
+        focusedJourneyStep = await focusJourneyStep();
+      }
+      if (focusedJourneyStep?.replan) {
+        await page.evaluate(() => refresh());
+        continue;
+      }
       assert(
         focusedJourneyStep,
         `journey should remain an available hand option toward ${nextName}: ${JSON.stringify({
@@ -9290,9 +9644,21 @@ async function main() {
       );
       const primary = focusedJourneyStep.text;
       if (focusedJourneyStep.intention === "scout" || /^(search|scout)\b/.test(primary)) {
-        await confirmRouteTo(nextName, `search for ${nextName}`, focusJourneyStep);
+        const searchResult = await confirmRouteTo(nextName, `search for ${nextName}`, focusJourneyStep);
+        if (searchResult?.replan) {
+          await page.evaluate(() => refresh());
+          continue;
+        }
+        pathwayActions += 1;
+        assert(pathwayActions <= 12, `segmented route to ${name} should finish without looping`);
         await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
         const afterSearch = await fetchCurrentState();
+        assert(
+          afterSearch.journey
+            ? Number(afterSearch.journey.destination_location_id || 0) === journeyDestinationId
+            : Number(afterSearch.location?.id || 0) === journeyDestinationId,
+          `Scout toward ${name} should preserve or complete the original journey: ${JSON.stringify({ journeyDestinationId, afterSearch: { location: afterSearch.location, journey: afterSearch.journey } })}`,
+        );
         assert(
           String(afterSearch.location?.name || "") === beforeLocation,
           `Scout should reveal the next adjacent location without moving: ${JSON.stringify({ beforeLocation, after: afterSearch.location })}`,
@@ -9308,13 +9674,32 @@ async function main() {
           `a revealed segment should offer ordinary Travel to ${nextName}: ${JSON.stringify(focusedJourneyStep)}`,
         );
         const travelResult = await confirmRouteTo(nextName, `travel to ${nextName}`, focusJourneyStep);
+        if (travelResult?.replan) {
+          await page.evaluate(() => refresh());
+          continue;
+        }
+        pathwayActions += 1;
+        assert(pathwayActions <= 12, `segmented route to ${name} should finish without looping`);
         await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
         const afterTravel = await fetchCurrentState();
+        assert(
+          afterTravel.journey
+            ? Number(afterTravel.journey.destination_location_id || 0) === journeyDestinationId
+            : Number(afterTravel.location?.id || 0) === journeyDestinationId,
+          `Travel toward ${name} should preserve or complete the original journey: ${JSON.stringify({ journeyDestinationId, afterTravel: { location: afterTravel.location, journey: afterTravel.journey } })}`,
+        );
         assert(
           String(afterTravel.location?.name || "") !== beforeLocation,
           `Travel should enter the next revealed segment instead of remaining in place: ${JSON.stringify({ location: afterTravel.location, travelResult })}`,
         );
       }
+    }
+    if (segmentedJourney) {
+      const arrived = await fetchCurrentState();
+      assert(
+        !arrived.journey && Number(arrived.location?.id || 0) === journeyDestinationId,
+        `segmented route to ${name} should finish at its original destination id: ${JSON.stringify({ journeyDestinationId, location: arrived.location, journey: arrived.journey })}`,
+      );
     }
     await waitForLocation(name);
   }
@@ -9618,7 +10003,16 @@ async function main() {
         const body = await clickDealtActionMatching(`take ${name}`, ["take", nameLower]);
         lastResult = { httpStatus: Number(body?.status || 200), body };
       } catch (error) {
-        if (allowResidentClaim) return false;
+        if (allowResidentClaim) {
+          await page.evaluate(() => refresh());
+          const claimedByResident = await page.evaluate((itemName) => {
+            const currentActorId = Number(actorId || 0);
+            const item = (state?.items || []).find((candidate) => candidate.name === itemName);
+            return Number(item?.holder_actor_id || 0) > 0
+              && Number(item?.holder_actor_id || 0) !== currentActorId;
+          }, name);
+          if (claimedByResident) return false;
+        }
         throw error;
       }
       steps.push({ label: `take ${name}`, attempt });
@@ -9639,23 +10033,70 @@ async function main() {
     throw new Error(`take ${name} stayed stale after three fresh offers: ${JSON.stringify(lastResult)}`);
   }
 
-  async function revealBySearchIfNeeded(itemName, searchNeedles, label) {
-    const itemNeedle = itemName.toLowerCase();
+  async function worldItemPlacement(itemName, itemId) {
+    return page.evaluate(async ({ expectedName, expectedId }) => {
+      const currentActorId = Number(actorId || 0);
+      const currentLocationId = Number(state?.location?.id || 0);
+      const projected = (state?.items || []).find((item) => (
+        Number(item.id || 0) === Number(expectedId) || item.name === expectedName
+      ));
+      if (Number(projected?.holder_actor_id || 0) === currentActorId) {
+        return { kind: "player", location: state?.location?.name || "" };
+      }
+      if (Number(projected?.holder_actor_id || 0) > 0) {
+        const holder = (state?.actors || []).find((actor) => (
+          Number(actor.id || 0) === Number(projected.holder_actor_id)
+        ));
+        if (holder) {
+          return { kind: "resident", holder: holder.name, location: state?.location?.name || "" };
+        }
+      }
+      if (projected && Number(projected.location_id || 0) === currentLocationId) {
+        return { kind: "loose", location: state?.location?.name || "" };
+      }
+      const currentActorSession = localStorage.getItem("cosyworld.actorSession") || "";
+      const params = new URLSearchParams({
+        actor_id: String(currentActorId),
+        actor_session: currentActorSession,
+        wallet_address: "dev-wallet",
+      });
+      const world = await fetch(`/world?${params}`).then((response) => response.json());
+      for (const location of world.locations || []) {
+        if ((location.items || []).some((item) => (
+          Number(item.id || 0) === Number(expectedId) || item.name === expectedName
+        ))) {
+          return { kind: "loose", location: location.name };
+        }
+        const holder = (location.actors || []).find((actor) => (
+          (actor.economy?.held_item_ids || []).some((heldId) => (
+            Number(heldId) === Number(expectedId)
+          ))
+        ));
+        if (holder) {
+          return Number(holder.id || 0) === currentActorId
+            ? { kind: "player", location: location.name }
+            : { kind: "resident", holder: holder.name, location: location.name };
+        }
+      }
+      return null;
+    }, { expectedName: itemName, expectedId: itemId });
+  }
+
+  async function revealBySearchIfNeeded(itemName, itemId, searchNeedles, label) {
+    const itemPlacement = () => worldItemPlacement(itemName, itemId);
+    const stoppedByPlacement = async () => Boolean(await itemPlacement());
+    const wasNotDealt = (error, expectedLabel) => String(error?.message || error)
+      .startsWith(`${expectedLabel} was not dealt within one full hand rotation:`);
     for (let attempt = 1; attempt <= 8; attempt += 1) {
-      const canTakeItem = await page.evaluate((needle) => actions.some((action) => (
-        ["take", "swap"].includes(String(action.label || "").toLowerCase())
-          && (
-            String(action.detail || action.command || "").toLowerCase().includes(needle)
-            || (action.choices || []).some((choice) => (
-              `${choice.label || ""} ${choice.detail || ""}`.toLowerCase().includes(needle)
-            ))
-          )
-      )), itemNeedle);
-      if (canTakeItem) return;
+      const beforeSearch = await itemPlacement();
+      if (beforeSearch) return beforeSearch;
       let searchCard;
       try {
-        searchCard = await drawRoomSearch(label, searchNeedles);
-      } catch {
+        searchCard = await drawRoomSearch(label, searchNeedles, stoppedByPlacement);
+      } catch (targetedError) {
+        if (!wasNotDealt(targetedError, label)) throw targetedError;
+        const afterTargetedDraw = await itemPlacement();
+        if (afterTargetedDraw) return afterTargetedDraw;
         const restAvailable = await page.evaluate(() => actions.some((action) => (
           String(action?.label || "").toLowerCase() === "rest"
         )));
@@ -9663,7 +10104,14 @@ async function main() {
           await drawPrimaryMatching(`${label} recovery`, ["rest", "feel fresh"]);
           await clickPrimary(`${label} recovery`);
         }
-        searchCard = await drawRoomSearch(`${label} room-wide`);
+        const afterRecovery = await itemPlacement();
+        if (afterRecovery) return afterRecovery;
+        searchCard = await drawRoomSearch(`${label} room-wide`, [], stoppedByPlacement);
+      }
+      if (!searchCard) {
+        const placement = await itemPlacement();
+        assert(placement, `${itemName} placement stopped its hand rotation but was not observable`);
+        return placement;
       }
       steps.push({ label, attempt, primary: searchCard });
       await clickSearchAndAssertProgress(`${label} ${attempt}`);
@@ -9809,62 +10257,106 @@ async function main() {
     await assertActionBarCapped("combat attack action bar");
   }
 
-  async function focusGiftForResident(name) {
+  async function focusGiftForResident(name, stopWhen = null) {
     await page.waitForFunction(() => (
       actionBusy === false
         && refreshInFlight === null
         && document.querySelector("#action-modal")?.hidden === true
     ), null, { timeout: 35_000 });
-    const result = await page.evaluate((residentName) => {
-      const needle = residentName.toLowerCase();
-      const index = actions.findIndex((action) => (
-        ["give", "swap", "trade"].includes(action.label)
-        && (
-          String(action.detail || "").toLowerCase().includes(needle)
-          || (action.choices || []).some((choice) => String(choice.label || "").toLowerCase().includes(needle))
-        )
-      ));
-      if (index < 0) {
+    const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
+    let result = null;
+    for (let draw = 0; draw < deckSize; draw += 1) {
+      result = await page.evaluate((residentName) => {
+        const needle = residentName.toLowerCase();
+        const action = actionBarActions().find((candidate) => (
+          ["give", "swap", "trade"].includes(candidate.label)
+          && (
+            String(candidate.detail || "").toLowerCase().includes(needle)
+            || (candidate.choices || []).some((choice) => String(choice.label || "").toLowerCase().includes(needle))
+          )
+        ));
+        if (!action) {
+          return {
+            ok: false,
+            actions: actionBarActions().map((candidate) => ({
+              label: candidate.label,
+              detail: candidate.detail,
+              choices: candidate.choices || [],
+            })),
+          };
+        }
+        focusIndex = action.actionIndex;
+        focusedKey = actionHandKey(actions[action.actionIndex]);
         return {
-          ok: false,
-          actions: actions.map((action) => ({ label: action.label, detail: action.detail, choices: action.choices || [] })),
+          ok: true,
+          handKey: actionHandKey(action),
+          offerIds: (action.offerIds || []).map(String),
+          generation: Number(state?.action_hand?.generation || 0),
+          text: [
+            action.label,
+            action.detail,
+            action.command,
+          ].filter(Boolean).join(" "),
         };
+      }, name);
+      if (result.ok) break;
+      if (stopWhen && await stopWhen()) return null;
+      if (draw + 1 < deckSize) {
+        await passCertifiedHandForDraw(`find ${name} gift`);
       }
-      focusIndex = index;
-      focusedKey = actionHandKey(actions[index]);
-      return {
-        ok: true,
-        text: [
-          actions[index].label,
-          actions[index].detail,
-          actions[index].command,
-        ].filter(Boolean).join(" "),
-      };
-    }, name);
-    assert(result.ok, `${name} should be carried by one Give or Swap card: ${JSON.stringify(result)}`);
+    }
+    assert(result?.ok, `${name} should be carried by one Give or Swap card: ${JSON.stringify(result)}`);
+    focusedSelectionIdentity = {
+      handKey: result.handKey,
+      offerIds: result.offerIds,
+      generation: result.generation,
+    };
+    useFocusedActionOnNextClick = true;
     await assertNoVisibleOverflow();
     return result.text;
   }
 
   async function giveFocusedCardTo(name, label) {
-    await page.evaluate(() => openActionModal(focusedAction()));
-    useFocusedActionOnNextClick = false;
-    await page.waitForSelector("#action-modal:not([hidden])");
-    const choices = page.locator("#action-modal-choices .action-choice");
-    const choiceCount = await choices.count();
-    if (choiceCount > 0) {
-      const targetChoice = choices.filter({ hasText: name });
-      assert(await targetChoice.count() === 1, `${name} should appear once in the Give choices`);
-      await targetChoice.click();
+    const result = await commitFocusedCertifiedAction(label, {
+      choiceText: name,
+      transferTarget: name,
+    });
+    if (!result.ok) return false;
+    const { submission } = result;
+    const transferReceipt = (result.body?.events || []).find((event) => (
+      event.type === "item.given"
+        && Number(event.item_id || 0) === Number(submission.itemId)
+        && Number(event.target_actor_id || 0) === Number(submission.targetActorId)
+    ));
+    assert(
+      transferReceipt,
+      `${name} gift should return an exact authoritative item.given receipt: ${JSON.stringify(result.body?.events || [])}`,
+    );
+    recordLivingItemEvidence({
+      type: "item.given",
+      resident: name,
+      item: transferReceipt.item_name || `item:${submission.itemId}`,
+    });
+    const transferVerified = await page.evaluate(async ({ itemId, targetActorId }) => {
+      const currentActorId = localStorage.getItem("cosyworld.actorId") || "";
+      const currentActorSession = localStorage.getItem("cosyworld.actorSession") || "";
+      const params = new URLSearchParams({
+        actor_id: currentActorId,
+        actor_session: currentActorSession,
+        wallet_address: "dev-wallet",
+      });
+      const world = await fetch(`/world?${params}`).then((worldResponse) => worldResponse.json());
+      const target = (world.locations || []).flatMap((location) => location.actors || [])
+        .find((actor) => Number(actor.id || 0) === Number(targetActorId));
+      return (target?.economy?.held_item_ids || []).some((heldId) => Number(heldId) === Number(itemId));
+    }, submission);
+    if (!transferVerified) {
+      steps.push({
+        label: `${name} settled ${submission.itemId} after receipt`,
+        outcome: "the shared world advanced after the exact gift",
+      });
     }
-    await page.locator("#action-modal-confirm").click();
-    await page.waitForFunction(() => (
-      actionBusy === false
-        && refreshInFlight === null
-        && document.querySelector("#action-modal")?.hidden === true
-    ), null, { timeout: 35_000 });
-    await assertNoVisibleOverflow();
-    steps.push({ label, primary: await primaryText(), location: await page.locator("#location-name").innerText() });
+    return true;
   }
 
   async function resolveHeldKeepsakeFor(name, label, itemName) {
@@ -9873,16 +10365,11 @@ async function main() {
     let lastPrimary = "";
     for (let attempt = 1; attempt <= 5; attempt += 1) {
       lastJourney = await joinResident(name);
-      const availability = await page.evaluate(({ residentName, itemName }) => ({
-        nearby: (state?.actors || []).some((actor) => actor.name === residentName),
-        give: actions.some((action) => (
-          ["give", "swap", "trade"].includes(action.label)
-            && (
-              String(action.detail || "").toLowerCase().includes(residentName.toLowerCase())
-              || (action.choices || []).some((choice) => String(choice.label || "").toLowerCase().includes(residentName.toLowerCase()))
-            )
-        )),
-        use: actions.some((action) => (
+      const availability = await page.evaluate(({ residentName, itemName }) => {
+        const dealt = actionBarActions();
+        const item = (state?.items || []).find((candidate) => candidate.name === itemName) || null;
+        const resident = (state?.actors || []).find((actor) => actor.name === residentName) || null;
+        const useAction = dealt.find((action) => (
           String(action.label || "").toLowerCase() === "use"
             && [
               action.detail,
@@ -9890,24 +10377,95 @@ async function main() {
               action.effect,
               ...(action.choices || []).flatMap((choice) => [choice.label, choice.detail]),
             ].filter(Boolean).join(" ").toLowerCase().includes(itemName.toLowerCase())
-        )),
-      }), { residentName: name, itemName });
+        ));
+        const matchingUseChoices = (useAction?.choices || []).filter((choice) => (
+          [choice.label, choice.detail]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase()
+            .includes(itemName.toLowerCase())
+        ));
+        return {
+          nearby: (state?.actors || []).some((actor) => actor.name === residentName),
+          give: dealt.some((action) => (
+            ["give", "swap", "trade"].includes(action.label)
+              && (
+                String(action.detail || "").toLowerCase().includes(residentName.toLowerCase())
+                || (action.choices || []).some((choice) => String(choice.label || "").toLowerCase().includes(residentName.toLowerCase()))
+              )
+          )),
+          use: useAction ? {
+            handKey: actionHandKey(useAction),
+            offerIds: (useAction.offerIds || []).map(String),
+            generation: Number(state?.action_hand?.generation || 0),
+            choiceValue: matchingUseChoices.length === 1
+              ? String(matchingUseChoices[0].value || "")
+              : "",
+            choiceCount: (useAction.choices || []).length,
+            matchingChoiceCount: matchingUseChoices.length,
+            itemId: Number(item?.id || 0),
+            locationId: Number(state?.location?.id || 0),
+            residentActorId: Number(resident?.id || 0),
+          } : null,
+        };
+      }, { residentName: name, itemName });
       lastAvailability = availability;
       if (!availability.nearby) continue;
-      if (!availability.give) {
-        if (availability.use) {
-          await clickActionMatching(`use ${itemName} for ${name}`, ["use", itemName.toLowerCase()]);
-          return lastJourney;
-        } else {
-          await listenAtCurrentLocation();
+      if (!availability.give && availability.use) {
+        assert(
+          availability.use.choiceCount === 0 || availability.use.matchingChoiceCount === 1,
+          `${itemName} should resolve to one exact authored Use mode: ${JSON.stringify(availability.use)}`,
+        );
+        focusedSelectionIdentity = availability.use;
+        useFocusedActionOnNextClick = true;
+        const useResult = await commitFocusedCertifiedAction(`use ${itemName} for ${name}`, {
+          choiceText: availability.use.choiceValue ? itemName : "",
+          choiceValue: availability.use.choiceValue,
+          expectedItemId: availability.use.itemId,
+          expectedLocationId: availability.use.locationId,
+        });
+        if (useResult.ok) {
+          const usedReceipt = (useResult.body?.events || []).some((event) => (
+            event.type === "item.used"
+              && Number(event.item_id || 0) === availability.use.itemId
+              && (!event.location_id || Number(event.location_id) === availability.use.locationId)
+          ));
+          const bondReceipt = (useResult.body?.events || []).some((event) => (
+            event.type === "bond.deepened"
+              && Number(event.target_actor_id || 0) === availability.use.residentActorId
+          ));
+          assert(
+            usedReceipt && bondReceipt,
+            `${itemName} Use should settle through its authored feature and ${name} bond: ${JSON.stringify(useResult.body?.events || [])}`,
+          );
+          recordLivingItemEvidence({
+            type: "item.used",
+            resident: name,
+            item: itemName,
+          });
+          return { journey: lastJourney, settled: true };
         }
         continue;
       }
-      lastPrimary = await focusGiftForResident(name);
+      lastPrimary = await focusGiftForResident(name, () => page.evaluate(
+        ({ residentName, heldItemName }) => (
+          !(state?.actors || []).some((actor) => actor.name === residentName)
+            || actionBarActions().some((action) => (
+              String(action.label || "").toLowerCase() === "use"
+                && [
+                  action.detail,
+                  action.command,
+                  action.effect,
+                  ...(action.choices || []).flatMap((choice) => [choice.label, choice.detail]),
+                ].filter(Boolean).join(" ").toLowerCase().includes(heldItemName.toLowerCase())
+            ))
+        ),
+        { residentName: name, heldItemName: itemName },
+      ));
+      if (!lastPrimary) continue;
       steps.push({ label: `focus ${name} gift`, attempt, primary: lastPrimary });
       if (!/^(give|swap|trade)\b/i.test(lastPrimary)) continue;
-      await giveFocusedCardTo(name, label);
-      return lastJourney;
+      if (await giveFocusedCardTo(name, label)) return { journey: lastJourney, settled: true };
     }
     throw new Error(`${name} did not expose a gift, discovery, or authored use: ${JSON.stringify({ lastJourney, lastAvailability, lastPrimary })}`);
   }
@@ -10001,7 +10559,7 @@ async function main() {
       if (await currentLocation() !== "Rain-Soft Garden") {
         await travelPathTo("Rain-Soft Garden");
       }
-      const residentHeld = await page.evaluate(async (expected) => {
+      const residentClaimState = await page.evaluate(async (expected) => {
         const actorId = Number(localStorage.getItem("cosyworld.actorId") || 0);
         const actorSession = localStorage.getItem("cosyworld.actorSession") || "";
         const params = new URLSearchParams({
@@ -10011,25 +10569,38 @@ async function main() {
         });
         const world = await fetch(`/world?${params}`).then((response) => response.json());
         const held = [];
+        const misdirected = [];
         for (const location of world.locations || []) {
           for (const resident of location.actors || []) {
             for (const keepsake of expected) {
               if (
-                resident.name === keepsake.residentName
+                resident.kind === "npc"
                 && (resident.economy?.held_item_ids || []).includes(keepsake.itemId)
               ) {
-                held.push({ ...keepsake, residentName: resident.name, location: location.name });
+                const claim = { ...keepsake, actualResidentName: resident.name, location: location.name };
+                if (resident.name === keepsake.residentName) held.push(claim);
+                else misdirected.push(claim);
               }
             }
           }
         }
-        return held;
+        return { held, misdirected };
       }, keepsakes);
-      for (const found of residentHeld) {
+      assert(
+        residentClaimState.misdirected.length === 0,
+        `garden keepsakes should not settle with the wrong resident: ${JSON.stringify(residentClaimState.misdirected)}`,
+      );
+      for (const found of residentClaimState.held) {
         if (delivered.has(found.itemName)) continue;
         delivered.add(found.itemName);
+        recordLivingItemEvidence({
+          type: "item.held",
+          resident: found.actualResidentName,
+          item: found.itemName,
+          location: found.location,
+        });
         steps.push({
-          label: `${found.residentName} found ${found.itemName}`,
+          label: `${found.actualResidentName} found ${found.itemName}`,
           location: found.location,
         });
       }
@@ -10045,11 +10616,28 @@ async function main() {
       }, [...itemToResident.keys()].filter((itemName) => !delivered.has(itemName)));
       if (carriedGift) {
         const recipientName = itemToResident.get(carriedGift.itemName);
-        await resolveHeldKeepsakeFor(recipientName, `give ${carriedGift.itemName}`, carriedGift.itemName);
+        const settlement = await resolveHeldKeepsakeFor(
+          recipientName,
+          `give ${carriedGift.itemName}`,
+          carriedGift.itemName,
+        );
         if (await currentLocation() !== "Rain-Soft Garden") {
           await travelPathTo("Rain-Soft Garden");
         }
-        delivered.add(carriedGift.itemName);
+        if (settlement?.settled) delivered.add(carriedGift.itemName);
+        continue;
+      }
+      const looseKeepsake = await page.evaluate((remainingItemNames) => {
+        const currentLocationId = Number(state?.location?.id || 0);
+        const item = (state?.items || []).find((candidate) => (
+          Number(candidate.holder_actor_id || 0) === 0
+            && Number(candidate.location_id || 0) === currentLocationId
+            && remainingItemNames.includes(candidate.name)
+        ));
+        return item ? { itemName: item.name } : null;
+      }, [...itemToResident.keys()].filter((itemName) => !delivered.has(itemName)));
+      if (looseKeepsake) {
+        await takeItem(looseKeepsake.itemName, { allowResidentClaim: true });
         continue;
       }
       const available = await page.evaluate(() => actions
@@ -10081,10 +10669,62 @@ async function main() {
           steps.push({ label: "clear garden floor", item: blockingItem });
           continue;
         }
-        const searchCard = await drawCertifiedGardenInspect("garden keepsake search");
+        const remainingKeepsakes = keepsakes.filter(({ itemName: remainingName }) => (
+          !delivered.has(remainingName)
+        ));
+        const gardenSceneChanged = () => page.evaluate(async (expected) => {
+          const currentActorId = Number(actorId || 0);
+          const currentLocationId = Number(state?.location?.id || 0);
+          const expectedNames = new Set(expected.map((item) => item.itemName));
+          if ((state?.items || []).some((item) => (
+            expectedNames.has(item.name)
+              && (
+                Number(item.holder_actor_id || 0) === currentActorId
+                  || Number(item.location_id || 0) === currentLocationId
+                  || (state?.actors || []).some((resident) => {
+                    const keepsake = expected.find((candidate) => Number(candidate.itemId) === Number(item.id));
+                    return keepsake
+                      && Number(resident.id || 0) === Number(item.holder_actor_id || 0)
+                      && resident.name === keepsake.residentName;
+                  })
+              )
+          ))) return true;
+          const visibleText = actionBarActions().map((action) => [
+            action.label,
+            action.detail,
+            action.command,
+            ...(action.choices || []).flatMap((choice) => [choice.label, choice.detail]),
+          ].filter(Boolean).join(" "));
+          if (visibleText.some((text) => (
+            [...expectedNames].some((name) => text.toLowerCase().includes(name.toLowerCase()))
+          ))) return true;
+          const currentActorSession = localStorage.getItem("cosyworld.actorSession") || "";
+          const params = new URLSearchParams({
+            actor_id: String(currentActorId),
+            actor_session: currentActorSession,
+            wallet_address: "dev-wallet",
+          });
+          const world = await fetch(`/world?${params}`).then((response) => response.json());
+          return (world.locations || []).some((location) => (
+            (location.actors || []).some((resident) => (
+              expected.some((keepsake) => (
+                resident.name === keepsake.residentName
+                  && (resident.economy?.held_item_ids || []).includes(Number(keepsake.itemId))
+              ))
+            ))
+          ));
+        }, remainingKeepsakes);
+        const searchCard = await drawCertifiedGardenInspect(
+          "garden keepsake search",
+          gardenSceneChanged,
+        );
+        if (searchCard === false) continue;
         if (!searchCard) {
-          await travelPathTo("The Cosy Cottage");
-          steps.push({ label: "let the garden turn without a legal Inspect", attempt });
+          if (await gardenSceneChanged()) continue;
+          if (attempt < 12) {
+            await passCertifiedHandForDraw("find remaining garden keepsake");
+            steps.push({ label: "rotate garden hand without a legal Inspect", attempt });
+          }
           continue;
         }
         steps.push({ label: "garden keepsake search", attempt, primary: searchCard });
@@ -10333,6 +10973,8 @@ async function main() {
         && result.emote.events.some((event) => event.type === "message.created" && event.content === "nods to the room."),
       `emote command should emit room narration: ${JSON.stringify(result.emote)}`,
     );
+    playerSpeechEvidence.add("hello room");
+    playerSpeechEvidence.add("nods to the room.");
     assert(result.primaryCommand.length > 0, `primary button should expose command metadata: ${JSON.stringify(result)}`);
     steps.push({ label: "mud command api", primaryCommand: result.primaryCommand });
   }
@@ -12445,6 +13087,7 @@ async function main() {
         && result.clean.events.some((event) => event.type === "message.created" && event.content === "The hearth hears a tiny hello."),
       `clean human speech should emit a room event: ${JSON.stringify(result.clean)}`,
     );
+    playerSpeechEvidence.add("The hearth hears a tiny hello.");
   }
 
   async function focusedChatTargetId() {
@@ -13004,15 +13647,136 @@ async function main() {
       await travelTo("Rain-Soft Garden");
     }
     await travelTo("Moonlit Trail");
+    const moonlitProjectStatus = async () => {
+      const current = await fetchCurrentState();
+      const progress = (current.clocks || []).find((clock) => clock.id === "moonlit-trail.progress");
+      const job = (current.jobs || []).find((entry) => entry.id === "moonlit-trail:quiet-the-echo");
+      const filled = Number(progress?.filled || 0);
+      return {
+        current,
+        filled,
+        status: job?.status || "missing",
+        completed: filled === 4 && job?.status === "completed",
+      };
+    };
+    const projectAdvancedBeyond = (baseline) => async () => {
+      const project = await moonlitProjectStatus();
+      return project.completed || project.filled > baseline;
+    };
+    const drawMoonlitProjectStrategy = async (
+      label,
+      { strategyId, needles, stopWhen },
+    ) => {
+      await page.waitForFunction(() => (
+        actionBusy === false
+          && refreshInFlight === null
+          && document.querySelector("#action-modal")?.hidden === true
+      ), null, { timeout: 35_000 });
+      const normalizedNeedles = needles.map((needle) => needle.toLowerCase());
+      const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
+      let lastHand = [];
+      for (let draw = 0; draw < deckSize; draw += 1) {
+        if (stopWhen && await stopWhen()) return null;
+        const result = await page.evaluate(({ expectedStrategyId, terms }) => {
+          const actionText = (action) => [
+            action?.label,
+            action?.detail,
+            action?.command,
+            action?.cost,
+            action?.risk,
+            action?.effect,
+            ...(action?.choices || []).flatMap((choice) => [choice.label, choice.detail]),
+          ].filter(Boolean).join(" ").toLowerCase();
+          const visible = actionBarActions();
+          const action = visible.find((candidate) => {
+            const source = actions[candidate.actionIndex];
+            return source?.project?.id === "moonlit-trail:quiet-the-echo"
+              && String(source?.project?.strategy_id || "") === String(expectedStrategyId || "")
+              && terms.every((term) => actionText(source).includes(term));
+          });
+          if (!action) {
+            return {
+              ok: false,
+              hand: visible.map((candidate) => {
+                const source = actions[candidate.actionIndex];
+                return {
+                  text: actionText(source),
+                  projectId: String(source?.project?.id || ""),
+                  strategyId: String(source?.project?.strategy_id || ""),
+                };
+              }),
+            };
+          }
+          const source = actions[action.actionIndex];
+          return {
+            ok: true,
+            index: action.actionIndex,
+            handKey: actionHandKey(source),
+            offerIds: (source.offerIds || []).map(String),
+            generation: Number(state?.action_hand?.generation || 0),
+            text: actionText(source),
+          };
+        }, { expectedStrategyId: strategyId, terms: normalizedNeedles });
+        if (result.ok) {
+          await page.evaluate((index) => {
+            focusIndex = index;
+            focusedKey = actionHandKey(actions[index]);
+          }, result.index);
+          focusedSelectionIdentity = {
+            handKey: result.handKey,
+            offerIds: result.offerIds,
+            generation: result.generation,
+          };
+          useFocusedActionOnNextClick = true;
+          await assertNoVisibleOverflow();
+          return result.text;
+        }
+        lastHand = result.hand;
+        if (draw + 1 < deckSize) {
+          await passCertifiedHandForDraw(`${label} draw ${draw + 1}`);
+        }
+      }
+      throw new Error(`${label} exact authored project card was not dealt within one full hand rotation: ${JSON.stringify(lastHand)}`);
+    };
+    const commitMoonlitProjectWithRetry = async (
+      label,
+      { strategyId, needles, stopWhen },
+    ) => {
+      let lastResult = null;
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        if (attempt > 1) {
+          if (stopWhen && await stopWhen()) {
+            return { ...lastResult, stopped: true };
+          }
+          const redrawn = await drawMoonlitProjectStrategy(`${label} retry ${attempt}`, {
+            strategyId,
+            needles,
+            stopWhen,
+          });
+          if (!redrawn) return { ...lastResult, stopped: true };
+        }
+        lastResult = await commitFocusedCertifiedAction(label, {
+          expectedProjectId: "moonlit-trail:quiet-the-echo",
+          expectedStrategyId: strategyId,
+        });
+        if (lastResult.ok) return lastResult;
+        assert(lastResult.stale, `${label} should retry only after exact stale-offer evidence`);
+        if (stopWhen && await stopWhen()) {
+          return { ...lastResult, stopped: true };
+        }
+      }
+      throw new Error(`${label} stayed stale after three fresh authored offers: ${JSON.stringify(lastResult)}`);
+    };
     const projectBeforePrimer = await fetchCurrentState();
     const projectProgressBeforePrimer = (projectBeforePrimer.clocks || []).find(
       (clock) => clock.id === "moonlit-trail.progress",
     );
+    const projectFilledBeforePrimer = Number(projectProgressBeforePrimer?.filled || 0);
     let progressPrimer = "resident feature use";
-    if (Number(projectProgressBeforePrimer?.filled || 0) === 1) {
+    if (projectFilledBeforePrimer >= 1) {
       steps.push({
         label: "resident primed project",
-        progress: "1/4",
+        progress: `${projectFilledBeforePrimer}/4`,
         item: "Wolfprint Charm",
       });
     } else {
@@ -13026,34 +13790,36 @@ async function main() {
         await takeItem("Wolfprint Charm");
         const projectCluePrimary = await primaryText();
         steps.push({ label: "project clue default", primary: projectCluePrimary });
-        const projectClueNeedles = await page.evaluate(() => {
-          const visibleActions = actions.map((action) => [
-            action.label,
-            action.detail,
-            action.command,
-          ].filter(Boolean).join(" ").toLowerCase());
-          if (visibleActions.some((text) => text.includes("investigate this place"))) {
-            return ["investigate this place"];
-          }
-          if (visibleActions.some((text) => (
-            text.includes("search") && text.includes("moonlit trail")
-          ))) {
-            return ["search", "moonlit trail"];
-          }
-          return null;
-        });
+        const projectClueNeedles = await page.evaluate(() => (
+          actions.some((action) => (
+            action?.project?.id === "moonlit-trail:quiet-the-echo"
+              && action?.project?.strategy_id === "listen-for-echo"
+          ))
+            ? ["listen for where the echo catches"]
+            : null
+        ));
         if (projectClueNeedles) {
-          await drawPrimaryMatching("investigate project clue", projectClueNeedles);
-          await clickPrimary("investigate project clue");
-          await page.waitForFunction(
-            () => !document.querySelector("#primary")?.disabled,
-          );
+          const projectClueCard = await drawMoonlitProjectStrategy("investigate project clue", {
+            strategyId: "listen-for-echo",
+            needles: projectClueNeedles,
+            stopWhen: projectAdvancedBeyond(projectFilledBeforePrimer),
+          });
+          let clueResult = null;
+          if (projectClueCard) {
+            clueResult = await commitMoonlitProjectWithRetry("investigate project clue", {
+              strategyId: "listen-for-echo",
+              needles: projectClueNeedles,
+              stopWhen: projectAdvancedBeyond(projectFilledBeforePrimer),
+            });
+          }
           const projectAfterClue = await fetchCurrentState();
           const projectProgressAfterClue = (projectAfterClue.clocks || []).find(
             (clock) => clock.id === "moonlit-trail.progress",
           );
-          primerCommitted = Number(projectProgressAfterClue?.filled || 0)
-            > Number(projectProgressBeforePrimer?.filled || 0);
+          primerCommitted = Number(projectProgressAfterClue?.filled || 0) > projectFilledBeforePrimer;
+          if (clueResult && !clueResult.ok) {
+            assert(primerCommitted, "stale project clue should coincide with authoritative progress");
+          }
           if (primerCommitted) {
             progressPrimer = "investigate project clue";
             steps.push({
@@ -13065,23 +13831,47 @@ async function main() {
       }
       let featureUseCommitted = primerCommitted;
       if (wolfprintAvailable && !featureUseCommitted) {
+        let projectUsePrimary = null;
         try {
-          const projectUsePrimary = await drawPrimaryMatching(
-            "project feature use",
-            ["use", "wolfprint charm"],
-          );
-          assert(
-            projectUsePrimary.includes("makes a little headway"),
-            "project feature use should preview its gentle progress without counting steps",
-          );
-          await clickPrimary("use project feature item");
-          featureUseCommitted = true;
+          projectUsePrimary = await drawMoonlitProjectStrategy("project feature use", {
+            strategyId: "set-wolfprint-marker",
+            needles: ["set the wolfprint marker"],
+            stopWhen: projectAdvancedBeyond(projectFilledBeforePrimer),
+          });
         } catch (error) {
+          if (!String(error?.message || error).startsWith("project feature use exact authored project card was not dealt")) {
+            throw error;
+          }
           progressPrimer = "safe help";
           steps.push({
             label: "project feature use unavailable",
             error: String(error.message || error).slice(0, 240),
           });
+        }
+        if (!projectUsePrimary) {
+          const project = await moonlitProjectStatus();
+          featureUseCommitted = project.completed || project.filled > projectFilledBeforePrimer;
+          if (featureUseCommitted) {
+            progressPrimer = "resident project contribution";
+            steps.push({ label: "resident primed project while drawing feature use", progress: `${project.filled}/4` });
+          }
+        } else {
+          const useResult = await commitMoonlitProjectWithRetry("use project feature item", {
+            strategyId: "set-wolfprint-marker",
+            needles: ["set the wolfprint marker"],
+            stopWhen: projectAdvancedBeyond(projectFilledBeforePrimer),
+          });
+          if (useResult.ok) {
+            assert(
+              useResult.submission.strategyId === "set-wolfprint-marker",
+              `Wolfprint use should resolve its exact authored strategy: ${JSON.stringify(useResult.submission)}`,
+            );
+            featureUseCommitted = true;
+          } else {
+            const project = await moonlitProjectStatus();
+            featureUseCommitted = project.completed || project.filled > projectFilledBeforePrimer;
+            assert(featureUseCommitted, "stale Wolfprint use should coincide with authoritative project progress");
+          }
         }
       }
       if (!featureUseCommitted) {
@@ -13090,43 +13880,142 @@ async function main() {
             && !actions.some((action) => String(action.label || "").toLowerCase() === "help")
         ));
         if (needsRest) {
-          await drawPrimaryMatching("rest before project help", ["rest", "feel fresh"]);
-          await clickPrimary("rest before helping project");
+          const restBeforeHelp = await drawPrimaryMatching(
+            "rest before project help",
+            ["rest", "feel fresh"],
+            projectAdvancedBeyond(projectFilledBeforePrimer),
+          );
+          if (restBeforeHelp) await clickPrimary("rest before helping project");
           progressPrimer = "rest then safe help";
         }
-        const legacyProjectHelpAvailable = await page.evaluate(() => (
-          actions.some((action) => {
-            const text = [
-              action.label,
-              action.detail,
-              action.command,
-              ...(action.choices || []).flatMap((choice) => [choice.label, choice.detail]),
-            ].filter(Boolean).join(" ").toLowerCase();
-            return text.includes("steady the trail together") && text.includes("coach");
-          })
-        ));
+        const legacyProjectHelpAvailable = await page.evaluate(() => actions.some((action) => (
+          action?.project?.id === "moonlit-trail:quiet-the-echo"
+            && action?.project?.strategy_id === "steady-beside-traveler"
+        )));
+        const projectBeforeSafeAction = await fetchCurrentState();
+        const progressBeforeSafeAction = Number((projectBeforeSafeAction.clocks || []).find(
+          (clock) => clock.id === "moonlit-trail.progress",
+        )?.filled || 0);
+        const stopForResidentProgress = projectAdvancedBeyond(progressBeforeSafeAction);
+        let safeProjectPrimary = null;
         if (legacyProjectHelpAvailable) {
-          const projectHelpPrimary = await drawPrimaryMatching(
-            "project safe help",
-            ["steady the trail together", "coach"],
-          );
-          assert(
-            projectHelpPrimary.toLowerCase().includes("quiet the echo"),
-            "fallback project help should retain the authored project card",
-          );
-          await clickPrimary("help project safely");
+          safeProjectPrimary = await drawMoonlitProjectStrategy("project safe help", {
+            strategyId: "steady-beside-traveler",
+            needles: ["steady the trail together", "coach"],
+            stopWhen: stopForResidentProgress,
+          });
         } else {
-          const projectInvestigatePrimary = await drawPrimaryMatching(
-            "project safe investigation",
-            ["investigate this place", "moonlit trail"],
-          );
-          assert(
-            projectInvestigatePrimary.toLowerCase().includes("choose an approach"),
-            "fallback project investigation should retain its authored approaches",
-          );
-          await clickPrimary("investigate project safely");
-          progressPrimer = "safe investigation";
+          safeProjectPrimary = await drawMoonlitProjectStrategy("project safe investigation", {
+            strategyId: "listen-for-echo",
+            needles: ["listen for where the echo catches"],
+            stopWhen: stopForResidentProgress,
+          });
+          if (safeProjectPrimary) {
+            assert(
+              safeProjectPrimary.toLowerCase().startsWith("listen for where the echo catches"),
+              "fallback project investigation should retain its exact authored card",
+            );
+            progressPrimer = "safe investigation";
+          }
         }
+        if (!safeProjectPrimary) {
+          const project = await moonlitProjectStatus();
+          assert(
+            project.completed || project.filled > progressBeforeSafeAction,
+            "project hand rotation should stop only for authoritative resident progress",
+          );
+          featureUseCommitted = true;
+          progressPrimer = "resident project contribution";
+          steps.push({
+            label: "resident primed project during hand rotation",
+            progress: `${project.filled}/4`,
+          });
+        } else {
+          const safeResult = await commitMoonlitProjectWithRetry(
+            legacyProjectHelpAvailable ? "help project safely" : "investigate project safely",
+            {
+              strategyId: legacyProjectHelpAvailable
+                ? "steady-beside-traveler"
+                : "listen-for-echo",
+              needles: legacyProjectHelpAvailable
+                ? ["steady the trail together", "coach"]
+                : ["listen for where the echo catches"],
+              stopWhen: stopForResidentProgress,
+            },
+          );
+          if (safeResult.ok) {
+            const project = await moonlitProjectStatus();
+            featureUseCommitted = project.completed || project.filled > progressBeforeSafeAction;
+            if (!featureUseCommitted) {
+              steps.push({
+                label: "project check made no headway",
+                strategy: safeResult.submission.strategyId,
+                progress: `${project.filled}/4`,
+              });
+            }
+          } else {
+            const project = await moonlitProjectStatus();
+            assert(
+              project.completed || project.filled > progressBeforeSafeAction,
+              "stale safe project action should coincide with authoritative progress",
+            );
+            featureUseCommitted = true;
+          }
+        }
+        if (!featureUseCommitted) {
+          const certainPrimer = await page.evaluate(() => {
+            const exact = (state?.action_offers || []).find((offer) => (
+              offer?.project?.id === "moonlit-trail:quiet-the-echo"
+                && ["steady-beside-traveler", "steady-trail"].includes(
+                  String(offer?.project?.strategy_id || ""),
+                )
+            ));
+            if (!exact) return null;
+            return {
+              strategyId: exact.project.strategy_id,
+              label: exact.project.strategy_id === "steady-beside-traveler"
+                ? "steady the trail together"
+                : "steady the trail",
+            };
+          });
+          if (certainPrimer) {
+            const certainCard = await drawMoonlitProjectStrategy("certain project primer", {
+              strategyId: certainPrimer.strategyId,
+              needles: [certainPrimer.label],
+              stopWhen: projectAdvancedBeyond(progressBeforeSafeAction),
+            });
+            if (certainCard) {
+              const certainResult = await commitMoonlitProjectWithRetry("advance project certainly", {
+                strategyId: certainPrimer.strategyId,
+                needles: [certainPrimer.label],
+                stopWhen: projectAdvancedBeyond(progressBeforeSafeAction),
+              });
+              if (certainResult.ok) {
+                const project = await moonlitProjectStatus();
+                featureUseCommitted = project.completed || project.filled > progressBeforeSafeAction;
+              }
+            }
+          }
+        }
+        if (!featureUseCommitted) {
+          const primerDeckSize = await page.evaluate(() => (
+            Math.max(1, Number(state?.action_hand?.deck_size || 1))
+          ));
+          for (let draw = 1; draw <= primerDeckSize && !featureUseCommitted; draw += 1) {
+            const beforePass = await moonlitProjectStatus();
+            featureUseCommitted = beforePass.completed
+              || beforePass.filled > progressBeforeSafeAction;
+            if (featureUseCommitted) break;
+            await passCertifiedHandForDraw(`wait for shared project primer ${draw}`);
+            const afterPass = await moonlitProjectStatus();
+            featureUseCommitted = afterPass.completed
+              || afterPass.filled > progressBeforeSafeAction;
+          }
+        }
+        assert(
+          featureUseCommitted,
+          "a failed project check should replan to certain or authoritative shared progress",
+        );
       }
     }
     await page.waitForFunction(() => {
@@ -13166,36 +14055,102 @@ async function main() {
           && !actions.some((action) => String(action.label || "").toLowerCase() === "prepare")
       ));
       if (mustRestBeforePrepare) {
-        await drawPrimaryMatching("rest before project prepare", ["rest", "feel fresh"]);
-        await clickPrimary("rest before preparing project");
+        const restBeforePrepare = await drawPrimaryMatching(
+          "rest before project prepare",
+          ["rest", "feel fresh"],
+          async () => (await moonlitProjectStatus()).completed,
+        );
+        if (restBeforePrepare) await clickPrimary("rest before preparing project");
       }
-      const projectCanPrepare = await page.evaluate(() => (
-        actions.some((action) => String(action.label || "").toLowerCase() === "prepare")
-      ));
+      const projectCanPrepare = !(await moonlitProjectStatus()).completed
+        && await page.evaluate(() => (
+          actions.some((action) => String(action.label || "").toLowerCase() === "prepare")
+        ));
       if (projectCanPrepare) {
-        const projectPreparePrimary = await drawPrimaryMatching("project prepare", [
-          "prepare",
-          "make the next try count",
-        ]);
-        assert(
-          projectPreparePrimary.includes("make the next try count"),
-          "used project feature should preview a strong prepared payoff without arithmetic",
-        );
-        assert(
-          !projectPreparePrimary.toLowerCase().includes("next project action"),
-          "prepared setup should not expose rules jargon in the primary button",
-        );
-        await clickPrimary("prepare informed project");
+        const progressBeforePrepare = (await moonlitProjectStatus()).filled;
+        const projectPreparePrimary = await drawMoonlitProjectStrategy("project prepare", {
+          strategyId: null,
+          needles: ["prepare", "make the next try count"],
+          stopWhen: projectAdvancedBeyond(progressBeforePrepare),
+        });
+        if (projectPreparePrimary) {
+          assert(
+            projectPreparePrimary.includes("make the next try count"),
+            "used project feature should preview a strong prepared payoff without arithmetic",
+          );
+          assert(
+            !projectPreparePrimary.toLowerCase().includes("next project action"),
+            "prepared setup should not expose rules jargon in the primary button",
+          );
+          const prepareStopped = async () => {
+            const preparedForActor = await page.evaluate(() => (
+              (state?.tags || []).some((tag) => (
+                tag.id === `actor:${Number(actorId)}:prepared:3`
+              ))
+            ));
+            return preparedForActor || projectAdvancedBeyond(progressBeforePrepare)();
+          };
+          const prepareResult = await commitMoonlitProjectWithRetry("prepare informed project", {
+            strategyId: null,
+            needles: ["prepare", "make the next try count"],
+            stopWhen: prepareStopped,
+          });
+          const preparedForActor = await page.evaluate(() => (
+            (state?.tags || []).some((tag) => (
+              tag.id === `actor:${Number(actorId)}:prepared:3`
+            ))
+          ));
+          if (prepareResult.ok) {
+            assert(preparedForActor, "successful project preparation should authoritatively prepare this actor");
+          } else {
+            const afterStalePrepare = await moonlitProjectStatus();
+            assert(
+              preparedForActor
+                || afterStalePrepare.completed
+                || afterStalePrepare.filled > progressBeforePrepare,
+              "stale project preparation should coincide with preparation or authoritative project progress",
+            );
+          }
+        }
       } else {
-        const projectStudyPrimary = await drawPrimaryMatching("project authored study", [
-          "quiet the echo",
-          "read the moonlit signs",
-        ]);
-        assert(
-          projectStudyPrimary.toLowerCase().includes("choose an approach"),
-          `the project card should keep its authored approaches together: ${projectStudyPrimary}`,
-        );
-        await clickPrimary("study informed project");
+        const progressBeforeStudy = (await moonlitProjectStatus()).filled;
+        const projectStudyPrimary = await drawMoonlitProjectStrategy("project authored study", {
+          strategyId: "read-moonlit-signs",
+          needles: ["read the moonlit signs"],
+          stopWhen: async () => (await moonlitProjectStatus()).completed,
+        });
+        if (!projectStudyPrimary) {
+          steps.push({ label: "shared project completed while drawing study", progress: "4/4" });
+        }
+        if (projectStudyPrimary) {
+          const currentProject = await moonlitProjectStatus();
+          if (currentProject.completed) {
+            steps.push({ label: "shared project completed before study", progress: "4/4" });
+          } else {
+            assert(
+              projectStudyPrimary.toLowerCase().startsWith("read the moonlit signs"),
+              `the remaining project study should retain its exact authored identity: ${projectStudyPrimary}`,
+            );
+            const studyResult = await commitMoonlitProjectWithRetry("study informed project", {
+              strategyId: "read-moonlit-signs",
+              needles: ["read the moonlit signs"],
+              stopWhen: projectAdvancedBeyond(progressBeforeStudy),
+            });
+            if (studyResult.ok) {
+              assert(
+                studyResult.submission.projectId === "moonlit-trail:quiet-the-echo"
+                  && studyResult.submission.strategyId === "read-moonlit-signs",
+                `project Study should resolve its exact authored strategy: ${JSON.stringify(studyResult.submission)}`,
+              );
+            } else {
+              const progressedProject = await moonlitProjectStatus();
+              assert(
+                progressedProject.completed || progressedProject.filled > progressBeforeStudy,
+                "stale project Study should coincide with authoritative progress",
+              );
+            }
+          }
+        }
       }
       for (let attempt = 1; attempt <= 3; attempt += 1) {
         await page.waitForFunction(() => (
@@ -13230,18 +14185,28 @@ async function main() {
           await clickPrimary(`rest before project completion ${attempt}`);
           continue;
         }
-        const completionAction = await focusPrimaryMatchingAcrossShuffles(
-          `project completion ${attempt}`,
-          (text) => text.startsWith("finish") || text.startsWith("work") || text.includes("quiet the echo"),
-          8,
-          () => page.evaluate(() => {
+        const completionAction = await drawMoonlitProjectStrategy(`project completion ${attempt}`, {
+          strategyId: "steady-trail",
+          needles: ["steady the trail"],
+          stopWhen: () => page.evaluate(() => {
             const progress = (state?.clocks || []).find((clock) => clock.id === "moonlit-trail.progress");
             const job = (state?.jobs || []).find((entry) => entry.id === "moonlit-trail:quiet-the-echo");
             return Number(progress?.filled || 0) === 4 && job?.status === "completed";
           }),
-        );
+        });
         if (!completionAction) break;
-        await clickPrimary(`complete project ${attempt}`);
+        const completionResult = await commitMoonlitProjectWithRetry(`complete project ${attempt}`, {
+          strategyId: "steady-trail",
+          needles: ["steady the trail"],
+          stopWhen: projectAdvancedBeyond(projectRecovery.progress),
+        });
+        if (!completionResult.ok) {
+          const progressedProject = await moonlitProjectStatus();
+          assert(
+            progressedProject.completed || progressedProject.filled > projectRecovery.progress,
+            "stale project completion should coincide with authoritative progress",
+          );
+        }
       }
     }
     await page.waitForFunction(() => {
@@ -13278,6 +14243,7 @@ async function main() {
       ),
       `resolving the project should apply its reward tag: ${JSON.stringify(completedProjectState.tags)}`,
     );
+    moonlitProjectObservedCompleted = true;
     const activeAvatarId = Number(await page.evaluate(() => actorId || 0));
     const projectLeftAvatarTired = (completedProjectState.tags || []).some((tag) => (
       tag.label === "tired"
@@ -13416,29 +14382,58 @@ async function main() {
         location: moonwoolResidentHolder.location,
       });
     } else {
-      await revealBySearchIfNeeded(
+      const moonwoolPlacement = await revealBySearchIfNeeded(
         "Moonwool Thread",
+        2004,
         ["thread"],
         "reveal Moonwool Thread",
       );
-      await takeItem("Moonwool Thread");
-      const ratiStillWantsMoonwool = await page.evaluate(async () => {
-        const currentActorId = localStorage.getItem("cosyworld.actorId");
-        const actorSession = localStorage.getItem("cosyworld.actorSession");
-        const params = new URLSearchParams({
-          actor_id: currentActorId,
-          actor_session: actorSession,
-          wallet_address: "dev-wallet",
+      let currentMoonwoolPlacement = moonwoolPlacement;
+      if (
+        currentMoonwoolPlacement.kind === "loose"
+          && currentMoonwoolPlacement.location
+          && currentMoonwoolPlacement.location !== await currentLocation()
+      ) {
+        await travelPathTo(currentMoonwoolPlacement.location);
+        currentMoonwoolPlacement = await worldItemPlacement("Moonwool Thread", 2004);
+      }
+      if (currentMoonwoolPlacement?.kind === "loose") {
+        assert(
+          !currentMoonwoolPlacement.location
+            || currentMoonwoolPlacement.location === await currentLocation(),
+          `Moonwool Thread moved before Take: ${JSON.stringify(currentMoonwoolPlacement)}`,
+        );
+        await takeItem("Moonwool Thread", { allowResidentClaim: true });
+        currentMoonwoolPlacement = await worldItemPlacement("Moonwool Thread", 2004);
+      }
+      if (currentMoonwoolPlacement?.kind === "resident") {
+        steps.push({
+          label: `${currentMoonwoolPlacement.holder} found Moonwool Thread during search`,
+          location: currentMoonwoolPlacement.location,
         });
-        const world = await fetch(`/world?${params}`).then((response) => response.json());
-        const rati = (world.locations || []).flatMap((location) => location.actors || [])
-          .find((actor) => actor.name === "Rati");
-        return Number(rati?.economy?.request?.item_id || 0) === 2004;
-      });
-      if (ratiStillWantsMoonwool) {
-        await giveHeldItemTo("Rati", "give Moonwool Thread");
       } else {
-        steps.push({ label: "Rati's Moonwool wish already changed", location: await currentLocation() });
+        assert(
+          currentMoonwoolPlacement?.kind === "player",
+          `Moonwool Thread should be held or resident-claimed before delivery: ${JSON.stringify(currentMoonwoolPlacement)}`,
+        );
+        const ratiStillWantsMoonwool = await page.evaluate(async () => {
+          const currentActorId = localStorage.getItem("cosyworld.actorId");
+          const actorSession = localStorage.getItem("cosyworld.actorSession");
+          const params = new URLSearchParams({
+            actor_id: currentActorId,
+            actor_session: actorSession,
+            wallet_address: "dev-wallet",
+          });
+          const world = await fetch(`/world?${params}`).then((response) => response.json());
+          const rati = (world.locations || []).flatMap((location) => location.actors || [])
+            .find((actor) => actor.name === "Rati");
+          return Number(rati?.economy?.request?.item_id || 0) === 2004;
+        });
+        if (ratiStillWantsMoonwool) {
+          await giveHeldItemTo("Rati", "give Moonwool Thread");
+        } else {
+          steps.push({ label: "Rati's Moonwool wish already changed", location: await currentLocation() });
+        }
       }
     }
     if ((await currentLocation()) !== "The Cosy Cottage") {
@@ -13455,6 +14450,7 @@ async function main() {
     }
   }
 
+  await Promise.all([...branchReceiptAudits]);
   const finalState = await page.evaluate(async () => {
     const actorId = localStorage.getItem("cosyworld.actorId");
     const actorSession = localStorage.getItem("cosyworld.actorSession");
@@ -13465,6 +14461,12 @@ async function main() {
       limit: "500",
     });
     const state = await fetch(`/state?${params}`).then((response) => response.json());
+    const worldParams = new URLSearchParams({
+      actor_id: actorId,
+      actor_session: actorSession,
+      wallet_address: "dev-wallet",
+    });
+    const world = await fetch(`/world?${worldParams}`).then((response) => response.json());
     const events = [];
     let after = 0;
     let replayCaughtUp = false;
@@ -13487,15 +14489,55 @@ async function main() {
       .filter((event) => (
         (event.type === "item.used" && event.actor_id !== Number(actorId))
         || (event.type === "item.given" && event.target_actor_id !== Number(actorId))
+        || (event.type === "bond.deepened" && event.target_actor_id !== Number(actorId))
         || event.type === "avatar.evolved"
       ))
       .map((event) => ({
         type: event.type,
-        resident: event.type === "item.given" || event.type === "avatar.evolved"
+        resident: ["item.given", "bond.deepened", "avatar.evolved"].includes(event.type)
           ? event.target_actor_name
           : event.actor_name,
         item: event.item_name,
       }));
+    const itemStoryMoments = events
+      .filter((event) => (
+        ["item.used", "item.given", "avatar.evolved"].includes(event.type)
+      ))
+      .map((event) => ({
+        type: event.type,
+        actor: event.actor_name,
+        resident: ["item.given", "avatar.evolved"].includes(event.type)
+          ? event.target_actor_name
+          : event.actor_name,
+        item: event.item_name,
+      }));
+    const residentKeepsakeState = [];
+    const expectedKeepsakes = [
+      { item: "Dewbright Button", itemId: 2002, resident: "Gust" },
+      { item: "Watch Bell", itemId: 2007, resident: "Skull" },
+    ];
+    for (const location of world.locations || []) {
+      for (const resident of location.actors || []) {
+        for (const keepsake of expectedKeepsakes) {
+          if (
+            resident.name === keepsake.resident
+              && (resident.economy?.held_item_ids || []).includes(keepsake.itemId)
+          ) {
+            residentKeepsakeState.push({
+              type: "item.held",
+              resident: resident.name,
+              item: keepsake.item,
+              location: location.name,
+            });
+          }
+        }
+      }
+    }
+    const moonlitProgress = (state.clocks || []).find((clock) => clock.id === "moonlit-trail.progress");
+    const moonlitJob = (state.jobs || []).find((job) => job.id === "moonlit-trail:quiet-the-echo");
+    const moonlitProjectCompleted = Number(moonlitProgress?.filled || 0) === 4
+      && moonlitJob?.status === "completed"
+      && (state.tags || []).some((tag) => tag.label === "quieted moonlight");
     const avatarMessages = events
       .filter((event) => event.type === "message.created" && event.actor_id === Number(actorId))
       .map((event) => event.content);
@@ -13518,6 +14560,9 @@ async function main() {
       replayCaughtUp,
       evolved,
       residentStoryMoments,
+      itemStoryMoments,
+      residentKeepsakeState,
+      moonlitProjectCompleted,
       avatarMessages,
       branchEvents,
       fleeEvents,
@@ -13528,31 +14573,57 @@ async function main() {
         .filter(Boolean),
     };
   });
+  finalState.livingItemEvidence = livingItemEvidence;
+  finalState.moonlitProjectObservedCompleted = moonlitProjectObservedCompleted;
+  finalState.playerSpeechEvidence = [...playerSpeechEvidence];
+  finalState.branchReceiptEvents = observedBranchEventReceipts;
   assert(finalState.replayCaughtUp, "final event replay should reach the current world sequence");
   if (runLivingWorldStress) {
-    const storyResidents = new Set(finalState.residentStoryMoments.map((moment) => moment.resident).filter(Boolean));
+    const residentStoryEvidence = [
+      ...finalState.residentStoryMoments,
+      ...finalState.residentKeepsakeState,
+      ...finalState.livingItemEvidence,
+    ];
+    const storyResidents = new Set(residentStoryEvidence.map((moment) => moment.resident).filter(Boolean));
     assert(
-      storyResidents.size >= 2,
-      `living items should shape stories for multiple residents: ${JSON.stringify(finalState.residentStoryMoments)}`,
+      storyResidents.has("Gust") && storyResidents.has("Skull"),
+      `living items should shape both Gust's and Skull's stories: ${JSON.stringify(residentStoryEvidence)}`,
     );
     assert(
-      finalState.residentStoryMoments.some((moment) => (
-        moment.type === "avatar.evolved"
+      finalState.itemStoryMoments.some((moment) => (
+        (moment.type === "avatar.evolved" && moment.resident === "Gust")
         || (moment.type === "item.used" && moment.item === "Wolfprint Charm")
-      )),
-      `the Wolfprint project clue should matter through resident use or evolution: ${JSON.stringify(finalState.residentStoryMoments)}`,
+      )) || finalState.moonlitProjectCompleted || finalState.moonlitProjectObservedCompleted,
+      `the Wolfprint clue should resolve through authored use, evolution, or its completed shared project: ${JSON.stringify({ itemStoryMoments: finalState.itemStoryMoments, moonlitProjectCompleted: finalState.moonlitProjectCompleted, moonlitProjectObservedCompleted: finalState.moonlitProjectObservedCompleted })}`,
     );
     assert(
-      finalState.residentStoryMoments.some((moment) => (
-        moment.type === "avatar.evolved"
-        || (["item.given", "item.used"].includes(moment.type) && moment.item === "Watch Bell")
+      finalState.itemStoryMoments.some((moment) => (
+        (moment.type === "avatar.evolved" && moment.resident === "Skull")
+        || (["item.given", "item.used"].includes(moment.type)
+          && moment.item === "Watch Bell"
+          && moment.resident === "Skull")
+      )) || finalState.livingItemEvidence.some((moment) => (
+        moment.item === "Watch Bell" && moment.resident === "Skull"
+      )) || finalState.residentKeepsakeState.some((moment) => (
+        moment.item === "Watch Bell" && moment.resident === "Skull"
       )),
-      `the Watch Bell should reach a resident, perform its authored use, or complete an evolution: ${JSON.stringify(finalState.residentStoryMoments)}`,
+      `the Watch Bell should reach Skull, perform its authored use, or complete an evolution: ${JSON.stringify({ itemStoryMoments: finalState.itemStoryMoments, residentKeepsakeState: finalState.residentKeepsakeState })}`,
     );
     assert(finalState.trailExitEvents.includes("Rain-Soft Garden"), "leaving Moonlit Trail should record a trail exit event");
   }
-  assert(finalState.avatarMessages.length >= 2, "moderated player speech should remain in the shared channel");
-  assert(finalState.branchEvents.length === 0, `normal play should not emit branch lifecycle events: ${JSON.stringify(finalState.branchEvents)}`);
+  const observedPlayerSpeech = new Set([
+    ...finalState.avatarMessages,
+    ...finalState.playerSpeechEvidence,
+  ]);
+  assert(
+    observedPlayerSpeech.size >= 2,
+    `moderated player speech should have authoritative shared-channel receipts: ${JSON.stringify([...observedPlayerSpeech])}`,
+  );
+  const allBranchEvents = [
+    ...finalState.branchEvents.map((type) => ({ type, source: "final replay" })),
+    ...finalState.branchReceiptEvents.map((event) => ({ ...event, source: "action receipt" })),
+  ];
+  assert(allBranchEvents.length === 0, `normal play should not emit branch lifecycle events: ${JSON.stringify(allBranchEvents)}`);
   assert(finalState.buttons.length >= 1 && finalState.buttons.length <= 2, `the journey should finish with at most two action cards: ${JSON.stringify(finalState.buttons)}`);
   await assertNoComposerOrDebugChrome();
   await page.setViewportSize({ width: 1280, height: 800 });


### PR DESCRIPTION
## Summary

- document capability-specific OpenRouter model evaluations and catalog coverage
- define the highlighted normalized `<3` Heart Score and the 1st/2nd/3rd/fail gate funnel
- specify mechanically neutral human/AI reaction provenance, storage, replay, abuse, and privacy contracts
- align release metadata at `0.0.317`

## Impact

Design-only RFC; no runtime or UI implementation.

## Validation

- `git diff --check`
- `npm run check:version`
- `npm test` (46 files, 530 tests)
- `npm run v2:worldpack`
- `npm run v2:kernel`
- `npm run v2:rust:test` (963 tests)
- `npm run v2:architecture`
- `npm run v2:syntax`
- `npm run v2:browser:check` (deterministic and living-world phases)

## Review checklist

- [x] No runtime behavior changed
- [x] No generated artifacts or secrets committed
- [x] npm and Rust release metadata aligned
