### PR TITLE
docs: record the avatar-NFT-only bridge decision

### DIFF
--- a/docs/backlog/avatar-nft-only-core.md
+++ b/docs/backlog/avatar-nft-only-core.md
@@ -1,0 +1,156 @@
+# Avatar-NFT-only core grooming
+
+Status: proposed product simplification. No destructive implementation work
+begins before [#681](https://github.com/cenetex/cosyworld/issues/681) is
+accepted. Removal/isolation is tracked by
+[#682](https://github.com/cenetex/cosyworld/issues/682), and the retained avatar
+bridge is tracked by [#688](https://github.com/cenetex/cosyworld/issues/688).
+
+## Recommendation
+
+Keep the parts that make CosyWorld a world, plus one narrow external bridge:
+supported NFT avatars join the shared world when their verified owning wallet
+is linked.
+
+The core consists of accounts, avatars, shared places, physical items, cards as
+presentation, action offers, Journal history, jobs, delivery, crafting,
+resident autonomy, generated public media, and deterministic replay. A wallet
+is never required for ordinary play.
+
+The NFT bridge supports actors only. It does not support keepsake collections,
+kept-close loadouts, Boxes, bundles, item or location NFTs, wallet-gated places,
+or item materialization. A beautiful card can represent a shared person, place,
+spell, or item without becoming a privately owned token.
+
+## Product boundary
+
+| Surface | Recommendation | Reason |
+| --- | --- | --- |
+| Cards | Keep as non-ownable UI projections | They make actions and world state legible. |
+| Physical items | Keep and deepen | They drive scarcity, delivery, equipment, crafting, and stories. |
+| Journal provenance | Keep as authority | It records who did what and why. |
+| Supported avatar NFTs | Keep through an isolated adapter | One verified asset can coherently introduce one persistent actor. |
+| Wallet link | Keep only for avatar discovery/custody | It is optional and never gates ordinary play. |
+| NFT metadata | Cosmetic allowlist only | It cannot safely author mechanics or prompts. |
+| Orbs | Decide separately | Shared-art funding can survive without collectible ownership. |
+| Keepsake collection | Remove | It duplicates card/item language without adding core play. |
+| Kept-close loadout | Remove | It is cosmetic client matching with vocabulary and UI cost. |
+| Box/bundle flow | Remove | It adds irreversible wallet operations unrelated to the shared-world loop. |
+| Item/location NFTs | Remove | They create pay-for-access/power pressure and duplicate world authority. |
+| Item materialization | Disable and migrate | It creates a second item plane and global uniqueness burden. |
+
+## Avatar NFT contract
+
+- A protected server adapter, never browser claims, verifies network,
+  collection authority, asset id, metadata, and current owner.
+- One allowlisted asset maps to one stable actor id and one first-
+  materialization receipt.
+- The actor arrives at a worldpack-authored threshold or entry location.
+- Repeated wallet links recover the same actor; they never create a clone.
+- The actor is autonomous by default. NFT custody supplies provenance/roster
+  authority, not arbitrary commands.
+- Custody transfer preserves canonical actor history and updates the verified
+  owner association.
+- Approved metadata may affect sanitized name and appearance only.
+- Rarity and metadata never improve stats, action economy, damage, access,
+  rewards, items, resident priority, or AI authority.
+- Disconnect/unlink can move an actor offstage only through an explicit safe-
+  boundary policy. It does not delete the actor or evade consequences.
+- The default composition and golden journey pass with the adapter absent.
+
+## Groomed issue map
+
+| Issue | Priority | Purpose |
+| --- | --- | --- |
+| [#681](https://github.com/cenetex/cosyworld/issues/681) | P1 / now | Accept the avatar-NFT-only product boundary. |
+| [#682](https://github.com/cenetex/cosyworld/issues/682) | P1 / next, blocked | Remove keepsake/item/location NFT surfaces and isolate the avatar adapter. |
+| [#688](https://github.com/cenetex/cosyworld/issues/688) | P1 / next, blocked | Productize supported NFT avatars joining on wallet link. |
+| [#683](https://github.com/cenetex/cosyworld/issues/683) | P0 / now | Prevent actor/item art funding before the full review path is available. |
+| [#684](https://github.com/cenetex/cosyworld/issues/684) | P1 / next | Match causal delivery jobs to the actual delivered resource. |
+| [#685](https://github.com/cenetex/cosyworld/issues/685) | P1 / now | Retire item materialization without duplicating live items. |
+| [#686](https://github.com/cenetex/cosyworld/issues/686) | P2 / later | Decide bounded item progression/attunement/enchantment. |
+| [#364](https://github.com/cenetex/cosyworld/issues/364) | Existing backlog | Route actor/item/location art through the correct worldpack media profile. |
+| [#523](https://github.com/cenetex/cosyworld/issues/523) | Completed pilot | Proves one Proxim8 joins exactly once as an autonomous actor. |
+
+## Recommended sequence
+
+### 0. Stop extending the broad collectible model
+
+- Do not add new Box products, item/location NFTs, wallet-gated official
+  places, collection mechanics, item card bindings, or native ownership-chain
+  work.
+- Fix only correctness, data-safety, and compatibility defects in the item
+  bridge while the decision is open.
+- Continue focused avatar-NFT work only through the actor materialization seam.
+
+### 1. Accept the boundary
+
+- Decide #681 and move ADR 0006 from Proposed to Accepted or Rejected.
+- Record automatic exactly-once roster for every supported owned asset; room
+  capacity sends excess actors offstage rather than adding a second join step.
+- Decide whether Orbs remain for shared art; that should not block removal of
+  the broad collectible model.
+- Publish the player vocabulary: *action*, *card*, *item*, *linked avatar*,
+  *Journal*, and *world pack*. No *keepsake* or *bundle* in new copy.
+
+### 2. Productize the avatar adapter
+
+- Generalize the Project 89 pilot into an allowlisted collection/profile
+  registry without moving wallet facts into the kernel.
+- Prove actor identity, arrival, autonomy, custody transfer, offstage policy,
+  replay, and metadata restrictions.
+- Keep adapter failure independent from ordinary account/avatar recovery.
+
+### 3. Disable and migrate the removed surfaces
+
+- Hide kept-close, collection, Box, bundle, item/location NFT, wallet-gate, and
+  item-materialization controls.
+- Reject new item materialization before migrating existing receipts.
+- Preserve one world item per active receipt through an idempotent migration.
+- Make legacy wallet and receipt data read-only, then remove runtime
+  dependencies only after replay and restore drills pass.
+
+### 4. Remove compatibility code
+
+- Remove core routes, fields, configuration, provider polling, chain RPC,
+  browser code, fixtures, and smoke paths not needed by the avatar adapter.
+- Retain only the focused wallet challenge, ownership adapter, actor binding,
+  custody, and audit surfaces required by supported avatar collections.
+
+## Item direction after keepsakes
+
+Removing keepsakes should make physical items more important, not less.
+
+- An item has one location/holder and one authoritative zone.
+- Equipment supplies typed, bounded effects; it does not rewrite arbitrary base
+  stats.
+- Crafting transforms authored templates through capable places and durable
+  receipts.
+- Delivery proves custody, movement, destination, and the requested resource.
+- Art is cosmetic and follows item/worldpack identity.
+- Any future enchantment is a closed recipe or attunement transformation, never
+  an NFT trait or generated free-form modifier; see #686.
+
+## Documentation status
+
+Until #681 is accepted, existing wallet/NFT documentation remains useful as a
+description of the live compatibility surface. It is not an invitation to add
+new product scope. `ECONOMY.md`, `ENG.md`, `PRD.md`, the player lexicon, and the
+traveler guide point here so current behavior and proposed direction are not
+confused.
+
+## Exit criteria
+
+- [ ] The default/core composition starts with no wallet, ownership feed, NFT,
+      Box, collection, or chain configuration.
+- [ ] A new ordinary player completes the first-session and golden-journey
+      paths without encountering keepsake, bundle, NFT, or materialization
+      concepts.
+- [ ] Linking a wallet makes every supported NFT avatar join according to the
+      accepted roster policy, exactly once per asset.
+- [ ] Cards remain useful presentation; world items retain full physical and
+      mechanical behavior.
+- [ ] Existing live materialized items are neither lost nor duplicated.
+- [ ] Historical receipts remain auditable under the accepted retention policy.
+- [ ] No official place, action, stat, item, image, or progression path depends
+      on external asset ownership.

--- a/docs/decisions/0006-avatar-nft-only-bridge.md
+++ b/docs/decisions/0006-avatar-nft-only-bridge.md
@@ -1,0 +1,142 @@
+# ADR 0006: a wallet-optional core with an avatar-NFT-only bridge
+
+- Status: Proposed
+- Date: 2026-08-02
+- Decision issue: [#681](https://github.com/cenetex/cosyworld/issues/681)
+- Removal migration: [#682](https://github.com/cenetex/cosyworld/issues/682)
+- Avatar bridge: [#688](https://github.com/cenetex/cosyworld/issues/688)
+- Decision owners: CosyWorld maintainers
+
+## Context
+
+CosyWorld currently has three concepts sharing one player-facing surface:
+
+1. physical world actors and items owned by the canonical kernel;
+2. cards that present actors, items, locations, actions, and spells;
+3. wallet or local collection records called keepsakes, including Boxes,
+   bundles, external entitlements, gated locations, and item materialization
+   receipts.
+
+The third concept adds wallet sessions, ownership feeds, chain verification,
+burn and reveal flows, collection loadouts, gated access, and a second item
+plane to the core runtime. It also makes *keepsake* mean both a collection
+representation and, in current content and copy, a physical world item.
+
+Avatar NFTs have a narrower and coherent world effect: a verified asset may
+introduce one persistent character. The Project 89 pilot in
+[#523](https://github.com/cenetex/cosyworld/issues/523) already proves this
+shape for one Proxim8 without granting its owner direct actor authority.
+
+## Proposed decision
+
+Make the default CosyWorld product wallet-optional and retain only an
+avatar-NFT bridge.
+
+- **Cards remain.** A card is a visual and interaction projection of
+  authoritative world state. It is not a general owned asset.
+- **World items remain.** Physical items continue to be scarce, transferable,
+  equipable, craftable, usable, and replay-derived kernel objects.
+- **The Journal is provenance.** Account identity plus canonical journal and
+  world events remain sufficient for ordinary play and craft/item lineage.
+- **Keepsake leaves the vocabulary.** New copy says *card* for presentation,
+  *item* for a physical object, and *linked avatar* for an NFT-backed actor.
+- **Supported avatar NFTs may join.** Linking a verified owning wallet resolves
+  allowlisted avatar assets through a protected server-side adapter. Each asset
+  binds idempotently to exactly one durable world actor and authored arrival
+  location.
+- **The actor is not the NFT record.** The kernel actor has canonical identity,
+  history, bonds, advancement, presence, and inventory. The external asset is
+  provenance and roster/custody evidence.
+- **Ownership is not command authority.** The default NFT avatar is autonomous,
+  following #523. A player-control model requires a separate decision.
+- **Metadata is cosmetic.** Approved identity and appearance fields may be
+  refreshed under policy. Rarity and metadata cannot author stats, actions,
+  access, items, rewards, prompts, or pack ids.
+- **Custody transfer preserves the actor.** The verified association follows a
+  legitimate transfer while canonical played history remains intact.
+- **Other NFT surfaces leave the core.** Box burn, bundle reveal, general
+  keepsake collections, item/location NFTs, wallet-gated places, and collection
+  item materialization are removed through a replay-safe migration.
+- **The adapter stays optional.** The default composition and complete ordinary
+  player loop boot with no wallet, chain, ownership-feed, or NFT configuration.
+- **Media stays public.** Generated art attaches to a world subject or event.
+  Funding never creates private ownership. The future of Orbs is a separate
+  question within #681.
+
+## Retained and retired concepts
+
+| Retain | Retire from the core |
+| --- | --- |
+| Actor accounts and sessions | Wallet requirement for ordinary play |
+| Allowlisted NFT avatar → actor bindings | General NFT/keepsake collection |
+| Wallet link for supported avatar discovery | NFT item/location/pass mechanics |
+| Journal/world-event provenance | Native transferable card ownership chain |
+| Card-shaped action and entity presentation | Kept-close collection loadout |
+| Physical world items and zones | Wallet/world item materialization bridge |
+| Craft receipts and item lineage | Box burn and bundle reveal |
+| Shared public media | Wallet-gated official-world continuity |
+| Worldpack-authored actor templates | NFT metadata-derived mechanics |
+
+## Avatar binding lifecycle
+
+1. A player links a wallet through the existing signed challenge flow.
+2. The server refreshes a protected ownership adapter; the browser cannot
+   supply authoritative asset or collection membership.
+3. Each allowlisted asset is matched to an authored actor profile and arrival
+   location. Unsupported or ambiguous assets fail closed.
+4. Every supported owned asset is rostered automatically. If room capacity is
+   full, excess actors enter the offstage presence state; no second collectible-
+   style join or materialize action is required.
+5. The first automatic join writes one immutable asset-to-actor binding and one
+   typed materialization receipt before the actor enters the world.
+6. Reconnect, retry, refresh, and restart recover the same actor.
+7. Disconnect, unlink, capacity pressure, transfer, or revocation changes
+   roster/presence at a safe boundary; it does not delete canonical history or
+   evade an active consequence.
+
+## Compatibility and migration
+
+Removal must not delete audit history or duplicate/lossily convert a live item
+or actor.
+
+1. Freeze new Box, keepsake, item/location NFT, wallet-gate, and item-
+   materialization work while #681 is open.
+2. Preserve and generalize the focused Project 89 avatar materialization seam;
+   do not move wallet data into the C kernel.
+3. Inventory wallet links, ownership snapshots, burn/open receipts, item
+   materialization receipts, external bindings, gated routes, UI, and tests.
+4. Disable new item materializations before converting existing ones.
+5. Convert each active materialized item into one ordinary world item, or return
+   it to archival state, according to one typed migration receipt.
+6. Preserve historical records as read-only audit data until a retention policy
+   explicitly permits deletion.
+7. Prove the default golden journey without the avatar adapter, then separately
+  prove every supported owned avatar joins exactly once after wallet link.
+
+The item bridge migration is tracked by
+[#685](https://github.com/cenetex/cosyworld/issues/685). Productizing the avatar
+bridge is tracked by [#688](https://github.com/cenetex/cosyworld/issues/688).
+
+## Relationship to earlier decisions
+
+If accepted, this ADR supersedes the item/location card, wallet-keepsake,
+portable-item, Box/bundle, gated-access, and general native-ownership direction
+in [ADR 0001](0001-cards-are-entitlements.md). It retains ADR 0001's useful
+boundary: external provenance and presentation never replace canonical world
+entities.
+
+[ADR 0002](0002-action-hand-is-authoritative-state.md) remains authoritative.
+Removing kept-close matching art makes its server-authored action-hand boundary
+smaller. NFT avatar ownership does not alter action legality or ranking.
+
+## Consequences
+
+- Ordinary play becomes easier to explain and operate without discarding the
+  avatar collections that can meaningfully populate the shared world.
+- Avatar identity gets one global asset-to-actor invariant instead of a general
+  portable card economy.
+- World-item scarcity has one authority and no wallet/world bridge.
+- Existing chain and wallet code requires deliberate archival migration, not
+  immediate destructive deletion.
+- A future item, location, pass, Box, or general collectible product requires a
+  new decision and cannot silently reuse the avatar adapter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.319",
+  "version": "0.0.320",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.319",
+      "version": "0.0.320",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.319",
+  "version": "0.0.320",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.319"
+version = "0.0.320"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.319"
+version = "0.0.320"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

Recovers the avatar-NFT-only design work from an unpushed local workspace snapshot (`codex/ranker-workspace-snapshot-20260802`) and lands it as a reviewable design record. This was the only content on that branch not already on `main`; the branch's other commits had landed via #664, #677, and #680.

- `docs/decisions/0006-avatar-nft-only-bridge.md` — proposed ADR for a wallet-optional core that retains only an avatar-NFT bridge.
- `docs/backlog/avatar-nft-only-core.md` — grooming notes and the product boundary table behind that proposal.

Both track open issues #681 (decision), #682 (removal/isolation), and #688 (retained avatar bridge). The ADR status is **Proposed**; nothing here authorizes implementation work.

## Renumbering

The snapshot numbered this ADR 0004, which already belongs to `0004-rest-grades-and-expedition-depth.md` on `main`. It is renumbered 0006 here, and the backlog doc's reference was updated to match. Its sibling links to ADR 0001 and ADR 0002 resolve.

## Verification

- `npm test` — 46 files, 531 tests, all passing
- `npm run check:version` — passes (0.0.319 → 0.0.320 in `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`)
- `git diff --check` — clean

Documentation only; no runtime, kernel, pack, or client surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)