### PR TITLE
Keep journey Travel pinned without starving the hand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.12 — 2026-08-12
+
+- Keep an active journey's exact next Travel card in one hand slot while every
+  other eligible action rotates fairly through the remaining slot.
+
 ## 1.0.11 — 2026-08-12
 
 - Record semantic instruments as subjective, replay-safe memory lenses and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -2331,6 +2331,58 @@ pub(super) fn compose_action_hand_at(
     }
 }
 
+fn pin_action_hand_offer(
+    hand: &mut ActionHandView,
+    offers: &[RankedActionOffer],
+    draw_count: usize,
+    pinned_offer: &RankedActionOffer,
+    excluded_offer_ids: &BTreeSet<String>,
+) {
+    let companion_capacity = usize::from(hand.capacity).saturating_sub(1);
+    let mut companion_candidates = offers
+        .iter()
+        .filter(|candidate| {
+            candidate.ranked_hand_eligible
+                && action_offer_is_reachable(candidate)
+                && !excluded_offer_ids.contains(&candidate.offer_id)
+        })
+        .collect::<Vec<_>>();
+    companion_candidates.sort_by(|left, right| {
+        left.provider
+            .priority
+            .cmp(&right.provider.priority)
+            .then_with(|| left.rank.cmp(&right.rank))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let mut seen_groups = BTreeSet::new();
+    companion_candidates.retain(|candidate| seen_groups.insert(action_offer_hand_group(candidate)));
+    let companion_count = companion_candidates.len();
+    let companions = if companion_count == 0 || companion_capacity == 0 {
+        Vec::new()
+    } else {
+        let start = draw_count.saturating_mul(companion_capacity) % companion_count;
+        (0..companion_capacity.min(companion_count))
+            .map(|offset| companion_candidates[(start + offset) % companion_count])
+            .collect::<Vec<_>>()
+    };
+    hand.entries = std::iter::once(ActionHandEntryView {
+        offer_id: pinned_offer.offer_id.clone(),
+        kind: pinned_offer.kind.clone(),
+        intention: pinned_offer.intention.clone(),
+        provider: pinned_offer.provider.clone(),
+    })
+    .chain(companions.into_iter().map(|companion| ActionHandEntryView {
+        offer_id: companion.offer_id.clone(),
+        kind: companion.kind.clone(),
+        intention: companion.intention.clone(),
+        provider: companion.provider.clone(),
+    }))
+    .collect();
+    let guided_deck_size = companion_count.saturating_add(1);
+    hand.deck_size = u16::try_from(guided_deck_size).unwrap_or(u16::MAX);
+    hand.draw_available = companion_count > companion_capacity;
+}
+
 impl RuntimeWorld {
     pub(super) fn current_action_hand_offers<'a>(
         &self,
@@ -2374,57 +2426,29 @@ impl RuntimeWorld {
             .unwrap_or_default();
         let mut hand = compose_action_hand_at(offers, draw_count);
         if let Some(actor_id) = actor_id {
-            let (advancing_offer_id, advancing_offer_ids) =
-                self.first_tale_advancing_offer_selection(actor_id, offers);
-            if let Some(advancing_offer_id) = advancing_offer_id.as_ref() {
-                if let Some(offer) = offers
-                    .iter()
-                    .find(|offer| offer.offer_id == *advancing_offer_id)
+            if let Some(journey_offer) = self.journey_advancing_offer(actor_id, offers) {
+                let journey_offer_ids = BTreeSet::from([journey_offer.offer_id.clone()]);
+                pin_action_hand_offer(
+                    &mut hand,
+                    offers,
+                    draw_count,
+                    journey_offer,
+                    &journey_offer_ids,
+                );
+            } else {
+                let (advancing_offer_id, advancing_offer_ids) =
+                    self.first_tale_advancing_offer_selection(actor_id, offers);
+                if let Some(offer) = advancing_offer_id
+                    .as_ref()
+                    .and_then(|offer_id| offers.iter().find(|offer| offer.offer_id == *offer_id))
                 {
-                    let companion_capacity = usize::from(hand.capacity).saturating_sub(1);
-                    let mut companion_candidates = offers
-                        .iter()
-                        .filter(|candidate| {
-                            candidate.ranked_hand_eligible
-                                && action_offer_is_reachable(candidate)
-                                && !advancing_offer_ids.contains(&candidate.offer_id)
-                        })
-                        .collect::<Vec<_>>();
-                    companion_candidates.sort_by(|left, right| {
-                        left.provider
-                            .priority
-                            .cmp(&right.provider.priority)
-                            .then_with(|| left.rank.cmp(&right.rank))
-                            .then_with(|| left.id.cmp(&right.id))
-                    });
-                    let mut seen_groups = BTreeSet::new();
-                    companion_candidates
-                        .retain(|candidate| seen_groups.insert(action_offer_hand_group(candidate)));
-                    let companion_count = companion_candidates.len();
-                    let companions = if companion_count == 0 || companion_capacity == 0 {
-                        Vec::new()
-                    } else {
-                        let start = draw_count.saturating_mul(companion_capacity) % companion_count;
-                        (0..companion_capacity.min(companion_count))
-                            .map(|offset| companion_candidates[(start + offset) % companion_count])
-                            .collect::<Vec<_>>()
-                    };
-                    hand.entries = std::iter::once(ActionHandEntryView {
-                        offer_id: offer.offer_id.clone(),
-                        kind: offer.kind.clone(),
-                        intention: offer.intention.clone(),
-                        provider: offer.provider.clone(),
-                    })
-                    .chain(companions.into_iter().map(|companion| ActionHandEntryView {
-                        offer_id: companion.offer_id.clone(),
-                        kind: companion.kind.clone(),
-                        intention: companion.intention.clone(),
-                        provider: companion.provider.clone(),
-                    }))
-                    .collect();
-                    let guided_deck_size = companion_count.saturating_add(1);
-                    hand.deck_size = u16::try_from(guided_deck_size).unwrap_or(u16::MAX);
-                    hand.draw_available = guided_deck_size > usize::from(hand.capacity);
+                    pin_action_hand_offer(
+                        &mut hand,
+                        offers,
+                        draw_count,
+                        offer,
+                        &advancing_offer_ids,
+                    );
                 }
             }
         }

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -402,6 +402,39 @@ impl RuntimeWorld {
         Some(journey)
     }
 
+    pub(super) fn journey_advancing_offer<'a>(
+        &self,
+        actor_id: u64,
+        offers: &'a [RankedActionOffer],
+    ) -> Option<&'a RankedActionOffer> {
+        let journey = self.journey_at_actor_location(actor_id)?;
+        let next_location_id = journey.path.get(journey.current_step + 1).copied()?;
+        offers
+            .iter()
+            .find(|offer| {
+                offer.ranked_hand_eligible
+                    && action_offer_is_reachable(offer)
+                    && offer.kind == "move"
+                    && offer
+                        .target
+                        .as_ref()
+                        .and_then(|target| target.id)
+                        .is_some_and(|target_id| target_id == next_location_id)
+            })
+            .or_else(|| {
+                offers.iter().find(|offer| {
+                    offer.ranked_hand_eligible
+                        && action_offer_is_reachable(offer)
+                        && offer.kind == "explore_path"
+                        && offer
+                            .target
+                            .as_ref()
+                            .and_then(|target| target.id)
+                            .is_some_and(|target_id| target_id == journey.destination_location_id)
+                })
+            })
+    }
+
     fn generated_pathway_for_edge(
         &self,
         from_location_id: u64,
@@ -877,6 +910,44 @@ mod tests {
         assert_eq!(recovered.next_location_id, Some(path[2]));
         assert_eq!(recovered.way_class, PathwayWayClass::Route);
         assert_eq!(recovered.way_name, "Unmarked way to Moonlit Trail");
+        let offers = runtime
+            .legal_action_candidates(Some(actor_id), &AccessContext::default())
+            .1;
+        let journey_offer = runtime
+            .journey_advancing_offer(actor_id, &offers)
+            .expect("the active journey has one exact advancing offer");
+        let expected_companions = offers
+            .iter()
+            .filter(|offer| {
+                offer.ranked_hand_eligible
+                    && action_offer_is_reachable(offer)
+                    && offer.offer_id != journey_offer.offer_id
+            })
+            .map(|offer| offer.offer_id.clone())
+            .collect::<BTreeSet<_>>();
+        let mut seen_companions = BTreeSet::new();
+        for generation in 0..expected_companions.len().max(1) {
+            runtime
+                .hand_generations
+                .insert(actor_id, u64::try_from(generation).unwrap());
+            let hand = runtime.action_hand_for(Some(actor_id), &offers);
+            assert_eq!(
+                hand.entries.first().map(|entry| entry.offer_id.as_str()),
+                Some(journey_offer.offer_id.as_str()),
+                "the exact next Travel card stays pinned"
+            );
+            assert_eq!(usize::from(hand.deck_size), expected_companions.len() + 1);
+            seen_companions.extend(
+                hand.entries
+                    .iter()
+                    .skip(1)
+                    .map(|entry| entry.offer_id.clone()),
+            );
+        }
+        assert_eq!(
+            seen_companions, expected_companions,
+            "every other eligible card rotates fairly beside Travel"
+        );
         let MovementPlan::Journey { mutation, .. } = runtime
             .plan_move_choice_action(actor_id, path[2], &AccessContext::default())
             .expect("the next revealed segment remains a legal Travel choice")


### PR DESCRIPTION
## What changed

Restores an active journey's exact next Travel/Scout offer as a guaranteed hand card without recreating the starvation bug found after #768.

- Reserves one of the two hand slots for the exact journey-advancing offer.
- Rotates every other reachable, hand-eligible exact offer fairly through the remaining slot.
- Gives active journey guidance precedence over First Tale guidance; First Tale keeps its existing fair guided-hand behavior when no journey is active.
- Keeps the published deck size and Think availability aligned with the complete finite rotation.
- Adds a regression that proves the Travel card stays pinned and every companion card surfaces.
- Releases as 1.0.12 without changing the guarded `main.rs` line count.

## Why

The first #768 CI repair removed journey pinning to stop one replaced slot from starving cards such as Void Token 001. That made the smoke pass but lost the intended journey guidance. This implementation reserves the slot before selection, so guidance and finite fairness hold simultaneously.

## Validation

- `npm run check` — pass outside the workspace sandbox (1,176 Rust tests plus Node, content, kernel, architecture, lint, and syntax gates)
- Targeted journey fairness regression — pass
- Existing First Tale guided-hand rotation regression — pass
- `npm run v2:composition:smoke` — pass, including Lantern Keeper / Void Token 001 and core-Ruby replay
- `main.rs` — 67,763 lines, unchanged at the enforced ceiling
- Clippy warnings — 225, unchanged at the enforced ceiling
- `git diff --check` — pass

Validated tree: `fe1d031f3ad49cfe74996f108e437e291c0abfdc`.
Head: `6b7a5f8cb330f74bec686e267b3258aa62654e0e`.