### PR TITLE
Fix guarded Hoppycat tenant bootstrap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -192,7 +192,14 @@ jobs:
               echo "::error::A recovery capture and fresh tenant bootstrap cannot be requested together"
               exit 1
             fi
-            flyctl ssh console -a cosyworld-lonelyforest -C 'test ! -e /data/worldpacks/hoppycat || test -z "$(find /data/worldpacks/hoppycat -mindepth 1 -print -quit)"'
+            if flyctl ssh console -a cosyworld-lonelyforest -C 'test -e /data/worldpacks/hoppycat'; then
+              flyctl ssh console -a cosyworld-lonelyforest -C 'test -d /data/worldpacks/hoppycat'
+              fresh_tenant_entry="$(flyctl ssh console -a cosyworld-lonelyforest -C 'find /data/worldpacks/hoppycat -mindepth 1 -print -quit')"
+              if [ -n "$fresh_tenant_entry" ]; then
+                echo "::error::Fresh Hoppycat tenant directory is not empty: $fresh_tenant_entry"
+                exit 1
+              fi
+            fi
             node v2/scripts/check-lonelyforest-worldpacks.mjs --fresh-empty-tenant hoppycat
           elif [ -n "$COSYWORLD_LONELYFOREST_RECOVERY_CAPTURE" ]; then
             node v2/scripts/check-lonelyforest-worldpacks.mjs --recovery-capture "$COSYWORLD_LONELYFOREST_RECOVERY_CAPTURE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.2 — 2026-08-12
+## 1.0.3 — 2026-08-12
 
 CosyWorld 1.0 is the first stable release of the canonical V2 product: a shared,
 persistent AI MUD with a deterministic rules kernel, a Rust HTTP/SSE host, and a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -175,6 +175,21 @@ describe('deploy workflow', () => {
     ).toBeLessThan(workflow.indexOf('Create rollback backup'));
   });
 
+  it('checks a fresh Hoppycat volume with direct remote commands', () => {
+    expect(workflow).toContain(
+      "-C 'test -e /data/worldpacks/hoppycat'"
+    );
+    expect(workflow).toContain(
+      "-C 'test -d /data/worldpacks/hoppycat'"
+    );
+    expect(workflow).toContain(
+      "-C 'find /data/worldpacks/hoppycat -mindepth 1 -print -quit'"
+    );
+    expect(workflow).not.toContain(
+      "-C 'test ! -e /data/worldpacks/hoppycat ||"
+    );
+  });
+
   it('serializes deployments across branch and tag refs', () => {
     expect(workflow).toContain('group: deploy-${{ github.repository }}');
     expect(workflow).toContain('cancel-in-progress: false');

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- replace the remote inline `||` expression with direct Fly commands for path existence, directory type, and first-entry checks
- preserve fail-closed behavior for any non-empty Hoppycat tenant directory
- lock the exact remote command shape in the deployment contract suite
- advance the still-in-progress release to `1.0.3`

## Failure evidence

The guarded `v1.0.2-rc.1` Hoppycat bootstrap reached the intended empty-volume check, but Fly executes `-C` as argv rather than a shell expression. The literal `||` was passed to `test`, which exited with `extra argument '||'`. The candidate did not back up, deploy, or change any Lonely Forest tenant. Existing tenants had already passed exact bundle matching.

## Validation

- deployment contract: 26/26 passed
- `npm run check:version`: passed
- `git diff --check`: passed