### PR TITLE
Preserve avatar identity across session recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/README.md
+++ b/v2/README.md
@@ -649,7 +649,9 @@ First entry shows The Cosy Cottage with one command: `create avatar`. The browse
 
 Returning players keep their local avatar id plus an opaque `actor_session` minted by `/avatar`, and re-enter through `/state?actor_id=...&actor_session=...`. If the server no longer recognizes that actor/session pair, the state contract falls back to `Create Avatar` instead of silently fabricating a character or letting another browser drive the avatar by guessing its id.
 
-When `/avatar` receives a signed `wallet_session`, the server treats the command as recover-or-create. The first call creates the human actor, records a durable wallet-to-avatar link, and returns an actor session. Later calls with the same signed wallet session recover that same live human actor and issue a fresh actor session without emitting duplicate `actor.created` world events. Dev reset clears those links along with the reseeded world.
+When `/avatar` receives a signed `wallet_session`, the server treats the command as recover-or-create. The first call creates the human actor, records a durable wallet-to-avatar link, and returns an actor session. Later calls with the same signed wallet session recover that same present human actor — active or knocked out — and issue a fresh actor session without emitting duplicate `actor.created` world events. Knockout never mints or links a replacement identity. Dev reset clears those links along with the reseeded world.
+
+`POST /avatar/session` renews credentials only for the same canonical actor. A current actor session may rotate itself; an expired actor session requires the signed wallet already linked to that actor. The route returns `409` for a terminal actor and never creates an avatar. Browser action retries use it once after a credential-specific failure and reuse the original command intent.
 
 Room presence is intentionally narrower than durable avatar existence. A human avatar persists in the world and can return with its actor session, but other players only see that human in room presence while the actor session has been touched recently by state/action/stream/presence traffic. Typed `look`, `who`, and `/state` use the same current-room roster projection. The one bounded exception is a lapsed avatar who still owns a focused turn: that holder stays visible until turn recovery hands off, but remains absent from actor-target offers and commands. The browser and terminal clients maintain explicit presence heartbeats. NPC residents stay visible according to world placement.
 
@@ -815,6 +817,7 @@ Dialogue prompts keep the latest 16 spoken lines per room in a bounded, snapshot
 - `GET /stream`
 - `POST /dev/reset` when `COSYWORLD_ENABLE_DEV_RESET=1`
 - `POST /avatar`
+- `POST /avatar/session`
 - `POST /commands` for read controls and certified Think/Pass
 - `POST /presence/ping`
 - `POST /presence/leave`

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -1,5 +1,164 @@
 use super::*;
 
+#[derive(Debug, Deserialize)]
+pub(super) struct RenewAvatarSessionRequest {
+    actor_id: u64,
+    actor_session: Option<String>,
+    wallet_session: Option<String>,
+    #[serde(default)]
+    rotate: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct RenewAvatarSessionResponse {
+    ok: bool,
+    status: u32,
+    actor: Option<ActorView>,
+    actor_session: Option<String>,
+    actor_session_expires_at_unix: Option<u64>,
+    renewed: bool,
+}
+
+fn actor_session_record(
+    actor_sessions: &StdMutex<ActorSessions>,
+    actor_id: u64,
+    session_token: &str,
+) -> Option<ActorSession> {
+    let token = session_token.trim();
+    if token.is_empty() {
+        return None;
+    }
+    let now = Instant::now();
+    let Ok(mut sessions) = actor_sessions.lock() else {
+        return None;
+    };
+    sessions
+        .sessions
+        .retain(|_, session| session.expires_at > now);
+    sessions
+        .sessions
+        .get(token)
+        .filter(|session| session.actor_id == actor_id)
+        .cloned()
+}
+
+fn retire_actor_session(state: &AppState, session_token: &str) -> io::Result<()> {
+    let token = session_token.trim();
+    if token.is_empty() {
+        return Ok(());
+    }
+    if let Some(path) = state.event_store_path.as_deref() {
+        init_event_store(path)?;
+        let conn = open_event_store(path)?;
+        conn.execute(
+            "DELETE FROM actor_sessions WHERE session_token = ?1",
+            params![token],
+        )
+        .map_err(sqlite_error)?;
+    }
+    if let Ok(mut sessions) = state.actor_sessions.lock() {
+        sessions.sessions.remove(token);
+    }
+    Ok(())
+}
+
+pub(super) async fn renew_avatar_session(
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    Json(payload): Json<RenewAvatarSessionRequest>,
+) -> Json<RenewAvatarSessionResponse> {
+    let rejected = |status| {
+        Json(RenewAvatarSessionResponse {
+            ok: false,
+            status,
+            actor: None,
+            actor_session: None,
+            actor_session_expires_at_unix: None,
+            renewed: false,
+        })
+    };
+    if !allow_actor_mutation(
+        &state,
+        client_addr,
+        payload.actor_id,
+        "avatar-session-actor",
+        GENERAL_ACTION_LIMIT,
+    ) {
+        return rejected(RATE_LIMITED_STATUS);
+    }
+    if let Some(token) = payload.actor_session.as_deref() {
+        if let Err(error) = refresh_actor_session_from_store(&state, token) {
+            warn!(
+                "failed to load CosyWorld actor session for renewal: {}",
+                error
+            );
+        }
+    }
+
+    let existing_session = payload.actor_session.as_deref().and_then(|token| {
+        (actor_for_session(&state.actor_sessions, token) == Some(payload.actor_id))
+            .then(|| actor_session_record(&state.actor_sessions, payload.actor_id, token))
+            .flatten()
+            .map(|session| (token.to_string(), session))
+    });
+    let wallet_authorized = payload
+        .wallet_session
+        .as_deref()
+        .and_then(|token| wallet_for_session(&state.wallet_sessions, token))
+        .and_then(|wallet| linked_actor_for_wallet(&state, &wallet))
+        == Some(payload.actor_id);
+    if existing_session.is_none() && !wallet_authorized {
+        return rejected(403);
+    }
+    if actor_is_suspended(&state, payload.actor_id) {
+        return rejected(403);
+    }
+
+    let actor = {
+        let runtime = state.inner.lock().await;
+        runtime
+            .actor_by_id(payload.actor_id)
+            .filter(|actor| runtime.client_actor_can_observe(actor.id))
+            .map(|actor| runtime.actor_view(actor))
+    };
+    let Some(actor) = actor else {
+        // A terminal or missing actor cannot be resurrected by credential
+        // renewal. Character creation is a separate, authoritative choice.
+        return rejected(409);
+    };
+
+    let replaced_session = if payload.rotate {
+        existing_session.as_ref().map(|(token, _)| token.clone())
+    } else {
+        None
+    };
+    let (actor_session, actor_session_record, renewed) =
+        if let Some((token, session)) = existing_session.filter(|_| !payload.rotate) {
+            (token, session, false)
+        } else {
+            let (token, session) = issue_actor_session(&state, payload.actor_id);
+            (token, session, true)
+        };
+    if let Some(replaced_session) = replaced_session {
+        if let Err(error) = retire_actor_session(&state, &replaced_session) {
+            warn!(
+                "failed to retire rotated CosyWorld actor session for {}: {}",
+                payload.actor_id, error
+            );
+            return rejected(500);
+        }
+    }
+    record_daily_visit(&state, payload.actor_id);
+    Json(RenewAvatarSessionResponse {
+        ok: true,
+        status: CW_OK,
+        actor: Some(actor),
+        actor_session: Some(actor_session),
+        actor_session_expires_at_unix: Some(actor_session_record.expires_at_unix),
+        renewed,
+    })
+}
+
 impl RuntimeWorld {
     pub(super) fn actor_is_present(actor: CwActor) -> bool {
         matches!(actor.kind, CW_ACTOR_HUMAN | CW_ACTOR_NPC)
@@ -19,6 +178,27 @@ impl RuntimeWorld {
         self.actor_by_id(actor_id)
             .is_some_and(Self::actor_is_present)
             && self.actor_control_mode(actor_id).is_direct_input()
+    }
+
+    pub(super) fn avatar_lifecycle_primary_action(&self, actor_id: u64) -> Option<PrimaryAction> {
+        let Some(actor) = self.actor_by_id(actor_id) else {
+            return Some(create_avatar_primary_action());
+        };
+
+        // Knockout changes the body, not its canonical identity. Keep the
+        // player attached to the same observable actor and deal no mutation
+        // while another participant can still rescue it. Only an
+        // authoritative terminal state opens character creation.
+        if Self::actor_is_present(actor) && !Self::actor_can_act(actor) {
+            return Some(PrimaryAction {
+                kind: "await_rescue".to_string(),
+                label: "Await Rescue".to_string(),
+                command: "observe".to_string(),
+                disabled: true,
+                options: Vec::new(),
+            });
+        }
+        (!Self::actor_can_act(actor)).then(create_avatar_primary_action)
     }
 
     pub(super) fn actor_visible_in_projection(
@@ -71,6 +251,16 @@ impl RuntimeWorld {
         Self::actor_can_act(actor)
             && combat_turn_view(self, actor.id, actor.location_id)
                 .is_some_and(|turn| turn.current_actor_id == Some(actor.id))
+    }
+}
+
+fn create_avatar_primary_action() -> PrimaryAction {
+    PrimaryAction {
+        kind: "create_avatar".to_string(),
+        label: "Create Avatar".to_string(),
+        command: "create avatar".to_string(),
+        disabled: false,
+        options: Vec::new(),
     }
 }
 
@@ -141,6 +331,22 @@ impl RuntimeWorld {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn insert_actor_presence_wallet_session(state: &AppState, token: &str, wallet_address: &str) {
+        state
+            .wallet_sessions
+            .lock()
+            .expect("wallet sessions")
+            .sessions
+            .insert(
+                token.to_string(),
+                WalletSession {
+                    wallet_address: wallet_address.to_string(),
+                    linked_wallet_addresses: Vec::new(),
+                    expires_at: Instant::now() + Duration::from_secs(3600),
+                },
+            );
+    }
 
     fn command_request(actor_id: u64, command: &str) -> CommandRequest {
         CommandRequest {
@@ -262,7 +468,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn knocked_out_avatar_is_offered_a_new_beginning_and_no_unplayable_hand() {
+    async fn knocked_out_avatar_keeps_its_identity_and_receives_no_unplayable_hand() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
             &mut runtime,
@@ -279,11 +485,8 @@ mod tests {
             .expect("the avatar exists");
         actor.status = CW_ACTOR_KNOCKED_OUT;
 
-        // The body stays in the world (see the presence contract below), but
-        // the player holding it has no legal move: every ordinary offer fails
-        // `actor_can_act` at submission. Until rescue or recovery exists, the
-        // projection must deal the one honest exit — the release path that
-        // lets the player begin again while the body persists.
+        // The body and its canonical identity stay in the world, but the
+        // player holding it has no legal mutation until rescue or recovery.
         let downed = runtime.state_response_with_presence(
             Some(5000),
             &AccessContext::default(),
@@ -291,18 +494,15 @@ mod tests {
             false,
         );
         assert_eq!(
-            downed.primary_action.kind, "create_avatar",
-            "a knocked-out avatar must be offered a new beginning, not ordinary play",
+            downed.primary_action.kind, "await_rescue",
+            "a knocked-out avatar must remain attached in observer mode",
         );
         assert!(
-            !downed.primary_action.disabled,
-            "the new beginning must be reachable",
+            downed.primary_action.disabled,
+            "observer mode cannot mutate the downed actor",
         );
         assert!(
-            downed
-                .action_offers
-                .iter()
-                .all(|offer| offer.kind == "create_avatar"),
+            downed.action_offers.is_empty(),
             "a knocked-out avatar must not be dealt offers it cannot submit: {:?}",
             downed
                 .action_offers
@@ -387,10 +587,11 @@ mod tests {
             .items
             .iter()
             .any(|item| item.id == STORY_BUTTON_ITEM_ID && item.holder_actor_id == Some(5001)));
-        // The fallen avatar's own projection deals the release path, not an
-        // unplayable hand: present and observable does not mean playable.
-        assert_eq!(observer_view.primary_action.kind, "create_avatar");
-        assert!(!observer_view.primary_action.disabled);
+        // Present and observable does not mean playable, and it does not mean
+        // the player may replace this still-living identity.
+        assert_eq!(observer_view.primary_action.kind, "await_rescue");
+        assert!(observer_view.primary_action.disabled);
+        assert!(observer_view.action_offers.is_empty());
 
         let who = runtime
             .resolve_command_with_presence(
@@ -447,6 +648,140 @@ mod tests {
                     && item.holder_actor_id == 5001
                     && item.location_id == 0
             }));
+    }
+
+    #[tokio::test]
+    async fn avatar_session_recovery_rotates_only_for_the_same_observable_actor() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Fallen Door Walker",
+        );
+        runtime.world.actors[..runtime.world.actor_count]
+            .iter_mut()
+            .find(|actor| actor.id == 5000)
+            .expect("linked avatar")
+            .status = CW_ACTOR_KNOCKED_OUT;
+        let actor_count = runtime.world.actor_count;
+        let state = test_app_state(runtime, None);
+        let wallet_address = "wallet-shared-by-every-door";
+        let wallet_session = "wallet-session-shared-by-every-door";
+        insert_actor_presence_wallet_session(&state, wallet_session, wallet_address);
+        link_wallet_actor(&state, wallet_address, 5000);
+
+        let recovered = renew_avatar_session(
+            ConnectInfo("127.0.0.1:45115".parse().expect("client address")),
+            State(state.clone()),
+            Json(RenewAvatarSessionRequest {
+                actor_id: 5000,
+                actor_session: Some("expired-door-session".to_string()),
+                wallet_session: Some(wallet_session.to_string()),
+                rotate: false,
+            }),
+        )
+        .await
+        .0;
+        assert!(recovered.ok, "{recovered:?}");
+        assert!(recovered.renewed);
+        assert_eq!(
+            recovered
+                .actor
+                .as_ref()
+                .map(|actor| (actor.id, actor.status.as_str())),
+            Some((5000, "knocked_out"))
+        );
+        let recovered_token = recovered
+            .actor_session
+            .clone()
+            .expect("recovery issues a replacement credential");
+
+        let checked = renew_avatar_session(
+            ConnectInfo("127.0.0.1:45115".parse().expect("client address")),
+            State(state.clone()),
+            Json(RenewAvatarSessionRequest {
+                actor_id: 5000,
+                actor_session: Some(recovered_token.clone()),
+                wallet_session: None,
+                rotate: false,
+            }),
+        )
+        .await
+        .0;
+        assert!(checked.ok, "{checked:?}");
+        assert!(!checked.renewed);
+        assert_eq!(
+            checked.actor_session.as_deref(),
+            Some(recovered_token.as_str())
+        );
+
+        let (parallel_token, _) = issue_actor_session(&state, 5000);
+        let rotated = renew_avatar_session(
+            ConnectInfo("127.0.0.1:45115".parse().expect("client address")),
+            State(state.clone()),
+            Json(RenewAvatarSessionRequest {
+                actor_id: 5000,
+                actor_session: Some(recovered_token.clone()),
+                wallet_session: None,
+                rotate: true,
+            }),
+        )
+        .await
+        .0;
+        assert!(rotated.ok, "{rotated:?}");
+        assert!(rotated.renewed);
+        let rotated_token = rotated
+            .actor_session
+            .clone()
+            .expect("rotation issues a fresh credential");
+        assert_ne!(rotated_token, recovered_token);
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &recovered_token),
+            None,
+            "the replaced credential must not keep presence alive",
+        );
+        assert_eq!(
+            actor_for_session(&state.actor_sessions, &parallel_token),
+            Some(5000),
+            "rotation must preserve other legitimate door sessions",
+        );
+
+        let wrong_actor = renew_avatar_session(
+            ConnectInfo("127.0.0.1:45115".parse().expect("client address")),
+            State(state.clone()),
+            Json(RenewAvatarSessionRequest {
+                actor_id: 5001,
+                actor_session: Some(rotated_token.clone()),
+                wallet_session: None,
+                rotate: true,
+            }),
+        )
+        .await
+        .0;
+        assert!(!wrong_actor.ok, "{wrong_actor:?}");
+        assert_eq!(wrong_actor.status, 403);
+
+        state.inner.lock().await.world.actors[..actor_count]
+            .iter_mut()
+            .find(|actor| actor.id == 5000)
+            .expect("linked avatar")
+            .status = CW_ACTOR_DEAD;
+        let terminal = renew_avatar_session(
+            ConnectInfo("127.0.0.1:45115".parse().expect("client address")),
+            State(state.clone()),
+            Json(RenewAvatarSessionRequest {
+                actor_id: 5000,
+                actor_session: Some(rotated_token),
+                wallet_session: None,
+                rotate: true,
+            }),
+        )
+        .await
+        .0;
+        assert!(!terminal.ok, "{terminal:?}");
+        assert_eq!(terminal.status, 409);
+        assert_eq!(state.inner.lock().await.world.actor_count, actor_count);
     }
 
     #[tokio::test]

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -460,7 +460,7 @@ impl RuntimeWorld {
                 primary_action.disabled = offer.disabled;
             }
             primary_action.command = offer.command.clone();
-        } else {
+        } else if !primary_action.disabled {
             primary_action = PrimaryAction {
                 kind: "wait".to_string(),
                 label: "Wait".to_string(),
@@ -500,13 +500,18 @@ impl RuntimeWorld {
                 "no_active_avatar",
             )];
         };
-        // A present avatar that cannot act (knocked out) has no legal move, so
-        // the hand deals only the release path. Dealing rest, exploration, or
-        // room offers alongside it would hand the player cards that every
-        // submission rejects.
+        // Knockout preserves the canonical actor but permits observation only.
+        // Terminal actors may begin again; downed actors receive no mutation
+        // offer while another participant can still rescue them.
         if self
             .actor_by_id(actor_id)
-            .is_some_and(|actor| !Self::actor_can_act(actor))
+            .is_some_and(|actor| Self::actor_is_present(actor) && !Self::actor_can_act(actor))
+        {
+            return Vec::new();
+        }
+        if self
+            .actor_by_id(actor_id)
+            .is_some_and(|actor| !Self::actor_is_present(actor) && !Self::actor_can_act(actor))
         {
             return vec![self.ranked_offer_from_parts(
                 "create_avatar",

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -4898,6 +4898,8 @@
   </div>
   <script>
     const avatarGateVersion = "2";
+    const actorSessionExpiryStorageKey = "cosyworld.actorSessionExpiresAtUnix";
+    const actorSessionRenewalWindowSeconds = 24 * 60 * 60;
     const walletRequestTimeoutMs = 20000;
     const presenceHeartbeatMs = 60000;
     const authoredCallingChoices = [
@@ -4986,9 +4988,13 @@
     const hasExplicitAvatar = localStorage.getItem("cosyworld.avatarGateVersion") === avatarGateVersion;
     let actorId = hasExplicitAvatar ? Number(localStorage.getItem("cosyworld.actorId") || 0) : 0;
     let actorSession = hasExplicitAvatar ? (localStorage.getItem("cosyworld.actorSession") || "") : "";
+    let actorSessionExpiresAtUnix = hasExplicitAvatar
+      ? Number(localStorage.getItem(actorSessionExpiryStorageKey) || 0)
+      : 0;
     if (!hasExplicitAvatar) {
       localStorage.removeItem("cosyworld.actorId");
       localStorage.removeItem("cosyworld.actorSession");
+      localStorage.removeItem(actorSessionExpiryStorageKey);
     }
     let state = null;
     let actions = [];
@@ -5020,6 +5026,8 @@
     let refreshQueued = false;
     let refreshAttemptId = 0;
     let recoveryRefreshAttemptId = 0;
+    let actorSessionRenewalInFlight = null;
+    let actorSessionTerminal = false;
     let transientStatus = null;
     let actionBusy = false;
     let actionSlow = false;
@@ -5089,6 +5097,7 @@
       localStorage.removeItem("cosyworld.actorId");
       localStorage.removeItem("cosyworld.actorSession");
       localStorage.removeItem("cosyworld.avatarGateVersion");
+      localStorage.removeItem(actorSessionExpiryStorageKey);
     }
 
     function loadDefeatTransition() {
@@ -5529,6 +5538,72 @@
       }
     }
 
+    function rememberActorSession(response) {
+      const nextActorId = Number(response?.actor?.id || 0);
+      const nextSession = String(response?.actor_session || "");
+      if (!nextActorId || nextActorId !== Number(actorId) || !nextSession) return false;
+      actorSession = nextSession;
+      actorSessionExpiresAtUnix = Math.max(
+        0,
+        Number(response?.actor_session_expires_at_unix || 0),
+      );
+      actorSessionTerminal = false;
+      localStorage.setItem("cosyworld.actorId", String(actorId));
+      localStorage.setItem("cosyworld.actorSession", actorSession);
+      localStorage.setItem("cosyworld.avatarGateVersion", avatarGateVersion);
+      if (actorSessionExpiresAtUnix) {
+        localStorage.setItem(actorSessionExpiryStorageKey, String(actorSessionExpiresAtUnix));
+      } else {
+        localStorage.removeItem(actorSessionExpiryStorageKey);
+      }
+      return true;
+    }
+
+    async function renewActorSession({ rotate = false } = {}) {
+      if (!actorId) return { ok: false, renewed: false, status: 400 };
+      if (actorSessionRenewalInFlight) return actorSessionRenewalInFlight;
+      const requestedActorId = Number(actorId);
+      actorSessionRenewalInFlight = (async () => {
+        const result = await postResult("/avatar/session", {
+          actor_id: requestedActorId,
+          ...(actorSession ? { actor_session: actorSession } : {}),
+          ...(walletSession ? { wallet_session: walletSession } : {}),
+          rotate,
+        });
+        if (requestedActorId !== Number(actorId)) {
+          return { ok: false, renewed: false, status: 409 };
+        }
+        if (!result.ok) {
+          if (Number(result.status || 0) === 409) actorSessionTerminal = true;
+          return { ok: false, renewed: false, status: Number(result.status || 0) };
+        }
+        if (!rememberActorSession(result)) {
+          return { ok: false, renewed: false, status: 409 };
+        }
+        if (result.renewed && stream) connectStream();
+        return {
+          ok: true,
+          renewed: Boolean(result.renewed),
+          status: Number(result.status || 0),
+        };
+      })();
+      try {
+        return await actorSessionRenewalInFlight;
+      } finally {
+        actorSessionRenewalInFlight = null;
+      }
+    }
+
+    async function rotateActorSessionIfNeeded() {
+      if (!actorId) return;
+      const now = Math.floor(Date.now() / 1000);
+      if (
+        actorSession
+        && actorSessionExpiresAtUnix > now + actorSessionRenewalWindowSeconds
+      ) return;
+      await renewActorSession({ rotate: true });
+    }
+
     async function createAvatar(selection = null) {
       const profile = selection?.profileId
         ? (state?.character_creation || [])
@@ -5551,10 +5626,7 @@
         throw new Error(avatarFailureMessage(avatar));
       }
       actorId = avatar.actor.id;
-      actorSession = avatar.actor_session || "";
-      localStorage.setItem("cosyworld.actorId", String(actorId));
-      if (actorSession) localStorage.setItem("cosyworld.actorSession", actorSession);
-      localStorage.setItem("cosyworld.avatarGateVersion", avatarGateVersion);
+      if (!rememberActorSession(avatar)) throw new Error("The avatar session could not be stored safely.");
       clearDefeatTransition();
       pushEvents(avatar.events || []);
       await pingPresence();
@@ -5597,10 +5669,20 @@
       const previousLocationId = state?.location?.id || null;
       const wasTired = actorIsTired(state);
       const requestedActorId = actorId;
-      const stateRequest = api(statePath());
+      await rotateActorSessionIfNeeded();
+      let stateRequest = api(statePath());
       const contentPacksRequest = ensureContentPacks().catch(() => null);
-      const nextState = await stateRequest;
+      let nextState = await stateRequest;
       if (requestedActorId !== actorId) return;
+      if (actorId && nextState.primary_action?.kind === "create_avatar") {
+        const recovery = await renewActorSession();
+        if (recovery.ok && recovery.renewed) {
+          stateRequest = api(statePath());
+          nextState = await stateRequest;
+        }
+      } else if (actorId) {
+        actorSessionTerminal = false;
+      }
       await contentPacksRequest;
       const timelineRewound = transcriptTimelineRewound(nextState);
       state = nextState;
@@ -5612,11 +5694,6 @@
         handDealNonce += 1;
         playerPromotedHandKey = "";
         handCompositionSignature = nextHandCompositionSignature;
-      }
-      if (actorId && state.primary_action?.kind === "create_avatar") {
-        actorId = 0;
-        clearLocalSession();
-        stopPresenceHeartbeat();
       }
       const locationChanged = previousLocationId && previousLocationId !== state.location?.id;
       if (logEvents.length === 0 || locationChanged || timelineRewound
@@ -6043,6 +6120,23 @@
 
     function buildActions(view) {
       if (view.primary_action?.kind === "create_avatar") {
+        if (actorId && !actorSessionTerminal) {
+          return [{
+            kind: "avatar-reconnect",
+            label: "reconnect",
+            detail: "restore this same avatar",
+            command: "reconnect avatar",
+            focusKey: "reconnect-avatar",
+            card: cardForActor(actorId) || cardForLocation(view.location?.id),
+            shape: "avatar",
+            modalTitle: "reconnect your avatar",
+            modalSummary: "Sign in to restore this avatar. No replacement.",
+            effect: "restores the same identity, belongings, bonds, and journal position",
+            busyLabel: "reconnecting",
+            busyDetail: "finding the same thread in the world…",
+            run: () => connectWallet(),
+          }];
+        }
         const beginningAgain = Boolean(defeatTransition);
         const creationProfile = (view.character_creation || [])[0] || null;
         const callingChoices = authoredCallingChoices.map((choice) => ({
@@ -6146,6 +6240,8 @@
             });
         return [action, campaignAction];
       }
+
+      if (view.primary_action?.kind === "await_rescue") return [];
 
       const characterIdentity = view.character_identity || null;
       if (characterIdentity?.class_selection_ready && !characterIdentity?.class_id) {
@@ -8365,8 +8461,10 @@
         void queueRefresh();
         return result;
       }
-      const result = offer
-          ? await postResult("/actions/submit", {
+      const submit = () => {
+        const currentPayload = withAccess(donatedPayload);
+        return offer
+          ? postResult("/actions/submit", {
               path,
               offer_id: offer.offer_id,
               composition_id: offer.composition_id,
@@ -8378,9 +8476,15 @@
               route: offer.route,
               target: offer.target,
               cost: offer.cost,
-              payload: authoritativePayload,
+              payload: currentPayload,
             })
-          : await postResult(path, authoritativePayload);
+          : postResult(path, currentPayload);
+      };
+      let result = await submit();
+      if (Number(result.status || 0) === 403) {
+        const recovery = await renewActorSession();
+        if (recovery.ok && recovery.renewed) result = await submit();
+      }
       pushEvents(result.events || []);
       if (!result.ok) {
         setError(actionFailureMessage(path, result));
@@ -8437,7 +8541,7 @@
       if (status === 503 && path === "/actions/model-interaction") {
         return "That model route is resting right now. Choose another action; nothing was spent.";
       }
-      if (status === 403) return "Your avatar slipped out of reach. Begin again or reconnect your account.";
+      if (status === 403) return "Reconnect your account to restore this same avatar. The world will not replace it.";
       if (status === 400 && path.includes("/actions/rest")) return "You are already steady enough to keep going.";
       if (status === 409) return "That choice changed while you were deciding. Nothing else happened; check what is here and choose again.";
       if (status === 423) return "This is an explicitly ordered scene. The named combat participant acts now; chat and inspection stay available.";
@@ -8450,7 +8554,7 @@
       const output = String(result.output || "").trim();
       if (output) return output;
       const status = Number(result.status || 0);
-      if (status === 403) return "Your avatar slipped out of reach. Begin again or reconnect your account.";
+      if (status === 403) return "Reconnect your account to restore this same avatar. The world will not replace it.";
       if (status === 409) return "That choice changed while you were deciding. Nothing else happened; look again.";
       if (status === 423) return "This is an explicitly ordered scene. The named combat participant acts now; chat and inspection stay available.";
       if (status === 429) return "The room needs a breath. Try again in a moment.";
@@ -8509,12 +8613,18 @@
         return null;
       }
       const beforeOrbs = economyOrbCount();
-      const result = await postResult("/commands", withAccess({
-        actor_id: actorId,
-        command,
-        ...(exactOffer?.offer_id ? { offer_id: exactOffer.offer_id } : {}),
-        envelope: canonicalCommandEnvelope(),
-      }));
+      const envelope = canonicalCommandEnvelope();
+      const submit = () => postResult("/commands", withAccess({
+          actor_id: actorId,
+          command,
+          ...(exactOffer?.offer_id ? { offer_id: exactOffer.offer_id } : {}),
+          envelope,
+        }));
+      let result = await submit();
+      if (Number(result.status || 0) === 403) {
+        const recovery = await renewActorSession();
+        if (recovery.ok && recovery.renewed) result = await submit();
+      }
       const resultEvents = result.events || [];
       pushEvents(resultEvents);
       if (result.output) pushCommandOutput(result.command || command, result.output, result.ok, resultEvents);
@@ -11895,19 +12005,21 @@
       const pendingModelOutputs = pendingModelInteractionsHtml();
       const pendingArrival = pendingAvatarArrivalHtml();
       const defeatScene = defeatTransitionHtml();
+      const observerScene = knockedOutObserverHtml();
       const hasTranscript = visibleEvents.length > 0
         || Boolean(pendingConversation)
         || Boolean(pendingChatReplies)
         || Boolean(pendingModelOutputs)
-        || Boolean(defeatScene);
+        || Boolean(defeatScene)
+        || Boolean(observerScene);
       const inferredOnly = visibleEvents.length > 0 && visibleEvents.every((event) => (
         ["message.created", "image.created", "model_interaction.output"].includes(event.type) && messageActorUsesInference(event)
       ));
       log.classList.toggle("library-mode", Boolean(libraryPanel));
       log.classList.toggle("account-mode", !libraryPanel && Boolean(accountPanel));
       log.classList.toggle("chat-mode", !libraryPanel && !accountPanel && hasTranscript);
-      log.classList.toggle("room-mode", !libraryPanel && !accountPanel && !hasTranscript && !pendingArrival && !defeatScene);
-      log.classList.toggle("arrival-mode", !libraryPanel && !accountPanel && Boolean(pendingArrival || defeatScene));
+      log.classList.toggle("room-mode", !libraryPanel && !accountPanel && !hasTranscript && !pendingArrival && !defeatScene && !observerScene);
+      log.classList.toggle("arrival-mode", !libraryPanel && !accountPanel && Boolean(pendingArrival || defeatScene || observerScene));
       log.classList.toggle("quiet-mode", !libraryPanel && !accountPanel && inferredOnly);
       const panelMode = libraryPanel ? "library" : (accountPanel ? "account" : "");
       document.querySelector(".terminal")?.classList.toggle("panel-open", Boolean(panelMode));
@@ -11954,7 +12066,7 @@
       ].join(":");
       const firstTranscriptRender = !renderedChatTailKey;
       renderedChatTailKey = chatTailKey;
-      log.innerHTML = `${visibleEvents.map(transcriptEventHtml).join("")}${defeatScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;
+      log.innerHTML = `${visibleEvents.map(transcriptEventHtml).join("")}${defeatScene}${observerScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;
       log.scrollTop = firstTranscriptRender || wasAtBottom
         ? log.scrollHeight
         : Math.min(previousScrollTop, Math.max(0, log.scrollHeight - log.clientHeight));
@@ -12212,10 +12324,20 @@
         ? `${actor} was knocked out by ${opponent}.`
         : `${actor} was defeated by ${opponent}.`;
       const cue = knockedOut
-        ? "Their body is still where it fell, and the world keeps it. Choose begin again below when you are ready."
+        ? "Their body is still where it fell, and the world keeps their identity, bonds, belongings, and journal. Stay with them while help arrives."
         : "This avatar is gone. Any linked account and items are still here. Choose begin again below when you are ready.";
       const aria = `${kicker}. ${text} ${cue}`;
       return `<div class="room-scene defeat-scene" role="alert" aria-label="${escapeAttr(aria)}"><span class="room-scene-kicker">${escapeHtml(kicker)}</span><span class="room-scene-text">${escapeHtml(text)}</span><span class="room-scene-cue">${escapeHtml(cue)}</span></div>`;
+    }
+
+    function knockedOutObserverHtml() {
+      if (defeatTransition || state?.primary_action?.kind !== "await_rescue") return "";
+      const actor = actorForId(actorId);
+      const name = actor?.name || "Your avatar";
+      const text = `${name} is knocked out, but still present in this one shared world.`;
+      const cue = "You can observe the room while another traveler brings help. This identity, its bonds, belongings, and journal remain attached.";
+      const aria = `awaiting rescue. ${text} ${cue}`;
+      return `<div class="room-scene defeat-scene" role="status" aria-label="${escapeAttr(aria)}"><span class="room-scene-kicker">awaiting rescue</span><span class="room-scene-text">${escapeHtml(text)}</span><span class="room-scene-cue">${escapeHtml(cue)}</span></div>`;
     }
 
     function quietRoomSceneHtml() {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -17804,28 +17804,8 @@ The relationship statement they are preserving is: {statement}"
             };
         };
 
-        // A defeated avatar still resolves through `actor_by_id`, so matching
-        // only on a missing actor left a defeated player being offered
-        // ordinary actions they can never submit: every offer fails
-        // `actor_can_act` as a stale offer, and the defeat copy instructs a
-        // beginning the projection never dealt. A knocked-out avatar keeps its
-        // presence in the world — the body stays visible and targetable — but
-        // the player holding it has no legal move until rescue or recovery
-        // exists, so any avatar that cannot act projects the same beginning as
-        // having no avatar at all. The client releases its binding and shows
-        // creation, while the body persists.
-        let departed = match self.actor_by_id(actor_id) {
-            None => true,
-            Some(actor) => !Self::actor_can_act(actor),
-        };
-        if departed {
-            return PrimaryAction {
-                kind: "create_avatar".to_string(),
-                label: "Create Avatar".to_string(),
-                command: "create avatar".to_string(),
-                disabled: false,
-                options: Vec::new(),
-            };
+        if let Some(action) = self.avatar_lifecycle_primary_action(actor_id) {
+            return action;
         }
 
         if let Some(encounter) = self.active_combat_encounter_for_actor(actor_id) {
@@ -22720,7 +22700,7 @@ async fn create_avatar(
             let runtime = state.inner.lock().await;
             if let Some(actor) = runtime
                 .actor_by_id(actor_id)
-                .filter(|actor| runtime.client_actor_can_submit(actor.id))
+                .filter(|actor| runtime.client_actor_can_observe(actor.id))
                 .map(|actor| runtime.actor_view(actor))
             {
                 drop(runtime);
@@ -25508,7 +25488,7 @@ async fn command_with_forwarding(
             return canonical_command_error(
                 &payload.command,
                 403,
-                "Your avatar slipped out of reach. Begin again or reconnect your account.",
+                "Reconnect your account to restore this same avatar; the world will not replace it.",
             );
         }
     }
@@ -26658,7 +26638,7 @@ async fn command_inner(
                     command: resolved.command,
                     verb: resolved.verb,
                     output: Some(
-                        "Your avatar slipped out of reach. Begin again or reconnect your account."
+                        "Reconnect your account to restore this same avatar; the world will not replace it."
                             .to_string(),
                     ),
                     error_kind: None,
@@ -27036,7 +27016,7 @@ async fn command_inner(
                     command: resolved.command,
                     verb: resolved.verb,
                     output: Some(
-                        "Your avatar slipped out of reach. Begin again or reconnect your account."
+                        "Reconnect your account to restore this same avatar; the world will not replace it."
                             .to_string(),
                     ),
                     error_kind: None,
@@ -40663,7 +40643,7 @@ mod tests {
         );
         assert_eq!(
             reconnect,
-            "Your avatar slipped out of reach. Begin again or reconnect your account."
+            "Reconnect your account to restore this same avatar; the world will not replace it."
         );
         assert_eq!(hurried, "The room needs a breath. Try again in a moment.");
         assert!(![lost, reconnect, hurried].iter().any(|copy| {
@@ -43952,10 +43932,12 @@ mod tests {
         assert!(INDEX_HTML.contains("sessionStorage.removeItem(\"cosyworld.openrouterApiKey\""));
         assert!(!INDEX_HTML.contains("sessionStorage.setItem(\"cosyworld.openrouterApiKey\""));
         assert!(INDEX_HTML.contains("walletRequestTimeoutMs"));
-        assert!(INDEX_HTML.contains("const stateRequest = api(statePath())"));
+        assert!(INDEX_HTML.contains("await rotateActorSessionIfNeeded();"));
+        assert!(INDEX_HTML.contains("let stateRequest = api(statePath())"));
+        assert!(INDEX_HTML.contains("if (recovery.ok && recovery.renewed)"));
         assert!(INDEX_HTML.contains("await Promise.all([pingPresence(), refresh()])"));
         assert!(INDEX_HTML.contains("async function postResult(path, payload)"));
-        assert!(INDEX_HTML.contains("await postResult(\"/commands\""));
+        assert!(INDEX_HTML.contains("const submit = () => postResult(\"/commands\""));
         assert!(INDEX_HTML.contains("await postResult(\"/presence/ping\""));
         assert!(!INDEX_HTML.contains("await post(\"/commands\""));
         assert!(!INDEX_HTML.contains("await post(\"/presence/ping\""));
@@ -44022,7 +44004,7 @@ mod tests {
         assert!(INDEX_HTML.contains("white-space: normal;"));
         assert!(INDEX_HTML.contains("const visibleEvents = sharedRoomTranscriptEvents(logEvents);"));
         assert!(INDEX_HTML.contains(
-            "log.innerHTML = `${visibleEvents.map(transcriptEventHtml).join(\"\")}${defeatScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;"
+            "log.innerHTML = `${visibleEvents.map(transcriptEventHtml).join(\"\")}${defeatScene}${observerScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;"
         ));
         assert!(INDEX_HTML.contains(
             "return [\"message.created\", \"image.created\", \"model_interaction.output\", \"avatar.thought\", \"avatar.dream\"].includes(event?.type);"
@@ -44190,11 +44172,14 @@ mod tests {
         ));
         assert!(INDEX_HTML.contains("function captureDefeatTransition"));
         assert!(INDEX_HTML.contains("this tale has ended"));
-        // A knockout is not an ended tale: the scene must say the body remains
-        // and still point at the one real exit.
+        // A knockout is not an ended tale: the scene keeps the same identity
+        // attached and waits for rescue rather than offering replacement.
         assert!(INDEX_HTML.contains("was knocked out by"));
         assert!(INDEX_HTML.contains("Their body is still where it fell"));
-        assert!(INDEX_HTML.contains("Choose begin again below when you are ready."));
+        assert!(INDEX_HTML.contains("Stay with them while help arrives."));
+        assert!(INDEX_HTML.contains("kind !== \"await_rescue\""));
+        assert!(INDEX_HTML.contains("/avatar/session"));
+        assert!(INDEX_HTML.contains("restore this same avatar"));
         assert!(INDEX_HTML.contains("label: beginningAgain ? \"begin again\" : \"begin\""));
         assert!(INDEX_HTML.contains("character_creation_id"));
         assert!(INDEX_HTML.contains("character_choice_id"));
@@ -48402,7 +48387,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wallet_linked_knocked_out_avatar_can_begin_a_new_tale() {
+    async fn wallet_linked_knocked_out_avatar_reconnects_without_replacement() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
             &mut runtime,
@@ -48415,6 +48400,7 @@ mod tests {
             .find(|actor| actor.id == 5000)
             .expect("linked avatar")
             .status = CW_ACTOR_KNOCKED_OUT;
+        let actor_count = runtime.world.actor_count;
 
         let state = test_app_state(runtime, None);
         let wallet_address = "wallet-ready-for-another-tale";
@@ -48426,7 +48412,7 @@ mod tests {
             ConnectInfo("127.0.0.1:45114".parse().expect("client address")),
             State(state.clone()),
             Json(CreateAvatarRequest {
-                name: Some("New Lantern".to_string()),
+                name: Some("Ignored Replacement".to_string()),
                 calling: None,
                 wallet_session: Some(wallet_session.to_string()),
                 character_creation_id: Some("the-lantern-keeper".to_string()),
@@ -48439,13 +48425,12 @@ mod tests {
         .0;
 
         assert!(response.ok, "{response:?}");
-        let actor = response.actor.expect("replacement avatar");
-        assert_ne!(actor.id, 5000);
-        assert_eq!(actor.status, "active");
-        assert_eq!(
-            linked_actor_for_wallet(&state, wallet_address),
-            Some(actor.id)
-        );
+        let actor = response.actor.expect("same observable avatar");
+        assert_eq!(actor.id, 5000);
+        assert_eq!(actor.status, "knocked_out");
+        assert!(response.actor_session.is_some());
+        assert!(response.events.is_empty());
+        assert_eq!(linked_actor_for_wallet(&state, wallet_address), Some(5000));
         assert_eq!(
             state
                 .inner
@@ -48456,6 +48441,7 @@ mod tests {
                 .status,
             CW_ACTOR_KNOCKED_OUT
         );
+        assert_eq!(state.inner.lock().await.world.actor_count, actor_count);
     }
 
     #[tokio::test]

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -489,7 +489,7 @@ pub(crate) fn command_action_failure_output(resolved: &ResolvedCommand, status: 
         return "The room needs a breath. Try again in a moment.".to_string();
     }
     if status == 403 {
-        return "Your avatar slipped out of reach. Begin again or reconnect your account."
+        return "Reconnect your account to restore this same avatar; the world will not replace it."
             .to_string();
     }
     if status >= 500 {

--- a/v2/orchestrator-rust/src/offer_commands.rs
+++ b/v2/orchestrator-rust/src/offer_commands.rs
@@ -371,7 +371,7 @@ pub(crate) async fn resolve_command_submission_at_boundary(
                 command: normalize_command_text(&payload.command),
                 verb: String::new(),
                 output: Some(
-                    "Your avatar slipped out of reach. Begin again or reconnect your account."
+                    "Reconnect your account to restore this same avatar; the world will not replace it."
                         .to_string(),
                 ),
                 error_kind: None,

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -207,6 +207,10 @@ pub(super) fn app_router(state: AppState) -> Router {
         )
         .route("/dev/reset", post(dev_reset))
         .route("/avatar", post(create_avatar))
+        .route(
+            "/avatar/session",
+            post(super::actor_presence::renew_avatar_session),
+        )
         .route("/avatar/class", post(choose_avatar_class))
         .route("/presence/ping", post(ping_presence))
         .route("/presence/leave", post(leave_presence))

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -251,4 +251,6 @@
 # snapshot and so rejected correct declarations naming a normally-empty field.
 # 67860 -> 67779: move avatar creation flavor and asynchronous AI identity
 # refinement behind avatar_identity.rs while adding keyed model-pool retries.
-67779
+# 67779 -> 67765: avatar session recovery and its tests live in
+# actor_presence.rs; primary_action delegates the lifecycle boundary there.
+67765

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -4590,6 +4590,7 @@ async function main() {
       const previousState = state;
       const previousActorId = actorId;
       const previousTransition = defeatTransition;
+      const previousActorSessionTerminal = actorSessionTerminal;
       const previousStoredTransition = sessionStorage.getItem(defeatTransitionStorageKey);
       try {
         actorId = 5000;
@@ -4612,6 +4613,15 @@ async function main() {
           target_actor_name: "Lantern Stitch",
         });
         const knockoutHtml = defeatTransitionHtml();
+        state = {
+          ...state,
+          actors: state.actors.map((actor) => actor.id === 5000
+            ? { ...actor, status: "knocked_out" }
+            : actor),
+          primary_action: { kind: "await_rescue", disabled: true, options: [] },
+          action_offers: [],
+        };
+        const knockoutActions = buildActions(state);
         clearDefeatTransition();
         const deathCaptured = captureDefeatTransition({
           seq: 100,
@@ -4627,11 +4637,13 @@ async function main() {
           primary_action: { kind: "create_avatar", options: [] },
           character_creation: [],
         };
+        actorSessionTerminal = true;
         const restart = buildActions(state)[0];
         return {
           captured,
           deathCaptured,
           knockoutHtml,
+          knockoutActionCount: knockoutActions.length,
           deathHtml,
           restartLabel: restart?.label || "",
           restartDetail: restart?.detail || "",
@@ -4641,6 +4653,7 @@ async function main() {
       } finally {
         state = previousState;
         actorId = previousActorId;
+        actorSessionTerminal = previousActorSessionTerminal;
         defeatTransition = previousTransition;
         if (previousStoredTransition === null) sessionStorage.removeItem(defeatTransitionStorageKey);
         else sessionStorage.setItem(defeatTransitionStorageKey, previousStoredTransition);
@@ -4649,9 +4662,10 @@ async function main() {
     assert(result.captured, `the player's knockout should capture an explicit defeat transition: ${JSON.stringify(result)}`);
     assert(/Lantern Stitch was knocked out by Moonlit Echo/i.test(result.knockoutHtml), `the knockout scene should name the outcome and both combatants without declaring the tale ended: ${JSON.stringify(result)}`);
     assert(!/this tale has ended/i.test(result.knockoutHtml) && /body is still where it fell/i.test(result.knockoutHtml), `a knockout is recoverable; the scene must not claim permanent loss: ${JSON.stringify(result)}`);
+    assert(result.knockoutActionCount === 0, `a knocked-out avatar should remain attached in observer mode without a replacement action: ${JSON.stringify(result)}`);
     assert(result.deathCaptured, `the player's death should capture an explicit defeat transition: ${JSON.stringify(result)}`);
     assert(/this tale has ended/i.test(result.deathHtml) && /This avatar is gone/i.test(result.deathHtml), `the death scene keeps the ended-tale copy: ${JSON.stringify(result)}`);
-    assert(result.restartLabel === "begin again" && result.restartDetail === "make a new avatar" && result.restartTitle === "begin another tale" && result.restartConfirm === "begin again", `the post-defeat action should be a deliberate restart rather than a silent reset: ${JSON.stringify(result)}`);
+    assert(result.restartLabel === "begin again" && result.restartDetail === "make a new avatar" && result.restartTitle === "begin another tale" && result.restartConfirm === "begin again", `an authoritative death should expose a deliberate restart rather than a silent reset: ${JSON.stringify(result)}`);
   }
 
   async function assertAvatarRailOwnsCombatTracker() {


### PR DESCRIPTION
## What changed

- keep a knocked-out walker attached to the same canonical avatar in observer mode, with bonds, belongings, location, and journal position intact
- recover wallet-linked knocked-out avatars without creating an `actor.created` event or replacement identity
- add `POST /avatar/session` for same-actor credential checks and rotation; expired credentials require the wallet already linked to that actor
- reject credential resurrection for missing, suspended, terminal, or different actors
- rotate browser credentials proactively and retry an interrupted action at most once, reusing the original command intent
- move lifecycle/session recovery into `actor_presence.rs`, preserve the `main.rs` architecture ceiling, document the route, and bump the release version to 1.0.6

## Why

Doors are routes through one shared world, not separate copies. Session wall-time and knockout must not silently fork a walker from the world's sequence-space identity.

## Validation

The repository's full pre-push gate passes against current `main`:

- 177 JavaScript tests
- all official/composed worldpack checks and strict proof-world verification
- kernel tests
- 1,153 Rust runtime tests, 12 library tests, 7 supporting binary tests, 5 integration tests, and doc tests
- architecture ceiling and Rust lint gate
- JavaScript and Python syntax checks

Focused recovery, knockout, command-failure, and browser regressions also pass.