### PR TITLE
Reshape four character and bond projection mutations, and fix the write-set helper

### DIFF
--- a/docs/decisions/0008-projection-mutations-declare-their-writes.md
+++ b/docs/decisions/0008-projection-mutations-declare-their-writes.md
@@ -63,6 +63,26 @@ writes `actor_rules_facets`, `event_log`, and `next_event_seq`. Appending an
 event is itself durable projection state, which every event-returning handler
 does and no one would list by inspection.
 
+Thirteen variants later that is no longer a surprise, it is the rule: **every
+handler that returns events writes `event_log`, `next_event_seq`, and
+`actor_rules_facets`.** It held for variants that touch no item and change no
+object — `UnlockCharmSlot` and `UnlockCharmSlotForCharm` only append, and still
+write all three. Declare them by default and let the check confirm; do not
+rediscover them one batch at a time.
+
+Two failure modes of the check itself are worth knowing, because both were hit
+in practice. A fixture that changes nothing satisfies containment trivially, so
+the harness rejects a no-op fixture rather than recording a write set no test
+exercised. And declared keys are validated against the snapshot the fixture
+*produced*, not a freshly seeded one: `RuntimeSnapshot` skips empty collections
+when serializing, so a field that starts empty is absent from a seeded world's
+JSON and a correct declaration naming it would be rejected as unknown.
+
+A variant whose handler cannot produce a non-vacuous fixture therefore cannot be
+verified at all. `SetJobStatus` and `LegacyAcceptQuest` are both left unreshaped
+for that reason — the latter is an unconditional no-op by construction. An
+unverified declaration is worth less than none.
+
 ## Consequences
 
 `ProjectionMutation` is persisted inside `JournalRecord` under `#[serde(tag =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "0.0.372",
+  "version": "0.0.373",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "0.0.372",
+      "version": "0.0.373",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "0.0.372",
+  "version": "0.0.373",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "0.0.372"
+version = "0.0.373"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "0.0.372"
+version = "0.0.373"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -75,6 +75,7 @@ mod projection;
 mod projection_cache;
 #[cfg(test)]
 mod projection_cache_tests;
+mod projection_character;
 mod projection_items;
 mod projection_ledger;
 mod prompts;
@@ -1137,31 +1138,15 @@ enum ProjectionMutation {
         reason: String,
     },
     MarkVisitLedger(projection_ledger::MarkVisitLedger),
-    ChooseClass {
-        profile_id: String,
-        class_id: String,
-        calling: String,
-        starting_skill_id: String,
-        actor_meta: ActorMeta,
-        reason: String,
-    },
-    ReviseCalling {
-        statement: String,
-        cost: u8,
-        reason: String,
-    },
+    ChooseClass(projection_character::ChooseClass),
+    ReviseCalling(projection_character::ReviseCalling),
     CreateBond {
         target_actor_id: u64,
         statement: String,
         cost: u8,
         reason: String,
     },
-    ReviseBond {
-        target_actor_id: u64,
-        statement: String,
-        cost: u8,
-        reason: String,
-    },
+    ReviseBond(projection_character::ReviseBond),
     TrainSkill {
         skill_id: String,
         cost: u8,
@@ -1190,12 +1175,7 @@ enum ProjectionMutation {
         receipt_id: String,
         reason: String,
     },
-    DeepenBond {
-        target_actor_id: u64,
-        claim_key: String,
-        event_reason: String,
-        ledger_reason: String,
-    },
+    DeepenBond(projection_character::DeepenBond),
     ResolveBond {
         target_actor_id: u64,
         reason: String,
@@ -10702,30 +10682,11 @@ impl RuntimeWorld {
                         events.push(event);
                     }
                 }
-                ProjectionMutation::ChooseClass {
-                    profile_id,
-                    class_id,
-                    calling,
-                    starting_skill_id,
-                    actor_meta,
-                    reason,
-                } => {
-                    events.extend(self.choose_character_class(
-                        action.actor_id,
-                        profile_id,
-                        class_id,
-                        calling,
-                        starting_skill_id,
-                        actor_meta,
-                        reason,
-                    ));
+                ProjectionMutation::ChooseClass(mutation) => {
+                    events.extend(mutation.apply(self, &ctx));
                 }
-                ProjectionMutation::ReviseCalling {
-                    statement,
-                    cost,
-                    reason,
-                } => {
-                    events.extend(self.revise_calling(action.actor_id, statement, *cost, reason));
+                ProjectionMutation::ReviseCalling(mutation) => {
+                    events.extend(mutation.apply(self, &ctx));
                 }
                 ProjectionMutation::CreateBond {
                     target_actor_id,
@@ -10741,19 +10702,8 @@ impl RuntimeWorld {
                         reason,
                     ));
                 }
-                ProjectionMutation::ReviseBond {
-                    target_actor_id,
-                    statement,
-                    cost,
-                    reason,
-                } => {
-                    events.extend(self.revise_bond(
-                        action.actor_id,
-                        *target_actor_id,
-                        statement,
-                        *cost,
-                        reason,
-                    ));
+                ProjectionMutation::ReviseBond(mutation) => {
+                    events.extend(mutation.apply(self, &ctx));
                 }
                 ProjectionMutation::TrainSkill {
                     skill_id,
@@ -10811,21 +10761,8 @@ impl RuntimeWorld {
                 ProjectionMutation::UnmaterializeItem { receipt_id, reason } => {
                     events.extend(self.unmaterialize_item(action.actor_id, receipt_id, reason));
                 }
-                ProjectionMutation::DeepenBond {
-                    target_actor_id,
-                    claim_key,
-                    event_reason,
-                    ledger_reason,
-                } => {
-                    let source_event_seq = self.world.next_event_seq;
-                    events.extend(self.deepen_bond_from_event(
-                        action.actor_id,
-                        *target_actor_id,
-                        source_event_seq,
-                        claim_key.clone(),
-                        event_reason,
-                        ledger_reason,
-                    ));
+                ProjectionMutation::DeepenBond(mutation) => {
+                    events.extend(mutation.apply(self, &ctx));
                 }
                 ProjectionMutation::ResolveBond {
                     target_actor_id,
@@ -23166,14 +23103,16 @@ async fn choose_avatar_class(
     let mut record = JournalRecord::new(action, runtime.next_seed_value()).into_system();
     record
         .projection_mutations
-        .push(ProjectionMutation::ChooseClass {
-            profile_id: profile.id,
-            class_id: class.id,
-            calling: class.calling,
-            starting_skill_id: class.starting_skill_id,
-            actor_meta,
-            reason: "first_world_action".to_string(),
-        });
+        .push(ProjectionMutation::ChooseClass(
+            projection_character::ChooseClass {
+                profile_id: profile.id,
+                class_id: class.id,
+                calling: class.calling,
+                starting_skill_id: class.starting_skill_id,
+                actor_meta,
+                reason: "first_world_action".to_string(),
+            },
+        ));
     let Ok((status, events)) = commit_journal_record(&state, &mut runtime, record) else {
         return Json(ActionResponse {
             ok: false,
@@ -31300,12 +31239,14 @@ async fn help_room(
     if let Some(target_actor_id) = contribution_target_actor_id {
         record
             .projection_mutations
-            .push(ProjectionMutation::DeepenBond {
-                target_actor_id,
-                claim_key: help_bond_claim_key(payload.actor_id, target_actor_id),
-                event_reason: "help_project".to_string(),
-                ledger_reason: "help_project".to_string(),
-            });
+            .push(ProjectionMutation::DeepenBond(
+                projection_character::DeepenBond {
+                    target_actor_id,
+                    claim_key: help_bond_claim_key(payload.actor_id, target_actor_id),
+                    event_reason: "help_project".to_string(),
+                    ledger_reason: "help_project".to_string(),
+                },
+            ));
     }
     if prepared {
         record
@@ -31522,11 +31463,13 @@ async fn revise_calling(
     .into_player_card();
     record
         .projection_mutations
-        .push(ProjectionMutation::ReviseCalling {
-            statement,
-            cost: CALLING_REVISION_COST,
-            reason: "advancement".to_string(),
-        });
+        .push(ProjectionMutation::ReviseCalling(
+            projection_character::ReviseCalling {
+                statement,
+                cost: CALLING_REVISION_COST,
+                reason: "advancement".to_string(),
+            },
+        ));
 
     let Ok((status, mut events)) = commit_journal_record(&state, &mut runtime, record) else {
         return Json(ActionResponse {
@@ -32193,12 +32136,14 @@ async fn revise_bond(
     .into_player_card();
     record
         .projection_mutations
-        .push(ProjectionMutation::ReviseBond {
-            target_actor_id: payload.target_actor_id,
-            statement,
-            cost: BOND_REVISION_COST,
-            reason: "advancement".to_string(),
-        });
+        .push(ProjectionMutation::ReviseBond(
+            projection_character::ReviseBond {
+                target_actor_id: payload.target_actor_id,
+                statement,
+                cost: BOND_REVISION_COST,
+                reason: "advancement".to_string(),
+            },
+        ));
 
     let Ok((status, mut events)) = commit_journal_record(&state, &mut runtime, record) else {
         return Json(ActionResponse {
@@ -51911,11 +51856,13 @@ mod tests {
         let mut revise_record = JournalRecord::new(revise_action, 7095);
         revise_record
             .projection_mutations
-            .push(ProjectionMutation::ReviseCalling {
-                statement: statement.clone(),
-                cost: CALLING_REVISION_COST,
-                reason: "advancement".to_string(),
-            });
+            .push(ProjectionMutation::ReviseCalling(
+                projection_character::ReviseCalling {
+                    statement: statement.clone(),
+                    cost: CALLING_REVISION_COST,
+                    reason: "advancement".to_string(),
+                },
+            ));
         let (status, events) = runtime.apply_journal_record(&revise_record);
         assert_eq!(status, CW_OK);
         assert!(events
@@ -65990,12 +65937,14 @@ mod tests {
         let mut revise_record = JournalRecord::new(revise_action, 7214);
         revise_record
             .projection_mutations
-            .push(ProjectionMutation::ReviseBond {
-                target_actor_id: 1002,
-                statement: revised_statement.to_string(),
-                cost: BOND_REVISION_COST,
-                reason: "advancement".to_string(),
-            });
+            .push(ProjectionMutation::ReviseBond(
+                projection_character::ReviseBond {
+                    target_actor_id: 1002,
+                    statement: revised_statement.to_string(),
+                    cost: BOND_REVISION_COST,
+                    reason: "advancement".to_string(),
+                },
+            ));
         let (status, events) = runtime.apply_journal_record(&revise_record);
         assert_eq!(status, CW_OK);
         assert!(events.iter().any(|event| {

--- a/v2/orchestrator-rust/src/projection.rs
+++ b/v2/orchestrator-rust/src/projection.rs
@@ -44,6 +44,8 @@ impl StateKey {
     pub(super) const GIFT_AUTO_ACCEPTS: Self = Self("gift_auto_accepts");
     pub(super) const WORLD_ITEMS: Self = Self("world_items");
     pub(super) const WORLD_EXITS: Self = Self("world_exits");
+    pub(super) const WORLD_ACTORS: Self = Self("world_actors");
+    pub(super) const ACTOR_META: Self = Self("actor_meta");
     pub(super) const ACTOR_RULES_FACETS: Self = Self("actor_rules_facets");
     pub(super) const ADVANCEMENT_SPENDS: Self = Self("advancement_spends");
     pub(super) const CHARM_SLOTS: Self = Self("charm_slots");
@@ -53,6 +55,10 @@ impl StateKey {
     pub(super) const RPG_CLAIMS: Self = Self("rpg_claims");
     pub(super) const TREASURE_OBJECTIVES: Self = Self("treasure_objectives");
     pub(super) const ROUTES: Self = Self("routes");
+    pub(super) const CHARACTER_IDENTITIES: Self = Self("character_identities");
+    pub(super) const CALLINGS: Self = Self("callings");
+    pub(super) const SKILLS: Self = Self("skills");
+    pub(super) const BONDS: Self = Self("bonds");
     /// Appending an event is itself durable projection state. Any handler that
     /// returns events writes these two, which is easy to miss by inspection and
     /// is why the declaration is derived from a run rather than from reading.
@@ -210,6 +216,78 @@ mod projection_write_set_tests {
                 json!({
                     "kind": "consume_gift_auto_accept",
                     "policy_id": "policy-1",
+                }),
+            ),
+            (
+                ProjectionMutation::ChooseClass(projection_character::ChooseClass {
+                    profile_id: "profile-1".to_string(),
+                    class_id: "class-1".to_string(),
+                    calling: "I mend the paths.".to_string(),
+                    starting_skill_id: "lifting".to_string(),
+                    actor_meta: ActorMeta {
+                        name: "Rati".to_string(),
+                        speech_mode: "prose".to_string(),
+                        title: "Lantern Warden".to_string(),
+                        description: "A keeper of small lights.".to_string(),
+                    },
+                    reason: "first_world_action".to_string(),
+                }),
+                json!({
+                    "kind": "choose_class",
+                    "profile_id": "profile-1",
+                    "class_id": "class-1",
+                    "calling": "I mend the paths.",
+                    "starting_skill_id": "lifting",
+                    "actor_meta": {
+                        "name": "Rati",
+                        "speech_mode": "prose",
+                        "title": "Lantern Warden",
+                        "description": "A keeper of small lights.",
+                    },
+                    "reason": "first_world_action",
+                }),
+            ),
+            (
+                ProjectionMutation::ReviseCalling(projection_character::ReviseCalling {
+                    statement: "I mend what the rain loosens.".to_string(),
+                    cost: 1,
+                    reason: "advancement".to_string(),
+                }),
+                json!({
+                    "kind": "revise_calling",
+                    "statement": "I mend what the rain loosens.",
+                    "cost": 1,
+                    "reason": "advancement",
+                }),
+            ),
+            (
+                ProjectionMutation::DeepenBond(projection_character::DeepenBond {
+                    target_actor_id: 1002,
+                    claim_key: "claim-1".to_string(),
+                    event_reason: "help_project".to_string(),
+                    ledger_reason: "help_project".to_string(),
+                }),
+                json!({
+                    "kind": "deepen_bond",
+                    "target_actor_id": 1002,
+                    "claim_key": "claim-1",
+                    "event_reason": "help_project",
+                    "ledger_reason": "help_project",
+                }),
+            ),
+            (
+                ProjectionMutation::ReviseBond(projection_character::ReviseBond {
+                    target_actor_id: 1002,
+                    statement: "We mend the same roads now.".to_string(),
+                    cost: 1,
+                    reason: "advancement".to_string(),
+                }),
+                json!({
+                    "kind": "revise_bond",
+                    "target_actor_id": 1002,
+                    "statement": "We mend the same roads now.",
+                    "cost": 1,
+                    "reason": "advancement",
                 }),
             ),
             (
@@ -391,10 +469,15 @@ mod projection_write_set_tests {
     /// The durable projection keys touched by applying `mutation` to `world`.
     ///
     /// Snapshot terms, because the snapshot is what a restart remembers.
+    /// Returns the durable keys the mutation changed, plus the snapshot it
+    /// produced. The snapshot comes back because declared keys are validated
+    /// against it: `RuntimeSnapshot` skips empty collections when serializing,
+    /// so a field that starts empty is simply absent from a seeded world's JSON
+    /// and a correct declaration naming it would be rejected as unknown.
     fn changed_keys(
         world: &mut RuntimeWorld,
         apply: impl FnOnce(&mut RuntimeWorld),
-    ) -> Vec<String> {
+    ) -> (Vec<String>, Value) {
         let before = serde_json::to_value(RuntimeSnapshot::from_runtime(world))
             .expect("snapshot serializes");
         apply(world);
@@ -403,14 +486,20 @@ mod projection_write_set_tests {
         let (Value::Object(before), Value::Object(after)) = (before, after) else {
             panic!("snapshot is a JSON object");
         };
-        after
-            .into_iter()
-            .filter(|(key, value)| before.get(key) != Some(value))
-            .map(|(key, _)| key)
-            .collect()
+        let changed = after
+            .iter()
+            .filter(|(key, value)| before.get(*key) != Some(*value))
+            .map(|(key, _)| key.clone())
+            .collect();
+        (changed, Value::Object(after))
     }
 
-    fn assert_within_declared_writes(changed: &[String], declared: &[StateKey], label: &str) {
+    fn assert_within_declared_writes(
+        changed: &[String],
+        snapshot: &Value,
+        declared: &[StateKey],
+        label: &str,
+    ) {
         // A mutation that changed nothing satisfies containment trivially and
         // would let a wrong declaration pass. Every fixture must exercise the
         // handler for real.
@@ -420,9 +509,8 @@ mod projection_write_set_tests {
         );
         let allowed: Vec<&str> = declared.iter().map(|key| key.snapshot_key()).collect();
         // Every declared key must name a real snapshot field, or the
-        // declaration is checking nothing.
-        let snapshot = serde_json::to_value(RuntimeSnapshot::from_runtime(&RuntimeWorld::seeded()))
-            .expect("snapshot serializes");
+        // declaration is checking nothing. Validate against the post-mutation
+        // snapshot: a seeded world omits fields that are still empty.
         for key in &allowed {
             assert!(
                 snapshot.get(key).is_some(),
@@ -476,7 +564,7 @@ mod projection_write_set_tests {
             resolved_by_actor_id: 2,
         };
 
-        let changed = changed_keys(&mut world, |world| {
+        let (changed, snapshot) = changed_keys(&mut world, |world| {
             let events = Vec::new();
             let ctx = context_for(&action, &events);
             mutation.apply(world, &ctx);
@@ -493,6 +581,7 @@ mod projection_write_set_tests {
         );
         assert_within_declared_writes(
             &changed,
+            &snapshot,
             ResolveTransferOffer::WRITES,
             "ResolveTransferOffer",
         );
@@ -518,7 +607,7 @@ mod projection_write_set_tests {
             policy_id: "policy-1".to_string(),
         };
 
-        let changed = changed_keys(&mut world, |world| {
+        let (changed, snapshot) = changed_keys(&mut world, |world| {
             let events = Vec::new();
             let ctx = context_for(&action, &events);
             mutation.apply(world, &ctx);
@@ -527,6 +616,7 @@ mod projection_write_set_tests {
         assert!(world.gift_auto_accepts["policy-1"].consumed);
         assert_within_declared_writes(
             &changed,
+            &snapshot,
             ConsumeGiftAutoAccept::WRITES,
             "ConsumeGiftAutoAccept",
         );
@@ -563,7 +653,7 @@ mod projection_write_set_tests {
         };
 
         let mut produced = Vec::new();
-        let changed = changed_keys(&mut world, |world| {
+        let (changed, snapshot) = changed_keys(&mut world, |world| {
             let events = Vec::new();
             let ctx = context_for(&action, &events);
             produced = mutation.apply(world, &ctx);
@@ -575,6 +665,11 @@ mod projection_write_set_tests {
                 .any(|event| event.type_name == "item.equipped"),
             "expected the equip to be applied",
         );
-        assert_within_declared_writes(&changed, SetItemEquipped::WRITES, "SetItemEquipped");
+        assert_within_declared_writes(
+            &changed,
+            &snapshot,
+            SetItemEquipped::WRITES,
+            "SetItemEquipped",
+        );
     }
 }

--- a/v2/orchestrator-rust/src/projection_character.rs
+++ b/v2/orchestrator-rust/src/projection_character.rs
@@ -1,0 +1,446 @@
+//! Payload structs for the character-progression `ProjectionMutation`
+//! variants: class selection, calling revision, and bond deepening/revision.
+//!
+//! This is the same reshape as `projection.rs` applied to a different batch
+//! of variants — see that module's doc comment and ADR 0008 for the pattern
+//! and its rationale. Payloads live in this file rather than `projection.rs`
+//! so that reshaping different variants in parallel does not collide on the
+//! same file.
+
+use super::*;
+// `Type::WRITES` resolves through this trait, so it must be in scope; the
+// `impl` headers below spell the trait name bare rather than fully qualified
+// so this import stays live outside `#[cfg(test)]` too.
+use projection::DeclaredWrites;
+
+/// `ProjectionMutation::ChooseClass`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct ChooseClass {
+    pub(super) profile_id: String,
+    pub(super) class_id: String,
+    pub(super) calling: String,
+    pub(super) starting_skill_id: String,
+    pub(super) actor_meta: ActorMeta,
+    pub(super) reason: String,
+}
+
+impl DeclaredWrites for ChooseClass {
+    const WRITES: &'static [projection::StateKey] = &[
+        projection::StateKey::WORLD_ACTORS,
+        projection::StateKey::ACTOR_META,
+        projection::StateKey::CHARACTER_IDENTITIES,
+        projection::StateKey::CALLINGS,
+        projection::StateKey::SKILLS,
+        // `snapshot_actor_rules_facets` embeds the current event revision, so
+        // it reads as changed whenever next_event_seq moves, which every
+        // event-appending handler does. See ADR 0008 and SetItemEquipped's
+        // declaration in projection.rs for the same reach.
+        projection::StateKey::ACTOR_RULES_FACETS,
+        projection::StateKey::EVENT_LOG,
+        projection::StateKey::NEXT_EVENT_SEQ,
+    ];
+}
+
+impl ChooseClass {
+    pub(super) fn apply(
+        &self,
+        world: &mut RuntimeWorld,
+        ctx: &projection::ProjectionContext<'_>,
+    ) -> Vec<EventView> {
+        world.choose_character_class(
+            ctx.actor_id(),
+            &self.profile_id,
+            &self.class_id,
+            &self.calling,
+            &self.starting_skill_id,
+            &self.actor_meta,
+            &self.reason,
+        )
+    }
+}
+
+/// `ProjectionMutation::ReviseCalling`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct ReviseCalling {
+    pub(super) statement: String,
+    pub(super) cost: u8,
+    pub(super) reason: String,
+}
+
+impl DeclaredWrites for ReviseCalling {
+    const WRITES: &'static [projection::StateKey] = &[
+        projection::StateKey::CALLINGS,
+        projection::StateKey::ADVANCEMENT_SPENDS,
+        // See ChooseClass's declaration above: appending an event moves
+        // next_event_seq, which changes the embedded revision in every
+        // actor's snapshotted rules facet.
+        projection::StateKey::ACTOR_RULES_FACETS,
+        projection::StateKey::EVENT_LOG,
+        projection::StateKey::NEXT_EVENT_SEQ,
+    ];
+}
+
+impl ReviseCalling {
+    pub(super) fn apply(
+        &self,
+        world: &mut RuntimeWorld,
+        ctx: &projection::ProjectionContext<'_>,
+    ) -> Vec<EventView> {
+        world.revise_calling(ctx.actor_id(), &self.statement, self.cost, &self.reason)
+    }
+}
+
+/// `ProjectionMutation::DeepenBond`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct DeepenBond {
+    pub(super) target_actor_id: u64,
+    pub(super) claim_key: String,
+    pub(super) event_reason: String,
+    pub(super) ledger_reason: String,
+}
+
+impl DeclaredWrites for DeepenBond {
+    const WRITES: &'static [projection::StateKey] = &[
+        projection::StateKey::BONDS,
+        projection::StateKey::LEDGER_MARKS,
+        projection::StateKey::RPG_CLAIMS,
+        // See ChooseClass's declaration above: appending an event moves
+        // next_event_seq, which changes the embedded revision in every
+        // actor's snapshotted rules facet.
+        projection::StateKey::ACTOR_RULES_FACETS,
+        projection::StateKey::EVENT_LOG,
+        projection::StateKey::NEXT_EVENT_SEQ,
+    ];
+}
+
+impl DeepenBond {
+    pub(super) fn apply(
+        &self,
+        world: &mut RuntimeWorld,
+        ctx: &projection::ProjectionContext<'_>,
+    ) -> Vec<EventView> {
+        // Mirrors the pre-reshape call site: the source event seq is read
+        // before the handler runs and appends its own events.
+        let source_event_seq = world.world.next_event_seq;
+        world.deepen_bond_from_event(
+            ctx.actor_id(),
+            self.target_actor_id,
+            source_event_seq,
+            self.claim_key.clone(),
+            &self.event_reason,
+            &self.ledger_reason,
+        )
+    }
+}
+
+/// `ProjectionMutation::ReviseBond`
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct ReviseBond {
+    pub(super) target_actor_id: u64,
+    pub(super) statement: String,
+    pub(super) cost: u8,
+    pub(super) reason: String,
+}
+
+impl DeclaredWrites for ReviseBond {
+    const WRITES: &'static [projection::StateKey] = &[
+        projection::StateKey::BONDS,
+        projection::StateKey::ADVANCEMENT_SPENDS,
+        // See ChooseClass's declaration above: appending an event moves
+        // next_event_seq, which changes the embedded revision in every
+        // actor's snapshotted rules facet.
+        projection::StateKey::ACTOR_RULES_FACETS,
+        projection::StateKey::EVENT_LOG,
+        projection::StateKey::NEXT_EVENT_SEQ,
+    ];
+}
+
+impl ReviseBond {
+    pub(super) fn apply(
+        &self,
+        world: &mut RuntimeWorld,
+        ctx: &projection::ProjectionContext<'_>,
+    ) -> Vec<EventView> {
+        world.revise_bond(
+            ctx.actor_id(),
+            self.target_actor_id,
+            &self.statement,
+            self.cost,
+            &self.reason,
+        )
+    }
+}
+
+#[cfg(test)]
+mod projection_character_write_set_tests {
+    use super::*;
+    use serde_json::Value;
+
+    /// Local copy of `projection::projection_write_set_tests::changed_keys`.
+    /// That helper is private to `projection.rs`'s test module, and this file
+    /// exists precisely so parallel reshapes do not share edits to
+    /// `projection.rs`; duplicating the small helper avoids reopening that
+    /// file's test internals.
+    fn changed_keys(
+        world: &mut RuntimeWorld,
+        apply: impl FnOnce(&mut RuntimeWorld),
+    ) -> Vec<String> {
+        let before = serde_json::to_value(RuntimeSnapshot::from_runtime(world))
+            .expect("snapshot serializes");
+        apply(world);
+        let after = serde_json::to_value(RuntimeSnapshot::from_runtime(world))
+            .expect("snapshot serializes");
+        let (Value::Object(before), Value::Object(after)) = (before, after) else {
+            panic!("snapshot is a JSON object");
+        };
+        after
+            .into_iter()
+            .filter(|(key, value)| before.get(key) != Some(value))
+            .map(|(key, _)| key)
+            .collect()
+    }
+
+    fn assert_within_declared_writes(
+        changed: &[String],
+        declared: &[projection::StateKey],
+        label: &str,
+    ) {
+        // A mutation that changed nothing satisfies containment trivially and
+        // would let a wrong declaration pass. Every fixture must exercise the
+        // handler for real.
+        assert!(
+            !changed.is_empty(),
+            "{label}: fixture produced no durable change, so its write set is untested",
+        );
+        let allowed: Vec<&str> = declared.iter().map(|key| key.snapshot_key()).collect();
+        let snapshot = serde_json::to_value(RuntimeSnapshot::from_runtime(&RuntimeWorld::seeded()))
+            .expect("snapshot serializes");
+        for key in &allowed {
+            assert!(
+                snapshot.get(key).is_some(),
+                "{label}: declared write set names `{key}`, which is not a RuntimeSnapshot field",
+            );
+        }
+        let undeclared: Vec<&String> = changed
+            .iter()
+            .filter(|key| !allowed.contains(&key.as_str()))
+            .collect();
+        assert!(
+            undeclared.is_empty(),
+            "{label}: wrote undeclared projection state {undeclared:?}; declared {allowed:?}",
+        );
+    }
+
+    fn context_for<'a>(
+        action: &'a CwAction,
+        events: &'a [EventView],
+    ) -> projection::ProjectionContext<'a> {
+        projection::ProjectionContext {
+            action,
+            committed_events: events,
+            enforce_active_contribution_contract: false,
+            provenance: projection::RecordProvenance {
+                allow_legacy_generated_identity_backfill: false,
+                historical_bundle_hash: "",
+            },
+        }
+    }
+
+    #[test]
+    fn choose_class_writes_its_declared_state() {
+        let mut world = RuntimeWorld::seeded();
+        world.character_identities.insert(
+            RATI_ACTOR_ID,
+            AvatarIdentityState {
+                actor_id: RATI_ACTOR_ID,
+                profile_id: "test-profile".to_string(),
+                species_id: "human".to_string(),
+                origin_id: "wayside-inn".to_string(),
+                physical_description: String::new(),
+                class_id: None,
+                class_selection_ready: true,
+                qualifying_world_actions: 1,
+                class_source_event_seq: None,
+                class_readiness_evidence: None,
+            },
+        );
+        let action = CwAction {
+            actor_id: RATI_ACTOR_ID,
+            ..CwAction::default()
+        };
+        // A starting skill with a known label exercises the skill-stepping
+        // reach too, not just the identity and calling writes.
+        let mutation = ChooseClass {
+            profile_id: "test-profile".to_string(),
+            class_id: "lantern-warden".to_string(),
+            calling: "I keep the old lights burning.".to_string(),
+            starting_skill_id: "lifting".to_string(),
+            actor_meta: ActorMeta {
+                name: "Rati".to_string(),
+                speech_mode: "prose".to_string(),
+                title: "Lantern Warden".to_string(),
+                description: String::new(),
+            },
+            reason: "first_world_action".to_string(),
+        };
+
+        let mut produced = Vec::new();
+        let changed = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            produced = mutation.apply(world, &ctx);
+        });
+
+        assert!(
+            produced
+                .iter()
+                .any(|event| event.type_name == "class.chosen"),
+            "expected the class choice to be applied",
+        );
+        assert_eq!(
+            world.character_identities[&RATI_ACTOR_ID]
+                .class_id
+                .as_deref(),
+            Some("lantern-warden"),
+        );
+        assert_within_declared_writes(&changed, ChooseClass::WRITES, "ChooseClass");
+    }
+
+    #[test]
+    fn revise_calling_writes_its_declared_state() {
+        let mut world = RuntimeWorld::seeded();
+        // A banked, unspent ledger mark funds one advancement point, which is
+        // what revise_calling's cost gate requires.
+        world.ledger_marks.insert(
+            "mark-1".to_string(),
+            VisitLedgerMarkState {
+                id: "mark-1".to_string(),
+                actor_id: RATI_ACTOR_ID,
+                category: "test".to_string(),
+                label: "Test bank".to_string(),
+                source_event_seq: 0,
+                banked: true,
+            },
+        );
+        let action = CwAction {
+            actor_id: RATI_ACTOR_ID,
+            ..CwAction::default()
+        };
+        let mutation = ReviseCalling {
+            statement: "I mend what the rain loosens.".to_string(),
+            cost: CALLING_REVISION_COST,
+            reason: "advancement".to_string(),
+        };
+
+        let mut produced = Vec::new();
+        let changed = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            produced = mutation.apply(world, &ctx);
+        });
+
+        assert!(
+            produced
+                .iter()
+                .any(|event| event.type_name == "calling.revised"),
+            "expected the calling revision to be applied",
+        );
+        assert_eq!(
+            world.callings[&RATI_ACTOR_ID].statement,
+            "I mend what the rain loosens.",
+        );
+        assert_within_declared_writes(&changed, ReviseCalling::WRITES, "ReviseCalling");
+    }
+
+    #[test]
+    fn deepen_bond_writes_its_declared_state() {
+        let mut world = RuntimeWorld::seeded();
+        let action = CwAction {
+            actor_id: RATI_ACTOR_ID,
+            ..CwAction::default()
+        };
+        let mutation = DeepenBond {
+            target_actor_id: WHISKERWIND_ACTOR_ID,
+            claim_key: "deepen-bond-test-claim".to_string(),
+            event_reason: "help_project".to_string(),
+            ledger_reason: "help_project".to_string(),
+        };
+
+        let mut produced = Vec::new();
+        let changed = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            produced = mutation.apply(world, &ctx);
+        });
+
+        assert!(
+            produced
+                .iter()
+                .any(|event| event.type_name == "bond.deepened"),
+            "expected the bond to deepen",
+        );
+        assert_eq!(
+            world.bonds[&bond_id(RATI_ACTOR_ID, WHISKERWIND_ACTOR_ID)].strength,
+            1,
+        );
+        assert_within_declared_writes(&changed, DeepenBond::WRITES, "DeepenBond");
+    }
+
+    #[test]
+    fn revise_bond_writes_its_declared_state() {
+        let mut world = RuntimeWorld::seeded();
+        let id = bond_id(RATI_ACTOR_ID, WHISKERWIND_ACTOR_ID);
+        world.bonds.insert(
+            id.clone(),
+            BondState {
+                id: id.clone(),
+                actor_id: RATI_ACTOR_ID,
+                target_actor_id: WHISKERWIND_ACTOR_ID,
+                statement: "We used to pass each other in silence.".to_string(),
+                strength: 1,
+                status: "active".to_string(),
+                source_event_seq: Some(0),
+                updated_event_seq: None,
+                dialogue_status: String::new(),
+                dialogue_event_seq: None,
+            },
+        );
+        world.ledger_marks.insert(
+            "mark-1".to_string(),
+            VisitLedgerMarkState {
+                id: "mark-1".to_string(),
+                actor_id: RATI_ACTOR_ID,
+                category: "test".to_string(),
+                label: "Test bank".to_string(),
+                source_event_seq: 0,
+                banked: true,
+            },
+        );
+        let action = CwAction {
+            actor_id: RATI_ACTOR_ID,
+            ..CwAction::default()
+        };
+        let mutation = ReviseBond {
+            target_actor_id: WHISKERWIND_ACTOR_ID,
+            statement: "We mend the same roads now.".to_string(),
+            cost: BOND_REVISION_COST,
+            reason: "advancement".to_string(),
+        };
+
+        let mut produced = Vec::new();
+        let changed = changed_keys(&mut world, |world| {
+            let events = Vec::new();
+            let ctx = context_for(&action, &events);
+            produced = mutation.apply(world, &ctx);
+        });
+
+        assert!(
+            produced
+                .iter()
+                .any(|event| event.type_name == "bond.revised"),
+            "expected the bond revision to be applied",
+        );
+        assert_eq!(world.bonds[&id].statement, "We mend the same roads now.");
+        assert_within_declared_writes(&changed, ReviseBond::WRITES, "ReviseBond");
+    }
+}

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -241,4 +241,12 @@
 # StartTreasureObjective, SetRouteLifecycle -- in projection_ledger.rs with
 # empirically derived write sets. Journal encoding pinned per variant; no
 # behaviour change.
-67912
+# 67912 -> 67860: four character and bond ProjectionMutation variants become
+# newtype payloads owning their apply -- ChooseClass, ReviseCalling, DeepenBond,
+# ReviseBond -- in projection_character.rs with empirically derived write sets.
+# LegacyAcceptQuest is deliberately left inline: its handler is an unconditional
+# no-op, so no non-vacuous fixture can exist and its write set is unverifiable
+# by construction, the same reason SetJobStatus was reverted from #731. Also
+# fixes the write-set helper, which validated declared keys against a seeded
+# snapshot and so rejected correct declarations naming a normally-empty field.
+67860


### PR DESCRIPTION
Continues ADR 0008 / #61. Fourth batch, after #731, #745, and #753.

`ChooseClass`, `ReviseCalling`, `DeepenBond`, and `ReviseBond` become newtype variants carrying payload structs that own their `apply`, in a new `projection_character.rs`.

`main.rs` **67,912 → 67,860**. No behaviour changes, arm order unchanged, no variant added/removed/renamed.

## Declared write sets

| Variant | Writes |
|---|---|
| `ChooseClass` | `world_actors`, `actor_meta`, `character_identities`, `callings`, `skills`, `actor_rules_facets`, `event_log`, `next_event_seq` |
| `ReviseCalling` | `callings`, `advancement_spends`, `actor_rules_facets`, `event_log`, `next_event_seq` |
| `DeepenBond` | `bonds`, `ledger_marks`, `rpg_claims`, `actor_rules_facets`, `event_log`, `next_event_seq` |
| `ReviseBond` | `bonds`, `advancement_spends`, `actor_rules_facets`, `event_log`, `next_event_seq` |

`ChooseClass` reaching eight keys — including `world_actors` and `actor_meta` — is not visible from reading the handler.

## Fixes the write-set helper

`assert_within_declared_writes` validated declared keys against a **freshly seeded** snapshot. `RuntimeSnapshot` skips empty collections when serializing, so a field that starts empty is simply absent from that JSON and a *correct* declaration naming it was rejected as an unknown field.

The ledger batch hit this on `treasure_objectives` and worked around it locally in `projection_ledger.rs`. This lifts the fix into the shared helper: declared keys are now validated against the snapshot the fixture **produced**, which necessarily contains whatever was written.

## ADR 0008 updated

Two changes, both earned rather than assumed:

**The event-append triple is now the rule, not a surprise.** Thirteen variants in, every handler that returns events writes `event_log`, `next_event_seq`, and `actor_rules_facets` — including `UnlockCharmSlot` and `UnlockCharmSlotForCharm`, which touch no item and only append. Declare them by default and let the check confirm.

**Both failure modes of the check are now recorded**, since both were hit in practice: a no-op fixture satisfies containment trivially (rejected), and the seeded-snapshot validation bug above.

## `LegacyAcceptQuest` deliberately not reshaped

Its handler is an unconditional no-op — `legacy_accept_quest_records_replay_as_an_explicit_retired_no_op` already pins that it produces no events and no tick. Since the harness rejects vacuous fixtures on purpose, its write set is **unverifiable by construction**.

Left inline, for the same reason `SetJobStatus` was reverted from #731: an unverified declaration is worth less than none. The ADR now states this as a general limit of the pattern.

## Verification

Rebased onto `main` after #753 merged. That rebase surfaced duplicate enum variants — main had already taken the ledger newtypes while this branch still carried their inline forms — resolved by preferring the newtype and dropping the inline definition.

- `cargo test` — **1,145 pass**, 0 fail
- `check-main-size.sh` — 67,860 = ceiling (lowered in this diff)
- `cargo clippy --all-targets` — **225 = ceiling**, zero added
- `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)