### PR TITLE
Log why a voice attempt failed at the provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.332",
+  "version": "0.0.333",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.332",
+      "version": "0.0.333",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.332",
+  "version": "0.0.333",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.332"
+version = "0.0.333"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.332"
+version = "0.0.333"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -1486,6 +1486,15 @@ async fn request_completion(
                 .unwrap_or("vision-config"),
             attempts = attempt,
             latency_ms = started_at.elapsed().as_millis() as u64,
+            // A completion that reaches this line is not necessarily one the
+            // publication gate accepts: finish_reason "length" is a truncated
+            // completion, and voice_finish_incomplete rejects it downstream.
+            // Without these, distinguishing a token budget that is really too
+            // tight from a model that stops cleanly but fails the structural
+            // check meant reproducing the failure locally.
+            finish_reason = %finish_reason,
+            requested_max_tokens = max_tokens,
+            completion_tokens = usage.completion_tokens.unwrap_or(0),
             "CosyWorld AI inference completed"
         );
         return Ok(AiCompletion {

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -425,12 +425,31 @@ async fn route_certified_voice_with(
             };
             let Ok((candidate, result)) = joined else {
                 provider_failures += 1;
+                tracing::warn!(
+                    generation_id = %generation_id,
+                    feature = request.feature,
+                    "AI voice attempt task did not complete (panicked or was aborted)"
+                );
                 continue;
             };
             completed_ordinals.insert(candidate.decision.ordinal);
             match result {
                 Err(error) => {
                     provider_failures += 1;
+                    // The aggregate `voice_provider_unavailable`/`voice_candidates_exhausted`
+                    // codes logged by the caller say a generation failed, not why. Without
+                    // this, diagnosing a real outage versus a client-side bug means
+                    // reproducing the failure locally instead of reading a log line.
+                    tracing::warn!(
+                        generation_id = %generation_id,
+                        feature = request.feature,
+                        candidate_round = candidate.decision.ordinal,
+                        provider = %candidate.decision.provider,
+                        requested_model = %candidate.decision.requested_model_id,
+                        error_code = error.code(),
+                        error = %error,
+                        "AI voice attempt failed at the provider"
+                    );
                     if error.affects_provider_health() {
                         record_provider_failure(
                             store_path,

--- a/v2/scripts/rust-lint-warning-ceiling.txt
+++ b/v2/scripts/rust-lint-warning-ceiling.txt
@@ -18,4 +18,12 @@
 # production; the pathway sanitizers only called each other, and the resident
 # reply wrapper's test duplicated coverage that already lives in
 # ai-model-rust/src/lib.rs.
-236
+#
+# 236 -> 240: no code moved this; stable Rust shipped new/changed lints since
+# 236 was set and this file was never re-pinned. `cargo clippy --all-targets`
+# on an unmodified main checkout already reports 240 under current stable
+# (verified on rustc 1.90.0 and 1.97.1, and on a local nightly). Confirmed the
+# extra 4 are pre-existing, not from this branch: diffed clippy's warning-line
+# output between an unmodified main checkout and this branch under all three
+# toolchains, and the sets were byte-identical every time.
+240


### PR DESCRIPTION
## Summary

The `voice_recent_duplicate` retry fix (#703) is live and confirmed working
in production. But post-deploy lonelyforest logs still show chat exchanges
ending early under *different* codes:

```
AI resident inference failed; ending chat exchange: voice_provider_unavailable
bounded avatar chat ended early: voice_provider_unavailable
...
AI resident inference failed; ending chat exchange: voice_candidates_exhausted
bounded avatar chat ended early: voice_candidates_exhausted   (round 2 rejected: voice_finish_incomplete)
```

Diagnosing either meant reproducing the failure locally, because the actual
error was discarded at the point of failure:

- A provider-level attempt failure only incremented a counter and wrote a
  bare `failure_code` string to the durable decision store. The
  `AiGatewayError`'s message — *why* the HTTP call actually failed (timeout,
  transport error, non-2xx response) — never reached a log line, so
  `voice_provider_unavailable` told us every attempt in a generation failed,
  never why.
- A completion that finishes truncated (`finish_reason: "length"`) reads
  identically in logs to one that completes cleanly: the existing
  `CosyWorld AI inference completed` line carries no `finish_reason` or token
  usage, so a token budget that's genuinely too tight is indistinguishable
  from a structurally malformed line that fails a different check.

## What changed

- `ai_voice_routing.rs`: a provider-level attempt failure now logs `feature`,
  `candidate_round`, `provider`, `requested_model`, `error_code`, and the
  full error message. A JoinSet task that panics/aborts (rare) is logged too.
- `ai_gateway.rs`: every completion now logs `finish_reason`,
  `requested_max_tokens`, and `completion_tokens` alongside the existing
  fields.
- No behavior change to routing, retries, or the publication gate — this is
  observability only, so the next `voice_provider_unavailable` or
  `voice_finish_incomplete` incident is diagnosable from `flyctl logs`
  without reproducing it.
- `v2/scripts/rust-lint-warning-ceiling.txt`: unrelated to the above, but
  needed to unblock the push — see the second commit and its message for the
  full rationale. Short version: an unmodified `main` checkout already
  reports 240 clippy warnings under current stable Rust (236 was stale by 4),
  verified across three toolchains with byte-identical warning sets between
  `main` and this branch, so this branch introduces zero new warnings.

## Validation

- `cargo test --bin cosyworld-orchestrator ai_gateway::` — 37 passed
- `cargo test --bin cosyworld-orchestrator ai_voice_routing::` — 24 passed
- `npm run v2:rust:test` (full suite, 998 tests) — all green
- `cargo fmt --check` — clean
- Full `npm run check` pre-push gate (tests, worldpack, kernel, Rust,
  architecture, syntax) passed, including `cargo clippy: 240 warnings
  (ceiling: 240)`

## Review checklist

- [x] Targeted and full Rust test suites pass
- [x] `cargo fmt --check` clean, clippy ceiling re-verified against a clean
      baseline under 3 toolchains
- [x] Root version bumped: 0.0.332 → 0.0.333
- [x] Logging-only change; no routing/retry/gate behavior altered
- [x] Deploy note: pushing to `main` redeploys both production Fly apps per
      standard CI; no manual deploy step needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)