### PR TITLE
Declare the live Bethlehem replay epoch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.355",
+  "version": "0.0.356",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.355",
+      "version": "0.0.356",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.355",
+  "version": "0.0.356",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/bethlehem/registry.json
+++ b/v2/content/bethlehem/registry.json
@@ -12,7 +12,8 @@
     "persistence_compatibility": {
       "schema_version": 1,
       "replay_compatible_bundle_hashes": [
-        "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df"
+        "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
+        "sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3"
       ]
     },
     "pack_lifecycle": {

--- a/v2/content/bethlehem/worldpack.json
+++ b/v2/content/bethlehem/worldpack.json
@@ -10,7 +10,8 @@
   "persistence_compatibility": {
     "schema_version": 1,
     "replay_compatible_bundle_hashes": [
-      "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df"
+      "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
+      "sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3"
     ]
   },
   "pack_lifecycle": {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.355"
+version = "0.0.356"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/holy-land-worldpack.test.mjs
+++ b/v2/scripts/holy-land-worldpack.test.mjs
@@ -135,13 +135,16 @@ test("the official world accepts replay from prior Holy Land bundles", () => {
   );
 });
 
-test("Bethlehem accepts the pre-context-dominant prompt bundle", () => {
+test("Bethlehem accepts every declared production replay epoch", () => {
   // #669 changed only authored voice text and prompt presentation: the world,
   // resource identities, rules profile, pack versions, and persisted-state
   // interpretation remain stable across this boundary.
+  // Tenant 7 persisted the second hash before v0.1.13; its journal uses the
+  // same canonical IDs and state interpretation as the current bundle.
   const compatible = bethlehemWorld.persistence_compatibility
     .replay_compatible_bundle_hashes;
   assert.deepEqual(compatible, [
     "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
+    "sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3",
   ]);
 });

--- a/v2/worlds/bethlehem/world.json
+++ b/v2/worlds/bethlehem/world.json
@@ -22,7 +22,8 @@
   "persistence_compatibility": {
     "schema_version": 1,
     "replay_compatible_bundle_hashes": [
-      "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df"
+      "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
+      "sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3"
     ]
   },
   "packs": [


### PR DESCRIPTION
## Summary

- declare Lonely Forest tenant 7's persisted Bethlehem bundle as replay-compatible
- regenerate the Bethlehem worldpack and registry without changing the candidate bundle identity
- lock the production replay epochs in the Holy Land contract test
- advance the synchronized runtime version to `0.0.356`

## Release context

`v0.1.13` passed the production gate and primary deployment but stopped safely before the Lonely Forest tenant backup/deploy because tenant 7's live bundle hash was not declared. The exact read-only live tenant gate now classifies tenant 7 as `declared_migration` from `sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3` to the unchanged candidate `sha256:2029c79967979ad2864570ea55708b6fdc02aced3c32ad80f88c646c330083f8`.

## Validation

- `npm test` — 178/178
- official and composed worldpacks + strict proof world
- live Lonely Forest all-tenant compatibility gate — pass
- Rust — 1,143/1,143
- kernel, architecture ceilings, Clippy ceiling, and syntax — pass
- mandatory pre-push `npm run check` — pass