### PR TITLE
Give projection mutations a payload and a declared write set

### DIFF
--- a/docs/decisions/0008-projection-mutations-declare-their-writes.md
+++ b/docs/decisions/0008-projection-mutations-declare-their-writes.md
@@ -1,0 +1,109 @@
+# ADR 0008: projection mutations carry their payload and declare their writes
+
+- Status: Accepted
+- Date: 2026-08-09
+- Decision owners: CosyWorld maintainers
+- Related: ADR 0003, #61, #255, #256
+
+## Context
+
+`ProjectionMutation` is the write API for the projection state that lives beside
+the deterministic kernel. `RuntimeWorld` holds one kernel field, `world:
+Box<CwWorld>`, and sixty-nine `BTreeMap`s of state the C world does not model —
+clocks, tags, jobs, bonds, beliefs, routes, journeys, ledgers. Those maps must
+survive journal replay and snapshot round trips, and per ADR 0003 they may lag
+the kernel but must never contradict it.
+
+`RuntimeWorld::apply_projection_mutations` is the interpreter for that API. It
+had grown to 1,210 lines across sixty-six variants, and #256 was raised to split
+it into per-variant handlers.
+
+Measuring it first changed the diagnosis. Fifty-four of sixty-five arms already
+delegate to named methods, so the extraction #256 described is largely done. The
+length is not logic. It is the cost of destructuring a variant's inline named
+fields and re-passing them positionally: a representative arm spends seventeen
+lines to make one call. Splitting bodies out again cannot recover lines that the
+call convention is spending.
+
+Two further measurements shaped the decision. Coupling is rare — only three arms
+touch more than one projection field, though `SetActorSafety` reaches from
+safety flags into pending transfer offers and gift auto-accept policies, which
+is invisible at the call site. And the interpreter takes seven positional
+arguments, two of which are facts about the journal record rather than about the
+runtime.
+
+## Decision
+
+Each `ProjectionMutation` variant carries a named payload struct that owns its
+`apply`, and each payload declares the projection state it may write.
+
+The enum stays closed, exhaustively matched, and applied in list order. No trait
+object, no dynamic dispatch, no registration. `DeclaredWrites` is a compile-time
+marker with an associated constant; it does not participate in dispatch. Replay
+determinism under ADR 0003 depends on a total, statically known order, and a
+subscriber registry would move part of that order out of the journal.
+
+The interpreter's positional arguments collapse into one `ProjectionContext`.
+The two record-derived flags become `RecordProvenance`, because
+`allow_legacy_generated_identity_backfill` is `record.version <
+JOURNAL_RECORD_VERSION` — a property of the record being applied, not a mode the
+runtime is in. Live commits and replayed records take the same path.
+
+Write sets are upper bounds, expressed in `RuntimeSnapshot` field names because
+the snapshot is what a restart remembers, and they are **enforced rather than
+trusted**. Handlers delegate through several layers, so a transitive write set
+cannot be read off the source by hand. The test applies a mutation to a seeded
+world, diffs the serialized snapshot, and fails if anything outside the
+declaration changed — or if nothing changed at all, since a no-op fixture would
+let a wrong declaration pass.
+
+That enforcement earned its place immediately. `SetItemEquipped` was declared
+against the item state it obviously touches; the check reported that it also
+writes `actor_rules_facets`, `event_log`, and `next_event_seq`. Appending an
+event is itself durable projection state, which every event-returning handler
+does and no one would list by inspection.
+
+## Consequences
+
+`ProjectionMutation` is persisted inside `JournalRecord` under `#[serde(tag =
+"kind")]`, so its JSON is a durable wire format. Internally tagged newtype
+variants flatten their payload's fields beside the tag, so the encoding is
+unchanged — but that is a property of serde's representation, not an obligation
+it promises to keep. `reshaped_variants_keep_their_journal_encoding` pins the
+exact JSON for every reshaped variant in both directions. A change that breaks
+it breaks replay of every journal written before that change.
+
+Reshaping is compiler-verified end to end: a variant's construction sites either
+update or fail to build. That makes it a lower-risk operation than moving
+handler bodies, which the compiler cannot check for behaviour. Work is therefore
+sized by construction sites, of which there are 416 across sixty-six variants,
+median four. Thirty-two variants have three or fewer.
+
+This subsumes rather than precedes the remaining #61 queue. A payload struct and
+its `apply` *are* the domain logic, so moving `SetTag` into `rpg/` and
+`BankVisitLedger` into `economy/` is the same operation as splitting the match,
+not a later stage. #61 lists "split the match", "RPG state", and "Economy" as
+separate entries; they are one operation applied sixty-six times.
+
+Grouping the sixty-nine `RuntimeWorld` fields into per-domain sub-structs stays
+out of scope. It changes snapshot shape, and boot correctness is where the worst
+outage of this system came from. It is also the change the accumulated write-set
+declarations will inform: fields that are always written together belong
+together, which becomes a query rather than an argument.
+
+Adding a variant is currently the cheapest way to change projection state, which
+is why this interpreter grew about thirty percent while #256 sat deferred. After
+this change a new variant means a payload struct and a declared write set in a
+domain module — priced like what it is, and landing where it belongs.
+
+## Non-goals
+
+- Reordering, merging, or deduplicating match arms. Order is behaviour.
+- Changing what any mutation does.
+- Dirty-region snapshotting. #481 already moved snapshot writes off the command
+  path, so the full serialize is no longer in the latency path, and partial
+  snapshots would add boot-merge complexity where this system is least
+  forgiving.
+- Partition declarations. Write sets are the input a fenced-ownership design
+  would need under ADR 0003's horizontal gate, but production is deliberately
+  single-writer and building for that now would be speculative.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,9 @@ do not define V2 behavior.
 - **[ADR 0007: Model Bindings and Item Devices](decisions/0007-model-bindings-and-item-devices.md)** —
   canonical embodiment law for conversational actors, portable/equipped/
   installed model-backed items, dormant capabilities, and Elysium migration.
+- **[ADR 0008: Projection Mutations Declare Their Writes](decisions/0008-projection-mutations-declare-their-writes.md)** —
+  why each `ProjectionMutation` carries a payload that owns its `apply` and
+  declares, under test, the projection state it may touch.
 - **[The CosyWorld Referee's Guide](dm-guide/README.md)** — source and build
   instructions for the illustrated guide to scenes, discovery, frontier
   forays, thresholds, tables, and strict AI refereeing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.354",
+  "version": "0.0.355",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.354",
+      "version": "0.0.355",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.354",
+  "version": "0.0.355",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.354"
+version = "0.0.355"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -68,6 +68,7 @@ mod offer_commands;
 mod ownership;
 #[cfg(test)]
 mod project_push_tests;
+mod projection;
 mod prompts;
 mod proxim8;
 mod quest_loot;
@@ -906,11 +907,7 @@ enum ProjectionMutation {
     CreateTransferOffer {
         offer: TransferOfferState,
     },
-    ResolveTransferOffer {
-        offer_id: String,
-        status: TransferOfferStatus,
-        resolved_by_actor_id: u64,
-    },
+    ResolveTransferOffer(projection::ResolveTransferOffer),
     SetActorSafety {
         actor_id: u64,
         target_actor_id: u64,
@@ -920,9 +917,7 @@ enum ProjectionMutation {
     SetGiftAutoAccept {
         policy: GiftAutoAcceptPolicy,
     },
-    ConsumeGiftAutoAccept {
-        policy_id: String,
-    },
+    ConsumeGiftAutoAccept(projection::ConsumeGiftAutoAccept),
     ShuffleHand {
         reason: String,
     },
@@ -1192,11 +1187,7 @@ enum ProjectionMutation {
         prepared: bool,
         reason: String,
     },
-    SetItemEquipped {
-        item_id: u64,
-        equipped: bool,
-        reason: String,
-    },
+    SetItemEquipped(projection::SetItemEquipped),
     SetItemContained {
         item_id: u64,
         container_item_id: Option<u64>,
@@ -9817,6 +9808,19 @@ impl RuntimeWorld {
         allow_legacy_generated_identity_backfill: bool,
         historical_bundle_hash: &str,
     ) -> Vec<EventView> {
+        // Handlers take this instead of a growing positional argument list.
+        // Reshaped variants read everything they need from it; the arms that
+        // still destructure inline keep using the bindings above until they
+        // are reshaped in turn.
+        let ctx = projection::ProjectionContext {
+            action,
+            committed_events,
+            enforce_active_contribution_contract,
+            provenance: projection::RecordProvenance {
+                allow_legacy_generated_identity_backfill,
+                historical_bundle_hash,
+            },
+        };
         let mut events = Vec::new();
         for mutation in mutations {
             match mutation {
@@ -9828,17 +9832,8 @@ impl RuntimeWorld {
                         .entry(offer.id.clone())
                         .or_insert_with(|| offer.clone());
                 }
-                ProjectionMutation::ResolveTransferOffer {
-                    offer_id,
-                    status,
-                    resolved_by_actor_id,
-                } => {
-                    if let Some(offer) = self.transfer_offers.get_mut(offer_id) {
-                        if offer.status == TransferOfferStatus::Pending || offer.status == *status {
-                            offer.status = *status;
-                            offer.resolved_by_actor_id = Some(*resolved_by_actor_id);
-                        }
-                    }
+                ProjectionMutation::ResolveTransferOffer(mutation) => {
+                    mutation.apply(self, &ctx);
                 }
                 ProjectionMutation::SetActorSafety {
                     actor_id,
@@ -9882,10 +9877,8 @@ impl RuntimeWorld {
                     self.gift_auto_accepts
                         .insert(policy.id.clone(), policy.clone());
                 }
-                ProjectionMutation::ConsumeGiftAutoAccept { policy_id } => {
-                    if let Some(policy) = self.gift_auto_accepts.get_mut(policy_id) {
-                        policy.consumed = true;
-                    }
+                ProjectionMutation::ConsumeGiftAutoAccept(mutation) => {
+                    mutation.apply(self, &ctx);
                 }
                 ProjectionMutation::ShuffleHand { reason } => {
                     events.push(self.append_hand_shuffled_event(action.actor_id, reason));
@@ -10937,17 +10930,8 @@ impl RuntimeWorld {
                         reason,
                     ));
                 }
-                ProjectionMutation::SetItemEquipped {
-                    item_id,
-                    equipped,
-                    reason,
-                } => {
-                    events.extend(self.set_item_equipped(
-                        action.actor_id,
-                        *item_id,
-                        *equipped,
-                        reason,
-                    ));
+                ProjectionMutation::SetItemEquipped(mutation) => {
+                    events.extend(mutation.apply(self, &ctx));
                 }
                 ProjectionMutation::SetItemContained {
                     item_id,
@@ -31339,9 +31323,11 @@ async fn give_item(
                 let mut record = JournalRecord::new(planned_action, runtime.next_seed_value());
                 record
                     .projection_mutations
-                    .push(ProjectionMutation::ConsumeGiftAutoAccept {
-                        policy_id: policy.id,
-                    });
+                    .push(ProjectionMutation::ConsumeGiftAutoAccept(
+                        projection::ConsumeGiftAutoAccept {
+                            policy_id: policy.id,
+                        },
+                    ));
                 let Ok((status, events)) = commit_journal_record(&state, &mut runtime, record)
                 else {
                     return Json(ActionResponse {
@@ -31659,11 +31645,13 @@ async fn resolve_transfer_offer(
     };
     record
         .projection_mutations
-        .push(ProjectionMutation::ResolveTransferOffer {
-            offer_id: offer.id.clone(),
-            status: resolved_status,
-            resolved_by_actor_id: payload.actor_id,
-        });
+        .push(ProjectionMutation::ResolveTransferOffer(
+            projection::ResolveTransferOffer {
+                offer_id: offer.id.clone(),
+                status: resolved_status,
+                resolved_by_actor_id: payload.actor_id,
+            },
+        ));
     let Ok((status, events)) = commit_journal_record(&state, &mut runtime, record) else {
         return Json(ActionResponse {
             ok: false,
@@ -33067,11 +33055,13 @@ async fn set_item_equipped(
     );
     record
         .projection_mutations
-        .push(ProjectionMutation::SetItemEquipped {
-            item_id: payload.item_id,
-            equipped: payload.equipped,
-            reason: "equipment_configuration".to_string(),
-        });
+        .push(ProjectionMutation::SetItemEquipped(
+            projection::SetItemEquipped {
+                item_id: payload.item_id,
+                equipped: payload.equipped,
+                reason: "equipment_configuration".to_string(),
+            },
+        ));
     let Ok((status, events)) = commit_journal_record(&state, &mut runtime, record) else {
         return Json(ActionResponse {
             ok: false,

--- a/v2/orchestrator-rust/src/projection.rs
+++ b/v2/orchestrator-rust/src/projection.rs
@@ -1,0 +1,426 @@
+//! Projection mutation context and declared write sets.
+//!
+//! `ProjectionMutation` is the write API for the projection state that lives
+//! beside the deterministic kernel: the `RuntimeWorld` maps that the C world
+//! does not model but that must still survive journal replay and snapshot
+//! round trips. `RuntimeWorld::apply_projection_mutations` is its interpreter.
+//!
+//! Two things live here.
+//!
+//! [`ProjectionContext`] carries what every handler needs besides
+//! `&mut RuntimeWorld`, so handlers take one borrow instead of a growing
+//! positional argument list.
+//!
+//! [`DeclaredWrites`] lets a mutation payload state which projection state it
+//! may touch. The declaration is an upper bound, not an exact set, and it is
+//! enforced by test rather than trusted: handlers delegate through several
+//! layers, so a transitive write set cannot be read off the source by hand.
+//! `projection_write_set_tests` applies each mutation to a seeded world and
+//! fails if anything outside the declaration changed.
+//!
+//! Declaring writes is worth the line it costs because the coupling is
+//! otherwise invisible. `SetActorSafety` looks like it sets safety flags; it
+//! also invalidates pending transfer offers and gift auto-accept policies. That
+//! kind of reach is what makes moving these handlers risky, and a declared,
+//! enforced write set is what makes it safe.
+
+use super::*;
+
+/// A durable projection field, named by its `RuntimeSnapshot` key.
+///
+/// Write sets are expressed in snapshot terms because the snapshot is the
+/// surface that has to survive replay; a mutation that changes state outside
+/// the snapshot changes nothing a restart would remember.
+// Keys and context fields are consumed as the remaining variants are reshaped;
+// until then some are declared but unread. Kept deliberately rather than added
+// piecemeal so every reshape is a copy of one pattern.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(super) struct StateKey(pub(super) &'static str);
+
+#[allow(dead_code)]
+impl StateKey {
+    pub(super) const TRANSFER_OFFERS: Self = Self("transfer_offers");
+    pub(super) const GIFT_AUTO_ACCEPTS: Self = Self("gift_auto_accepts");
+    pub(super) const WORLD_ITEMS: Self = Self("world_items");
+    pub(super) const ACTOR_RULES_FACETS: Self = Self("actor_rules_facets");
+    /// Appending an event is itself durable projection state. Any handler that
+    /// returns events writes these two, which is easy to miss by inspection and
+    /// is why the declaration is derived from a run rather than from reading.
+    pub(super) const EVENT_LOG: Self = Self("event_log");
+    pub(super) const NEXT_EVENT_SEQ: Self = Self("next_event_seq");
+
+    pub(super) const fn snapshot_key(self) -> &'static str {
+        self.0
+    }
+}
+
+/// Facts about the journal record being applied.
+///
+/// Live commits and replayed records take the same path; what differs is the
+/// record, so these belong to the record rather than to a runtime mode.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(super) struct RecordProvenance<'a> {
+    /// Records written before `JOURNAL_RECORD_VERSION` predate generated
+    /// identity binding and may backfill it.
+    pub(super) allow_legacy_generated_identity_backfill: bool,
+    /// The worldpack bundle hash recorded with this record.
+    pub(super) historical_bundle_hash: &'a str,
+}
+
+/// Everything a projection handler needs besides `&mut RuntimeWorld`.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ProjectionContext<'a> {
+    pub(super) action: &'a CwAction,
+    pub(super) committed_events: &'a [EventView],
+    pub(super) enforce_active_contribution_contract: bool,
+    pub(super) provenance: RecordProvenance<'a>,
+}
+
+impl<'a> ProjectionContext<'a> {
+    pub(super) fn actor_id(&self) -> u64 {
+        self.action.actor_id
+    }
+}
+
+/// A mutation payload that states which projection state it may write.
+///
+/// This is a compile-time marker with an associated constant. It introduces no
+/// dynamic dispatch: `ProjectionMutation` stays a closed enum matched
+/// exhaustively in list order, which is what journal replay determinism
+/// depends on.
+#[allow(dead_code)]
+pub(super) trait DeclaredWrites {
+    const WRITES: &'static [StateKey];
+}
+
+/// `ProjectionMutation::ResolveTransferOffer`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct ResolveTransferOffer {
+    pub(super) offer_id: String,
+    pub(super) status: TransferOfferStatus,
+    pub(super) resolved_by_actor_id: u64,
+}
+
+impl DeclaredWrites for ResolveTransferOffer {
+    const WRITES: &'static [StateKey] = &[StateKey::TRANSFER_OFFERS];
+}
+
+impl ResolveTransferOffer {
+    pub(super) fn apply(&self, world: &mut RuntimeWorld, _ctx: &ProjectionContext<'_>) {
+        let Some(offer) = world.transfer_offers.get_mut(&self.offer_id) else {
+            return;
+        };
+        if offer.status == TransferOfferStatus::Pending || offer.status == self.status {
+            offer.status = self.status;
+            offer.resolved_by_actor_id = Some(self.resolved_by_actor_id);
+        }
+    }
+}
+
+/// `ProjectionMutation::ConsumeGiftAutoAccept`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct ConsumeGiftAutoAccept {
+    pub(super) policy_id: String,
+}
+
+impl DeclaredWrites for ConsumeGiftAutoAccept {
+    const WRITES: &'static [StateKey] = &[StateKey::GIFT_AUTO_ACCEPTS];
+}
+
+impl ConsumeGiftAutoAccept {
+    pub(super) fn apply(&self, world: &mut RuntimeWorld, _ctx: &ProjectionContext<'_>) {
+        if let Some(policy) = world.gift_auto_accepts.get_mut(&self.policy_id) {
+            policy.consumed = true;
+        }
+    }
+}
+
+/// `ProjectionMutation::SetItemEquipped`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct SetItemEquipped {
+    pub(super) item_id: u64,
+    pub(super) equipped: bool,
+    pub(super) reason: String,
+}
+
+impl DeclaredWrites for SetItemEquipped {
+    const WRITES: &'static [StateKey] = &[
+        StateKey::WORLD_ITEMS,
+        StateKey::ACTOR_RULES_FACETS,
+        StateKey::EVENT_LOG,
+        StateKey::NEXT_EVENT_SEQ,
+    ];
+}
+
+impl SetItemEquipped {
+    pub(super) fn apply(
+        &self,
+        world: &mut RuntimeWorld,
+        ctx: &ProjectionContext<'_>,
+    ) -> Vec<EventView> {
+        world.set_item_equipped(ctx.actor_id(), self.item_id, self.equipped, &self.reason)
+    }
+}
+
+#[cfg(test)]
+mod projection_write_set_tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    /// `ProjectionMutation` is `#[serde(tag = "kind")]` and is persisted inside
+    /// `JournalRecord`, so its JSON is a durable wire format, not an
+    /// implementation detail. Reshaping a variant from inline named fields to a
+    /// newtype payload must keep that encoding byte-identical or every journal
+    /// written before the change becomes unreadable.
+    ///
+    /// These literals are the encoding produced by the pre-reshape enum. They
+    /// are the contract; if a change makes them fail, the change breaks replay.
+    #[test]
+    fn reshaped_variants_keep_their_journal_encoding() {
+        let cases: Vec<(ProjectionMutation, Value)> = vec![
+            (
+                ProjectionMutation::ResolveTransferOffer(ResolveTransferOffer {
+                    offer_id: "offer-1".to_string(),
+                    status: TransferOfferStatus::Accepted,
+                    resolved_by_actor_id: 42,
+                }),
+                json!({
+                    "kind": "resolve_transfer_offer",
+                    "offer_id": "offer-1",
+                    "status": "accepted",
+                    "resolved_by_actor_id": 42,
+                }),
+            ),
+            (
+                ProjectionMutation::ConsumeGiftAutoAccept(ConsumeGiftAutoAccept {
+                    policy_id: "policy-1".to_string(),
+                }),
+                json!({
+                    "kind": "consume_gift_auto_accept",
+                    "policy_id": "policy-1",
+                }),
+            ),
+            (
+                ProjectionMutation::SetItemEquipped(SetItemEquipped {
+                    item_id: 7,
+                    equipped: true,
+                    reason: "equipment_configuration".to_string(),
+                }),
+                json!({
+                    "kind": "set_item_equipped",
+                    "item_id": 7,
+                    "equipped": true,
+                    "reason": "equipment_configuration",
+                }),
+            ),
+        ];
+
+        for (mutation, expected) in cases {
+            let encoded = serde_json::to_value(&mutation).expect("mutation serializes");
+            assert_eq!(
+                encoded, expected,
+                "journal encoding changed for {mutation:?}; existing journals would not replay",
+            );
+            // A journal is read back, not just written.
+            let decoded: ProjectionMutation =
+                serde_json::from_value(expected).expect("mutation round-trips from its encoding");
+            assert_eq!(
+                serde_json::to_value(&decoded).expect("re-encode"),
+                serde_json::to_value(&mutation).expect("re-encode"),
+            );
+        }
+    }
+
+    /// The durable projection keys touched by applying `mutation` to `world`.
+    ///
+    /// Snapshot terms, because the snapshot is what a restart remembers.
+    fn changed_keys(
+        world: &mut RuntimeWorld,
+        apply: impl FnOnce(&mut RuntimeWorld),
+    ) -> Vec<String> {
+        let before = serde_json::to_value(RuntimeSnapshot::from_runtime(world))
+            .expect("snapshot serializes");
+        apply(world);
+        let after = serde_json::to_value(RuntimeSnapshot::from_runtime(world))
+            .expect("snapshot serializes");
+        let (Value::Object(before), Value::Object(after)) = (before, after) else {
+            panic!("snapshot is a JSON object");
+        };
+        after
+            .into_iter()
+            .filter(|(key, value)| before.get(key) != Some(value))
+            .map(|(key, _)| key)
+            .collect()
+    }
+
+    fn assert_within_declared_writes(changed: &[String], declared: &[StateKey], label: &str) {
+        // A mutation that changed nothing satisfies containment trivially and
+        // would let a wrong declaration pass. Every fixture must exercise the
+        // handler for real.
+        assert!(
+            !changed.is_empty(),
+            "{label}: fixture produced no durable change, so its write set is untested",
+        );
+        let allowed: Vec<&str> = declared.iter().map(|key| key.snapshot_key()).collect();
+        // Every declared key must name a real snapshot field, or the
+        // declaration is checking nothing.
+        let snapshot = serde_json::to_value(RuntimeSnapshot::from_runtime(&RuntimeWorld::seeded()))
+            .expect("snapshot serializes");
+        for key in &allowed {
+            assert!(
+                snapshot.get(key).is_some(),
+                "{label}: declared write set names `{key}`, which is not a RuntimeSnapshot field",
+            );
+        }
+        let undeclared: Vec<&String> = changed
+            .iter()
+            .filter(|key| !allowed.contains(&key.as_str()))
+            .collect();
+        assert!(
+            undeclared.is_empty(),
+            "{label}: wrote undeclared projection state {undeclared:?}; declared {allowed:?}",
+        );
+    }
+
+    fn context_for<'a>(action: &'a CwAction, events: &'a [EventView]) -> ProjectionContext<'a> {
+        ProjectionContext {
+            action,
+            committed_events: events,
+            enforce_active_contribution_contract: false,
+            provenance: RecordProvenance {
+                allow_legacy_generated_identity_backfill: false,
+                historical_bundle_hash: "",
+            },
+        }
+    }
+
+    #[test]
+    fn resolve_transfer_offer_writes_only_transfer_offers() {
+        let mut world = RuntimeWorld::seeded();
+        world.transfer_offers.insert(
+            "offer-1".to_string(),
+            TransferOfferState {
+                id: "offer-1".to_string(),
+                kind: TransferOfferKind::Gift,
+                offered_by_actor_id: 1,
+                offered_to_actor_id: 2,
+                offered_item_id: 3,
+                requested_item_id: None,
+                created_tick: 0,
+                expires_tick: 100,
+                status: TransferOfferStatus::Pending,
+                resolved_by_actor_id: None,
+            },
+        );
+        let action = CwAction::default();
+        let mutation = ResolveTransferOffer {
+            offer_id: "offer-1".to_string(),
+            status: TransferOfferStatus::Accepted,
+            resolved_by_actor_id: 2,
+        };
+
+        let changed = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            mutation.apply(world, &ctx);
+        });
+
+        // The mutation must actually do something, or containment is vacuous.
+        assert_eq!(
+            world.transfer_offers["offer-1"].status,
+            TransferOfferStatus::Accepted,
+        );
+        assert!(
+            !changed.is_empty(),
+            "expected the offer resolution to be durable"
+        );
+        assert_within_declared_writes(
+            &changed,
+            ResolveTransferOffer::WRITES,
+            "ResolveTransferOffer",
+        );
+    }
+
+    #[test]
+    fn consume_gift_auto_accept_writes_only_gift_auto_accepts() {
+        let mut world = RuntimeWorld::seeded();
+        world.gift_auto_accepts.insert(
+            "policy-1".to_string(),
+            GiftAutoAcceptPolicy {
+                id: "policy-1".to_string(),
+                recipient_actor_id: 1,
+                offered_by_actor_id: 2,
+                item_id: 3,
+                created_tick: 0,
+                expires_tick: 100,
+                consumed: false,
+            },
+        );
+        let action = CwAction::default();
+        let mutation = ConsumeGiftAutoAccept {
+            policy_id: "policy-1".to_string(),
+        };
+
+        let changed = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            mutation.apply(world, &ctx);
+        });
+
+        assert!(world.gift_auto_accepts["policy-1"].consumed);
+        assert_within_declared_writes(
+            &changed,
+            ConsumeGiftAutoAccept::WRITES,
+            "ConsumeGiftAutoAccept",
+        );
+    }
+
+    #[test]
+    fn set_item_equipped_writes_only_its_declared_state() {
+        let mut world = RuntimeWorld::seeded();
+        // Same fixture shape the playable-core equip tests use: the actor must
+        // actually hold the item, carried, before equipping does anything.
+        let item = world
+            .world
+            .items
+            .iter_mut()
+            .take(world.world.item_count)
+            .find(|item| item.id == 2012)
+            .expect("playable core item exists");
+        item.holder_actor_id = 5000;
+        item.location_id = 0;
+        item.zone = CW_CARD_ZONE_CARRIED;
+        item.container_item_id = 0;
+
+        let action = CwAction {
+            actor_id: 5000,
+            ..CwAction::default()
+        };
+        // Equipping reaches through item lookup, zone assignment, and deck
+        // events. The declaration is an upper bound over that whole reach,
+        // which is why it is checked rather than read off the source.
+        let mutation = SetItemEquipped {
+            item_id: 2012,
+            equipped: true,
+            reason: "equipment_configuration".to_string(),
+        };
+
+        let mut produced = Vec::new();
+        let changed = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            produced = mutation.apply(world, &ctx);
+        });
+
+        assert!(
+            produced
+                .iter()
+                .any(|event| event.type_name == "item.equipped"),
+            "expected the equip to be applied",
+        );
+        assert_within_declared_writes(&changed, SetItemEquipped::WRITES, "SetItemEquipped");
+    }
+}

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -207,4 +207,13 @@
 #
 # 71371 -> 71047: delete the remaining compiler-proven dead merged-inline
 # resident continuity copies; the live implementations stay in continuity.rs.
-71047
+# 71047 -> 71037: the first three ProjectionMutation variants become newtype
+# payloads owning their own apply, and the interpreter's seven positional
+# arguments collapse into one ProjectionContext. ResolveTransferOffer,
+# ConsumeGiftAutoAccept, and SetItemEquipped land; SetJobStatus was reverted
+# because seeding a JobState fixture is more than this change should carry, and
+# an unverified write-set declaration is worth less than none. Net -10 lines
+# with the context block added, so the remaining ~62 variants should each pay
+# for themselves. Payloads and their declared write sets live in projection.rs;
+# no behaviour changes and the journal encoding is pinned by test.
+71037


### PR DESCRIPTION
Refs #61, #255, #256. Adds ADR 0008.

## Why this shape, and not #256's

#256 proposed splitting `apply_projection_mutations` into per-variant handlers. Measuring it first changed the diagnosis:

- **54 of 65 arms already delegate** to named methods. That extraction is largely done.
- The 1,210 lines are the **call convention**, not logic. A representative arm spends 17 lines destructuring a variant's inline fields and re-passing them positionally to make one call. Splitting bodies out again cannot recover lines the convention is spending.
- Only **3 arms** touch more than one projection field.
- `RuntimeWorld` is one kernel field plus **69 BTreeMaps**. `ProjectionMutation` is the write API for those maps.

So each variant carries a named payload struct owning its `apply`, and the seven positional arguments collapse into one `ProjectionContext`.

## Declared write sets, enforced not trusted

Each payload declares the projection state it may write, in `RuntimeSnapshot` terms because the snapshot is what a restart remembers. Handlers delegate through several layers, so a transitive write set cannot be read off the source by hand. The test applies a mutation to a seeded world, diffs the serialized snapshot, and fails if anything outside the declaration changed — **or if nothing changed at all**, since a no-op fixture would let a wrong declaration pass.

It earned its place immediately. `SetItemEquipped` was declared against the item state it obviously touches. The check reported it also writes `actor_rules_facets`, `event_log`, and `next_event_seq` — appending an event is itself durable state, which every event-returning handler does and no one would list by inspection.

That is the same class of reach that makes `SetActorSafety` invalidate pending transfer offers and gift policies from what looks like a safety flag, and it is what makes moving these handlers risky.

## Journal encoding is a wire format

`ProjectionMutation` is persisted in `JournalRecord` under `#[serde(tag = "kind")]`. Internally tagged newtype variants flatten their payload beside the tag, so the encoding is unchanged — but that is serde's representation, not a promise it owes us. `reshaped_variants_keep_their_journal_encoding` pins the exact JSON in both directions for every reshaped variant. **Breaking that test breaks replay of every journal written before the change.**

## Scope

Three variants land: `ResolveTransferOffer`, `ConsumeGiftAutoAccept`, `SetItemEquipped`.

`SetJobStatus` was reshaped and then reverted: seeding a `JobState` fixture is more than this change should carry, and an unverified declaration is worth less than none.

No behaviour changes. Arm order is unchanged. No variant added, removed, or renamed.

## Why this subsumes queue items rather than preceding them

A payload struct and its `apply` *are* the domain logic, so moving `SetTag` into `rpg/` and `BankVisitLedger` into `economy/` is the same operation as splitting the match. #61 lists "split the match", "RPG state", and "Economy" as separate entries; they are one operation applied 66 times.

Reshaping is compiler-verified end to end — a variant's construction sites either update or fail to build — which makes it lower risk than moving handler bodies. Sizing by construction sites (416 across 66 variants, median 4; 32 variants have ≤3) suggests roughly 18 PRs rather than 69.

## Verification

- `npm run v2:rust:test` — 1,147 pass
- `npm run v2:architecture` — main.rs 71,361 (ceiling lowered 71,371 → 71,361, **net −10** with the context block added); clippy 237 warnings, **no ceiling raise**
- `npm run v2:syntax` — pass

Net negative on the first three variants means the remaining ~62 should each pay for themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)