### PR TITLE
Stop banning Elysium's own "model avatar" vocabulary from room memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.333",
+  "version": "0.0.334",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.333",
+      "version": "0.0.334",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.333",
+  "version": "0.0.334",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.333"
+version = "0.0.334"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.333"
+version = "0.0.334"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -31109,7 +31109,6 @@ fn sanitize_room_memory_summary(value: &str) -> Option<String> {
         " event ",
         " ledger ",
         " log ",
-        " model ",
         " policy ",
         " prompt ",
         " rag ",
@@ -31120,6 +31119,13 @@ fn sanitize_room_memory_summary(value: &str) -> Option<String> {
     ]
     .iter()
     .any(|needle| lowered.contains(needle))
+        // Elysium's canonical resident type is a "model avatar", and every one
+        // of its locations says so in its own authored memory (see location
+        // 652052, "Void 053"). A bare " model " ban meant that location could
+        // never pass this filter: the prompt hands the model its own memory
+        // text verbatim, so summarizing it necessarily reuses that phrase. The
+        // narrower phrase still catches an actual 4th-wall break.
+        || lowered.contains("language model")
     {
         return None;
     }
@@ -45013,6 +45019,24 @@ mod tests {
         assert!(
             sanitize_room_memory_summary("Log room state / recent voices / movement").is_none()
         );
+    }
+
+    /// Elysium's canonical resident type is a "model avatar", and every one of
+    /// its locations says so in its own authored memory. A bare "model" ban
+    /// meant a summary of that memory could never pass, so those rooms never
+    /// got a memory chapter (location 652052, "Void 053", in production). The
+    /// narrower "language model" phrase still catches an actual 4th-wall
+    /// break.
+    #[test]
+    fn ai_room_memory_allows_elysiums_own_model_avatar_vocabulary() {
+        assert!(sanitize_room_memory_summary(
+            "The model avatar rests quietly beside the unlit marker tonight."
+        )
+        .is_some());
+        assert!(sanitize_room_memory_summary(
+            "The room recalls it is only a language model rendering this scene."
+        )
+        .is_none());
     }
 
     #[test]

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -180,4 +180,9 @@
 # reply wrapper's only remaining caller went with them. Its test duplicated
 # coverage that already lives in ai-model-rust/src/lib.rs, so it moved out
 # rather than being copied again.
-71729
+#
+# 71729 -> 71753: narrow one leakage-word entry in the existing
+# sanitize_room_memory_summary filter (bare "model" -> the phrase "language
+# model") plus its regression. Existing function, no new system; the same
+# collision was already fixed in the voice publication gate by #698.
+71753


### PR DESCRIPTION
## Summary

You asked me to check `0.lonelyforest.com` / Void 053 for chat problems.
Found something bigger than a chat issue: **room memory has never worked for
any Elysium location.**

Fresh logs for location 652052 ("Void 053"):
```
CosyWorld AI inference completed feature="room_memory" ... attempts=1 latency_ms=2122
AI room memory summary failed for location 652052: AI room memory response was not usable
```
Repeating every 2-3 seconds. The completion succeeds — the model returns a
usable-looking sentence — but `sanitize_room_memory_summary` rejects every
single one.

## Root cause

The room-memory prompt hands the model the location's own authored
`description`/`persona`/`memory` text verbatim and asks for a plain-sentence
summary. Void 053's own memory says:

> "This private cell contains one **model** avatar and one unique inert
> marker."

`sanitize_room_memory_summary`'s leakage filter bans any bare `" model "`.
A faithful summary of a Void 053 memory chapter almost always says "model
avatar" back — so it can never pass.

This isn't one room. Elysium's residents are literally AI-model avatars, and
**all 485 of its locations** describe them that way in their own authored
text (verified against `v2/content/elysium/locations.json`):

```
model: 485/485
ai: 0/485 · advancement: 0/485 · archive: 0/485 · chapter: 0/485
event: 0/485 · ledger: 0/485 · log: 0/485 · policy: 0/485 · prompt: 0/485
rag: 0/485 · summary: 0/485 · system: 0/485 · ui: 0/485
```

Only "model" collides — the other thirteen banned words in the filter don't
appear anywhere in the location data, so this is the whole fix.

This is the identical collision #698 already fixed in the voice publication
gate's `contains_instruction_leakage` ("Elysium's residents are named after
models and talk about them, so this gate silenced the exact world it was
protecting"). That fix kept "language model" as an explicit phrase while
dropping the bare word. `sanitize_room_memory_summary` is a separate,
sibling filter in `main.rs` that #698 didn't touch, so it kept the bare
ban.

## What changed

- `main.rs`: `sanitize_room_memory_summary` drops the bare `" model "` entry
  and adds the phrase `"language model"` in its place — same shape as #698's
  fix, so a genuine 4th-wall break ("...it is only a language model...") is
  still caught, while "the model avatar rests here" passes.
- One regression test pinning both sides of that line.
- `main-rs-line-ceiling.txt` bumped 71729 → 71753 for the fix + test, with
  the standard "existing function, no new system" justification.

## Validation

- `cargo test --bin cosyworld-orchestrator ai_room_memory` — 2 passed
- `npm run v2:rust:test` (full suite, 999 tests) — all green
- `cargo fmt --check` — clean
- Full `npm run check` pre-push gate passed: `main.rs: 71753 lines (ceiling:
  71753)`, `cargo clippy: 240 warnings (ceiling: 240)`
- Confirmed via `v2/content/elysium/locations.json` that "model" is the only
  one of the filter's fourteen banned words present in Elysium's authored
  location content (485/485 vs 0/485 for the rest)

## Review checklist

- [x] Targeted and full Rust test suites pass
- [x] `cargo fmt --check` clean
- [x] Root version bumped: 0.0.333 → 0.0.334
- [x] `main-rs-line-ceiling.txt` raised with inline justification, matching
      the file's established pattern for existing-function fixes
- [x] Deploy note: pushing to `main` redeploys both production Fly apps per
      standard CI; no manual deploy step needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)