### PR TITLE
Include content engine marker in production image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 !deploy/lonelyforest/
 !deploy/lonelyforest/**
 !v2/
+!v2/content-engine-version.txt
 !v2/ai-model-rust/
 !v2/ai-model-rust/Cargo.toml
 !v2/ai-model-rust/Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.0 — 2026-08-11
+## 1.0.2 — 2026-08-12
 
 CosyWorld 1.0 is the first stable release of the canonical V2 product: a shared,
 persistent AI MUD with a deterministic rules kernel, a Rust HTTP/SSE host, and a
@@ -16,6 +16,7 @@ small card-driven browser interface.
   and seventh-visit memory proof.
 - The Project 89 composition with playable onboarding, populated actors, durable
   progress, and the narrow optional Proxim8 linked-avatar pilot.
+- The illustrated Hoppycat living archive as a dedicated Lonely Forest tenant.
 - Version-locked world packs, deterministic content compilation, explicit upgrade
   compatibility, and production recovery evidence.
 - Browser coverage for onboarding, card actions, persistence, failure states,
@@ -46,3 +47,5 @@ retained journal cursor; it must not reseed or fork the canonical world.
 
 The final GitHub release and issue #533 record the immutable candidate and final
 tag workflow runs, production observations, and the completed milestone evidence.
+The earlier `v1.0.0-rc.1` candidate failed during image construction before any
+production process was replaced; its tag remains immutable as failure evidence.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN cargo chef cook --release --recipe-path /app/recipe.json
 
 COPY v2/core-c /app/v2/core-c
 COPY v2/content /app/v2/content
+COPY v2/content-engine-version.txt /app/v2/content-engine-version.txt
 COPY v2/media /app/v2/media
 COPY v2/ai-model-rust /app/v2/ai-model-rust
 COPY v2/orchestrator-rust /app/v2/orchestrator-rust

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -510,14 +510,24 @@ describe('deploy workflow', () => {
     }
   });
 
-  it('copies compile-time media registries into the release image build', () => {
+  it('copies every out-of-crate compile-time input into the release image build', () => {
     const dependencyBuild = 'RUN cargo chef cook --release --recipe-path /app/recipe.json';
+    const engineVersionCopy =
+      'COPY v2/content-engine-version.txt /app/v2/content-engine-version.txt';
     const mediaCopy = 'COPY v2/media /app/v2/media';
     const releaseBuild = 'RUN cargo build --release';
 
+    expect(dockerignore).toContain('!v2/content-engine-version.txt');
     expect(dockerignore).toContain('!v2/media/');
     expect(dockerignore).toContain('!v2/media/**');
+    expect(dockerfile).toContain(engineVersionCopy);
     expect(dockerfile).toContain(mediaCopy);
+    expect(dockerfile.indexOf(dependencyBuild)).toBeLessThan(
+      dockerfile.indexOf(engineVersionCopy)
+    );
+    expect(dockerfile.indexOf(engineVersionCopy)).toBeLessThan(
+      dockerfile.indexOf(releaseBuild)
+    );
     expect(dockerfile.indexOf(dependencyBuild)).toBeLessThan(
       dockerfile.indexOf(mediaCopy)
     );

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- include `v2/content-engine-version.txt` in the Docker build context
- copy the compile-time marker before the release Rust build
- lock both the Docker ignore rule and build ordering in the deployment contract test
- rebase over the newly merged Hoppycat worldpack and advance the release to `1.0.2`

## Failure evidence

The earlier `v1.0.0-rc.1` candidate passed CI but the Fly build failed before rollout because `include_str!("../../content-engine-version.txt")` could not find the marker inside the Docker image. No 1.0 process replaced production, and the failed tag remains immutable.

While this fix was in review, #756 merged Hoppycat and advanced `main` to `1.0.1`. This PR therefore becomes `1.0.2`, the first deployable stable 1.0 release, rather than rewinding published version history.

## Validation

- deployment contract: 25/25 passed after rebase
- `npm run check:version`: passed
- `git diff --check`: passed
- prior PR head passed full content/kernel, publication, Rust, architecture, binary, composition, and clean-world browser gates; all required gates rerun on this rebased head before merge