### PR TITLE
Record ADR 0010 and ADR 0011: semantic instruments and reflective batch work

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -8,6 +8,14 @@ an item device. The model is not automatically a person. Actor-versus-device
 embodiment follows
 [ADR 0007](docs/decisions/0007-model-bindings-and-item-devices.md).
 
+An embedding or rerank device changes whose memory surfaces and in what order,
+never what happened; the journal stays the one history and only access to it is
+subjective, per
+[ADR 0010](docs/decisions/0010-semantic-instruments-shape-memory.md). Work no
+player is waiting on — consolidation, identity refinement, journals, and
+objectives — runs in batch off the tick, per
+[ADR 0011](docs/decisions/0011-reflective-work-runs-in-batch.md).
+
 `Chat` is the player-facing friendship action. It appears only when the avatar
 has banked advancement and a nearby resident is eligible for a new Bond; playing
 it spends one advancement point, creates that friendship, and passes the room

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.11 — 2026-08-12
+
+- Record semantic instruments as subjective, replay-safe memory lenses and
+  reflective resident work as off-tick batch computation that cannot mint
+  history.
+
 ## 1.0.10 — 2026-08-12
 
 - Lock Hoppycat's pregenerated avatar and location cards as canonical local

--- a/docs/decisions/0010-semantic-instruments-shape-memory.md
+++ b/docs/decisions/0010-semantic-instruments-shape-memory.md
@@ -1,0 +1,131 @@
+# ADR 0010: semantic instruments shape recall, not history
+
+- Status: Accepted
+- Date: 2026-08-12
+- Decision owners: CosyWorld maintainers
+- Related: ADR 0003, ADR 0007, `authoritative-room-message-resonance-v1`
+
+## Context
+
+[ADR 0007](0007-model-bindings-and-item-devices.md) settled the ontology: a model
+that only embeds or reranks powers a "bounded semantic instrument" — an item, not
+a resident. It names the shape of such a thing (a resonance compass, an echo
+sorter) and gives every model-backed item an activation mode, where `equipped`
+means "a typed equipment slot activates persistent settings or modifiers."
+
+It did not say what such an instrument modifies. This decision answers that.
+
+The runtime now has the retrieval half. Room-message resonance ranks earlier
+visible lines against the latest one through a rerank or embeddings profile,
+anchored to an exact `semantic_query_event_seq`, and refuses a query that cannot
+name its position in the journal.
+
+It also has the memory half, unused. Residents accumulate `entity_memories` with
+per-atom `salience`, and hold `beliefs` carrying `confidence`, `salience`, and
+`hops` — the last recording how far a belief travelled between residents. At the
+time of this decision, recorded memory atoms are read essentially never: their
+`use_count` is zero across almost every record. The world keeps a detailed
+account of what each resident knows and consults it for nothing.
+
+So retrieval exists and points at the transcript, while the durable memory it
+could rank goes unread. The question is not how to build recall. It is what
+should decide *whose* recall differs.
+
+## Decision
+
+A semantic instrument is an item that changes how its holder's memory is ranked.
+It never changes what happened.
+
+The canonical journal remains the single history. An instrument alters only the
+projection of that history into one resident's recall: which memories surface,
+in what order, and how many. Two residents who witnessed the same committed event
+may recall it differently, and both are correct, because they disagree about
+salience rather than about fact.
+
+This keeps the split ADR 0003 depends on. There is one authoritative history and
+no merge algorithm for divergent ones. Subjectivity lives strictly in the read
+path.
+
+### What an instrument may modify
+
+| Surface | Permitted |
+| --- | --- |
+| Candidate set (which memories are eligible) | Yes |
+| Ranking function over candidates | Yes |
+| Result count | Yes |
+| Recorded salience of an atom | Yes, as derived projection state |
+| Committed events, entity versions, world sequence | **No** |
+| Whether an action is legal or an offer is dealt | **No** |
+| Clocks, dice, possession, access, currency | **No** |
+
+An instrument is a lens over the record. It is never evidence.
+
+### Why the model may differ per holder
+
+Two embedding models do not merely rank with different confidence; they define
+different notions of resemblance. Equipping a different instrument therefore
+changes what "reminds me of this" means for that resident, rather than applying a
+recall bonus. Associative character follows from the binding instead of being
+authored.
+
+This is the intended mechanic. Instruments are chosen for their metric, not their
+strength, and a coarse instrument is not a worse one.
+
+### Determinism
+
+A model must never be called during replay. Retrieval follows the rule already
+established by room-message resonance: the model proposes a ranking, the ranking
+is committed through the ordinary world-event path anchored to an exact event
+sequence, and replay reads the committed ranking.
+
+Consequently:
+
+- An instrument declares a versioned device mechanics profile that binds an exact
+  model identity, in the manner of the card-policy model hash and the pinned
+  verifier profiles.
+- Retiring or replacing a bound model never invalidates a journal, because no
+  journal depends on the model — only on the ranking it once proposed.
+- A retrieval that cannot name its query event sequence is refused rather than
+  answered.
+
+### Custody and provenance
+
+An instrument is an ordinary item and inherits the whole item contract: one live
+disposition, custody, transfer, activation, uses, and provenance. That yields the
+following without new machinery.
+
+- An instrument may be lent, traded, or lost. Handing over a compass hands over a
+  way of remembering.
+- An exhaustible instrument makes recall a resource rather than an ambient
+  faculty.
+- Provenance is meaningful. An instrument that belonged to another resident
+  carries that resident's associations, so inheriting a lens is inheriting a
+  sense of what mattered.
+
+## Consequences
+
+Recall becomes a scarce, transferable, characterful capability rather than a
+uniform background service, and it does so by pointing existing retrieval at
+existing memory through the existing item system.
+
+Revisiting is worth something. A location already visited yields different recall
+under a different instrument, which produces replayable content without authoring
+new content.
+
+Unreliable narration becomes available to a world whose defining property is one
+authoritative history. The history stays canonical; access to it does not.
+
+The cost is one more place where a model sits behind an authoritative commit, and
+that path must stay honest: a proposal, validated and committed, never a direct
+mutation.
+
+## Non-goals
+
+- Per-resident private histories, forked worlds, or any second source of truth.
+- Instruments that gate legality, alter offers, or influence the card policy
+  ranker. Ranking memory and ranking actions stay separate.
+- Calling a model during replay, or any retrieval whose result is recomputed
+  rather than read from the journal.
+- Retiring room-message resonance. Ranking the live transcript and ranking
+  durable memory are complementary; this decision adds the second candidate set
+  rather than replacing the first.

--- a/docs/decisions/0011-reflective-work-runs-in-batch.md
+++ b/docs/decisions/0011-reflective-work-runs-in-batch.md
@@ -1,0 +1,108 @@
+# ADR 0011: reflective work runs in batch, off the tick
+
+- Status: Accepted
+- Date: 2026-08-12
+- Decision owners: CosyWorld maintainers
+- Related: ADR 0003, ADR 0010, `v2/docs/world-simulation.md`
+
+## Context
+
+CosyWorld's wider world changes through committed play and never through elapsed
+wall time. Reads, speech, resident-only actions, process uptime, and time spent
+offline do not advance the simulation. Residents are funded by a small attention
+budget that accrues when a player commits a tick nearby and is spent when they
+act.
+
+That has an unusual consequence for inference cost. Because nothing decays while
+the world waits, latency off the immediate conversation path is nearly free. No
+clock runs down, no state goes stale, and no player is kept waiting by work that
+happens between visits. Most games cannot say this.
+
+The runtime does not yet exploit it. Inference is treated uniformly, one call at
+a time, at interactive latency and interactive prices, including for work that
+nobody is waiting on. Embedding and reranking in particular batch well by nature:
+ranking many candidates or embedding many records is one request, not many.
+
+There is also already a scheduled reflective pass. Avatar identity refinement is
+scheduled rather than immediate, which establishes that some work about a
+resident may legitimately happen outside their turn.
+
+## Decision
+
+Inference is divided by whether a player is waiting for it.
+
+**Interactive work** stays on the request path at interactive latency: room
+dialogue, and anything whose absence would leave a turn visibly unanswered.
+
+**Reflective work** runs in batch, off the tick, and may take arbitrarily long:
+memory consolidation, identity refinement, journal and thought composition, and
+objective selection. Batch execution is the default for this class, and a
+provider batch interface is preferred where one exists.
+
+Reflective work is what a resident does while the world is stopped. It is
+therefore the only resident activity that does not require a tick, and the
+correct name for it is dreaming: it is not an event, produces no public history
+by itself, and cannot be observed as having happened at a particular moment.
+
+### The boundary that makes this safe
+
+Reflective work may compute freely and may write derived projection state such as
+recomputed salience, embeddings, consolidated memory atoms, and refined
+description. It may not, by itself, advance the world.
+
+| Reflective output | Path |
+| --- | --- |
+| Recomputed salience, embeddings, consolidated atoms | Derived projection state; no tick, no event |
+| A proposed objective, promise, or intent | Ordinary validated commit through the world-event path |
+| Anything affecting legality, possession, clocks, or currency | Forbidden as a batch output |
+
+A batch job never mints history. Where reflection concludes something the world
+should know, it produces a proposal that is validated and committed exactly like
+any other AI proposal, and takes its sequence at commit time rather than at
+compute time. Nothing in a journal may depend on when a batch ran.
+
+This preserves replay. A batch result is either derived state, rebuildable from
+the journal and therefore disposable in the manner of a snapshot, or it is a
+committed event that replays like any other.
+
+### Relationship to attention
+
+Attention credits and batch capacity govern different things and must not be
+conflated.
+
+- Attention credits are earned from player presence and spent on acting. They
+  bound what a resident may **do**.
+- Batch capacity is offline and player-independent. It bounds what a resident may
+  **think about**.
+
+A resident with no credits may still consolidate memory. A resident with credits
+and nothing reflected upon still acts. Reflection never grants the right to act,
+and acting never requires a fresh reflection.
+
+## Consequences
+
+Per-resident reflective cost falls sharply. Consolidating one hundred residents
+becomes one batched job rather than one hundred interactive calls, and batch
+provider pricing applies on top. This matters directly: the system has already
+been halted by an exhausted inference balance, and the reflective class is where
+most avoidable spend sits.
+
+Reflection gains room to be slower and better. Work that need not return in
+seconds may consider more context, which is precisely the work — consolidation,
+identity, objectives — where quality compounds and latency does not matter.
+
+The cost is a second execution path with its own failure modes, and a rule that
+must hold under pressure: a batch result that arrives late is still only a
+proposal, and a batch result that never arrives must leave the world unchanged
+rather than partially advanced.
+
+## Non-goals
+
+- Batching room dialogue or anything a player is waiting on.
+- Batching the card-policy ranker. It is a small deterministic integer model on
+  the turn path and is already effectively free.
+- Wall-clock scheduling of world change. Batch decides when *thinking* happens,
+  never when the world advances; consequential change still requires relevant
+  committed play.
+- Allowing a batch job to write authoritative state directly, under any latency
+  or cost argument.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,12 @@ do not define V2 behavior.
   accepted party and travel model: explicit social membership and consent,
   shared undertakings, walking/vehicle/delve Formations, detachments, honest
   progress, and vehicles that remain independent world objects.
+- **[ADR 0010: Semantic Instruments Shape Recall](decisions/0010-semantic-instruments-shape-memory.md)** —
+  embedding and rerank devices change whose memory surfaces and in what order,
+  never what happened; one canonical history, subjective access.
+- **[ADR 0011: Reflective Work Runs in Batch](decisions/0011-reflective-work-runs-in-batch.md)** —
+  consolidation, identity, journals, and objectives run off the tick because a
+  world that advances only on committed play pays nothing for latency.
 - **[The CosyWorld Referee's Guide](dm-guide/README.md)** — source and build
   instructions for the illustrated guide to scenes, discovery, frontier
   forays, thresholds, tables, and strict AI refereeing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/ai-capability-registry.md
+++ b/v2/docs/ai-capability-registry.md
@@ -19,6 +19,12 @@ candidate and sends only that model ID to the provider.
   rather than borrowing a model from a global text pool. Under
   [ADR 0007](../../docs/decisions/0007-model-bindings-and-item-devices.md), an
   image-only subject is a model-backed item device rather than a resident.
+- `embeddings` and `rerank` rank existing records against a query. Under
+  [ADR 0010](../../docs/decisions/0010-semantic-instruments-shape-memory.md) a
+  binding of either kind powers a semantic instrument: an item whose holder gets
+  a different ordering of the same history. The ranking is committed against an
+  exact query event sequence and replay reads that commit, so no journal depends
+  on the bound model and retiring one invalidates nothing.
 
 Capabilities are independent. Discovery metadata is retained for inspection
 but never grants eligibility. Only a normalized declared capability enters a

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Two accepted decisions that complete boundaries the codebase had already partly established.

## ADR 0010 — semantic instruments shape recall, not history

Embedding and rerank devices alter which committed memories surface and in what order. They never change history, legality, or replay authority. Different instruments provide different notions of resemblance rather than stronger or weaker recall.

## ADR 0011 — reflective work runs in batch, off the tick

Memory consolidation, identity refinement, journals, and objective selection may run asynchronously because the world advances only through committed play. Batch work may update derived projections or propose a normal validated event, but it cannot mint history.

## Also

- Documents `embeddings` and `rerank` in the AI capability registry.
- Links both decisions from `AI.md` and the documentation index.
- Preserves ADR 0009 for the already-merged Companies, Ventures, Formations, and Shared Travel decision.
- Rebases onto release 1.0.10 and assigns release version 1.0.11.

## Verification

- `npm run check:version` — pass
- `npm test` — 177 pass
- `npm run lint` — pass
- New and updated ADR links resolve
- `git diff --check` — pass
- Clean GitHub Linux CI is the authoritative full merge gate

Validated head: `b47cf00b7a6a4b70346195d719884133aabcf20c`.