### PR TITLE
Accept avatar NFT-only ownership model

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -442,6 +442,11 @@ concern.
 
 - Generated media belongs to the world event/card it was generated for, not to a private chat.
 - A contribution buys no ownership, access, power, or private control over the prompt.
+- ADR 0006 permits external ownership only as provenance for one allowlisted
+  linked avatar. Reviewed cosmetic appearance fields may inform that avatar's
+  presentation, but NFT metadata cannot author prompts, personality, memory,
+  mechanics, items, rewards, access, pack ids, or controller mode. Item and
+  location NFTs are never media-authority inputs.
 - Each `{subject kind, subject id, level}` generation is unique and replay-safe. Multiple avatars may pool its exact level-sized cost.
 - The prompt captures public card history through a committed sequence. When the card reaches a later level, its one newly unlocked image can evolve in response to everything that happened since.
 - Fully funded jobs may be retried without another Orb debit. Before any actor,

--- a/ECONOMY.md
+++ b/ECONOMY.md
@@ -1,14 +1,22 @@
-# CosyWorld 2.0 Economy And NFT Integration
+# CosyWorld Economy And Legacy NFT Migration
 
 ## Summary
 
-CosyWorld should use two currency-like resources with different trust models:
+ADR 0006 accepts a wallet-optional core with one narrow external bridge:
+supported avatar NFTs may register or recover one durable autonomous actor.
+Wallet ownership does not grant actor control, world items, place access,
+progression, rewards, or private media.
 
-- `Orbs`: fungible, off-chain game currency held in the v2 account ledger. Orbs are earned by solving challenges, completing puzzles, winning small encounters, or advancing world goals. Their only player spend is community image generation for generated collectible cards.
-- `Intricately Carved Wooden Boxes`: wallet-owned NFTs. A Box is an irreversible burn voucher. Burning one creates an avatar card pack in the Ruby High card-pack style; opening that pack reveals avatar cards from the CosyWorld/Ruby High world catalog.
+- `Orbs`: non-transferable, off-chain game currency held in the v2 account ledger. Their only player spend is community image generation for shared world subjects.
+- `Linked avatars`: an optional allowlisted adapter verifies an avatar NFT and binds it idempotently to one canonical actor. The actor is autonomous by default and keeps the same identity and history across custody changes.
 - AI provider accounts and server budgets are operational concerns, not a second in-world price for conversation. Chat is public and Orb-free, but is an advancement-backed friendship action rather than an always-available free verb.
 
-This is deliberately not one generic wallet balance. Orbs are MMO play energy. Boxes are on-chain collectible inventory. Avatar cards, item cards, and location cards remain shared-world inputs, not private instances.
+Intricately Carved Wooden Boxes, pack reveals, keepsake collections, item/location
+NFTs, wallet-gated places, native transferable card ownership, and collection
+item materialization are legacy compatibility surfaces scheduled for replay-safe
+removal under #682 and #685. Their implementation detail remains below as
+migration and audit inventory; it is not product direction and must not receive
+new feature work.
 
 ## Source Findings
 
@@ -21,7 +29,7 @@ Relevant systems:
 - `src/services/battle/combatEncounterService.mjs` contains D&D-shaped turn/combat mechanics, rate limits, HP/AC/damage, and encounter cleanup. V2 should pull combat rules into the C kernel and award Orbs from committed outcomes.
 - `src/services/web/server/routes/claims.js` has an `orbGate` claim policy, but that gate means "hold an Orb NFT collection token." It is not a fungible game-currency ledger and should not be reused as the new Orbs balance.
 - `src/services/payment/pricingService.mjs`, `src/services/payment/x402Service.mjs`, and `src/services/payment/marketplaceService.mjs` are external payment rails using USDC/x402 or service marketplace pricing. They should stay outside the in-world Orb economy.
-- `src/services/crossmint/crossmintService.mjs` and token routes are useful migration references for legacy avatar/item/location NFT issuance, but the v2 pack and burn path should follow Ruby High's Solana/Core pattern.
+- `src/services/crossmint/crossmintService.mjs` and token routes are useful migration references for inventorying and archiving legacy avatar/item/location NFT issuance; they are not templates for new pack/burn product work.
 
 Migration reading: legacy CosyWorld knows how to make the game objects interesting. It does not yet have the right economy boundary for a shared MMO.
 
@@ -36,7 +44,9 @@ Relevant systems:
 - `../app-ruby-high/src/services/ruby-high-service.ts` has the durable account-side mutations: `recordHallPassPackMint`, `openHallPassPack`, `convertBurnedHallPassCardsToHallPasses`, and `cosyWorldWalletCards`.
 - `../app-ruby-high/src/viewer-parts/card-burn-selector.ts`, `billing-products.ts`, `pack-mint-progress.ts`, and `account-hall-pass-cards-panel.ts` show the right UX boundary: card pack and burn operations live in an account/card surface, not inside the primary world transcript.
 
-Migration reading: Ruby High already has the pack, burn, ownership, idempotency, and proof patterns. CosyWorld should consume or adapt those patterns, not recreate them in the C kernel.
+Migration reading: Ruby High's ownership, idempotency, and proof patterns remain
+useful for verified avatar custody and legacy receipt audit. CosyWorld does not
+recreate pack/burn or broad collection logic in the C kernel.
 
 ## Product Model
 
@@ -50,7 +60,7 @@ Rules:
 - The C kernel may emit rule outcomes that cause Orb awards, but it does not own the wallet ledger.
 - Orbs are awarded only from committed game events: challenge solved, puzzle solved, encounter resolved, daily room contribution, or world goal contribution.
 - Orbs never pay for Chat, Say, Listen/Notice, combat, travel, access, success, progression, resident heartbeats, or any other ordinary world verb.
-- A generated collectible may receive one community-funded image at each level.
+- An eligible world subject may receive one community-funded image at each level.
 - The total pooled price of that image is exactly its level in Orbs: level 1 costs 1, level 2 costs 2, and so on.
 - Contributions are journaled per avatar and capped at the remaining pooled price. Once fully funded, retries never take more Orbs.
 - The generation prompt includes public history through the funding event, so later-level images can visibly evolve with the card's story.
@@ -65,7 +75,7 @@ Current v2 implementation:
 - Automatic rule rewards are claim-key gated by actor/context, so replaying the same Listen/combat/flee outcome does not mint duplicate Orbs.
 - `ai_usage_ledger` records system-funded resident inference and community image jobs as `community_orbs`, with feature, status, source event id, Orb delta, and latency.
 - Player OpenRouter keys remain transient. The ledger records payer mode, not secrets.
-- Trusted ownership feeds can include active Wooden Boxes and unopened avatar packs; `/state` exposes compact counts and asset ids without trusting client query params.
+- Legacy ownership feeds can still include active Wooden Boxes and unopened avatar packs while #682 migrates them; `/state` must never trust client query parameters and the default target removes those projections.
 - Development reset clears projected events, action journal, sessions, wallet links, suspensions, Orb ledger rows, and AI usage rows together.
 
 UI implication:
@@ -76,9 +86,30 @@ UI implication:
 - A fully funded or failed job can be nudged/retried without another debit. A completed card says that its next image unlocks at the next level.
 - The Orb balance can be visible as compact status text, but it must not turn the MUD into a dashboard.
 
-### Intricately Carved Wooden Boxes
+### Linked Avatar Bridge
 
-Boxes are NFTs and should be treated as scarce wallet assets.
+Rules:
+
+- Linking a wallet is optional and ordinary play never requires it.
+- A protected allowlisted adapter, never browser claims, verifies network,
+  collection authority, asset id, current custody, and the authored actor
+  profile.
+- One verified asset registers or recovers exactly one durable actor and one
+  immutable first-link receipt.
+- The actor arrives through its authored worldpack threshold when presence
+  permits; otherwise it remains offstage.
+- The actor is autonomous by default. Wallet custody grants association and
+  chronicle visibility, not direct commands or mechanical advantage.
+- Transfer, unlink, revocation, or stale ownership changes association only at
+  a safe boundary. The actor's identity, Journal, Bonds, advancement, and
+  world inventory persist.
+- Only reviewed cosmetic appearance fields may refresh. Metadata cannot author
+  prompts, personality, mechanics, items, access, rewards, or pack ids.
+
+### Intricately Carved Wooden Boxes — Legacy Compatibility
+
+Boxes are shipped legacy NFTs. Freeze new product work; preserve their receipts
+for audit and remove the player/runtime surface through #682.
 
 Rules:
 
@@ -97,7 +128,7 @@ UI implication:
 - The main transcript can show a compact room event after a pack reveal, for example: `[System] Lantern Stitch opened a Wooden Box. Three avatar cards joined the world archive.`
 - The one-button room rule still holds. If the player focuses a Box, the one contextual button can become `Open Box`; otherwise it remains world play.
 
-### Avatar Cards From Packs
+### Avatar Cards From Packs — Legacy Compatibility
 
 Avatar cards are collectible and world-influencing, but they do not create private NPC copies.
 
@@ -113,7 +144,7 @@ Rules:
 
 Each authored world-item id is one shard-local object. Resident desires, attachments, evolution requirements, and recipe inputs can deliberately overlap; they are reasons to move and negotiate over the shared object, not separate reservations or promises that every demand can be satisfied at once. Giving, trading, evolution placement, and crafting preserve their input objects, so the same singleton can support several stories in sequence. The browser shows a sought item's authoritative current availability beside the resident's fallible memory, making current contention legible.
 
-Wallet keepsakes are a separate ownership plane and never inflate this count. The worldpack inspector's `world_item_economy` audit reports only kernel-owned world supply against authored demand.
+Legacy wallet keepsakes never inflate this count and are being archived. The worldpack inspector's `world_item_economy` audit reports only kernel-owned world supply against authored demand.
 
 ## Integration Points
 
@@ -147,8 +178,8 @@ Add services/modules:
 
 - `economy`: Orb balance, idempotent ledger mutations, spend/award policies.
 - `ai_gateway`: player OpenRouter payer verification, AI usage ledger entries, model routing, and media calls.
-- `wallet_assets`: signed wallet sessions, ownership feed hydration, Box/card/location projections.
-- `packs`: Box burn prepare/confirm, pack creation, pack open/reveal, card grants.
+- `avatar_links`: signed wallet sessions, allowlisted avatar ownership verification, exactly-once actor binding, custody association, and safe offstage policy.
+- Legacy `wallet_assets` and `packs`: freeze and archive Box/card/location projections, burn/open flows, and receipts under #682/#685.
 - `challenges`: one-button challenge selection, kernel submission, Orb awards.
 
 Update existing flows:
@@ -160,7 +191,9 @@ Update existing flows:
 - `/world` and room state include newly granted avatar cards through the same card projection map.
 - `/meta` exposes economy feature flags without secrets.
 
-Recommended new routes:
+Avatar-link routes should be narrow, protected, and adapter-owned. The ordinary
+economy/AI/action routes below remain normal product surface; the `/nft/*`
+routes are existing legacy compatibility endpoints scheduled for removal:
 
 ```text
 GET  /economy
@@ -175,11 +208,14 @@ POST /nft/packs/open
 
 The route names can change, but the phases should not collapse into an unaudited one-shot mutation.
 
-### Ownership Feed
+### Ownership Feed — Legacy Inventory And Target Adapter
 
-The current v2 `OwnershipIndex` already consumes Ruby High-style wallet card exports. Extend the feed contract rather than adding a second source of truth.
+The current v2 `OwnershipIndex` consumes Ruby High-style wallet card exports.
+Do not extend its Box, item, location, pass, or general-card roles. #682 reduces
+the protected feed to allowlisted avatar discovery/custody and read-only legacy
+audit data.
 
-Needed additions:
+Legacy fields to inventory and remove from live projection:
 
 - `boxes`: active Box NFTs by wallet with asset address, metadata URI, serial, collection, and status.
 - `packs`: unopened/opened avatar packs by wallet with asset address or receipt id.
@@ -327,7 +363,7 @@ Migrate concepts, not old runtime coupling:
 - From `quests`: condition model and daily challenge generation.
 - From `combat`: stats, action cooldowns, encounter outcomes, and combat-derived Orb awards.
 - From `claims`: wallet signature and collection policy ideas, but not `orbGate` as Orbs.
-- From `payment`: external purchase rails only. USDC/x402 can later sell Boxes or premium bundles, but it must not be the in-world Orb ledger.
+- From `payment`: external purchase rails remain outside the in-world Orb ledger. They do not sell Boxes, item/location NFTs, access, or progression in the accepted core product.
 - From Discord routes: none of the v2 economy should depend on Discord channel objects.
 
 ## Migration Plan
@@ -335,8 +371,8 @@ Migrate concepts, not old runtime coupling:
 ### Stage 0: Schema And Fixtures
 
 - Add this economy doc to the v2 contract.
-- Add seed fixture entries for Orbs, Boxes, and avatar packs.
-- Extend smoke-owned wallet fixtures with one active Box.
+- Keep Orb seed fixtures. Legacy Box/avatar-pack fixtures remain only until
+  #682/#685 replace them with linked-avatar and archival-migration coverage.
 
 ### Stage 1: Orbs Ledger
 
@@ -365,7 +401,11 @@ Current status: Chat is advancement-backed and Orb-free; the delayed resident re
 - Keep challenge content tied to location, resident, item, and stat context.
 Current status: partially implemented in the Moonlit Trail sparring loop. The remaining work is richer encounter lifecycle and balancing.
 
-### Stage 4: Box Ownership Projection
+The remaining stages document shipped legacy behavior so migration can preserve
+audit history and avoid duplicate/lost world entities. They are not future
+delivery stages.
+
+### Stage 4: Box Ownership Projection — Shipped Legacy
 
 Current status: implemented for trusted feed projection.
 
@@ -379,7 +419,7 @@ Current status: implemented for trusted feed projection.
   transcript. Support-grade provenance inspection can build on the same durable
   receipt/opening rows.
 
-### Stage 5: Box Burn And Pack Creation
+### Stage 5: Box Burn And Pack Creation — Shipped Legacy
 
 Current status: implemented as a signed-wallet route flow with production transaction construction and confirm-side chain verification.
 
@@ -399,7 +439,7 @@ Current status: implemented as a signed-wallet route flow with production transa
   external snapshots are also compared with those receipts before merge; protected moderator
   resolution notes persist the operator disposition of reported contradictions.
 
-### Stage 6: Pack Reveal And Card Grants
+### Stage 6: Pack Reveal And Card Grants — Shipped Legacy
 
 Current status: implemented as deterministic local reveal provenance.
 
@@ -414,10 +454,10 @@ Current status: implemented as deterministic local reveal provenance.
   as content/operations follow-up, not blockers for the signed-wallet route
   contract.
 
-### Stage 7: Production Chain Hardening
+### Stage 7: Legacy Archival And Removal
 
-- Restore Ruby High's upstream Solana RPC capacity, deploy feed-health telemetry, and rerun the
-  hosted smoke against the actual protected export.
+- Keep the existing verifier and reconciliation path fail-closed while new Box
+  burns and pack opens are disabled.
 - Active Boxes and unopened packs already follow each successful trusted snapshot, so transfers,
   external burns, and externally opened packs disappear from the effective base index on refresh.
 - Successful startup and refresh snapshots are now compared with durable local burn/opening
@@ -427,20 +467,20 @@ Current status: implemented as deterministic local reveal provenance.
 - Protected moderators can resolve open anomaly runs with an identity and note through the API or
   economy panel in `/moderation`; clear runs are non-actionable and repeated resolution is
   idempotent.
-- Continue the operator workflow with support-facing search, retention policy, and alerts for new
-  anomalies.
+- Preserve support-facing search and an explicit retention policy for archived
+  receipts; do not build new collection product surface.
 - Add alerting for duplicate signatures, impossible balances, and failed pack reveals.
 
 ## Invariants
 
 - The Cosy Cottage remains public.
-- NFT ownership unlocks shared rooms and influences shared residents; it does not create private rooms.
+- Wallet ownership never unlocks, owns, or controls a shared room, item, action, reward, or resident.
 - Human players do not type chat.
 - AI speech is one-to-many through room events.
 - Orbs are spent only for committed community image generation.
 - Automatic Orb rewards are claim-gated by stable actor/context keys.
 - Player OpenRouter payment changes payer only, never room visibility.
-- Boxes are burned only through verified irreversible wallet actions.
-- Production Box burn receipts must come from verified Solana/Core burn confirmations, not the local staging trust path.
-- Every burn, pack, and Orb mutation is idempotent and replayable.
+- New Box burns and pack reveals are disabled before legacy receipt conversion begins.
+- Historical Box/pack receipts remain idempotent, replayable, and auditable through migration.
+- One supported avatar asset maps to one actor; retries, restarts, wallets, and custody transfers cannot clone it.
 - The C kernel never parses wallet data.

--- a/ENG.md
+++ b/ENG.md
@@ -1,13 +1,13 @@
 # CosyWorld Engineering Plan
 
-Last major revision: 2026-07-25. This document replaces the CosyWorld 2.0 engineering plan, which was written before the V2 runtime existed. The architecture it proposed is now built and live-tested with simultaneous players; this document describes that architecture as it stands and sets the engineering priorities from here — including the card-composed world, non-consuming arrangement evolution, and crafting adopted in `PRD.md`.
+Last major revision: 2026-08-09. This document replaces the CosyWorld 2.0 engineering plan, which was written before the V2 runtime existed. The architecture it proposed is now built and live-tested with simultaneous players; this document describes that architecture as it stands and sets the engineering priorities from here — including the card-composed world, non-consuming arrangement evolution, crafting, and the wallet-optional avatar-link boundary adopted in `PRD.md` and ADR 0006.
 
 Companion documents:
 
 - `PRD.md` — product direction this plan serves, including the Card-Composed World rules.
-- `docs/systems/09-cosyworld-rpg-system.md` (the RPG Bible) — authoritative RPG mechanics design, phase status, on-fill descriptor spec, claim-key spec, and ownership-chain design.
+- `docs/systems/09-cosyworld-rpg-system.md` (the RPG Bible) — authoritative RPG mechanics design, phase status, on-fill descriptor spec, claim-key spec, and ADR 0006 ownership-boundary integration.
 - `AI.md` — AI gateway, payer modes, and media pipeline design detail.
-- `ECONOMY.md` — economy and NFT-bridge design detail.
+- `ECONOMY.md` — Orb economy, linked-avatar adapter, and legacy NFT migration inventory.
 - `v2/README.md` — runtime operations guide: run, deploy, endpoints, environment.
 
 ## System Shape
@@ -59,6 +59,7 @@ These are the engineering enforcement of the PRD's pillars. Code review holds th
 9. **The kernel stays wallet-blind and IO-free.** Stable numeric ids, type flags, and rule fields only. Ownership feeds, card metadata, signatures, and money are Rust concerns.
 10. **One shard per process.** A process owns one world, one store, one stream. Horizontal scale is more processes with isolated state; cross-shard routing is out of scope this era.
 11. **Structured content over free-form.** Anything that can change authoritative state — clock on-fill effects, crafting recipes, generated evolution patterns — is a closed-vocabulary descriptor that compiles to kernel actions or typed projection mutations, dry-run validated, fail-closed.
+12. **External ownership is avatar-link provenance only.** A verified allowlisted avatar asset may bind to one durable autonomous actor. Wallet state never grants commands, item supply, place access, action legality, progression, rewards, or private media. The default composition boots and plays without wallet, chain, or ownership-feed configuration.
 
 ## Current State
 
@@ -66,10 +67,11 @@ The one-paragraph version: the kernel,
 orchestrator, avatar gate, advancement-backed Chat, coalescing
 contextual room heartbeats, shared live rooms with room turns and ping/pong
 pacing, resident autonomy, transcript-rendered world feedback, items/evolution,
-card projection, wallet-gated expansion access, economy MVP (Orbs, claim keys,
-image-only community spends, Box/pack bridge), moderation basics, the RPG layer
+card projection, legacy wallet-gated expansion access, economy MVP (Orbs, claim keys,
+image-only community spends, legacy Box/pack bridge), moderation basics, the RPG layer
 first slice, deterministic frontier simulation, both clients, and the production
-deploy profile are live and covered by `./v2/mvp.sh check`.
+deploy profile are live and covered by `./v2/mvp.sh check`. The wallet gates and
+Box/pack surfaces are migration inventory under #682/#685, not target architecture.
 
 ## Engineering Priorities
 
@@ -81,13 +83,14 @@ Ordered. Priorities 1–3 are the foundation everything else builds on.
 
 - `world/` — world projection, presence, placement, resident autonomy.
 - `cards.rs` — card projection and asset resolution.
-- `economy/` — Orb ledger, claim sets, Box/pack flows.
+- `economy/` — Orb ledger and claim sets; isolate then archive legacy Box/pack flows.
+- `avatar_links/` — optional allowlisted ownership adapter, exactly-once actor binding, custody association, and offstage policy.
 - `rpg/` — clocks, tags, bonds, journal, jobs, fronts (and later covenants).
 - `ai_gateway/` — see priority 3.
 - `persistence.rs` — journal, events, snapshot, sessions.
 - `moderation.rs` — reports, suspension, protected views.
 
-Rule going forward: **no major new system lands in `main.rs`.** `npm run v2:architecture` ratchets its total physical line count, including inline tests, and the Rust clippy warning count. Extracted systems take their tests with them. A deliberate exception must raise the matching ceiling in the same reviewed diff; every shrink lowers it again. Card-zone and scene-composition work, crafting, media jobs, and the ownership chain each arrive as modules. Decomposition is mechanical (move code, keep tests green under `./v2/mvp.sh check`), not a rewrite.
+Rule going forward: **no major new system lands in `main.rs`.** `npm run v2:architecture` ratchets its total physical line count, including inline tests, and the Rust clippy warning count. Extracted systems take their tests with them. A deliberate exception must raise the matching ceiling in the same reviewed diff; every shrink lowers it again. Card-zone and scene-composition work, crafting, media jobs, the avatar-link adapter, and legacy ownership migration each arrive as modules. Decomposition is mechanical (move code, keep tests green under `./v2/mvp.sh check`), not a rewrite.
 
 ### 2. Economy circulation
 
@@ -135,12 +138,26 @@ Implements PRD "Next" #1 — item meets room:
 - `recipes.json` in the worldpack: tag-keyed inputs (`warm + bright`, `thread + button`), output templates with fixed type/tags/rules, optional room requirements (forge at hearth), and a `balance` declaration for any new physical item. `check-worldpack.mjs` gains recipe validation: every recipe's inputs are producible, every output's tags resolve, no orphan chains, and every item-creating recipe declares the location/avatar/covenant/evolution capacity it unlocks or feeds.
 - Kernel: a `craft` action validates that the actor holds one input and the room floor holds the other, then emits a deterministic craft event keyed by recipe and input item ids. If the recipe creates a physical item, the kernel creates it only into a legal empty slot declared by the recipe: usually the floor of a newly unlocked location, sometimes an existing empty floor or a newly available avatar/resident hand. Inputs are never deleted.
 - Projection/AI: the whimsical name and blurb are AI proposals in the Adjective-Noun house voice, sanitized, with authored fallback names per recipe. Craft events can set room/item tags, unlock exits, reveal locations, call residents, and feed the media pipeline for card art.
-- Ownership tie-in: a craft result is both a physical world item when the recipe declares one and a native card mint bound to the craft event with `parent_merkle` lineage from both ingredients — the play-side mint faucet of the provenance log (priority 8). The card collection and the physical item slot remain separate surfaces.
+- Provenance tie-in: a craft result is a physical world item when the recipe declares one and carries a canonical craft receipt with lineage from both ingredients. Presentation cards project that item and receipt; they do not create a transferable ownership plane.
 - Balance and anti-deadlock: search tables bias toward ingredients and arrangement needs not currently represented nearby. Authored supply, claim keys, and played-time seasons bound faucets; weight, size, containers, typed slots, exhaustion, readiness, recharge, access, and placement bound usable supply. Every recipe that creates a physical item must declare the capacity, desire, route, or story possibility it adds, and content-ratio validation must prove that output has a reachable use.
 
-### 8. Native ownership chain
+### 8. Avatar-link boundary and legacy ownership retirement
 
-The signed provenance log from the RPG Bible: Ed25519 identities, content-addressed card types, `card_events` (mint/transfer/gift/swap) signed per authority, ownership as a verified fold over the log, gifting, world-bound co-signed trading, and commit-reveal poem claims. Reuse the sibling `signal` project's `chain_log`/`signal_verify` substrate. Run federated (operator authority, quorum 1) first. The kernel stays out of it entirely; mints bind to kernel world events by `because: event_id` — pack reveals and craft events are the two mint faucets. Schemas and route shapes: `ECONOMY.md` and the RPG Bible.
+Implement ADR 0006 through three bounded paths:
+
+- #688 generalizes the Project 89 pilot into an optional allowlisted adapter:
+  verified asset identity and custody in, exactly one durable autonomous actor
+  binding out.
+- #682 removes keepsake, Box/bundle, item/location NFT, wallet-gate, and native
+  transferable-card surfaces from ordinary runtime and UI dependencies.
+- #685 disables new item materialization before converting or archiving every
+  existing receipt exactly once, without duplicating or losing a live world
+  item.
+
+Keep the C kernel wallet-blind. Persist immutable first-link and migration
+receipts, freeze association changes on stale/contradictory ownership data,
+apply transfer/unlink only at safe boundaries, and prove the default golden
+journey without any wallet configuration.
 
 ### 9. Content pipeline
 
@@ -157,14 +174,14 @@ The worldpack is the designer contract. Keep `check-worldpack.mjs` strict and ex
   `lonelyforestlibrary.com` S3/CloudFront site; dormant ECS/EFS/ALB resources
   exist only for the documented rollback window. The runtime contract remains
   host-agnostic: a persistent volume at `/data`, the production-profile env
-  (protected ownership feed + bearer, SQLite event store, moderation token,
+  (optional protected avatar-ownership adapter when configured, SQLite event store, moderation token,
   process id), and `/meta` as the deploy smoke surface.
-- Restore Ruby High's upstream Solana RPC capacity, deploy the ownership-feed health telemetry, and rerun the hosted smoke against the actual protected export. The hosted path is configured and has been exercised, but the export currently fails on upstream RPC quota exhaustion.
+- Keep legacy ownership reconciliation observable and fail-closed during archival. Do not make ordinary production boot depend on Ruby High, Solana RPC capacity, or a broad ownership feed.
 - SQLite backup, retention, and restore-drill policy for `/data`.
 - Observability past `/meta`: request/latency metrics, AI provider and dialogue inference failure rates, ledger anomaly counts, ping-to-skip rates.
 - World hygiene rituals: a documented wipe/reset procedure before playtests (no smoke-avatar residue in first impressions), and presence/turn eligibility windows tuned so ghosts are rare rather than merely skippable.
 - Keep resident placement player-powered: overlap tie rotation uses world-tick seasons rather than wall-clock days, and future placement changes should be audited world actions rather than invisible time.
-- Deploy and smoke the configured production Box burn builder/verifier, then extend the protected reconciliation resolution console with support search, alerts, and retention policy.
+- Disable new Box burns before receipt migration; retain only the verifier, support search, alerts, and retention controls needed to audit historical receipts safely.
 
 ## The Hand as Transport Contract
 
@@ -174,7 +191,7 @@ The shipped control surface — server-ranked action offers dealt as a labeled c
 
 The route table lives in `v2/orchestrator-rust/src/routes.rs`; operational docs in `v2/README.md`. Conventions all new endpoints follow:
 
-- Player mutations require `actor_id` + matching `actor_session`; expansion access adds `wallet_session`. Wrong/missing session → `403`, never a silent fallback to another identity.
+- Player mutations require `actor_id` + matching `actor_session`. Only the optional avatar-link/custody adapter requires `wallet_session`; ordinary access and expansion play do not. Wrong/missing session → `403`, never a silent fallback to another identity.
 - Rejected input → `400` with no world event; rate limit → `429`; duplicate in-flight turn → `409`; not-your-turn → `423` with a `turn.waiting` event and a human-readable reason on the typed path; irreversible flows are idempotent by explicit key.
 - Turn consumption follows the fixed taxonomy (invariant 7); new verbs declare turn-consuming or turn-exempt at review time.
 - New player-visible state goes through `/state` / `/world` projections and the `/stream` event contract — clients never get a side channel.
@@ -192,12 +209,12 @@ Standing rules for new work:
 - Every new core world verb demonstrates its deterministic non-AI path and declares its turn taxonomy. Dialogue capabilities demonstrate visible, uncharged failure when inference is unavailable.
 - New persistent state is added to snapshot/journal handling in the same change (a claim set that isn't persisted re-mints on restart).
 - Generated-content paths (crafted names, quest lists) ship with their compiler rejection tests: an invalid proposal must fail closed to the authored fallback, visibly in the audit trail.
-- The multi-card carrying migration lands with weight/size/container coverage, multiple loose room items, capacity-aware search and drop behavior, non-consuming two-player ceremonies, and craft-event mints without input deletion.
+- The multi-card carrying migration lands with weight/size/container coverage, multiple loose room items, capacity-aware search and drop behavior, non-consuming two-player ceremonies, and replay-safe craft receipts without input deletion.
 - UI changes that alter the shell update visual baselines deliberately, never as drive-by churn.
 
 ## Deployment and Scale
 
-`COSYWORLD_DEPLOY_PROFILE=production` refuses to boot without the protected remote ownership feed + bearer, the SQLite event store, a moderation token, a shard id, and with any dev shortcut enabled. Kernel capacities are compiled (1024 actors, 1024 items, 2048 locations, 4096 exits) and exposed with live counters on `/meta`; approaching them is a sharding conversation, not a hot patch. Locations and exits are sized so a single world can mount every authored pack at once — that union currently seeds 555 locations and 1151 exits — with room for generated pathway descendants. Actors and items are not: the same union seeds 565 actors and 540 items, which leaves under half of each cap for live play. Track live-item growth against authored faucet bounds and content-ratio validation; raise a capacity or retention decision before the item counter approaches its compiled cap.
+The current `COSYWORLD_DEPLOY_PROFILE=production` still requires the protected remote ownership feed + bearer when the active compatibility composition declares that authority. #682 removes that requirement from the default/core target; only a configured avatar adapter may require its protected feed. SQLite event storage, moderation, process identity, and disabled dev shortcuts remain production requirements. Kernel capacities are compiled (1024 actors, 1024 items, 2048 locations, 4096 exits) and exposed with live counters on `/meta`; approaching them is a sharding conversation, not a hot patch. Locations and exits are sized so a single world can mount every authored pack at once — that union currently seeds 555 locations and 1151 exits — with room for generated pathway descendants. Actors and items are not: the same union seeds 565 actors and 540 items, which leaves under half of each cap for live play. Track live-item growth against authored faucet bounds and content-ratio validation; raise a capacity or retention decision before the item counter approaches its compiled cap.
 
 Scale model: one shard per process, isolated stores, route players to their shard at a layer above. Revisit only when a single world's concurrency actually demands it.
 
@@ -205,8 +222,7 @@ Scale model: one shard per process, isolated stores, route players to their shar
 
 - **Community image governance.** Orbs now have one identity and one sink. Open questions are how items/locations gain authoritative levels, how a community previews history input, and how moderation replaces an inappropriate ready image without charging again.
 - **Generated-pattern curation.** Do generated evolution quest lists go live automatically after compiler validation, or behind an operator approve queue for the first season? Start curated, measure rejection rates, then decide.
-- **Player identity for the ownership chain.** When is the Ed25519 keypair generated, where does it live, and what is recovery? (Wallet-linked recovery exists; a native keypair story does not yet.)
+- **Avatar metadata allowlist.** Which reviewed cosmetic fields may refresh without changing canonical actor identity, voice, continuity, or mechanics? Start with appearance-only fields and pin every identity/mechanical fact at first link.
 - **Kernel promotion policy.** Prepare/Rest/Work/Help are projection verbs; the standing answer is "move a verb into C only when it needs hard authority" — each promotion should record why. Search-reveal goes straight to the kernel because it creates a physical item placement; craft goes to the kernel because it must validate item co-presence, create any physical output in a legal slot, and emit an authoritative provenance event even when inputs are not consumed. Listen-absorbs-bank stays projection.
 - **SQLite ceiling.** Per-shard SQLite is fine now; define the signals (write contention, backup size, multi-reader needs) that would trigger a storage change rather than deciding one prematurely.
 - **Legacy Node companion.** Which integrations (Discord bridge, media references) are worth porting as adapters over the V2 API, and when does the rest get archived?
-- **P2P quorum trigger.** Federation (quorum 1) is the plan of record; name the concrete condition — shard count, operator-trust incident, community demand — that funds the P2P endpoint.

--- a/PRD.md
+++ b/PRD.md
@@ -1,13 +1,13 @@
 # CosyWorld Product Requirements
 
-Last major revision: 2026-07-27. This document replaces the CosyWorld 2.0 PRD, which was written for the original one-room, Chat-only MVP and survived as a stack of amendments. The world it described has shipped and grown past it; this document sets direction from where the product actually is — including the turn system, resident autonomy, and the card-composed world.
+Last major revision: 2026-08-09. This document replaces the CosyWorld 2.0 PRD, which was written for the original one-room, Chat-only MVP and survived as a stack of amendments. The world it described has shipped and grown past it; this document sets direction from where the product actually is — including the turn system, resident autonomy, the card-composed world, and the accepted wallet-optional ownership boundary in ADR 0006.
 
 Companion documents:
 
 - `docs/systems/09-cosyworld-rpg-system.md` (the RPG Bible) — authoritative mechanics design: Callings, Bonds, Clocks, Jobs, Fronts, Covenants, the Visit Ledger, ownership, and poems. This PRD does not restate it.
 - `docs/systems/04-action-system.md` — authoritative target for card zones, deterministic scene composition, rules-bound offers, loadouts, and pack extensions.
 - `ENG.md` — architecture and engineering priorities.
-- `ECONOMY.md` — Orbs, Boxes, packs, and the NFT bridge in detail.
+- `ECONOMY.md` — Orbs, shared media funding, the avatar-NFT bridge, and the legacy Box/collection migration inventory.
 - `AI.md` — AI gateway, payer modes, media pipeline, and combat design in detail.
 - `docs/backlog/community-art-evolution.md` — shipped slice, production gaps, and acceptance invariants for the image-only Orb economy.
 
@@ -21,13 +21,13 @@ The product should feel like living in a small fantasy world that remembers you 
 
 CosyWorld V2 is a playable, production-deployable game, live-tested with simultaneous human and agent players:
 
-- CosyWorld Core (free) and the Ruby High: First Bell expansion (card-gated), with compiled cards and complete room sheets validated by the content gate. Release counts are generated from the compiled worldpack rather than maintained in this prose.
+- CosyWorld Core and Ruby High: First Bell, with compiled cards and complete room sheets validated by the content gate. Legacy card-gated access remains migration inventory; the accepted target never makes wallet possession a condition of ordinary or expansion play. Release counts are generated from the compiled worldpack rather than maintained in this prose.
 - The full verb surface: advancement-backed Chat (begin a friendship), Listen, Travel, Take, Drop, Give, Use, Trade, Prepare, Rest, Work, Help, Attack, Defend, Flee, plus Calling/Bond/skill/growth actions.
 - The card-hand control surface: exactly two dealt action cards with art and labels plus a certified **Think**/**Pass** control. Pass commits the turn and deals the next deterministic hand; it is never a free redeal.
 - Room turn-taking for co-present humans, with ping/pong pacing: waiting players can ping the current player; unresponsive players are skipped, not waited on.
-- Resident autonomy on played time: residents wander, remember, and hunt the items they desire — a resident reclaiming her own lost keepsake is now an observed, emergent story beat.
+- Resident autonomy on played time: residents wander, remember, and hunt the items they desire — a resident reclaiming her own lost cherished item is now an observed, emergent story beat.
 - The RPG retention layer: Callings, first-class Bonds, sanctuary/frontier zoning, progress and danger clocks, seeded Jobs and Fronts, factions, the Visit Ledger with growth banking into skill steps and bond slots — all rendered in the shared transcript (arrivals, callings, clues, dice, growth).
-- An economy MVP: starter Orbs, claim-key-gated rewards, image-only community spends, durable Orb/AI-usage ledgers, and the Wooden Box burn → pack reveal bridge with production Solana/Core verification.
+- An economy MVP: starter Orbs, claim-key-gated rewards, image-only community spends, and durable Orb/AI-usage ledgers. The shipped Wooden Box and pack-reveal bridge is legacy compatibility scheduled for replay-safe removal under #682/#685.
 - Moderation basics: player reports, an operator console, protected all-room replay, actor suspension, and report retention.
 - Browser and terminal clients over the same API, with a Playwright smoke, visual baselines, and a production deployment profile with strict guardrails.
 
@@ -37,14 +37,14 @@ The question this PRD answers is no longer "can the loop exist?" It is: **why do
 
 Every feature must serve at least one of these; a feature that serves none does not ship.
 
-1. **One shared world.** No private room copies, no resident DMs, no per-player AI responses. A resident reply is a world event broadcast to everyone present. Card ownership unlocks shared places, never private instances.
+1. **One shared world.** No private room copies, no resident DMs, no per-player AI responses. A resident reply is a world event broadcast to everyone present. Wallet or card ownership never unlocks, owns, or controls a shared place.
 2. **Cozy by guarantee, stakes by consent.** The home and sanctuary rooms never decay, never see combat, and never advance while nobody is playing. Danger, player-powered clocks, and loss exist only on the frontier — where the player chose to walk.
 3. **The world runs on played time.** World time advances only through committed player turns — never on a wall clock. A quiet world is still, not rotting; a busy world is alive because people are in it. "The world moved while you were away" is always true in a populated shard, and it always means other players moved it.
 4. **Identity through play.** A player should be able to say "I am the kind soul who ___, my home is ___, and I am slowly ___" after ten minutes. Callings, Bonds, and the Journal make that sentence mechanical and publicly remembered.
 5. **One meaningful action hand.** The resting UI is exactly two labeled, server-authored actions and a certified **Think**/**Pass** control. Pass binds the actor, current scene/focus, state revision, and hand generation; it commits one turn and deals the next deterministic hand. Each selected action shows its target, cost, and risk before commit. Inspection and moderation remain turn-exempt. The small hand is a focus mechanism, not an inventory limit.
 6. **AI is a world actor, not the product.** AI proposes narration, resident speech, and media; the kernel decides truth. Core world actions remain playable without inference. Dialogue is never fabricated from canned text: an explicit dialogue action fails visibly and without charge when inference is unavailable, while incidental resident speech is skipped.
 7. **Progression is earned, never bought.** Orbs buy only shared images — never Chat, power, access, success, or growth. Every ordinary world verb has a zero-Orb path.
-8. **Ownership without a token.** The target ownership layer is CosyWorld's own signed provenance log (Ed25519, content-addressed, append-only) — gifting free and first-class, trading world-bound and lineage-preserving, secret poems as commit-reveal claim tickets. External NFTs remain an optional bridge that gates official expansions, never the base game.
+8. **World truth owns itself.** Actors, items, places, cards, and Journal history are canonical world facts, not wallet assets. An optional allowlisted avatar-NFT bridge may register or recover one durable autonomous actor per verified asset. It grants no command authority, power, item, reward, or place access. Item/location NFTs, Boxes, bundles, wallet gates, and native transferable card ownership are outside the core product; see ADR 0006.
 
 ## The Concept Budget
 
@@ -61,7 +61,7 @@ Two rules follow.
 | Calling | who you are | calling tags, ledger triggers |
 | Friends | bonds with residents and players | bond entities, reaction states, evolution gates |
 | Journal | memories that settle into growth | Visit Ledger marks, advancement points, skill steps |
-| Cards | your collection and deck; the people, things, places, and spells that meet in a scene | ownership records, card zones, carrying capacity, scene composition, rules bindings |
+| Cards | visual and interaction views of the people, things, places, spells, and actions that meet in a scene | authoritative world entities, item/spell zones, carrying capacity, scene composition, rules bindings |
 | Orbs | the one visible currency | ledgers, payer modes, claim gating |
 
 Everything else is *fiction, not vocabulary*: a clock is "the trail feels safer lately," a job is "someone needs help," a front is weather and trouble, a faction is who a character stands with. System names (clock, front, claim key, projection, sanctuary/frontier) never appear in the player UI. A new feature must fit an existing noun or replace one — the budget does not grow by default.
@@ -70,9 +70,9 @@ Everything else is *fiction, not vocabulary*: a clock is "the trail feels safer 
 
 ## The Card-Composed World
 
-Adopted direction (2026-07-19), superseding the one-hand/one-floor simplification. CosyWorld is already a world of cards: a player's deck meets the cards contributed by a location, its residents, its items, and its live conditions. These rules make that reality authoritative instead of pretending that a single physical slot is the system:
+Adopted direction (2026-07-19), superseding the one-hand/one-floor simplification. ADR 0006 further clarifies that a card is presentation of authoritative world state, not a transferable ownership record. CosyWorld is already a world of cards: a player's carried and prepared state meets the cards contributed by a location, its residents, its items, and its live conditions. These rules make that reality authoritative instead of pretending that a single physical slot is the system:
 
-1. **Cards live in explicit zones.** Collection, carried deck, equipped loadout, spell deck/hand, exhausted/discard, world, and escrow/transfer are authoritative states. The action hand is a server-authored projection and never doubles as an ownership record. Every transition names the card instance, source, destination, actor, reason, and idempotency key.
+1. **Contributing state lives in explicit zones.** Carried items, equipped loadout, spell deck/hand, exhausted/discard, contained items, and world placement are authoritative states. The card and action-hand surfaces are server-authored projections and never double as ownership records. Every physical transition names the world instance, source, destination, actor, reason, and idempotency key.
 2. **A scene is a composition.** On entry and whenever relevant state changes, the server composes the active rules profile, location and room-feature cards, visible resident/avatar and world-item cards, clocks/conditions, and the player's carried/equipped/spell cards. That composition produces legal actions and a ranked action hand; it does not transfer ownership or let presentation text acquire authority.
 3. **Capacity is physical, not arbitrary.** An avatar may carry multiple cards. Legality comes from weight, size, physical ability, containers, and typed equipment slots. Bracelet advancement opens space for skill charms; it does not conjure a skill. Bags extend usable carrying capacity only while validly equipped and cannot create recursive capacity.
 4. **Search circulates cards through world state.** Search may reveal or make reachable cards when the location, feature, supply, season, or claim state permits it. An empty visual floor can be one authored condition, but it is never the universal faucet. Discovery and materialization remain kernel-validated, journaled, capacity-aware, and idempotent.
@@ -85,7 +85,7 @@ The old phrases “one hand” and “one floor” may survive as scene copy or 
 
 - **The new wanderer.** Arrives with no context. Needs to become someone, learn one true thing, and feel the room notice them — within the first session, without typing, on a phone.
 - **The returning regular.** The retention audience. Needs bonds that deepen, a Journal worth settling, a covenant that is theirs, and a frontier that visibly changed because players spent turns there.
-- **The collector and supporter.** Holds cards, opens packs, unlocks expansions, gifts, trades, and crafts. Must always feel additive: their money makes the world fancier for everyone, never gates another player's progression.
+- **The linked-avatar holder and supporter.** May link an allowlisted avatar NFT so one durable autonomous actor joins the world, and may contribute Orbs to shared public media. Neither wallet custody nor payment grants command authority, power, access, or ownership of world items and places.
 - **The world designer.** Authors rooms, residents, jobs, fronts, recipes, and evolution tracks as worldpack data with a validation gate — not by editing runtime code.
 - **The operator.** Runs the official canonical world: moderation queue, suspension, economy audit, deployment guardrails. Later: self-hosted installation operators with their own world identity, content, and gates.
 
@@ -99,8 +99,9 @@ The loop exists and multiplayer works; the priority is making the world worth re
 2. **The card-composed world.** Land explicit zones, weight/size/container capacity, typed loadouts, and deterministic scene composition. Complete the multi-card migration without reintroducing a parallel single-item authority model.
 3. **First-session arc.** Instrument the arc: arrive → become someone → play a first card → learn a truth → meet a resident → settle the Journal. Target: a first-time mobile visitor settles their first growth in under ten minutes without typing.
 4. **Turn cadence legibility.** The shipped room-turn system (one committed card per active human, ping/pong pacing, speech always turn-exempt) needs its remaining visibility work: a visible ping countdown for both sides, a clear "you've been pinged — play or pass" signal, and warm copy when a room's action hand genuinely offers only exits.
-5. **Economy circulation and card art.** Wire the already-designed job Orb payouts; add witness credit; recover world-bound cards from inactive avatars; scope faucets to played-time seasons; complete the generalized community media queue. Each generated collectible unlocks one shared image per authoritative level, with pooled cost equal to that level and history-aware visual evolution.
+5. **Economy circulation and public art.** Wire the already-designed job Orb payouts; add witness credit; recover world items from inactive avatars; scope faucets to played-time seasons; complete the generalized community media queue. Each eligible world subject unlocks one shared image per authoritative level, with pooled cost equal to that level and history-aware visual evolution.
 6. **Real faces and public-traffic safety.** Replace deterministic SVG placeholders with generated avatar portraits and card art through the media pipeline, while completing pre-commit filtering, operator resolution workflows, resident line-variety cooldowns, and abuse review.
+7. **Ownership-boundary migration.** Keep ordinary play wallet-free, freeze new keepsake/Box/item-location NFT scope, disable and archive legacy collection flows without duplicating or deleting live world items, and isolate the supported linked-avatar adapter.
 
 ### Next — a world that makes things
 
@@ -109,7 +110,7 @@ The loop exists and multiplayer works; the priority is making the world worth re
 3. **A living frontier.** The first slice is live: every sixth committed player tick drives deterministic ambient weather and opportunity-level route trade, faction movement, and conflict pressure. Stakes remain local and consensual: only a recorded action at the affected frontier can let pressure advance its danger clock, while sanctuary and unrelated players remain untouched. Next, let those audited consequences create new Jobs so the Wanderer returns to fresh work produced by play. Spent encounters reset through the same played-time seasons.
 4. **Evolution as arrangement.** Placement-pattern evolution tracks with generated per-level quest lists, replacing the fixed two-item gift: patterns compile through the same fail-closed descriptor seam as clock effects, the kernel checks satisfaction against real world state, and ceremonies pay witness credit. This is the renewable quest engine — every resident level mints a fresh constellation of things to find, carry, place, and guard.
 5. **Conflict with objectives.** Objective clocks in danger rooms, nonlethal outcomes, gear durability that breaks to absorb harm, and Flee as a first-class success path. Combat stays one risk mode among many, never the default verb. (RPG Bible Phase 6.)
-6. **Native ownership, phase one.** The signed card provenance log: native mints bound to the world events that earned them — including craft events — free gifting, world-bound co-signed trading, and commit-reveal poem claims. A player owns, gifts, and trades a base-game card with no wallet.
+6. **Linked-avatar bridge.** Productize allowlisted avatar profiles, exactly-once asset-to-actor binding, safe offstage presence, custody transfer, cosmetic metadata allowlisting, and recovery of the same actor across retries and restarts. Direct control remains a separate decision.
 
 ### Later — many hearths
 
@@ -151,7 +152,7 @@ The loop exists and multiplayer works; the priority is making the world worth re
 ### P2 — designed, staged behind P1
 
 - Crafting live: recipes.json, tag-keyed combination, AI-decorated names within rails, crafted items, crafted exits/unlocks, recipe balance declarations, and non-consuming craft-event card mints.
-- Native provenance log live: native mints, gifting, world-bound trading, one-time poem claims and world-gate incantations (repeatable).
+- Avatar-only migration complete: legacy collection/item/location ownership surfaces archived, default play wallet-free, and the optional linked-avatar adapter proven exactly once under transfer/restart.
 - Covenant-spawned jobs and played-time seasonal cadence.
 - Self-hosted installation configuration surface.
 - Higher-level evolution tracks.
@@ -161,7 +162,7 @@ The loop exists and multiplayer works; the priority is making the world worth re
 - No private AI companions, teacher DMs, or per-user room instances — for any price.
 - No pay-for-power, no purchasable progression, no anonymous secondary market, no speculation loop.
 - Not a full D&D engine; the rules layer stays compact, legible, and kernel-audited.
-- No unlimited or spreadsheet-like inventory. A carried deck is bounded by weight, size, containers, typed slots, and access costs; the wider collection remains distinct from cards materialized in the shared world.
+- No unlimited or spreadsheet-like inventory. Physical carrying is bounded by weight, size, containers, typed slots, and access costs; presentation cards do not create a second collection or world-item plane.
 - No consumable world items — use, craft, and evolution may exhaust or transform meaning, but must not delete physical items from the world.
 - No dashboard/admin chrome in the player surface; operator tools live behind protected routes.
 - No wall-clock world simulation; the world's pulse is its players.
@@ -189,18 +190,18 @@ World health:
 
 Economy health:
 
-- Orb faucet/sink balance per cohort week; percentage of sessions blocked on an Orb wall for a core-loop action (target: zero); pack/burn completion without support intervention; craft events per active player once crafting lands.
+- Orb faucet/sink balance per cohort week; percentage of sessions blocked on an Orb wall for a core-loop action (target: zero); linked-avatar recovery without duplication; unresolved legacy ownership-migration anomalies; craft events per active player once crafting lands.
 
 ## Risks
 
-- **Card-zone ambiguity creates duplicate authority.** Collection ownership, world possession, carried cards, equipped cards, spell preparation, and the action hand must never collapse into one field or be inferred from the browser. Migrate each legacy field through a versioned boundary and reject ambiguous state rather than guessing.
+- **Card-zone ambiguity creates duplicate authority.** World possession, carried/equipped items, spell preparation, presentation cards, legacy collection records, and the action hand must never collapse into one field or be inferred from the browser. Archive each legacy field through a versioned boundary and reject ambiguous state rather than guessing.
 - **Scene composition can become illegible.** The underlying merge may be deep while the resting surface stays small. Keep the two-card action hand, make precedence inspectable, and test that each current card and Think/Pass certificate remains current and explicit.
 - **Retention layer under-delivers.** If Journal marks feel like chores, the whole Now bet fails. Keep marks tied to genuinely novel events (truths, bonds, frontier returns, witnessed moments), never grind.
 - **Crafting opens a generative moderation surface.** AI-decorated names/blurbs on player-triggered mints must pass the same sanitizer as speech, with authored fallbacks — and recipe outputs must never be kernel-arbitrary.
 - **Moderation debt blocks launch.** One shared world with open traffic and thin filtering is an incident, not a risk. Public-traffic moderation is a P1 gate.
 - **UI creep.** Every new system (covenants, trading, crafting, media) will ask for chrome. The hand rule and transcript-first surface are product law; new surfaces must be focus states, not panels.
 - **Economy drift.** Any negative Orb ledger reason other than `community_image_generation`, or any image contribution that buys outcomes or ownership, breaks pillar 7. Review must enforce the single-sink invariant and level-sized pooled cap.
-- **Trading reintroduces speculation.** World-bound, co-signed, lineage-preserving trades are the line; hold it even when a marketplace would be easier.
+- **External ownership leaks into world authority.** Wallet custody must never become command authority, item supply, location access, action legality, or progression. Fail closed whenever an adapter cannot prove the narrow linked-avatar contract.
 - **Turn systems can suffocate a chat world.** Speech stays turn-exempt, browsing stays free, and absent players are skippable — if any of those three slips, shared rooms stop feeling alive.
 - **Scope gravity toward simulation.** Covenants, fronts, seasons, and crafting can each become a management game. Ship the smallest slice that serves a fantasy, per the RPG Bible's acceptance criteria.
 

--- a/docs/backlog/avatar-nft-only-core.md
+++ b/docs/backlog/avatar-nft-only-core.md
@@ -1,8 +1,7 @@
 # Avatar-NFT-only core grooming
 
-Status: proposed product simplification. No destructive implementation work
-begins before [#681](https://github.com/cenetex/cosyworld/issues/681) is
-accepted. Removal/isolation is tracked by
+Status: accepted product boundary as of 2026-08-09. Replay-safe removal and
+isolation are tracked by
 [#682](https://github.com/cenetex/cosyworld/issues/682), and the retained avatar
 bridge is tracked by [#688](https://github.com/cenetex/cosyworld/issues/688).
 
@@ -62,7 +61,7 @@ spell, or item without becoming a privately owned token.
 
 | Issue | Priority | Purpose |
 | --- | --- | --- |
-| [#681](https://github.com/cenetex/cosyworld/issues/681) | P1 / now | Accept the avatar-NFT-only product boundary. |
+| [#681](https://github.com/cenetex/cosyworld/issues/681) | Accepted | Avatar-NFT-only product boundary recorded in ADR 0006. |
 | [#682](https://github.com/cenetex/cosyworld/issues/682) | P1 / next, blocked | Remove keepsake/item/location NFT surfaces and isolate the avatar adapter. |
 | [#688](https://github.com/cenetex/cosyworld/issues/688) | P1 / next, blocked | Productize supported NFT avatars joining on wallet link. |
 | [#683](https://github.com/cenetex/cosyworld/issues/683) | P0 / now | Prevent actor/item art funding before the full review path is available. |
@@ -83,13 +82,17 @@ spell, or item without becoming a privately owned token.
   bridge while the decision is open.
 - Continue focused avatar-NFT work only through the actor materialization seam.
 
-### 1. Accept the boundary
+### 1. Boundary accepted — 2026-08-09
 
-- Decide #681 and move ADR 0006 from Proposed to Accepted or Rejected.
-- Record automatic exactly-once roster for every supported owned asset; room
+- ADR 0006 is Accepted and supersedes the broader ownership direction in ADR
+  0001.
+- Automatic exactly-once registration applies to every supported linked asset;
+  room
   capacity sends excess actors offstage rather than adding a second join step.
-- Decide whether Orbs remain for shared art; that should not block removal of
-  the broad collectible model.
+- The avatar is autonomous by default. Direct player control requires a
+  separate decision.
+- Orbs remain a separate shared-art question and do not block removal of the
+  broad collectible model.
 - Publish the player vocabulary: *action*, *card*, *item*, *linked avatar*,
   *Journal*, and *world pack*. No *keepsake* or *bundle* in new copy.
 
@@ -133,14 +136,16 @@ Removing keepsakes should make physical items more important, not less.
 
 ## Documentation status
 
-Until #681 is accepted, existing wallet/NFT documentation remains useful as a
-description of the live compatibility surface. It is not an invitation to add
-new product scope. `ECONOMY.md`, `ENG.md`, `PRD.md`, the player lexicon, and the
-traveler guide point here so current behavior and proposed direction are not
-confused.
+The avatar-only boundary is accepted. Existing wallet/NFT documentation may
+still describe the live compatibility surface until #682 and #685 remove it;
+those sections are implementation inventory, not product direction. New work
+and player copy follow ADR 0006. `ECONOMY.md`, `ENG.md`, `PRD.md`, the player
+lexicon, and the traveler guide distinguish that target from the migration
+surface.
 
 ## Exit criteria
 
+- [x] ADR 0006 accepts the wallet-optional, avatar-NFT-only product boundary.
 - [ ] The default/core composition starts with no wallet, ownership feed, NFT,
       Box, collection, or chain configuration.
 - [ ] A new ordinary player completes the first-session and golden-journey

--- a/docs/decisions/0001-cards-are-entitlements.md
+++ b/docs/decisions/0001-cards-are-entitlements.md
@@ -2,6 +2,11 @@
 
 - Status: Accepted
 - Date: 2026-07-16
+- Superseded in part: 2026-08-09 by
+  [ADR 0006](0006-avatar-nft-only-bridge.md). Its separation of cards from
+  canonical world entities remains authoritative; its external-card,
+  entitlement-gated-place, portable-item, Box/bundle, and general collectible
+  product direction does not.
 - Decision owners: CosyWorld maintainers
 - Related: #20, #23, #24, #25, #26, #27, #48, #51, #52
 

--- a/docs/decisions/0006-avatar-nft-only-bridge.md
+++ b/docs/decisions/0006-avatar-nft-only-bridge.md
@@ -1,7 +1,8 @@
 # ADR 0006: a wallet-optional core with an avatar-NFT-only bridge
 
-- Status: Proposed
-- Date: 2026-08-02
+- Status: Accepted
+- Proposed: 2026-08-02
+- Accepted: 2026-08-09
 - Decision issue: [#681](https://github.com/cenetex/cosyworld/issues/681)
 - Removal migration: [#682](https://github.com/cenetex/cosyworld/issues/682)
 - Avatar bridge: [#688](https://github.com/cenetex/cosyworld/issues/688)
@@ -27,7 +28,7 @@ introduce one persistent character. The Project 89 pilot in
 [#523](https://github.com/cenetex/cosyworld/issues/523) already proves this
 shape for one Proxim8 without granting its owner direct actor authority.
 
-## Proposed decision
+## Decision
 
 Make the default CosyWorld product wallet-optional and retain only an
 avatar-NFT bridge.
@@ -63,6 +64,19 @@ avatar-NFT bridge.
   Funding never creates private ownership. The future of Orbs is a separate
   question within #681.
 
+## Gameplay ownership boundary
+
+| Asset | What a wallet proves | How it plays | What it never grants |
+| --- | --- | --- | --- |
+| Supported avatar NFT | One allowlisted asset may register or recover one durable linked actor. | The actor arrives through its worldpack threshold, acts through the ordinary action/resident pipeline, and keeps one canonical history. | Direct command authority, better mechanics, exclusive actions, rewards, or place access. |
+| Item NFT | Nothing in the core product. | Items are physical world facts acquired, carried, equipped, traded, dropped, consumed, or lost through canonical play. | Item spawning, reclaiming, duplication, or wallet-derived power. |
+| Location NFT | Nothing in the shared canonical world. | Places are discovered, established, changed, and remembered through world events and worldpack policy. | Access gates, rent, topology control, renaming authority, or exclusion. |
+
+The player-facing promise is **link an avatar**, not *own a character*. The
+wallet holder controls whether the adapter may associate the asset with their
+account; the linked actor retains its own agency. Ordinary accounts and actors
+remain fully playable without a wallet.
+
 ## Retained and retired concepts
 
 | Retain | Retire from the core |
@@ -84,23 +98,44 @@ avatar-NFT bridge.
    supply authoritative asset or collection membership.
 3. Each allowlisted asset is matched to an authored actor profile and arrival
    location. Unsupported or ambiguous assets fail closed.
-4. Every supported owned asset is rostered automatically. If room capacity is
-   full, excess actors enter the offstage presence state; no second collectible-
-   style join or materialize action is required.
-5. The first automatic join writes one immutable asset-to-actor binding and one
-   typed materialization receipt before the actor enters the world.
+4. Every supported owned asset registers or recovers exactly one durable actor
+   automatically. A newly registered actor enters through its authored
+   threshold when presence permits; excess actors remain offstage. No second
+   collectible-style join or materialize action exists.
+5. The first accepted link writes one immutable asset-to-actor binding and one
+   typed first-link receipt before the actor enters the world.
 6. Reconnect, retry, refresh, and restart recover the same actor.
 7. Disconnect, unlink, capacity pressure, transfer, or revocation changes
-   roster/presence at a safe boundary; it does not delete canonical history or
-   evade an active consequence.
+   roster/presence only at a safe boundary. It cannot interrupt an active
+   consequence, delete canonical history, reset relationships, duplicate the
+   actor, or teleport it for convenience.
+8. A verified transfer changes the wallet association, not the actor. The new
+   holder recovers the same actor, Journal, Bonds, advancement, and inventory.
+   An unavailable, stale, or contradictory ownership feed freezes association
+   changes and fails closed.
+
+### Metadata and arrival items
+
+- Network, collection authority, asset id, actor id, originating worldpack,
+  actor template, first arrival, canonical name, and first-link facts are
+  pinned at the accepted link.
+- Only reviewed cosmetic appearance fields may refresh. External metadata
+  cannot author prompts, personality, memory, stats, skills, actions, items,
+  access, rewards, pack ids, or controller mode.
+- A worldpack may give the actor one bounded authored arrival kit under the
+  same budget as an ordinary authored arrival. The kit cannot derive from NFT
+  rarity or mutable metadata. Once committed, every item is an ordinary world
+  item that can be traded, lost, consumed, or stolen and cannot be respawned by
+  the wallet.
 
 ## Compatibility and migration
 
 Removal must not delete audit history or duplicate/lossily convert a live item
 or actor.
 
-1. Freeze new Box, keepsake, item/location NFT, wallet-gate, and item-
-   materialization work while #681 is open.
+1. Freeze new Box, keepsake, item/location NFT, wallet-gate, native transferable
+   card-ownership, and item-materialization product work. Only safety,
+   compatibility, archival migration, and the focused avatar adapter continue.
 2. Preserve and generalize the focused Project 89 avatar materialization seam;
    do not move wallet data into the C kernel.
 3. Inventory wallet links, ownership snapshots, burn/open receipts, item
@@ -111,7 +146,8 @@ or actor.
 6. Preserve historical records as read-only audit data until a retention policy
    explicitly permits deletion.
 7. Prove the default golden journey without the avatar adapter, then separately
-  prove every supported owned avatar joins exactly once after wallet link.
+   prove every supported linked avatar registers or recovers exactly once after
+   wallet link.
 
 The item bridge migration is tracked by
 [#685](https://github.com/cenetex/cosyworld/issues/685). Productizing the avatar
@@ -119,7 +155,7 @@ bridge is tracked by [#688](https://github.com/cenetex/cosyworld/issues/688).
 
 ## Relationship to earlier decisions
 
-If accepted, this ADR supersedes the item/location card, wallet-keepsake,
+This ADR supersedes the item/location card, wallet-keepsake,
 portable-item, Box/bundle, gated-access, and general native-ownership direction
 in [ADR 0001](0001-cards-are-entitlements.md). It retains ADR 0001's useful
 boundary: external provenance and presentation never replace canonical world

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,11 @@ do not define V2 behavior.
   consolidated story, avatar, resident, faction, item, location, map, and
   relationship review, including the Signal Anchor contract.
 - **[Product Requirements](../PRD.md)** — current product law, including the
-  card-composed world, seventh-visit priority, and acceptance criteria.
+  card-composed world, wallet-optional avatar-link boundary, seventh-visit
+  priority, and acceptance criteria.
+- **[ADR 0006: Wallet-Optional Core and Avatar-NFT-Only Bridge](decisions/0006-avatar-nft-only-bridge.md)** —
+  accepted ownership boundary: one supported asset may link one durable
+  autonomous actor; items, locations, access, and cards remain world truth.
 - **[SRD-Backed Action and Collectible System](systems/04-action-system.md)** —
   card zones, scene composition, action offers, skill charms, weapons, spells,
   and rules/pack authority.
@@ -44,8 +48,8 @@ do not define V2 behavior.
 - **[ADR 0005: Thresholds, Trails, and the Strict Referee](decisions/0005-thresholds-trails-and-strict-referee.md)** —
   topology/legibility/access/safety ownership, discovery procedures, table
   authority, Anchor/foray law, and migration compatibility.
-- **[Economy](../ECONOMY.md)** — Orbs, Boxes, packs, provenance, and the optional
-  NFT bridge.
+- **[Economy](../ECONOMY.md)** — Orbs, shared media, the optional linked-avatar
+  adapter, and the legacy Box/collection migration inventory.
 - **[AI](../AI.md)** — inference, payer modes, media, and the boundary between AI
   proposals and authoritative world state.
 

--- a/docs/systems/04-action-system.md
+++ b/docs/systems/04-action-system.md
@@ -209,13 +209,18 @@ This reuses the same inventory, artwork, provenance, trade, theft, loadout, and
 action-card UI instead of adding separate skill trees, spell books, and weapon
 panels.
 
-Collectibility and world authority are related but distinct:
+ADR 0006 supersedes the broad collectible-entitlement direction. Cards remain
+presentation and rules projections; item and location NFTs do not create
+world authority. The only external ownership bridge is one verified supported
+avatar asset linked exactly once to one durable autonomous actor.
+
+Presentation and world authority are distinct:
 
 | Collectible | What the card can represent | Authority boundary |
 | --- | --- | --- |
-| Location | Discovery, travel access, art, a route or scene-specific offer | Owning a card does not let a player rewrite a shared location. |
-| Avatar | A playable avatar, resident facet, relationship hook, or art/provenance | Owning a resident card does not grant control of the shared NPC. |
-| Item | An entitlement to materialize, equip, gift, or use an item profile | Account ownership is not the same as a shard-local world item. Materialization must be journaled and idempotent. |
+| Location | Discovery, art, a route, or a scene-specific offer | A card presents the shared location. Wallet ownership never grants access, topology, naming, or control. |
+| Avatar | A world actor, resident facet, relationship hook, or art/provenance | One allowlisted avatar NFT may establish one durable link; the actor remains autonomous and canonical. Other avatar cards grant no control. |
+| Item | A physical world item profile and its current authoritative instance | A card presents custody and use. Wallet ownership cannot materialize, reclaim, or duplicate the item. |
 | Weapon item | An equipped or played profile that qualifies or shapes Attack offers | The kernel derives the attack; the client or art never supplies damage. |
 | Skill-charm item | A physical skill and bonus worn in a bracelet slot, such as a lucky raven feather that grants `+1` to an eligible skill check | The skill and bonus belong to the charm instance and apply only while the actor possesses and equips it. |
 | Spell item | A card prepared or drawn from a spell deck that supplies one bounded Magic effect | It requires implemented targeting, timing, use, recovery, and resolver rules; prose alone has no authority. |
@@ -281,27 +286,27 @@ actor, item instance/version, exact binding/profile, settings, scene, payer,
 custody policy, and state revision before dispatch, then become busy or
 exhausted according to their mechanics.
 
-## Collection, Deck, Hand, and Card Zones
+## Items, Deck, Hand, And Legacy Card Zones
 
-The runtime uses an authoritative multi-card collection and deck model with
-clear zones:
+Physical items, prepared spells, and the action hand remain distinct. The
+current runtime also carries legacy Collection/materialization zones; ADR 0006
+freezes those as migration state for #682/#685 rather than product direction:
 
 | Zone | Meaning |
 | --- | --- |
-| Collection | Every card instance the account owns, including cards not carried by the active avatar. |
-| Carried deck | The item cards the avatar physically brings into play. Legality is derived from item weight/size, avatar carrying capacity, and equipped containers—not a fixed card count. |
+| Legacy Collection | Historical external-card/account state retained until #682 archives it; it grants no new world authority. |
+| Carried items | Physical items the avatar brings into play. Legality is derived from item weight/size, avatar carrying capacity, and equipped containers—not a fixed card count. |
 | Equipped | Persistent active cards in typed slots: bracelet charms, weapon, armor/tool, and similar roles. |
 | Spell deck/hand | Prepared spell cards and, under a declared draw profile, the currently playable subset. |
 | Action hand | Contextual server-authored offers produced from base rules, scene nouns, deck, and equipped cards. It is not itself the ownership ledger. |
 | Exhausted/discard | Temporarily unavailable item/spell cards with explicit recovery rules. |
-| World | A card instance materialized as a shard-local item at a location or in an avatar's possession. |
-| Escrow/transfer | A temporary authoritative zone used for an atomic gift, trade, or theft resolution. |
+| World | A canonical physical item at a location or in an avatar's possession. |
+| Transfer | A temporary authoritative custody state used for an atomic gift, trade, or theft resolution; it is not wallet/card ownership. |
 
-Every move between zones names the card instance, actor/account, source zone,
-destination zone, reason, and idempotency key. The server validates capacity,
-ownership, possession, access, and timing before journaling it. A client must
-never represent deck construction as a comma-separated item field or infer
-ownership from a rendered card.
+Every physical move names the item instance, actor, source zone, destination
+zone, reason, and idempotency key. The server validates capacity, custody,
+possession, access, and timing before journaling it. A client must never infer
+world ownership or possession from a rendered card.
 
 ## Scene Composition Contract
 
@@ -317,8 +322,8 @@ The composition inputs are:
 3. visible resident/avatar cards and materialized world-item cards;
 4. the active avatar's carried deck, equipped loadout, prepared spell cards,
    conditions, Calling, Bonds, and eligible Journal state; and
-5. access grants and pack contributions that are valid for this shard and
-   player.
+5. world-state requirements and pack contributions that are valid for this
+   composition and actor; wallet possession never supplies access.
 
 These inputs produce two different outputs:
 
@@ -419,11 +424,12 @@ The Menu contains:
 - **Deck & Loadout** — carried/current/max weight, size or container conflicts,
   bags, bracelet slots, equipped weapons/tools, spell deck/hand, exhausted
   cards, and validation warnings;
-- **Collection & Account** — owned cards, rarity/provenance, gifts/trades,
-  expansion entitlements, and account recovery;
-- **Sign in / Identity** — native identity, optional wallet bridge, sessions,
-  and delegated agents;
-- **World & Packs** — current shard, map, installed packs, gates, and profile;
+- **Linked Avatars & Account** — ordinary account recovery plus the optional
+  allowlisted avatar-link roster and chronicle; no item/location collection;
+- **Sign in / Identity** — native account identity, optional avatar-NFT wallet
+  link, sessions, and delegated agents;
+- **World & Packs** — current shard, map, installed packs, world-state gates,
+  and profile; wallet possession cannot mount or unlock content;
 - **Journal & Export** — Visit Ledger, public history, provenance, and journal
   export/import tools;
 - **Orbs** — balance, earn/spend history, and amplification controls; and
@@ -490,9 +496,9 @@ profile, and extension set used to produce them.
 | --- | --- | --- |
 | Rules authority | `cosyworld.srd5/1` under `cosyworld.rules/2`, startup validation, `/meta`, inspector, and exact conformance coverage. | SRD reference text remains non-executable; unsupported actions stay absent. |
 | Vocabulary and offers | Stable bindings, operations, authoritative envelopes, deterministic legal set/hand, source/target traces, and stale/tamper rejection. | Friendly labels remain pack presentation. |
-| Collectible binding | Item roles, physical zones/capacity, empty-storage-only bags, charms/slots, weapon profile, spell deck/exhaustion, receipts, theft, and provenance. | Broader armor, spell, and equipment catalogs require future authored contracts. |
+| Item/card binding | Item roles, physical zones/capacity, empty-storage-only bags, charms/slots, weapon profile, spell deck/exhaustion, receipts, theft, and provenance. | #682/#685 remove legacy collection/materialization authority; broader equipment catalogs require authored contracts. |
 | Pack composition | Reskin/offer/variant/extension schemas, mutation/conflict gates, exact deltas, fixtures, precedence, inspector output. | No implicit or load-order override path exists. |
-| Player shell | One Menu, Deck/loadout/Collection pages, materialize/return controls, terminal parity, server validation. | UI polish can evolve without changing rules. |
+| Player shell | One Menu, Deck/loadout pages, legacy Collection/materialize controls, terminal parity, server validation. | #682 removes legacy collection controls and adds the optional linked-avatar roster/chronicle. |
 | Licensing/provenance | Source/version/reference fields, compiled attributions, machine-readable modified-material report, and traceable offers. | Product-name/marketing claims still require independent review. |
 | Replay/tests | Append-only codes, profile/extension identity, offline golden replay, kernel/Rust/worldpack/browser/CLI/conformance/power gates. | A new mechanic must add its own protocol identity and fixtures. |
 

--- a/docs/systems/09-cosyworld-rpg-system.md
+++ b/docs/systems/09-cosyworld-rpg-system.md
@@ -9,10 +9,11 @@ Visit Ledger, and advancement projections are implemented in Rust over the C
 kernel. `cosyworld.srd5/1` now supplies the active stable-action profile:
 Search/Study, Influence, Help/Ready/Utilize project bindings, Attack/Dodge,
 bounded Magic, and explicit unsupported actions. The item-card layer has
-authoritative Collection/Carried/Equipped/Spell deck/Exhausted/Contained/World/
-Escrow zones, weight and size, equipped non-recursive containers, bracelet
+authoritative Carried/Equipped/Spell deck/Exhausted/Contained/World zones,
+weight and size, equipped non-recursive containers, bracelet
 slots, possession-bound skill charms, weapon profiles, executable spell cards,
-idempotent collection materialization, theft, and provenance. Deterministic
+theft, and provenance. Legacy Collection/Escrow and item-materialization state
+remains replay-readable pending #682/#685. Deterministic
 scene composition produces an internal legal deck and the current two-card
 hand for browser and terminal clients. Certified Think/Pass rotates by two and yields the turn;
 there is no complete client chooser. Legacy
@@ -28,7 +29,8 @@ Anchor files:
 - [C kernel rules](../../v2/core-c/src/cosy_kernel.c)
 - [Rust kernel bridge](../../v2/orchestrator-rust/src/kernel.rs)
 - [RPG reference shelf](../../reference-library/rpg-systems/README.md)
-- [Signal chain substrate](../../../signal/docs/decentralization-synthesis.md) — the signed-provenance-log model CosyWorld reuses for ownership (see [Ownership, Cards, And Secret Poems](#ownership-cards-and-secret-poems))
+- [ADR 0006](../decisions/0006-avatar-nft-only-bridge.md) — the accepted
+  wallet-optional, avatar-NFT-only ownership boundary.
 
 ## One-Sentence Design
 
@@ -42,7 +44,7 @@ CosyWorld is a shared-world cozy adventure RPG where you keep a home you own, fo
 - Every player-visible AI output is committed as a shared room event.
 - **The home is a sanctuary.** A player's cottage and equivalent starting homes never decay, are never invaded, and reject combat by default. Pressure is something you choose to walk toward, not something that comes to you at home.
 - **Progression is earned, never bought.** Advancement comes from play; currency buys amplification and cosmetics, never power, success, access, or rules outcomes.
-- **The collectible subject cosmology is avatar, item, and location.** Skills,
+- **The presentation subject cosmology is avatar, item, and location.** Skills,
   weapons, spells, tools, and relics are roles of playable Item cards, not new
   entity families with separate interfaces.
 - **The core loop is free.** A player with zero currency can always do the meaningful thing — listen, help, bond, travel — without paying.
@@ -55,9 +57,15 @@ CosyWorld is a shared-world cozy adventure RPG where you keep a home you own, fo
 - **The world degrades gracefully without AI.** Core world actions remain deterministic and playable when generation is unavailable. Explicit dialogue fails visibly without charge or substitute speech; incidental dialogue is skipped.
 - There are no private resident conversations in the main world loop.
 - The client never decides affordability, model access, combat outcomes, rewards, room access, inventory grants, or quest completion.
-- **Ownership is native and token-free.** Cards, items, and avatars are owned through CosyWorld's own signed provenance log (an Ed25519 + content-addressed chain, not a blockchain or token). External NFTs are an optional *bridge* that gates official expansions — never the base game's ownership layer.
-- **A private key is never a poem.** Identity and ownership are real Ed25519 keypairs held by the client. Poems unlock and gift; they do not control keys.
-- CosyWorld Core must remain playable without NFTs. Official NFTs unlock expansions, not the base game.
+- **World truth owns itself.** Actors, physical items, locations, cards, and
+  Journal history are canonical world facts. Wallet custody cannot own or gate
+  them. One verified allowlisted avatar NFT may link to one durable autonomous
+  actor without granting control or mechanical advantage.
+- **A private key is never a poem.** Poems may be authored public
+  incantations or replay-safe claim receipts; they never derive identity keys
+  or a transferable ownership layer.
+- CosyWorld Core and expansion play remain fully playable without NFTs. Wallet
+  ownership never unlocks a shared place or worldpack.
 - Rules text is original CosyWorld writing. Where adapting source wording is unavoidable, prefer CC-BY material with attribution and treat CC-BY-SA material as reference-first unless we intentionally accept share-alike obligations.
 
 ## The Player Fantasy
@@ -659,9 +667,17 @@ Keys include `actor_id`, so two players earning at the same clock in the same ti
 
 ## Ownership, Cards, And Secret Poems
 
-CosyWorld owns its things without a blockchain or a token. Ownership rides a **signed, content-addressed, append-only provenance log** — the same substrate Signal already ships ([decentralization synthesis](../../../signal/docs/decentralization-synthesis.md)): Ed25519 identity everywhere, content hashes with merkle provenance, a per-authority signed event log, and Arweave for permanence. It is closer to "git with signatures and provenance" than to Ethereum: no consensus, no gas, no token, no global state machine.
+**Ownership boundary update (2026-08-09):** ADR 0006 supersedes the
+transferable card-ownership, wallet-gated expansion, item/location NFT, and
+portable-item direction in this section. The signed provenance substrate and
+trading-card design below are retained as historical design evidence, not
+current product scope. Canonical world entities, physical item custody,
+worldpack composition, craft receipts, Journal history, and public
+incantations remain. The only supported external ownership bridge is an
+optional allowlisted avatar NFT linked exactly once to one durable autonomous
+actor.
 
-### The substrate
+### Historical signed ownership substrate — superseded
 
 - **Identity** is an Ed25519 keypair held by the client. Players and authorities (the kernel, a covenant) are pubkeys.
 - **Assets are content-addressed.** A card *type* is the hash of its definition `{art, name, tags, edition}`; a card *instance* is `card_type + serial + mint_event`, carrying a `parent_merkle` that records exactly where it came from.
@@ -670,7 +686,7 @@ CosyWorld owns its things without a blockchain or a token. Ownership rides a **s
 
 Be precise about the claim: in federation this is **verifiable and permanent**, not yet **trustless** — players trust the operator not to rewrite the log, but signatures make tampering detectable. Full trustlessness is the P2P endpoint.
 
-### Trading cards
+### Historical transferable cards — superseded
 
 A trading card is an `Item` with a chain instance behind it. Mint is bound to the moment it was earned (`because: event_id`), so a card carries its own story — *minted by calming the Moonlit Echo, Season 3*. Value is **provenance, not artificial scarcity**.
 
@@ -682,8 +698,9 @@ CosyWorld defaults to a **provenance-preserving** stance — the cozy middle bet
 
 ### Playable item cards
 
-Weapon, skill, and spell collection uses the same Item-card language as the
-rest of the world:
+Weapon, skill, and spell presentation uses the same Item-card language as the
+rest of the world while physical world instances and their custody remain
+authoritative:
 
 - A **weapon card** is equipped or played to supply an authoritative Attack
   profile.
@@ -707,17 +724,29 @@ best-in-slot power; progression remains earned through play.
 
 ### Secret poems
 
-Poems are the cozy face of cryptographic unlocks — the principle that *short phrases are mechanically real*, taken to its end. They do three distinct jobs, and the security of each is different:
+Poems remain the cozy face of authored incantations and claim receipts. The
+former transferable-card claim/gift design is superseded with the native
+ownership chain; public world-gate incantations remain valid when the kernel
+can verify them without treating the poem as a key.
 
-- **Claiming and gifting → commit-reveal claim ticket (consumable).** A card minted as a reward can carry a claim poem. To claim, you first commit `hash(poem + your_pubkey)`, then reveal — so a watcher scraping the public log cannot front-run you. Reciting binds the card to your key *once*; afterward the poem is spent and inert. Gifting a card can be as simple as whispering its poem.
+- **Historical card claiming/gifting — superseded.** The commit-reveal card
+  ticket design does not create a transferable ownership plane in the accepted
+  product. Historical receipts remain auditable.
 - **World gates → public incantation (repeatable).** A poem can be lore, not a secret: reciting it as a validated Say/Chat action triggers a kernel-checked unlock (a hidden exit, a covenant boon). Repeatable and shared — a covenant learns the Hearth-Song together. No key risk, because there is no key.
 - **Never poem-as-key.** A poem must never *derive* the owning keypair. Low-entropy brainwallets are drained by bots that pre-hash every poem ever written, and in a world where everything is public a spoken poem would be a published private key. Keys are keys; poems are tickets and incantations.
 
 Rule of thumb: card claims are **consumable** (first reciter binds it, then spent); world gates are **repeatable** (lore that spreads).
 
-### External NFT bridge
+### External avatar-NFT bridge
 
-External Solana NFTs (Ruby High cards, burnable Boxes) are an **optional bridge that gates official expansions**, not the base game's ownership layer. A held NFT can be projected into the native chain as a card and can count toward expansion access; the base game's cards, gifting, trading, and poems never require a wallet. This satisfies the invariant that CosyWorld Core is fully playable, ownable, and tradeable without NFTs.
+External ownership has one narrow effect: a protected allowlisted adapter may
+register or recover one durable autonomous actor for one verified avatar asset.
+Wallet custody supplies provenance and association, not direct control, stats,
+actions, items, rewards, location access, or worldpack mounting. Transfer and
+unlink preserve the actor's history and apply presence changes only at safe
+boundaries. Item/location NFTs, burnable Boxes, general card collections, and
+wallet-gated expansions are legacy compatibility surfaces removed through
+#682/#685. Ordinary play requires no wallet.
 
 ## Combat And Conflict
 
@@ -799,7 +828,7 @@ This is enforced as an acceptance criterion for core world rules: reaction-state
 
 ## Data Migration Direction
 
-Suggested new projection stores: `tags`, `clocks`, `bonds`, `callings`, `jobs`, `fronts`, `room_sheets`, `resident_sheets`, `covenants`, `ledger_marks`, `season_turns`, plus the ownership chain: `identities` (pubkeys), `card_instances` (with `parent_merkle`), `card_events` (the signed mint/transfer/gift/swap log), and `poem_claims` (commit-reveal state). For SQLite, flexible JSON columns are fine for effect descriptors and sheets, but index lookup fields: `scope`, `scope_id`, `status`, `zone`, `visible_to_players`, `updated_at_ms`. Keep kernel state small and deterministic; projection state can be richer as long as it cannot contradict the kernel.
+Suggested new projection stores: `tags`, `clocks`, `bonds`, `callings`, `jobs`, `fronts`, `room_sheets`, `resident_sheets`, `covenants`, `ledger_marks`, and `season_turns`. The optional avatar adapter additionally owns immutable `avatar_links`, first-link receipts, verified custody associations, and safe-boundary presence state; legacy card/Box/materialization records remain read-only migration data. For SQLite, flexible JSON columns are fine for effect descriptors and sheets, but index lookup fields: `scope`, `scope_id`, `status`, `zone`, `visible_to_players`, `updated_at_ms`. Keep kernel state small, deterministic, and wallet-blind; projection state can be richer as long as it cannot contradict the kernel.
 
 ## Implementation Roadmap
 

--- a/docs/travelers-guide.md
+++ b/docs/travelers-guide.md
@@ -35,11 +35,17 @@ people take turns so one player cannot silently act over another.
 | **Orbs** | An optional contribution to shared images, never a price on play or power. |
 
 An **action** is a legal choice you can make now. It is not owned or collected.
-An **item** is a physical thing in the shared world. A **keepsake** is an
-actor, item, or location represented in your collection; owning it does not
-replace or privately own the shared subject. A **pass** explains access to a
-gated place. A **bundle** is a one-time collection reveal from a Box. A
-**world pack** is mounted experience content.
+A **card** is the illustrated way CosyWorld presents an action, person, item,
+or place; it does not make the subject privately owned. An **item** is a
+physical thing in the shared world. A **linked avatar** is one supported
+NFT-backed character associated with a verified wallet. The character remains
+an autonomous world actor rather than a puppet or stat grant. A **world pack**
+is mounted experience content, and wallet possession cannot mount it or open a
+shared place.
+
+Legacy keepsake, Box, bundle, and wallet-pass controls may still appear while
+their receipts are migrated safely. They are compatibility surfaces, not
+future play, and they never replace world truth.
 
 Some unusual items are **curious devices**: cameras, voiceboxes, listeners,
 instruments, or stranger tools powered by an exact model. Carrying one may add
@@ -50,6 +56,27 @@ what is unavailable, but it is not dealt as an action until it can really work.
 
 Jobs, clocks, tags, rules profiles, and claim keys exist behind the surface.
 You should not need those terms to decide what to do.
+
+## Wallets And Linked Avatars
+
+A wallet is optional. Linking one asks a protected adapter whether it contains
+an avatar from an allowlisted collection. One supported asset registers or
+recovers one durable actor:
+
+1. A new actor arrives through its worldpack-authored threshold when the world
+   has room; otherwise it waits offstage.
+2. The actor uses the same legal actions, resident autonomy, consequences, and
+   Journal rules as everyone else. The wallet holder cannot command it.
+3. Reconnecting or transferring the asset recovers the same actor, history,
+   Bonds, advancement, and inventory rather than creating a copy.
+4. Unlink, revocation, or uncertain custody changes association only at a safe
+   boundary; it never interrupts an active consequence or deletes the actor.
+
+Item custody is earned and changed through world actions such as Take, Give,
+Trade, Drop, Use, and crafting. A wallet cannot spawn or reclaim an item.
+Places belong to the shared world's topology and history: they can be
+discovered, founded, changed, and remembered through play, but never owned or
+gated by an item or location NFT.
 
 ## Reading An Action
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.356",
+  "version": "0.0.357",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.356",
+      "version": "0.0.357",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.356",
+  "version": "0.0.357",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -7,7 +7,14 @@ data, and the local smoke/deployment gates.
 The older Node service remains in the repository as a legacy companion for
 integrations and migration work. Gameplay truth lives here.
 
-For the Orbs, Intricately Carved Wooden Boxes, Ruby High pack/burn adapter, and legacy migration plan, see `../ECONOMY.md`.
+ADR 0006 accepts a wallet-optional core with an avatar-NFT-only bridge. The
+Box/pack, keepsake, wallet-gate, and item/location materialization routes
+documented below are live legacy compatibility surfaces being removed through
+#682/#685; they are not product direction. New external-ownership work belongs
+only in the optional linked-avatar adapter.
+
+For Orbs, linked avatars, legacy receipt inventory, and the migration plan, see
+`../ECONOMY.md`.
 
 For free public Chat, community-funded evolving card art, combat rewards, and self-expanding swarm design, see `../AI.md`.
 

--- a/v2/docs/player-lexicon.md
+++ b/v2/docs/player-lexicon.md
@@ -1,100 +1,111 @@
 # Player lexicon
 
-CosyWorld uses different nouns for a choice, a collectible memory, access, a
-collection reveal, installed world content, and the chronicle of a place.
-Internal schemas retain their stable `card_*`, `*_card_ids`, and `pack_*`
-fields; this glossary governs player-facing copy, accessibility labels, and
-analytics names.
+ADR 0006 accepts a wallet-optional core with one narrow external concept:
+**linked avatar**. Cards present authoritative world state; items and locations
+remain shared-world facts. New player copy does not call actor/item/location
+cards owned keepsakes, does not reveal bundles, and does not describe wallet
+possession as place access.
+
+Internal schemas retain stable `card_*`, `*_card_ids`, `pack_*`, receipt, and
+legacy ownership fields through the #682/#685 migration. Those implementation
+names do not define player vocabulary.
 
 ## Canonical concepts
 
 | Concept | Player-facing noun | Ownership and authority | Lifecycle | Primary affordance |
 | --- | --- | --- | --- | --- |
 | A verb offered by the action controller | **action** | The engine derives legal actions from authoritative room state. A player chooses one; it is not owned or collected. | Replaced when room state changes; exactly two are dealt at a time. | Command-shaped button in the two-action hand; `data-player-concept="action"`. |
-| The voluntary end-of-hand control | **Think** (ordinary) / **Pass** (focused turn) | The engine certifies the actor, scene/focus, state revision, and hand generation before accepting it. It is neither an entitlement pass nor a free redeal. | Consumes one turn, journals the next deterministic hand, and becomes stale when the scene changes. | Third hand control; `data-player-concept="pass"`. |
-| An actor, item, or location representation in the collection | **keepsake** | A wallet or local collection may hold the representation. It may supply matching art or cosmetic annotation, but never replaces the world entity or changes action eligibility, order, rank, cost, odds, or effect. | Persists in the collection; up to three may be kept close. | Illustrated collection tile and details dialog; `data-player-concept="keepsake"`. |
-| Permission to enter a gated place | **pass** or **access** | A mounted world pack declares the grant; a verified entitlement provider proves it. The kernel receives only allowed/denied movement. | Dormant if its consuming world pack is unmounted; does not alter world state. | Locked-place badge reading “pass required”; `data-player-concept="pass"`. |
-| A revealable group of keepsakes | **bundle** | A verified Box receipt or trusted ownership feed associates the unopened bundle with an account. | Opened once; yields keepsakes and leaves a durable receipt. | Avatar Bundle tile and “open bundle” action; `data-player-concept="bundle"`. |
-| Installable or mounted experience content | **world pack** | The canonical world composition owns the mount decision; wallet possession cannot mount code or content. | Installed, mounted, unmounted, and version-locked by operators. | World Library entry; `data-player-concept="world-pack"`. |
-| The player-facing chronicle of a place | **Journal** | Canonical events remain world authority; the server deterministically groups their meaningful outcomes for presentation. | Current context and open threads change with state; story history remains ordered and replay-derived. | Journal toggle, semantic history entries, and useful disclosures; `data-player-concept="journal"`. |
+| The voluntary end-of-hand control | **Think** (ordinary) / **Pass** (focused turn) | The engine certifies the actor, scene/focus, state revision, and hand generation before accepting it. It is not an entitlement or a free redeal. | Consumes one turn, journals the next deterministic hand, and becomes stale when the scene changes. | Third hand control; `data-player-concept="pass"`. |
+| A visual or interaction representation | **card** | A card projects an actor, item, location, spell, or action. It never owns or replaces its subject and cannot create authority from art or text. | Reprojects from canonical state; historical art/provenance may remain inspectable. | Illustrated subject/action surface; target `data-player-concept="card"`. |
+| A supported NFT-backed actor association | **linked avatar** | A protected adapter verifies one allowlisted asset and binds it to one durable autonomous actor. Wallet custody grants association, not command authority, power, items, rewards, or access. | First link creates one binding; later links and transfers recover the same actor and history. | Linked-avatar roster/chronicle; target `data-player-concept="linked-avatar"`. |
+| A physical thing in the shared world | **item** | Custody and location come from the canonical world. A wallet cannot spawn, reclaim, or duplicate it. | May be found, carried, equipped, traded, dropped, installed, consumed, lost, or stolen under world rules. | Item card/inspector plus exact world actions; `data-player-concept="item"`. |
+| Installable or mounted experience content | **world pack** | The canonical world composition owns the mount decision. Wallet possession cannot mount content or grant access. | Installed, mounted, unmounted, and version-locked by operators. | World Library entry; `data-player-concept="world-pack"`. |
+| The player-facing chronicle of a place | **Journal** | Canonical events remain world authority; the server deterministically groups meaningful outcomes for presentation. | Current context and open threads change with state; story history remains ordered and replay-derived. | Journal toggle and semantic history; `data-player-concept="journal"`. |
 
-A **Box** keeps its proper name. It is the on-chain object consumed by the
-receipted flow that creates an Avatar Bundle; it is neither the bundle nor a
-world pack.
+Access is explained through the fiction and exact world requirement: a key,
+relationship, completed Job, represented permission, or mounted composition.
+There is no wallet-owned location **pass** in the accepted target.
+
+## Legacy compatibility vocabulary
+
+The current runtime may still expose **keepsake**, **bundle**, **Box**, and
+wallet **pass** copy while #682 removes the broad collection model and #685
+migrates materialization receipts. These nouns identify compatibility surfaces;
+they are frozen and must not appear in new product copy, new analytics, or new
+worldpack requirements.
+
+Existing accessibility selectors and analytics such as
+`data-player-concept="keepsake"`, `data-player-concept="bundle"`,
+`keepsake.open`, and `bundle.open` remain temporarily test-covered so the
+migration cannot silently strand users. #682 removes or replaces those tests
+with the target concepts above in the same change that removes the UI.
 
 ## Copy rules
 
 - Use **action** in hand instructions, turn cues, and action accessibility
   labels. “Action card” is acceptable only in developer documentation that is
   explicitly discussing the deck/hand implementation.
-- Use **keepsake** for collection tiles, entity art/details, and the “kept
-  close” loadout. Owning a keepsake never means owning the shared entity.
-- Use **pass** when the missing entitlement corresponds to a location. Use
-  **access** when no player-facing pass representation exists.
-- Use **bundle** for the one-time group revealed by the Box flow. Do not call it
-  a pack in player copy.
-- Use **world pack** in the World Library and content architecture. Do not use
-  bare “pack” when a bundle could be meant.
-- Use **Journal** for the player chronicle. Its three regions are current
-  place, open threads, and story so far. Do not call it an event Log, debug
-  console, quest dashboard, or raw history.
+- Use **card** for a visual or interaction representation. Never say that a
+  player owns the represented resident, item, or location.
+- Use **linked avatar** for a supported NFT-backed actor association. Prefer
+  “link this avatar” and “this avatar joined the world”; never “materialize,”
+  “mint,” “play as,” or “control” unless a later decision explicitly creates
+  that authority.
+- Use **item** for a physical world object. Custody is described with ordinary
+  verbs such as carry, equip, give, trade, drop, install, consume, lose, or
+  recover.
+- Explain access with the exact world requirement. Do not use wallet, NFT,
+  card ownership, or a generic pass as a substitute for world truth.
+- Use **world pack** in the World Library and content architecture.
+- Use **Journal** for the player chronicle. Its regions are current place, open
+  threads, and story so far; it is not an event log or quest dashboard.
 - Journal category labels come from the closed set **story**, **discovery**,
   **travel**, **search**, **relationship**, **growth**, **work**, **item**, and
-  **consequence**. The implementation may group multiple source events beneath
-  one entry; “story beat” is projection terminology, not required player copy.
-- Never expose **event**, **tag**, dotted event keys, source sequence numbers,
-  payload delimiters, arrow movement, or “Something changed” as Journal copy.
-  An unmapped source is omitted and reported as missing presentation coverage.
-- A Journal row is expandable only when the expanded content adds a fact. The
-  header ticker repeats the latest visible entry headline exactly.
+  **consequence**.
+- Never expose dotted event keys, source sequence numbers, payload delimiters,
+  arrow movement, or “Something changed” as Journal copy.
 
-The internal API remains compatible: `cards`, `card_id`, `required_card_id`,
-`unopened_pack_ids`, `/nft/packs/open`, and related database names do not change.
-Adapters may also continue to recognize legacy error text such as “card
-required,” but new player-visible errors use this glossary.
+The internal API remains migration-compatible: `cards`, `card_id`,
+`required_card_id`, `unopened_pack_ids`, `/nft/packs/open`, and related database
+names do not change in this decision-only revision. #682/#685 remove or archive
+them deliberately rather than reinterpreting historical records.
 
 ## Accessibility and analytics
 
-Interactive surfaces expose the same concept nouns through
-`data-player-concept`. Analytics hooks use namespaced event names rather than a
-generic `card.click` or `pack.open`:
+Target interactive surfaces expose the same concept nouns through
+`data-player-concept`. New analytics use these namespaces:
 
 | Event | Meaning |
 | --- | --- |
-| `action.select`, `action.confirm`, `action.pass` | choose, confirm, or certified Think/Pass through the two suggestions |
-| `keepsake.collection.open`, `keepsake.open`, `keepsake.toggle` | inspect the collection, inspect a keepsake, or change the kept-close loadout |
-| `bundle.open` | reveal one Avatar Bundle |
+| `action.select`, `action.confirm`, `action.pass` | choose, confirm, or Think/Pass through the two suggestions |
+| `card.open` | inspect the presentation of one world subject |
+| `linked_avatar.open`, `linked_avatar.link` | inspect or initiate the protected linked-avatar flow |
 | `world_pack.library.open` | open the mounted World Library |
 | `journal.open`, `journal.close` | open or close the player Journal |
 | `journal.entry.expand` | reveal additive context for one Journal entry |
 
-Pass requirements are currently read-only badges, so they expose a concept but
-do not emit a click event. If a pass-purchase or claim flow is added, its event
-namespace is `pass.*`. Journal entries expose no raw event identity through
-accessibility labels; the accessible headline and detail follow the same
-semantic projection as the visual row.
+Legacy collection analytics remain readable but receive no new producers after
+their migration lands. Journal entries expose no raw event identity through
+accessibility labels.
 
 ## Six-task comprehension check
-
-The UI copy contract answers these six tasks without relying on art or layout:
 
 | Task | The player should choose or identify | Required cue |
 | --- | --- | --- |
 | Make the avatar do something now | an **action** | “Choose an action below” and action-labelled hand buttons |
-| Inspect or keep a collected memory close | a **keepsake** | “your keepsakes,” “keepsake details,” and “keep close” |
-| Explain why a school room is locked | a **pass** | “Ruby High: First Bell location pass required” |
-| Reveal the contents produced by a Box | an Avatar **Bundle** | “open bundle” and “Opened avatar bundle” |
-| Find or inspect mounted experience content | a **world pack** | the World Library count and world-pack entries |
-| Review what changed in the current place | the **Journal** | current place, open threads, and story-so-far entries written as player-facing outcomes |
+| Inspect the person, thing, or place being shown | a **card** | the subject's name, kind, and inspectable world facts |
+| Understand why a wallet-linked character appears | a **linked avatar** | “linked avatar,” its authored arrival, and its continuing chronicle |
+| Explain why a route or room is unavailable | the exact world requirement | the key, relationship, Job, permission, or composition condition |
+| Find mounted experience content | a **world pack** | World Library count and world-pack entries |
+| Review what changed in the current place | the **Journal** | current place, open threads, and story-so-far outcomes |
 
-Regression tests check all six cues together and reject the former ambiguous
-phrases. A future moderated usability study can add human evidence without
-changing these baseline nouns.
+The #682 browser migration updates the current legacy comprehension test to
+these six target tasks when it removes the corresponding UI.
 
 ## Architecture relationship
 
 This is the player-facing layer of
-[ADR 0001](../../docs/decisions/0001-cards-are-entitlements.md). The ADR defines
-world entity, external card, facet, and entitlement identity. This glossary
-names how those records appear to players. World-pack compilation and API
-fields are documented separately in [Worldpacks](worldpacks.md).
+[ADR 0006](../../docs/decisions/0006-avatar-nft-only-bridge.md), which
+supersedes ADR 0001's broader external-card, entitlement, and portable-item
+product direction. World entities, physical custody, Journal events, and
+worldpack composition remain canonical authority.

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.356"
+version = "0.0.357"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What changed

- Accept ADR 0006 as the ownership boundary for CosyWorld.
- Define one supported avatar NFT as an optional, exactly-once link to one durable autonomous actor.
- Make wallet custody provenance and association only: it grants no commands, stats, items, rewards, access, or private control.
- Keep item custody and location truth inside the shared world; retire item and location NFTs from the core product.
- Define transfer, stale-custody, metadata, starting-item, and migration behavior.
- Align the product, engineering, economy, AI, RPG, action-system, player-language, and traveler documentation.
- Mark Box, pack, keepsake, wallet-gate, and materialization surfaces as legacy compatibility work tracked by #682 and #685.

## Why

Issue #681 blocked the avatar registration and legacy NFT cleanup work because ownership authority, transfer behavior, metadata authority, and item/location semantics were unresolved. This records one consistent model across the documentation before runtime migration begins.

## Impact

Ordinary play remains wallet-optional. A linked avatar keeps the same identity, history, Bonds, advancement, and world inventory across reconnects and custody changes. Items remain physical world objects, and locations remain shared world topology and history.

This pull request changes documentation and product contracts only; runtime migration remains in the downstream implementation issues.

## Validation

- `git diff --check`
- `npm run docs`
- `npm test -- --run test/v2/player-lexicon.test.mjs` — 4 passed
- Full JavaScript suite — 178 passed
- Worldpack, proof-world, and C-kernel checks passed
- `npm run v2:rust:test` passed outside the sandbox
- Architecture, lint, and syntax gates passed

Closes #681