### PR TITLE
fix(topology): retire routes a declared migration dropped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.324",
+  "version": "0.0.325",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.324",
+      "version": "0.0.325",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.324",
+  "version": "0.0.325",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.324"
+version = "0.0.325"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.324"
+version = "0.0.325"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -200,6 +200,19 @@ impl RuntimeWorld {
         self.ensure_authored_route_records();
         self.ensure_hidden_route_records();
         self.migrate_generated_pathways_for_snapshot(snapshot_version, historical_bundle_hash)?;
+        if declared_worldpack_migration {
+            // Only a declared migration may retire routes. An exact snapshot
+            // stays fail-closed above, so this can never silently drop a route
+            // from a bundle that was supposed to match.
+            let retired = self.retire_routes_absent_from_active_bundle()?;
+            if !retired.is_empty() {
+                tracing::warn!(
+                    retired_route_count = retired.len(),
+                    retired_routes = ?retired,
+                    "declared worldpack migration retired routes the active bundle no longer declares"
+                );
+            }
+        }
         self.validate_canonical_route_records()
     }
 
@@ -488,7 +501,13 @@ impl RuntimeWorld {
         Ok(())
     }
 
-    pub(super) fn validate_canonical_route_records(&self) -> Result<(), String> {
+    /// The canonical route set the active bundle declares: authored exits,
+    /// hidden exits, and the edges of every generated pathway. Both
+    /// validation and declared-migration retirement read this one
+    /// definition so they can never disagree about what is canonical.
+    pub(super) fn canonical_route_expectations(
+        &self,
+    ) -> Result<BTreeMap<String, RouteRecordState>, String> {
         let mut expected = BTreeMap::<String, RouteRecordState>::new();
         for exit in &active_content().exits {
             let owner_pack_id = if exit.pack_id.is_empty() {
@@ -624,6 +643,37 @@ impl RuntimeWorld {
                 }
             }
         }
+        Ok(expected)
+    }
+
+    /// Retires persisted canonical routes the migrated bundle no longer
+    /// declares.
+    ///
+    /// `ensure_authored_route_records` and `ensure_hidden_route_records` add
+    /// and reconcile what the new bundle gained, but nothing removed what it
+    /// dropped, so a declared migration that retired an authored exit left a
+    /// persisted route with no canonical counterpart and failed validation on
+    /// boot. Returns the retired ids so the caller can record them; the
+    /// journal is untouched, since retiring a route forgets a path forward
+    /// rather than rewriting the history that used it.
+    pub(super) fn retire_routes_absent_from_active_bundle(
+        &mut self,
+    ) -> Result<Vec<String>, String> {
+        let expected = self.canonical_route_expectations()?;
+        let retired = self
+            .routes
+            .keys()
+            .filter(|route_id| !expected.contains_key(*route_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        for route_id in &retired {
+            self.routes.remove(route_id);
+        }
+        Ok(retired)
+    }
+
+    pub(super) fn validate_canonical_route_records(&self) -> Result<(), String> {
+        let expected = self.canonical_route_expectations()?;
 
         for (storage_key, route) in &self.routes {
             if storage_key != &route.id
@@ -3820,6 +3870,71 @@ mod tests {
         let replayed = RuntimeSnapshot::from_runtime(&restored)
             .into_runtime()
             .expect("the migrated current checkpoint is idempotent");
+        assert_eq!(replayed.routes, restored.routes);
+    }
+
+    /// Issue #696: the Elysium rhizome (#680) retired the authored exit
+    /// between locations 652001 and 652002. Lonely Forest tenant 0 still had
+    /// that route in its snapshot, so the declared migration loaded it, found
+    /// no canonical counterpart, and crash-looped the whole multitenant app.
+    #[test]
+    fn declared_worldpack_migration_retires_routes_the_new_bundle_dropped() {
+        let runtime = RuntimeWorld::seeded();
+        let seed_route = runtime
+            .route_for_edge(700, 712)
+            .expect("Holy Land authored route")
+            .clone();
+        // A canonical authored id for a pair the active bundle does not join.
+        let dropped_id = canonical_authored_route_id(&seed_route.owner_pack_id, 652_001, 652_002);
+        assert!(
+            !runtime.routes.contains_key(&dropped_id),
+            "fixture must name a route the active bundle does not declare"
+        );
+        let dropped = RouteRecordState {
+            canonical_id: dropped_id.clone(),
+            id: dropped_id.clone(),
+            edges: vec![
+                RouteEdgeState {
+                    from_location_id: 652_001,
+                    to_location_id: 652_002,
+                    flags: 0,
+                },
+                RouteEdgeState {
+                    from_location_id: 652_002,
+                    to_location_id: 652_001,
+                    flags: 0,
+                },
+            ],
+            ..seed_route
+        };
+
+        // An exact snapshot stays fail-closed: only a declared migration may retire.
+        let mut exact = RuntimeSnapshot::from_runtime(&runtime);
+        exact.routes.insert(dropped_id.clone(), dropped.clone());
+        assert!(
+            exact.into_runtime().is_err(),
+            "an exact bundle must never silently drop a route it still claims to match"
+        );
+
+        let mut migrated = RuntimeSnapshot::from_runtime(&runtime);
+        migrated.worldpack_bundle_hash =
+            "sha256:94464a2d997bfa589f39091a6644444f879b8f1a3a3e81c054951ba51b153170".to_string();
+        migrated.routes.insert(dropped_id.clone(), dropped);
+        let restored = migrated
+            .into_runtime()
+            .expect("a declared migration must boot after retiring a dropped route");
+        assert!(
+            !restored.routes.contains_key(&dropped_id),
+            "the retired route must not survive the migration"
+        );
+        assert!(
+            restored.routes.contains_key(&seed_route.id),
+            "retirement must not disturb routes the bundle still declares"
+        );
+
+        let replayed = RuntimeSnapshot::from_runtime(&restored)
+            .into_runtime()
+            .expect("the retired checkpoint is idempotent");
         assert_eq!(replayed.routes, restored.routes);
     }
 


### PR DESCRIPTION
Fixes #696.

## The failure

Lonely Forest tenant `0` crash-looped every two seconds after the `v0.1.0` deploy, and the multitenant supervisor returned 503 for every sibling tenant because one tenant never came up.

```
WARN  loading snapshot through declared worldpack migration:
      sha256:f4579bd4… -> sha256:a7080f42…
WARN  journal checkpoint /data/worldpacks/0/snapshot.json is unavailable;
      attempting full replay: route route://cosyworld.elysium/authored/…/652001|652002
      is not a canonical authored, hidden, or generated route
Error: production continuity cannot replay action journal:
       action journal was compacted through checkpoint 1681;
       a matching snapshot is required
```

## Root cause

A declared worldpack migration could **add** and reconcile routes but never **remove** one. `ensure_authored_route_records` and `ensure_hidden_route_records` reconcile what the new bundle gained; nothing dropped what it lost. `validate_canonical_route_records` then rejected the orphan.

Traced to the content change exactly:

| commit | direct 652001↔652002 edges |
|---|---|
| `a6de5a3a` — Elysium OpenRouter model world (#656) | **2** |
| `5c2223db` — Weave the Elysium void rhizome (#680) | **0** |

Tenant 0's snapshot predates the rhizome. #691 correctly declared the bundles replay-compatible, which made the snapshot load under the new bundle — and *that* is what failed, on a route the rhizome had retired. The compaction error was a consequence, not the cause: replay was only attempted because the snapshot load failed.

## The fix

Retire persisted canonical routes the active bundle no longer declares, **only under a declared migration**. An exact snapshot stays fail-closed, so this can never silently drop a route from a bundle that claims to match. Retired ids are logged with `tracing::warn!`.

The journal is untouched. Retiring a route forgets a path forward; it does not rewrite the history that used it.

The canonical expectation set is extracted into `canonical_route_expectations` so retirement and validation read one definition and cannot disagree about what is canonical.

## Test

`declared_worldpack_migration_retires_routes_the_new_bundle_dropped` pins the exact tenant-0 shape — an authored reciprocal route between 652001 and 652002 that the active bundle does not declare — and asserts all four directions:

- an **exact** bundle still rejects it (fail-closed preserved)
- a **declared migration** boots after retiring it
- routes the bundle still declares are undisturbed
- the resulting checkpoint is idempotent

## Verification

- `cargo test --release` — 998 tests passing
- `npm test` — 176 passing
- `npm run v2:kernel` — passes
- `check-main-size.sh` 73319 / 73319, `check-rust-lint.sh` 236 / 236 — both unchanged
- `npm run check:version` — 0.0.324 → 0.0.325

## After this lands

Lonely Forest is currently rolled back to `0.0.311` (image `deployment-01KYZCDJHN6XY38JWEGP4ZN4W2`) and healthy. With this fix it can take a current build again — tenant 0 will boot, retire the dropped route, and log it. That unblocks every future release for that app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)