### PR TITLE
fix(deploy): declare Elysium journal compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.321",
+  "version": "0.0.322",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.321",
+      "version": "0.0.322",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.321",
+  "version": "0.0.322",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/worldpack-bundle-gate.test.mjs
+++ b/test/v2/worldpack-bundle-gate.test.mjs
@@ -22,6 +22,10 @@ const lanternRegistryPath = path.join(
   repoRoot,
   "v2/content/lantern-keeper/registry.json",
 );
+const elysiumRegistryPath = path.join(
+  repoRoot,
+  "v2/content/elysium-only/registry.json",
+);
 
 function digest(value) {
   return `sha256:${crypto.createHash("sha256").update(value).digest("hex")}`;
@@ -32,6 +36,8 @@ const CANDIDATE_HASH = digest("candidate-bundle");
 const OLDER_HASH = digest("older-declared-bundle");
 const LANTERN_ACTIVE_HASH = "sha256:f16b48db1690307acb9861bc2d5005f143ec776060d98315dd95fa21befb7911";
 const LANTERN_PERSISTED_HASH = "sha256:29db5ba3069c84dea79e90a5f707d0c1fc730c446f3948224f70539c91fe2bfb";
+const ELYSIUM_ACTIVE_HASH = "sha256:a7080f42667d80fc2d43ea31900fc096b869784ad10ac5ec712d6a9012b7557e";
+const ELYSIUM_PERSISTED_HASH = "sha256:f4579bd48d2dfb99498c1af83a9008702ce7f54dd2b036e446c98d38a991fbbf";
 
 function registry(overrides = {}) {
   return {
@@ -281,6 +287,18 @@ describe("worldpack deploy gate CLI", () => {
       candidateHash: candidate.bundleHash,
       candidateReplayCompatible: candidate.replayCompatible,
       liveHash: LANTERN_PERSISTED_HASH,
+    })).toMatchObject({ ok: true, status: "declared_migration" });
+  });
+
+  it("accepts the exact deployed Elysium journal bundle migration", async () => {
+    const registry = JSON.parse(await readFile(elysiumRegistryPath, "utf8"));
+    const candidate = candidateFromRegistry(registry);
+    expect(candidate.bundleHash).toBe(ELYSIUM_ACTIVE_HASH);
+    expect(candidate.replayCompatible).toContain(ELYSIUM_PERSISTED_HASH);
+    expect(evaluateWorldpackGate({
+      candidateHash: candidate.bundleHash,
+      candidateReplayCompatible: candidate.replayCompatible,
+      liveHash: ELYSIUM_PERSISTED_HASH,
     })).toMatchObject({ ok: true, status: "declared_migration" });
   });
 });

--- a/v2/content/elysium-only/registry.json
+++ b/v2/content/elysium-only/registry.json
@@ -9,6 +9,12 @@
     "version": 2,
     "description": "The standalone Elysium AI zone, woven as a scoutable Fibonacci-Wythoff rhizome.",
     "entry_location": "cosyworld.elysium:location/652000",
+    "persistence_compatibility": {
+      "schema_version": 1,
+      "replay_compatible_bundle_hashes": [
+        "sha256:f4579bd48d2dfb99498c1af83a9008702ce7f54dd2b036e446c98d38a991fbbf"
+      ]
+    },
     "rules_profile": "cosyworld.srd5/1",
     "active_rules_variants": [],
     "active_rules_extensions": [],

--- a/v2/content/elysium-only/worldpack.json
+++ b/v2/content/elysium-only/worldpack.json
@@ -7,6 +7,12 @@
   "version": 2,
   "description": "The standalone Elysium AI zone, woven as a scoutable Fibonacci-Wythoff rhizome.",
   "entry_location": "cosyworld.elysium:location/652000",
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:f4579bd48d2dfb99498c1af83a9008702ce7f54dd2b036e446c98d38a991fbbf"
+    ]
+  },
   "rules_profile": "cosyworld.srd5/1",
   "active_rules_variants": [],
   "active_rules_extensions": [],

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.321"
+version = "0.0.322"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.321"
+version = "0.0.322"
 edition = "2021"
 publish = false
 

--- a/v2/worlds/elysium/world.json
+++ b/v2/worlds/elysium/world.json
@@ -6,6 +6,12 @@
   "description": "The standalone Elysium AI zone, woven as a scoutable Fibonacci-Wythoff rhizome.",
   "entry_location": "cosyworld.elysium:location/652000",
   "rules_profile": "cosyworld.srd5/1",
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:f4579bd48d2dfb99498c1af83a9008702ce7f54dd2b036e446c98d38a991fbbf"
+    ]
+  },
   "packs": [
     "cosyworld.elysium",
     "cosyworld.rules-srd-5.2.1",


### PR DESCRIPTION
## What changed

- declares the deployed Elysium bundle `sha256:f4579bd48d2dfb99498c1af83a9008702ce7f54dd2b036e446c98d38a991fbbf` replay-compatible with candidate `sha256:a7080f42667d80fc2d43ea31900fc096b869784ad10ac5ec712d6a9012b7557e`
- regenerates the committed Elysium manifest and registry
- pins the exact migration pair in the deploy-gate regression suite
- bumps the Node and Rust runtime versions to `0.0.322`

## Why

Release `v0.0.98` failed closed before Lonely Forest backup or deployment because tenant `0` still has a journal written under the pre-rhizome Elysium bundle. The new pack retained all 2,555 canonical references with zero removals and zero runtime-handle remaps; only the Elysium pack version changed from `0.1.0` to `0.2.0`, so the declared migration keeps those records resolvable.

## Validation

- live five-tenant `check-lonelyforest-worldpacks.mjs`: Elysium `declared_migration`; all other tenants `exact`
- full pre-push `npm run check`
- 532 Node tests passed
- 997 Rust tests across library/binaries passed
- all worldpack, kernel, architecture, lint, and syntax gates passed