### PR TITLE
Simplify travel card labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.15 — 2026-08-12
+
+- Simplify single-destination Travel cards to their concise route label while
+  preserving full context for confirmation, execution, and accessibility.
+
 ## 1.0.14 — 2026-08-12
 
 - Declare tenant 7's live Bethlehem bundle replay-compatible with the Emmaus

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -7679,6 +7679,13 @@
             ? (routeVerbLower.endsWith(" toward") ? "" : "toward ")
             : (fleeing ? "" : (routeVerbLower.endsWith(" to") ? "" : "to "));
           const routeLabel = String(firstExit.route_label || "").trim();
+          const conciseRouteLabel = routeLabel.replace(
+            /^(.*?)\s+from\s+.+\s+to\s+(.+)$/i,
+            "$1 to $2",
+          );
+          const destinationOnlyCardLabel = onePath && !searchingPathway && !fleeing
+            ? (conciseRouteLabel || firstPathwayDirection?.endpointName || firstExit.destination_location_name)
+            : "";
           const routeTargetLabel = targetBearingLabel(routeIntention, routeVerb, firstExit.destination_location_name);
           const routeAccessibleLabel = firstPathwayDirection
             ? `${routeVerb} toward ${firstPathwayDirection.endpointName}`
@@ -7696,6 +7703,10 @@
             ...semanticAction(routeOffer, routeIntention, routeAccessibleLabel),
             pathwayDirection: firstPathwayDirection,
             label: routeVerb.toLowerCase(),
+            destinationOnlyCardLabel,
+            destinationOnlyCardAriaLabel: destinationOnlyCardLabel
+              ? `${routeVerb}${routeLabel ? " via " : " to "}${destinationOnlyCardLabel}`
+              : "",
             detail: onePath
               ? (firstPathwayDirection
                 ? `toward ${firstPathwayDirection.endpointName}`
@@ -16059,12 +16070,13 @@
         ? (typeof action.busyDetail === "function" ? action.busyDetail() : action.busyDetail)
         : "";
       const detail = friendlyActionText(pendingDetail || action.detail);
+      const destinationOnlyCardLabel = String(action.destinationOnlyCardLabel || "").trim();
       button.setAttribute(
         "aria-label",
         [
-          action.accessibleLabel || action.label,
-          detail,
-          handProviderReason(action),
+          action.destinationOnlyCardAriaLabel || action.accessibleLabel || action.label,
+          destinationOnlyCardLabel ? "" : detail,
+          destinationOnlyCardLabel ? "" : handProviderReason(action),
           storyGuideLabel,
           count ? `suggestion ${count}` : "",
           action.busy ? "in progress" : "",
@@ -16082,12 +16094,16 @@
         ? `<span class="thumb pathway-direction-thumb" aria-hidden="true">${directionArrow}</span>`
         : thumbnailHtml(action, false, "action-mini-card");
       button.classList.add("has-copy");
-      const labelText = compactActionLabel(action) || String(action.command || "action").toLowerCase();
-      const detailHtml = detail ? `<span class="detail">${escapeHtml(detail)}</span>` : "";
-      const storyHtml = storyGuide
+      const labelText = destinationOnlyCardLabel
+        || compactActionLabel(action)
+        || String(action.command || "action").toLowerCase();
+      const detailHtml = detail && !destinationOnlyCardLabel
+        ? `<span class="detail">${escapeHtml(detail)}</span>`
+        : "";
+      const storyHtml = storyGuide && !destinationOnlyCardLabel
         ? `<span class="story-call">✦ ${escapeHtml(storyGuideLabel)}</span>`
         : "";
-      const providerReason = handProviderReason(action);
+      const providerReason = destinationOnlyCardLabel ? "" : handProviderReason(action);
       const providerHtml = providerReason
         ? `<span class="provider-call">↳ ${escapeHtml(providerReason)}</span>`
         : "";

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -3600,6 +3600,16 @@ async function main() {
         state = singleState;
         actions = buildActions(singleState);
         const single = actions.find((action) => action.label === "travel") || null;
+        renderButton("primary", single);
+        const singleButton = document.querySelector("#primary");
+        const singleCard = {
+          text: singleButton?.innerText?.trim().replace(/\s+/g, " ") || "",
+          label: singleButton?.querySelector(".cmd-label")?.textContent?.trim() || "",
+          detail: singleButton?.querySelector(".detail")?.textContent?.trim() || "",
+          provider: singleButton?.querySelector(".provider-call")?.textContent?.trim() || "",
+          story: singleButton?.querySelector(".story-call")?.textContent?.trim() || "",
+          aria: singleButton?.getAttribute("aria-label") || "",
+        };
         return {
           count: routes.length,
           detail: route?.detail || "",
@@ -3613,6 +3623,7 @@ async function main() {
           busy,
           modal,
           selectedPreview,
+          singleCard,
           single: single ? {
             accessibleLabel: single.accessibleLabel,
             detail: single.detail,
@@ -3688,6 +3699,15 @@ async function main() {
     assert(
       result.single?.accessibleLabel === "Travel to Rain-Silver Crossing via Route from Bethlehem to Jerusalem",
       `single-route accessibility copy should carry the same direction-aware identity: ${JSON.stringify(result)}`,
+    );
+    assert(
+      result.singleCard?.text === "Route to Jerusalem"
+        && result.singleCard?.label === "Route to Jerusalem"
+        && !result.singleCard?.detail
+        && !result.singleCard?.provider
+        && !result.singleCard?.story
+        && result.singleCard?.aria === "Travel via Route to Jerusalem",
+      `a single Travel card should show only its concise destination: ${JSON.stringify(result)}`,
     );
     assert(result.single?.choices?.length === 0 && result.single?.payload?.destination_location_id === 2, `single-path Travel should not add an unnecessary choice: ${JSON.stringify(result)}`);
   }
@@ -14334,6 +14354,7 @@ async function main() {
       const reason = handProviderReason(action);
       return {
         label: action?.label || "",
+        destinationOnlyCardLabel: action?.destinationOnlyCardLabel || "",
         offerKinds: action?.offerKinds || [],
         reason,
         providerCopy: button.querySelector(".provider-call")?.textContent.trim() || "",
@@ -14354,8 +14375,9 @@ async function main() {
         || action.aria.includes("next tale beat")
       )
         && action.reason
-        && action.providerCopy.includes(action.reason)
-        && action.aria.includes(action.reason)
+        && (action.destinationOnlyCardLabel
+          ? !action.providerCopy && !action.aria.includes(action.reason)
+          : action.providerCopy.includes(action.reason) && action.aria.includes(action.reason))
     ))
       && /(path to Rain-Soft Garden is waiting|few distant routes are waiting|(?:nearby )?avatar.*(?:hoping|waiting).*item)/i.test(projectedRoomHand.thread)
       && projectedRoomHand.redundantSurface === false,


### PR DESCRIPTION
## Summary

- render single-destination travel cards with only the concise way/destination label, such as `Path to Void 033` or `Road to Emmaus`
- remove redundant verb, intermediate-room detail, provider origin, and story-guide lines from those cards
- preserve full route context for confirmation, execution, and accessible button naming
- keep grouped multi-destination travel choosers unchanged
- add browser regression coverage and release as 1.0.15

## Why

Travel cards repeated the same movement context across the verb, destination detail, full origin-to-destination route, and provider-origin line. This made a simple destination choice visually noisy.

The root cause was that the compact renderer treated travel cards like general action cards even when the card already had one authoritative destination.

## Impact

Single-destination travel cards are now immediately scannable while retaining their existing behavior and accessible intent. Other action cards and grouped travel choices keep their current presentation.

## Validation

- focused headless-browser render check: `Path to Void 033`, no detail/provider lines, accessible name `Travel via Path to Void 033`
- original full required `npm run check` suite passed
- rebased 1.0.15 tree: version gate, 177 Vitest tests, syntax checks, and diff checks passed locally
- GitHub CI is the final merge gate