### PR TITLE
Name the repeated phrase in a duplicate-rejection retry

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -28,6 +28,11 @@ primary_region = "sjc"
   COSYWORLD_CARD_POLICY_MODE = "shadow"
   COSYWORLD_CARD_POLICY_MODEL_PATH = "/app/models/card-policy/incumbent.cwrank"
   COSYWORLD_CARD_POLICY_TOP_K = "3"
+  # The registry below pins one voice model, so every retry is a resample of it
+  # and two samples were not enough to clear the recent-duplicate gate: eight of
+  # nine generations were rejected in the 2026-08-03 production window. Four
+  # samples stay well inside the 2000 microdollar spend ceiling.
+  COSYWORLD_AI_VOICE_MAX_ATTEMPTS = "4"
   COSYWORLD_AI_REGISTRY_JSON = '{"schema_version":1,"snapshot_version":"cosyworld-prod-2026-07-28b","declared":[{"requested_model_id":"openai/gpt-5.6-luna","provider":"openrouter","concrete_model":{"model_id":"openai/gpt-5.6-luna"},"input_modalities":["text"],"output_modalities":["text"],"supported_parameters":{"structured_output":true,"json_mode":true,"tools":true,"seed":true,"stop":true},"data_policy":{"retention":"none","training":"prohibited"},"capabilities":["voice","intent_json","world_content"],"prompt_adapter":{"id":"openai-chat","version":"1"},"sampling":{"hard_output_cap":2048}}],"discovered":[]}'
   RUST_LOG = "cosyworld_orchestrator=info,tower_http=warn"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.329",
+  "version": "0.0.330",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.329",
+      "version": "0.0.330",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.329",
+  "version": "0.0.330",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.329"
+version = "0.0.330"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.329"
+version = "0.0.330"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -238,6 +238,11 @@ impl CertifiedSpeech {
 pub(crate) struct PublicationRejection {
     pub(crate) receipt: AiPublicationReceipt,
     pub(crate) failure_code: PublicationCheckCode,
+    /// The normalized run of words that tripped the recent-duplicate check, so
+    /// a retry can be told which phrase to drop. Deliberately kept off the
+    /// receipt: the receipt is persisted, and only this in-memory hint is
+    /// allowed to carry wording from a rejected candidate.
+    pub(crate) repeated_phrase: Option<String>,
 }
 
 impl std::fmt::Display for PublicationRejection {
@@ -266,6 +271,11 @@ pub(crate) fn certify_speech(
     let publication_id = sha256_hex(format!("{}\0{}", generation_id, output_hash).as_bytes());
 
     let checks = evaluate_checks(&text, candidate_text, &completion.finish_reason, &context);
+    let repeated_phrase = checks
+        .iter()
+        .any(|check| check.code == PublicationCheckCode::VoiceRecentDuplicate && !check.passed)
+        .then(|| duplicated_phrase(&text, &context))
+        .flatten();
     let prompt_adapter_id = completion
         .model_attribution
         .as_ref()
@@ -315,6 +325,7 @@ pub(crate) fn certify_speech(
         return Err(Box::new(PublicationRejection {
             receipt,
             failure_code,
+            repeated_phrase,
         }));
     }
     Ok(CertifiedSpeech {
@@ -462,6 +473,10 @@ pub(crate) fn record_rejected_ai_publication(
             feature = %rejection.receipt.feature,
             failure_code = rejection.failure_code.as_str(),
             candidate_round = rejection.receipt.candidate_round,
+            // Which run tripped the gate, so a duplicate storm is diagnosable
+            // from logs alone. Normalized tokens from a line no player saw, and
+            // only ever on the rejection path.
+            repeated_phrase = rejection.repeated_phrase.as_deref().unwrap_or("-"),
             "AI voice candidate rejected by publication gate"
         );
     }
@@ -806,17 +821,96 @@ pub(crate) fn voice_signature_shingle_hashes(value: &str) -> Vec<u64> {
 }
 
 fn shares_recent_speaker_phrase(value: &str, recent_shingle_hashes: &[u64]) -> bool {
+    shared_speaker_phrase(value, recent_shingle_hashes).is_some()
+}
+
+/// The speaker's own wording that the candidate reused, as the run of words the
+/// shared shingles cover. Adjacent shingles overlap by `width - 1` words, so a
+/// run of `VOICE_SIGNATURE_MIN_SHARED_SHINGLES` adjacent shingles covers
+/// `VOICE_SIGNATURE_MIN_SHARED_SHINGLES + VOICE_SIGNATURE_SHINGLE_WIDTH - 1` words.
+fn shared_speaker_phrase(value: &str, recent_shingle_hashes: &[u64]) -> Option<String> {
     if recent_shingle_hashes.is_empty() {
-        return false;
+        return None;
     }
     let recent = recent_shingle_hashes
         .iter()
         .copied()
         .collect::<BTreeSet<_>>();
-    let candidate_hashes = voice_signature_shingle_hashes(value);
-    candidate_hashes
+    let start = voice_signature_shingle_hashes(value)
         .windows(VOICE_SIGNATURE_MIN_SHARED_SHINGLES)
-        .any(|window| window.iter().all(|hash| recent.contains(hash)))
+        .position(|window| window.iter().all(|hash| recent.contains(hash)))?;
+    let words = normalized_words(value)
+        .into_iter()
+        .take(VOICE_SIGNATURE_WORD_LIMIT)
+        .collect::<Vec<_>>();
+    let end = (start + VOICE_SIGNATURE_MIN_SHARED_SHINGLES + VOICE_SIGNATURE_SHINGLE_WIDTH - 1)
+        .min(words.len());
+    Some(words[start..end].join(" "))
+}
+
+/// The concrete wording behind a `VoiceRecentDuplicate` verdict, checked along
+/// the same two paths `evaluate_checks` uses to fail it. A retry that is told
+/// which phrase to drop can keep the rest of an otherwise good line, where a
+/// bare "use fresh wording" leaves the model guessing — and with one pinned
+/// model it usually guesses the same way twice.
+fn duplicated_phrase(text: &str, context: &SpeechGateContext) -> Option<String> {
+    shared_speaker_phrase(text, &context.recent_speaker_shingle_hashes)
+        .or_else(|| repeated_dialogue_phrase(text, context))
+}
+
+/// The run `repeats_recent_dialogue` matched against, found the same way it
+/// attributes a recent line: a verbatim echo of another speaker, or a
+/// near-duplicate of the candidate's own prior words.
+fn repeated_dialogue_phrase(text: &str, context: &SpeechGateContext) -> Option<String> {
+    let candidate_key = normalized_resident_speech_key(text);
+    context
+        .recent_lines
+        .iter()
+        .find_map(|recent| match attributed_recent_line(recent, context) {
+            Some(spoken) => (candidate_key == normalized_resident_speech_key(spoken))
+                .then(|| longest_shared_run(text, spoken))
+                .flatten(),
+            None => {
+                let spoken = spoken_words_of(recent, context);
+                near_duplicate(text, spoken)
+                    .then(|| longest_shared_run(text, spoken))
+                    .flatten()
+            }
+        })
+}
+
+/// The longest run of words a duplicate candidate shares with the recent line
+/// it duplicated. `near_duplicate` compares token sets, so a reordered
+/// restatement can have no long contiguous run at all; the caller then keeps
+/// the generic instruction.
+fn longest_shared_run(candidate: &str, recent: &str) -> Option<String> {
+    const MIN_SHARED_RUN_WORDS: usize = 3;
+
+    let candidate = normalized_words(candidate);
+    let recent = normalized_words(recent);
+    if candidate.is_empty() || recent.is_empty() {
+        return None;
+    }
+    let mut previous = vec![0usize; recent.len() + 1];
+    let mut current = vec![0usize; recent.len() + 1];
+    let mut best_len = 0usize;
+    let mut best_end = 0usize;
+    for (row, word) in candidate.iter().enumerate() {
+        for (column, other) in recent.iter().enumerate() {
+            current[column + 1] = if word == other {
+                previous[column] + 1
+            } else {
+                0
+            };
+            if current[column + 1] > best_len {
+                best_len = current[column + 1];
+                best_end = row + 1;
+            }
+        }
+        std::mem::swap(&mut previous, &mut current);
+        current.iter_mut().for_each(|cell| *cell = 0);
+    }
+    (best_len >= MIN_SHARED_RUN_WORDS).then(|| candidate[best_end - best_len..best_end].join(" "))
 }
 
 fn has_multiple_speakers(value: &str, context: &SpeechGateContext) -> bool {
@@ -1827,6 +1921,32 @@ mod tests {
         );
     }
 
+    /// Production rejected eight of nine generations in an hour with
+    /// `voice_recent_duplicate`, and with a single pinned voice model the
+    /// retry only asked for "fresh wording" and resampled the same phrase. The
+    /// rejection now carries the run that tripped it so a retry can be told
+    /// exactly what to drop.
+    #[test]
+    fn a_reused_speaker_phrase_is_named_on_the_rejection() {
+        let prior = "Bethlehem at last! My biscuit survived the journey, though my knees are filing a formal complaint.";
+        let candidate = "Bethlehem at last—my biscuit survived the journey, though it now has the structural integrity of damp parchment.";
+        let mut gate = context(&["Bethlehem".to_string()], &[]);
+        gate.max_words = 30;
+        gate.recent_speaker_shingle_hashes = voice_signature_shingle_hashes(prior);
+
+        let rejection = certify_speech(None, completion(candidate), candidate, gate)
+            .expect_err("a reused run of shared shingles is a repeated phrase");
+
+        assert_eq!(
+            rejection.failure_code,
+            PublicationCheckCode::VoiceRecentDuplicate
+        );
+        assert_eq!(
+            rejection.repeated_phrase.as_deref(),
+            Some("bethlehem at last my biscuit")
+        );
+    }
+
     #[test]
     fn voice_recent_duplicate_does_not_reject_a_three_word_coincidence() {
         let prior = "My boots filed a formal complaint beside the Bethlehem gate.";
@@ -1920,6 +2040,10 @@ mod tests {
             rejection.failure_code,
             PublicationCheckCode::VoiceRecentDuplicate
         );
+        assert_eq!(
+            rejection.repeated_phrase.as_deref(),
+            Some("the marker keeps its own slow warmth")
+        );
     }
 
     #[test]
@@ -1941,6 +2065,30 @@ mod tests {
             rejection.failure_code,
             PublicationCheckCode::VoiceRecentDuplicate
         );
+        assert_eq!(
+            rejection.repeated_phrase.as_deref(),
+            Some("the marker keeps its own slow warmth")
+        );
+    }
+
+    /// A rejection unrelated to duplication carries no phrase, so the retry
+    /// keeps its generic instruction rather than quoting an innocent line back.
+    #[test]
+    fn a_non_duplicate_rejection_names_no_phrase() {
+        let anchors = vec!["teapot".to_string()];
+        let rejection = certify_speech(
+            None,
+            completion("I hate you, teapot"),
+            "I hate you, teapot",
+            context(&anchors, &[]),
+        )
+        .expect_err("an unsafe line is rejected");
+
+        assert_eq!(
+            rejection.failure_code,
+            PublicationCheckCode::VoiceUnsafeTone
+        );
+        assert_eq!(rejection.repeated_phrase, None);
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -30,6 +30,11 @@ pub(crate) const VOICE_EXPLORATION_FLOOR_BPS_ENV: &str = "COSYWORLD_AI_VOICE_EXP
 const MAX_VOICE_ATTEMPTS: u8 = 10;
 const MAX_JOB_LEASE_RETRIES: u32 = 1;
 const VOICE_RETRY_FEEDBACK_RESERVE_TOKENS: u32 = 96;
+/// Production runs up to ten attempts against one pinned model, so a blocklist
+/// of two throws away most of what the earlier rounds proved. Four normalized
+/// phrases cost roughly a third of the retry feedback reserve and still leave
+/// room for the shape and register clauses.
+const MAX_NAMED_REPEATED_PHRASES: usize = 4;
 
 #[derive(Clone, Debug)]
 pub(crate) struct VoiceRoutingConfig {
@@ -664,7 +669,32 @@ fn retry_instruction(
             PublicationCheckCode::VoiceRepeatedNgram | PublicationCheckCode::VoiceRecentDuplicate
         )
     }) {
-        clauses.push("fresh wording · no repeated phrase".to_string());
+        // Naming the offending run is the whole point of this clause: with one
+        // pinned voice model every retry is a resample of the same model, and a
+        // generic "fresh wording" reliably resamples the same phrase. Only the
+        // normalized token run crosses over — never the rejected line itself.
+        // Newest first: with up to ten attempts the early rounds are stale, and
+        // slicing a sorted set would pin the blocklist to whatever happened to
+        // sort first rather than to what the model just did. The set only dedupes.
+        let mut seen = BTreeSet::new();
+        let reused = rejections
+            .iter()
+            .rev()
+            .filter_map(|rejection| rejection.repeated_phrase.as_deref())
+            .filter(|phrase| seen.insert(*phrase))
+            .take(MAX_NAMED_REPEATED_PHRASES)
+            .collect::<Vec<_>>();
+        clauses.push(match reused.is_empty() {
+            true => "fresh wording · no repeated phrase".to_string(),
+            false => format!(
+                "fresh wording · do not reuse {}",
+                reused
+                    .into_iter()
+                    .map(|phrase| format!("\"{phrase}\""))
+                    .collect::<Vec<_>>()
+                    .join(" or ")
+            ),
+        });
     }
     if failed.contains(&PublicationCheckCode::VoiceMultipleSpeakers) {
         clauses.push("one voice · no speaker labels".to_string());
@@ -2269,6 +2299,116 @@ mod tests {
             .iter()
             .chain(&users)
             .all(|prompt| !prompt.contains(rejected)));
+    }
+
+    /// The retry now names the run that tripped the duplicate check. This is
+    /// the one place a rejected candidate's wording is allowed to reach a
+    /// later prompt, and only as normalized tokens — never the rejected line, and
+    /// never anywhere a player can see.
+    #[tokio::test]
+    async fn a_duplicate_retry_names_the_phrase_to_drop() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 2,
+            hedge_width: 1,
+            ..VoiceRoutingConfig::default()
+        });
+        let rejected = "White moths crowd the cold lamp cages again.";
+        let backend = MockBackend::with_outputs([
+            ("provider/tiny-a", rejected, 0),
+            ("provider/tiny-a", "Teapot ready.", 0),
+        ]);
+        let mut publication_gate = gate("duplicate-beat");
+        publication_gate.anchors = vec!["teapot".to_string(), "moths".to_string()];
+        publication_gate.recent_speaker_shingle_hashes =
+            crate::ai_publication::voice_signature_shingle_hashes(
+                "White moths crowd the cold lamp cages tonight.",
+            );
+
+        let certified = route_certified_voice_with(
+            &config,
+            None,
+            request("dialogue_avatar"),
+            publication_gate,
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect("the corrected retry certifies");
+
+        assert_eq!(certified.text(), "Teapot ready.");
+        let (systems, users) = backend.rendered_prompts();
+        assert_eq!(
+            systems[1],
+            "Write one short anchored line.\nagain · fresh wording · do not reuse \"white moths crowd the cold\"",
+        );
+        assert!(
+            systems
+                .iter()
+                .chain(&users)
+                .all(|prompt| !prompt.contains(rejected)),
+            "the rejected line itself still never reaches a prompt",
+        );
+    }
+
+    /// Production rejected eight consecutive rounds against one pinned model,
+    /// so every later retry must carry what the earlier ones proved rather
+    /// than repeating a single stale hint.
+    #[tokio::test]
+    async fn a_duplicate_blocklist_accumulates_across_rounds() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 3,
+            hedge_width: 1,
+            spend_ceiling_microdollars: u64::MAX,
+            ..VoiceRoutingConfig::default()
+        });
+        let backend = MockBackend::with_outputs([
+            (
+                "provider/tiny-a",
+                "White moths crowd the cold lamp cages again.",
+                0,
+            ),
+            (
+                "provider/tiny-a",
+                "I keep my small plans close beside the teapot.",
+                0,
+            ),
+            ("provider/tiny-a", "Teapot ready.", 0),
+        ]);
+        let mut publication_gate = gate("accumulating-beat");
+        publication_gate.anchors = vec!["teapot".to_string(), "moths".to_string()];
+        publication_gate.recent_speaker_shingle_hashes = [
+            crate::ai_publication::voice_signature_shingle_hashes(
+                "White moths crowd the cold lamp cages tonight.",
+            ),
+            crate::ai_publication::voice_signature_shingle_hashes(
+                "I keep my small plans close until morning.",
+            ),
+        ]
+        .concat();
+
+        let certified = route_certified_voice_with(
+            &config,
+            None,
+            request("dialogue_avatar"),
+            publication_gate,
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect("the third attempt certifies");
+
+        assert_eq!(certified.text(), "Teapot ready.");
+        let (systems, _) = backend.rendered_prompts();
+        assert!(
+            systems[1].ends_with("do not reuse \"white moths crowd the cold\""),
+            "the first retry names only what round one proved: {}",
+            systems[1]
+        );
+        assert!(
+            systems[2].ends_with(
+                "do not reuse \"i keep my small plans\" or \"white moths crowd the cold\""
+            ),
+            "the second retry carries both rounds, newest first: {}",
+            systems[2]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Chat exchanges on `cosyworld-lonelyforest` were still ending early after
#698–701 landed. Fly logs from the 2026-08-03 21:00–22:10 UTC window show
`voice_recent_duplicate` rejections climbing to `candidate_round=8` on the
primary app, and on lonelyforest a live exchange dying outright:

```
AI resident narration failed: voice_candidates_exhausted     (x3, actor job 65)
actor job 65 dialogue failed: voice_candidates_exhausted      (x3)
AI resident inference failed; ending chat exchange: voice_candidates_exhausted
bounded avatar chat ended early: voice_candidates_exhausted
```

#698–701 made the duplicate gate itself less trigger-happy (adjacent-shingle
requirement, cross-speaker reply exemption, short-line floor), but did
nothing for a retry that legitimately trips it: the feedback was a generic
`fresh wording · no repeated phrase`, and with one pinned voice model
(`openai/gpt-5.6-luna`) every retry is a resample of the same model, so it
reliably resampled the same phrase and burned through the attempt budget.

## What changed

- `PublicationRejection` now carries the normalized run of words that
  tripped `voice_recent_duplicate`, found along whichever of the gate's two
  duplicate paths failed it (shared shingle, or word-overlap against recent
  dialogue). Only normalized tokens are captured — never routed onto the
  persisted receipt, and never anywhere a player can see.
- The retry prompt names it directly: `fresh wording · do not reuse "..."`,
  accumulating up to 4 phrases across rounds, newest first.
- `COSYWORLD_AI_VOICE_MAX_ATTEMPTS` moves from the default of 2 to 4, giving
  the corrected retry more rounds to use inside the existing 2000
  microdollar spend ceiling.
- Rejection logging now includes the offending phrase so a duplicate storm
  is diagnosable from logs alone.

## Validation

- `cargo test --bin cosyworld-orchestrator ai_publication::` — 52 passed
- `cargo test --bin cosyworld-orchestrator ai_voice_routing::` — 24 passed
- `npm run v2:rust:test` (full suite, 994 tests) — all green
- `cargo fmt --check` — clean
- Confirmed the one full-suite chaos-test failure seen during iteration
  (`hot_room_and_regional_chaos_preserve_one_committed_world`, a write-
  authority contention test unrelated to this change) is a pre-existing
  flake: passed 3/3 in isolated reruns.
- Full `npm run check` pre-push gate (tests, worldpack, kernel, Rust,
  architecture, syntax) passed.

## Review checklist

- [x] Targeted and full Rust test suites pass
- [x] `cargo fmt --check` clean
- [x] Root version bumped (`package.json`, `package-lock.json`, `Cargo.toml`,
      `Cargo.lock`): 0.0.329 → 0.0.330
- [x] No behavior change to the duplicate-detection gate itself — only the
      retry feedback loop and the attempt-budget env var
- [x] Deploy note: pushing to `main` redeploys both production Fly apps
      per standard CI; no manual deploy step needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)