### PR TITLE
Reshape four ledger and route projection mutations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.371",
+  "version": "0.0.372",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.371",
+      "version": "0.0.372",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.371",
+  "version": "0.0.372",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.371"
+version = "0.0.372"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.371"
+version = "0.0.372"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/card_policy_objective.rs
+++ b/v2/orchestrator-rust/src/card_policy_objective.rs
@@ -143,7 +143,9 @@ pub(super) async fn start_treasure_objective(
     .into_system();
     record
         .projection_mutations
-        .push(ProjectionMutation::StartTreasureObjective { start });
+        .push(ProjectionMutation::StartTreasureObjective(
+            projection_ledger::StartTreasureObjective { start },
+        ));
 
     if !treasure_objective_record_preconditions_hold(&runtime, &record) {
         return objective_response(
@@ -193,7 +195,7 @@ pub(super) fn treasure_objective_record_preconditions_hold(
         .projection_mutations
         .iter()
         .filter_map(|mutation| match mutation {
-            ProjectionMutation::StartTreasureObjective { start } => Some(start),
+            ProjectionMutation::StartTreasureObjective(mutation) => Some(&mutation.start),
             _ => None,
         })
         .collect::<Vec<_>>();
@@ -1052,15 +1054,17 @@ mod tests {
         .into_system();
         record
             .projection_mutations
-            .push(ProjectionMutation::StartTreasureObjective {
-                start: TreasureObjectiveStart {
-                    schema_version: TREASURE_OBJECTIVE_SCHEMA_VERSION,
-                    objective_id: "objective:test".to_string(),
-                    actor_id,
-                    treasure_item_id,
-                    max_turns,
+            .push(ProjectionMutation::StartTreasureObjective(
+                projection_ledger::StartTreasureObjective {
+                    start: TreasureObjectiveStart {
+                        schema_version: TREASURE_OBJECTIVE_SCHEMA_VERSION,
+                        objective_id: "objective:test".to_string(),
+                        actor_id,
+                        treasure_item_id,
+                        max_turns,
+                    },
                 },
-            });
+            ));
         record
     }
 

--- a/v2/orchestrator-rust/src/chat_action.rs
+++ b/v2/orchestrator-rust/src/chat_action.rs
@@ -503,12 +503,14 @@ pub(super) async fn commit_completed_chat(
         });
     record
         .projection_mutations
-        .push(ProjectionMutation::MarkVisitLedger {
-            category: "witness".to_string(),
-            label: format!("shared a little chat with {target_name}."),
-            source_event_seq,
-            reason: format!("chat:{actor_id}:{target_actor_id}"),
-        });
+        .push(ProjectionMutation::MarkVisitLedger(
+            projection_ledger::MarkVisitLedger {
+                category: "witness".to_string(),
+                label: format!("shared a little chat with {target_name}."),
+                source_event_seq,
+                reason: format!("chat:{actor_id}:{target_actor_id}"),
+            },
+        ));
     let Ok((status, events)) = commit_journal_record(state, &mut runtime, record) else {
         return Vec::new();
     };

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -76,6 +76,7 @@ mod projection_cache;
 #[cfg(test)]
 mod projection_cache_tests;
 mod projection_items;
+mod projection_ledger;
 mod prompts;
 mod proxim8;
 mod quest_loot;
@@ -921,16 +922,12 @@ enum ProjectionMutation {
         control: ActorSafetyControl,
         enabled: bool,
     },
-    SetGiftAutoAccept {
-        policy: GiftAutoAcceptPolicy,
-    },
+    SetGiftAutoAccept(projection_ledger::SetGiftAutoAccept),
     ConsumeGiftAutoAccept(projection::ConsumeGiftAutoAccept),
     ShuffleHand {
         reason: String,
     },
-    StartTreasureObjective {
-        start: TreasureObjectiveStart,
-    },
+    StartTreasureObjective(projection_ledger::StartTreasureObjective),
     UpdateCardPolicyPreference {
         update: CardPolicyPreferenceUpdate,
     },
@@ -1139,12 +1136,7 @@ enum ProjectionMutation {
     SettleVisitLedgerAfterDiscovery {
         reason: String,
     },
-    MarkVisitLedger {
-        category: String,
-        label: String,
-        source_event_seq: u64,
-        reason: String,
-    },
+    MarkVisitLedger(projection_ledger::MarkVisitLedger),
     ChooseClass {
         profile_id: String,
         class_id: String,
@@ -9776,9 +9768,8 @@ impl RuntimeWorld {
                         }
                     }
                 }
-                ProjectionMutation::SetGiftAutoAccept { policy } => {
-                    self.gift_auto_accepts
-                        .insert(policy.id.clone(), policy.clone());
+                ProjectionMutation::SetGiftAutoAccept(mutation) => {
+                    mutation.apply(self, &ctx);
                 }
                 ProjectionMutation::ConsumeGiftAutoAccept(mutation) => {
                     mutation.apply(self, &ctx);
@@ -9786,8 +9777,8 @@ impl RuntimeWorld {
                 ProjectionMutation::ShuffleHand { reason } => {
                     events.push(self.append_hand_shuffled_event(action.actor_id, reason));
                 }
-                ProjectionMutation::StartTreasureObjective { start } => {
-                    if let Some(event) = self.apply_treasure_objective_start(start) {
+                ProjectionMutation::StartTreasureObjective(mutation) => {
+                    if let Some(event) = mutation.apply(self, &ctx) {
                         events.push(event);
                     }
                 }
@@ -10116,14 +10107,8 @@ impl RuntimeWorld {
                         }
                     }
                 }
-                ProjectionMutation::SetRouteLifecycle(transition) => {
-                    if let Some(event) = self.apply_route_lifecycle_mutation(
-                        action.actor_id,
-                        &transition.route_id,
-                        transition.expected_version,
-                        transition.lifecycle,
-                        &transition.reason,
-                    ) {
+                ProjectionMutation::SetRouteLifecycle(mutation) => {
+                    if let Some(event) = mutation.apply(self, &ctx) {
                         events.push(event);
                     }
                 }
@@ -10712,19 +10697,8 @@ impl RuntimeWorld {
                     // have been projected. Keeping this as an explicit journal
                     // mutation preserves the historical order for older records.
                 }
-                ProjectionMutation::MarkVisitLedger {
-                    category,
-                    label,
-                    source_event_seq,
-                    reason,
-                } => {
-                    if let Some(event) = self.mark_visit_ledger(
-                        action.actor_id,
-                        category,
-                        label,
-                        *source_event_seq,
-                        reason,
-                    ) {
+                ProjectionMutation::MarkVisitLedger(mutation) => {
+                    if let Some(event) = mutation.apply(self, &ctx) {
                         events.push(event);
                     }
                 }
@@ -30719,9 +30693,11 @@ async fn request_gift_auto_accept(
         );
         record
             .projection_mutations
-            .push(ProjectionMutation::SetGiftAutoAccept {
-                policy: policy.clone(),
-            });
+            .push(ProjectionMutation::SetGiftAutoAccept(
+                projection_ledger::SetGiftAutoAccept {
+                    policy: policy.clone(),
+                },
+            ));
         if commit_journal_record(&state, &mut runtime, record).is_err() {
             return Json(ActionResponse {
                 ok: false,

--- a/v2/orchestrator-rust/src/projection.rs
+++ b/v2/orchestrator-rust/src/projection.rs
@@ -43,11 +43,16 @@ impl StateKey {
     pub(super) const TRANSFER_OFFERS: Self = Self("transfer_offers");
     pub(super) const GIFT_AUTO_ACCEPTS: Self = Self("gift_auto_accepts");
     pub(super) const WORLD_ITEMS: Self = Self("world_items");
+    pub(super) const WORLD_EXITS: Self = Self("world_exits");
     pub(super) const ACTOR_RULES_FACETS: Self = Self("actor_rules_facets");
     pub(super) const ADVANCEMENT_SPENDS: Self = Self("advancement_spends");
     pub(super) const CHARM_SLOTS: Self = Self("charm_slots");
     pub(super) const EQUIPPED_CHARMS: Self = Self("equipped_charms");
     pub(super) const PREPARED_SPELLS: Self = Self("prepared_spells");
+    pub(super) const LEDGER_MARKS: Self = Self("ledger_marks");
+    pub(super) const RPG_CLAIMS: Self = Self("rpg_claims");
+    pub(super) const TREASURE_OBJECTIVES: Self = Self("treasure_objectives");
+    pub(super) const ROUTES: Self = Self("routes");
     /// Appending an event is itself durable projection state. Any handler that
     /// returns events writes these two, which is easy to miss by inspection and
     /// is why the declaration is derived from a run rather than from reading.
@@ -283,6 +288,86 @@ mod projection_write_set_tests {
                     "item_id": 2014,
                     "prepared": true,
                     "reason": "spell_deck_configuration",
+                }),
+            ),
+            (
+                ProjectionMutation::SetGiftAutoAccept(
+                    crate::projection_ledger::SetGiftAutoAccept {
+                        policy: GiftAutoAcceptPolicy {
+                            id: "policy-1".to_string(),
+                            recipient_actor_id: 1,
+                            offered_by_actor_id: 2,
+                            item_id: 3,
+                            created_tick: 10,
+                            expires_tick: 110,
+                            consumed: false,
+                        },
+                    },
+                ),
+                json!({
+                    "kind": "set_gift_auto_accept",
+                    "policy": {
+                        "id": "policy-1",
+                        "recipient_actor_id": 1,
+                        "offered_by_actor_id": 2,
+                        "item_id": 3,
+                        "created_tick": 10,
+                        "expires_tick": 110,
+                        "consumed": false,
+                    },
+                }),
+            ),
+            (
+                ProjectionMutation::MarkVisitLedger(crate::projection_ledger::MarkVisitLedger {
+                    category: "witness".to_string(),
+                    label: "saw something happen".to_string(),
+                    source_event_seq: 5,
+                    reason: "chat:1:2".to_string(),
+                }),
+                json!({
+                    "kind": "mark_visit_ledger",
+                    "category": "witness",
+                    "label": "saw something happen",
+                    "source_event_seq": 5,
+                    "reason": "chat:1:2",
+                }),
+            ),
+            (
+                ProjectionMutation::StartTreasureObjective(
+                    crate::projection_ledger::StartTreasureObjective {
+                        start: TreasureObjectiveStart {
+                            schema_version: 1,
+                            objective_id: "objective:test".to_string(),
+                            actor_id: 1,
+                            treasure_item_id: 2012,
+                            max_turns: 48,
+                        },
+                    },
+                ),
+                json!({
+                    "kind": "start_treasure_objective",
+                    "start": {
+                        "schema_version": 1,
+                        "objective_id": "objective:test",
+                        "actor_id": 1,
+                        "treasure_item_id": 2012,
+                        "max_turns": 48,
+                    },
+                }),
+            ),
+            (
+                ProjectionMutation::SetRouteLifecycle(RouteLifecycleMutation {
+                    route_id: "route:authored:1:2".to_string(),
+                    expected_version: 3,
+                    lifecycle: RouteLifecycle::Blocked,
+                    reason: "test".to_string(),
+                }),
+                json!({
+                    "kind": "set_route_lifecycle",
+                    "route_id": "route:authored:1:2",
+                    "expected_version": 3,
+                    "lifecycle": "blocked",
+                    "reason": "test",
                 }),
             ),
         ];

--- a/v2/orchestrator-rust/src/projection_ledger.rs
+++ b/v2/orchestrator-rust/src/projection_ledger.rs
@@ -1,0 +1,367 @@
+//! Payload structs for `ProjectionMutation` variants reshaped from inline
+//! named fields into newtypes that own their `apply`.
+//!
+//! This is the same pattern as `projection.rs`: each payload declares the
+//! projection state it may write via `DeclaredWrites`, and the declaration is
+//! enforced by a per-mutation fixture test rather than trusted. See
+//! `docs/decisions/0008-projection-mutations-declare-their-writes.md`.
+//!
+//! The journal-encoding pin for every variant reshaped here lives in
+//! `projection::projection_write_set_tests::reshaped_variants_keep_their_journal_encoding`,
+//! alongside the pins for variants reshaped elsewhere, so that guarantee stays
+//! in one place.
+
+use super::*;
+use projection::{DeclaredWrites, ProjectionContext, StateKey};
+
+/// `ProjectionMutation::SetGiftAutoAccept`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct SetGiftAutoAccept {
+    pub(super) policy: GiftAutoAcceptPolicy,
+}
+
+impl DeclaredWrites for SetGiftAutoAccept {
+    const WRITES: &'static [StateKey] = &[StateKey::GIFT_AUTO_ACCEPTS];
+}
+
+impl SetGiftAutoAccept {
+    pub(super) fn apply(&self, world: &mut RuntimeWorld, _ctx: &ProjectionContext<'_>) {
+        world
+            .gift_auto_accepts
+            .insert(self.policy.id.clone(), self.policy.clone());
+    }
+}
+
+/// `ProjectionMutation::MarkVisitLedger`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct MarkVisitLedger {
+    pub(super) category: String,
+    pub(super) label: String,
+    pub(super) source_event_seq: u64,
+    pub(super) reason: String,
+}
+
+impl DeclaredWrites for MarkVisitLedger {
+    // `EVENT_LOG` and `NEXT_EVENT_SEQ` because a mark appends a `ledger.marked`
+    // event. `ACTOR_RULES_FACETS` is not touched directly; it appears because
+    // `snapshot_actor_rules_facets` re-stamps every active facet's
+    // `last_saved_at_revision` from `next_event_seq` on every snapshot, so any
+    // handler that advances `next_event_seq` perturbs it too. Same surprise the
+    // ADR documents for `SetItemEquipped`.
+    const WRITES: &'static [StateKey] = &[
+        StateKey::LEDGER_MARKS,
+        StateKey::RPG_CLAIMS,
+        StateKey::ACTOR_RULES_FACETS,
+        StateKey::EVENT_LOG,
+        StateKey::NEXT_EVENT_SEQ,
+    ];
+}
+
+impl MarkVisitLedger {
+    pub(super) fn apply(
+        &self,
+        world: &mut RuntimeWorld,
+        ctx: &ProjectionContext<'_>,
+    ) -> Option<EventView> {
+        world.mark_visit_ledger(
+            ctx.actor_id(),
+            &self.category,
+            &self.label,
+            self.source_event_seq,
+            &self.reason,
+        )
+    }
+}
+
+/// `ProjectionMutation::StartTreasureObjective`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct StartTreasureObjective {
+    pub(super) start: TreasureObjectiveStart,
+}
+
+impl DeclaredWrites for StartTreasureObjective {
+    // `ACTOR_RULES_FACETS` is the same `next_event_seq`-revision surprise as
+    // `MarkVisitLedger`: starting an objective appends a
+    // `treasure_objective.started` event.
+    const WRITES: &'static [StateKey] = &[
+        StateKey::TREASURE_OBJECTIVES,
+        StateKey::ACTOR_RULES_FACETS,
+        StateKey::EVENT_LOG,
+        StateKey::NEXT_EVENT_SEQ,
+    ];
+}
+
+impl StartTreasureObjective {
+    pub(super) fn apply(
+        &self,
+        world: &mut RuntimeWorld,
+        _ctx: &ProjectionContext<'_>,
+    ) -> Option<EventView> {
+        world.apply_treasure_objective_start(&self.start)
+    }
+}
+
+/// `ProjectionMutation::SetRouteLifecycle`
+///
+/// The payload, `RouteLifecycleMutation`, is defined in `topology.rs` next to
+/// the route model it transitions, and predates this reshape. Its
+/// `DeclaredWrites` and `apply` live here instead, alongside the rest of this
+/// batch, rather than in `topology.rs` or `projection.rs`.
+impl DeclaredWrites for RouteLifecycleMutation {
+    // `ACTOR_RULES_FACETS` is the same `next_event_seq`-revision surprise as
+    // `MarkVisitLedger`: a lifecycle change that actually transitions the
+    // route appends a `route.<state>` event.
+    const WRITES: &'static [StateKey] = &[
+        StateKey::ROUTES,
+        StateKey::WORLD_EXITS,
+        StateKey::ACTOR_RULES_FACETS,
+        StateKey::EVENT_LOG,
+        StateKey::NEXT_EVENT_SEQ,
+    ];
+}
+
+impl RouteLifecycleMutation {
+    pub(super) fn apply(
+        &self,
+        world: &mut RuntimeWorld,
+        ctx: &ProjectionContext<'_>,
+    ) -> Option<EventView> {
+        world.apply_route_lifecycle_mutation(
+            ctx.actor_id(),
+            &self.route_id,
+            self.expected_version,
+            self.lifecycle,
+            &self.reason,
+        )
+    }
+}
+
+#[cfg(test)]
+mod projection_ledger_write_set_tests {
+    use super::*;
+    use projection::RecordProvenance;
+    use serde_json::Value;
+
+    /// The durable projection keys touched by applying `mutation` to `world`,
+    /// plus the post-mutation snapshot they were read from.
+    ///
+    /// A local copy of `projection::projection_write_set_tests::changed_keys`;
+    /// that helper is private to its own test module, and duplicating a dozen
+    /// lines here is cheaper than widening its visibility and risking a
+    /// collision with the other agents reshaping adjacent variants in
+    /// `projection.rs`. This copy diverges in one deliberate way: it also
+    /// returns `after` so `assert_within_declared_writes` can validate field
+    /// names against it instead of a freshly seeded world. Some snapshot
+    /// fields (e.g. `treasure_objectives`) carry
+    /// `skip_serializing_if = "BTreeMap::is_empty"`, so a field that is real
+    /// but empty on a fresh world silently vanishes from its JSON and reads
+    /// as "not a RuntimeSnapshot field". `after` is guaranteed non-empty for
+    /// any key the fixture actually wrote.
+    fn changed_keys(
+        world: &mut RuntimeWorld,
+        apply: impl FnOnce(&mut RuntimeWorld),
+    ) -> (Vec<String>, Value) {
+        let before = serde_json::to_value(RuntimeSnapshot::from_runtime(world))
+            .expect("snapshot serializes");
+        apply(world);
+        let after = serde_json::to_value(RuntimeSnapshot::from_runtime(world))
+            .expect("snapshot serializes");
+        let Value::Object(before_map) = &before else {
+            panic!("snapshot is a JSON object");
+        };
+        let Value::Object(after_map) = &after else {
+            panic!("snapshot is a JSON object");
+        };
+        let changed = after_map
+            .iter()
+            .filter(|(key, value)| before_map.get(key.as_str()) != Some(*value))
+            .map(|(key, _)| key.clone())
+            .collect();
+        (changed, after)
+    }
+
+    fn assert_within_declared_writes(
+        changed: &[String],
+        after: &Value,
+        declared: &[StateKey],
+        label: &str,
+    ) {
+        // A mutation that changed nothing satisfies containment trivially and
+        // would let a wrong declaration pass. Every fixture must exercise the
+        // handler for real.
+        assert!(
+            !changed.is_empty(),
+            "{label}: fixture produced no durable change, so its write set is untested",
+        );
+        let allowed: Vec<&str> = declared.iter().map(|key| key.snapshot_key()).collect();
+        // Every declared key must name a real snapshot field, or the
+        // declaration is checking nothing. Checked against `after` rather
+        // than a fresh seeded snapshot; see `changed_keys`.
+        for key in &allowed {
+            assert!(
+                after.get(key).is_some(),
+                "{label}: declared write set names `{key}`, which is not a RuntimeSnapshot field",
+            );
+        }
+        let undeclared: Vec<&String> = changed
+            .iter()
+            .filter(|key| !allowed.contains(&key.as_str()))
+            .collect();
+        assert!(
+            undeclared.is_empty(),
+            "{label}: wrote undeclared projection state {undeclared:?}; declared {allowed:?}",
+        );
+    }
+
+    fn context_for<'a>(action: &'a CwAction, events: &'a [EventView]) -> ProjectionContext<'a> {
+        ProjectionContext {
+            action,
+            committed_events: events,
+            enforce_active_contribution_contract: false,
+            provenance: RecordProvenance {
+                allow_legacy_generated_identity_backfill: false,
+                historical_bundle_hash: "",
+            },
+        }
+    }
+
+    fn first_actor_id(world: &RuntimeWorld) -> u64 {
+        world.world.actors[..world.world.actor_count][0].id
+    }
+
+    #[test]
+    fn set_gift_auto_accept_writes_only_gift_auto_accepts() {
+        let mut world = RuntimeWorld::seeded();
+        let action = CwAction::default();
+        let mutation = SetGiftAutoAccept {
+            policy: GiftAutoAcceptPolicy {
+                id: "policy-1".to_string(),
+                recipient_actor_id: 1,
+                offered_by_actor_id: 2,
+                item_id: 3,
+                created_tick: 0,
+                expires_tick: 100,
+                consumed: false,
+            },
+        };
+
+        let (changed, after) = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            mutation.apply(world, &ctx);
+        });
+
+        assert!(world.gift_auto_accepts.contains_key("policy-1"));
+        assert_within_declared_writes(
+            &changed,
+            &after,
+            SetGiftAutoAccept::WRITES,
+            "SetGiftAutoAccept",
+        );
+    }
+
+    #[test]
+    fn mark_visit_ledger_writes_its_declared_state() {
+        let mut world = RuntimeWorld::seeded();
+        let actor_id = first_actor_id(&world);
+        let action = CwAction {
+            actor_id,
+            ..CwAction::default()
+        };
+        let mutation = MarkVisitLedger {
+            category: "witness".to_string(),
+            label: "saw something happen".to_string(),
+            source_event_seq: 0,
+            reason: "test:mark".to_string(),
+        };
+
+        let mut produced = None;
+        let (changed, after) = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            produced = mutation.apply(world, &ctx);
+        });
+
+        assert!(produced.is_some(), "expected the mark to be applied");
+        assert!(world
+            .ledger_marks
+            .values()
+            .any(|mark| mark.actor_id == actor_id && mark.category == "witness"),);
+        assert_within_declared_writes(&changed, &after, MarkVisitLedger::WRITES, "MarkVisitLedger");
+    }
+
+    #[test]
+    fn start_treasure_objective_writes_its_declared_state() {
+        let mut world = RuntimeWorld::seeded();
+        let actor_id = first_actor_id(&world);
+        let treasure_item_id = world.world.items[..world.world.item_count][0].id;
+        let action = CwAction {
+            actor_id,
+            ..CwAction::default()
+        };
+        let mutation = StartTreasureObjective {
+            start: TreasureObjectiveStart {
+                schema_version: 1,
+                objective_id: "objective:test".to_string(),
+                actor_id,
+                treasure_item_id,
+                max_turns: 10,
+            },
+        };
+
+        let mut produced = None;
+        let (changed, after) = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            produced = mutation.apply(world, &ctx);
+        });
+
+        assert!(
+            produced.is_some(),
+            "expected the objective start to be applied"
+        );
+        assert!(world.treasure_objectives.contains_key("objective:test"));
+        assert_within_declared_writes(
+            &changed,
+            &after,
+            StartTreasureObjective::WRITES,
+            "StartTreasureObjective",
+        );
+    }
+
+    #[test]
+    fn set_route_lifecycle_writes_its_declared_state() {
+        let mut world = RuntimeWorld::seeded();
+        let route_id = world
+            .routes
+            .values()
+            .find(|route| route.lifecycle == RouteLifecycle::Open)
+            .expect("seeded world has an open route")
+            .id
+            .clone();
+        let expected_version = world.routes[&route_id].entity_version;
+        let action = CwAction::default();
+        let mutation = RouteLifecycleMutation {
+            route_id: route_id.clone(),
+            expected_version,
+            lifecycle: RouteLifecycle::Blocked,
+            reason: "test:block".to_string(),
+        };
+
+        let mut produced = None;
+        let (changed, after) = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            produced = mutation.apply(world, &ctx);
+        });
+
+        assert!(produced.is_some(), "expected the transition to be applied");
+        assert_eq!(world.routes[&route_id].lifecycle, RouteLifecycle::Blocked);
+        assert_within_declared_writes(
+            &changed,
+            &after,
+            RouteLifecycleMutation::WRITES,
+            "SetRouteLifecycle",
+        );
+    }
+}

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -236,4 +236,9 @@
 # like a property of event-appending handlers generally rather than the
 # item-specific effect ADR 0008 recorded for SetItemEquipped. No behaviour
 # changes; journal encoding pinned by test for each variant.
-67935
+# 67935 -> 67912: four ledger and route ProjectionMutation variants become
+# newtype payloads owning their apply -- SetGiftAutoAccept, MarkVisitLedger,
+# StartTreasureObjective, SetRouteLifecycle -- in projection_ledger.rs with
+# empirically derived write sets. Journal encoding pinned per variant; no
+# behaviour change.
+67912


### PR DESCRIPTION
Continues ADR 0008 / #61. Third batch, after #731 and #745.

`SetGiftAutoAccept`, `MarkVisitLedger`, `StartTreasureObjective`, and `SetRouteLifecycle` become newtype variants carrying payload structs that own their `apply`, in a new `projection_ledger.rs`.

`main.rs` **67,935 → 67,912**. No behaviour changes, arm order unchanged, no variant added/removed/renamed.

## Declared write sets

Derived empirically — start from an empty set, run the fixture, read back the keys that actually changed.

| Variant | Writes |
|---|---|
| `SetGiftAutoAccept` | `gift_auto_accepts` |
| `MarkVisitLedger` | `ledger_marks`, `rpg_claims`, `actor_rules_facets`, `event_log`, `next_event_seq` |
| `StartTreasureObjective` | `treasure_objectives`, `actor_rules_facets`, `event_log`, `next_event_seq` |
| `SetRouteLifecycle` | `routes`, `world_exits`, `actor_rules_facets`, `event_log`, `next_event_seq` |

## A latent bug in the shared helper, found and worked around here

`assert_within_declared_writes` validates that each declared key names a real `RuntimeSnapshot` field — but it validated against a **freshly seeded** world. `RuntimeSnapshot` has `skip_serializing_if` fields, so an empty `BTreeMap` (e.g. `treasure_objectives`) is simply absent from that JSON, and a perfectly correct declaration gets rejected as "not a RuntimeSnapshot field."

`projection_ledger.rs` validates against the **post**-mutation snapshot instead, which necessarily contains anything the fixture wrote.

`projection.rs`'s copy still carries the latent gap — none of its already-reshaped variants happen to hit it. **Worth porting before the next batch**, since any variant touching a normally-empty map will trip it.

## Journal encoding

Pinned for all four. `ProjectionMutation` is persisted in `JournalRecord` under `#[serde(tag = "kind")]`; a changed encoding breaks replay of every existing journal.

## Verification

Rebased onto `04507cd7` and re-run after resolving conflicts:

- `cargo test` — **1,141 pass**, 0 fail
- `check-main-size.sh` — 67,912 = ceiling (lowered in this diff)
- `cargo check --tests` — clean

Untouched by design: `SetActorSafety` (a deliberate three-field cascade, held back for separate handling), `CreateTransferOffer`, `ResolveTransferOffer`, `ConsumeGiftAutoAccept`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)