### PR TITLE
Mount Bethlehem character art provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.3 — 2026-08-12
+## 1.0.4 — 2026-08-12
 
 CosyWorld 1.0 is the first stable release of the canonical V2 product: a shared,
 persistent AI MUD with a deterministic rules kernel, a Rust HTTP/SSE host, and a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/bethlehem/assets.json
+++ b/v2/content/bethlehem/assets.json
@@ -37,5 +37,18 @@
     "content_hash": "sha256:61865d00e777907b22ad2411651e5ec638362e346661ac81e3f5e191054de9e2",
     "optional": false,
     "fallback": null
+  },
+  {
+    "pack_id": "cosyworld.lonely-forest.characters",
+    "pack_version": "1.1.1",
+    "pack_integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+    "provider": "cosyworld.lonely-forest.characters/assets",
+    "mount": "characters",
+    "root": "lonely-forest",
+    "directory": "assets/characters/slices",
+    "public_prefix": "/assets/lonely-forest/characters",
+    "content_hash": "sha256:d45eb30a962de236ddba913834e8bdaa7b9c530bc6b66383e272118218797d93",
+    "optional": false,
+    "fallback": null
   }
 ]

--- a/v2/content/bethlehem/licenses.json
+++ b/v2/content/bethlehem/licenses.json
@@ -83,5 +83,18 @@
       "source_url": "https://github.com/cenetex/cosyworld"
     },
     "notices": []
+  },
+  {
+    "pack_id": "cosyworld.lonely-forest.characters",
+    "name": "Lonely Forest Character Art",
+    "version": "1.1.1",
+    "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+    "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "Cenetex Lonely Forest character art",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
   }
 ]

--- a/v2/content/bethlehem/registry.json
+++ b/v2/content/bethlehem/registry.json
@@ -14,7 +14,8 @@
       "replay_compatible_bundle_hashes": [
         "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
         "sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3",
-        "sha256:2029c79967979ad2864570ea55708b6fdc02aced3c32ad80f88c646c330083f8"
+        "sha256:2029c79967979ad2864570ea55708b6fdc02aced3c32ad80f88c646c330083f8",
+        "sha256:782e5c77078ffe57d9cb31ed070ca8ba14a9158084e13f08fea17d9497a8b347"
       ]
     },
     "pack_lifecycle": {
@@ -723,7 +724,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:782e5c77078ffe57d9cb31ed070ca8ba14a9158084e13f08fea17d9497a8b347",
+    "bundle_hash": "sha256:e02e7f097c390244005c2ccebbdcec82dc2618ede05fac998716f6a03bdcc63e",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -2413,6 +2414,96 @@
           "path": "../../content/core-holy-land-bridge"
         },
         "integrity": "sha256:33ec60037a997b8a40d92805bb2a9aff60428eeadf32a78489c179ef160af3d9"
+      },
+      {
+        "id": "cosyworld.lonely-forest.characters",
+        "name": "Lonely Forest Character Art",
+        "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
+        "version": "1.1.1",
+        "kind": "assets",
+        "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+        "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.lonely-forest.characters/assets",
+            "kind": "assets",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core",
+          "cosyworld.rules-profile-srd5"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          },
+          {
+            "id": "cosyworld.rules-profile-srd5",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.rules-profile-srd5/rules"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.rules-srd-5.2.1",
+          "cosyworld.rules-profile-srd5",
+          "cosyworld.core"
+        ],
+        "default_ruleset": null,
+        "entry_points": [
+          {
+            "kind": "asset_mount",
+            "id": "characters"
+          }
+        ],
+        "provenance": {
+          "author": "Cenetex",
+          "source_name": "Cenetex Lonely Forest character art",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "actor_facets": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 0,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "action_vocabulary": 0,
+          "fronts": 0,
+          "cards": 0,
+          "card_bindings": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "external_cards": 0,
+          "assets": 1,
+          "rules": 0,
+          "character_creation": 0,
+          "reskins": 0,
+          "offers": 0,
+          "variants": 0,
+          "extensions": 0
+        },
+        "rules_profile": "cosyworld.srd5/1",
+        "source": {
+          "type": "workspace",
+          "path": "../../content/lonely-forest"
+        },
+        "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff"
       }
     ],
     "files": {
@@ -11760,6 +11851,19 @@
       "content_hash": "sha256:61865d00e777907b22ad2411651e5ec638362e346661ac81e3f5e191054de9e2",
       "optional": false,
       "fallback": null
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "pack_version": "1.1.1",
+      "pack_integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+      "provider": "cosyworld.lonely-forest.characters/assets",
+      "mount": "characters",
+      "root": "lonely-forest",
+      "directory": "assets/characters/slices",
+      "public_prefix": "/assets/lonely-forest/characters",
+      "content_hash": "sha256:d45eb30a962de236ddba913834e8bdaa7b9c530bc6b66383e272118218797d93",
+      "optional": false,
+      "fallback": null
     }
   ],
   "rules": [
@@ -13272,6 +13376,19 @@
       "provenance": {
         "author": "Cenetex",
         "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "version": "1.1.1",
+      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
         "source_url": "https://github.com/cenetex/cosyworld"
       },
       "notices": []

--- a/v2/content/bethlehem/worldpack.json
+++ b/v2/content/bethlehem/worldpack.json
@@ -12,7 +12,8 @@
     "replay_compatible_bundle_hashes": [
       "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
       "sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3",
-      "sha256:2029c79967979ad2864570ea55708b6fdc02aced3c32ad80f88c646c330083f8"
+      "sha256:2029c79967979ad2864570ea55708b6fdc02aced3c32ad80f88c646c330083f8",
+      "sha256:782e5c77078ffe57d9cb31ed070ca8ba14a9158084e13f08fea17d9497a8b347"
     ]
   },
   "pack_lifecycle": {
@@ -721,7 +722,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:782e5c77078ffe57d9cb31ed070ca8ba14a9158084e13f08fea17d9497a8b347",
+  "bundle_hash": "sha256:e02e7f097c390244005c2ccebbdcec82dc2618ede05fac998716f6a03bdcc63e",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -2411,6 +2412,96 @@
         "path": "../../content/core-holy-land-bridge"
       },
       "integrity": "sha256:33ec60037a997b8a40d92805bb2a9aff60428eeadf32a78489c179ef160af3d9"
+    },
+    {
+      "id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
+      "version": "1.1.1",
+      "kind": "assets",
+      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "engine": ">=0.0.20 <0.1.0",
+      "capabilities": [
+        {
+          "id": "cosyworld.lonely-forest.characters/assets",
+          "kind": "assets",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        "cosyworld.core",
+        "cosyworld.rules-profile-srd5"
+      ],
+      "dependency_requirements": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core"
+      ],
+      "default_ruleset": null,
+      "entry_points": [
+        {
+          "kind": "asset_mount",
+          "id": "characters"
+        }
+      ],
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "resource_counts": {
+        "actors": 0,
+        "actor_facets": 0,
+        "access_gates": 0,
+        "factions": 0,
+        "items": 0,
+        "locations": 0,
+        "exits": 0,
+        "hidden_exits": 0,
+        "room_features": 0,
+        "room_sheets": 0,
+        "clocks": 0,
+        "jobs": 0,
+        "action_vocabulary": 0,
+        "fronts": 0,
+        "cards": 0,
+        "card_bindings": 0,
+        "lifecycle_hooks": 0,
+        "evolution_tracks": 0,
+        "recipes": 0,
+        "sentences": 0,
+        "external_cards": 0,
+        "assets": 1,
+        "rules": 0,
+        "character_creation": 0,
+        "reskins": 0,
+        "offers": 0,
+        "variants": 0,
+        "extensions": 0
+      },
+      "rules_profile": "cosyworld.srd5/1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/lonely-forest"
+      },
+      "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff"
     }
   ],
   "files": {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/holy-land-worldpack.test.mjs
+++ b/v2/scripts/holy-land-worldpack.test.mjs
@@ -16,6 +16,7 @@ const cards = readJson("the-holy-land", "cards.json");
 const jobs = readJson("the-holy-land", "jobs.json");
 const holyLandPack = readJson("the-holy-land", "pack.json");
 const bridgePack = readJson("core-holy-land-bridge", "pack.json");
+const bethlehemRegistry = readJson("bethlehem", "registry.json");
 const officialWorld = JSON.parse(
   fs.readFileSync(path.resolve(scriptDir, "../worlds/official/world.json"), "utf8"),
 );
@@ -140,13 +141,27 @@ test("Bethlehem accepts every declared production replay epoch", () => {
   // resource identities, rules profile, pack versions, and persisted-state
   // interpretation remain stable across this boundary.
   // Tenant 7 persisted the second and third hashes before later content-pack
-  // compiler releases; their journals use the same canonical IDs and state
-  // interpretation as the current bundle.
+  // compiler releases. The fourth is the provider-less bundle replaced by the
+  // Lonely Forest art mount; all use the same canonical IDs and state meaning.
   const compatible = bethlehemWorld.persistence_compatibility
     .replay_compatible_bundle_hashes;
   assert.deepEqual(compatible, [
     "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
     "sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3",
     "sha256:2029c79967979ad2864570ea55708b6fdc02aced3c32ad80f88c646c330083f8",
+    "sha256:782e5c77078ffe57d9cb31ed070ca8ba14a9158084e13f08fea17d9497a8b347",
   ]);
+});
+
+test("Bethlehem mounts a provider for every authored card image", () => {
+  const prefixes = bethlehemRegistry.assets.map(({ public_prefix }) => public_prefix);
+  for (const card of bethlehemRegistry.resources.cards) {
+    if (!card.image_url?.startsWith("/assets/")) continue;
+    assert.ok(
+      prefixes.some(
+        (prefix) => card.image_url === prefix || card.image_url.startsWith(`${prefix}/`),
+      ),
+      `${card.card_id} has no mounted asset provider for ${card.image_url}`,
+    );
+  }
 });

--- a/v2/scripts/smoke-standalone-compositions.mjs
+++ b/v2/scripts/smoke-standalone-compositions.mjs
@@ -47,6 +47,7 @@ const worldCases = [
       "cosyworld.core",
       "cosyworld.the-holy-land",
       "cosyworld.composition.core-holy-land",
+      "cosyworld.lonely-forest.characters",
     ],
     location: "Bethlehem",
     locationPack: "cosyworld.the-holy-land",
@@ -54,6 +55,7 @@ const worldCases = [
     capability: "cosyworld.core/rules",
     offerVerb: null,
     firstTaleAbsent: true,
+    cardImagePath: "/assets/lonely-forest/characters/34-armored-winged-hero.png",
   },
   {
     label: "Lantern Keeper",
@@ -1294,6 +1296,20 @@ async function runWorldLoop(spec) {
   try {
     first = await startServer(tempDir, spec.registryPath, spec.entryLocationId);
     assertMountedComposition(first.meta, spec);
+    if (spec.cardImagePath) {
+      const image = await fetch(`${first.baseUrl}${spec.cardImagePath}`, {
+        signal: AbortSignal.timeout(5_000),
+      });
+      assert(image.ok, `${spec.label} card image returned HTTP ${image.status}`);
+      assert(
+        image.headers.get("content-type") === "image/png",
+        `${spec.label} card image used ${image.headers.get("content-type")}`,
+      );
+      assert(
+        !image.headers.has("x-cosyworld-asset-diagnostic"),
+        `${spec.label} card image returned an asset-provider diagnostic`,
+      );
+    }
     let created;
     try {
       created = await postJson(

--- a/v2/worlds/bethlehem/pack.lock.json
+++ b/v2/worlds/bethlehem/pack.lock.json
@@ -8,7 +8,8 @@
     "cosyworld.rules-profile-srd5",
     "cosyworld.core",
     "cosyworld.the-holy-land",
-    "cosyworld.composition.core-holy-land"
+    "cosyworld.composition.core-holy-land",
+    "cosyworld.lonely-forest.characters"
   ],
   "packs": [
     {
@@ -224,6 +225,50 @@
         "source_name": "CosyWorld official composition",
         "source_url": "https://github.com/cenetex/cosyworld"
       }
+    },
+    {
+      "id": "cosyworld.lonely-forest.characters",
+      "version": "1.1.1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/lonely-forest"
+      },
+      "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+      "dependencies": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core"
+      ],
+      "capabilities": [
+        {
+          "id": "cosyworld.lonely-forest.characters/assets",
+          "kind": "assets",
+          "version": "1.0.0"
+        }
+      ],
+      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      }
     }
   ],
   "license_records": [
@@ -308,6 +353,19 @@
       "provenance": {
         "author": "Cenetex",
         "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "version": "1.1.1",
+      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
         "source_url": "https://github.com/cenetex/cosyworld"
       },
       "notices": []

--- a/v2/worlds/bethlehem/world.json
+++ b/v2/worlds/bethlehem/world.json
@@ -24,7 +24,8 @@
     "replay_compatible_bundle_hashes": [
       "sha256:463890e096d1ebb1bc253e20af8173bf3cf3a78ee508e3236e18ba002f03b0df",
       "sha256:0d989794764b86a1b3067a3c1ca43078dbacfece38a84371039d5a16af80e2f3",
-      "sha256:2029c79967979ad2864570ea55708b6fdc02aced3c32ad80f88c646c330083f8"
+      "sha256:2029c79967979ad2864570ea55708b6fdc02aced3c32ad80f88c646c330083f8",
+      "sha256:782e5c77078ffe57d9cb31ed070ca8ba14a9158084e13f08fea17d9497a8b347"
     ]
   },
   "packs": [
@@ -32,6 +33,7 @@
     "cosyworld.rules-srd-5.2.1",
     "cosyworld.rules-profile-srd5",
     "cosyworld.the-holy-land",
+    "cosyworld.lonely-forest.characters",
     "cosyworld.composition.core-holy-land"
   ]
 }


### PR DESCRIPTION
## What changed

- mount the Lonely Forest character-art pack in the Bethlehem composition
- regenerate the Bethlehem worldpack, registry, asset, license, and lock artifacts
- preserve replay compatibility with the previously deployed provider-less bundle
- add regression coverage for every authored Bethlehem card image and an end-to-end PNG smoke check
- bump the release version to 1.0.4 as required by the repository commit guard

## Why

Bethlehem includes Core-authored character cards such as Samael, but it did not mount the Lonely Forest asset provider that owns their PNGs. Requests therefore returned the `WORLD PACK PROVIDER NOT MOUNTED` diagnostic instead of character art.

## Impact

Bethlehem and tenant 7 now serve the real character PNGs. Existing journals remain replay-compatible.

## Validation

- Bethlehem composition smoke, including Samael's exact PNG and journal replay
- Holy Land and authored-card provider regression tests
- Bethlehem worldpack compile and validation
- Lonely Forest multitenant contract tests
- pre-push JavaScript suite: 177 passed
- all worldpack, proof-world, and kernel checks passed
- Rust suite reached 1,145/1,146 passing; the remaining version-alignment test was run against another branch after a concurrent checkout switch. The isolated branch contains matching package and Cargo version 1.0.4; a later isolated relink was blocked by local disk exhaustion. GitHub CI will rerun the clean suite.