### PR TITLE
Validate every shipped runtime worldpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.16 — 2026-08-12
+
+- Restore Hoppycat startup by aligning authored job-strategy provenance with
+  its current pack, and require every shipped registry to pass runtime loading.
+
 ## 1.0.15 — 2026-08-12
 
 - Simplify single-destination Travel cards to their concise route label while

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/content-pack-contract.test.mjs
+++ b/test/v2/content-pack-contract.test.mjs
@@ -303,12 +303,14 @@ describe("Content Pack Manifest v1", () => {
       const worldPath = path.join(worldDir, "world.json");
       const corePackPath = path.join(contentRoot, "core/pack.json");
       const rulesPackPath = path.join(contentRoot, "rules-profile-commons/pack.json");
+      const jobsPath = path.join(contentRoot, "core/jobs.json");
       const profilesPath = path.join(contentRoot, "rules-profile-commons/profiles.json");
       const actionsPath = path.join(contentRoot, "rules-profile-commons/actions.json");
       const conformancePath = path.join(contentRoot, "rules-profile-commons/conformance.json");
       const world = JSON.parse(fs.readFileSync(worldPath, "utf8"));
       const corePack = JSON.parse(fs.readFileSync(corePackPath, "utf8"));
       const rulesPack = JSON.parse(fs.readFileSync(rulesPackPath, "utf8"));
+      const jobs = JSON.parse(fs.readFileSync(jobsPath, "utf8"));
       const profiles = JSON.parse(fs.readFileSync(profilesPath, "utf8"));
       const actions = JSON.parse(fs.readFileSync(actionsPath, "utf8"))
         .filter((action) => action.id !== "srd5.2.1:dash");
@@ -330,9 +332,16 @@ describe("Content Pack Manifest v1", () => {
       rulesPack.capabilities[0].id = `${fixtureProvider}/rules`;
       rulesPack.rules_profile = fixtureProfile;
       profiles[0].id = fixtureProfile;
+      for (const job of jobs) {
+        for (const strategy of job.contribution_strategies ?? []) {
+          strategy.rules_profile = fixtureProfile;
+          strategy.rules_pack_id = fixtureProvider;
+        }
+      }
       writeJson(worldPath, world);
       writeJson(corePackPath, corePack);
       writeJson(rulesPackPath, rulesPack);
+      writeJson(jobsPath, jobs);
       writeJson(profilesPath, profiles);
       writeJson(actionsPath, actions);
       writeJson(conformancePath, conformance);

--- a/test/v2/worldpack-access.test.mjs
+++ b/test/v2/worldpack-access.test.mjs
@@ -96,6 +96,20 @@ describe("worldpack progression access validation", () => {
     );
   });
 
+  it("rejects stale job contribution provenance before runtime startup", () => {
+    const root = worldpackFixture();
+    const jobs = JSON.parse(fs.readFileSync(path.join(root, "jobs.json"), "utf8"));
+    jobs[0].contribution_strategies[0].pack_version = "0.0.0";
+    writeJson(root, "jobs.json", jobs);
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `job ${jobs[0].id} strategy ${jobs[0].contribution_strategies[0].id} has stale pack or rules provenance`,
+    );
+  });
+
   it("rejects an unsupported authored delivery matcher", () => {
     const root = worldpackFixture();
     const jobs = JSON.parse(fs.readFileSync(path.join(root, "jobs.json"), "utf8"));

--- a/v2/content/hoppycat-archive/jobs.json
+++ b/v2/content/hoppycat-archive/jobs.json
@@ -31,7 +31,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -50,7 +50,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -69,7 +69,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -88,7 +88,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -107,7 +107,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       }
     ]
   },
@@ -143,7 +143,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -162,7 +162,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -181,7 +181,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       }
     ]
   },
@@ -217,7 +217,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -236,7 +236,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -255,7 +255,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       }
     ]
   }

--- a/v2/content/hoppycat-archive/pack.json
+++ b/v2/content/hoppycat-archive/pack.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "hoppycat.archive",
   "name": "Hoppycat: February Third",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "kind": "world",
   "description": "An original cosy-weird world of tea, tides, prisms, careful memory, impossible dreams, and a day trying to become tomorrow.",
   "license": "MIT",
@@ -12,7 +12,7 @@
     {
       "id": "hoppycat.archive/world",
       "kind": "world",
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "id": "hoppycat.archive/assets",

--- a/v2/content/hoppycat/assets.json
+++ b/v2/content/hoppycat/assets.json
@@ -1,8 +1,8 @@
 [
   {
     "pack_id": "hoppycat.archive",
-    "pack_version": "0.3.1",
-    "pack_integrity": "sha256:9e01b6d1e9f2dd07333126d8db2c722e73a7dca14f7366d1c431f4bda7065218",
+    "pack_version": "0.3.2",
+    "pack_integrity": "sha256:5293ca21cb130b4c19d52a3a468dcb68a23478c9bc5637de0c0fcbf7cc7573c9",
     "provider": "hoppycat.archive/assets",
     "mount": "cards",
     "root": "hoppycat-archive",

--- a/v2/content/hoppycat/character_creation.json
+++ b/v2/content/hoppycat/character_creation.json
@@ -1,7 +1,7 @@
 [
   {
     "pack_id": "hoppycat.archive",
-    "pack_version": "0.3.1",
+    "pack_version": "0.3.2",
     "profiles": [
       {
         "schema_version": 2,

--- a/v2/content/hoppycat/content_refs.json
+++ b/v2/content/hoppycat/content_refs.json
@@ -1045,7 +1045,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771000",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771000",
       "legacy_runtime_id": 771000,
@@ -1054,7 +1054,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771001",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771001",
       "legacy_runtime_id": 771001,
@@ -1063,7 +1063,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771002",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771002",
       "legacy_runtime_id": 771002,
@@ -1072,7 +1072,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771003",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771003",
       "legacy_runtime_id": 771003,
@@ -1081,7 +1081,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771004",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771004",
       "legacy_runtime_id": 771004,
@@ -1090,7 +1090,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771005",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771005",
       "legacy_runtime_id": 771005,
@@ -1099,7 +1099,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771006",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771006",
       "legacy_runtime_id": 771006,
@@ -1108,7 +1108,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771007",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771007",
       "legacy_runtime_id": 771007,
@@ -1117,7 +1117,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/actor/771008",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "actor",
       "local_id": "771008",
       "legacy_runtime_id": 771008,
@@ -1126,7 +1126,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-concordance-compass",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-concordance-compass",
       "runtime_handle": 2695838178583255
@@ -1134,7 +1134,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-concordance-tidelands",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-concordance-tidelands",
       "runtime_handle": 8694585919826001
@@ -1142,7 +1142,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-context-greenhouse",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-context-greenhouse",
       "runtime_handle": 8214761955000570
@@ -1150,7 +1150,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-context-seed",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-context-seed",
       "runtime_handle": 2979768036449922
@@ -1158,7 +1158,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-fermata-clapper",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-fermata-clapper",
       "runtime_handle": 5433334197444757
@@ -1166,7 +1166,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-glim-twice",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-glim-twice",
       "runtime_handle": 8993719384874424
@@ -1174,7 +1174,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-goldfish-tank",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-goldfish-tank",
       "runtime_handle": 3375150165234834
@@ -1182,7 +1182,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-halfway-cup",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-halfway-cup",
       "runtime_handle": 3933949806499525
@@ -1190,7 +1190,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-halfway-tea-garden",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-halfway-tea-garden",
       "runtime_handle": 3279721367433985
@@ -1198,7 +1198,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-hoppy-cat",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-hoppy-cat",
       "runtime_handle": 1209808962780418
@@ -1206,7 +1206,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-loop-token",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-loop-token",
       "runtime_handle": 4594384809369304
@@ -1214,7 +1214,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-lumen-facet",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-lumen-facet",
       "runtime_handle": 163470443226722
@@ -1222,7 +1222,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-meraki-atelier",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-meraki-atelier",
       "runtime_handle": 2013815173421492
@@ -1230,7 +1230,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-meraki-brush",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-meraki-brush",
       "runtime_handle": 4528585693379106
@@ -1238,7 +1238,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-mira-meraki",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-mira-meraki",
       "runtime_handle": 1785036496012002
@@ -1246,7 +1246,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-nix-fermata",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-nix-fermata",
       "runtime_handle": 6348981773496291
@@ -1254,7 +1254,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-open-record-cathedral",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-open-record-cathedral",
       "runtime_handle": 7315742551547995
@@ -1262,7 +1262,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-patch-fern",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-patch-fern",
       "runtime_handle": 496523796551250
@@ -1270,7 +1270,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-penny-vellum",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-penny-vellum",
       "runtime_handle": 7625041499244878
@@ -1278,7 +1278,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-prism-foundry",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-prism-foundry",
       "runtime_handle": 3988985693429934
@@ -1286,7 +1286,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-provenance-card",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-provenance-card",
       "runtime_handle": 3727337615563386
@@ -1294,7 +1294,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-red-thread-belfry",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-red-thread-belfry",
       "runtime_handle": 4734156656297255
@@ -1302,7 +1302,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-red-thread-spool",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-red-thread-spool",
       "runtime_handle": 2936804407219753
@@ -1310,7 +1310,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-return-path-checklist",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-return-path-checklist",
       "runtime_handle": 5080329651835421
@@ -1318,7 +1318,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-rill-current",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-rill-current",
       "runtime_handle": 6796864570677903
@@ -1326,7 +1326,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-settled-light-theatre",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-settled-light-theatre",
       "runtime_handle": 6892873403937145
@@ -1334,7 +1334,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-signal-jetty",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-signal-jetty",
       "runtime_handle": 7256845172796470
@@ -1342,7 +1342,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-tapi-lilt",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-tapi-lilt",
       "runtime_handle": 3829393037121064
@@ -1350,7 +1350,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/card/hoppycat-unfinished-prism",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "card",
       "local_id": "hoppycat-unfinished-prism",
       "runtime_handle": 6947234232139200
@@ -1358,7 +1358,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/character-profile/hoppycat-february-third",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "character-profile",
       "local_id": "hoppycat-february-third",
       "runtime_handle": 4099596499450194
@@ -1366,7 +1366,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.february-third",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "clock",
       "local_id": "hoppycat.february-third",
       "runtime_handle": 866791295174334
@@ -1374,7 +1374,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.impossible-thing",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "clock",
       "local_id": "hoppycat.impossible-thing",
       "runtime_handle": 8656072555730574
@@ -1382,7 +1382,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.living-footnote",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "clock",
       "local_id": "hoppycat.living-footnote",
       "runtime_handle": 1695257728265603
@@ -1390,7 +1390,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.perfect-copy",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "clock",
       "local_id": "hoppycat.perfect-copy",
       "runtime_handle": 8888187303607665
@@ -1398,7 +1398,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.perpetual-draft",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "clock",
       "local_id": "hoppycat.perpetual-draft",
       "runtime_handle": 7829749567222477
@@ -1406,7 +1406,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.rendering-adrift",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "clock",
       "local_id": "hoppycat.rendering-adrift",
       "runtime_handle": 3495568490381831
@@ -1414,7 +1414,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/faction/hoppycat_halfway_guild",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "faction",
       "local_id": "hoppycat_halfway_guild",
       "runtime_handle": 8765200303351410
@@ -1422,7 +1422,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/faction/hoppycat_lantern_theatre",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "faction",
       "local_id": "hoppycat_lantern_theatre",
       "runtime_handle": 245843518233087
@@ -1430,7 +1430,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/faction/hoppycat_open_record_assembly",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "faction",
       "local_id": "hoppycat_open_record_assembly",
       "runtime_handle": 6516002870863676
@@ -1438,7 +1438,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/front/hoppycat%3Athe-drifting-play",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "front",
       "local_id": "hoppycat:the-drifting-play",
       "runtime_handle": 3148436933585044
@@ -1446,7 +1446,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/front/hoppycat%3Athe-holding-pattern",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "front",
       "local_id": "hoppycat:the-holding-pattern",
       "runtime_handle": 2563869279526722
@@ -1454,7 +1454,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/front/hoppycat%3Athe-ninth-drawer",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "front",
       "local_id": "hoppycat:the-ninth-drawer",
       "runtime_handle": 6013057273453556
@@ -1462,7 +1462,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772000",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772000",
       "legacy_runtime_id": 772000,
@@ -1471,7 +1471,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772001",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772001",
       "legacy_runtime_id": 772001,
@@ -1480,7 +1480,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772002",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772002",
       "legacy_runtime_id": 772002,
@@ -1489,7 +1489,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772003",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772003",
       "legacy_runtime_id": 772003,
@@ -1498,7 +1498,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772004",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772004",
       "legacy_runtime_id": 772004,
@@ -1507,7 +1507,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772005",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772005",
       "legacy_runtime_id": 772005,
@@ -1516,7 +1516,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772006",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772006",
       "legacy_runtime_id": 772006,
@@ -1525,7 +1525,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772007",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772007",
       "legacy_runtime_id": 772007,
@@ -1534,7 +1534,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772008",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772008",
       "legacy_runtime_id": 772008,
@@ -1543,7 +1543,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/item/772009",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "item",
       "local_id": "772009",
       "legacy_runtime_id": 772009,
@@ -1552,7 +1552,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/job/hoppycat%3Amake-one-impossible-thing",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "job",
       "local_id": "hoppycat:make-one-impossible-thing",
       "runtime_handle": 6142929071647343
@@ -1560,7 +1560,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/job/hoppycat%3Arestore-the-living-footnote",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "job",
       "local_id": "hoppycat:restore-the-living-footnote",
       "runtime_handle": 4146285819368618
@@ -1568,7 +1568,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/job/hoppycat%3Aring-in-february-third",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "job",
       "local_id": "hoppycat:ring-in-february-third",
       "runtime_handle": 4034107060405225
@@ -1576,7 +1576,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770000",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770000",
       "legacy_runtime_id": 770000,
@@ -1585,7 +1585,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770001",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770001",
       "legacy_runtime_id": 770001,
@@ -1594,7 +1594,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770002",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770002",
       "legacy_runtime_id": 770002,
@@ -1603,7 +1603,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770003",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770003",
       "legacy_runtime_id": 770003,
@@ -1612,7 +1612,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770004",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770004",
       "legacy_runtime_id": 770004,
@@ -1621,7 +1621,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770005",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770005",
       "legacy_runtime_id": 770005,
@@ -1630,7 +1630,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770006",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770006",
       "legacy_runtime_id": 770006,
@@ -1639,7 +1639,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770007",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770007",
       "legacy_runtime_id": 770007,
@@ -1648,7 +1648,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770008",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770008",
       "legacy_runtime_id": 770008,
@@ -1657,7 +1657,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/location/770009",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "location",
       "local_id": "770009",
       "legacy_runtime_id": 770009,
@@ -1666,7 +1666,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770000",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770000",
       "runtime_handle": 7962370760623531
@@ -1674,7 +1674,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770001",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770001",
       "runtime_handle": 1887474897071479
@@ -1682,7 +1682,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770002",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770002",
       "runtime_handle": 2808615781583618
@@ -1690,7 +1690,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770003",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770003",
       "runtime_handle": 4179680991921153
@@ -1698,7 +1698,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770004",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770004",
       "runtime_handle": 1816566124417204
@@ -1706,7 +1706,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770005",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770005",
       "runtime_handle": 8049815281327942
@@ -1714,7 +1714,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770006",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770006",
       "runtime_handle": 2746659676767094
@@ -1722,7 +1722,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770007",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770007",
       "runtime_handle": 6528720267136628
@@ -1730,7 +1730,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770008",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770008",
       "runtime_handle": 1865211277563474
@@ -1738,7 +1738,7 @@
     {
       "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770009",
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "kind": "room-sheet",
       "local_id": "hoppycat:room:770009",
       "runtime_handle": 7611499658358011

--- a/v2/content/hoppycat/jobs.json
+++ b/v2/content/hoppycat/jobs.json
@@ -70,7 +70,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -106,7 +106,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -142,7 +142,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -178,7 +178,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -214,7 +214,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       }
     ],
     "pack_id": "hoppycat.archive"
@@ -281,7 +281,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -317,7 +317,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -353,7 +353,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       }
     ],
     "pack_id": "hoppycat.archive"
@@ -424,7 +424,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -462,7 +462,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       },
       {
         "version": 1,
@@ -498,7 +498,7 @@
         "rules_pack_id": "cosyworld.rules-profile-srd5",
         "rules_pack_version": "1.0.0",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.0"
+        "pack_version": "0.3.2"
       }
     ],
     "pack_id": "hoppycat.archive"

--- a/v2/content/hoppycat/licenses.json
+++ b/v2/content/hoppycat/licenses.json
@@ -48,7 +48,7 @@
   {
     "pack_id": "hoppycat.archive",
     "name": "Hoppycat: February Third",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "license_identifier": "MIT",
     "license_url": "https://opensource.org/license/mit/",
     "provenance": {

--- a/v2/content/hoppycat/registry.json
+++ b/v2/content/hoppycat/registry.json
@@ -13,7 +13,8 @@
       "schema_version": 1,
       "replay_compatible_bundle_hashes": [
         "sha256:4033bce20f86585f2fc5221ab7e3aeac637358b4b395ded6dc0b2e71fd1e6035",
-        "sha256:4972bbf08959881440c0ab6b718789f6d5822fc3b2898ce7c785ddeb1fe3d475"
+        "sha256:4972bbf08959881440c0ab6b718789f6d5822fc3b2898ce7c785ddeb1fe3d475",
+        "sha256:d1030b7fa7d0e6bb2e801928e54b461171d871e60e41756b517c1462f4c7382c"
       ]
     },
     "rules_profile": "cosyworld.srd5/1",
@@ -184,7 +185,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:d1030b7fa7d0e6bb2e801928e54b461171d871e60e41756b517c1462f4c7382c",
+    "bundle_hash": "sha256:18d7c38d6fd234817cae5fd9ad1bc473fd27eef7924986cffc7c3bd67bc36eab",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -348,7 +349,7 @@
         "id": "hoppycat.archive",
         "name": "Hoppycat: February Third",
         "description": "An original cosy-weird world of tea, tides, prisms, careful memory, impossible dreams, and a day trying to become tomorrow.",
-        "version": "0.3.1",
+        "version": "0.3.2",
         "kind": "world",
         "license": "MIT",
         "license_url": "https://opensource.org/license/mit/",
@@ -357,7 +358,7 @@
           {
             "id": "hoppycat.archive/world",
             "kind": "world",
-            "version": "0.3.1"
+            "version": "0.3.2"
           },
           {
             "id": "hoppycat.archive/assets",
@@ -538,7 +539,7 @@
           "type": "workspace",
           "path": "../../content/hoppycat-archive"
         },
-        "integrity": "sha256:9e01b6d1e9f2dd07333126d8db2c722e73a7dca14f7366d1c431f4bda7065218"
+        "integrity": "sha256:5293ca21cb130b4c19d52a3a468dcb68a23478c9bc5637de0c0fcbf7cc7573c9"
       }
     ],
     "files": {
@@ -2191,7 +2192,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           },
           {
             "version": 1,
@@ -2227,7 +2228,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           },
           {
             "version": 1,
@@ -2263,7 +2264,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           },
           {
             "version": 1,
@@ -2299,7 +2300,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           },
           {
             "version": 1,
@@ -2335,7 +2336,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           }
         ],
         "pack_id": "hoppycat.archive"
@@ -2402,7 +2403,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           },
           {
             "version": 1,
@@ -2438,7 +2439,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           },
           {
             "version": 1,
@@ -2474,7 +2475,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           }
         ],
         "pack_id": "hoppycat.archive"
@@ -2545,7 +2546,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           },
           {
             "version": 1,
@@ -2583,7 +2584,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           },
           {
             "version": 1,
@@ -2619,7 +2620,7 @@
             "rules_pack_id": "cosyworld.rules-profile-srd5",
             "rules_pack_version": "1.0.0",
             "pack_id": "hoppycat.archive",
-            "pack_version": "0.3.0"
+            "pack_version": "0.3.2"
           }
         ],
         "pack_id": "hoppycat.archive"
@@ -3161,8 +3162,8 @@
   "assets": [
     {
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
-      "pack_integrity": "sha256:9e01b6d1e9f2dd07333126d8db2c722e73a7dca14f7366d1c431f4bda7065218",
+      "pack_version": "0.3.2",
+      "pack_integrity": "sha256:5293ca21cb130b4c19d52a3a468dcb68a23478c9bc5637de0c0fcbf7cc7573c9",
       "provider": "hoppycat.archive/assets",
       "mount": "cards",
       "root": "hoppycat-archive",
@@ -4627,7 +4628,7 @@
     {
       "pack_id": "hoppycat.archive",
       "name": "Hoppycat: February Third",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit/",
       "provenance": {
@@ -5286,7 +5287,7 @@
   "character_creation": [
     {
       "pack_id": "hoppycat.archive",
-      "pack_version": "0.3.1",
+      "pack_version": "0.3.2",
       "profiles": [
         {
           "schema_version": 2,
@@ -6457,7 +6458,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771000",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771000",
         "legacy_runtime_id": 771000,
@@ -6466,7 +6467,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771001",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771001",
         "legacy_runtime_id": 771001,
@@ -6475,7 +6476,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771002",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771002",
         "legacy_runtime_id": 771002,
@@ -6484,7 +6485,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771003",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771003",
         "legacy_runtime_id": 771003,
@@ -6493,7 +6494,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771004",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771004",
         "legacy_runtime_id": 771004,
@@ -6502,7 +6503,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771005",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771005",
         "legacy_runtime_id": 771005,
@@ -6511,7 +6512,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771006",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771006",
         "legacy_runtime_id": 771006,
@@ -6520,7 +6521,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771007",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771007",
         "legacy_runtime_id": 771007,
@@ -6529,7 +6530,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/actor/771008",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "actor",
         "local_id": "771008",
         "legacy_runtime_id": 771008,
@@ -6538,7 +6539,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-concordance-compass",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-concordance-compass",
         "runtime_handle": 2695838178583255
@@ -6546,7 +6547,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-concordance-tidelands",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-concordance-tidelands",
         "runtime_handle": 8694585919826001
@@ -6554,7 +6555,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-context-greenhouse",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-context-greenhouse",
         "runtime_handle": 8214761955000570
@@ -6562,7 +6563,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-context-seed",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-context-seed",
         "runtime_handle": 2979768036449922
@@ -6570,7 +6571,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-fermata-clapper",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-fermata-clapper",
         "runtime_handle": 5433334197444757
@@ -6578,7 +6579,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-glim-twice",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-glim-twice",
         "runtime_handle": 8993719384874424
@@ -6586,7 +6587,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-goldfish-tank",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-goldfish-tank",
         "runtime_handle": 3375150165234834
@@ -6594,7 +6595,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-halfway-cup",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-halfway-cup",
         "runtime_handle": 3933949806499525
@@ -6602,7 +6603,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-halfway-tea-garden",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-halfway-tea-garden",
         "runtime_handle": 3279721367433985
@@ -6610,7 +6611,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-hoppy-cat",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-hoppy-cat",
         "runtime_handle": 1209808962780418
@@ -6618,7 +6619,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-loop-token",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-loop-token",
         "runtime_handle": 4594384809369304
@@ -6626,7 +6627,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-lumen-facet",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-lumen-facet",
         "runtime_handle": 163470443226722
@@ -6634,7 +6635,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-meraki-atelier",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-meraki-atelier",
         "runtime_handle": 2013815173421492
@@ -6642,7 +6643,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-meraki-brush",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-meraki-brush",
         "runtime_handle": 4528585693379106
@@ -6650,7 +6651,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-mira-meraki",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-mira-meraki",
         "runtime_handle": 1785036496012002
@@ -6658,7 +6659,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-nix-fermata",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-nix-fermata",
         "runtime_handle": 6348981773496291
@@ -6666,7 +6667,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-open-record-cathedral",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-open-record-cathedral",
         "runtime_handle": 7315742551547995
@@ -6674,7 +6675,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-patch-fern",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-patch-fern",
         "runtime_handle": 496523796551250
@@ -6682,7 +6683,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-penny-vellum",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-penny-vellum",
         "runtime_handle": 7625041499244878
@@ -6690,7 +6691,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-prism-foundry",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-prism-foundry",
         "runtime_handle": 3988985693429934
@@ -6698,7 +6699,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-provenance-card",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-provenance-card",
         "runtime_handle": 3727337615563386
@@ -6706,7 +6707,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-red-thread-belfry",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-red-thread-belfry",
         "runtime_handle": 4734156656297255
@@ -6714,7 +6715,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-red-thread-spool",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-red-thread-spool",
         "runtime_handle": 2936804407219753
@@ -6722,7 +6723,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-return-path-checklist",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-return-path-checklist",
         "runtime_handle": 5080329651835421
@@ -6730,7 +6731,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-rill-current",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-rill-current",
         "runtime_handle": 6796864570677903
@@ -6738,7 +6739,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-settled-light-theatre",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-settled-light-theatre",
         "runtime_handle": 6892873403937145
@@ -6746,7 +6747,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-signal-jetty",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-signal-jetty",
         "runtime_handle": 7256845172796470
@@ -6754,7 +6755,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-tapi-lilt",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-tapi-lilt",
         "runtime_handle": 3829393037121064
@@ -6762,7 +6763,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/card/hoppycat-unfinished-prism",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "card",
         "local_id": "hoppycat-unfinished-prism",
         "runtime_handle": 6947234232139200
@@ -6770,7 +6771,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/character-profile/hoppycat-february-third",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "character-profile",
         "local_id": "hoppycat-february-third",
         "runtime_handle": 4099596499450194
@@ -6778,7 +6779,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.february-third",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "clock",
         "local_id": "hoppycat.february-third",
         "runtime_handle": 866791295174334
@@ -6786,7 +6787,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.impossible-thing",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "clock",
         "local_id": "hoppycat.impossible-thing",
         "runtime_handle": 8656072555730574
@@ -6794,7 +6795,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.living-footnote",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "clock",
         "local_id": "hoppycat.living-footnote",
         "runtime_handle": 1695257728265603
@@ -6802,7 +6803,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.perfect-copy",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "clock",
         "local_id": "hoppycat.perfect-copy",
         "runtime_handle": 8888187303607665
@@ -6810,7 +6811,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.perpetual-draft",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "clock",
         "local_id": "hoppycat.perpetual-draft",
         "runtime_handle": 7829749567222477
@@ -6818,7 +6819,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/clock/hoppycat.rendering-adrift",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "clock",
         "local_id": "hoppycat.rendering-adrift",
         "runtime_handle": 3495568490381831
@@ -6826,7 +6827,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/faction/hoppycat_halfway_guild",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "faction",
         "local_id": "hoppycat_halfway_guild",
         "runtime_handle": 8765200303351410
@@ -6834,7 +6835,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/faction/hoppycat_lantern_theatre",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "faction",
         "local_id": "hoppycat_lantern_theatre",
         "runtime_handle": 245843518233087
@@ -6842,7 +6843,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/faction/hoppycat_open_record_assembly",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "faction",
         "local_id": "hoppycat_open_record_assembly",
         "runtime_handle": 6516002870863676
@@ -6850,7 +6851,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/front/hoppycat%3Athe-drifting-play",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "front",
         "local_id": "hoppycat:the-drifting-play",
         "runtime_handle": 3148436933585044
@@ -6858,7 +6859,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/front/hoppycat%3Athe-holding-pattern",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "front",
         "local_id": "hoppycat:the-holding-pattern",
         "runtime_handle": 2563869279526722
@@ -6866,7 +6867,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/front/hoppycat%3Athe-ninth-drawer",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "front",
         "local_id": "hoppycat:the-ninth-drawer",
         "runtime_handle": 6013057273453556
@@ -6874,7 +6875,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772000",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772000",
         "legacy_runtime_id": 772000,
@@ -6883,7 +6884,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772001",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772001",
         "legacy_runtime_id": 772001,
@@ -6892,7 +6893,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772002",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772002",
         "legacy_runtime_id": 772002,
@@ -6901,7 +6902,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772003",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772003",
         "legacy_runtime_id": 772003,
@@ -6910,7 +6911,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772004",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772004",
         "legacy_runtime_id": 772004,
@@ -6919,7 +6920,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772005",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772005",
         "legacy_runtime_id": 772005,
@@ -6928,7 +6929,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772006",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772006",
         "legacy_runtime_id": 772006,
@@ -6937,7 +6938,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772007",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772007",
         "legacy_runtime_id": 772007,
@@ -6946,7 +6947,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772008",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772008",
         "legacy_runtime_id": 772008,
@@ -6955,7 +6956,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/item/772009",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "item",
         "local_id": "772009",
         "legacy_runtime_id": 772009,
@@ -6964,7 +6965,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/job/hoppycat%3Amake-one-impossible-thing",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "job",
         "local_id": "hoppycat:make-one-impossible-thing",
         "runtime_handle": 6142929071647343
@@ -6972,7 +6973,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/job/hoppycat%3Arestore-the-living-footnote",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "job",
         "local_id": "hoppycat:restore-the-living-footnote",
         "runtime_handle": 4146285819368618
@@ -6980,7 +6981,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/job/hoppycat%3Aring-in-february-third",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "job",
         "local_id": "hoppycat:ring-in-february-third",
         "runtime_handle": 4034107060405225
@@ -6988,7 +6989,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770000",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770000",
         "legacy_runtime_id": 770000,
@@ -6997,7 +6998,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770001",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770001",
         "legacy_runtime_id": 770001,
@@ -7006,7 +7007,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770002",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770002",
         "legacy_runtime_id": 770002,
@@ -7015,7 +7016,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770003",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770003",
         "legacy_runtime_id": 770003,
@@ -7024,7 +7025,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770004",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770004",
         "legacy_runtime_id": 770004,
@@ -7033,7 +7034,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770005",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770005",
         "legacy_runtime_id": 770005,
@@ -7042,7 +7043,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770006",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770006",
         "legacy_runtime_id": 770006,
@@ -7051,7 +7052,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770007",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770007",
         "legacy_runtime_id": 770007,
@@ -7060,7 +7061,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770008",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770008",
         "legacy_runtime_id": 770008,
@@ -7069,7 +7070,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/location/770009",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "location",
         "local_id": "770009",
         "legacy_runtime_id": 770009,
@@ -7078,7 +7079,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770000",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770000",
         "runtime_handle": 7962370760623531
@@ -7086,7 +7087,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770001",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770001",
         "runtime_handle": 1887474897071479
@@ -7094,7 +7095,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770002",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770002",
         "runtime_handle": 2808615781583618
@@ -7102,7 +7103,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770003",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770003",
         "runtime_handle": 4179680991921153
@@ -7110,7 +7111,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770004",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770004",
         "runtime_handle": 1816566124417204
@@ -7118,7 +7119,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770005",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770005",
         "runtime_handle": 8049815281327942
@@ -7126,7 +7127,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770006",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770006",
         "runtime_handle": 2746659676767094
@@ -7134,7 +7135,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770007",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770007",
         "runtime_handle": 6528720267136628
@@ -7142,7 +7143,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770008",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770008",
         "runtime_handle": 1865211277563474
@@ -7150,7 +7151,7 @@
       {
         "canonical_ref": "pack://hoppycat.archive/room-sheet/hoppycat%3Aroom%3A770009",
         "pack_id": "hoppycat.archive",
-        "pack_version": "0.3.1",
+        "pack_version": "0.3.2",
         "kind": "room-sheet",
         "local_id": "hoppycat:room:770009",
         "runtime_handle": 7611499658358011

--- a/v2/content/hoppycat/worldpack.json
+++ b/v2/content/hoppycat/worldpack.json
@@ -11,7 +11,8 @@
     "schema_version": 1,
     "replay_compatible_bundle_hashes": [
       "sha256:4033bce20f86585f2fc5221ab7e3aeac637358b4b395ded6dc0b2e71fd1e6035",
-      "sha256:4972bbf08959881440c0ab6b718789f6d5822fc3b2898ce7c785ddeb1fe3d475"
+      "sha256:4972bbf08959881440c0ab6b718789f6d5822fc3b2898ce7c785ddeb1fe3d475",
+      "sha256:d1030b7fa7d0e6bb2e801928e54b461171d871e60e41756b517c1462f4c7382c"
     ]
   },
   "rules_profile": "cosyworld.srd5/1",
@@ -182,7 +183,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:d1030b7fa7d0e6bb2e801928e54b461171d871e60e41756b517c1462f4c7382c",
+  "bundle_hash": "sha256:18d7c38d6fd234817cae5fd9ad1bc473fd27eef7924986cffc7c3bd67bc36eab",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -346,7 +347,7 @@
       "id": "hoppycat.archive",
       "name": "Hoppycat: February Third",
       "description": "An original cosy-weird world of tea, tides, prisms, careful memory, impossible dreams, and a day trying to become tomorrow.",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "kind": "world",
       "license": "MIT",
       "license_url": "https://opensource.org/license/mit/",
@@ -355,7 +356,7 @@
         {
           "id": "hoppycat.archive/world",
           "kind": "world",
-          "version": "0.3.1"
+          "version": "0.3.2"
         },
         {
           "id": "hoppycat.archive/assets",
@@ -536,7 +537,7 @@
         "type": "workspace",
         "path": "../../content/hoppycat-archive"
       },
-      "integrity": "sha256:9e01b6d1e9f2dd07333126d8db2c722e73a7dca14f7366d1c431f4bda7065218"
+      "integrity": "sha256:5293ca21cb130b4c19d52a3a468dcb68a23478c9bc5637de0c0fcbf7cc7573c9"
     }
   ],
   "files": {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.15"
+version = "1.0.16"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/content_registry.rs
+++ b/v2/orchestrator-rust/src/content_registry.rs
@@ -1127,6 +1127,33 @@ mod tests {
     use super::*;
 
     #[test]
+    fn every_shipped_registry_passes_runtime_startup_validation() {
+        let content_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../content");
+        let mut registries = fs::read_dir(&content_root)
+            .expect("shipped content directory")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path().join("registry.json"))
+            .filter(|path| path.is_file())
+            .collect::<Vec<_>>();
+        registries.sort();
+        assert!(
+            !registries.is_empty(),
+            "no shipped content registries found"
+        );
+
+        for path in registries {
+            let value = fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("could not read {}: {error}", path.display()));
+            ContentRegistry::from_json(&value, content_engine_version()).unwrap_or_else(|error| {
+                panic!(
+                    "shipped registry {} failed runtime validation: {error}",
+                    path.display()
+                )
+            });
+        }
+    }
+
+    #[test]
     fn holy_land_disciples_have_distinct_planner_only_search_motivations() {
         let disciples = active_content()
             .actors

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -2360,6 +2360,14 @@ for (const job of jobs) {
       fail(`job ${job.id} strategy ${strategy.id} has unroutable action_kind ${strategy.action_kind}`);
       continue;
     }
+    const ownerPack = packs.find((candidate) => candidate.id === strategy.pack_id);
+    const rulesPack = packs.find((candidate) => candidate.id === strategy.rules_pack_id);
+    if (strategy.pack_id !== job.pack_id
+        || ownerPack?.version !== strategy.pack_version
+        || strategy.rules_profile !== manifest.rules_profile
+        || rulesPack?.version !== strategy.rules_pack_version) {
+      fail(`job ${job.id} strategy ${strategy.id} has stale pack or rules provenance`);
+    }
     const resolutionKind = strategy.resolution?.kind;
     if (["work", "help"].includes(strategy.action_kind) && resolutionKind !== "certain") {
       fail(`job ${job.id} strategy ${strategy.id} must use certain resolution`);

--- a/v2/scripts/hoppycat-worldpack.test.mjs
+++ b/v2/scripts/hoppycat-worldpack.test.mjs
@@ -13,6 +13,7 @@ const compiledRoot = path.resolve(scriptDir, "../content/hoppycat");
 const deployedBundleHashes = [
   "sha256:4033bce20f86585f2fc5221ab7e3aeac637358b4b395ded6dc0b2e71fd1e6035",
   "sha256:4972bbf08959881440c0ab6b718789f6d5822fc3b2898ce7c785ddeb1fe3d475",
+  "sha256:d1030b7fa7d0e6bb2e801928e54b461171d871e60e41756b517c1462f4c7382c",
 ];
 
 function readJson(fileName) {
@@ -23,7 +24,7 @@ function readJsonFrom(root, fileName) {
   return JSON.parse(fs.readFileSync(path.join(root, fileName), "utf8"));
 }
 
-test("Hoppycat accepts replay from deployed bundles before locked item art", () => {
+test("Hoppycat accepts replay from every deployed predecessor", () => {
   // #764 added avatar identity and naming metadata, and #767 locks local art
   // for all item cards. Neither changes resource identities, topology, rules,
   // or the meaning of persisted gameplay state.

--- a/v2/worlds/hoppycat/pack.lock.json
+++ b/v2/worlds/hoppycat/pack.lock.json
@@ -78,12 +78,12 @@
     },
     {
       "id": "hoppycat.archive",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "source": {
         "type": "workspace",
         "path": "../../content/hoppycat-archive"
       },
-      "integrity": "sha256:9e01b6d1e9f2dd07333126d8db2c722e73a7dca14f7366d1c431f4bda7065218",
+      "integrity": "sha256:5293ca21cb130b4c19d52a3a468dcb68a23478c9bc5637de0c0fcbf7cc7573c9",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",
@@ -101,7 +101,7 @@
         {
           "id": "hoppycat.archive/world",
           "kind": "world",
-          "version": "0.3.1"
+          "version": "0.3.2"
         },
         {
           "id": "hoppycat.archive/assets",
@@ -169,7 +169,7 @@
     {
       "pack_id": "hoppycat.archive",
       "name": "Hoppycat: February Third",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license_identifier": "MIT",
       "license_url": "https://opensource.org/license/mit/",
       "provenance": {

--- a/v2/worlds/hoppycat/world.json
+++ b/v2/worlds/hoppycat/world.json
@@ -11,7 +11,8 @@
     "schema_version": 1,
     "replay_compatible_bundle_hashes": [
       "sha256:4033bce20f86585f2fc5221ab7e3aeac637358b4b395ded6dc0b2e71fd1e6035",
-      "sha256:4972bbf08959881440c0ab6b718789f6d5822fc3b2898ce7c785ddeb1fe3d475"
+      "sha256:4972bbf08959881440c0ab6b718789f6d5822fc3b2898ce7c785ddeb1fe3d475",
+      "sha256:d1030b7fa7d0e6bb2e801928e54b461171d871e60e41756b517c1462f4c7382c"
     ]
   },
   "packs": [


### PR DESCRIPTION
## What changed

- align every Hoppycat job contribution strategy with the current `hoppycat.archive` pack version
- declare the deployed `d103…` Hoppycat bundle replay-compatible with the corrected provenance-only bundle
- make the offline worldpack checker reject stale strategy owner/rules provenance
- make Rust tests load every shipped compiled registry through the real production startup validator
- bump the release to 1.0.16

## Production incident

The 1.0.14 Lonely Forest deployment passed compatibility, volume, contract, and rollback-backup gates, then crash-looped because Hoppycat’s pack was `0.3.1` while its job strategies still claimed `0.3.0`. The runtime correctly rejected the registry, but the offline checker did not enforce the same provenance contract.

Lonely Forest was restored to exact known-good Fly release 260 before this PR was published; its full multitenant smoke test is green.

## Validation

- complete `npm run check`
- 178 Vitest tests
- all worldpack, proof-world, and kernel checks
- 1,156 Rust orchestrator tests plus integration/doc tests
- every shipped registry loaded through `ContentRegistry::from_json`
- architecture/lint ceilings and syntax checks
- full production multitenant smoke after rollback