### PR TITLE
Require community art preflight before funding

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -371,19 +371,24 @@ a separate future media-job concern.
 - A contribution buys no ownership, access, power, or private control over the prompt.
 - Each `{subject kind, subject id, level}` generation is unique and replay-safe. Multiple avatars may pool its exact level-sized cost.
 - The prompt captures public card history through a committed sequence. When the card reaches a later level, its one newly unlocked image can evolve in response to everything that happened since.
-- Fully funded jobs may be retried without another Orb debit. A location job
-  first runs a known-safe solid-color base64 fixture through a matching
-  capability policy and the strict-schema review path, so a missing or
-  incompatible reviewer fails before either funding or a billable Replicate
-  request. The generated image still receives the full landscape publication
-  policy below.
-- Location art is published only after a strict vision-policy review finds no
-  people, characters, creatures, text, logos, or watermarks. The downloaded
-  candidate is durably stored before review; reviewer outages and restarts
-  reuse those bytes rather than purchasing another image. Actual provider
+- Fully funded jobs may be retried without another Orb debit. Before any actor,
+  item, or location contribution is journaled, the server resolves the exact
+  frozen media brief and recipe, proves candidate/quarantine/publication and
+  verdict storage, checks the provider route, and runs a known-safe solid-color
+  base64 fixture through the configured strict-schema reviewer. That capability
+  request carries the real frozen publication policy, while explicitly exempting
+  the synthetic fixture from subject-identity and environment matching. Missing
+  or incompatible reviewers therefore fail before either funding or a billable
+  Replicate request.
+- Every community-art candidate is published only after a strict vision-policy
+  review. Actor and item reviews enforce their frozen subject identity; location
+  reviews additionally reject people, characters, creatures, text, logos, and
+  watermarks. The downloaded candidate is durably stored before review; reviewer
+  outages and restarts reuse those bytes rather than purchasing another image.
+  Actual reviewer attempts and latency are retained in the verdict audit. Provider
   generation attempts are journal-counted and capped at three per
   `{subject kind, subject id, level}`. Rejection, review failure, and missing
-  review configuration all leave the deterministic landscape fallback visible.
+  review configuration all leave deterministic fallback art visible.
 - Location generation keeps the configured CosyWorld style LoRA but replaces
   the avatar portrait/card prefix with a landscape-only prefix and reduces
   public history to environmental traces without actor names or dialogue.

--- a/ECONOMY.md
+++ b/ECONOMY.md
@@ -155,7 +155,7 @@ Update existing flows:
 
 - `/state` returns compact economy state plus level-scoped `community_art` funding on eligible generated cards. Legacy Chat-cost fields remain zero-valued for client compatibility.
 - `/actions/create-bond` is presented as `Chat` and requires avatar session, room access, an eligible nearby resident, turn legality, rate limit, and one advancement point. Legacy `/actions/chat` delegates to that contract. Neither path checks or spends Orbs.
-- `/actions/fund-image` validates the session, visible eligible card, current level, provider availability, remaining pooled cost, and contributor balance before atomically journaling one Orb.
+- `/actions/fund-image` validates the session, visible eligible card, current level, remaining pooled cost, and contributor balance, then proves the exact frozen media recipe, provider route, candidate/quarantine/publication storage, verdict store, and vision-review capability before atomically journaling one Orb. Preflight failures return a stable `error_code` and record zero Orb delta.
 - Community generation completion/failure is journaled separately; the image asset becomes the card's current art only after the ready event commits.
 - `/world` and room state include newly granted avatar cards through the same card projection map.
 - `/meta` exposes economy feature flags without secrets.

--- a/docs/backlog/community-art-evolution.md
+++ b/docs/backlog/community-art-evolution.md
@@ -1,6 +1,8 @@
 # Community Art Evolution
 
-Status: first vertical slice shipped in the Rust/browser implementation; production hardening remains.
+Status: planning document. The first vertical slice shipped in the Rust/browser
+implementation; immediate production hardening is tracked in GitHub, currently
+[#683](https://github.com/cenetex/cosyworld/issues/683).
 
 The follow-on epic — [Reference-Composed World
 Scenes](#follow-on-epic-reference-composed-world-scenes) — was groomed
@@ -39,9 +41,15 @@ The generated image belongs to the public card. Its prompt uses the card identit
 - Funding and status survive snapshots and action-journal replay. In-flight job de-duplication is currently process-local.
 - The existing keepsake modal shows pooled progress and provides the contribution/retry action; no separate currency UI was added.
 
-## Groomed backlog
+## Planning horizons
 
-### P0 — production safety
+These horizons preserve product and architecture direction; they are not a
+live task list. When a bounded slice becomes immediate, its GitHub issue owns
+scope, acceptance, dependencies, milestone, delivery labels, and status. This
+document keeps only the durable rationale and sequencing that future issues
+should reference.
+
+### Production-hardening horizon
 
 - Move generation into a durable `media_jobs` queue with leases, retries, dead-letter state, and startup recovery for fully funded jobs.
 - Store assets in durable object storage and retain immutable `{subject, level, revision}` provenance instead of replacing one local file.
@@ -49,7 +57,7 @@ The generated image belongs to the public card. Its prompt uses the card identit
 - Add moderator reject/replace controls. Rejection and replacement must never charge the community again.
 - Record provider/model/prompt version, history range, contributor totals, source funding event, output digest, and moderation status in the media asset record.
 
-### P1 — complete the collectible model
+### Collectible-model horizon
 
 - Make level authoritative for generated items and locations, not just avatars. Define the gameplay event that advances each type; Orb funding must never advance it.
 - Decide whether one level unlock applies per card identity, per shard-local instance, or per canonical collectible. Default: canonical shared subject for locations/avatars; instance for materially distinct crafted items.
@@ -57,7 +65,7 @@ The generated image belongs to the public card. Its prompt uses the card identit
 - Add optional reference-image composition from the prior ready level to preserve recognizability across evolution.
 - Let contributors inspect the public history summary and cost before contributing, without exposing raw prompts or private/moderation data.
 
-### P2 — community and operations
+### Community and operations horizon
 
 - Show contributor attribution and funding completion in the public Journal/chronicle without turning the room transcript into a transaction feed.
 - Add operator views for funding funnels, provider failures, generation latency, retry count, cost per ready image, and abandoned partial pools.
@@ -69,7 +77,7 @@ The generated image belongs to the public card. Its prompt uses the card identit
 1. A zero-Orb avatar can Say, Listen, Help, travel, fight, grow, and manage cards; it can Chat whenever banked advancement makes that friendship action available.
 2. For subject `S` at level `L`, accepted contributions total at most `L` Orbs and at most one image becomes ready.
 3. Concurrent/replayed contribution requests cannot overfund, double-debit, or create multiple generation jobs.
-4. A provider outage, invalid subject, invisible card, completed level, or retry after full funding debits zero Orbs.
+4. A provider or reviewer outage, invalid subject, invisible card, completed level, failed media-storage/quarantine preflight, or retry after full funding debits zero Orbs. Actor, item, and location preflight failures expose stable subject-neutral error codes.
 5. The prompt is derived only from committed public history through a recorded sequence.
 6. A ready image changes presentation only; mechanics and ownership are byte-for-byte unaffected.
 7. Reaching level `L+1` creates a fresh pool of `L+1` Orbs while preserving the prior level's provenance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ do not define V2 behavior.
 - **[Deployment](deployment/07-deployment.md)** and
   **[release process](release.md)** — operating and shipping the repository.
 
-## Groomed local backlogs
+## Planning documents
 
 - **[Card-Composed Character Creation](backlog/card-composed-character-creation.md)** —
   account-owned Species, Class, and Origin cards, classless level-zero arrival,
@@ -123,19 +123,25 @@ do not define V2 behavior.
 
 ## How design and execution are split
 
-**Design lives in markdown. GitHub Issues are only what we are actively
-doing.**
+**Planning lives in markdown. Immediate work lives in GitHub Issues.**
 
-- A contract, a rule, an invariant, an acceptance gate, or a shape we have
-  argued ourselves into belongs in one of the documents above — where it can be
-  read whole, revised in a diff, and linked to.
-- An issue is a unit of work someone could pick up this week. It carries a
-  milestone or it does not exist.
+- Planning documents own product rationale, durable contracts, invariants,
+  architectural shape, sequencing constraints, and possible future horizons.
+  They are not a second execution queue.
+- A GitHub issue owns every immediate implementation slice: its current scope,
+  acceptance checklist, dependencies, delivery labels, milestone, and status.
+  If someone could pick the work up now, track it in an issue and link back to
+  the relevant planning section instead of duplicating the checklist here.
+- An active issue carries a milestone and exactly one priority, horizon, and
+  state label. Work without those fields is not in the delivery queue.
 - `state:parked` and `horizon:later` are not a filing system for design. If work
-  is not being done, its thinking belongs in a backlog document and the issue
+  is not being done, its thinking belongs in a planning document and the issue
   should close with a pointer to that section.
 - Closing an issue into a document is not cancellation. The design survives; the
   queue stops pretending it is scheduled.
+- When work lands, close the issue and update the canonical product or system
+  documentation. Keep the planning document only for rationale and work that
+  has not yet been activated.
 
 ## Legacy service archive
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.338",
+  "version": "0.0.339",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.338",
+      "version": "0.0.339",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.338",
+  "version": "0.0.339",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -487,17 +487,21 @@ Avatar art prompts start with the configured LoRA trigger and combine a stable,
 persisted physical description with the avatar's current species, origin,
 class or classless state, level, calling, location, and carried/equipped items.
 Item and location generations likewise include their authoritative card and
-world details plus committed public history. Location images are withheld until
-the configured vision model confirms that they contain no people, characters,
-creatures, text, logos, or watermarks. Before funding can complete, the server
-checks that the configured reviewer accepts the exact base64-image and strict
-JSON-schema request. Each downloaded candidate is stored before review, so a
-review outage or restart retries the saved bytes without another Replicate
-prediction. Policy-rejected candidates may be replaced, but provider attempts
-are journaled and capped at three for that card level; after the cap, the
-browser disables retry and states that no more provider credits will be used.
-Unavailable or invalid review leaves the deterministic landscape fallback
-visible.
+world details plus committed public history. Every actor, item, and location
+candidate is withheld until the configured vision model approves its frozen
+subject-specific publication policy; locations additionally forbid people,
+characters, creatures, text, logos, and watermarks. Before any Orb contribution
+commits, the server resolves that exact frozen brief and media recipe, checks the
+provider route, probes candidate/quarantine/publication and verdict storage, and
+passes a known-safe base64 fixture plus the real policy through the strict
+JSON-schema reviewer. Failures return a stable subject-neutral `error_code` with
+zero debit. Each downloaded candidate is stored before review, so a review
+outage or restart retries the saved bytes without another Replicate prediction.
+Policy-rejected candidates may be replaced, but provider attempts are journaled
+and capped at three for that card level; after the cap, the browser disables
+retry and states that no more provider credits will be used. Persisted verdicts
+retain actual reviewer attempts and latency. Unavailable or invalid review
+leaves deterministic fallback art visible.
 
 `Chat` appears only when the avatar has banked advancement and an eligible nearby resident can become a new friend. Playing it spends one advancement point, creates the Bond, and passes the room turn; it never accepts human text or spends Orbs. Human-authored room speech is the separate moderated, turn-exempt `say` path.
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.338"
+version = "0.0.339"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.338"
+version = "0.0.339"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -723,6 +723,8 @@ pub(crate) struct ImagePolicyDecision {
     pub(crate) allowed: bool,
     pub(crate) violations: Vec<String>,
     pub(crate) summary: String,
+    pub(crate) attempts: u8,
+    pub(crate) latency: Duration,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1168,12 +1170,16 @@ pub(crate) async fn request_image_policy_decision(
         None,
     )
     .await?;
-    parse_image_policy_decision(&completion.text).map_err(|message| AiGatewayError {
-        kind: AiFailureKind::InvalidResponse,
-        message,
-        attempts: completion.attempts,
-        latency: completion.latency,
-    })
+    let mut decision =
+        parse_image_policy_decision(&completion.text).map_err(|message| AiGatewayError {
+            kind: AiFailureKind::InvalidResponse,
+            message,
+            attempts: completion.attempts,
+            latency: completion.latency,
+        })?;
+    decision.attempts = completion.attempts;
+    decision.latency = completion.latency;
+    Ok(decision)
 }
 
 fn parse_image_policy_decision(value: &str) -> Result<ImagePolicyDecision, String> {
@@ -1220,6 +1226,8 @@ fn parse_image_policy_decision(value: &str) -> Result<ImagePolicyDecision, Strin
         allowed: raw.allowed,
         violations: raw.violations,
         summary,
+        attempts: 0,
+        latency: Duration::ZERO,
     })
 }
 

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -20,9 +20,10 @@ use tracing::warn;
 use crate::media_recipes::media_verdict::{
     bounded_brief_constraints, make_visual_verdict, media_candidate_approved,
     media_candidate_digest, media_candidate_violations, media_provider_route_available,
-    prepare_media_candidate, prepare_rejected_media_candidate_replacement,
-    record_media_provider_failure, record_media_review_unavailable, record_media_visual_verdict,
-    FrozenMediaBrief, MediaCandidateInput, MediaVerdictDisposition, MediaViolation,
+    preflight_media_verdict_storage, prepare_media_candidate,
+    prepare_rejected_media_candidate_replacement, record_media_provider_failure,
+    record_media_review_unavailable, record_media_visual_verdict, FrozenMediaBrief,
+    MediaCandidateInput, MediaVerdictDisposition, MediaViolation,
 };
 use crate::{
     active_content, backfill_legacy_community_asset, broadcast_events,
@@ -222,14 +223,6 @@ impl CommunityArtImagePolicy {
         }
     }
 
-    fn preflight_review(self) -> &'static str {
-        match self {
-            Self::LocationLandscape => {
-                "Allow this image only if it is a uniform solid-green square with no visible person, character, creature, text, logo, or watermark."
-            }
-        }
-    }
-
     fn generation_prompt_prefix(self) -> &'static str {
         match self {
             Self::LocationLandscape => LOCATION_LANDSCAPE_PROMPT_PREFIX,
@@ -291,10 +284,23 @@ impl CommunityArtGenerationError {
             Self::Preflight(_) => "community_art_preflight_failed",
             Self::BriefInvalid(_) => COMMUNITY_ART_BRIEF_INVALID_CODE,
             Self::CandidateQuarantine(_) => COMMUNITY_ART_CANDIDATE_QUARANTINE_FAILED_CODE,
-            Self::PolicyUnavailable => "community_art_policy_unconfigured",
+            Self::PolicyUnavailable => "community_art_reviewer_unavailable",
             Self::PolicyReview(_) => "community_art_policy_review_failed",
             Self::PolicyRejected(_) => "community_art_policy_rejected",
             Self::Storage(_) => "community_art_storage_failed",
+        }
+    }
+
+    pub(super) fn stage(&self) -> &'static str {
+        match self {
+            Self::Provider(_) | Self::ProviderUnavailable(_) => "provider",
+            Self::Preflight(_) => "recipe",
+            Self::BriefInvalid(_) => "brief",
+            Self::CandidateQuarantine(_) => "quarantine",
+            Self::PolicyUnavailable => "reviewer",
+            Self::PolicyReview(_) => "review",
+            Self::PolicyRejected(_) => "policy",
+            Self::Storage(_) => "storage",
         }
     }
 
@@ -314,7 +320,7 @@ impl CommunityArtGenerationError {
                 format!("invalid community-art candidate could not be quarantined: {error}")
             }
             Self::PolicyUnavailable => {
-                "location art policy review is not configured; output withheld".to_string()
+                "community-art publication reviewer is not configured; output withheld".to_string()
             }
             Self::PolicyReview(error) => format!("image policy review failed: {error}"),
             Self::PolicyRejected(violations) => format!(
@@ -980,17 +986,32 @@ impl RuntimeWorld {
     }
 }
 
-pub(super) async fn preflight_community_art_policy(
-    config: Option<&AiConfig>,
-    policy: CommunityArtImagePolicy,
+pub(super) async fn preflight_community_art_funding(
+    generation_config: &ReplicateAvatarArtConfig,
+    policy_config: Option<&AiConfig>,
+    generated_asset_dir: &Path,
+    plan: &CommunityArtPlan,
 ) -> Result<(), CommunityArtGenerationError> {
-    let config = config.ok_or(CommunityArtGenerationError::PolicyUnavailable)?;
+    let policy_config = policy_config.ok_or(CommunityArtGenerationError::PolicyUnavailable)?;
+    let media_brief = community_art_media_brief(plan);
+    media_brief
+        .validate()
+        .map_err(CommunityArtGenerationError::BriefInvalid)?;
+    preflight_community_art_storage(generated_asset_dir, plan)?;
+    preflight_media_verdict_storage(generated_asset_dir, &media_brief)
+        .map_err(CommunityArtGenerationError::Storage)?;
+    // This performs the same media-registry resolution, provider request
+    // construction, route/cooldown check, saved-candidate validation, and
+    // quarantine recovery as the funded worker, but never calls Replicate.
+    prepare_community_art_generation(generation_config, generated_asset_dir, plan)?;
+    let review_policy = community_art_review_policy(&media_brief, plan);
+    let capability_policy = community_art_reviewer_capability_policy(&review_policy);
     let decision = request_image_policy_decision(
-        config,
+        policy_config,
         ImagePolicyRequest {
-            feature: "media.location_image_policy_preflight",
+            feature: "media.community_art_publication_preflight",
             image_url: POLICY_PREFLIGHT_IMAGE_URL,
-            policy: policy.preflight_review(),
+            policy: &capability_policy,
             timeout: Duration::from_secs(10),
             max_attempts: 1,
             referer: "https://cosyworld.fly.dev",
@@ -1007,6 +1028,86 @@ pub(super) async fn preflight_community_art_policy(
                 decision.violations.join(", ")
             }
         )));
+    }
+    Ok(())
+}
+
+fn community_art_review_policy(media_brief: &FrozenMediaBrief, plan: &CommunityArtPlan) -> String {
+    let mut review_policy = media_brief.review_policy();
+    if let Some(policy) = plan.image_policy {
+        review_policy.push(' ');
+        review_policy.push_str(policy.review());
+    }
+    review_policy
+}
+
+fn community_art_reviewer_capability_policy(review_policy: &str) -> String {
+    format!(
+        "This is a publication-reviewer capability check, not a candidate verdict. Allow the known-safe fixture only if it is a uniform solid-green square with no visible person, character, creature, text, logo, watermark, or UI chrome. Confirm that you can receive and evaluate the production policy below, but do not apply its subject-identity or environment requirements to this synthetic fixture. Production policy: {review_policy}"
+    )
+}
+
+fn preflight_community_art_storage(
+    generated_asset_dir: &Path,
+    plan: &CommunityArtPlan,
+) -> Result<(), CommunityArtGenerationError> {
+    let candidate_path = community_art_candidate_image_path(generated_asset_dir, plan);
+    let candidate_parent = candidate_path.parent().ok_or_else(|| {
+        CommunityArtGenerationError::Storage(
+            "community-art candidate path has no parent".to_string(),
+        )
+    })?;
+    let public_path =
+        stored_community_art_image_path(generated_asset_dir, &plan.subject_kind, plan.subject_id);
+    let public_parent = public_path.parent().ok_or_else(|| {
+        CommunityArtGenerationError::Storage(
+            "community-art publication path has no parent".to_string(),
+        )
+    })?;
+    let quarantine_root = community_art_candidate_quarantine_root(generated_asset_dir, plan);
+    for (directory, label) in [
+        (candidate_parent, "candidate"),
+        (quarantine_root.as_path(), "quarantine"),
+        (public_parent, "publication"),
+    ] {
+        preflight_community_art_directory(directory, label)
+            .map_err(CommunityArtGenerationError::Storage)?;
+    }
+    Ok(())
+}
+
+fn preflight_community_art_directory(directory: &Path, label: &str) -> Result<(), String> {
+    fs::create_dir_all(directory).map_err(|error| {
+        format!(
+            "failed to create community-art {label} directory {}: {error}",
+            directory.display()
+        )
+    })?;
+    let probe = directory.join(format!(
+        ".preflight-{label}-{}-{}-{}",
+        std::process::id(),
+        now_millis(),
+        crate::random_hex(6)
+    ));
+    let renamed = probe.with_extension("ready");
+    let result = (|| -> io::Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&probe)?;
+        file.write_all(b"cosyworld-community-art-preflight")?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&probe, &renamed)?;
+        fs::remove_file(&renamed)
+    })();
+    if let Err(error) = result {
+        let _ = fs::remove_file(&probe);
+        let _ = fs::remove_file(&renamed);
+        return Err(format!(
+            "community-art {label} storage probe failed in {}: {error}",
+            directory.display()
+        ));
     }
     Ok(())
 }
@@ -1340,11 +1441,7 @@ async fn generate_and_store_prepared_community_art(
             MediaVerdictDisposition::ReviewPending => {
                 let policy_config =
                     policy_config.ok_or(CommunityArtGenerationError::PolicyUnavailable)?;
-                let mut review_policy = media_brief.review_policy();
-                if let Some(policy) = plan.image_policy {
-                    review_policy.push(' ');
-                    review_policy.push_str(policy.review());
-                }
+                let review_policy = community_art_review_policy(&media_brief, plan);
                 let image_url = community_art_candidate_data_url(&image)?;
                 let decision = request_image_policy_decision(
                     policy_config,
@@ -1380,8 +1477,8 @@ async fn generate_and_store_prepared_community_art(
                     decision.allowed,
                     violations,
                     decision.summary,
-                    1,
-                    0,
+                    decision.attempts,
+                    decision.latency.as_millis() as u64,
                     0,
                 )
                 .map_err(CommunityArtGenerationError::Storage)?;
@@ -1798,6 +1895,8 @@ pub(super) fn schedule_community_art_generation(
                     provider_attempt,
                     reused_candidate = outcome.reused_candidate,
                     prediction_id = outcome.prediction_id.as_deref().unwrap_or("unknown"),
+                    failure_stage = error.stage(),
+                    failure_code = error.code(),
                     "community art generation failed for {}: {}",
                     key,
                     error.message()

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -27,8 +27,8 @@ fn test_art_config() -> ReplicateAvatarArtConfig {
     }
 }
 
-fn gate_png() -> Vec<u8> {
-    let pixels = ImageBuffer::from_fn(16, 9, |x, y| {
+fn gate_png_with_dimensions(width: u32, height: u32) -> Vec<u8> {
+    let pixels = ImageBuffer::from_fn(width, height, |x, y| {
         Rgba([
             (x as u8).wrapping_mul(17),
             (y as u8).wrapping_mul(29),
@@ -41,6 +41,14 @@ fn gate_png() -> Vec<u8> {
         .write_to(&mut bytes, ImageFormat::Png)
         .expect("encode gate PNG");
     bytes.into_inner()
+}
+
+fn gate_png() -> Vec<u8> {
+    gate_png_with_dimensions(16, 9)
+}
+
+fn square_gate_png() -> Vec<u8> {
+    gate_png_with_dimensions(16, 16)
 }
 
 /// Mirrors the production location plan: `community_art_plan` joins the
@@ -346,12 +354,264 @@ async fn location_art_funding_fails_before_debit_without_policy_review() {
 
     assert!(!response.ok);
     assert_eq!(response.status, 503);
+    assert_eq!(
+        response.error_code.as_deref(),
+        Some("community_art_reviewer_unavailable")
+    );
     assert!(response.events.is_empty());
     let runtime = state.inner.lock().await;
     assert_eq!(runtime.orb_balance(5000), STARTING_ORBS);
     assert!(!runtime
         .community_art_generations
         .contains_key(&community_art_generation_key("location", waypoint_id, 1)));
+}
+
+#[tokio::test]
+async fn actor_and_item_funding_fail_before_debit_without_publication_reviewer() {
+    let nonce = format!("{}-{}", std::process::id(), now_seed());
+    let event_store_path =
+        std::env::temp_dir().join(format!("cosyworld-art-preflight-ledger-{nonce}.sqlite"));
+    let generated_dir =
+        std::env::temp_dir().join(format!("cosyworld-art-preflight-assets-{nonce}"));
+    let _ = fs::remove_file(&event_store_path);
+    let _ = fs::remove_dir_all(&generated_dir);
+
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Universal Preflight Patron",
+    );
+    let item = runtime.world.items[..runtime.world.item_count]
+        .iter_mut()
+        .find(|item| item.id == 8403)
+        .expect("pending-art item is mounted");
+    item.holder_actor_id = 5000;
+    item.location_id = 0;
+
+    let mut state = test_app_state(runtime, Some(event_store_path.clone()));
+    state.avatar_art_config = Arc::new(Some(test_art_config()));
+    state.generated_asset_dir = Arc::new(generated_dir.clone());
+    assert!(state.ai_config.as_ref().is_none());
+    let (actor_session, _) = issue_actor_session(&state, 5000);
+
+    for (subject_kind, subject_id) in [("actor", 5000), ("item", 8403)] {
+        let response = fund_community_image(
+            ConnectInfo("127.0.0.1:44994".parse().expect("client address")),
+            State(state.clone()),
+            Json(FundCommunityImageRequest {
+                actor_id: 5000,
+                actor_session: Some(actor_session.clone()),
+                subject_kind: subject_kind.to_string(),
+                subject_id,
+                intent_id: format!("test-{subject_kind}-reviewer-unavailable"),
+            }),
+        )
+        .await
+        .0;
+
+        assert!(!response.ok, "{subject_kind} funding must fail closed");
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response.error_code.as_deref(),
+            Some("community_art_reviewer_unavailable")
+        );
+        assert!(response.events.is_empty());
+    }
+
+    let runtime = state.inner.lock().await;
+    assert_eq!(runtime.orb_balance(5000), STARTING_ORBS);
+    assert!(!runtime
+        .community_art_generations
+        .contains_key(&community_art_generation_key("actor", 5000, 1)));
+    assert!(!runtime
+        .community_art_generations
+        .contains_key(&community_art_generation_key("item", 8403, 1)));
+    drop(runtime);
+
+    let conn = open_event_store(&event_store_path).expect("open preflight usage ledger");
+    let failures: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM ai_usage_ledger
+             WHERE feature = 'community_image_publication_preflight'
+               AND status = 'failed'
+               AND orb_delta = 0
+               AND error_code = 'community_art_reviewer_unavailable'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count typed publication-preflight failures");
+    assert_eq!(failures, 2);
+
+    let _ = fs::remove_dir_all(generated_dir);
+    let _ = fs::remove_file(event_store_path);
+}
+
+#[tokio::test]
+async fn candidate_storage_preflight_fails_before_orb_debit() {
+    let nonce = format!("{}-{}", std::process::id(), now_seed());
+    let generated_root =
+        std::env::temp_dir().join(format!("cosyworld-unwritable-art-root-{nonce}"));
+    let event_store_path =
+        std::env::temp_dir().join(format!("cosyworld-storage-preflight-{nonce}.sqlite"));
+    let _ = fs::remove_file(&generated_root);
+    let _ = fs::remove_file(&event_store_path);
+    fs::write(
+        &generated_root,
+        b"this file blocks generated-media directories",
+    )
+    .expect("create blocked generated-media root");
+
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Storage Preflight Patron",
+    );
+    let mut state = test_app_state(runtime, Some(event_store_path.clone()));
+    state.avatar_art_config = Arc::new(Some(test_art_config()));
+    state.ai_config = Arc::new(Some(AiConfig {
+        api_key: "test".to_string(),
+        base_url: "http://127.0.0.1:1".to_string(),
+        model: "test-model".to_string(),
+        vision_model: "test-vision-model".to_string(),
+        reasoning_effort: None,
+        vision_reasoning_effort: None,
+        ..AiConfig::default()
+    }));
+    state.generated_asset_dir = Arc::new(generated_root.clone());
+    let (actor_session, _) = issue_actor_session(&state, 5000);
+
+    let response = fund_community_image(
+        ConnectInfo("127.0.0.1:44997".parse().expect("client address")),
+        State(state.clone()),
+        Json(FundCommunityImageRequest {
+            actor_id: 5000,
+            actor_session: Some(actor_session),
+            subject_kind: "actor".to_string(),
+            subject_id: 5000,
+            intent_id: "test-storage-preflight".to_string(),
+        }),
+    )
+    .await
+    .0;
+
+    assert!(!response.ok);
+    assert_eq!(response.status, 503);
+    assert_eq!(
+        response.error_code.as_deref(),
+        Some("community_art_storage_failed")
+    );
+    assert!(response.events.is_empty());
+    let runtime = state.inner.lock().await;
+    assert_eq!(runtime.orb_balance(5000), STARTING_ORBS);
+    assert!(!runtime
+        .community_art_generations
+        .contains_key(&community_art_generation_key("actor", 5000, 1)));
+    drop(runtime);
+
+    let conn = open_event_store(&event_store_path).expect("open storage-preflight ledger");
+    let failures: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM ai_usage_ledger
+             WHERE feature = 'community_image_publication_preflight'
+               AND error_code = 'community_art_storage_failed'
+               AND orb_delta = 0",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count typed storage-preflight failure");
+    assert_eq!(failures, 1);
+
+    let _ = fs::remove_file(generated_root);
+    let _ = fs::remove_file(event_store_path);
+}
+
+#[tokio::test]
+async fn incomplete_candidate_quarantine_fails_before_orb_debit() {
+    let nonce = format!("{}-{}", std::process::id(), now_seed());
+    let generated_dir =
+        std::env::temp_dir().join(format!("cosyworld-quarantine-preflight-assets-{nonce}"));
+    let event_store_path =
+        std::env::temp_dir().join(format!("cosyworld-quarantine-preflight-{nonce}.sqlite"));
+    let _ = fs::remove_dir_all(&generated_dir);
+    let _ = fs::remove_file(&event_store_path);
+
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Quarantine Preflight Patron",
+    );
+    let plan = runtime
+        .community_art_plan(5000, "actor", 5000)
+        .expect("visible avatar has a community-art plan");
+    let marker = test_candidate_quarantine_marker(&generated_dir, &plan);
+    fs::create_dir_all(marker.parent().expect("quarantine marker parent"))
+        .expect("create candidate directory");
+    fs::write(&marker, b"incomplete quarantine transaction")
+        .expect("stage incomplete quarantine marker");
+
+    let mut state = test_app_state(runtime, Some(event_store_path.clone()));
+    state.avatar_art_config = Arc::new(Some(test_art_config()));
+    state.ai_config = Arc::new(Some(AiConfig {
+        api_key: "test".to_string(),
+        base_url: "http://127.0.0.1:1".to_string(),
+        model: "test-model".to_string(),
+        vision_model: "test-vision-model".to_string(),
+        reasoning_effort: None,
+        vision_reasoning_effort: None,
+        ..AiConfig::default()
+    }));
+    state.generated_asset_dir = Arc::new(generated_dir.clone());
+    let (actor_session, _) = issue_actor_session(&state, 5000);
+
+    let response = fund_community_image(
+        ConnectInfo("127.0.0.1:44998".parse().expect("client address")),
+        State(state.clone()),
+        Json(FundCommunityImageRequest {
+            actor_id: 5000,
+            actor_session: Some(actor_session),
+            subject_kind: "actor".to_string(),
+            subject_id: 5000,
+            intent_id: "test-quarantine-preflight".to_string(),
+        }),
+    )
+    .await
+    .0;
+
+    assert!(!response.ok);
+    assert_eq!(response.status, 503);
+    assert_eq!(
+        response.error_code.as_deref(),
+        Some(COMMUNITY_ART_CANDIDATE_QUARANTINE_FAILED_CODE)
+    );
+    assert!(response.events.is_empty());
+    let runtime = state.inner.lock().await;
+    assert_eq!(runtime.orb_balance(5000), STARTING_ORBS);
+    assert!(!runtime
+        .community_art_generations
+        .contains_key(&community_art_generation_key("actor", 5000, 1)));
+    drop(runtime);
+
+    let conn = open_event_store(&event_store_path).expect("open quarantine-preflight ledger");
+    let failures: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM ai_usage_ledger
+             WHERE feature = 'community_image_publication_preflight'
+               AND error_code = 'community_art_candidate_quarantine_failed'
+               AND orb_delta = 0",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count typed quarantine-preflight failure");
+    assert_eq!(failures, 1);
+
+    let _ = fs::remove_dir_all(generated_dir);
+    let _ = fs::remove_file(event_store_path);
 }
 
 #[tokio::test]
@@ -466,7 +726,195 @@ async fn concurrent_location_funding_coalesces_policy_preflight_and_orb_debit() 
 }
 
 #[tokio::test]
+async fn item_funding_reaches_reviewed_publication_without_a_second_orb_debit() {
+    let review_requests = Arc::new(AtomicUsize::new(0));
+    let app = Router::new().route(
+        "/chat/completions",
+        post({
+            let review_requests = review_requests.clone();
+            move |Json(body): Json<serde_json::Value>| {
+                let review_requests = review_requests.clone();
+                async move {
+                    review_requests.fetch_add(1, Ordering::SeqCst);
+                    let image_url = body
+                        .pointer("/messages/1/content/1/image_url/url")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default();
+                    assert!(image_url.starts_with("data:image/png;base64,"));
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    Json(serde_json::json!({
+                        "choices": [{
+                            "message": {
+                                "content": r#"{"allowed":true,"violations":[],"summary":"The item candidate satisfies the frozen publication brief."}"#
+                            }
+                        }]
+                    }))
+                }
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind item publication reviewer");
+    let address = listener.local_addr().expect("item reviewer address");
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let generated_dir = std::env::temp_dir().join(format!(
+        "cosyworld-item-publication-{}-{}",
+        std::process::id(),
+        now_seed()
+    ));
+    let _ = fs::remove_dir_all(&generated_dir);
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Item Art Patron",
+    );
+    let item = runtime.world.items[..runtime.world.item_count]
+        .iter_mut()
+        .find(|item| item.id == 8403)
+        .expect("pending-art item is mounted");
+    item.holder_actor_id = 5000;
+    item.location_id = 0;
+    let plan = runtime
+        .community_art_plan(5000, "item", 8403)
+        .expect("held pending-art item can be funded");
+    let candidate_bytes = square_gate_png();
+    let prediction_id = "saved-item-candidate";
+    store_community_art_candidate(
+        &generated_dir,
+        &plan,
+        &DownloadedReplicateImage {
+            bytes: candidate_bytes.clone(),
+            content_type: "image/png".to_string(),
+            source_url: "https://replicate.delivery/pbxt/item-candidate.png".to_string(),
+            prediction_id: Some(prediction_id.to_string()),
+        },
+    )
+    .expect("store paid item candidate before funding recovery");
+
+    let mut state = test_app_state(runtime, None);
+    state.avatar_art_config = Arc::new(Some(test_art_config()));
+    state.ai_config = Arc::new(Some(AiConfig {
+        api_key: "test".to_string(),
+        base_url: format!("http://{address}"),
+        model: "test-model".to_string(),
+        vision_model: "test-vision-model".to_string(),
+        reasoning_effort: None,
+        vision_reasoning_effort: None,
+        ..AiConfig::default()
+    }));
+    state.generated_asset_dir = Arc::new(generated_dir.clone());
+    let (actor_session, _) = issue_actor_session(&state, 5000);
+
+    let response = fund_community_image(
+        ConnectInfo("127.0.0.1:44995".parse().expect("client address")),
+        State(state.clone()),
+        Json(FundCommunityImageRequest {
+            actor_id: 5000,
+            actor_session: Some(actor_session),
+            subject_kind: "item".to_string(),
+            subject_id: 8403,
+            intent_id: "test-item-reviewed-publication".to_string(),
+        }),
+    )
+    .await
+    .0;
+
+    assert!(response.ok, "item funding should be accepted: {response:?}");
+    assert_eq!(response.status, CW_OK);
+    assert!(response.error_code.is_none());
+    assert_eq!(
+        response
+            .events
+            .iter()
+            .filter(|event| event.type_name == "community_art.funded")
+            .count(),
+        1
+    );
+
+    let key = community_art_generation_key("item", 8403, 1);
+    let generation = wait_for_community_art_status(&state, &key, "ready").await;
+    assert_eq!(generation.funded_orbs, 1);
+    assert_eq!(generation.provider_attempts, 0);
+    assert_eq!(
+        generation.last_prediction_id.as_deref(),
+        Some(prediction_id)
+    );
+    assert_eq!(review_requests.load(Ordering::SeqCst), 2);
+    let runtime = state.inner.lock().await;
+    assert_eq!(runtime.orb_balance(5000), STARTING_ORBS - 1);
+    drop(runtime);
+
+    let mut canonical = None;
+    for _ in 0..100 {
+        canonical = canonical_community_media_asset_bytes(
+            &generated_dir,
+            "item",
+            8403,
+            1,
+            Some(prediction_id),
+        )
+        .ok();
+        if canonical.is_some() && !community_art_candidate_exists(&generated_dir, &plan) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let (published_bytes, published_type) = canonical.expect("item asset becomes canonical");
+    assert_eq!(published_bytes, candidate_bytes);
+    assert_eq!(published_type, "image/png");
+    assert!(!community_art_candidate_exists(&generated_dir, &plan));
+
+    let record_id = format!("{:x}", Sha256::digest(key.as_bytes()));
+    let verdict: serde_json::Value = serde_json::from_slice(
+        &fs::read(
+            generated_dir
+                .join("media-verdicts/v1")
+                .join(record_id)
+                .join("record.json"),
+        )
+        .expect("read persisted item verdict"),
+    )
+    .expect("parse persisted item verdict");
+    assert!(
+        verdict["candidates"][0]["visual"]["latency_ms"]
+            .as_u64()
+            .is_some_and(|latency| latency > 0),
+        "review latency must survive into the verdict audit"
+    );
+
+    let _ = fs::remove_dir_all(generated_dir);
+    server.abort();
+}
+
+#[tokio::test]
 async fn evolution_endpoint_freezes_prior_and_pools_without_extra_orb_or_turn() {
+    let app = Router::new().route(
+        "/chat/completions",
+        post(|| async {
+            Json(serde_json::json!({
+                "choices": [{
+                    "message": {
+                        "content": r#"{"allowed":true,"violations":[],"summary":"Known-safe publication preflight accepted."}"#
+                    }
+                }]
+            }))
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind evolution publication preflight fixture");
+    let address = listener
+        .local_addr()
+        .expect("evolution publication preflight address");
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
     let mut runtime = RuntimeWorld::seeded();
     create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Art Patron");
     runtime.world.actors[..runtime.world.actor_count]
@@ -478,6 +926,15 @@ async fn evolution_endpoint_freezes_prior_and_pools_without_extra_orb_or_turn() 
     let before_tick = runtime.world.tick;
     let mut state = test_app_state(runtime, None);
     state.avatar_art_config = Arc::new(Some(test_art_config()));
+    state.ai_config = Arc::new(Some(AiConfig {
+        api_key: "test".to_string(),
+        base_url: format!("http://{address}"),
+        model: "test-model".to_string(),
+        vision_model: "test-vision-model".to_string(),
+        reasoning_effort: None,
+        vision_reasoning_effort: None,
+        ..AiConfig::default()
+    }));
     let prior_bytes = BASE64_STANDARD
         .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XqgWAAAAAElFTkSuQmCC")
         .expect("decode prior-level PNG");
@@ -565,10 +1022,11 @@ async fn evolution_endpoint_freezes_prior_and_pools_without_extra_orb_or_turn() 
         evolution.prior_asset_digest,
         format!("{:x}", Sha256::digest(&prior_bytes))
     );
+    server.abort();
 }
 
 #[tokio::test]
-async fn location_policy_preflight_uses_a_known_safe_capability_contract() {
+async fn community_art_preflight_uses_the_frozen_publication_policy_with_a_safe_fixture() {
     let capability_contract_seen = Arc::new(AtomicBool::new(false));
     let app = Router::new().route(
         "/chat/completions",
@@ -594,7 +1052,9 @@ async fn location_policy_preflight_uses_a_known_safe_capability_contract() {
                                 == Some("cosyworld_image_policy")
                             && image_url == POLICY_PREFLIGHT_IMAGE_URL
                             && review.contains("uniform solid-green square")
-                            && !review.contains("Publish only a landscape"),
+                            && review.contains("Production policy:")
+                            && review.contains("Publish only a landscape")
+                            && review.contains("Foxglove Turn"),
                         Ordering::SeqCst,
                     );
                     Json(serde_json::json!({
@@ -627,11 +1087,19 @@ async fn location_policy_preflight_uses_a_known_safe_capability_contract() {
         ..AiConfig::default()
     };
 
-    preflight_community_art_policy(Some(&config), CommunityArtImagePolicy::LocationLandscape)
+    let generated_dir = std::env::temp_dir().join(format!(
+        "cosyworld-community-art-capability-preflight-{}-{}",
+        std::process::id(),
+        now_seed()
+    ));
+    let _ = fs::remove_dir_all(&generated_dir);
+    let plan = location_art_plan(181_727, "16:9", "chalk lanes and reed beds");
+    preflight_community_art_funding(&test_art_config(), Some(&config), &generated_dir, &plan)
         .await
         .expect("known-safe preflight fixture is accepted");
 
     assert!(capability_contract_seen.load(Ordering::SeqCst));
+    let _ = fs::remove_dir_all(generated_dir);
     server.abort();
 }
 
@@ -1999,7 +2467,7 @@ async fn scheduler_candidate_review_retry_records_no_provider_attempt_or_usage()
     );
     assert_eq!(
         generation.last_error_code.as_deref(),
-        Some("community_art_policy_unconfigured")
+        Some("community_art_reviewer_unavailable")
     );
     assert!(
         community_art_candidate_exists(&generated_dir, &plan),
@@ -2013,6 +2481,78 @@ async fn scheduler_candidate_review_retry_records_no_provider_attempt_or_usage()
 
     let _ = fs::remove_dir_all(generated_dir);
     let _ = fs::remove_file(event_store_path);
+}
+
+#[tokio::test]
+async fn fully_funded_candidate_retry_never_debits_or_calls_the_provider_again() {
+    let generated_dir = std::env::temp_dir().join(format!(
+        "cosyworld-funded-candidate-endpoint-retry-{}-{}",
+        std::process::id(),
+        now_seed()
+    ));
+    let _ = fs::remove_dir_all(&generated_dir);
+    let actor_id = 5000;
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        actor_id,
+        COSY_COTTAGE_LOCATION_ID,
+        "Already Funded Patron",
+    );
+    let plan = runtime
+        .community_art_plan(actor_id, "actor", actor_id)
+        .expect("visible avatar has a community-art plan");
+    let key = community_art_generation_key("actor", actor_id, plan.level);
+    fund_test_community_art(&mut runtime, actor_id, &plan, "already-funded-intent", 7084);
+    store_community_art_candidate(
+        &generated_dir,
+        &plan,
+        &DownloadedReplicateImage {
+            bytes: gate_png_with_dimensions(16, 24),
+            content_type: "image/png".to_string(),
+            source_url: "https://replicate.delivery/pbxt/already-funded.png".to_string(),
+            prediction_id: Some("already-funded-prediction".to_string()),
+        },
+    )
+    .expect("store the recoverable paid candidate");
+
+    let mut state = test_app_state(runtime, None);
+    state.avatar_art_config = Arc::new(Some(test_art_config()));
+    state.generated_asset_dir = Arc::new(generated_dir.clone());
+    let (actor_session, _) = issue_actor_session(&state, actor_id);
+    let balance_before = state.inner.lock().await.orb_balance(actor_id);
+
+    let response = fund_community_image(
+        ConnectInfo("127.0.0.1:44996".parse().expect("client address")),
+        State(state.clone()),
+        Json(FundCommunityImageRequest {
+            actor_id,
+            actor_session: Some(actor_session),
+            subject_kind: "actor".to_string(),
+            subject_id: actor_id,
+            intent_id: "retry-must-not-fund-again".to_string(),
+        }),
+    )
+    .await
+    .0;
+
+    assert!(response.ok);
+    assert_eq!(response.status, CW_OK);
+    assert!(response.events.is_empty());
+    assert!(response.error_code.is_none());
+    let generation = wait_for_community_art_status(&state, &key, "review_unavailable").await;
+    assert_eq!(generation.provider_attempts, 0);
+    assert_eq!(generation.funded_orbs, generation.required_orbs);
+    assert!(!generation
+        .funding_intent_ids
+        .contains("retry-must-not-fund-again"));
+    assert_eq!(
+        state.inner.lock().await.orb_balance(actor_id),
+        balance_before
+    );
+    assert!(community_art_candidate_exists(&generated_dir, &plan));
+
+    let _ = fs::remove_dir_all(generated_dir);
 }
 
 #[test]

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -3308,6 +3308,39 @@ struct ActionResponse {
     events: Vec<EventView>,
 }
 
+#[derive(Debug, Serialize)]
+struct FundCommunityImageResponse {
+    ok: bool,
+    status: u32,
+    events: Vec<EventView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_code: Option<String>,
+}
+
+impl FundCommunityImageResponse {
+    fn action(ok: bool, status: u32, events: Vec<EventView>) -> Json<Self> {
+        Json(Self {
+            ok,
+            status,
+            events,
+            error_code: None,
+        })
+    }
+
+    fn failure(status: u32, error_code: &str) -> Json<Self> {
+        Json(Self {
+            ok: false,
+            status,
+            events: Vec::new(),
+            error_code: Some(error_code.to_string()),
+        })
+    }
+
+    fn from_action(response: Json<ActionResponse>) -> Json<Self> {
+        Self::action(response.0.ok, response.0.status, response.0.events)
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct ActionOfferSubmissionRequest {
     path: String,
@@ -25180,7 +25213,7 @@ async fn fund_community_image(
     ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
     Json(payload): Json<FundCommunityImageRequest>,
-) -> Json<ActionResponse> {
+) -> Json<FundCommunityImageResponse> {
     if !allow_actor_mutation(
         &state,
         client_addr,
@@ -25188,14 +25221,15 @@ async fn fund_community_image(
         "community-image-actor",
         CHAT_ACTION_LIMIT,
     ) {
-        return action_rate_limited_response();
+        return FundCommunityImageResponse::from_action(action_rate_limited_response());
     }
     if state.avatar_art_config.as_ref().is_none() {
-        return Json(ActionResponse {
-            ok: false,
-            status: 503,
-            events: Vec::new(),
-        });
+        warn!(
+            failure_stage = "provider",
+            failure_code = "community_art_provider_unavailable",
+            "community art funding preflight failed: Replicate is not configured"
+        );
+        return FundCommunityImageResponse::failure(503, "community_art_provider_unavailable");
     }
     let intent_id = payload.intent_id.trim();
     if intent_id.is_empty()
@@ -25204,11 +25238,7 @@ async fn fund_community_image(
             .chars()
             .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | ':' | '.'))
     {
-        return Json(ActionResponse {
-            ok: false,
-            status: 400,
-            events: Vec::new(),
-        });
+        return FundCommunityImageResponse::action(false, 400, Vec::new());
     }
 
     let (initial_plan, initial_generation_fingerprint) = {
@@ -25219,7 +25249,7 @@ async fn fund_community_image(
             payload.actor_id,
             payload.actor_session.as_deref(),
         ) {
-            return client_actor_rejected_response();
+            return FundCommunityImageResponse::from_action(client_actor_rejected_response());
         }
         let plan = match runtime.community_art_plan(
             payload.actor_id,
@@ -25228,11 +25258,7 @@ async fn fund_community_image(
         ) {
             Ok(plan) => plan,
             Err(_) => {
-                return Json(ActionResponse {
-                    ok: false,
-                    status: 404,
-                    events: Vec::new(),
-                });
+                return FundCommunityImageResponse::action(false, 404, Vec::new());
             }
         };
         let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
@@ -25260,7 +25286,7 @@ async fn fund_community_image(
             payload.actor_id,
             payload.actor_session.as_deref(),
         ) {
-            return client_actor_rejected_response();
+            return FundCommunityImageResponse::from_action(client_actor_rejected_response());
         }
         let mut plan = match runtime.community_art_plan(
             payload.actor_id,
@@ -25269,19 +25295,11 @@ async fn fund_community_image(
         ) {
             Ok(plan) => plan,
             Err(_) => {
-                return Json(ActionResponse {
-                    ok: false,
-                    status: 404,
-                    events: Vec::new(),
-                });
+                return FundCommunityImageResponse::action(false, 404, Vec::new());
             }
         };
         if freeze_community_art_evolution(&state.generated_asset_dir, &mut plan).is_err() {
-            return Json(ActionResponse {
-                ok: false,
-                status: 409,
-                events: Vec::new(),
-            });
+            return FundCommunityImageResponse::action(false, 409, Vec::new());
         }
         let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
         let existing = runtime.community_art_generations.get(&key);
@@ -25312,21 +25330,13 @@ async fn fund_community_image(
             if working && retry_generation {
                 schedule_community_art_generation(&state, payload.actor_id, plan);
             }
-            return Json(ActionResponse {
-                ok: true,
-                status: CW_OK,
-                events: Vec::new(),
-            });
+            return FundCommunityImageResponse::action(true, CW_OK, Vec::new());
         }
         if existing.is_some_and(|generation| {
             generation.funding_intent_ids.contains(intent_id)
                 && generation.funded_orbs < generation.required_orbs
         }) {
-            return Json(ActionResponse {
-                ok: true,
-                status: CW_OK,
-                events: Vec::new(),
-            });
+            return FundCommunityImageResponse::action(true, CW_OK, Vec::new());
         }
         if existing.is_some_and(|generation| {
             generation
@@ -25335,74 +25345,69 @@ async fn fund_community_image(
                 .is_some_and(|amount| *amount > 0)
                 && generation.funded_orbs < generation.required_orbs
         }) {
-            return Json(ActionResponse {
-                ok: false,
-                status: 409,
-                events: Vec::new(),
-            });
+            return FundCommunityImageResponse::action(false, 409, Vec::new());
         }
         if working {
             drop(runtime);
             if retry_generation {
                 schedule_community_art_generation(&state, payload.actor_id, plan);
             }
-            return Json(ActionResponse {
-                ok: true,
-                status: CW_OK,
-                events: Vec::new(),
-            });
+            return FundCommunityImageResponse::action(true, CW_OK, Vec::new());
         }
         if existing.is_some_and(|generation| generation.status == "ready") {
-            return Json(ActionResponse {
-                ok: same_intent,
-                status: if same_intent { CW_OK } else { 409 },
-                events: Vec::new(),
-            });
+            return FundCommunityImageResponse::action(
+                same_intent,
+                if same_intent { CW_OK } else { 409 },
+                Vec::new(),
+            );
         }
         if existing.is_some_and(|generation| {
             generation.funded_orbs >= generation.required_orbs && !retry_generation
         }) {
-            return Json(ActionResponse {
-                ok: same_intent,
-                status: if same_intent { CW_OK } else { 409 },
-                events: Vec::new(),
-            });
+            return FundCommunityImageResponse::action(
+                same_intent,
+                if same_intent { CW_OK } else { 409 },
+                Vec::new(),
+            );
         }
         plan
     };
 
-    if let Some(policy) = preflight_plan.image_policy {
-        let started_at = Instant::now();
-        if let Err(error) =
-            preflight_community_art_policy(state.ai_config.as_ref().as_ref(), policy).await
-        {
-            warn!(
-                "community art policy preflight failed for {}: {}",
-                community_art_generation_key(
-                    &preflight_plan.subject_kind,
-                    preflight_plan.subject_id,
-                    preflight_plan.level
-                ),
-                error.message()
-            );
-            record_ai_usage(
-                &state,
-                Some(payload.actor_id),
-                "community_image_policy_preflight",
-                "cosyworld_system",
-                state.ai_config.as_ref().as_ref(),
-                "failed",
-                None,
-                0,
-                Some(error.code()),
-                started_at.elapsed(),
-            );
-            return Json(ActionResponse {
-                ok: false,
-                status: 503,
-                events: Vec::new(),
-            });
-        }
+    let started_at = Instant::now();
+    if let Err(error) = preflight_community_art_funding(
+        state
+            .avatar_art_config
+            .as_ref()
+            .as_ref()
+            .expect("community-art provider was checked before planning"),
+        state.ai_config.as_ref().as_ref(),
+        &state.generated_asset_dir,
+        &preflight_plan,
+    )
+    .await
+    {
+        warn!(
+            failure_stage = error.stage(),
+            failure_code = error.code(),
+            subject_kind = preflight_plan.subject_kind,
+            subject_id = preflight_plan.subject_id,
+            level = preflight_plan.level,
+            "community art funding preflight failed: {}",
+            error.message()
+        );
+        record_ai_usage(
+            &state,
+            Some(payload.actor_id),
+            "community_image_publication_preflight",
+            "cosyworld_system",
+            state.ai_config.as_ref().as_ref(),
+            "failed",
+            None,
+            0,
+            Some(error.code()),
+            started_at.elapsed(),
+        );
+        return FundCommunityImageResponse::failure(503, error.code());
     }
 
     let mut runtime = state.inner.lock().await;
@@ -25412,7 +25417,7 @@ async fn fund_community_image(
         payload.actor_id,
         payload.actor_session.as_deref(),
     ) {
-        return client_actor_rejected_response();
+        return FundCommunityImageResponse::from_action(client_actor_rejected_response());
     }
     let mut plan = match runtime.community_art_plan(
         payload.actor_id,
@@ -25421,19 +25426,11 @@ async fn fund_community_image(
     ) {
         Ok(plan) => plan,
         Err(_) => {
-            return Json(ActionResponse {
-                ok: false,
-                status: 404,
-                events: Vec::new(),
-            });
+            return FundCommunityImageResponse::action(false, 404, Vec::new());
         }
     };
     if freeze_community_art_evolution(&state.generated_asset_dir, &mut plan).is_err() {
-        return Json(ActionResponse {
-            ok: false,
-            status: 409,
-            events: Vec::new(),
-        });
+        return FundCommunityImageResponse::action(false, 409, Vec::new());
     }
     let key = community_art_generation_key(&plan.subject_kind, plan.subject_id, plan.level);
     let existing = runtime.community_art_generations.get(&key);
@@ -25447,11 +25444,7 @@ async fn fund_community_image(
         if retry_generation {
             schedule_community_art_generation(&state, payload.actor_id, plan);
         }
-        return Json(ActionResponse {
-            ok: true,
-            status: CW_OK,
-            events: Vec::new(),
-        });
+        return FundCommunityImageResponse::action(true, CW_OK, Vec::new());
     }
     if existing.is_some_and(|generation| {
         generation
@@ -25460,39 +25453,23 @@ async fn fund_community_image(
             .is_some_and(|amount| *amount > 0)
             && generation.funded_orbs < generation.required_orbs
     }) {
-        return Json(ActionResponse {
-            ok: false,
-            status: 409,
-            events: Vec::new(),
-        });
+        return FundCommunityImageResponse::action(false, 409, Vec::new());
     }
     if existing.is_some_and(|generation| generation.status == "ready") {
-        return Json(ActionResponse {
-            ok: false,
-            status: 409,
-            events: Vec::new(),
-        });
+        return FundCommunityImageResponse::action(false, 409, Vec::new());
     }
     if existing.is_some_and(|generation| {
         generation.funded_orbs >= generation.required_orbs
             && !plan.generation_retryable(generation, candidate_retry_path)
     }) {
-        return Json(ActionResponse {
-            ok: false,
-            status: 409,
-            events: Vec::new(),
-        });
+        return FundCommunityImageResponse::action(false, 409, Vec::new());
     }
     let funded_orbs = existing
         .map(|generation| generation.funded_orbs)
         .unwrap_or(0);
     let contribution = plan.required_orbs.saturating_sub(funded_orbs).min(1);
     if contribution > 0 && runtime.orb_balance(payload.actor_id) < contribution {
-        return Json(ActionResponse {
-            ok: false,
-            status: 402,
-            events: Vec::new(),
-        });
+        return FundCommunityImageResponse::action(false, 402, Vec::new());
     }
 
     let events = if contribution > 0 {
@@ -25525,18 +25502,10 @@ async fn fund_community_image(
         match commit_journal_record(&state, &mut runtime, record) {
             Ok((CW_OK, events)) => events,
             Ok((status, events)) => {
-                return Json(ActionResponse {
-                    ok: false,
-                    status,
-                    events,
-                });
+                return FundCommunityImageResponse::action(false, status, events);
             }
             Err(_) => {
-                return Json(ActionResponse {
-                    ok: false,
-                    status: 500,
-                    events: Vec::new(),
-                });
+                return FundCommunityImageResponse::action(false, 500, Vec::new());
             }
         }
     } else {
@@ -25553,11 +25522,7 @@ async fn fund_community_image(
     if fully_funded {
         schedule_community_art_generation(&state, payload.actor_id, plan);
     }
-    Json(ActionResponse {
-        ok: true,
-        status: CW_OK,
-        events,
-    })
+    FundCommunityImageResponse::action(true, CW_OK, events)
 }
 
 async fn commit_chat_status(

--- a/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
+++ b/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
@@ -420,6 +420,25 @@ pub(crate) fn prepare_media_candidate(
     Ok(disposition)
 }
 
+/// Proves that the exact verdict identity for a frozen brief is compatible
+/// with any existing record and that both record and candidate directories can
+/// complete the atomic-write lifecycle used after a paid provider response.
+/// The probe leaves no verdict record or candidate behind.
+pub(crate) fn preflight_media_verdict_storage(
+    root: &Path,
+    brief: &FrozenMediaBrief,
+) -> Result<(), String> {
+    brief.validate()?;
+    let brief_digest = brief.digest()?;
+    let _guard = media_verdict_lock()?;
+    let record = load_or_create_record(root, brief.clone(), &brief_digest)?;
+    preflight_atomic_write_directory(&record_dir(root, &record.record_id), "record")?;
+    preflight_atomic_write_directory(
+        &record_dir(root, &record.record_id).join("candidates"),
+        "candidate",
+    )
+}
+
 /// Retires a rejected candidate's immutable review record when a legacy retry
 /// must adopt a newly frozen brief. Approved or still-pending work remains
 /// fail-closed: only an explicitly rejected active candidate may be replaced.
@@ -1183,6 +1202,28 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
     ));
     fs::write(&temporary, bytes).map_err(|error| error.to_string())?;
     fs::rename(&temporary, path).map_err(|error| error.to_string())
+}
+
+fn preflight_atomic_write_directory(directory: &Path, label: &str) -> Result<(), String> {
+    fs::create_dir_all(directory).map_err(|error| {
+        format!(
+            "failed to create media verdict {label} directory {}: {error}",
+            directory.display()
+        )
+    })?;
+    let probe = directory.join(format!(
+        ".preflight-{label}-{}-{}-{}",
+        std::process::id(),
+        crate::now_millis(),
+        crate::random_hex(6)
+    ));
+    atomic_write(&probe, b"cosyworld-media-verdict-preflight")?;
+    fs::remove_file(&probe).map_err(|error| {
+        format!(
+            "failed to remove media verdict {label} probe {}: {error}",
+            probe.display()
+        )
+    })
 }
 
 fn record_dir(root: &Path, record_id: &str) -> PathBuf {

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -199,4 +199,4 @@
 # both directions, the empty-store and inconsistent-store boundaries, and the
 # health contract; the checkpoint-refusal half lives in snapshot_persistence.rs
 # beside the writer that owns it.
-72007
+71972

--- a/v2/scripts/rust-lint-warning-ceiling.txt
+++ b/v2/scripts/rust-lint-warning-ceiling.txt
@@ -26,4 +26,4 @@
 # extra 4 are pre-existing, not from this branch: diffed clippy's warning-line
 # output between an unmodified main checkout and this branch under all three
 # toolchains, and the sets were byte-identical every time.
-240
+238


### PR DESCRIPTION
## Summary

- require actor, item, and location community-art funding to prove the exact frozen media brief, recipe, provider route, writable storage, and vision reviewer before an Orb journal mutation
- return stable subject-neutral preflight error codes and structured failure-stage telemetry
- preserve actual reviewer attempts and latency in durable media verdicts while keeping fully funded saved-candidate retries free and provider-free
- document GitHub Issues as the source of truth for immediate work and planning documents as the home for rationale, invariants, architecture, and future horizons
- bump the synchronized release version to `0.0.337`

## Root cause

The old funding path only ran the reviewer capability preflight when the optional location landscape policy was present. Actor and item contributions could therefore commit funding before discovering that their required publication reviewer was unavailable.

## Impact

Unavailable or incompatible generation/publication infrastructure now fails before funding for every supported subject type. Existing recoverable candidates remain reusable without another debit or provider call.

## Validation

- `npm run check`
- 178 JavaScript tests passed
- 1,029 Rust tests passed
- worldpack and strict proof-world gates passed
- kernel, formatting, architecture/clippy, and syntax gates passed

Closes #683