### PR TITLE
Redesign travel confirmation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.20 — 2026-08-12
+## 1.0.21 — 2026-08-12
 
 - Redesign Travel confirmation around the destination and route context, with
   compact neutral and primary actions instead of repetitive copy and controls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.20 — 2026-08-12
+
+- Redesign Travel confirmation around the destination and route context, with
+  compact neutral and primary actions instead of repetitive copy and controls.
+
 ## 1.0.19 — 2026-08-12
 
 - Keep one illustrated journey tracker and fold its way, party, and next-step

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.20"
+version = "1.0.21"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.19"
+version = "1.0.20"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2820,19 +2820,22 @@
     }
     .action-dialog {
       display: grid;
-      gap: 10px;
+      gap: 0;
+      width: min(440px, calc(100vw - 28px));
+      padding: 0;
+      overflow: hidden auto;
     }
     .action-art {
       clear: both;
-      border: 1px solid var(--line-strong);
+      border: 0;
+      border-bottom: 1px solid var(--line);
       background: rgba(101, 230, 138, 0.06);
-      border-radius: 4px;
       overflow: hidden;
     }
     .action-art img {
       display: block;
       width: 100%;
-      aspect-ratio: 16 / 10;
+      aspect-ratio: 16 / 9;
       object-fit: cover;
       background: rgba(16, 25, 18, 0.72);
     }
@@ -2845,21 +2848,44 @@
         radial-gradient(circle at 50% 42%, rgba(239, 201, 107, 0.12), transparent 56%),
         rgba(16, 25, 18, 0.72);
     }
+    .action-copy {
+      display: grid;
+      gap: 5px;
+      padding: 16px 18px 0;
+    }
+    .action-eyebrow {
+      color: var(--dim);
+      font-size: 11px;
+      font-weight: 900;
+      letter-spacing: 0.12em;
+      line-height: 1.2;
+      text-transform: uppercase;
+    }
+    .action-eyebrow[hidden],
+    .action-summary:empty {
+      display: none;
+    }
     .action-title {
       margin: 0;
       color: var(--amber);
-      font-size: 18px;
+      font-size: 22px;
       font-weight: 900;
-      line-height: 1.15;
+      line-height: 1.12;
+      text-wrap: balance;
     }
     .action-summary {
-      color: var(--text);
-      line-height: 1.35;
+      color: var(--dim);
+      font-size: 14px;
+      line-height: 1.4;
       overflow-wrap: anywhere;
     }
     .action-meta {
       display: grid;
       gap: 6px;
+      margin: 14px 18px 0;
+    }
+    .action-meta:empty {
+      display: none;
     }
     .action-row {
       display: grid;
@@ -2884,6 +2910,7 @@
     .action-choice-list {
       display: grid;
       gap: 7px;
+      margin: 14px 18px 0;
     }
     .action-choice-list[hidden] {
       display: none;
@@ -2925,33 +2952,45 @@
     }
     .action-confirm {
       min-height: 42px;
+      padding: 0 16px;
       border: 1px solid rgba(101, 230, 138, 0.5);
       border-radius: 4px;
-      background: rgba(101, 230, 138, 0.14);
-      color: var(--green);
+      background: rgba(101, 230, 138, 0.18);
+      color: var(--amber);
       font: inherit;
       font-weight: 900;
+    }
+    .action-confirm:hover {
+      background: rgba(101, 230, 138, 0.25);
     }
     .action-confirm:focus-visible {
       outline: 2px solid rgba(101, 230, 138, 0.86);
       outline-offset: 2px;
     }
     .action-cancel {
-      width: 100%;
       min-height: 40px;
-      border: 1px solid rgba(var(--type-danger-rgb), 0.58);
+      padding: 0 16px;
+      border: 1px solid var(--line);
       border-radius: 4px;
-      background: rgba(var(--type-danger-rgb), 0.16);
-      color: var(--red);
+      background: transparent;
+      color: var(--dim);
       font: inherit;
-      font-weight: 900;
+      font-weight: 800;
     }
     .action-cancel:hover {
-      background: rgba(var(--type-danger-rgb), 0.24);
+      border-color: var(--line-strong);
+      background: rgba(216, 247, 220, 0.06);
+      color: var(--text);
     }
     .action-cancel:focus-visible {
-      outline: 2px solid rgba(var(--type-danger-rgb), 0.86);
+      outline: 2px solid var(--amber);
       outline-offset: 2px;
+    }
+    .action-actions {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      gap: 8px;
+      padding: 18px;
     }
     .wallet-title {
       clear: both;
@@ -5074,12 +5113,17 @@
   <div class="action-modal" id="action-modal" hidden>
     <section class="action-dialog" role="dialog" aria-modal="true" aria-labelledby="action-modal-title" tabindex="-1" data-player-concept="action">
       <div class="action-art"><img id="action-modal-image" alt="" /></div>
-      <h2 class="action-title" id="action-modal-title"></h2>
-      <div class="action-summary" id="action-modal-summary"></div>
+      <div class="action-copy">
+        <div class="action-eyebrow" id="action-modal-eyebrow" hidden></div>
+        <h2 class="action-title" id="action-modal-title"></h2>
+        <div class="action-summary" id="action-modal-summary"></div>
+      </div>
       <div class="action-meta" id="action-modal-meta"></div>
       <div class="action-choice-list" id="action-modal-choices" hidden></div>
-      <button class="action-confirm" id="action-modal-confirm" type="button" data-analytics-event="action.confirm">confirm</button>
-      <button class="action-cancel" id="action-modal-cancel" type="button" data-action-close>cancel</button>
+      <div class="action-actions">
+        <button class="action-cancel" id="action-modal-cancel" type="button" data-action-close>not now</button>
+        <button class="action-confirm" id="action-modal-confirm" type="button" data-analytics-event="action.confirm">confirm</button>
+      </div>
     </section>
   </div>
   <div class="wallet-modal" id="wallet-modal" hidden>
@@ -7504,6 +7548,7 @@
             ? (routeVerbLower.endsWith(" toward") ? "" : "toward ")
             : (fleeing ? "" : (routeVerbLower.endsWith(" to") ? "" : "to "));
           const routeLabel = String(firstExit.route_label || "").trim();
+          const routeWayName = routeLabel.replace(/\s+from\s+.+\s+to\s+.+$/i, "").trim();
           const conciseRouteLabel = routeLabel.replace(
             /^(.*?)\s+from\s+.+\s+to\s+(.+)$/i,
             "$1 to $2",
@@ -7551,22 +7596,25 @@
               : (cardForLocation(view.location?.id) || cardForLocation(firstExit.destination_location_id)),
             shape: "location",
             priority: Number(routeOffer?.rank || (searchingPathway ? 55 : (fleeing ? 50 : 80))),
+            modalEyebrow: onePath
+              ? (firstPathwayDirection ? "On the road" : (fleeing ? "Way out" : (searchingPathway ? "Pathway scout" : "Destination")))
+              : (fleeing ? "Way out" : (searchingPathway ? "Pathway scout" : "Travel")),
             modalTitle: onePath
-              ? undefined
-              : (fleeing ? "choose where to flee" : (searchingPathway ? "choose where to scout" : "choose where to travel")),
+              ? (firstPathwayDirection?.endpointName || firstExit.destination_location_name)
+              : (fleeing ? "Choose a way out" : "Choose a destination"),
             modalSummary: onePath
               ? (firstPathwayDirection
-                ? `Move one stretch toward ${firstPathwayDirection.endpointName}.`
+                ? `Take the next stretch${routeWayName ? ` via ${routeWayName}` : ""}.`
                 : fleeing
-                ? `Leave the danger behind and hurry toward ${firstExit.destination_location_name}.`
+                ? `Leave the danger behind${routeWayName ? ` via ${routeWayName}` : ""}.`
                 : (searchingPathway
-                  ? `Reveal the first adjacent stretch toward ${firstExit.destination_location_name} without moving.`
-                  : `Travel to ${firstExit.destination_location_name}.`))
+                  ? "Reveal the first adjacent stretch without moving."
+                  : `${view.location?.name ? `From ${view.location.name}` : "From here"}${routeWayName ? ` via ${routeWayName}` : ""}.`))
               : (fleeing
-                ? "Choose a way out."
+                ? "Leave the danger behind."
                 : (searchingPathway
-                  ? "Choose a destination and reveal its next adjacent route segment without moving."
-                  : "Choose where to travel.")),
+                  ? "Reveal its next adjacent route segment without moving."
+                  : `${view.location?.name ? `From ${view.location.name}.` : "Choose where the road leads next."}`)),
             effect: onePath
               ? (firstPathwayDirection
                 ? (Number(firstExit.destination_location_id) === Number(firstPathwayDirection.endpointId)
@@ -15290,7 +15338,10 @@
       if (String(action?.intention || "") === "contribute") {
         return String(action?.project?.verb || "contribute").toLowerCase();
       }
-      if (["notice", "inspect", "scout", "travel"].includes(String(action?.intention || ""))) {
+      if (String(action?.intention || "") === "travel") {
+        return action?.choices?.length ? "travel" : "travel there";
+      }
+      if (["notice", "inspect", "scout"].includes(String(action?.intention || ""))) {
         return label || String(action.intention);
       }
       if (label === "begin again") return "begin again";
@@ -15315,6 +15366,12 @@
       return fallback === "act" ? "take this turn" : fallback;
     }
 
+    function actionCancelLabel(action) {
+      if (action?.creationStage === "origin") return "back";
+      if (["travel", "flee"].includes(String(action?.intention || "").toLowerCase())) return "stay here";
+      return "not now";
+    }
+
     function openActionModal(action) {
       if (!action || actionBusy) return;
       if (action.kind === "orb-chat" && pendingChats.length) {
@@ -15328,13 +15385,16 @@
         ? (action.choices.find((choice) => String(choice.value || "") === String(action.selectedChoice || "")) || action.choices[0])
         : null;
       syncActionChoicePreview(action, selectedChoice);
+      const eyebrow = String(action.modalEyebrow || "").trim();
+      $("action-modal-eyebrow").textContent = eyebrow;
+      $("action-modal-eyebrow").hidden = !eyebrow;
       $("action-modal-title").textContent = label;
       $("action-modal-summary").textContent = journalSentence(actionSummary(action));
       renderActionModalRows(action);
       renderActionChoices(action);
       renderRoomAvatarRail();
       $("action-modal-confirm").textContent = actionConfirmLabel(action);
-      $("action-modal-cancel").textContent = action?.creationStage === "origin" ? "back" : "cancel";
+      $("action-modal-cancel").textContent = actionCancelLabel(action);
       openModal("action-modal", $("action-modal-confirm"));
     }
 
@@ -15405,7 +15465,9 @@
       $("action-modal-meta").innerHTML = "";
       $("action-modal-choices").hidden = true;
       $("action-modal-choices").innerHTML = "";
-      $("action-modal-cancel").textContent = "cancel";
+      $("action-modal-eyebrow").hidden = true;
+      $("action-modal-eyebrow").textContent = "";
+      $("action-modal-cancel").textContent = "not now";
       actionConfirmAction = null;
       renderRoomAvatarRail();
     }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -44047,7 +44047,7 @@ mod tests {
         assert!(INDEX_HTML.contains("!candidate.nextStretchRevealed"));
         assert!(!INDEX_HTML.contains("function mergeDuplicateSearchCards"));
         assert!(!INDEX_HTML.contains("Follow the revealed path into ${nextName}."));
-        assert!(INDEX_HTML.contains("Reveal the first adjacent stretch toward"));
+        assert!(INDEX_HTML.contains("Reveal the first adjacent stretch without moving."));
         assert!(!INDEX_HTML.contains("journey-step:"));
         assert!(!INDEX_HTML.contains("travel turn"));
         assert!(INDEX_HTML.contains("const thumb = action.pathwayDirection"));
@@ -44143,7 +44143,7 @@ mod tests {
         assert!(INDEX_HTML.contains("into your keeping"));
         assert!(INDEX_HTML.contains("function smallNumberWord"));
         assert!(INDEX_HTML.contains("choose who receives it"));
-        assert!(INDEX_HTML.contains("Travel to ${firstExit.destination_location_name}."));
+        assert!(INDEX_HTML.contains("From ${view.location.name}"));
         assert!(INDEX_HTML.contains("catch your breath"));
         assert!(!INDEX_HTML.contains("reply hook"));
         assert!(!INDEX_HTML.contains("authors a line"));

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -1737,8 +1737,8 @@ async function main() {
     assert(locationSearch?.summary === "Inspect The Cosy Cottage for one hidden thing.", `room Inspect should promise one meaningful discovery in story language: ${JSON.stringify(result)}`);
     assert(locationSearch?.rows?.some((row) => row[1] === "one hidden thing in The Cosy Cottage comes to light"), `room Search outcome should promise concrete progress: ${JSON.stringify(result)}`);
     assert(!/searches .*; can reveal|\b(?:progress|clock|tag)\b/i.test(JSON.stringify(locationSearch)), `room Search confirmation should hide resolver jargon: ${JSON.stringify(result)}`);
-    assert(travel?.title === "travel to rain-soft garden", `Travel confirmation should name the destination plainly: ${JSON.stringify(result)}`);
-    assert(travel?.summary === "Travel to Rain-Soft Garden.", `Travel confirmation should describe the story beat: ${JSON.stringify(result)}`);
+    assert(travel?.title === "Rain-Soft Garden", `Travel confirmation should use the destination as its heading: ${JSON.stringify(result)}`);
+    assert(travel?.summary === "From The Cosy Cottage.", `Travel confirmation should add origin context without repeating the destination: ${JSON.stringify(result)}`);
     assert(travel?.rows?.some((row) => row[1] === "you arrive in Rain-Soft Garden"), `Travel confirmation should explain where the player ends up: ${JSON.stringify(result)}`);
   }
 
@@ -3545,15 +3545,16 @@ async function main() {
         const confirmButton = document.querySelector("#action-modal-confirm");
         const cancelButton = document.querySelector("#action-modal [data-action-close]");
         const modal = {
+          eyebrow: document.querySelector("#action-modal-eyebrow")?.textContent?.trim() || "",
           title: document.querySelector("#action-modal-title")?.textContent?.trim() || "",
           summary: document.querySelector("#action-modal-summary")?.textContent?.trim() || "",
           confirm: document.querySelector("#action-modal-confirm")?.textContent?.trim() || "",
           cancel: cancelButton?.textContent?.trim() || "",
           cancelClass: cancelButton?.classList.contains("action-cancel") || false,
-          cancelAfterConfirm: Boolean(
+          cancelBeforeConfirm: Boolean(
             confirmButton
               && cancelButton
-              && (confirmButton.compareDocumentPosition(cancelButton) & Node.DOCUMENT_POSITION_FOLLOWING),
+              && (cancelButton.compareDocumentPosition(confirmButton) & Node.DOCUMENT_POSITION_FOLLOWING),
           ),
           confirmStyle: confirmButton ? {
             color: getComputedStyle(confirmButton).color,
@@ -3672,17 +3673,18 @@ async function main() {
         && result.selectedPreview.objectFit === "cover",
       `selecting a Travel destination should preview that Location card: ${JSON.stringify(result)}`,
     );
-    assert(result.modal.title === "choose where to travel", `grouped Travel should introduce its destination choice clearly: ${JSON.stringify(result)}`);
-    assert(result.modal.summary === "Choose where to travel.", `grouped Travel should explain the gesture plainly: ${JSON.stringify(result)}`);
+    assert(result.modal.eyebrow === "Travel", `grouped Travel should identify the action without repeating it in the heading: ${JSON.stringify(result)}`);
+    assert(result.modal.title === "Choose a destination", `grouped Travel should introduce its destination choice clearly: ${JSON.stringify(result)}`);
+    assert(result.modal.summary === "From Bethlehem.", `grouped Travel should add useful origin context: ${JSON.stringify(result)}`);
     assert(result.modal.confirm === "travel", `grouped Travel should keep the core Travel confirmation: ${JSON.stringify(result)}`);
     assert(
-      result.modal.cancel === "cancel"
+      result.modal.cancel === "stay here"
         && result.modal.cancelClass
-        && result.modal.cancelAfterConfirm
-        && result.modal.cancelStyle?.width === result.modal.confirmStyle?.width
+        && result.modal.cancelBeforeConfirm
+        && result.modal.cancelStyle?.width !== result.modal.confirmStyle?.width
         && result.modal.cancelStyle?.color !== result.modal.confirmStyle?.color
         && result.modal.cancelStyle?.background !== result.modal.confirmStyle?.background,
-      `action modals should place a full-width red Cancel button below the confirmation: ${JSON.stringify(result)}`,
+      `Travel modals should place a quiet Stay here choice beside the primary action: ${JSON.stringify(result)}`,
     );
     assert(result.modal.rows.length === 0, `Travel confirmation should stay to one sentence plus the destination choices: ${JSON.stringify(result)}`);
     assert(
@@ -12558,7 +12560,7 @@ async function main() {
         .length,
     }));
     assert(modal.backgroundInert && modal.activeInside && modal.heading === "H2" && modal.exposedBackgroundControls === 0, `${label}: action dialog should isolate focus and expose a heading: ${JSON.stringify(modal)}`);
-    await page.locator("#action-modal [data-action-close]").focus();
+    await page.locator("#action-modal-confirm").focus();
     await page.keyboard.press("Tab");
     assert(await page.evaluate(() => {
       const modal = document.querySelector("#action-modal");
@@ -12567,7 +12569,7 @@ async function main() {
       return document.activeElement === first;
     }), `${label}: Tab should wrap from the last dialog control to the first`);
     await page.keyboard.press("Shift+Tab");
-    assert(await page.evaluate(() => document.activeElement?.matches?.("#action-modal [data-action-close]")), `${label}: Shift+Tab should wrap from the first dialog control to the last`);
+    assert(await page.evaluate(() => document.activeElement?.matches?.("#action-modal-confirm")), `${label}: Shift+Tab should wrap from the first dialog control to the last`);
     await page.keyboard.press("Escape");
     await page.waitForFunction(() => document.querySelector("#action-modal")?.hidden === true && !document.querySelector(".shell")?.hasAttribute("inert"));
     await page.waitForFunction(() => document.activeElement?.id === "primary");


### PR DESCRIPTION
## Summary

- redesign the shared action modal with a tighter destination-first hierarchy, shorter artwork, and compact side-by-side actions
- replace repetitive Travel headings and summaries with the destination, origin, and concise route context
- make cancellation a neutral “Stay here” choice while keeping the primary action prominent
- update browser and embedded-shell contracts, and bump the release version to 1.0.21

## Why

The Travel modal promoted a long accessibility label into the visible heading, then repeated the same destination in the summary and confirmation button. The full-width red Cancel control also made a harmless dismissal look destructive.

Players now see the place they are choosing, the useful route context, and one clear decision without duplicated prose.

## Validation

- `npm run check` via the pre-push hook
  - 178 Vitest tests
  - official and composed worldpack validation
  - kernel checks
  - 1,180 Rust tests
  - architecture, lint-ceiling, and syntax checks
- deterministic browser smoke passed, including modal keyboard focus and mobile containment
- the optional living-world stress retry still encounters the pre-existing Hearthstone Tag inventory race