### PR TITLE
Prevent adjacent-place names from certifying arrival speech

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.367",
+  "version": "0.0.368",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.367",
+      "version": "0.0.368",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.367",
+  "version": "0.0.368",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.367"
+version = "0.0.368"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.367"
+version = "0.0.368"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -63,6 +63,7 @@ pub(crate) enum PublicationCheckCode {
     // new variant never changes how an old rejection reads.
     VoiceObjectAgency,
     VoiceFallbackIdentity,
+    VoiceSignpostOpening,
 }
 
 impl PublicationCheckCode {
@@ -82,6 +83,7 @@ impl PublicationCheckCode {
             Self::VoiceProposedActionClaim => "voice_proposed_action_claim",
             Self::VoiceObjectAgency => "voice_object_agency",
             Self::VoiceFallbackIdentity => "voice_fallback_identity",
+            Self::VoiceSignpostOpening => "voice_signpost_opening",
         }
     }
 }
@@ -96,6 +98,10 @@ pub(crate) struct SpeechGateContext {
     pub(crate) mode: SpeechMode,
     pub(crate) max_words: usize,
     pub(crate) anchors: Vec<String>,
+    /// Place names that must not be used as the first words of a conversational
+    /// opening. They remain valid anchors later in the line; this only rejects
+    /// the repetitive signpost shape ("Mossbell Inn, I've arrived").
+    pub(crate) signpost_openers: Vec<String>,
     pub(crate) recent_lines: Vec<String>,
     pub(crate) recent_speaker_shingle_hashes: Vec<u64>,
     pub(crate) has_proposed_action: bool,
@@ -122,12 +128,16 @@ pub(crate) fn score_speech_candidate(
     let words = normalized_words(value);
     let candidate_words = words.iter().cloned().collect::<BTreeSet<_>>();
     let anchors = anchor_tokens(&context.anchors);
+    let place_name_tokens = anchor_tokens(&context.signpost_openers);
     let anchor_matches = candidate_words
         .iter()
         .filter(|word| {
-            anchors
+            !place_name_tokens
                 .iter()
-                .any(|anchor| anchor_words_match(word, anchor))
+                .any(|place| anchor_words_match(word, place))
+                && anchors
+                    .iter()
+                    .any(|anchor| anchor_words_match(word, anchor))
         })
         .count()
         // More than four scene references mostly rewards longer, anchor-stuffed
@@ -374,6 +384,7 @@ pub(crate) fn certified_test_speech(
         mode: SpeechMode::Prose,
         max_words: 80,
         anchors: vec!["Keeper Brass Key".to_string()],
+        signpost_openers: Vec::new(),
         recent_lines: Vec::new(),
         recent_speaker_shingle_hashes: Vec::new(),
         has_proposed_action: false,
@@ -665,11 +676,41 @@ fn evaluate_checks(
             PublicationCheckCode::VoiceFallbackIdentity,
             raw || !contains_numeric_traveler_identity(text),
         ),
+        (
+            PublicationCheckCode::VoiceSignpostOpening,
+            context.mode != SpeechMode::Prose
+                || !has_non_signpost_anchor(context)
+                || !starts_with_signpost_anchor(text, &context.signpost_openers),
+        ),
     ];
     checks
         .into_iter()
         .map(|(code, passed)| PublicationCheck { code, passed })
         .collect()
+}
+
+fn starts_with_signpost_anchor(value: &str, anchors: &[String]) -> bool {
+    let candidate = normalized_words(value);
+    anchors.iter().any(|anchor| {
+        let anchor = normalized_words(anchor);
+        !anchor.is_empty() && candidate.starts_with(&anchor)
+    })
+}
+
+fn has_non_signpost_anchor(context: &SpeechGateContext) -> bool {
+    let mut anchors = anchor_tokens(&context.anchors);
+    for signpost in &context.signpost_openers {
+        for word in normalized_words(signpost) {
+            anchors.remove(&word);
+        }
+    }
+    // The speaker's own name is prompt identity, not a natural scene detail.
+    // Counting it here would claim every solitary scene has an easy alternative
+    // and could turn the signpost check into a bounded but fruitless retry loop.
+    for word in normalized_words(&context.speaker_name) {
+        anchors.remove(&word);
+    }
+    !anchors.is_empty()
 }
 
 fn contains_numeric_traveler_identity(value: &str) -> bool {
@@ -1532,12 +1573,27 @@ mod tests {
             mode: SpeechMode::Prose,
             max_words: 8,
             anchors: anchors.to_vec(),
+            signpost_openers: Vec::new(),
             recent_lines: recent.to_vec(),
             recent_speaker_shingle_hashes: Vec::new(),
             has_proposed_action: false,
             envelope_valid: true,
             candidate_round: 1,
         }
+    }
+
+    #[test]
+    fn a_place_only_scene_does_not_enter_a_signpost_rejection_loop() {
+        let place = "Moonlit Trail".to_string();
+        let mut gate = context(std::slice::from_ref(&place), &[]);
+        gate.signpost_openers = vec![place.clone()];
+        certify_speech(
+            None,
+            completion("Moonlit Trail is quiet."),
+            "Moonlit Trail is quiet.",
+            gate,
+        )
+        .expect("without another usable anchor, the required place anchor remains eligible");
     }
 
     fn rejected_code(text: &str, context: SpeechGateContext) -> PublicationCheckCode {
@@ -2165,6 +2221,19 @@ mod tests {
     }
 
     #[test]
+    fn place_names_do_not_inflate_candidate_grounding_rank() {
+        let mut gate = context(&["Moonlit Trail".to_string(), "teapot".to_string()], &[]);
+        gate.signpost_openers = vec!["Moonlit Trail".to_string()];
+
+        let place_only = score_speech_candidate("I have reached Moonlit Trail.", &gate);
+        let scene_detail = score_speech_candidate("The teapot is warm.", &gate);
+
+        assert_eq!(place_only.anchor_matches, 0);
+        assert_eq!(scene_detail.anchor_matches, 1);
+        assert!(scene_detail > place_only);
+    }
+
+    #[test]
     fn voice_unsafe_tone_check_is_deterministic() {
         let anchors = vec!["teapot".to_string()];
         assert_eq!(
@@ -2430,6 +2499,7 @@ mod tests {
                 mode: SpeechMode::Prose,
                 max_words: 20,
                 anchors: vec!["teapot".to_string()],
+                signpost_openers: Vec::new(),
                 recent_lines: Vec::new(),
                 recent_speaker_shingle_hashes: Vec::new(),
                 has_proposed_action: false,
@@ -2492,6 +2562,7 @@ mod tests {
                 mode: SpeechMode::Prose,
                 max_words: 12,
                 anchors: vec!["teapot".to_string()],
+                signpost_openers: Vec::new(),
                 recent_lines: Vec::new(),
                 recent_speaker_shingle_hashes: Vec::new(),
                 has_proposed_action: false,

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -746,6 +746,9 @@ fn retry_instruction(
     if failed.contains(&PublicationCheckCode::VoiceObjectAgency) {
         clauses.push("objects don't think or choose".to_string());
     }
+    if failed.contains(&PublicationCheckCode::VoiceSignpostOpening) {
+        clauses.push("start with a person, object, action, or sensation · mention the place later only if it matters".to_string());
+    }
     (!clauses.is_empty()).then(|| format!("again · {}", clauses.join(" · ")))
 }
 
@@ -1863,6 +1866,7 @@ mod tests {
             mode: crate::ai_publication::SpeechMode::Prose,
             max_words: 20,
             anchors: vec!["teapot".to_string()],
+            signpost_openers: Vec::new(),
             recent_lines: Vec::new(),
             recent_speaker_shingle_hashes: Vec::new(),
             has_proposed_action: false,
@@ -2680,6 +2684,39 @@ mod tests {
         assert_eq!(
             users[1],
             "raw scene\nagain · one complete response · at most 64 words · touch something already present"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_signpost_retry_names_a_non_location_way_to_begin() {
+        let config = single_candidate(VoiceRoutingConfig {
+            max_attempts: 2,
+            hedge_width: 1,
+            ..VoiceRoutingConfig::default()
+        });
+        let backend = MockBackend::with_outputs([
+            ("provider/tiny-a", "Moonlit Trail at last!", 0),
+            ("provider/tiny-a", "The teapot is warm.", 0),
+        ]);
+        let mut publication_gate = gate("signpost-feedback-beat");
+        publication_gate.anchors = vec!["Moonlit Trail".to_string(), "teapot".to_string()];
+        publication_gate.signpost_openers = vec!["Moonlit Trail".to_string()];
+
+        let certified = route_certified_voice_with(
+            &config,
+            None,
+            request("dialogue_avatar"),
+            publication_gate,
+            Arc::new(backend.clone()),
+        )
+        .await
+        .expect("the signpost-corrected retry certifies");
+
+        assert_eq!(certified.text(), "The teapot is warm.");
+        let (systems, _) = backend.rendered_prompts();
+        assert_eq!(
+            systems[1],
+            "Write one short anchored line.\nagain · start with a person, object, action, or sensation · mention the place later only if it matters"
         );
     }
 

--- a/v2/orchestrator-rust/src/avatar_context_spine.rs
+++ b/v2/orchestrator-rust/src/avatar_context_spine.rs
@@ -172,6 +172,12 @@ pub(crate) struct AvatarContextSpine {
     pub(crate) recent_dialogue: Vec<AvatarContextDialogueTurn>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) recent_activity: Vec<String>,
+    /// Current or non-local place names that are actually present in this
+    /// conversation context. The voice publication gate uses these as typed
+    /// provenance so an adjacent place mentioned by a pathway event cannot be
+    /// mistaken for the room the speaker currently occupies.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) known_place_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) recollection_candidates: Vec<AvatarContextRecollection>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -681,10 +687,52 @@ impl RuntimeWorld {
                 .into_iter()
                 .map(|line| line.replace(&authored_actor_name, &grounded_actor_name))
                 .collect(),
+            known_place_names: Vec::new(),
             recollection_candidates,
             selected_recollections: Vec::new(),
             self_description_due,
         };
+        let contextual_text = std::iter::once(spine.current_beat.as_str())
+            .chain(
+                spine
+                    .incoming_turn
+                    .iter()
+                    .flat_map(|turn| [turn.speaker_name.as_str(), turn.content.as_str()]),
+            )
+            .chain(
+                spine
+                    .location_evidence
+                    .iter()
+                    .map(|evidence| evidence.text.as_str()),
+            )
+            .chain(
+                spine
+                    .public_room_memory
+                    .iter()
+                    .map(|evidence| evidence.text.as_str()),
+            )
+            .chain(spine.recent_activity.iter().map(String::as_str))
+            .chain(
+                spine
+                    .recent_dialogue
+                    .iter()
+                    .map(|turn| turn.content.as_str()),
+            )
+            .chain(spine.goals.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase();
+        spine.known_place_names = self
+            .locations
+            .iter()
+            .filter(|(location_id, name)| {
+                **location_id == actor.location_id || contextual_text.contains(&name.to_lowercase())
+            })
+            .map(|(_, name)| name.clone())
+            .filter(|name| !name.trim().is_empty())
+            .collect();
+        spine.known_place_names.sort();
+        spine.known_place_names.dedup();
         spine.refresh_semantic_recollections();
         Some(spine)
     }

--- a/v2/orchestrator-rust/src/avatar_reflections.rs
+++ b/v2/orchestrator-rust/src/avatar_reflections.rs
@@ -482,6 +482,7 @@ fn reflection_gate(job: &AvatarReflectionJob) -> SpeechGateContext {
             AvatarReflectionKind::Dream => 75,
         },
         anchors,
+        signpost_openers: Vec::new(),
         recent_lines: job.recent_lines.clone(),
         recent_speaker_shingle_hashes: Vec::new(),
         has_proposed_action: false,
@@ -665,6 +666,7 @@ async fn complete_avatar_self_description(
             mode: speech_mode,
             max_words: SELF_DESCRIPTION_MAX_WORDS,
             anchors: spine.anchors(AvatarContextMode::SelfDescription),
+            signpost_openers: Vec::new(),
             recent_lines: spine
                 .recent_dialogue
                 .iter()
@@ -805,6 +807,7 @@ async fn complete_world_entity_self_description(
             mode: SpeechMode::Prose,
             max_words,
             anchors: spine.anchors(),
+            signpost_openers: Vec::new(),
             recent_lines: spine
                 .selected_recollections
                 .iter()
@@ -1097,6 +1100,7 @@ mod tests {
                 mode: SpeechMode::Prose,
                 max_words: 8,
                 anchors: vec!["Teapot".to_string()],
+                signpost_openers: Vec::new(),
                 recent_lines: Vec::new(),
                 recent_speaker_shingle_hashes: Vec::new(),
                 has_proposed_action: false,

--- a/v2/orchestrator-rust/src/prompts.rs
+++ b/v2/orchestrator-rust/src/prompts.rs
@@ -555,7 +555,7 @@ fn avatar_chat_prompt(plan: &AvatarChatPlan, followup: bool) -> PromptEnvelope {
             )
         } else {
             format!(
-                "Open a conversation with {} because {}'s controller selected Chat. Follow a concrete live detail, preference, curiosity, or open thread. Do not ask about real-world work or tasks, and do not merely mirror a prior question.",
+                "Open a conversation with {} because {}'s controller selected Chat. Begin with a concrete live detail, preference, curiosity, or open thread rather than announcing a place name. Do not ask about real-world work or tasks, and do not merely mirror a prior question.",
                 plan.target_actor_name, plan.actor_name
             )
         },
@@ -752,7 +752,7 @@ fn resident_voice_prompt(plan: &AvatarReplyPlan, planning_brief: &str) -> Prompt
         )
     } else {
         format!(
-            "Give {}'s immediate in-world response to the current beat. Prefer a concrete reaction, preference, or self-directed intention over generic assistance. {}",
+            "Give {}'s immediate in-world response to the current beat. Begin with a concrete reaction, preference, or self-directed intention rather than announcing a place name. {}",
             plan.speaker_name, planning_brief
         )
     };
@@ -832,6 +832,16 @@ fn resident_voice_action_brief(action: &AvatarProposedAction) -> String {
     action.kind.replace('_', " ")
 }
 
+fn opening_place_names(current: &str, spine: &AvatarContextSpine) -> Vec<String> {
+    let mut names = std::iter::once(current.to_string())
+        .chain(spine.known_place_names.iter().cloned())
+        .filter(|name| !name.trim().is_empty())
+        .collect::<Vec<_>>();
+    names.sort_by_key(|name| name.to_lowercase());
+    names.dedup_by(|left, right| left.eq_ignore_ascii_case(right));
+    names
+}
+
 fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGateContext {
     let recent_lines = if followup && !plan.exchange_turns.is_empty() {
         plan.exchange_turns
@@ -895,6 +905,11 @@ fn avatar_chat_gate_context(plan: &AvatarChatPlan, followup: bool) -> SpeechGate
         mode: SpeechMode::Prose,
         max_words: if followup { 28 } else { 34 },
         anchors,
+        signpost_openers: if followup {
+            Vec::new()
+        } else {
+            opening_place_names(&plan.location_name, &plan.context_spine)
+        },
         recent_lines,
         recent_speaker_shingle_hashes: plan.recent_speaker_shingle_hashes.clone(),
         has_proposed_action: false,
@@ -960,6 +975,11 @@ fn resident_gate_context(plan: &AvatarReplyPlan, has_proposed_action: bool) -> S
         mode: SpeechMode::from_name(&plan.speech_mode),
         max_words: resident_word_budget(plan),
         anchors,
+        signpost_openers: if plan.incoming_turn.is_some() {
+            Vec::new()
+        } else {
+            opening_place_names(&plan.location_name, &plan.context_spine)
+        },
         recent_lines: plan.recent_lines.clone(),
         recent_speaker_shingle_hashes: plan.resident_continuity.recent_voice_shingle_hashes.clone(),
         has_proposed_action,
@@ -1344,6 +1364,117 @@ mod publication_tests {
                 context.anchors
             );
         }
+    }
+
+    /// The residual #553 case after present-cast grounding shipped in #620:
+    /// pathway discovery is visible at both ends, so its narration enters the
+    /// current room's activity and anchor set while naming a different place.
+    /// The other place remains discussable, but cannot masquerade as the
+    /// speaker's location by opening a line like an arrival signpost.
+    #[test]
+    fn adjacent_pathway_place_is_context_not_an_arrival_signpost() {
+        let mut runtime = RuntimeWorld::seeded();
+        let current_name = runtime
+            .location_name(COSY_COTTAGE_LOCATION_ID)
+            .expect("seeded current place has a name");
+        let adjacent_name = runtime
+            .location_name(MOONLIT_TRAIL_LOCATION_ID)
+            .expect("seeded adjacent place has a name");
+        runtime.event_log.push(EventView {
+            seq: runtime.world.next_event_seq,
+            type_name: "pathway.discovered".to_string(),
+            success: true,
+            actor_id: Some(RATI_ACTOR_ID),
+            actor_name: Some("Rati".to_string()),
+            location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            location_name: Some(current_name),
+            destination_location_id: Some(MOONLIT_TRAIL_LOCATION_ID),
+            destination_location_name: Some(adjacent_name.clone()),
+            content: Some(format!(
+                "Rati reads the ground beyond the cottage. A way into {adjacent_name} takes shape."
+            )),
+            ..EventView::default()
+        });
+
+        let chat = runtime
+            .avatar_chat_plan_for(RATI_ACTOR_ID, 1002)
+            .expect("seeded cottage avatars can chat");
+        let context = avatar_chat_gate_context(&chat, false);
+        assert!(
+            context
+                .anchors
+                .iter()
+                .any(|anchor| anchor.contains(&adjacent_name)),
+            "pathway narration really does put the adjacent place in the anchor set: {:?}",
+            context.anchors
+        );
+        assert!(
+            context
+                .signpost_openers
+                .iter()
+                .any(|name| name == &adjacent_name),
+            "typed place provenance must survive alongside the free-form anchor text: {:?}",
+            context.signpost_openers
+        );
+
+        let wrong_place_opening = format!("{adjacent_name} at last!");
+        let rejection = certify_speech(
+            None,
+            gate_completion(&wrong_place_opening),
+            &wrong_place_opening,
+            context.clone(),
+        )
+        .expect_err("an adjacent place cannot certify as the speaker's arrival location");
+        assert_eq!(
+            rejection.failure_code,
+            PublicationCheckCode::VoiceSignpostOpening
+        );
+        assert!(
+            rejection.receipt.checks.iter().any(|check| {
+                check.code == PublicationCheckCode::VoiceAnchorMissing && check.passed
+            }),
+            "the adjacent name would have passed the old anchor gate"
+        );
+
+        let current_place_opening = format!("{} at last!", chat.location_name);
+        let rejection = certify_speech(
+            None,
+            gate_completion(&current_place_opening),
+            &current_place_opening,
+            context.clone(),
+        )
+        .expect_err("the current room name is not a conversational opening either");
+        assert_eq!(
+            rejection.failure_code,
+            PublicationCheckCode::VoiceSignpostOpening
+        );
+
+        let grounded_reference = format!("The way into {adjacent_name} has opened; shall we look?");
+        certify_speech(
+            None,
+            gate_completion(&grounded_reference),
+            &grounded_reference,
+            context,
+        )
+        .expect("an adjacent place remains discussable as a discovered route");
+    }
+
+    #[test]
+    fn directed_replies_do_not_apply_the_opening_signpost_check() {
+        let (chat, reply) = seeded_plans();
+        assert!(
+            avatar_chat_gate_context(&chat, true)
+                .signpost_openers
+                .is_empty(),
+            "a follow-up line is not a conversation opening"
+        );
+        assert!(reply.incoming_turn.is_some());
+        assert!(
+            resident_gate_context(&reply, false)
+                .signpost_openers
+                .is_empty(),
+            "a directed reply is not an ambient opening"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- preserve typed place-name provenance in avatar conversation context
- reject current or adjacent place names used as GPS-style opening signposts while keeping grounded later references valid
- exempt directed replies, non-prose modes, and place-only scenes to avoid retry loops
- remove place-name tokens from candidate grounding rewards and provide bounded retry guidance
- add regressions for the residual adjacent-place pathway case left after #620

## Why

`pathway.discovered` narration is visible at both endpoints and could add an adjacent place name to the speech anchor set. A generated line could therefore announce the wrong place as an arrival and still pass deterministic grounding.

## Validation

- full pre-push `npm run check`
- 176/176 Node tests
- 1126/1126 orchestrator tests plus library/bin/doc tests
- all worldpack compositions and strict proof-world checks
- kernel, architecture, formatting, syntax, and version checks

Closes #553