### PR TITLE
fix(deploy): recover transient production checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,7 +110,21 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Verify primary readiness and persistence
-        run: node v2/scripts/smoke-deployed-ruby-high.mjs https://cosyworld.fly.dev
+        run: |
+          # A fresh process refreshes the remote ownership feed every 60 seconds.
+          # Allow one full refresh interval, its bounded 15-second request, and
+          # a small scheduling margin before declaring the release unhealthy.
+          for attempt in {1..13}; do
+            if node v2/scripts/smoke-deployed-ruby-high.mjs https://cosyworld.fly.dev; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 13 ]; then
+              echo "Primary readiness remained degraded after 120 seconds" >&2
+              exit 1
+            fi
+            echo "::warning::Primary readiness attempt $attempt failed; retrying in 10 seconds"
+            sleep 10
+          done
 
   lonelyforest-fly:
     name: Deploy Lonely Forest to Fly

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,7 +177,17 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
 
       - name: Build and deploy Lonely Forest
-        run: flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false --strategy rolling
+        run: |
+          for attempt in 1 2; do
+            if flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false --strategy rolling; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              exit 1
+            fi
+            echo "::warning::Lonely Forest deploy polling failed; retrying once in 15 seconds"
+            sleep 15
+          done
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.324",
+  "version": "0.0.325",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.324",
+      "version": "0.0.325",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.324",
+  "version": "0.0.325",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -205,6 +205,16 @@ describe('deploy workflow', () => {
     );
   });
 
+  it('allows the primary ownership feed one scheduled refresh before failing readiness', () => {
+    const primaryFly = job('primary-fly', 'lonelyforest-fly');
+    expect(primaryFly).toContain('for attempt in {1..13}');
+    expect(primaryFly).toContain(
+      'node v2/scripts/smoke-deployed-ruby-high.mjs https://cosyworld.fly.dev'
+    );
+    expect(primaryFly).toContain('sleep 10');
+    expect(primaryFly).toContain('remained degraded after 120 seconds');
+  });
+
   it('auto-extends both data volumes before the deploy guard, with bounded spend', () => {
     for (const config of [primaryFlyConfig, lonelyForestFlyConfig]) {
       expect(config).toContain('auto_extend_size_threshold = 80');

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -215,6 +215,15 @@ describe('deploy workflow', () => {
     expect(primaryFly).toContain('remained degraded after 120 seconds');
   });
 
+  it('retries a Lonely Forest rolling deploy after a transient Fly polling failure', () => {
+    const lonelyForestFly = job('lonelyforest-fly', 'github-release');
+    expect(lonelyForestFly).toContain('for attempt in 1 2');
+    expect(lonelyForestFly).toContain(
+      'flyctl deploy --remote-only --config fly.lonelyforest.toml --ha=false --strategy rolling'
+    );
+    expect(lonelyForestFly).toContain('retrying once in 15 seconds');
+  });
+
   it('auto-extends both data volumes before the deploy guard, with bounded spend', () => {
     for (const config of [primaryFlyConfig, lonelyForestFlyConfig]) {
       expect(config).toContain('auto_extend_size_threshold = 80');

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.324"
+version = "0.0.325"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.324"
+version = "0.0.325"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- retry the primary production smoke for up to 120 seconds after a Fly rollout
- cover the runtime's 60-second ownership-feed refresh plus its bounded 15-second request and scheduling margin
- retry the idempotent Lonely Forest rolling deploy once when Fly control-plane polling times out after a machine starts
- retain fail-closed behavior when either recovery window is exhausted
- bump the application and orchestrator version to 0.0.325

## Why

The 0.0.324 image was healthy and recovered its Ruby High ownership feed on the scheduled refresh, but both main and v0.1.0 workflows probed immediately after restart and failed on the initial timeout. The v0.1.0 Lonely Forest image also built and reached a started machine before `api.machines.dev` polling was canceled after five minutes.

## Verification

- 178 JavaScript tests passed, including 25 deploy-workflow contract tests
- 81 schema tests passed
- 978 Rust tests passed
- all worldpacks, kernel, architecture, Clippy ceiling, and syntax checks passed