### PR TITLE
fix(ai): stop the publication gate silencing every reply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.325",
+  "version": "0.0.326",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.325",
+      "version": "0.0.326",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.325",
+  "version": "0.0.326",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/ai-capability-registry.md
+++ b/v2/docs/ai-capability-registry.md
@@ -127,8 +127,10 @@ cannot count as a content failure.
 
 The router is bounded by:
 
-- `COSYWORLD_AI_VOICE_MAX_ATTEMPTS` (1–3, default 2);
-- `COSYWORLD_AI_VOICE_HEDGE_WIDTH` (1–3 and no greater than attempts, default 1);
+- `COSYWORLD_AI_VOICE_MAX_ATTEMPTS` (1–10, default 2); this is also the
+  maximum response-pool size;
+- `COSYWORLD_AI_VOICE_HEDGE_WIDTH` (1–10 and no greater than attempts, default
+  1);
 - `COSYWORLD_AI_VOICE_LATENCY_CEILING_MS` (default 12000);
 - `COSYWORLD_AI_VOICE_SPEND_CEILING_MICRODOLLARS` (default 2000);
 - `COSYWORLD_AI_VOICE_UNKNOWN_COST_MICRODOLLARS` (default 250); and
@@ -136,13 +138,23 @@ The router is bounded by:
 
 Each generation is a durable leased job in the orchestrator SQLite store.
 Every provider request is pinned to one selected candidate with provider-local
-retries disabled. The first publication-gate pass wins an atomic compare-and-set
-and cancels remaining hedges. Duplicate or restarted work returns the accepted
-text and receipt without selecting again; an expired lease receives at most one
-named retry. Exhausted bounds return a stable typed unavailable code. Rejected
-candidates persist hashes, evidence, and decision metadata, never raw output
-bytes. The existing publication journal precondition remains the single writer
-for the final world-visible line.
+retries disabled. All responses completed inside the configured bounds pass
+through the hard publication gate. Certified responses are ranked
+deterministically by scene-anchor depth, novelty against recent dialogue, and
+lexical diversity; candidate ID is the stable final tie-break. The highest
+ranked response wins one atomic compare-and-set. Duplicate or restarted work
+returns the accepted text and receipt without selecting again; an expired lease
+receives at most one named retry. Exhausted bounds return a stable typed
+unavailable code. Rejected candidates persist hashes, evidence, and decision
+metadata, never raw output bytes. The existing publication journal precondition
+remains the single writer for the final world-visible line.
+
+A ten-response pool must opt in to both the attempt and spend limits. For
+example, set `COSYWORLD_AI_VOICE_MAX_ATTEMPTS=10` and size
+`COSYWORLD_AI_VOICE_SPEND_CEILING_MICRODOLLARS` for the selected model. Use
+`COSYWORLD_AI_VOICE_HEDGE_WIDTH` to choose how much of that pool may run
+concurrently. Production defaults remain conservative so enabling ranking does
+not silently jump every chat to ten provider calls.
 
 Resident intelligence uses the same bounded Voice router for public prose.
 Decision beats make one separate `intent_json` request containing only the

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.325"
+version = "0.0.326"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.325"
+version = "0.0.326"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -11,6 +11,7 @@ use std::{collections::BTreeSet, io, path::Path};
 
 pub(crate) const AI_PUBLICATION_RECEIPT_VERSION: u32 = 1;
 pub(crate) const VOICE_SIGNATURE_SHINGLE_WIDTH: usize = 4;
+const VOICE_SIGNATURE_MIN_SHARED_SHINGLES: usize = 2;
 const VOICE_SIGNATURE_WORD_LIMIT: usize = 64;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -100,6 +101,64 @@ pub(crate) struct SpeechGateContext {
     pub(crate) has_proposed_action: bool,
     pub(crate) envelope_valid: bool,
     pub(crate) candidate_round: u8,
+}
+
+/// A deterministic rank for candidates that have already passed every hard
+/// publication check. This is intentionally not another safety gate and does
+/// not ask a second model to judge the first one: it only prefers deeper scene
+/// grounding, then wording that is less similar to recent dialogue, then
+/// lexical variety. The tuple ordering is the selection policy.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct SpeechCandidateScore {
+    pub(crate) anchor_matches: u16,
+    pub(crate) novelty_bps: u16,
+    pub(crate) lexical_diversity_bps: u16,
+}
+
+pub(crate) fn score_speech_candidate(
+    value: &str,
+    context: &SpeechGateContext,
+) -> SpeechCandidateScore {
+    let words = normalized_words(value);
+    let candidate_words = words.iter().cloned().collect::<BTreeSet<_>>();
+    let anchors = anchor_tokens(&context.anchors);
+    let anchor_matches = candidate_words
+        .iter()
+        .filter(|word| {
+            anchors
+                .iter()
+                .any(|anchor| anchor_words_match(word, anchor))
+        })
+        .count()
+        // More than four scene references mostly rewards longer, anchor-stuffed
+        // prose rather than a better conversational reply.
+        .min(4) as u16;
+    let max_recent_similarity_bps = context
+        .recent_lines
+        .iter()
+        .map(|recent| token_set_similarity_bps(&candidate_words, recent))
+        .max()
+        .unwrap_or_default();
+    let lexical_diversity_bps = if words.is_empty() {
+        0
+    } else {
+        ((candidate_words.len() * 10_000) / words.len()).min(10_000) as u16
+    };
+    SpeechCandidateScore {
+        anchor_matches,
+        novelty_bps: 10_000u16.saturating_sub(max_recent_similarity_bps),
+        lexical_diversity_bps,
+    }
+}
+
+fn token_set_similarity_bps(candidate_words: &BTreeSet<String>, other: &str) -> u16 {
+    let other_words = normalized_words(other).into_iter().collect::<BTreeSet<_>>();
+    if candidate_words.is_empty() || other_words.is_empty() {
+        return 0;
+    }
+    let overlap = candidate_words.intersection(&other_words).count();
+    let union = candidate_words.union(&other_words).count();
+    ((overlap * 10_000) / union).min(10_000) as u16
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -719,13 +778,8 @@ fn canonical_speaker_label(value: &str) -> String {
 
 fn normalized_words(value: &str) -> Vec<String> {
     value
-        .split_whitespace()
-        .map(|word| {
-            word.chars()
-                .filter(|character| character.is_alphanumeric() || *character == '\'')
-                .collect::<String>()
-                .to_lowercase()
-        })
+        .split(|character: char| !character.is_alphanumeric() && character != '\'')
+        .map(str::to_lowercase)
         .filter(|word| !word.is_empty())
         .collect()
 }
@@ -762,9 +816,10 @@ fn shares_recent_speaker_phrase(value: &str, recent_shingle_hashes: &[u64]) -> b
         .iter()
         .copied()
         .collect::<BTreeSet<_>>();
-    voice_signature_shingle_hashes(value)
-        .into_iter()
-        .any(|hash| recent.contains(&hash))
+    let candidate_hashes = voice_signature_shingle_hashes(value);
+    candidate_hashes
+        .windows(VOICE_SIGNATURE_MIN_SHARED_SHINGLES)
+        .any(|window| window.iter().all(|hash| recent.contains(hash)))
 }
 
 fn has_multiple_speakers(value: &str, context: &SpeechGateContext) -> bool {
@@ -900,11 +955,15 @@ fn looks_like_speaker_label(value: &str) -> bool {
 }
 
 fn contains_instruction_leakage(value: &str) -> bool {
-    let phrase = [
+    [
         "system prompt",
+        "system message",
         "developer message",
+        "developer instruction",
         "ignore previous",
         "hidden instruction",
+        "my instructions",
+        "your instructions",
         "language model",
         "as an ai",
         "prompt version",
@@ -914,19 +973,7 @@ fn contains_instruction_leakage(value: &str) -> bool {
         "policy says",
     ]
     .iter()
-    .any(|needle| value.contains(needle));
-    let padded = format!(" {} ", normalized_words(value).join(" "));
-    phrase
-        || [
-            " ai ",
-            " prompt ",
-            " system ",
-            " developer ",
-            " model ",
-            " assistant ",
-        ]
-        .iter()
-        .any(|needle| padded.contains(needle))
+    .any(|needle| value.contains(needle))
 }
 
 fn mode_matches(value: &str, mode: SpeechMode) -> bool {
@@ -1643,6 +1690,20 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_story_uses_of_meta_sounding_nouns_are_not_instruction_leakage() {
+        let anchors = vec!["teapot".to_string()];
+        for candidate in [
+            "The model village has a teapot by the bell system.",
+            "The developer left the teapot with her assistant.",
+        ] {
+            let mut gate = context(&anchors, &[]);
+            gate.max_words = 12;
+            certify_speech(None, completion(candidate), candidate, gate)
+                .expect("an ordinary story noun is not evidence of prompt leakage");
+        }
+    }
+
+    #[test]
     fn voice_mode_mismatch_check_is_deterministic() {
         let anchors = vec!["teapot".to_string()];
         assert_eq!(
@@ -1703,6 +1764,46 @@ mod tests {
 
         certify_speech(None, completion(candidate), candidate, gate)
             .expect("a shared phrase shorter than four words remains eligible");
+    }
+
+    #[test]
+    fn voice_recent_duplicate_does_not_reject_one_shared_four_word_shingle() {
+        let prior = "I filed a formal complaint beside Bethlehem.";
+        let candidate = "We filed a formal complaint near Bethlehem.";
+        let mut gate = context(&["Bethlehem".to_string()], &[]);
+        gate.recent_speaker_shingle_hashes = voice_signature_shingle_hashes(prior);
+
+        certify_speech(None, completion(candidate), candidate, gate)
+            .expect("one generic four-word overlap is too little evidence of a catchphrase");
+    }
+
+    #[test]
+    fn voice_recent_duplicate_requires_adjacent_shared_shingles() {
+        let candidate = "Tea waits by the warm hearth while biscuit rests on the round shelf.";
+        let mut gate = context(&["tea".to_string()], &[]);
+        gate.max_words = 20;
+        gate.recent_speaker_shingle_hashes = [
+            voice_signature_shingle_hashes("Tea waits by the red window."),
+            voice_signature_shingle_hashes("Biscuit rests on the blue table."),
+        ]
+        .concat();
+
+        certify_speech(None, completion(candidate), candidate, gate)
+            .expect("two unrelated four-word overlaps are not one repeated phrase");
+    }
+
+    #[test]
+    fn certified_candidate_score_prefers_deeper_grounding_before_novelty() {
+        let gate = context(
+            &["teapot".to_string(), "biscuit".to_string()],
+            &["A teapot waits by the window.".to_string()],
+        );
+        let shallow = score_speech_candidate("Teapot ready.", &gate);
+        let deeper = score_speech_candidate("Teapot and biscuit ready.", &gate);
+
+        assert_eq!(shallow.anchor_matches, 1);
+        assert_eq!(deeper.anchor_matches, 2);
+        assert!(deeper > shallow);
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     ai_publication::{
         append_ai_publication_attempt, certify_speech, publication_generation_id,
-        AiPublicationReceipt, CertifiedSpeech, PublicationCheckCode, PublicationRejection,
-        SpeechGateContext, SpeechMode,
+        score_speech_candidate, AiPublicationReceipt, CertifiedSpeech, PublicationCheckCode,
+        PublicationRejection, SpeechCandidateScore, SpeechGateContext, SpeechMode,
     },
 };
 use rusqlite::{params, Connection, OptionalExtension};
@@ -27,7 +27,7 @@ pub(crate) const VOICE_UNKNOWN_COST_MICRODOLLARS_ENV: &str =
     "COSYWORLD_AI_VOICE_UNKNOWN_COST_MICRODOLLARS";
 pub(crate) const VOICE_EXPLORATION_FLOOR_BPS_ENV: &str = "COSYWORLD_AI_VOICE_EXPLORATION_FLOOR_BPS";
 
-const MAX_VOICE_ATTEMPTS: u8 = 3;
+const MAX_VOICE_ATTEMPTS: u8 = 10;
 const MAX_JOB_LEASE_RETRIES: u32 = 1;
 const VOICE_RETRY_FEEDBACK_RESERVE_TOKENS: u32 = 96;
 
@@ -63,8 +63,12 @@ impl VoiceRoutingConfig {
             1,
             MAX_VOICE_ATTEMPTS as u64,
         )? as u8;
-        let hedge_width =
-            env_integer(VOICE_HEDGE_WIDTH_ENV, defaults.hedge_width as u64, 1, 3)? as u8;
+        let hedge_width = env_integer(
+            VOICE_HEDGE_WIDTH_ENV,
+            defaults.hedge_width as u64,
+            1,
+            MAX_VOICE_ATTEMPTS as u64,
+        )? as u8;
         if hedge_width > max_attempts {
             return Err(format!(
                 "{VOICE_HEDGE_WIDTH_ENV} must not exceed {VOICE_MAX_ATTEMPTS_ENV}"
@@ -197,6 +201,12 @@ struct PlannedCandidate {
     selection: PinnedModelSelection,
     decision: VoiceSelectionDecision,
     retry_feedback_cost_microdollars: u64,
+}
+
+struct RankedCertifiedCandidate {
+    candidate: PlannedCandidate,
+    speech: CertifiedSpeech,
+    score: SpeechCandidateScore,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -346,7 +356,8 @@ async fn route_certified_voice_with(
     let mut provider_failures = 0usize;
     let mut next_candidate = 0usize;
     let mut first_batch = true;
-    while next_candidate < planned.len() {
+    let mut certified_candidates = Vec::new();
+    'generation: while next_candidate < planned.len() {
         let remaining_candidates = planned.len() - next_candidate;
         // Hedges are peers, not retries. Keep one bounded attempt in reserve so
         // every multi-attempt configuration can act on a publication-gate verdict.
@@ -364,12 +375,16 @@ async fn route_certified_voice_with(
         first_batch = false;
         let elapsed = started.elapsed();
         let Some(remaining) = config.voice_routing.latency_ceiling.checked_sub(elapsed) else {
-            mark_timed_out_batch(store_path, &generation_id, batch);
+            mark_timed_out_batch(store_path, &generation_id, batch, &BTreeSet::new());
+            if !certified_candidates.is_empty() {
+                break 'generation;
+            }
             let code = "voice_latency_exhausted";
             finish_voice_job_unavailable(store_path, &generation_id, &owner, code);
             return Err(routing_error(code, rejections));
         };
         let mut attempts = JoinSet::new();
+        let mut completed_ordinals = BTreeSet::new();
         for candidate in batch.iter().cloned() {
             let backend = Arc::clone(&backend);
             let request = request_with_retry_feedback(&request, &rejections, &gate);
@@ -385,7 +400,10 @@ async fn route_certified_voice_with(
             let elapsed = started.elapsed();
             let Some(remaining) = config.voice_routing.latency_ceiling.checked_sub(elapsed) else {
                 attempts.abort_all();
-                mark_timed_out_batch(store_path, &generation_id, batch);
+                mark_timed_out_batch(store_path, &generation_id, batch, &completed_ordinals);
+                if !certified_candidates.is_empty() {
+                    break 'generation;
+                }
                 let code = "voice_latency_exhausted";
                 finish_voice_job_unavailable(store_path, &generation_id, &owner, code);
                 return Err(routing_error(code, rejections));
@@ -393,7 +411,10 @@ async fn route_certified_voice_with(
             let joined = tokio::time::timeout(remaining, attempts.join_next()).await;
             let Some(joined) = joined.ok().flatten() else {
                 attempts.abort_all();
-                mark_timed_out_batch(store_path, &generation_id, batch);
+                mark_timed_out_batch(store_path, &generation_id, batch, &completed_ordinals);
+                if !certified_candidates.is_empty() {
+                    break 'generation;
+                }
                 let code = "voice_latency_exhausted";
                 finish_voice_job_unavailable(store_path, &generation_id, &owner, code);
                 return Err(routing_error(code, rejections));
@@ -402,6 +423,7 @@ async fn route_certified_voice_with(
                 provider_failures += 1;
                 continue;
             };
+            completed_ordinals.insert(candidate.decision.ordinal);
             match result {
                 Err(error) => {
                     provider_failures += 1;
@@ -470,42 +492,99 @@ async fn route_certified_voice_with(
                                 speech.receipt().model_attribution.as_ref(),
                                 true,
                             );
-                            let speech = speech.with_prior_rejections(rejections.clone());
-                            if accept_voice_job(
-                                store_path,
-                                &generation_id,
-                                &owner,
-                                &candidate.decision.family,
-                                &speech,
-                            ) {
-                                record_decision_result(
-                                    store_path,
-                                    &generation_id,
-                                    candidate.decision.ordinal,
-                                    "accepted",
-                                    None,
-                                );
-                                attempts.abort_all();
-                                return Ok(speech);
-                            }
+                            let score = score_speech_candidate(speech.text(), &gate);
+                            tracing::info!(
+                                generation_id = %generation_id,
+                                candidate_round = candidate.decision.ordinal,
+                                anchor_matches = score.anchor_matches,
+                                novelty_bps = score.novelty_bps,
+                                lexical_diversity_bps = score.lexical_diversity_bps,
+                                "AI voice candidate passed the gate and entered ranking"
+                            );
                             record_decision_result(
                                 store_path,
                                 &generation_id,
                                 candidate.decision.ordinal,
-                                "certified_loser",
+                                "certified",
                                 None,
                             );
-                            if let Some(cached) =
-                                load_accepted_voice_job(store_path, &generation_id)
-                            {
-                                attempts.abort_all();
-                                return Ok(cached);
-                            }
+                            certified_candidates.push(RankedCertifiedCandidate {
+                                candidate,
+                                speech,
+                                score,
+                            });
                         }
                     }
                 }
             }
         }
+    }
+
+    if !certified_candidates.is_empty() {
+        let certified_pool_size = certified_candidates.len();
+        let winner_index = certified_candidates
+            .iter()
+            .enumerate()
+            .max_by(|(_, left), (_, right)| {
+                left.score.cmp(&right.score).then_with(|| {
+                    right
+                        .speech
+                        .receipt()
+                        .candidate_id
+                        .cmp(&left.speech.receipt().candidate_id)
+                })
+            })
+            .map(|(index, _)| index)
+            .expect("non-empty certified candidate pool has a winner");
+        let winner = certified_candidates.swap_remove(winner_index);
+        for loser in certified_candidates {
+            record_decision_result(
+                store_path,
+                &generation_id,
+                loser.candidate.decision.ordinal,
+                "certified_loser",
+                None,
+            );
+        }
+        let speech = winner.speech.with_prior_rejections(rejections.clone());
+        tracing::info!(
+            generation_id = %generation_id,
+            candidate_round = winner.candidate.decision.ordinal,
+            certified_pool_size,
+            anchor_matches = winner.score.anchor_matches,
+            novelty_bps = winner.score.novelty_bps,
+            lexical_diversity_bps = winner.score.lexical_diversity_bps,
+            "selected the highest-ranked certified AI voice candidate"
+        );
+        if accept_voice_job(
+            store_path,
+            &generation_id,
+            &owner,
+            &winner.candidate.decision.family,
+            &speech,
+        ) {
+            record_decision_result(
+                store_path,
+                &generation_id,
+                winner.candidate.decision.ordinal,
+                "accepted",
+                None,
+            );
+            return Ok(speech);
+        }
+        record_decision_result(
+            store_path,
+            &generation_id,
+            winner.candidate.decision.ordinal,
+            "certified_loser",
+            None,
+        );
+        if let Some(cached) = load_accepted_voice_job(store_path, &generation_id) {
+            return Ok(cached);
+        }
+        let code = "voice_job_store_unavailable";
+        finish_voice_job_unavailable(store_path, &generation_id, &owner, code);
+        return Err(routing_error(code, rejections));
     }
 
     let code = if provider_failures == planned.len() {
@@ -1377,8 +1456,16 @@ fn record_decision_result(
     );
 }
 
-fn mark_timed_out_batch(path: Option<&Path>, generation_id: &str, batch: &[PlannedCandidate]) {
-    for candidate in batch {
+fn mark_timed_out_batch(
+    path: Option<&Path>,
+    generation_id: &str,
+    batch: &[PlannedCandidate],
+    completed_ordinals: &BTreeSet<u8>,
+) {
+    for candidate in batch
+        .iter()
+        .filter(|candidate| !completed_ordinals.contains(&candidate.decision.ordinal))
+    {
         record_provider_failure(
             path,
             &candidate.decision.provider,
@@ -1741,6 +1828,35 @@ mod tests {
                 .count(),
             2,
             "only the filler attempts are marked as resampled",
+        );
+    }
+
+    #[test]
+    fn attempt_budget_can_build_a_ten_response_pool() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 10,
+            hedge_width: 10,
+            spend_ceiling_microdollars: u64::MAX,
+            ..VoiceRoutingConfig::default()
+        });
+        let (planned, _) = build_voice_plan(
+            None,
+            "generation-ten-response-pool",
+            5_000,
+            "prose",
+            &request("dialogue_avatar"),
+            &config.voice_routing,
+            config.pin_models(ModelCapability::Voice).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(planned.len(), 10);
+        assert_eq!(
+            planned
+                .iter()
+                .filter(|candidate| candidate.decision.resampled)
+                .count(),
+            9,
         );
     }
 
@@ -2154,6 +2270,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn every_passing_candidate_is_ranked_before_one_is_accepted() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 3,
+            hedge_width: 3,
+            spend_ceiling_microdollars: u64::MAX,
+            ..VoiceRoutingConfig::default()
+        });
+        let backend = MockBackend::with_outputs([
+            ("provider/tiny-a", "Teapot ready.", 0),
+            ("provider/tiny-a", "Teapot waits beside the window.", 10),
+            ("provider/tiny-a", "Teapot and biscuit ready.", 0),
+        ]);
+        let mut publication_gate = gate("ranked-pool-beat");
+        publication_gate.anchors = vec!["teapot".to_string(), "biscuit".to_string()];
+
+        let certified = route_certified_voice_with(
+            &config,
+            None,
+            request("dialogue_avatar"),
+            publication_gate,
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect("the best passing candidate is selected");
+
+        assert_eq!(backend.call_count(), 3);
+        assert_eq!(certified.text(), "Teapot and biscuit ready.");
+    }
+
+    #[tokio::test]
     async fn raw_retry_keeps_feedback_in_the_single_user_envelope() {
         let config = single_candidate(VoiceRoutingConfig {
             max_attempts: 2,
@@ -2297,7 +2443,11 @@ mod tests {
         .await
         .expect("one hedge certifies");
         assert!(certified.text().contains("Teapot"));
-        assert_eq!(backend.call_count(), 2);
+        assert_eq!(
+            backend.call_count(),
+            3,
+            "all bounded candidates are compared before the durable winner is accepted"
+        );
         let cached_backend = MockBackend::default();
         let cached = route_certified_voice_with(
             &config,

--- a/v2/orchestrator-rust/src/chat_action.rs
+++ b/v2/orchestrator-rust/src/chat_action.rs
@@ -564,6 +564,17 @@ mod tests {
             .any(|event| event.type_name == "message.created"));
     }
 
+    /// The scripted exchange the fake provider plays back, in order. Turn
+    /// selection reads the transcript already in the prompt rather than a call
+    /// counter, because voice routing asks the provider more than once per
+    /// turn and then ranks the certified candidates.
+    const CHAT_SCRIPT: [&str; 4] = [
+        "I found a quiet minute. How is the cottage treating you?",
+        "Kindly enough, though the kettle has opinions about punctuality.",
+        "Then I will keep one ear on the kettle and one on your story.",
+        "A sensible arrangement. Come back before the kettle starts whistling secrets.",
+    ];
+
     #[tokio::test]
     async fn completed_chat_commits_exactly_two_lines_from_each_participant() {
         let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -574,21 +585,30 @@ mod tests {
                 let calls = calls.clone();
                 let requests = requests.clone();
                 move |Json(request): Json<serde_json::Value>| {
-                    let index = calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    // Voice routing certifies and ranks several candidates per
+                    // turn, so a scripted reply cannot key off the call count.
+                    // Answer the turn the prompt is actually asking for: each
+                    // committed line adds one "said to" row to the transcript.
+                    // Voice routing certifies and ranks several candidates per
+                    // turn, so a scripted reply cannot key off the call count.
+                    // Answer whichever turn the transcript has not reached yet;
+                    // the prompt already carries every committed line.
+                    let payload = request.to_string();
+                    let index = CHAT_SCRIPT
+                        .iter()
+                        .rposition(|line| payload.contains(line))
+                        .map(|position| position + 1)
+                        .unwrap_or_default();
                     requests
                         .lock()
                         .expect("capture Chat inference request")
                         .push(request);
                     async move {
-                        let content = [
-                            "I found a quiet minute. How is the cottage treating you?",
-                            "Kindly enough, though the kettle has opinions about punctuality.",
-                            "Then I will keep one ear on the kettle and one on your story.",
-                            "A sensible arrangement. Come back before it starts whistling secrets.",
-                        ]
-                        .get(index)
-                        .copied()
-                        .unwrap_or("The conversation has already settled.");
+                        let content = CHAT_SCRIPT
+                            .get(index)
+                            .copied()
+                            .unwrap_or("The conversation has already settled.");
                         Json(serde_json::json!({
                             "model": "test-chat-model",
                             "choices": [{
@@ -687,17 +707,30 @@ mod tests {
             .any(|event| event.type_name == "chat.failed"));
         drop(runtime);
         let captured = requests.lock().expect("inspect Chat inference requests");
-        let followup_request = captured.get(2).expect("avatar follow-up request");
-        let followup_prompt = followup_request["messages"]
-            .as_array()
-            .and_then(|messages| {
+        // Voice routing ranks several certified candidates before accepting
+        // one, so the follow-up is no longer at a fixed request offset. Select
+        // it by the speaker it is written for instead of by position.
+        let last_user_prompt = |request: &serde_json::Value| -> Option<String> {
+            request["messages"].as_array().and_then(|messages| {
                 messages.iter().rev().find_map(|message| {
                     (message["role"].as_str() == Some("user"))
                         .then(|| message["content"].as_str())
                         .flatten()
+                        .map(str::to_string)
                 })
             })
-            .expect("follow-up user prompt");
+        };
+        // The opener is also written for Inference Tester, so match the
+        // follow-up by the transcript it must carry back into the prompt.
+        let followup_prompt = captured
+            .iter()
+            .filter_map(last_user_prompt)
+            .rfind(|prompt| {
+                prompt.contains("i am Inference Tester")
+                    && prompt.contains("Inference Tester said to Rati:")
+            })
+            .expect("avatar follow-up prompt carrying the exchange transcript");
+        let followup_prompt = followup_prompt.as_str();
         assert!(followup_prompt.contains("i am Inference Tester"));
         assert!(followup_prompt.contains("Inference Tester said to Rati:"));
         assert!(followup_prompt.contains("Rati said to Inference Tester:"));

--- a/v2/orchestrator-rust/src/relationships.rs
+++ b/v2/orchestrator-rust/src/relationships.rs
@@ -782,7 +782,12 @@ mod tests {
                 .dialogue_status,
             RELATIONSHIP_DIALOGUE_DELIVERED
         );
-        assert_eq!(requests.load(Ordering::SeqCst), 1);
+        // Voice routing now certifies every planned candidate and ranks them
+        // before accepting one, so a two-attempt plan asks the provider twice
+        // and publishes the better line. The contract this test guards is that
+        // exactly one reply is delivered with no fallback, not that only one
+        // candidate was ever generated.
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
         drop(runtime);
         server.abort();
     }


### PR DESCRIPTION
Residents on `0.lonelyforest.com` answer nothing. This is why.

## The failure

The gateway is healthy — `dialogue_avatar` inference completes in 1–2s against `openai/gpt-5.6-luna`. Every candidate then dies at the publication gate:

```
WARN  AI voice candidate rejected by publication gate  feature=dialogue_avatar
      failure_code="voice_recent_duplicate"  candidate_round=1
WARN  AI voice candidate rejected by publication gate  feature=dialogue_avatar
      failure_code="voice_recent_duplicate"  candidate_round=2
WARN  queued AI avatar inference failed: voice_candidates_exhausted
```

Silence is the correct response to an exhausted gate — AI must never invent fallback speech — so the bug is that the gate rejects far too much.

## Two blunt gates

**`voice_recent_duplicate`** rejected any line sharing a *single* four-word shingle with the speaker's recent dialogue. Ordinary phrasing collides that often. It now requires **two adjacent** shared shingles, which is the shape of a repeated catchphrase rather than a coincidence.

**`contains_instruction_leakage`** rejected any line containing the bare words `ai`, `prompt`, `system`, `developer`, `model`, or `assistant`. Elysium's residents are *named after models and talk about them*, so this gate silenced the exact world it was meant to protect. Only explicit leakage phrases remain, plus four additions (`system message`, `developer instruction`, `my instructions`, `your instructions`).

## Best-of-N selection

Voice routing now certifies every planned candidate and ranks them — scene grounding, then novelty against recent dialogue, then lexical variety — instead of publishing whichever returned first. Deterministic; no second model judging the first.

## Two tests encoded the old contract

- `fake_provider_delivers_one_grounded_mara_reply_without_fallback` asserted exactly one provider call. A two-attempt plan now asks twice and publishes the better line. The contract it guards — one delivered reply, no fallback — still holds.
- `completed_chat_commits_exactly_two_lines_from_each_participant` read the follow-up at a fixed request offset and scripted replies by call count. Both assumptions break when a turn costs more than one call. It now finds the follow-up by the transcript it carries, and the fake provider answers whichever turn the prompt is actually asking for.

**That second test was passing by accident.** Its closing line carried no scene anchor and fails `voice_anchor_missing` on `main` too — I verified this with a probe against clean main. It only passed because the retry ran off the end of the script and returned a fallback string that happened to satisfy the gate. The closing line now names the kettle, so the exchange is certified on its merits.

## Verification

- `cargo test --release` — 1004 tests passing
- `npm test` — 178 passing
- `npm run v2:kernel` — passes
- `check-main-size.sh` 73319/73319, `check-rust-lint.sh` **236/236** — I fixed the one new warning my test introduced rather than raise the ceiling
- `npm run check:version` — 0.0.325 → 0.0.326

## Note on the other failure mode

The logs also show `actor job 609 dialogue failed: voice_spend_exhausted` — a separate path where every model is excluded by `spend_ceiling` before any inference runs. That is **not fixed here**. `COSYWORLD_AI_VOICE_SPEND_CEILING_MICRODOLLARS` defaults to 2,000 (\$0.002/job), which is plausibly too low for a world whose residents are frontier models. Best-of-N also increases calls per turn, so that ceiling matters more now, not less. It is a config decision on the Fly app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)