### PR TITLE
fix(ai): let a reply reuse the words of the line it answers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.326",
+  "version": "0.0.327",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.326",
+      "version": "0.0.327",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.326",
+  "version": "0.0.327",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.326"
+version = "0.0.327"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.326"
+version = "0.0.327"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -600,10 +600,7 @@ fn evaluate_checks(
         ),
         (
             PublicationCheckCode::VoiceRecentDuplicate,
-            !context
-                .recent_lines
-                .iter()
-                .any(|recent| near_duplicate(text, recent))
+            !repeats_recent_dialogue(text, context)
                 && !shares_recent_speaker_phrase(text, &context.recent_speaker_shingle_hashes),
         ),
         (
@@ -1090,6 +1087,47 @@ fn anchor_words_match(candidate: &str, anchor: &str) -> bool {
         (anchor, candidate)
     };
     shorter.len() >= MIN_SHARED_PREFIX && longer.starts_with(shorter)
+}
+
+/// Whether a candidate repeats dialogue the room has already heard.
+///
+/// `recent_lines` holds every speaker's recent lines as `"{Name}: {content}"`,
+/// so the word-overlap test only applies to the candidate speaker's own lines.
+/// A reply necessarily reuses the vocabulary of the line it answers — in a
+/// two-person exchange that pushed set overlap past the threshold on almost
+/// every turn, and both candidate rounds were rejected until the conversation
+/// ended early. Repeating *another* speaker verbatim is still caught, because
+/// echoing someone's exact words back at them is never the intended reply.
+fn repeats_recent_dialogue(text: &str, context: &SpeechGateContext) -> bool {
+    let candidate_key = normalized_resident_speech_key(text);
+    context.recent_lines.iter().any(|recent| {
+        match attributed_recent_line(recent, context) {
+            // Another speaker said it. Only a verbatim echo is a duplicate,
+            // because a reply is supposed to reuse the words it answers.
+            Some(spoken) => candidate_key == normalized_resident_speech_key(spoken),
+            // The candidate's own line, or one this gate cannot attribute.
+            // Hold the stricter word-overlap bar in both cases.
+            None => near_duplicate(text, recent),
+        }
+    })
+}
+
+/// The words of `recent` when some *other* speaker said them.
+///
+/// Room lines arrive as `"{Name}: {content}"`. An unprefixed line carries no
+/// attribution, so it is treated as the candidate speaker's own and held to the
+/// stricter bar rather than assumed to belong to someone else.
+fn attributed_recent_line<'a>(recent: &'a str, context: &SpeechGateContext) -> Option<&'a str> {
+    let (speaker, spoken) = recent.split_once(':')?;
+    let speaker = speaker.trim();
+    if speaker.is_empty() || speaker.eq_ignore_ascii_case(context.speaker_name.trim()) {
+        return None;
+    }
+    context
+        .other_speaker_names
+        .iter()
+        .any(|name| name.trim().eq_ignore_ascii_case(speaker))
+        .then_some(spoken)
 }
 
 fn near_duplicate(left: &str, right: &str) -> bool {
@@ -1764,6 +1802,70 @@ mod tests {
 
         certify_speech(None, completion(candidate), candidate, gate)
             .expect("a shared phrase shorter than four words remains eligible");
+    }
+
+    /// A resident answering a player reuses the player's words. Comparing the
+    /// candidate against every speaker's recent lines therefore rejected almost
+    /// every reply in a two-person exchange, exhausted both candidate rounds,
+    /// and ended the conversation early. Chatting with Morph in Void 231 failed
+    /// this way in production.
+    #[test]
+    fn a_reply_may_reuse_the_words_of_the_line_it_answers() {
+        let recent =
+            vec!["Traveller: Is the marker in this cell still warm to the touch?".to_string()];
+        let mut gate = context(&["marker".to_string()], &recent);
+        gate.speaker_name = "Morph".to_string();
+        gate.other_speaker_names = vec!["Traveller".to_string()];
+        gate.max_words = 16;
+
+        certify_speech(
+            None,
+            completion("The marker in this cell is still warm to the touch."),
+            "The marker in this cell is still warm to the touch.",
+            gate,
+        )
+        .expect("answering a question may reuse the words of the question");
+    }
+
+    #[test]
+    fn a_speaker_still_may_not_repeat_their_own_recent_line() {
+        let recent = vec!["Morph: The marker keeps its own slow warmth.".to_string()];
+        let mut gate = context(&["marker".to_string()], &recent);
+        gate.speaker_name = "Morph".to_string();
+        gate.max_words = 16;
+
+        let rejection = certify_speech(
+            None,
+            completion("The marker keeps its own slow warmth."),
+            "The marker keeps its own slow warmth.",
+            gate,
+        )
+        .expect_err("a speaker repeating themselves is still a duplicate");
+        assert_eq!(
+            rejection.failure_code,
+            PublicationCheckCode::VoiceRecentDuplicate
+        );
+    }
+
+    #[test]
+    fn echoing_another_speaker_verbatim_is_still_a_duplicate() {
+        let recent = vec!["Traveller: The marker keeps its own slow warmth.".to_string()];
+        let mut gate = context(&["marker".to_string()], &recent);
+        gate.speaker_name = "Morph".to_string();
+        gate.other_speaker_names = vec!["Traveller".to_string()];
+        gate.max_words = 16;
+
+        let rejection = certify_speech(
+            None,
+            completion("The marker keeps its own slow warmth."),
+            "The marker keeps its own slow warmth.",
+            gate,
+        )
+        .expect_err("parroting another speaker word for word is never a reply");
+        assert_eq!(
+            rejection.failure_code,
+            PublicationCheckCode::VoiceRecentDuplicate
+        );
     }
 
     #[test]


### PR DESCRIPTION
Chatting with Morph in Void 231 (location `652230`) ended early in production. This is why.

## The failure

```
AI voice candidate rejected by publication gate  feature=dialogue_resident_raw
  failure_code="voice_recent_duplicate"  candidate_round=1
AI voice candidate rejected by publication gate  feature=dialogue_resident_raw
  failure_code="voice_recent_duplicate"  candidate_round=2
AI resident inference failed; ending chat exchange: voice_candidates_exhausted
bounded avatar chat ended early: voice_candidates_exhausted
AI room memory summary failed for location 652230
```

Every rejection in the production buffer was this shape — **8 rejections across 2 failed chats, all on `dialogue_resident` or `dialogue_resident_raw`**, never on ambient room speech.

## Root cause

`voice_recent_duplicate` has two independent paths. #698 fixed the shingle path. This is the other one:

```rust
!context.recent_lines.iter().any(|recent| near_duplicate(text, recent))
```

`recent_lines` holds **every speaker's** recent room lines (`"{Name}: {content}"`), and `near_duplicate` compares word *sets* at 80% Jaccard.

A reply necessarily reuses the vocabulary of the line it answers. So in a two-person exchange the resident's answer reads as a duplicate **of the player's question**, both candidate rounds fail, the pool exhausts, and the chat ends.

That is exactly the "failing some of the time" pattern: quiet two-speaker Void cells collide almost every turn, while busy rooms dilute the overlap.

## The fix

Word overlap now applies only to the candidate speaker's **own** recent lines — matching how the shingle path already worked. Another speaker's line counts as a duplicate only when echoed **verbatim**, since parroting someone's exact words back is never the intended reply. A line the gate cannot attribute is held to the stricter bar rather than assumed to belong to someone else.

## Tests

Three regressions pin all three directions:

- `a_reply_may_reuse_the_words_of_the_line_it_answers` — the Morph shape
- `a_speaker_still_may_not_repeat_their_own_recent_line`
- `echoing_another_speaker_verbatim_is_still_a_duplicate`

My first attempt broke `voice_recent_duplicate_check_is_deterministic`, which passes unprefixed recent lines. That caught a real hole — unattributed lines were being treated as someone else's and getting the looser bar. They now take the strict path, and the existing test passes unchanged.

## Verification

- `cargo test --release` — 1007 tests passing
- `npm test` — 178 passing
- `npm run v2:kernel` — passes
- `check-main-size.sh` 73319/73319, `check-rust-lint.sh` 236/236 — both unchanged
- `npm run check:version` — 0.0.326 → 0.0.327

🤖 Generated with [Claude Code](https://claude.com/claude-code)