### PR TITLE
Declare Hoppycat replay compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.8 — 2026-08-12
+
+- Declare the exact Hoppycat bundle currently deployed to Lonely Forest as
+  replay-compatible with the avatar identity and naming update, preserving its
+  journal and checkpoint while keeping all other bundle transitions fail-closed.
+
 ## 1.0.4 — 2026-08-12
 
 CosyWorld 1.0 is the first stable release of the canonical V2 product: a shared,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/content/hoppycat/registry.json
+++ b/v2/content/hoppycat/registry.json
@@ -9,6 +9,12 @@
     "version": 4,
     "description": "A cosy-weird world of tea, tides, prisms, careful memory, impossible dreams, and a day trying to become tomorrow.",
     "entry_location": "hoppycat.archive:location/770000",
+    "persistence_compatibility": {
+      "schema_version": 1,
+      "replay_compatible_bundle_hashes": [
+        "sha256:4033bce20f86585f2fc5221ab7e3aeac637358b4b395ded6dc0b2e71fd1e6035"
+      ]
+    },
     "rules_profile": "cosyworld.srd5/1",
     "active_rules_variants": [],
     "active_rules_extensions": [],

--- a/v2/content/hoppycat/worldpack.json
+++ b/v2/content/hoppycat/worldpack.json
@@ -7,6 +7,12 @@
   "version": 4,
   "description": "A cosy-weird world of tea, tides, prisms, careful memory, impossible dreams, and a day trying to become tomorrow.",
   "entry_location": "hoppycat.archive:location/770000",
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:4033bce20f86585f2fc5221ab7e3aeac637358b4b395ded6dc0b2e71fd1e6035"
+    ]
+  },
   "rules_profile": "cosyworld.srd5/1",
   "active_rules_variants": [],
   "active_rules_extensions": [],

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/hoppycat-worldpack.test.mjs
+++ b/v2/scripts/hoppycat-worldpack.test.mjs
@@ -4,12 +4,44 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { evaluateWorldpackGate } from "./check-deploy-worldpack.mjs";
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packRoot = path.resolve(scriptDir, "../content/hoppycat-archive");
+const worldRoot = path.resolve(scriptDir, "../worlds/hoppycat");
+const compiledRoot = path.resolve(scriptDir, "../content/hoppycat");
+const deployedBundleHash =
+  "sha256:4033bce20f86585f2fc5221ab7e3aeac637358b4b395ded6dc0b2e71fd1e6035";
 
 function readJson(fileName) {
   return JSON.parse(fs.readFileSync(path.join(packRoot, fileName), "utf8"));
 }
+
+function readJsonFrom(root, fileName) {
+  return JSON.parse(fs.readFileSync(path.join(root, fileName), "utf8"));
+}
+
+test("Hoppycat accepts replay from its deployed pre-identity bundle", () => {
+  // #764 added avatar identity and naming metadata without changing resource
+  // identities, topology, rules, or the meaning of persisted gameplay state.
+  const world = readJsonFrom(worldRoot, "world.json");
+  const registry = readJsonFrom(compiledRoot, "registry.json");
+  const authoredHashes = world.persistence_compatibility
+    .replay_compatible_bundle_hashes;
+  const compiledHashes = registry.manifest.persistence_compatibility
+    .replay_compatible_bundle_hashes;
+
+  assert.deepEqual(authoredHashes, [deployedBundleHash]);
+  assert.deepEqual(compiledHashes, authoredHashes);
+
+  const decision = evaluateWorldpackGate({
+    candidateHash: registry.manifest.bundle_hash,
+    candidateReplayCompatible: compiledHashes,
+    liveHash: deployedBundleHash,
+  });
+  assert.equal(decision.ok, true);
+  assert.equal(decision.status, "declared_migration");
+});
 
 test("Hoppycat residents are a mobile illustrated cast led by Hoppy Cat", () => {
   const actors = readJson("actors.json");

--- a/v2/worlds/hoppycat/world.json
+++ b/v2/worlds/hoppycat/world.json
@@ -7,6 +7,12 @@
   "entry_location": "hoppycat.archive:location/770000",
   "rules_profile": "cosyworld.srd5/1",
   "avatar_naming": "../shared/hoppycat-avatar-naming.json",
+  "persistence_compatibility": {
+    "schema_version": 1,
+    "replay_compatible_bundle_hashes": [
+      "sha256:4033bce20f86585f2fc5221ab7e3aeac637358b4b395ded6dc0b2e71fd1e6035"
+    ]
+  },
   "packs": [
     "hoppycat.archive",
     "cosyworld.rules-srd-5.2.1",


### PR DESCRIPTION
## What

- declare the exact Hoppycat bundle currently deployed to Lonely Forest as replay-compatible
- carry that declaration into the compiled Hoppycat registry and worldpack
- add a regression that exercises the real deploy-gate decision
- release as 1.0.8

## Why

PR #764 added avatar identity and naming metadata, changing the compiled Hoppycat bundle from `sha256:4033bce…` to `sha256:4972bbf…`, but did not declare the deployed predecessor replay-compatible. The production guard correctly blocked Lonely Forest before backup or deployment.

## Safety and impact

This declaration accepts only the exact deployed predecessor hash. The transition changes avatar naming/identity metadata and generated presentation data; resource identities, topology, rules, and persisted gameplay-state meaning are unchanged. Every other unknown bundle transition remains fail-closed.

## Checks

- `npm run v2:worldpack:hoppycat`
- `npm run check:version`
- command-level deploy-gate simulation: `declared_migration`
- `npm run check` (run twice, including the pre-push guard)
