### PR TITLE
Ground generated route names without leaking endpoint provenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.368",
+  "version": "0.0.369",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.368",
+      "version": "0.0.369",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.368",
+  "version": "0.0.369",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.368"
+version = "0.0.369"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.368"
+version = "0.0.369"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -7228,8 +7228,11 @@
           const routeTargetPrefix = searchingPathway
             ? (routeVerbLower.endsWith(" toward") ? "" : "toward ")
             : (fleeing ? "" : (routeVerbLower.endsWith(" to") ? "" : "to "));
-          const routeAccessibleLabel = targetBearingLabel(routeIntention, routeVerb, firstExit.destination_location_name);
           const routeLabel = String(firstExit.route_label || "").trim();
+          const routeTargetLabel = targetBearingLabel(routeIntention, routeVerb, firstExit.destination_location_name);
+          const routeAccessibleLabel = onePath && routeLabel
+            ? `${routeTargetLabel} via ${routeLabel}`
+            : routeTargetLabel;
           const routeGuidance = onePath
             && !searchingPathway
             && !fleeing

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -10067,41 +10067,7 @@ impl RuntimeWorld {
                     refined.familiar |= current.familiar;
                     refined.traffic_count = current.traffic_count;
                     refined.way_class = PathwayWayClass::for_traffic(refined.traffic_count);
-                    let current_waypoint_ids = current
-                        .waypoints
-                        .iter()
-                        .map(|waypoint| waypoint.id)
-                        .collect::<BTreeSet<_>>();
-                    let mut occupied_names = self
-                        .generated_pathways
-                        .values()
-                        .filter(|existing| existing.id != refined.id)
-                        .flat_map(|existing| existing.waypoints.iter())
-                        .map(|waypoint| waypoint.name.to_ascii_lowercase())
-                        .chain(
-                            self.locations
-                                .iter()
-                                .filter(|(location_id, _)| {
-                                    !current_waypoint_ids.contains(location_id)
-                                })
-                                .map(|(_, name)| name.to_ascii_lowercase()),
-                        )
-                        .collect::<BTreeSet<_>>();
-                    let pathway_canonical_id = refined.canonical_id.clone();
-                    for (index, (waypoint, fallback)) in refined
-                        .waypoints
-                        .iter_mut()
-                        .zip(&current.waypoints)
-                        .enumerate()
-                    {
-                        waypoint.name = reserve_unique_pathway_name(
-                            &mut occupied_names,
-                            &waypoint.name,
-                            &fallback.name,
-                            &pathway_canonical_id,
-                            index,
-                        );
-                    }
+                    self.reserve_refined_generated_pathway_names(&current, &mut refined);
                     for waypoint in &refined.waypoints {
                         self.locations.insert(waypoint.id, waypoint.name.clone());
                         self.location_meta
@@ -10179,6 +10145,27 @@ impl RuntimeWorld {
                     {
                         continue;
                     }
+                    if !self.generated_pathways.contains_key(&proposed_pathway.id) {
+                        self.reserve_unique_generated_pathway_names(&mut proposed_pathway);
+                    }
+                    let name_changes = pathway
+                        .waypoints
+                        .iter()
+                        .zip(&proposed_pathway.waypoints)
+                        .filter(|(proposed, committed)| proposed.name != committed.name)
+                        .map(|(proposed, committed)| {
+                            (proposed.name.clone(), committed.name.clone())
+                        })
+                        .collect::<Vec<_>>();
+                    let mut committed_narration = narration.clone();
+                    for (index, (previous_name, _)) in name_changes.iter().enumerate() {
+                        committed_narration = committed_narration
+                            .replace(previous_name, &format!("{{route-waypoint-name-{index}}}"));
+                    }
+                    for (index, (_, committed_name)) in name_changes.iter().enumerate() {
+                        committed_narration = committed_narration
+                            .replace(&format!("{{route-waypoint-name-{index}}}"), committed_name);
+                    }
                     let mut next_pathway = self
                         .generated_pathways
                         .get(&proposed_pathway.id)
@@ -10201,6 +10188,13 @@ impl RuntimeWorld {
                         next_pathway.traffic_count.saturating_add(traffic_delta);
                     next_pathway.way_class =
                         PathwayWayClass::for_traffic(next_pathway.traffic_count);
+                    for waypoint in &next_pathway.waypoints {
+                        if let Some(location_name) = self.locations.get_mut(&waypoint.id) {
+                            *location_name = waypoint.name.clone();
+                            self.location_meta
+                                .insert(waypoint.id, waypoint.meta.clone());
+                        }
+                    }
                     self.generated_pathways
                         .insert(next_pathway.id.clone(), next_pathway.clone());
                     if let Some(journey) = journey {
@@ -10218,7 +10212,7 @@ impl RuntimeWorld {
                     let event = self.append_journey_event(
                         event_type,
                         action.actor_id,
-                        narration,
+                        &committed_narration,
                         journey_destination,
                     );
                     for (from_location_id, to_location_id) in reveal_edges {
@@ -42930,10 +42924,6 @@ mod tests {
             Some(first_waypoint_id),
             "the route handoff points at the newly revealed waypoint"
         );
-        assert!(first_travel_offer
-            .accessible_label
-            .starts_with("Travel to "));
-
         let (first_travel, mut first_travel_mutation, first_travel_narration) = runtime
             .plan_journey_move(5000, first_waypoint_id)
             .expect("first segment travel planning succeeds")

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -148,7 +148,7 @@ impl PathwayWayClass {
     }
 }
 
-pub(super) fn pathway_anchor_name_token(name: &str) -> String {
+fn legacy_pathway_anchor_name_token(name: &str) -> String {
     name.split_whitespace()
         .find_map(|word| {
             let word = word
@@ -160,32 +160,108 @@ pub(super) fn pathway_anchor_name_token(name: &str) -> String {
         .unwrap_or_else(|| "Known".to_string())
 }
 
+const PATHWAY_NAME_ADJECTIVES: &[&str] = &[
+    "Amber",
+    "Autumn",
+    "Bright",
+    "Dappled",
+    "Dawnlit",
+    "Dewy",
+    "Fern-Green",
+    "Golden",
+    "Heathered",
+    "Hushed",
+    "Lantern-Lit",
+    "Misty",
+    "Moonlit",
+    "Mossy",
+    "Rain-Silver",
+    "Reed-Green",
+    "Russet",
+    "Shaded",
+    "Soft",
+    "Starry",
+    "Sunlit",
+    "Twilight",
+    "Warm",
+    "Willow-Pale",
+];
+
+const PATHWAY_NAME_ECOLOGY: &[&str] = &[
+    "Bluebell", "Bramble", "Cedar", "Clover", "Fern", "Foxglove", "Hawthorn", "Heather", "Juniper",
+    "Lantern", "Lichen", "Meadow", "Moss", "Orchard", "Pine", "Primrose", "Reed", "Rosemary",
+    "Rowan", "Sage", "Thistle", "Willow", "Woodbine", "Yarrow",
+];
+
+const PATHWAY_NAME_FEATURES: &[&str] = &[
+    "Bend",
+    "Brook",
+    "Crossing",
+    "Dell",
+    "Fold",
+    "Glade",
+    "Grove",
+    "Hollow",
+    "Mile",
+    "Reach",
+    "Rise",
+    "Run",
+    "Steps",
+    "Turn",
+    "Vale",
+    "Verge",
+    "Walk",
+    "Way",
+    "Wold",
+    "Meander",
+    "Passage",
+    "Promenade",
+    "Terrace",
+    "Trace",
+];
+
+const PATHWAY_PROSE_NAME_VARIANTS: u64 = (PATHWAY_NAME_ADJECTIVES.len()
+    * PATHWAY_NAME_ECOLOGY.len()
+    * PATHWAY_NAME_FEATURES.len()) as u64;
+
+pub(super) fn deterministic_pathway_fallback_name(
+    pathway_canonical_id: &str,
+    waypoint_index: usize,
+) -> String {
+    deterministic_pathway_prose_name(pathway_canonical_id, waypoint_index, 0)
+}
+
+fn deterministic_pathway_prose_name(
+    pathway_canonical_id: &str,
+    waypoint_index: usize,
+    variant: u64,
+) -> String {
+    assert!(
+        variant < PATHWAY_PROSE_NAME_VARIANTS,
+        "pathway prose-name namespace exhausted"
+    );
+    let seed = stable_pathway_hash(&format!("{pathway_canonical_id}:{waypoint_index}"));
+    let slot = (seed % PATHWAY_PROSE_NAME_VARIANTS + variant) % PATHWAY_PROSE_NAME_VARIANTS;
+    let slot = slot as usize;
+    let ecology_and_feature_slots = PATHWAY_NAME_ECOLOGY.len() * PATHWAY_NAME_FEATURES.len();
+    format!(
+        "{} {} {}",
+        PATHWAY_NAME_ADJECTIVES[slot / ecology_and_feature_slots],
+        PATHWAY_NAME_ECOLOGY[(slot / PATHWAY_NAME_FEATURES.len()) % PATHWAY_NAME_ECOLOGY.len()],
+        PATHWAY_NAME_FEATURES[slot % PATHWAY_NAME_FEATURES.len()],
+    )
+}
+
 pub(super) fn deterministic_pathway_collision_name(
     pathway_canonical_id: &str,
     waypoint_index: usize,
-    fallback_name: &str,
     collision_attempt: u64,
 ) -> String {
-    let mut value = stable_pathway_hash(&format!("{pathway_canonical_id}:{waypoint_index}"));
-    let mut token = String::with_capacity(5);
-    for _ in 0..5 {
-        token.push(char::from(b'a' + (value % 26) as u8));
-        value /= 26;
-    }
-    if collision_attempt == 0 {
-        return format!("{fallback_name}-{token}");
-    }
-    let mut attempt = collision_attempt - 1;
-    let mut attempt_token = String::new();
-    loop {
-        attempt_token.push(char::from(b'a' + (attempt % 26) as u8));
-        if attempt < 26 {
-            break;
-        }
-        attempt = attempt / 26 - 1;
-    }
-    let attempt_token = attempt_token.chars().rev().collect::<String>();
-    format!("{fallback_name}-{token}-{attempt_token}")
+    deterministic_pathway_prose_name(
+        pathway_canonical_id,
+        waypoint_index,
+        collision_attempt.saturating_add(1),
+    )
 }
 
 pub(super) fn reserve_unique_pathway_name(
@@ -206,7 +282,6 @@ pub(super) fn reserve_unique_pathway_name(
         let candidate = deterministic_pathway_collision_name(
             pathway_canonical_id,
             waypoint_index,
-            fallback_name,
             collision_attempt,
         );
         if occupied_names.insert(candidate.to_ascii_lowercase()) {
@@ -216,6 +291,22 @@ pub(super) fn reserve_unique_pathway_name(
             .checked_add(1)
             .expect("pathway collision namespace exhausted");
     }
+}
+
+pub(super) fn strip_legacy_pathway_endpoint_prefix(
+    name: &str,
+    origin_name: &str,
+    destination_name: &str,
+) -> Option<String> {
+    let prefix = format!(
+        "{}-{} ",
+        legacy_pathway_anchor_name_token(origin_name),
+        legacy_pathway_anchor_name_token(destination_name),
+    );
+    name.strip_prefix(&prefix)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
 }
 
 fn generated_pathway_edge_direction(
@@ -563,8 +654,11 @@ impl RuntimeWorld {
         );
         offer.verb = verb.clone();
         offer.label = label.clone();
-        offer.accessible_label =
-            self.action_offer_accessible_label(&offer.kind, &verb, &label, Some(&target), None);
+        offer.accessible_label = format!(
+            "{} via {}",
+            self.action_offer_accessible_label(&offer.kind, &verb, &label, Some(&target), None),
+            exit.route_label,
+        );
         offer.command = normalize_command_text(&format!(
             "{} {}",
             if offer.kind == "flee" {
@@ -753,7 +847,7 @@ mod tests {
     }
 
     #[test]
-    fn route_labels_are_directional_and_traffic_does_not_reallocate_identity() {
+    fn route_grounding_labels_are_directional_and_traffic_preserves_identity() {
         let mut runtime = RuntimeWorld::seeded();
         let mut pathway = runtime
             .generated_pathway(RATI_ACTOR_ID, 700, 712, 2)
@@ -867,6 +961,18 @@ mod tests {
             runtime.route_label_for_edge(712, waypoint_id),
             "Highway from Jerusalem to Bethlehem"
         );
+    }
+
+    #[test]
+    fn route_grounding_collision_namespace_does_not_cycle_at_ten_thousand_names() {
+        let canonical_id = "generated-pathway:route://test/example@1";
+        let names = (0..10_000)
+            .map(|attempt| deterministic_pathway_collision_name(canonical_id, 0, attempt))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(names.len(), 10_000);
+        assert!(names
+            .iter()
+            .all(|name| sanitize_generated_pathway_name(name).is_some()));
     }
 
     #[test]
@@ -1013,6 +1119,19 @@ mod tests {
                         .as_deref()
                         .is_some_and(|label| offer.label.contains(label))
             }) && offer.route.is_some()
+        }));
+        assert!(direct_offers.iter().all(|offer| {
+            let target = offer.target.as_ref().expect("route target");
+            let exit = exits
+                .iter()
+                .find(|exit| Some(exit.destination_location_id) == target.id)
+                .expect("matching exit");
+            offer.accessible_label
+                == format!(
+                    "Travel to {} via {}",
+                    target.label.as_deref().unwrap(),
+                    exit.route_label
+                )
         }));
         assert!(
             direct_offers.iter().all(|offer| {

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -162,6 +162,41 @@ fn generated_route_id(pathway: &GeneratedPathwayState, left: u64, right: u64) ->
     Some(format!("{pathway_id}/route/{segment}"))
 }
 
+pub(super) fn rename_generated_waypoint_prose(waypoint: &mut GeneratedWaypointState, name: String) {
+    let previous_name = std::mem::replace(&mut waypoint.name, name.clone());
+    if previous_name == name {
+        return;
+    }
+    waypoint.meta.title = waypoint.meta.title.replace(&previous_name, &name);
+    waypoint.meta.description = waypoint.meta.description.replace(&previous_name, &name);
+    waypoint.meta.persona = waypoint.meta.persona.replace(&previous_name, &name);
+    for memory in &mut waypoint.meta.memory {
+        *memory = memory.replace(&previous_name, &name);
+    }
+    if let Some(art_prompt) = waypoint.meta.art_prompt.as_mut() {
+        *art_prompt = art_prompt.replace(&previous_name, &name);
+    }
+}
+
+fn reserve_pathway_names_in_namespace(
+    pathway: &mut GeneratedPathwayState,
+    occupied_names: &mut BTreeSet<String>,
+) {
+    let pathway_canonical_id = pathway.canonical_id.clone();
+    for (index, waypoint) in pathway.waypoints.iter_mut().enumerate() {
+        let proposed_name = waypoint.name.clone();
+        let fallback_name = deterministic_pathway_fallback_name(&pathway_canonical_id, index);
+        let reserved_name = reserve_unique_pathway_name(
+            occupied_names,
+            &proposed_name,
+            &fallback_name,
+            &pathway_canonical_id,
+            index,
+        );
+        rename_generated_waypoint_prose(waypoint, reserved_name);
+    }
+}
+
 impl RouteRecordState {
     pub(super) fn contains_edge(&self, from_location_id: u64, to_location_id: u64) -> bool {
         self.edges.iter().any(|edge| {
@@ -330,6 +365,7 @@ impl RuntimeWorld {
         historical_bundle_hash: &str,
     ) -> Result<(), String> {
         let pathway_ids = self.generated_pathways.keys().cloned().collect::<Vec<_>>();
+        let mut pathways = BTreeMap::new();
         for pathway_id in pathway_ids {
             let mut pathway = self
                 .generated_pathways
@@ -341,8 +377,32 @@ impl RuntimeWorld {
                 snapshot_version < 14,
                 Some(historical_bundle_hash),
             )?;
-            self.generated_pathways.insert(pathway_id, pathway);
+            pathways.insert(pathway_id, pathway);
         }
+        let generated_location_ids = pathways
+            .values()
+            .flat_map(|pathway| pathway.waypoints.iter())
+            .map(|waypoint| waypoint.id)
+            .collect::<BTreeSet<_>>();
+        let mut occupied_names = self
+            .locations
+            .iter()
+            .filter(|(location_id, _)| !generated_location_ids.contains(location_id))
+            .map(|(_, name)| name.to_ascii_lowercase())
+            .collect::<BTreeSet<_>>();
+        for pathway in pathways.values_mut() {
+            reserve_pathway_names_in_namespace(pathway, &mut occupied_names);
+        }
+        for pathway in pathways.values() {
+            for waypoint in &pathway.waypoints {
+                if let Some(location_name) = self.locations.get_mut(&waypoint.id) {
+                    *location_name = waypoint.name.clone();
+                    self.location_meta
+                        .insert(waypoint.id, waypoint.meta.clone());
+                }
+            }
+        }
+        self.generated_pathways = pathways;
         self.validate_generated_pathway_identity_claims()?;
         self.validate_journey_topology()?;
         if snapshot_version < 13 {
@@ -763,6 +823,20 @@ impl RuntimeWorld {
         historical_bundle_hash: Option<&str>,
     ) -> Result<(), String> {
         pathway.way_class = PathwayWayClass::for_traffic(pathway.traffic_count);
+        let origin_name = self
+            .location_name(pathway.origin_location_id)
+            .unwrap_or_default();
+        let destination_name = self
+            .location_name(pathway.destination_location_id)
+            .unwrap_or_default();
+        for waypoint in &mut pathway.waypoints {
+            let legacy_name = waypoint.name.clone();
+            if let Some(name) =
+                strip_legacy_pathway_endpoint_prefix(&legacy_name, &origin_name, &destination_name)
+            {
+                rename_generated_waypoint_prose(waypoint, name);
+            }
+        }
         if pathway.origin_location_id == pathway.destination_location_id
             || !(2..=8).contains(&pathway.distance)
             || pathway.waypoints.len() != usize::from(pathway.distance.saturating_sub(1))
@@ -1176,6 +1250,72 @@ impl RuntimeWorld {
         .is_ok()
     }
 
+    pub(super) fn reserve_unique_generated_pathway_names(
+        &self,
+        pathway: &mut GeneratedPathwayState,
+    ) {
+        let waypoint_ids = pathway
+            .waypoints
+            .iter()
+            .map(|waypoint| waypoint.id)
+            .collect::<BTreeSet<_>>();
+        let mut occupied_names = self
+            .generated_pathways
+            .values()
+            .filter(|existing| existing.id != pathway.id)
+            .flat_map(|existing| existing.waypoints.iter())
+            .map(|waypoint| waypoint.name.to_ascii_lowercase())
+            .chain(
+                self.locations
+                    .iter()
+                    .filter(|(location_id, _)| !waypoint_ids.contains(location_id))
+                    .map(|(_, name)| name.to_ascii_lowercase()),
+            )
+            .collect::<BTreeSet<_>>();
+        reserve_pathway_names_in_namespace(pathway, &mut occupied_names);
+    }
+
+    pub(super) fn reserve_refined_generated_pathway_names(
+        &self,
+        current: &GeneratedPathwayState,
+        refined: &mut GeneratedPathwayState,
+    ) {
+        let current_waypoint_ids = current
+            .waypoints
+            .iter()
+            .map(|waypoint| waypoint.id)
+            .collect::<BTreeSet<_>>();
+        let mut occupied_names = self
+            .generated_pathways
+            .values()
+            .filter(|existing| existing.id != refined.id)
+            .flat_map(|existing| existing.waypoints.iter())
+            .map(|waypoint| waypoint.name.to_ascii_lowercase())
+            .chain(
+                self.locations
+                    .iter()
+                    .filter(|(location_id, _)| !current_waypoint_ids.contains(location_id))
+                    .map(|(_, name)| name.to_ascii_lowercase()),
+            )
+            .collect::<BTreeSet<_>>();
+        let pathway_canonical_id = refined.canonical_id.clone();
+        for (index, (waypoint, fallback)) in refined
+            .waypoints
+            .iter_mut()
+            .zip(&current.waypoints)
+            .enumerate()
+        {
+            let reserved_name = reserve_unique_pathway_name(
+                &mut occupied_names,
+                &waypoint.name,
+                &fallback.name,
+                &pathway_canonical_id,
+                index,
+            );
+            rename_generated_waypoint_prose(waypoint, reserved_name);
+        }
+    }
+
     pub(super) fn generated_pathway(
         &self,
         actor_id: u64,
@@ -1214,26 +1354,27 @@ impl RuntimeWorld {
         let pathway_id = generated_pathway_canonical_id(source_route);
         let generation_policy =
             generated_policy_binding(source_route, origin_location_id, destination_location_id)?;
-        let seed = stable_pathway_hash(&pathway_id);
         let waypoint_count = usize::from(distance.saturating_sub(1));
-        let names = [
-            "Lantern Bend",
-            "Mossy Verge",
-            "Rain-Silver Crossing",
-            "Foxglove Turn",
-            "Quiet Rise",
-            "Bramble Mile",
-        ];
-        let route_name_prefix = format!(
-            "{}-{}",
-            pathway_anchor_name_token(&origin_name),
-            pathway_anchor_name_token(&destination_name),
-        );
+        let mut occupied_names = self
+            .generated_pathways
+            .values()
+            .flat_map(|pathway| pathway.waypoints.iter())
+            .map(|waypoint| waypoint.name.to_ascii_lowercase())
+            .chain(
+                self.locations
+                    .values()
+                    .map(|name| name.to_ascii_lowercase()),
+            )
+            .collect::<BTreeSet<_>>();
         let waypoints = (0..waypoint_count)
             .map(|index| {
-                let landmark_name = format!(
-                    "{route_name_prefix} {}",
-                    names[(seed as usize + index) % names.len()]
+                let fallback_name = deterministic_pathway_fallback_name(&pathway_id, index);
+                let landmark_name = reserve_unique_pathway_name(
+                    &mut occupied_names,
+                    &fallback_name,
+                    &fallback_name,
+                    &pathway_id,
+                    index,
                 );
                 let canonical_id = generated_waypoint_canonical_id(&pathway_id, index);
                 let id = generated_pathway_location_id(&canonical_id);
@@ -3324,7 +3465,7 @@ mod tests {
     }
 
     #[test]
-    fn repeated_generated_names_fall_back_by_endpoint_and_replay_identically() {
+    fn route_grounding_repeated_names_use_prose_fallbacks_and_replay_identically() {
         let seed = RuntimeWorld::seeded();
         let pathway_a = seed
             .generated_pathway(RATI_ACTOR_ID, 700, 712, 2)
@@ -3341,7 +3482,7 @@ mod tests {
         let fallback_b = pathway_b.waypoints[0].name.clone();
         let repeated_name = "Rain-Silver Crossing";
         let first_collision_name =
-            deterministic_pathway_collision_name(&pathway_b.canonical_id, 0, &fallback_b, 0);
+            deterministic_pathway_collision_name(&pathway_b.canonical_id, 0, 0);
         pathway_c.waypoints[0].name = fallback_b.clone();
         pathway_d.waypoints[0].name = first_collision_name.clone();
         let discovery_record = |pathway: &GeneratedPathwayState, seed| JournalRecord {
@@ -3349,7 +3490,7 @@ mod tests {
                 pathway: pathway.clone(),
                 journey: None,
                 reveal_edges: vec![(pathway.origin_location_id, pathway.waypoints[0].id)],
-                narration: "A route becomes shared geography.".to_string(),
+                narration: format!("The way reaches {}.", pathway.waypoints[0].name),
                 event_type: "pathway.discovered".to_string(),
             }],
             ..JournalRecord::new(
@@ -3402,9 +3543,10 @@ mod tests {
             committed.generated_pathways[&pathway_a.id].waypoints[0].name,
             repeated_name
         );
+        let committed_b_name = deterministic_pathway_collision_name(&pathway_b.canonical_id, 0, 1);
         assert_eq!(
             committed.generated_pathways[&pathway_b.id].waypoints[0].name,
-            deterministic_pathway_collision_name(&pathway_b.canonical_id, 0, &fallback_b, 1)
+            committed_b_name
         );
         assert_eq!(
             committed.generated_pathways[&pathway_d.id].waypoints[0].name,
@@ -3421,20 +3563,35 @@ mod tests {
             names.len(),
             "every simultaneously offered generated destination stays unique"
         );
-        let endpoint_prefix = format!(
-            "{}-{}",
-            pathway_anchor_name_token(
-                &committed
-                    .location_name(pathway_b.origin_location_id)
-                    .expect("origin name"),
-            ),
-            pathway_anchor_name_token(
-                &committed
-                    .location_name(pathway_b.destination_location_id)
-                    .expect("destination name"),
-            ),
+        let origin_name = committed
+            .location_name(pathway_b.origin_location_id)
+            .expect("origin name");
+        let destination_name = committed
+            .location_name(pathway_b.destination_location_id)
+            .expect("destination name");
+        assert!(generated_pathway_name_avoids_anchors(
+            &fallback_b,
+            &[&origin_name, &destination_name],
+        ));
+        assert!(sanitize_generated_pathway_name(&fallback_b).is_some());
+        let committed_b_narration = committed
+            .event_log
+            .iter()
+            .rev()
+            .find(|event| event.type_name == "pathway.discovered")
+            .and_then(|event| event.content.as_deref())
+            .expect("committed discovery narration");
+        assert!(committed_b_narration.contains(&committed_b_name));
+        assert!(!committed_b_narration.contains(&fallback_b));
+        assert_eq!(
+            replayed
+                .event_log
+                .iter()
+                .rev()
+                .find(|event| event.type_name == "pathway.discovered")
+                .and_then(|event| event.content.as_deref()),
+            Some(committed_b_narration),
         );
-        assert!(fallback_b.starts_with(&endpoint_prefix));
 
         let stable_projection = |runtime: &RuntimeWorld| {
             serde_json::to_vec(&(
@@ -3454,6 +3611,181 @@ mod tests {
             .into_runtime()
             .expect("restart collision fixture");
         assert_eq!(stable_projection(&restarted), committed_bytes);
+    }
+
+    #[test]
+    fn route_grounding_migrates_endpoint_prefixed_prose_without_changing_identity() {
+        let seed = RuntimeWorld::seeded();
+        let mut pathway = seed
+            .generated_pathway(RATI_ACTOR_ID, 1, 700, 3)
+            .expect("Core-to-Bethlehem bridge route");
+        let waypoint = pathway
+            .waypoints
+            .first_mut()
+            .expect("distance three has a waypoint");
+        waypoint.name = "Cosy-Bethlehem Bramble Mile".to_string();
+        waypoint.meta.description =
+            "At Cosy-Bethlehem Bramble Mile, wet stones hold the evening light.".to_string();
+        waypoint.meta.persona =
+            "Cosy-Bethlehem Bramble Mile gathers quiet footprints after rain.".to_string();
+        waypoint.meta.art_prompt =
+            Some("cozy storybook landscape, Cosy-Bethlehem Bramble Mile".to_string());
+        let pathway_identity = (
+            pathway.id.clone(),
+            pathway.canonical_id.clone(),
+            pathway.source_route_id.clone(),
+            pathway.source_route_version,
+            pathway
+                .waypoints
+                .iter()
+                .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+                .collect::<Vec<_>>(),
+        );
+        let record = JournalRecord {
+            projection_mutations: vec![ProjectionMutation::JourneyTransition {
+                pathway: pathway.clone(),
+                journey: None,
+                reveal_edges: vec![(pathway.origin_location_id, pathway.waypoints[0].id)],
+                narration: "The way reaches Cosy-Bethlehem Bramble Mile.".to_string(),
+                event_type: "pathway.discovered".to_string(),
+            }],
+            ..JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_NONE,
+                    actor_id: RATI_ACTOR_ID,
+                    ..CwAction::default()
+                },
+                333_100,
+            )
+        };
+        let replay_record: JournalRecord = serde_json::from_slice(
+            &serde_json::to_vec(&record).expect("serialize legacy-name record"),
+        )
+        .expect("deserialize legacy-name record");
+
+        let mut committed = RuntimeWorld::seeded();
+        let mut replayed = RuntimeWorld::seeded();
+        assert_eq!(committed.apply_journal_record(&record).0, CW_OK);
+        assert_eq!(replayed.apply_journal_record(&replay_record).0, CW_OK);
+        let migrated = &committed.generated_pathways[&pathway.id];
+        assert_eq!(migrated.waypoints[0].name, "Bramble Mile");
+        assert!(!migrated.waypoints[0]
+            .meta
+            .description
+            .contains("Cosy-Bethlehem"));
+        assert!(!migrated.waypoints[0]
+            .meta
+            .persona
+            .contains("Cosy-Bethlehem"));
+        assert!(!migrated.waypoints[0]
+            .meta
+            .art_prompt
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Cosy-Bethlehem"));
+        let narration = committed
+            .event_log
+            .iter()
+            .rev()
+            .find(|event| event.type_name == "pathway.discovered")
+            .and_then(|event| event.content.as_deref())
+            .expect("migrated pathway narration");
+        assert_eq!(narration, "The way reaches Bramble Mile.");
+        assert_eq!(
+            (
+                migrated.id.clone(),
+                migrated.canonical_id.clone(),
+                migrated.source_route_id.clone(),
+                migrated.source_route_version,
+                migrated
+                    .waypoints
+                    .iter()
+                    .map(|waypoint| (waypoint.id, waypoint.canonical_id.clone()))
+                    .collect::<Vec<_>>(),
+            ),
+            pathway_identity,
+        );
+        assert_eq!(
+            serde_json::to_vec(&replayed.generated_pathways[&pathway.id])
+                .expect("serialize replayed pathway"),
+            serde_json::to_vec(migrated).expect("serialize committed pathway"),
+        );
+        let restarted = RuntimeSnapshot::from_runtime(&committed)
+            .into_runtime()
+            .expect("restart migrated pathway");
+        assert_eq!(
+            restarted.generated_pathways[&pathway.id].waypoints[0].name,
+            "Bramble Mile"
+        );
+    }
+
+    #[test]
+    fn route_grounding_snapshot_migration_re_reserves_collapsed_legacy_names() {
+        let mut runtime = RuntimeWorld::seeded();
+        let mut cottage_route = runtime
+            .generated_pathway(RATI_ACTOR_ID, 1, 700, 2)
+            .expect("Core-to-Bethlehem bridge route");
+        let mut jerusalem_route = runtime
+            .generated_pathway(RATI_ACTOR_ID, 700, 712, 2)
+            .expect("Bethlehem-to-Jerusalem route");
+        rename_generated_waypoint_prose(
+            &mut cottage_route.waypoints[0],
+            "Cosy-Bethlehem Bramble Mile".to_string(),
+        );
+        rename_generated_waypoint_prose(
+            &mut jerusalem_route.waypoints[0],
+            "Bethlehem-Jerusalem Bramble Mile".to_string(),
+        );
+        for pathway in [&mut cottage_route, &mut jerusalem_route] {
+            let edge = (pathway.origin_location_id, pathway.waypoints[0].id);
+            pathway
+                .revealed_edges
+                .insert(pathway_edge_key(edge.0, edge.1));
+            runtime.ensure_generated_pathway_route_records(pathway);
+            runtime.ensure_generated_pathway_edge(pathway, edge.0, edge.1);
+            runtime
+                .generated_pathways
+                .insert(pathway.id.clone(), pathway.clone());
+        }
+
+        let restored = RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .expect("migrate colliding legacy waypoint prose");
+        let waypoint_names = [
+            cottage_route.waypoints[0].id,
+            jerusalem_route.waypoints[0].id,
+        ]
+        .map(|location_id| {
+            restored
+                .location_name(location_id)
+                .expect("restored waypoint name")
+        });
+        assert_eq!(
+            waypoint_names
+                .iter()
+                .map(|name| name.to_ascii_lowercase())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            2,
+        );
+        assert!(waypoint_names.iter().all(|name| {
+            sanitize_generated_pathway_name(name).is_some()
+                && !name.contains("Cosy-Bethlehem")
+                && !name.contains("Bethlehem-Jerusalem")
+        }));
+        let stable_projection = |runtime: &RuntimeWorld| {
+            serde_json::to_vec(&(
+                runtime.generated_pathways.clone(),
+                runtime.locations.clone(),
+                runtime.location_meta.clone(),
+            ))
+            .expect("serialize migrated names")
+        };
+        let restored_bytes = stable_projection(&restored);
+        let restarted = RuntimeSnapshot::from_runtime(&restored)
+            .into_runtime()
+            .expect("restart migrated collision fixture");
+        assert_eq!(stable_projection(&restarted), restored_bytes);
     }
 
     #[test]

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -236,4 +236,4 @@
 # like a property of event-appending handlers generally rather than the
 # item-specific effect ADR 0008 recorded for SetItemEquipped. No behaviour
 # changes; journal encoding pinned by test for each variant.
-67945
+67935

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -3472,7 +3472,7 @@ async function main() {
       const previousActorId = actorId;
       const previousActions = actions;
       const fakeState = {
-        location: { id: 1, name: "The Cosy Cottage" },
+        location: { id: 1, name: "Bethlehem" },
         primary_action: {
           kind: "move",
           options: [{ kind: "move" }],
@@ -3481,15 +3481,15 @@ async function main() {
           {
             offer_id: "move:rain-soft-garden",
             kind: "move",
-            target: { kind: "location", id: 2, label: "Rain-Soft Garden" },
-            provider: { kind: "location", id: "location:1", label: "The Cosy Cottage" },
+            target: { kind: "location", id: 2, label: "Rain-Silver Crossing" },
+            provider: { kind: "location", id: "location:1", label: "Bethlehem" },
             effect: "moves to an accessible adjacent room",
           },
           {
             offer_id: "move:homeroom",
             kind: "move",
-            target: { kind: "location", id: 11, label: "Homeroom" },
-            provider: { kind: "location", id: "location:1", label: "The Cosy Cottage" },
+            target: { kind: "location", id: 11, label: "Rain-Silver Crossing" },
+            provider: { kind: "location", id: "location:1", label: "Bethlehem" },
             effect: "moves to an accessible adjacent room",
           },
         ],
@@ -3502,16 +3502,16 @@ async function main() {
         exits: [
           {
             destination_location_id: 2,
-            destination_location_name: "Rain-Soft Garden",
-            route_label: "Route from The Cosy Cottage to Rain-Soft Garden",
+            destination_location_name: "Rain-Silver Crossing",
+            route_label: "Route from Bethlehem to Jerusalem",
             direction: "east",
             accessible: true,
             locked: false,
           },
           {
             destination_location_id: 11,
-            destination_location_name: "Homeroom",
-            route_label: "Route from The Cosy Cottage to Homeroom",
+            destination_location_name: "Rain-Silver Crossing",
+            route_label: "Route from Bethlehem to Emmaus",
             direction: "north",
             accessible: true,
             locked: false,
@@ -3522,9 +3522,9 @@ async function main() {
           actors: {},
           items: {},
           locations: {
-            1: { card_id: "cosy-cottage", display_name: "The Cosy Cottage", role: "location", aspect: "wide", image_url: "/choice-cottage.png" },
-            2: { card_id: "rain-soft-garden", display_name: "Rain-Soft Garden", role: "location", aspect: "wide", image_url: "/choice-garden.png" },
-            11: { card_id: "homeroom", display_name: "Homeroom", role: "location", aspect: "wide", image_url: "/choice-homeroom.png" },
+            1: { card_id: "bethlehem", display_name: "Bethlehem", role: "location", aspect: "wide", image_url: "/choice-cottage.png" },
+            2: { card_id: "rain-silver-east", display_name: "Rain-Silver Crossing", role: "location", aspect: "wide", image_url: "/choice-garden.png" },
+            11: { card_id: "rain-silver-north", display_name: "Rain-Silver Crossing", role: "location", aspect: "wide", image_url: "/choice-homeroom.png" },
           },
         },
         access: {},
@@ -3563,6 +3563,8 @@ async function main() {
             .map((node) => node.textContent.trim().replace(/\s+/g, " ")),
           choices: [...document.querySelectorAll("#action-modal-choices .action-choice")]
             .map((node) => node.textContent.trim().replace(/\s+/g, " ")),
+          choiceAria: [...document.querySelectorAll("#action-modal-choices input[name='action-choice']")]
+            .map((node) => node.getAttribute("aria-label") || ""),
         };
         if (route?.choices?.length > 1) chooseActionModalChoice(1);
         const selectedPreview = {
@@ -3606,6 +3608,7 @@ async function main() {
           modal,
           selectedPreview,
           single: single ? {
+            accessibleLabel: single.accessibleLabel,
             detail: single.detail,
             command: single.command,
             choices: single.choices || [],
@@ -3624,8 +3627,8 @@ async function main() {
     assert(result.detail === "choose a path" && result.command === "go", `grouped Travel should carry its destination choice: ${JSON.stringify(result)}`);
     assert(
       [
-        "Route from The Cosy Cottage to Rain-Soft Garden",
-        "Route from The Cosy Cottage to Homeroom",
+        "Route from Bethlehem to Jerusalem",
+        "Route from Bethlehem to Emmaus",
       ].every((name) => result.choices.some((choice) => choice.label === name)),
       `Travel should distinguish routes from their next location cards: ${JSON.stringify(result)}`,
     );
@@ -3634,20 +3637,20 @@ async function main() {
       `grouped Travel should retain every exit focus anchor: ${JSON.stringify(result)}`,
     );
     assert(result.selectedChoice === "11" && result.selectedPayload?.destination_location_id === 11, `Travel confirmation should use the selected destination: ${JSON.stringify(result)}`);
-    assert(result.busyLabel === "travelling" && result.busyDetail === "following the path to Homeroom…", `Travel should name the destination while it is in progress: ${JSON.stringify(result)}`);
+    assert(result.busyLabel === "travelling" && result.busyDetail === "following the path to Rain-Silver Crossing…", `Travel should name the destination while it is in progress: ${JSON.stringify(result)}`);
     assert(
       result.busy?.ariaBusy === "true"
         && result.busy?.ariaLabel.includes("in progress")
         && result.busy?.progressBars === 1
         && result.busy?.opacity === "1"
         && result.busy?.cursor === "progress"
-        && /travelling.*following the path to Homeroom/i.test(result.busy?.text || ""),
+        && /travelling.*following the path to Rain-Silver Crossing/i.test(result.busy?.text || ""),
       `Travel should remain legible and show an accessible progress rail while pending: ${JSON.stringify(result)}`,
     );
     assert(result.choices.every((choice) => choice.card?.role === "location"), `each Travel destination should carry its own Location card: ${JSON.stringify(result)}`);
     assert(
       result.selectedPreview.src === "/choice-homeroom.png"
-        && result.selectedPreview.alt === "Homeroom"
+        && result.selectedPreview.alt === "Rain-Silver Crossing"
         && result.selectedPreview.shape.includes("location")
         && result.selectedPreview.objectFit === "cover",
       `selecting a Travel destination should preview that Location card: ${JSON.stringify(result)}`,
@@ -3665,8 +3668,21 @@ async function main() {
       `action modals should place a full-width red Cancel button below the confirmation: ${JSON.stringify(result)}`,
     );
     assert(result.modal.rows.length === 0, `Travel confirmation should stay to one sentence plus the destination choices: ${JSON.stringify(result)}`);
-    assert(["Rain-Soft Garden", "Homeroom"].every((name) => result.modal.choices.some((choice) => choice.includes(name))), `Travel modal should render both destinations: ${JSON.stringify(result)}`);
-    assert(result.single?.detail === "to Rain-Soft Garden" && result.single?.command === "go Rain-Soft Garden", `a single open path should stay a target-bearing Travel card: ${JSON.stringify(result)}`);
+    assert(
+      ["Route from Bethlehem to Jerusalem", "Route from Bethlehem to Emmaus"]
+        .every((name) => result.modal.choices.some((choice) => choice.includes(name))
+          && result.modal.choiceAria.some((label) => label.includes(name))),
+      `Travel modal and accessibility labels should distinguish same-named waypoints by route: ${JSON.stringify(result)}`,
+    );
+    assert(
+      result.single?.detail === "to Rain-Silver Crossing · Route from Bethlehem to Jerusalem"
+        && result.single?.command === "go Rain-Silver Crossing",
+      `a single open path should stay target-bearing while retaining route context: ${JSON.stringify(result)}`,
+    );
+    assert(
+      result.single?.accessibleLabel === "Travel to Rain-Silver Crossing via Route from Bethlehem to Jerusalem",
+      `single-route accessibility copy should carry the same direction-aware identity: ${JSON.stringify(result)}`,
+    );
     assert(result.single?.choices?.length === 0 && result.single?.payload?.destination_location_id === 2, `single-path Travel should not add an unnecessary choice: ${JSON.stringify(result)}`);
   }
 


### PR DESCRIPTION
## What changed

- keep canonical route identity stable while generating ecological, prose-only waypoint names
- remove endpoint/composition leakage from deterministic fallbacks and reserve unique names during generation, commit, replay, and snapshot migration
- rewrite frozen journey narration and waypoint metadata together when a commit-time collision changes the final name
- make direction-aware route labels and accessibility copy distinguish same-named destinations
- add collision, replay, migration, concurrency, large-namespace, API, and browser regressions
- lower the `main.rs` line ceiling after extracting route-name reservation into the topology seam

## Why

Generated routes could expose endpoint tokens such as `Cosy-Bethlehem ...`, and concurrent or legacy pathways could collapse onto the same visible name. That made route choices ambiguous and let descriptive names drift from canonical route identity.

## Validation

- full pre-push `npm run check`
- 176/176 Node tests
- 1127/1127 orchestrator tests plus library/bin/doc tests
- route-grounding and movement-offer focused tests
- deterministic browser route/a11y fixture
- worldpack, kernel, architecture, formatting, syntax, and version checks

Closes #333