### PR TITLE
Let an unreachable primary app deploy from an audited identity capture

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: ""
         type: string
+      primary_recovery_capture:
+        description: Reviewed committed capture path, only when the primary app's live /meta is unavailable
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: deploy-${{ github.repository }}
@@ -96,8 +101,20 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      # An unreachable primary app fails this gate closed, which blocks the very
+      # deploy that would fix it. Supply a reviewed committed capture of the
+      # last known /meta to recover; the captured hash is still evaluated
+      # against the candidate registry exactly like a live identity.
       - name: Guard primary worldpack bundle compatibility
-        run: node v2/scripts/check-deploy-worldpack.mjs https://cosyworld.fly.dev
+        run: |
+          if [ -n "$COSYWORLD_PRIMARY_RECOVERY_CAPTURE" ]; then
+            node v2/scripts/check-deploy-worldpack.mjs https://cosyworld.fly.dev \
+              --recovery-capture "$COSYWORLD_PRIMARY_RECOVERY_CAPTURE"
+          else
+            node v2/scripts/check-deploy-worldpack.mjs https://cosyworld.fly.dev
+          fi
+        env:
+          COSYWORLD_PRIMARY_RECOVERY_CAPTURE: ${{ inputs.primary_recovery_capture }}
 
       - name: Create rollback backup
         run: scripts/backup-fly-v2.sh cosyworld primary

--- a/docs/deployment/07-deployment.md
+++ b/docs/deployment/07-deployment.md
@@ -141,6 +141,53 @@ NODE_OPTIONS="--max-old-space-size=4096"
 
 ---
 
+## Recovery when the primary app is already unavailable
+
+The pre-deploy bundle gate reads the live `/meta` and fails closed, which is
+correct for a stale-checkout deploy but deadlocks the case that matters most:
+`cosyworld.fly.dev` is unreachable *because* it needs the deploy. That blocked
+recovery twice — the failed v557 release on 2026-08-05 and again on 2026-08-07,
+a ~2.5 day outage.
+
+Do not bypass the guard and do not blank a persisted bundle hash.
+
+1. Obtain the app's persisted identity from the running process or its volume.
+   The orchestrator serves `/meta` internally even while the Fly proxy has
+   removed the machine from rotation, so
+   `fly ssh console --app cosyworld -C "curl -s http://127.0.0.1:3000/meta"`
+   usually still works. Never infer the hash from the candidate image.
+2. Store a capture with this exact shape and review it with the recovery change:
+
+   ```json
+   {
+     "schema_version": 1,
+     "source": "app-volume",
+     "captured_at": "2026-08-07T18:40:00Z",
+     "meta": { "worldpack": { "bundle_hash": "sha256:<64 lowercase hex>" } }
+   }
+   ```
+
+   `source` may instead be `operator-capture`, but it must still contain the
+   unmodified observed `/meta` identity and a reviewable timestamp. The capture
+   must be committed: the guard refuses an untracked file or any path outside
+   the checkout.
+3. Run `Deploy` via `workflow_dispatch` with `target: primary` and
+   `primary_recovery_capture` set to the committed capture path. The guard
+   records the capture path, source, and time, then applies the normal
+   exact/declaration comparison — a genuine mismatch still fails closed.
+4. Preserve the workflow log and capture with the incident record, then verify
+   `/meta` after recovery before the next release.
+
+If GitHub Actions itself is unavailable, the same two steps the workflow runs
+can be performed directly, and they keep the rollback snapshot:
+
+```sh
+bash scripts/backup-fly-v2.sh cosyworld primary
+flyctl deploy --remote-only --config fly.toml --strategy rolling
+```
+
+---
+
 ## Monitoring
 
 - V2 health endpoints: `/health`, `/meta`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.335",
+  "version": "0.0.336",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.335",
+      "version": "0.0.336",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.335",
+  "version": "0.0.336",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -343,6 +343,15 @@ older bundle cannot declare a newer hash. The gate never mutates the journal,
 the snapshot, or the recorded hashes; the remedy for a blocked deploy is the
 declared migration path above, never a hand-edited hash.
 
+Failing closed on an unreachable app would otherwise block the very deploy that
+recovers it. Both release targets therefore accept a reviewed, committed capture
+of the last observed `/meta` in place of a live read: `primary_recovery_capture`
+for the primary app and `lonelyforest_recovery_capture` for a Lonely Forest
+tenant. This is an audited recovery path, not a bypass — the captured hash runs
+through the same exact/declaration comparison, an untracked capture or one
+outside the checkout is refused, and a genuine mismatch still fails closed. See
+[the primary recovery procedure](../../docs/deployment/07-deployment.md#recovery-when-the-primary-app-is-already-unavailable).
+
 Lonely Forest is one Fly Machine containing several isolated world processes.
 Its release gate applies this same proof to every required tenant registry and
 public `/meta` identity, rather than treating the root host as evidence for

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.335"
+version = "0.0.336"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.335"
+version = "0.0.336"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/check-deploy-worldpack.mjs
+++ b/v2/scripts/check-deploy-worldpack.mjs
@@ -26,10 +26,17 @@
  *   node v2/scripts/check-deploy-worldpack.mjs <fly-app | https://base-url>
  *     [--registry v2/content/official/registry.json]
  *     [--meta-file captured-meta.json]   # read /meta from disk instead of HTTP
+ *     [--recovery-capture ops/capture.json]  # audited stand-in for an
+ *                                            # unreachable /meta; see below
  *     [--timeout-ms 15000]
  *
  * Exit codes: 0 compatible; 1 incompatible or live identity unreadable
  * (fail closed); 2 usage or local registry error.
+ *
+ * When the target app is unreachable, failing closed blocks the deploy that
+ * would fix it. `--recovery-capture` accepts a committed, reviewable capture of
+ * the last known /meta so recovery stays possible without weakening the gate:
+ * the captured hash is evaluated exactly like a live identity.
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -180,7 +187,74 @@ function currentCommit() {
   return result.status === 0 ? result.stdout.trim() : "unknown";
 }
 
-const VALUE_OPTIONS = new Set(["--registry", "--meta-file", "--timeout-ms"]);
+const VALUE_OPTIONS = new Set([
+  "--registry",
+  "--meta-file",
+  "--recovery-capture",
+  "--timeout-ms",
+]);
+
+const CAPTURE_SOURCES = new Set(["app-volume", "operator-capture"]);
+
+/**
+ * Read the audited recovery capture that stands in for an unreachable /meta.
+ *
+ * Failing closed on an unreachable app is correct for a stale-checkout deploy,
+ * but it deadlocks the case that matters most: the app is unreachable *because*
+ * it needs the deploy. That blocked production recovery twice (v557 on
+ * 2026-08-05 and again on 2026-08-07, a ~2.5 day outage) because the primary
+ * app had no recovery path while Lonely Forest did.
+ *
+ * This is an audited recovery path, not a bypass. The capture must be a
+ * committed, reviewable file recording its source, timestamp, and the
+ * unmodified /meta response, and the hash it carries is evaluated against the
+ * candidate registry exactly like a live identity — a genuine mismatch still
+ * fails. Mirrors `--recovery-capture` in check-lonelyforest-worldpacks.mjs.
+ */
+function recoveryCaptureHash(capturePath) {
+  const absolutePath = path.resolve(repoRoot, capturePath);
+  const relativePath = path.relative(repoRoot, absolutePath);
+  if (!relativePath || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw new UsageError(
+      `--recovery-capture must be a reviewed file inside the committed checkout, got ${capturePath}`,
+    );
+  }
+  const tracked = spawnSync("git", ["ls-files", "--error-unmatch", "--", relativePath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (tracked.status !== 0) {
+    throw new UsageError(
+      `--recovery-capture must be committed and reviewable at ${relativePath} before a production deploy`,
+    );
+  }
+  let capture;
+  try {
+    capture = JSON.parse(fs.readFileSync(absolutePath, "utf8"));
+  } catch (error) {
+    throw new UsageError(`cannot read --recovery-capture ${capturePath}: ${error.message}`);
+  }
+  if (capture?.schema_version !== 1
+    || !CAPTURE_SOURCES.has(capture?.source)
+    || typeof capture?.captured_at !== "string"
+    || Number.isNaN(Date.parse(capture.captured_at))) {
+    throw new UsageError(
+      `--recovery-capture ${relativePath} must contain schema_version: 1, source `
+      + "('app-volume' or 'operator-capture'), and an ISO captured_at",
+    );
+  }
+  const liveHash = capture?.meta?.worldpack?.bundle_hash;
+  if (typeof liveHash !== "string" || !SHA256_PATTERN.test(liveHash)) {
+    throw new UsageError(
+      `--recovery-capture ${relativePath} has no sha256 meta.worldpack.bundle_hash`,
+    );
+  }
+  console.log(
+    `::notice::using audited recovery capture ${relativePath} `
+    + `(source=${capture.source}, captured_at=${capture.captured_at}) instead of a live /meta read`,
+  );
+  return liveHash;
+}
 
 function positionalTarget(args) {
   for (let index = 0; index < args.length; index += 1) {
@@ -198,6 +272,10 @@ async function main(args) {
   const target = positionalTarget(args);
   const registryPath = option(args, "--registry") ?? DEFAULT_REGISTRY_PATH;
   const metaFile = option(args, "--meta-file");
+  const recoveryCapture = option(args, "--recovery-capture");
+  if (metaFile && recoveryCapture) {
+    throw new UsageError("--meta-file and --recovery-capture are mutually exclusive");
+  }
   const timeoutOption = option(args, "--timeout-ms");
   const timeoutMs = timeoutOption === undefined
     ? DEFAULT_TIMEOUT_MS
@@ -218,7 +296,9 @@ async function main(args) {
   const candidate = candidateFromRegistry(registry);
 
   let liveHash;
-  if (metaFile) {
+  if (recoveryCapture) {
+    liveHash = recoveryCaptureHash(recoveryCapture);
+  } else if (metaFile) {
     try {
       const body = JSON.parse(fs.readFileSync(path.resolve(metaFile), "utf8"));
       const reported = body?.worldpack?.bundle_hash;
@@ -268,7 +348,8 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(scriptPath
       if (error instanceof UsageError) {
         console.error(
           "usage: check-deploy-worldpack.mjs <fly-app | https://base-url> "
-          + "[--registry registry.json] [--meta-file meta.json] [--timeout-ms N]",
+          + "[--registry registry.json] [--meta-file meta.json] "
+          + "[--recovery-capture ops/capture.json] [--timeout-ms N]",
         );
         process.exit(2);
       }


### PR DESCRIPTION
## Summary

The pre-deploy bundle gate reads the live `/meta` and fails closed. That is right for a stale-checkout deploy, but it deadlocks the case that matters most: **`cosyworld.fly.dev` is unreachable *because* it needs the deploy.**

It blocked recovery twice — the failed v557 release on 2026-08-05, and again on 2026-08-07 during the ~2.5 day event-cursor outage (#713):

```
worldpack deploy gate failed: could not read live worldpack identity
from https://cosyworld.fly.dev/meta: This operation was aborted
```

Lonely Forest already had an audited `--recovery-capture` escape hatch. The primary app had none, so recovery required deploying outside the workflow — losing the rollback snapshot and readiness verification.

`check-deploy-worldpack.mjs` gains `--recovery-capture`, wired to a new `primary_recovery_capture` `workflow_dispatch` input, mirroring the Lonely Forest capture contract (`schema_version: 1`, declared `source`, ISO `captured_at`, unmodified `/meta`).

## This is an audited recovery path, not a bypass

- The capture must be **committed and inside the checkout** — an untracked file or an outside path is refused, so it is always reviewable.
- The captured hash runs through the **same exact/declaration comparison**, so a genuine mismatch still fails closed.
- The run logs the capture path, source, and timestamp.
- Mutually exclusive with the looser `--meta-file` diagnostic flag, so the audited path can't be confused with the unaudited one.

## Validation

Every branch of the new flag exercised against the real production identity:

| Case | Result |
| --- | --- |
| Matching hash, committed capture | `status=exact`, exit **0**, audit notice logged |
| **Genuine mismatch** | exit **1** — fails closed, gate not weakened |
| Uncommitted capture | refused |
| Path outside the checkout | refused |
| `--recovery-capture` + `--meta-file` | refused |
| Default path, no capture (live read) | `status=exact`, exit 0 — unchanged |

| Command | Result |
| --- | --- |
| `npm run check:local` | pass |
| `npm run check:version` | pass (`0.0.335` → `0.0.336`) |
| `node v2/scripts/lonelyforest-multitenant-contract.test.mjs` | pass — shared imports unaffected |
| `git diff --check` | clean |

Workflow YAML re-parsed to confirm the input and `env` wiring resolve.

## Deployment notes

No behavior changes on the normal push-to-`main` path: the guard only takes the capture branch when `primary_recovery_capture` is set, which is `workflow_dispatch`-only.

Docs added in `docs/deployment/07-deployment.md` (mirroring the Lonely Forest procedure), including how to capture `/meta` from a machine the proxy has already dropped — the orchestrator still serves it internally — plus the direct `backup-fly-v2.sh` + `flyctl deploy` fallback that preserves the rollback snapshot if GitHub Actions is itself unavailable. `v2/docs/worldpacks.md` cross-references both targets.

**Follow-up worth considering:** the primary and Lonely Forest capture validators are now near-duplicates and could share one helper. Left out here to keep this PR to one behavior.

## Review checklist

- [x] Tests cover the changed behavior — all six flag paths verified, including that a genuine mismatch still fails closed.
- [x] No generated worldpack files or locks affected.
- [x] No changes under `v2/content/**` — register review not applicable.
- [x] No new horror — genre review not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)