### PR TITLE
Recover stale command observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.17 — 2026-08-12
+
+- Recover once from stale command observations when the refreshed hand still
+  contains the same certified choice, while preserving fail-closed concurrency.
+
 ## 1.0.16 — 2026-08-12
 
 - Restore Hoppycat startup by aligning authored job-strategy provenance with

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.16"
+version = "1.0.17"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/canonical_identity_tests.rs
+++ b/v2/orchestrator-rust/src/canonical_identity_tests.rs
@@ -253,3 +253,137 @@ fn run_durable_entity_version_rehydration() {
     );
     let _ = fs::remove_file(path);
 }
+
+fn canonical_version_test_offer_request(
+    runtime: &mut RuntimeWorld,
+    actor_id: u64,
+    actor_session: &str,
+    intent_id: &str,
+) -> CommandRequest {
+    let actor = runtime
+        .actor_by_id(actor_id)
+        .expect("canonical version test actor");
+    let actor_ref = runtime
+        .canonical_ref("actor", actor_id)
+        .expect("canonical version test actor ref")
+        .to_string();
+    let location_ref = runtime
+        .canonical_ref("location", actor.location_id)
+        .expect("canonical version test location ref")
+        .to_string();
+    let offer_id = runtime
+        .draw_until_test_offer(actor_id, &AccessContext::default(), |offer| {
+            offer.kind == "search"
+        })
+        .expect("search rotates into the canonical version test hand")
+        .offer_id;
+    CommandRequest {
+        actor_id,
+        actor_session: Some(actor_session.to_string()),
+        command: "offer identity selects the action".to_string(),
+        offer_id: Some(offer_id),
+        wallet_session: None,
+        envelope: Some(CanonicalCommandEnvelope {
+            world_id: OFFICIAL_WORLD_ID.to_string(),
+            intent_id: intent_id.to_string(),
+            actor_ref: actor_ref.clone(),
+            observed: CanonicalObservedVersions {
+                actor_version: Some(runtime.entity_version(&actor_ref)),
+                location_version: Some(runtime.entity_version(&location_ref)),
+                entities: BTreeMap::new(),
+            },
+            last_world_seq: runtime.world.next_event_seq.saturating_sub(1),
+        }),
+    }
+}
+
+#[tokio::test]
+async fn stale_canonical_entity_versions_fail_closed_with_typed_errors() {
+    let actor_id = 5000;
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        actor_id,
+        COSY_COTTAGE_LOCATION_ID,
+        "Versioned Neighbour",
+    );
+    let state = test_app_state(runtime, None);
+    let actor_session = create_actor_session(&state.actor_sessions, actor_id).0;
+    let first_request = {
+        let mut runtime = state.inner.lock().await;
+        canonical_version_test_offer_request(
+            &mut runtime,
+            actor_id,
+            &actor_session,
+            "test:advance-version",
+        )
+    };
+    let mut stale_request = first_request.clone();
+    stale_request
+        .envelope
+        .as_mut()
+        .expect("canonical envelope")
+        .intent_id = "test:stale-version".to_string();
+    let client = ConnectInfo("127.0.0.1:45130".parse().expect("client address"));
+
+    let first = command(client, State(state.clone()), Json(first_request))
+        .await
+        .0;
+    assert!(first.ok, "{first:?}");
+    let event_count_after_first = state.inner.lock().await.event_log.len();
+    let stale = command(client, State(state.clone()), Json(stale_request.clone()))
+        .await
+        .0;
+    assert_eq!(stale.error_kind, Some(CommandErrorKind::StaleActorVersion));
+
+    let mut stale_location_request = stale_request.clone();
+    {
+        let runtime = state.inner.lock().await;
+        let actor = runtime.actor_by_id(actor_id).expect("versioned actor");
+        let actor_ref = runtime.canonical_ref("actor", actor_id).unwrap();
+        let location_ref = runtime
+            .canonical_ref("location", actor.location_id)
+            .unwrap();
+        let envelope = stale_location_request.envelope.as_mut().unwrap();
+        envelope.intent_id = "test:stale-location-version".to_string();
+        envelope.observed.actor_version = Some(runtime.entity_version(actor_ref));
+        envelope.observed.location_version =
+            Some(runtime.entity_version(location_ref).saturating_add(1));
+    }
+    let stale_location = command(client, State(state.clone()), Json(stale_location_request))
+        .await
+        .0;
+    assert_eq!(
+        stale_location.error_kind,
+        Some(CommandErrorKind::StaleLocationVersion)
+    );
+
+    let mut stale_entity_request = stale_request;
+    {
+        let runtime = state.inner.lock().await;
+        let actor = runtime.actor_by_id(actor_id).expect("versioned actor");
+        let actor_ref = runtime.canonical_ref("actor", actor_id).unwrap();
+        let location_ref = runtime
+            .canonical_ref("location", actor.location_id)
+            .unwrap();
+        let envelope = stale_entity_request.envelope.as_mut().unwrap();
+        envelope.intent_id = "test:stale-entity-version".to_string();
+        envelope.observed.actor_version = Some(runtime.entity_version(actor_ref));
+        envelope.observed.location_version = Some(runtime.entity_version(location_ref));
+        envelope.observed.entities.insert(
+            actor_ref.to_string(),
+            runtime.entity_version(actor_ref).saturating_add(1),
+        );
+    }
+    let stale_entity = command(client, State(state.clone()), Json(stale_entity_request))
+        .await
+        .0;
+    assert_eq!(
+        stale_entity.error_kind,
+        Some(CommandErrorKind::StaleEntityVersion)
+    );
+    assert_eq!(
+        state.inner.lock().await.event_log.len(),
+        event_count_after_first
+    );
+}

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -8963,6 +8963,9 @@
     }
 
     function commandFailureMessage(result = {}) {
+      if (isStaleCommandObservation(result)) {
+        return "That choice changed while you were deciding. Nothing else happened; check what is here and choose again.";
+      }
       const output = String(result.output || "").trim();
       if (output) return output;
       const status = Number(result.status || 0);
@@ -8971,6 +8974,17 @@
       if (status === 423) return "This is an explicitly ordered scene. The named combat participant acts now; chat and inspection stay available.";
       if (status === 429) return "The room needs a breath. Try again in a moment.";
       return "The room did not catch that. Look around and try another choice.";
+    }
+
+    function isStaleCommandObservation(result = {}) {
+      if (Number(result.status || 0) !== 409) return false;
+      if ([
+        "stale_actor_version",
+        "stale_location_version",
+        "stale_entity_version",
+      ].includes(String(result.error_kind || ""))) return true;
+      return /stale (?:actor|location) version|stale or unknown entity version|refresh before retrying/i
+        .test(String(result.output || ""));
     }
 
     function isNetworkError(error) {
@@ -9010,6 +9024,47 @@
       };
     }
 
+    function commandOfferRetryFingerprint(offer = {}) {
+      return JSON.stringify({
+        kind: String(offer.kind || ""),
+        command: String(offer.command || "").trim(),
+        operation: String(offer.operation || ""),
+        rules_action: String(offer.rules_action || ""),
+        rules_profile: String(offer.rules_profile || ""),
+        target: offer.target ? {
+          kind: String(offer.target.kind || ""),
+          id: String(offer.target.id || ""),
+        } : null,
+        provider: offer.provider ? {
+          kind: String(offer.provider.kind || ""),
+          id: String(offer.provider.id || ""),
+        } : null,
+        project: offer.project ? {
+          id: String(offer.project.id || ""),
+          strategy_id: String(offer.project.strategy_id || ""),
+        } : null,
+        threshold_method: offer.threshold_method ? {
+          descriptor_id: String(offer.threshold_method.descriptor_id || ""),
+          method_id: String(offer.threshold_method.method_id || ""),
+        } : null,
+        cost: offer.cost || null,
+        effect: String(offer.effect || ""),
+        risk: String(offer.risk || ""),
+      });
+    }
+
+    function equivalentCommandOffer(previousOffer) {
+      const fingerprint = commandOfferRetryFingerprint(previousOffer);
+      const handOfferIds = new Set((state?.action_hand?.entries || [])
+        .map((entry) => String(entry?.offer_id || ""))
+        .filter(Boolean));
+      const matches = (state?.action_offers || []).filter((offer) => (
+        handOfferIds.has(String(offer?.offer_id || ""))
+          && commandOfferRetryFingerprint(offer) === fingerprint
+      ));
+      return matches.length === 1 ? matches[0] : null;
+    }
+
     async function runCommandText(commandText, exactOffer = null) {
       const command = String(commandText || "").trim();
       if (!command) return;
@@ -9025,11 +9080,12 @@
         return null;
       }
       const beforeOrbs = economyOrbCount();
-      const envelope = canonicalCommandEnvelope();
+      let envelope = canonicalCommandEnvelope();
+      let submittedOffer = exactOffer;
       const submit = () => postResult("/commands", withAccess({
           actor_id: actorId,
           command,
-          ...(exactOffer?.offer_id ? { offer_id: exactOffer.offer_id } : {}),
+          ...(submittedOffer?.offer_id ? { offer_id: submittedOffer.offer_id } : {}),
           envelope,
         }));
       let result = await submit();
@@ -9037,12 +9093,28 @@
         const recovery = await renewActorSession();
         if (recovery.ok && recovery.renewed) result = await submit();
       }
+      if (isStaleCommandObservation(result)) {
+        await refresh();
+        const refreshedOffer = exactOffer ? equivalentCommandOffer(exactOffer) : null;
+        if (!exactOffer || refreshedOffer) {
+          submittedOffer = refreshedOffer;
+          envelope = canonicalCommandEnvelope();
+          result = await submit();
+          if (Number(result.status || 0) === 403) {
+            const recovery = await renewActorSession();
+            if (recovery.ok && recovery.renewed) result = await submit();
+          }
+        }
+      }
       const resultEvents = result.events || [];
       pushEvents(resultEvents);
-      if (result.output) pushCommandOutput(result.command || command, result.output, result.ok, resultEvents);
+      const visibleOutput = !result.ok && isStaleCommandObservation(result)
+        ? commandFailureMessage(result)
+        : result.output;
+      if (visibleOutput) pushCommandOutput(result.command || command, visibleOutput, result.ok, resultEvents);
       if (!result.ok) {
         const message = commandFailureMessage(result);
-        if (!result.output) pushCommandOutput(result.command || command, message, false, resultEvents);
+        if (!visibleOutput) pushCommandOutput(result.command || command, message, false, resultEvents);
         setError(message);
       }
       if (result.ok && clearFirstTaleAfterAction) {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -25179,13 +25179,22 @@ fn canonical_command_error(
     status: u32,
     output: impl Into<String>,
 ) -> Json<CommandResponse> {
+    canonical_command_error_with_kind(command, status, output, None)
+}
+
+fn canonical_command_error_with_kind(
+    command: &str,
+    status: u32,
+    output: impl Into<String>,
+    error_kind: Option<CommandErrorKind>,
+) -> Json<CommandResponse> {
     Json(CommandResponse {
         ok: false,
         status,
         command: normalize_command_text(command),
         verb: String::new(),
         output: Some(output.into()),
-        error_kind: None,
+        error_kind,
         action: None,
         receipt: None,
         events: Vec::new(),
@@ -25492,12 +25501,13 @@ async fn command_with_forwarding(
         if let Some(observed) = envelope.observed.actor_version {
             let current = runtime.entity_version(&envelope.actor_ref);
             if observed != current {
-                return canonical_command_error(
+                return canonical_command_error_with_kind(
                     &payload.command,
                     409,
                     format!(
                         "Stale actor version: observed {observed}, current {current}. Refresh before retrying."
                     ),
+                    Some(CommandErrorKind::StaleActorVersion),
                 );
             }
         }
@@ -25508,12 +25518,13 @@ async fn command_with_forwarding(
                 .map(|canonical_ref| runtime.entity_version(canonical_ref))
                 .unwrap_or_default();
             if observed != current {
-                return canonical_command_error(
+                return canonical_command_error_with_kind(
                     &payload.command,
                     409,
                     format!(
                         "Stale location version: observed {observed}, current {current}. Refresh before retrying."
                     ),
+                    Some(CommandErrorKind::StaleLocationVersion),
                 );
             }
         }
@@ -25524,12 +25535,13 @@ async fn command_with_forwarding(
                 .get(canonical_ref)
                 .copied();
             if current != Some(*observed) {
-                return canonical_command_error(
+                return canonical_command_error_with_kind(
                     &payload.command,
                     409,
                     format!(
                         "Stale or unknown entity version for {canonical_ref}. Refresh before retrying."
                     ),
+                    Some(CommandErrorKind::StaleEntityVersion),
                 );
             }
         }
@@ -40331,55 +40343,6 @@ mod tests {
         assert!(restored.command_receipts.len() <= COMMAND_RECEIPT_CACHE_MAX_ENTRIES);
     }
 
-    #[tokio::test]
-    async fn stale_canonical_entity_versions_fail_closed() {
-        let actor_id = 5000;
-        let mut runtime = RuntimeWorld::seeded();
-        create_test_human(
-            &mut runtime,
-            actor_id,
-            COSY_COTTAGE_LOCATION_ID,
-            "Versioned Neighbour",
-        );
-        let state = test_app_state(runtime, None);
-        let actor_session = create_actor_session(&state.actor_sessions, actor_id).0;
-        let first_request = {
-            let mut runtime = state.inner.lock().await;
-            canonical_test_offer_request(
-                &mut runtime,
-                actor_id,
-                &actor_session,
-                "test:advance-version",
-                "search",
-            )
-        };
-        let mut stale_request = first_request.clone();
-        stale_request
-            .envelope
-            .as_mut()
-            .expect("canonical envelope")
-            .intent_id = "test:stale-version".to_string();
-        let client = ConnectInfo("127.0.0.1:45130".parse().expect("client address"));
-
-        let first = command(client, State(state.clone()), Json(first_request))
-            .await
-            .0;
-        assert!(first.ok, "{first:?}");
-        let event_count_after_first = state.inner.lock().await.event_log.len();
-        let stale = command(client, State(state.clone()), Json(stale_request))
-            .await
-            .0;
-
-        assert!(!stale.ok);
-        assert_eq!(stale.status, 409);
-        assert!(stale
-            .output
-            .as_deref()
-            .is_some_and(|output| output.contains("Stale actor version")));
-        let runtime = state.inner.lock().await;
-        assert_eq!(runtime.event_log.len(), event_count_after_first);
-    }
-
     fn discover_seed_exit_for_test(
         runtime: &mut RuntimeWorld,
         from_location_id: u64,
@@ -43881,6 +43844,9 @@ mod tests {
         assert!(INDEX_HTML.contains("if (recovery.ok && recovery.renewed)"));
         assert!(INDEX_HTML.contains("await Promise.all([pingPresence(), refresh()])"));
         assert!(INDEX_HTML.contains("async function postResult(path, payload)"));
+        assert!(INDEX_HTML.contains("function isStaleCommandObservation(result = {})"));
+        assert!(INDEX_HTML.contains("function equivalentCommandOffer(previousOffer)"));
+        assert!(INDEX_HTML.contains("if (isStaleCommandObservation(result))"));
         assert!(INDEX_HTML.contains("const submit = () => postResult(\"/commands\""));
         assert!(INDEX_HTML.contains("await postResult(\"/presence/ping\""));
         assert!(!INDEX_HTML.contains("await post(\"/commands\""));

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -40,6 +40,9 @@ pub(crate) enum CommandErrorKind {
     StaleOffer,
     UnknownOffer,
     DisabledOffer,
+    StaleActorVersion,
+    StaleLocationVersion,
+    StaleEntityVersion,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -257,4 +257,6 @@
 # focused helper while adding the occupied distinctive-word check.
 # 67763 -> 67709: move process lifecycle composition into startup.rs, leaving
 # main as a thin async entry point without changing boot or shutdown order.
-67709
+# 67709 -> 67675: move canonical entity-version conflict coverage beside the
+# canonical identity seam while adding typed stale-observation responses.
+67675


### PR DESCRIPTION
## What changed

- return machine-readable conflict kinds for stale actor, location, and entity observations
- refresh and retry browser commands once when the same certified choice is still available
- replace internal stale-version text with a player-friendly conflict message
- move canonical version coverage into the canonical identity test seam and lower the `main.rs` line ceiling
- bump the project version to 1.0.17

## Why

Background world activity can advance an actor or location version after the browser builds a command but before the server receives it. The server correctly rejects that stale observation, but the browser previously exposed the raw conflict instead of recovering.

## Safety

The optimistic-concurrency guard remains fail-closed. Certified card actions retry only when the refreshed hand contains exactly one semantically identical offer with the same action, target, provider, project, cost, effect, and risk.

## Validation

- full required `npm run check`
- 178 Vitest tests
- worldpack, proof-world, and C kernel checks
- 1,156 Rust orchestrator tests plus integration and doc tests
- Rust architecture/lint ceiling and syntax checks
- focused stale-version and browser contract tests
