### PR TITLE
Reconcile the restored event cursor with the durable commit point

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.334",
+  "version": "0.0.335",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.334",
+      "version": "0.0.335",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.334",
+  "version": "0.0.335",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.334"
+version = "0.0.335"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.334"
+version = "0.0.335"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -37231,7 +37231,9 @@ fn commit_journal_record(
                     "canonical journal commit failed for actor {} action {}: {}",
                     record.action.actor_id, record.action.kind, error
                 );
-                state.record_event_store_append_failure(&error);
+                if canonical_commit_error_is_store_fault(&error) {
+                    state.record_event_store_append_failure(&error);
+                }
                 return Err(error);
             }
         };
@@ -37355,6 +37357,27 @@ fn rebuild_runtime_from_durable_state(
         restored.apply_wallet_overlap_placements(&ownership, placement_rotation);
     }
     Ok(Box::new(restored))
+}
+
+/// Does a failed canonical commit mean the event store itself is unwell?
+///
+/// Only a real persistence fault may degrade event-store health. A rejected
+/// proposal - a stale sequence, a lost lease, a duplicate event, a malformed
+/// payload - says nothing about whether the store can be written to, and
+/// `sqlite_error` reports genuine faults as `Other`. Conflating the two is what
+/// turned a single rejected write into a total outage on 2026-08-05: the
+/// rejection marked the store degraded, `/health` began answering 503, Fly took
+/// the machine out of the load balancer, and because only a *successful* append
+/// clears the counter the process could never earn its way back.
+fn canonical_commit_error_is_store_fault(error: &io::Error) -> bool {
+    !matches!(
+        error.kind(),
+        io::ErrorKind::InvalidData
+            | io::ErrorKind::InvalidInput
+            | io::ErrorKind::AlreadyExists
+            | io::ErrorKind::PermissionDenied
+            | io::ErrorKind::WouldBlock
+    )
 }
 
 fn journal_commit_recovery_error(
@@ -38777,13 +38800,49 @@ fn max_event_store_seq(path: &Path) -> io::Result<u64> {
     Ok(max_seq.unwrap_or(0).max(0) as u64)
 }
 
+/// Reconcile the restored event cursor with the durable commit point.
+///
+/// Proposals are minted from `next_event_seq`, but `validate_next_world_sequence`
+/// accepts them only against `canonical_world_state.committed_seq`. Raising the
+/// cursor to the last stored row is therefore not enough: a checkpoint written
+/// while the runtime led the commit point freezes that lead into every later
+/// boot, so the first commit proposes a sequence the journal can never accept
+/// and the world becomes permanently unwritable. Reconcile in both directions.
 fn advance_runtime_next_event_seq_from_store(
     runtime: &mut RuntimeWorld,
     path: &Path,
 ) -> io::Result<()> {
     let max_seq = max_event_store_seq(path)?;
-    if runtime.world.next_event_seq <= max_seq {
-        runtime.world.next_event_seq = max_seq.saturating_add(1);
+    let committed_seq = current_world_seq(&open_event_store(path)?, OFFICIAL_WORLD_ID)?;
+    let durable_tip = max_seq.max(committed_seq);
+    if runtime.world.next_event_seq <= durable_tip {
+        runtime.world.next_event_seq = durable_tip.saturating_add(1);
+        return Ok(());
+    }
+    if max_seq != committed_seq {
+        // The stored rows and the commit cursor disagree, so neither is
+        // authoritative. Leave the restored cursor alone and let the commit
+        // path keep failing loudly rather than guess which one to believe.
+        warn!(
+            "CosyWorld event store is inconsistent: world_events ends at {} but the canonical \
+             commit cursor is {}; leaving the restored event cursor {} untouched",
+            max_seq, committed_seq, runtime.world.next_event_seq
+        );
+        return Ok(());
+    }
+    if durable_tip > 0 {
+        // An empty store still carries its seeded event log in memory, so only
+        // lower the cursor once something durable exists to lower it to.
+        let restored = runtime.world.next_event_seq;
+        runtime.world.next_event_seq = durable_tip.saturating_add(1);
+        warn!(
+            "restored CosyWorld event cursor {} leads the durable commit point {}; reconciled to \
+             {} ({} uncommitted event(s) are absent from durable history)",
+            restored,
+            durable_tip,
+            runtime.world.next_event_seq,
+            restored.saturating_sub(durable_tip).saturating_sub(1)
+        );
     }
     Ok(())
 }
@@ -48246,6 +48305,201 @@ mod tests {
         advance_runtime_next_event_seq_from_store(&mut replayed, &path)
             .expect("advance runtime sequence");
         assert_eq!(replayed.world.next_event_seq, replay_next_seq + 8);
+
+        let _ = fs::remove_file(path);
+    }
+
+    /// A checkpoint written while the runtime led the commit point used to
+    /// freeze that lead into every later boot, so the first commit proposed a
+    /// sequence the journal could never accept and the world became
+    /// permanently unwritable.
+    #[test]
+    fn a_restored_event_cursor_reconciles_down_to_the_durable_commit_point() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-cursor-reconcile-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        init_event_store(&path).expect("initialize event store");
+        append_event_store(
+            &path,
+            &[EventView {
+                seq: 1,
+                type_name: "actor.presence".to_string(),
+                success: true,
+                location_id: Some(1),
+                content: Some("active".to_string()),
+                ..EventView::default()
+            }],
+        )
+        .expect("append durable event");
+
+        let conn = open_event_store(&path).expect("open event store");
+        assert_eq!(
+            current_world_seq(&conn, OFFICIAL_WORLD_ID).expect("commit cursor"),
+            1
+        );
+        drop(conn);
+        assert_eq!(max_event_store_seq(&path).expect("stored tip"), 1);
+
+        let mut runtime = RuntimeWorld::seeded();
+        runtime.world.next_event_seq = 4;
+        advance_runtime_next_event_seq_from_store(&mut runtime, &path)
+            .expect("reconcile runtime sequence");
+        assert_eq!(runtime.world.next_event_seq, 2);
+
+        let _ = fs::remove_file(path);
+    }
+
+    /// An empty store still carries its seeded event log in memory, so there is
+    /// no durable tip to reconcile against and the cursor must be left alone.
+    #[test]
+    fn an_empty_event_store_never_lowers_the_seeded_event_cursor() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-cursor-empty-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        init_event_store(&path).expect("initialize event store");
+
+        let mut runtime = RuntimeWorld::seeded();
+        let seeded = runtime.world.next_event_seq;
+        advance_runtime_next_event_seq_from_store(&mut runtime, &path)
+            .expect("reconcile runtime sequence");
+        assert_eq!(runtime.world.next_event_seq, seeded);
+
+        let _ = fs::remove_file(path);
+    }
+
+    /// Stored rows disagreeing with the commit cursor is real corruption, and
+    /// guessing which one to believe could reuse a sequence that already has a
+    /// row. Leave the cursor alone so the commit path keeps failing loudly.
+    #[test]
+    fn an_inconsistent_event_store_leaves_the_restored_cursor_untouched() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-cursor-inconsistent-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        init_event_store(&path).expect("initialize event store");
+        append_event_store(
+            &path,
+            &[EventView {
+                seq: 1,
+                type_name: "actor.presence".to_string(),
+                success: true,
+                location_id: Some(1),
+                content: Some("active".to_string()),
+                ..EventView::default()
+            }],
+        )
+        .expect("append durable event");
+
+        // Rewind only the commit cursor, leaving the stored row behind.
+        let conn = open_event_store(&path).expect("open event store");
+        conn.execute(
+            "UPDATE canonical_world_state SET committed_seq = 0 WHERE world_id = ?1",
+            params![OFFICIAL_WORLD_ID],
+        )
+        .expect("rewind commit cursor");
+        drop(conn);
+
+        let mut runtime = RuntimeWorld::seeded();
+        runtime.world.next_event_seq = 9;
+        advance_runtime_next_event_seq_from_store(&mut runtime, &path)
+            .expect("reconcile runtime sequence");
+        assert_eq!(runtime.world.next_event_seq, 9);
+
+        let _ = fs::remove_file(path);
+    }
+
+    /// A rejected proposal says nothing about whether the store can be written
+    /// to. Counting it as an append failure degraded event-store health, which
+    /// failed `/health`, which took the machine out of the load balancer - and
+    /// because only a *successful* append clears the counter, no traffic could
+    /// ever reach the process to restore it.
+    #[test]
+    fn a_rejected_commit_leaves_event_store_health_untouched() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-rejected-commit-health-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        init_event_store(&path).expect("initialize event store");
+        let state = test_app_state(RuntimeWorld::seeded(), Some(path.clone()));
+        {
+            let mut runtime = state.inner.blocking_lock();
+            let mut create_record = JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_CREATE_ACTOR,
+                    actor_id: 5000,
+                    location_id: COSY_COTTAGE_LOCATION_ID,
+                    ..CwAction::default()
+                },
+                17632,
+            );
+            create_record.actor_meta_upserts.insert(
+                5000,
+                ActorMeta {
+                    name: "Health Baseline".to_string(),
+                    speech_mode: "prose".to_string(),
+                    title: "Health Tester".to_string(),
+                    description: "A test avatar committed before the rejection.".to_string(),
+                },
+            );
+            assert_eq!(
+                commit_journal_record(&state, &mut runtime, create_record)
+                    .expect("commit health test baseline")
+                    .0,
+                CW_OK
+            );
+            restore_runtime_from_durable_state(&state, &mut runtime, &path)
+                .expect("normalize the baseline from durable state");
+            {
+                let health = state.event_store_health.lock().expect("health lock");
+                assert_eq!(health.status(true), "healthy");
+            }
+
+            // Lead the durable commit point exactly as a checkpoint written
+            // mid-flight does on boot.
+            runtime.world.next_event_seq = runtime.world.next_event_seq.saturating_add(2);
+            let mut stale_record = JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_CREATE_ACTOR,
+                    actor_id: 5001,
+                    location_id: COSY_COTTAGE_LOCATION_ID,
+                    ..CwAction::default()
+                },
+                17633,
+            );
+            stale_record.actor_meta_upserts.insert(
+                5001,
+                ActorMeta {
+                    name: "Stale Cursor".to_string(),
+                    speech_mode: "prose".to_string(),
+                    title: "Rejection Tester".to_string(),
+                    description: "A test avatar proposed from a stale cursor.".to_string(),
+                },
+            );
+            assert!(
+                commit_journal_record(&state, &mut runtime, stale_record).is_err(),
+                "a proposal that leads the commit point must be rejected"
+            );
+
+            // Recovery reconciles the cursor, so the world stays writable.
+            let conn = open_event_store(&path).expect("open event store");
+            let committed = current_world_seq(&conn, OFFICIAL_WORLD_ID).expect("commit cursor");
+            drop(conn);
+            assert_eq!(runtime.world.next_event_seq, committed.saturating_add(1));
+        }
+
+        let health = state.event_store_health.lock().expect("health lock");
+        assert_eq!(health.consecutive_append_failures, 0);
+        assert_eq!(health.status(true), "healthy");
 
         let _ = fs::remove_file(path);
     }

--- a/v2/orchestrator-rust/src/snapshot_persistence.rs
+++ b/v2/orchestrator-rust/src/snapshot_persistence.rs
@@ -118,9 +118,47 @@ impl SnapshotJob {
         }
     }
 
+    /// Is the captured cursor backed by the durable commit point?
+    ///
+    /// A checkpoint whose `next_event_seq` leads `committed_seq` is not a valid
+    /// checkpoint: every boot restores that lead, and the first commit then
+    /// proposes a sequence the journal must reject. Keeping the previous good
+    /// checkpoint is strictly better than freezing a torn cursor, and skipping
+    /// the write also skips compaction, so nothing is discarded behind it.
+    fn checkpoint_cursor_is_durable(&self) -> bool {
+        let (Some(path), Some(snapshot)) =
+            (self.event_store_path.as_deref(), self.snapshot.as_ref())
+        else {
+            return true;
+        };
+        let committed_seq = match open_event_store(path)
+            .and_then(|conn| current_world_seq(&conn, OFFICIAL_WORLD_ID))
+        {
+            Ok(committed_seq) => committed_seq,
+            // The commit point is unreadable, so there is nothing to contradict
+            // the capture. Let the write proceed rather than stall checkpoints.
+            Err(_) => return true,
+        };
+        // A store with no commit point yet still carries a freshly seeded world's
+        // bootstrap events in memory only, so there is nothing to contradict.
+        if committed_seq == 0 || snapshot.next_event_seq <= committed_seq.saturating_add(1) {
+            return true;
+        }
+        error!(
+            "refusing to checkpoint CosyWorld snapshot: captured event cursor {} leads the durable \
+             commit point {}; keeping the previous checkpoint",
+            snapshot.next_event_seq, committed_seq
+        );
+        false
+    }
+
     fn write(self) -> io::Result<()> {
+        // Resident continuity is independent of the world cursor, so a rejected
+        // checkpoint must not stall it. Gating `snapshot_saved` also gates
+        // compaction, which must never run behind a checkpoint we refused.
+        let cursor_is_durable = self.checkpoint_cursor_is_durable();
         let snapshot_saved = match (self.snapshot_path.as_deref(), self.snapshot.as_ref()) {
-            (Some(path), Some(snapshot)) => {
+            (Some(path), Some(snapshot)) if cursor_is_durable => {
                 write_json_atomically(path, snapshot, snapshot_temp_path(path))?;
                 true
             }
@@ -298,5 +336,59 @@ mod tests {
         let restored = RuntimeWorld::load_snapshot(&snapshot_path).expect("latest snapshot loads");
         assert_eq!(restored.world.tick, runtime.world.tick);
         let _ = fs::remove_file(snapshot_path);
+    }
+
+    /// A checkpoint whose cursor leads the commit point is not a checkpoint:
+    /// every later boot restores that lead and the first commit is rejected.
+    /// Keeping the previous good checkpoint is strictly better than freezing a
+    /// torn cursor into the only file a compacted journal can be rebuilt from.
+    #[test]
+    fn a_checkpoint_that_leads_the_commit_point_is_refused() {
+        let snapshot_path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-torn-cursor-snapshot-{}-{}.json",
+            std::process::id(),
+            now_millis()
+        ));
+        let store_path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-torn-cursor-store-{}-{}.sqlite",
+            std::process::id(),
+            now_millis()
+        ));
+        let _ = fs::remove_file(&snapshot_path);
+        let _ = fs::remove_file(&store_path);
+
+        let mut state = test_app_state(RuntimeWorld::seeded(), Some(store_path.clone()));
+        state.snapshot_path = Some(Arc::new(snapshot_path.clone()));
+        state.snapshot_writer = Some(Arc::new(SnapshotWriter::spawn().expect("snapshot writer")));
+        append_event_store(
+            &store_path,
+            &[EventView {
+                seq: 1,
+                type_name: "actor.presence".to_string(),
+                success: true,
+                location_id: Some(1),
+                content: Some("active".to_string()),
+                ..EventView::default()
+            }],
+        )
+        .expect("append durable event");
+
+        // A cursor level with the commit point checkpoints normally.
+        let mut runtime = RuntimeWorld::seeded();
+        runtime.world.next_event_seq = 2;
+        runtime.world.tick = 11;
+        persist_runtime_now(&state, &runtime);
+        let durable = RuntimeWorld::load_snapshot(&snapshot_path).expect("durable snapshot loads");
+        assert_eq!(durable.world.tick, 11);
+
+        // A cursor that leads it must not overwrite that checkpoint.
+        runtime.world.next_event_seq = 5;
+        runtime.world.tick = 22;
+        persist_runtime_now(&state, &runtime);
+        let kept = RuntimeWorld::load_snapshot(&snapshot_path).expect("previous snapshot survives");
+        assert_eq!(kept.world.tick, 11);
+
+        let _ = fs::remove_file(snapshot_path);
+        let _ = fs::remove_file(store_path);
     }
 }

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -185,4 +185,18 @@
 # sanitize_room_memory_summary filter (bare "model" -> the phrase "language
 # model") plus its regression. Existing function, no new system; the same
 # collision was already fixed in the voice publication gate by #698.
-71753
+# 71753 -> 72007: reconcile the restored event cursor against the durable commit
+# point, and stop a rejected proposal from degrading event-store health. A
+# checkpoint written while the runtime led the commit point froze that lead into
+# every later boot, so the first commit proposed a sequence the journal could
+# never accept; the rejection was then counted as an append failure, which
+# failed /health, which took the machine out of the load balancer, and only a
+# successful append clears that counter. Production was unreachable for ~19h on
+# 2026-08-05. Both fixes sit on functions main.rs already owns
+# (advance_runtime_next_event_seq_from_store and the journal commit path), so
+# relocating them would be an unrelated extraction inside a behavior change.
+# ~215 of the 254 lines are the four regressions that pin the reconciliation in
+# both directions, the empty-store and inconsistent-store boundaries, and the
+# health contract; the checkpoint-refusal half lives in snapshot_persistence.rs
+# beside the writer that owns it.
+72007


### PR DESCRIPTION
## Summary

`cosyworld.fly.dev` was unreachable for ~19 hours. The process was healthy and serving normally — it was failing *its own* health check, so Fly's proxy had no routable candidate and every request hung (`could not find a good candidate within 40 attempts at load balancing`).

**Trigger.** Proposals are minted from in-memory `next_event_seq`, but `validate_next_world_sequence` accepts them only against `canonical_world_state.committed_seq`. Boot only ever *raised* the cursor toward `MAX(world_events.seq)` — it never consulted the commit cursor and never lowered it. A checkpoint written while the runtime led the commit point froze `next_event_seq: 350` against a durable tip of 347, so every boot restored the same divergence and the first write was always rejected.

**Amplifier.** That rejection was recorded as an event-store *append failure*, making health `degraded` → `/health` 503 → machine pulled from the load balancer. Only a **successful** append clears the counter, so no traffic could reach the process to restore it. A single rejected write black-holed the site, and restarting could not fix it.

Three changes:

- **`advance_runtime_next_event_seq_from_store`** reconciles in both directions against `max(max_seq, committed_seq) + 1`, so a seq that already has a row can never be reused. It refuses to act when stored rows and the commit cursor disagree (real corruption — must keep failing loudly), and leaves an empty store alone, where a seeded world's bootstrap events legitimately live only in memory.
- **The journal commit path** no longer treats rejected proposals as persistence faults. Genuine faults arrive from `sqlite_error` as `Other` and still degrade health; the `tx.commit()` failure path is unchanged.
- **The snapshot writer** refuses to checkpoint a cursor that leads the commit point, closing the source. Gating `snapshot_saved` keeps resident continuity persisting and stops compaction running behind a refused checkpoint.

## Deployment note

**No production data surgery is required.** `committed_seq` and `MAX(world_events.seq)` already agree at 347, so the reconciliation heals production on boot: the cursor drops `350 → 348` and the world becomes writable again.

Deleting the snapshot would **not** have been safe: compaction has already removed 214 action-journal rows (`action_journal_floor_seq: 215`), so the checkpoint is load-bearing rather than a disposable boot accelerator.

Two events minted only in memory are absent from event history. Their state effects are preserved in the checkpoint, so no world state is lost.

## Validation

| Command | Result |
| --- | --- |
| `npm run v2:rust:test` | 1004 passed, 0 failed |
| `npm run check:local` | pass |
| `npm run check:version` | pass (`0.0.334` → `0.0.335`) |
| `git diff --check` | clean |

Five new regressions cover reconciliation in both directions, the empty-store and inconsistent-store boundaries, the health contract, and checkpoint refusal. Reverting the health fix makes `a_rejected_commit_leaves_event_store_health_untouched` fail with `left: 1, right: 0`, confirming it pins the actual defect.

`main.rs` ceiling raised `71753 → 72007` with a justification comment in the file's established format.

### Pre-existing flake, not from this change

`smoke-standalone-compositions.mjs` intermittently fails with *"Lantern Keeper first committed action did not freeze its Class evidence"*. Measured **1-in-6 on clean `main`** and 1-in-5 with this branch — same assertion, and consistent with `e327c70e` recently touching that test. It may fail CI here. Fix tracked separately.

## Review checklist

- [x] Tests cover the changed behavior.
- [x] No generated worldpack files or locks affected.
- [x] No changes under `v2/content/**` — register review not applicable.
- [x] No new horror — genre review not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)