### PR TITLE
Reduce client state exposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.21 — 2026-08-12
+
+- Restrict the browser state projection to an explicit public allowlist, load
+  room history separately, and validate action details on the server.
+
 ## 1.0.20 — 2026-08-12
 
 - Clarify that semantic instruments rank only facts a holder can already reach,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.20"
+version = "1.0.21"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_practice.rs
+++ b/v2/orchestrator-rust/src/actor_practice.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) const DEED_SCHEMA_VERSION: u32 = 1;
@@ -117,19 +117,34 @@ impl Default for ActorPracticeState {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(crate) struct ActorPracticeView {
     pub schema_version: u32,
     pub actor_id: u64,
     pub epithet: String,
     pub known_for: String,
     pub primary: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub secondary: Option<String>,
     pub evidence: Vec<PracticeEvidenceView>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+impl Serialize for ActorPracticeView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ActorPracticeView", 4)?;
+        out.serialize_field("epithet", &self.epithet)?;
+        out.serialize_field("known_for", &self.known_for)?;
+        out.serialize_field("primary", &self.primary)?;
+        out.serialize_field("evidence", &self.evidence)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(crate) struct PracticeEvidenceView {
     pub category: String,
     pub description: String,
@@ -137,6 +152,19 @@ pub(crate) struct PracticeEvidenceView {
     pub target_kind: String,
     pub target_id: String,
     pub location_id: Option<u64>,
+}
+
+impl Serialize for PracticeEvidenceView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("PracticeEvidenceView", 3)?;
+        out.serialize_field("category", &self.category)?;
+        out.serialize_field("target_kind", &self.target_kind)?;
+        out.serialize_field("target_id", &self.target_id)?;
+        out.end()
+    }
 }
 
 pub(crate) fn project_practice(

--- a/v2/orchestrator-rust/src/cards.rs
+++ b/v2/orchestrator-rust/src/cards.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde::ser::SerializeStruct;
 
 #[derive(Debug, Serialize)]
 pub(super) struct AccountView {
@@ -30,7 +31,8 @@ pub(super) struct CardTransactionView {
     pub(super) source_event_seq: Option<u64>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct CardView {
     pub(super) pack_id: Option<String>,
     pub(super) card_id: String,
@@ -51,13 +53,40 @@ pub(super) struct CardView {
     pub(super) terrain: Vec<String>,
     pub(super) image_url: Option<String>,
     pub(super) chain_image_uri: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) generation_policy: Option<GeneratedPolicyBinding>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) community_art: Option<CommunityArtView>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+impl Serialize for CardView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("CardView", 12)?;
+        out.serialize_field("card_id", &self.card_id)?;
+        out.serialize_field("display_name", &self.display_name)?;
+        out.serialize_field("role", &self.role)?;
+        out.serialize_field("rarity", &self.rarity)?;
+        out.serialize_field("title", &self.title)?;
+        out.serialize_field("blurb", &self.blurb)?;
+        out.serialize_field("level", &self.level)?;
+        out.serialize_field("aspect", &self.aspect)?;
+        if let Some(value) = &self.biome {
+            out.serialize_field("biome", value)?;
+        }
+        out.serialize_field("terrain", &self.terrain)?;
+        if let Some(value) = &self.image_url {
+            out.serialize_field("image_url", value)?;
+        }
+        if let Some(value) = &self.community_art {
+            out.serialize_field("community_art", value)?;
+        }
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct CommunityArtView {
     pub(super) level: u8,
     pub(super) required_orbs: i32,
@@ -69,6 +98,25 @@ pub(super) struct CommunityArtView {
     pub(super) provider_attempts: u8,
     pub(super) max_provider_attempts: u8,
     pub(super) retryable_without_orbs: bool,
+}
+
+impl Serialize for CommunityArtView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("CommunityArtView", 9)?;
+        out.serialize_field("level", &self.level)?;
+        out.serialize_field("required_orbs", &self.required_orbs)?;
+        out.serialize_field("funded_orbs", &self.funded_orbs)?;
+        out.serialize_field("remaining_orbs", &self.remaining_orbs)?;
+        out.serialize_field("viewer_contributed", &self.viewer_contributed)?;
+        out.serialize_field("status", &self.status)?;
+        out.serialize_field("provider_attempts", &self.provider_attempts)?;
+        out.serialize_field("max_provider_attempts", &self.max_provider_attempts)?;
+        out.serialize_field("retryable_without_orbs", &self.retryable_without_orbs)?;
+        out.end()
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -143,11 +143,16 @@ fn submitted_stable_offer_payload_matches(
 }
 
 fn submitted_offer_legacy_id(submission: &ActionOfferSubmissionRequest) -> Option<&str> {
-    let prefix = format!(
-        "{}:{}:",
-        submission.rules_profile, submission.state_revision
-    );
-    submission.offer_id.strip_prefix(&prefix)
+    let mut parts = submission.offer_id.splitn(3, ':');
+    parts.next()?;
+    parts.next()?.parse::<u64>().ok()?;
+    parts.next()
+}
+
+fn submitted_offer_state_revision(submission: &ActionOfferSubmissionRequest) -> Option<u64> {
+    let mut parts = submission.offer_id.splitn(3, ':');
+    parts.next()?;
+    parts.next()?.parse().ok()
 }
 
 fn action_offer_kind_requires_actor_target(kind: &str) -> bool {
@@ -168,15 +173,18 @@ fn offer_composition_matches_at_submitted_revision(
     offer: &RankedActionOffer,
     submission: &ActionOfferSubmissionRequest,
 ) -> bool {
-    if offer.state_revision <= submission.state_revision {
+    let Some(submitted_revision) = submitted_offer_state_revision(submission) else {
+        return false;
+    };
+    if offer.state_revision <= submitted_revision {
         return false;
     }
     // Unrelated world events advance every offer envelope. Rebind only that
     // volatile revision so the certificate still detects real scene changes.
     let mut trace = offer.composition_trace.clone();
-    trace.state_revision = submission.state_revision;
+    trace.state_revision = submitted_revision;
     if let Some(rules_context) = trace.rules_context.as_mut() {
-        rules_context.state_revision = submission.state_revision;
+        rules_context.state_revision = submitted_revision;
     }
     trace.certificate() == submission.composition_id
 }
@@ -268,16 +276,26 @@ impl RuntimeWorld {
             && (exact_offer.is_none() || offer.composition_id != submission.composition_id)
         {
             Err("the scene composition changed; refresh and choose a current action")
-        } else if offer.kind != submission.kind
-            || offer.rules_action != submission.rules_action
-            || offer.operation != submission.operation
-            || offer.rules_profile != submission.rules_profile
-            || (offer.state_revision != submission.state_revision && !revision_rebound)
-            || offer.route != submission.route
-            || offer.target != submission.target
-            || offer.cost != submission.cost
-            || offer.disabled
+        } else if offer.kind != submission.kind || offer.disabled {
+            Err("offer identity, rules binding, target, cost, or availability was changed")
+        } else if (!submission.rules_profile.is_empty()
+            || submission.state_revision != 0
+            || submission.rules_action.is_some()
+            || submission.operation.is_some()
+            || submission.route.is_some()
+            || submission.target.is_some()
+            || submission.cost.is_some())
+            && (offer.rules_action != submission.rules_action
+                || offer.operation != submission.operation
+                || offer.rules_profile != submission.rules_profile
+                || (offer.state_revision != submission.state_revision && !revision_rebound)
+                || offer.route != submission.route
+                || offer.target != submission.target
+                || offer.cost != submission.cost)
         {
+            // Older clients echoed this expanded identity. Accept it only when
+            // every field still matches, while current clients submit the
+            // opaque offer/composition certificates and action payload alone.
             Err("offer identity, rules binding, target, cost, or availability was changed")
         } else if offer.target.as_ref().is_some_and(|target| {
             target.id.is_some_and(|expected| {

--- a/v2/orchestrator-rust/src/discovery_pipeline.rs
+++ b/v2/orchestrator-rust/src/discovery_pipeline.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde::ser::SerializeStruct;
 
 pub(super) const DISCOVERY_PIPELINE_SCHEMA_VERSION: u8 = 1;
 pub(super) const DISCOVERY_PROCEDURE_VERSION: &str = "discovery-procedure-v2";
@@ -85,7 +86,7 @@ pub(super) struct DiscoveryOfferView {
     pub(super) resolution: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct DiscoverySceneNoticeView {
     schema_version: u8,
     slot_id: String,
@@ -96,6 +97,29 @@ pub(super) struct DiscoverySceneNoticeView {
     phase: String,
     tells: Vec<DiscoveryTell>,
     resolution: String,
+}
+
+impl Serialize for DiscoverySceneNoticeView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct PublicTell<'a> {
+            text: &'a str,
+        }
+
+        let tells = self
+            .tells
+            .iter()
+            .map(|tell| PublicTell {
+                text: tell.text.as_str(),
+            })
+            .collect::<Vec<_>>();
+        let mut out = serializer.serialize_struct("DiscoverySceneNoticeView", 1)?;
+        out.serialize_field("tells", &tells)?;
+        out.end()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5211,6 +5211,7 @@
     let handPassSubmission = null;
     let recoveryPromptPending = false;
     let logEvents = [];
+    let roomHistoryHydrated = false;
     const seenSeq = new Set();
     const worldBeatPresentationContractVersion = 1;
     const worldBeatReceiptState = new Map();
@@ -5871,6 +5872,9 @@
       const wasTired = actorIsTired(state);
       const requestedActorId = actorId;
       await rotateActorSessionIfNeeded();
+      const historyWasNeeded = !roomHistoryHydrated
+        || pendingModelInteractionRehydrationRequired;
+      let recentEventsRequest = historyWasNeeded ? fetchRecentEvents() : null;
       let stateRequest = api(statePath());
       const contentPacksRequest = ensureContentPacks().catch(() => null);
       let nextState = await stateRequest;
@@ -5879,6 +5883,7 @@
         const recovery = await renewActorSession();
         if (recovery.ok && recovery.renewed) {
           stateRequest = api(statePath());
+          if (historyWasNeeded) recentEventsRequest = fetchRecentEvents();
           nextState = await stateRequest;
         }
       } else if (actorId) {
@@ -5897,9 +5902,12 @@
         handCompositionSignature = nextHandCompositionSignature;
       }
       const locationChanged = previousLocationId && previousLocationId !== state.location?.id;
-      if (logEvents.length === 0 || locationChanged || timelineRewound
+      if (historyWasNeeded || locationChanged || timelineRewound
           || pendingModelInteractionRehydrationRequired) {
-        rebuildLogFromAuthoritativeState(state);
+        const replay = recentEventsRequest
+          ? await recentEventsRequest
+          : await fetchRecentEvents();
+        rebuildLogFromAuthoritativeEvents(replay?.events || []);
       }
       if (locationChanged) {
         handKeys = [];
@@ -5967,6 +5975,20 @@
       const params = requestParams();
       const qs = params.toString();
       return `/state${qs ? `?${qs}` : ""}`;
+    }
+
+    function eventsPath(limit = 80) {
+      const params = requestParams();
+      params.set("limit", String(limit));
+      return `/events?${params.toString()}`;
+    }
+
+    async function fetchRecentEvents() {
+      const replay = await api(eventsPath());
+      if (!replay || !Array.isArray(replay.events)) {
+        throw new Error("Room history received an invalid /events response.");
+      }
+      return replay;
     }
 
     async function exportJournal() {
@@ -6054,11 +6076,10 @@
 
     function transcriptTimelineRewound(view, localLatest = latestSeenSeq()) {
       if (!localLatest) return false;
-      const serverLatest = (view?.recent_events || []).reduce(
-        (latest, event) => Math.max(latest, Number(event?.seq) || 0),
-        0,
-      );
-      return serverLatest < localLatest;
+      if (state?.world_epoch !== undefined
+          && view?.world_epoch !== undefined
+          && Number(view.world_epoch) !== Number(state.world_epoch)) return true;
+      return Number(view?.room_event_seq ?? view?.world_seq ?? 0) < localLatest;
     }
 
     function streamPath() {
@@ -6823,7 +6844,7 @@
           command: String(
             offer.command || `${binding.procedure} ${targetLabel}`
           ).trim(),
-          focusKey: `discovery:${binding.claim_key}:${binding.procedure}`,
+          focusKey: `discovery:${binding.slot_id}:${binding.procedure}`,
           card: binding.target_kind === "item" && targetId
             ? cardForItem(targetId)
             : cardForLocation(view.location?.id),
@@ -8706,13 +8727,6 @@
               offer_id: offer.offer_id,
               composition_id: offer.composition_id,
               kind: offer.kind,
-              rules_action: offer.rules_action,
-              operation: offer.operation,
-              rules_profile: offer.rules_profile,
-              state_revision: offer.state_revision,
-              route: offer.route,
-              target: offer.target,
-              cost: offer.cost,
               payload: currentPayload,
             })
           : postResult(path, currentPayload);
@@ -8833,17 +8847,16 @@
     }
 
     function canonicalCommandEnvelope() {
-      const actor = (state?.actors || []).find((candidate) => Number(candidate?.id) === Number(actorId));
-      const location = state?.location || {};
+      const commandContext = state?.command_context || {};
       const randomIntent = globalThis.crypto?.randomUUID?.()
         || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
       return {
         world_id: state?.world_id || "world://cosyworld/official",
         intent_id: `web:${randomIntent}`,
-        actor_ref: actor?.canonical_ref || "",
+        actor_ref: commandContext.actor_ref || "",
         observed: {
-          ...(Number(actor?.entity_version) > 0 ? { actor_version: Number(actor.entity_version) } : {}),
-          ...(Number(location?.entity_version) > 0 ? { location_version: Number(location.entity_version) } : {}),
+          ...(Number(commandContext.actor_version) > 0 ? { actor_version: Number(commandContext.actor_version) } : {}),
+          ...(Number(commandContext.location_version) > 0 ? { location_version: Number(commandContext.location_version) } : {}),
         },
         last_world_seq: Math.max(0, Number(state?.world_seq) || latestSeenSeq() || 0),
       };
@@ -8853,9 +8866,6 @@
       return JSON.stringify({
         kind: String(offer.kind || ""),
         command: String(offer.command || "").trim(),
-        operation: String(offer.operation || ""),
-        rules_action: String(offer.rules_action || ""),
-        rules_profile: String(offer.rules_profile || ""),
         target: offer.target ? {
           kind: String(offer.target.kind || ""),
           id: String(offer.target.id || ""),
@@ -9949,9 +9959,14 @@
       renderJournalActivity();
     }
 
-    function rebuildLogFromAuthoritativeState(view = state) {
-      rebuildLog([...(view?.recent_events || [])].reverse());
+    function rebuildLogFromAuthoritativeEvents(events = []) {
+      rebuildLog(Array.isArray(events) ? events : []);
+      roomHistoryHydrated = true;
       pendingModelInteractionRehydrationRequired = false;
+    }
+
+    function rebuildLogFromAuthoritativeState(view = state) {
+      rebuildLogFromAuthoritativeEvents([...(view?.recent_events || [])].reverse());
     }
 
     function eventIsMuted(event) {
@@ -10577,6 +10592,7 @@
       pendingChats = [];
       pendingModelInteractions = [];
       logEvents = [];
+      roomHistoryHydrated = false;
       seenSeq.clear();
       pendingModelInteractionRehydrationRequired = true;
     }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -2821,7 +2821,8 @@ struct CharacterIdentityView {
     level: u8,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 struct RoomMemoryView {
     location_id: u64,
     summary: String,
@@ -2958,7 +2959,7 @@ struct ActionOption {
     command: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 struct RankedActionOffer {
     id: String,
     offer_id: String,
@@ -2973,11 +2974,8 @@ struct RankedActionOffer {
     composition_trace: ActionCompositionTraceView,
     composition_id: String,
     state_revision: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
     route: Option<RouteOfferBinding>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     threshold_method: Option<ThresholdMethodOfferView>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     discovery: Option<DiscoveryOfferView>,
 
     category: String,
@@ -2999,11 +2997,10 @@ struct RankedActionOffer {
     progress: Option<u8>,
     claim_key: Option<String>,
     reason: String,
-    #[serde(skip)]
     ranked_hand_eligible: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct ActionSourceCollectibleView {
     kind: String,
     instance_id: u64,
@@ -3037,7 +3034,8 @@ struct ActionProviderView {
     priority: u8,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 struct ActionHandView {
     schema_version: u8,
     capacity: u8,
@@ -3048,7 +3046,8 @@ struct ActionHandView {
     entries: Vec<ActionHandEntryView>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 struct ActionHandPassView {
     offer_id: String,
     label: String,
@@ -3057,7 +3056,7 @@ struct ActionHandPassView {
     scene_key: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 struct ActionHandEntryView {
     offer_id: String,
     kind: String,
@@ -3082,7 +3081,7 @@ struct ActionProjectView {
     claim_key: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 struct ActionTargetView {
     kind: String,
     id: Option<u64>,
@@ -3093,66 +3092,6 @@ struct ActionTargetView {
 struct ActionCostView {
     orbs: i32,
     reason: String,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct EventView {
-    #[serde(default = "official_world_id")]
-    world_id: String,
-    #[serde(default = "official_world_epoch")]
-    world_epoch: u64,
-    seq: u64,
-    #[serde(rename = "type")]
-    type_name: String,
-    success: bool,
-    reason: u16,
-    actor_id: Option<u64>,
-    actor_name: Option<String>,
-    target_actor_id: Option<u64>,
-    target_actor_name: Option<String>,
-    location_id: Option<u64>,
-    location_name: Option<String>,
-    destination_location_id: Option<u64>,
-    destination_location_name: Option<String>,
-    content_id: Option<u64>,
-    content: Option<String>,
-    item_id: Option<u64>,
-    item_name: Option<String>,
-    target_item_id: Option<u64>,
-    target_item_name: Option<String>,
-    raw_roll: Option<i16>,
-    modifier: Option<i16>,
-    total: Option<i16>,
-    dc: Option<i16>,
-    damage: Option<i16>,
-    current_hp: Option<i16>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    combat_method: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    ability: Option<String>,
-    clock_id: Option<String>,
-    clock_scope: Option<String>,
-    clock_scope_id: Option<u64>,
-    clock_kind: Option<String>,
-    clock_label: Option<String>,
-    clock_filled: Option<u8>,
-    clock_segments: Option<u8>,
-    clock_delta: Option<i16>,
-    tag_id: Option<String>,
-    tag_scope: Option<String>,
-    tag_scope_id: Option<u64>,
-    tag_kind: Option<String>,
-    tag_label: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    caused_by_event_seq: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    source_world_tick: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    observed_through_seq: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    source_location_id: Option<u64>,
-    #[serde(default, skip_serializing_if = "content_reference_context_is_empty")]
-    content_context: ContentReferenceContext,
 }
 
 fn content_reference_context_is_empty(context: &ContentReferenceContext) -> bool {
@@ -3290,7 +3229,9 @@ struct ActionOfferSubmissionRequest {
     kind: String,
     rules_action: Option<String>,
     operation: Option<String>,
+    #[serde(default)]
     rules_profile: String,
+    #[serde(default)]
     state_revision: u64,
     #[serde(default)]
     route: Option<RouteOfferBinding>,

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -3002,7 +3002,7 @@ struct RankedActionOffer {
     ranked_hand_eligible: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 struct ActionSourceCollectibleView {
     kind: String,
     instance_id: u64,

--- a/v2/orchestrator-rust/src/spatial.rs
+++ b/v2/orchestrator-rust/src/spatial.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde::ser::SerializeStruct;
 use sha2::{Digest, Sha256};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -60,7 +61,8 @@ pub(super) struct SeedSpatialConstraint {
     pub(super) label: String,
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct SpatialSceneView {
     pub(super) schema_version: u8,
     pub(super) id: String,
@@ -77,13 +79,30 @@ pub(super) struct SpatialSceneView {
     pub(super) viewer: Option<SpatialViewerView>,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for SpatialSceneView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("SpatialSceneView", 8)?;
+        out.serialize_field("schema_version", &self.schema_version)?;
+        out.serialize_field("projection", &self.projection)?;
+        out.serialize_field("sites", &self.sites)?;
+        out.serialize_field("links", &self.links)?;
+        out.serialize_field("tokens", &self.tokens)?;
+        out.serialize_field("portals", &self.portals)?;
+        out.serialize_field("constraints", &self.constraints)?;
+        out.serialize_field("viewer", &self.viewer)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct SpatialTokenView {
     pub(super) ref_id: String,
     pub(super) kind: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) actor_id: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) feature_key: Option<String>,
     pub(super) label: String,
     pub(super) site_id: String,
@@ -92,7 +111,24 @@ pub(super) struct SpatialTokenView {
     pub(super) offer_ids: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for SpatialTokenView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("SpatialTokenView", 6)?;
+        out.serialize_field("ref_id", &self.ref_id)?;
+        out.serialize_field("kind", &self.kind)?;
+        out.serialize_field("label", &self.label)?;
+        out.serialize_field("site_id", &self.site_id)?;
+        out.serialize_field("hostile", &self.hostile)?;
+        out.serialize_field("offer_ids", &self.offer_ids)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct SpatialPortalView {
     pub(super) ref_id: String,
     pub(super) destination_location_id: u64,
@@ -105,7 +141,24 @@ pub(super) struct SpatialPortalView {
     pub(super) offer_ids: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for SpatialPortalView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("SpatialPortalView", 6)?;
+        out.serialize_field("ref_id", &self.ref_id)?;
+        out.serialize_field("label", &self.label)?;
+        out.serialize_field("direction", &self.direction)?;
+        out.serialize_field("site_id", &self.site_id)?;
+        out.serialize_field("blocked", &self.blocked)?;
+        out.serialize_field("offer_ids", &self.offer_ids)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct SpatialConstraintView {
     pub(super) id: String,
     pub(super) kind: String,
@@ -115,11 +168,38 @@ pub(super) struct SpatialConstraintView {
     pub(super) active: bool,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for SpatialConstraintView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("SpatialConstraintView", 4)?;
+        out.serialize_field("subject_ref", &self.subject_ref)?;
+        out.serialize_field("object_ref", &self.object_ref)?;
+        out.serialize_field("label", &self.label)?;
+        out.serialize_field("active", &self.active)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct SpatialViewerView {
     pub(super) actor_id: u64,
     pub(super) site_id: String,
     pub(super) placement: &'static str,
+}
+
+impl Serialize for SpatialViewerView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("SpatialViewerView", 2)?;
+        out.serialize_field("actor_id", &self.actor_id)?;
+        out.serialize_field("site_id", &self.site_id)?;
+        out.end()
+    }
 }
 
 pub(super) fn validate_seed_spatial_scenes(content: &SeedContent) -> Result<(), String> {

--- a/v2/orchestrator-rust/src/tests/action_hand_tests.rs
+++ b/v2/orchestrator-rust/src/tests/action_hand_tests.rs
@@ -2161,6 +2161,11 @@ fn public_state_keeps_the_action_hand_bounded() {
                 "offer.provider.{hidden} leaked"
             );
         }
+        if let Some(source) = offer.get("source_collectible") {
+            for hidden in ["pack_id", "pack_version", "card_id", "provider_id"] {
+                assert!(source.get(hidden).is_none(), "offer source.{hidden} leaked");
+            }
+        }
     }
     assert!(
         state["safety"].get("blocked_actor_ids").is_none(),

--- a/v2/orchestrator-rust/src/tests/action_hand_tests.rs
+++ b/v2/orchestrator-rust/src/tests/action_hand_tests.rs
@@ -2155,12 +2155,16 @@ fn public_state_keeps_the_action_hand_bounded() {
         ] {
             assert!(offer.get(hidden).is_none(), "offer.{hidden} leaked");
         }
-        for hidden in ["label", "reason"] {
-            assert!(
-                offer["provider"].get(hidden).is_none(),
-                "offer.provider.{hidden} leaked"
-            );
-        }
+        assert!(
+            offer["provider"].get("label").is_none(),
+            "offer.provider.label leaked"
+        );
+        assert!(
+            offer["provider"]["reason"]
+                .as_str()
+                .is_some_and(|reason| !reason.is_empty()),
+            "the browser-rendered provider reason must remain public"
+        );
         if let Some(source) = offer.get("source_collectible") {
             for hidden in ["pack_id", "pack_version", "card_id", "provider_id"] {
                 assert!(source.get(hidden).is_none(), "offer source.{hidden} leaked");

--- a/v2/orchestrator-rust/src/tests/action_hand_tests.rs
+++ b/v2/orchestrator-rust/src/tests/action_hand_tests.rs
@@ -21,6 +21,27 @@ fn submission_for_offer(
     }
 }
 
+fn compact_submission_for_offer(
+    offer: &RankedActionOffer,
+    path: &str,
+    payload: serde_json::Value,
+) -> ActionOfferSubmissionRequest {
+    ActionOfferSubmissionRequest {
+        path: path.to_string(),
+        offer_id: offer.offer_id.clone(),
+        composition_id: offer.composition_id.clone(),
+        kind: offer.kind.clone(),
+        rules_action: None,
+        operation: None,
+        rules_profile: String::new(),
+        state_revision: 0,
+        route: None,
+        target: None,
+        cost: None,
+        payload,
+    }
+}
+
 fn live_command_request(actor_id: u64, actor_session: &str, offer_id: String) -> CommandRequest {
     CommandRequest {
         actor_id,
@@ -328,7 +349,7 @@ async fn live_story_button_hand_lifecycle() {
     let pickup = submit_action_offer(
         ConnectInfo("127.0.0.1:44274".parse().expect("client address")),
         State(state.clone()),
-        Json(submission_for_offer(
+        Json(compact_submission_for_offer(
             &pickup_offer,
             "/actions/pick-up",
             serde_json::json!({
@@ -2027,24 +2048,157 @@ async fn legacy_pass_endpoint_refuses_an_uncertified_request() {
 
 #[test]
 fn public_state_keeps_the_action_hand_bounded() {
-    let runtime = RuntimeWorld::seeded();
-    let state = serde_json::to_value(
-        runtime.state_response(Some(RATI_ACTOR_ID), &AccessContext::default()),
-    )
-    .expect("serialize public state");
-    assert!(
-        state.get("rules_context").is_some(),
-        "rules_context remains part of the public state contract"
+    let mut runtime = RuntimeWorld::seeded();
+    create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Public State Tester",
     );
-    for hidden in ["factions", "card_transactions", "inspector"] {
+    let encoded =
+        serde_json::to_vec(&runtime.state_response(Some(5000), &AccessContext::default()))
+            .expect("serialize public state");
+    assert!(
+        encoded.len() < 32 * 1024,
+        "the seeded browser state grew past its 32 KiB contract: {} bytes",
+        encoded.len()
+    );
+    let state: serde_json::Value = serde_json::from_slice(&encoded).expect("decode public state");
+    for hidden in [
+        "account",
+        "rules_context",
+        "goals",
+        "chat_bond_claimed_target_ids",
+        "factions",
+        "card_transactions",
+        "inspector",
+    ] {
         assert!(state.get(hidden).is_none(), "{hidden} must remain internal");
     }
+    assert!(
+        state["command_context"]["actor_ref"].is_string(),
+        "the browser gets only the opaque concurrency context it must submit"
+    );
+    assert!(
+        state.get("recent_events").is_none(),
+        "bounded event history belongs to /events, not the current-state payload"
+    );
     assert!(state["action_offers"]
         .as_array()
         .is_some_and(|offers| offers.len() <= 2));
     assert!(state["action_hand"]["entries"]
         .as_array()
         .is_some_and(|entries| entries.len() <= 2));
+    assert!(state["journal_beats"]
+        .as_array()
+        .is_some_and(|beats| beats.len() <= 60));
+
+    let location = state["location"].as_object().expect("public location");
+    for hidden in [
+        "canonical_ref",
+        "entity_version",
+        "pack_id",
+        "persona",
+        "memory",
+        "factions",
+    ] {
+        assert!(location.get(hidden).is_none(), "location.{hidden} leaked");
+    }
+    for actor in state["actors"].as_array().expect("public actors") {
+        for hidden in [
+            "canonical_ref",
+            "entity_version",
+            "pack_id",
+            "speech_mode",
+            "factions",
+            "bloodied",
+        ] {
+            assert!(actor.get(hidden).is_none(), "actor.{hidden} leaked");
+        }
+        assert_eq!(
+            actor["stats"]
+                .as_object()
+                .expect("public actor stats")
+                .keys()
+                .cloned()
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from(["hp_base".to_string(), "level".to_string()]),
+            "actor stats must contain only values rendered by the client"
+        );
+    }
+    for item in state["items"].as_array().expect("public items") {
+        for hidden in [
+            "canonical_ref",
+            "entity_version",
+            "pack_id",
+            "mechanics",
+            "provenance",
+        ] {
+            assert!(item.get(hidden).is_none(), "item.{hidden} leaked");
+        }
+    }
+    for offer in state["action_offers"].as_array().expect("public offers") {
+        for hidden in [
+            "rules_action",
+            "operation",
+            "rules_profile",
+            "resolver",
+            "pack_provenance",
+            "composition_trace",
+            "state_revision",
+            "route",
+            "category",
+            "zone",
+            "source",
+            "claim_key",
+            "reason",
+        ] {
+            assert!(offer.get(hidden).is_none(), "offer.{hidden} leaked");
+        }
+        for hidden in ["label", "reason"] {
+            assert!(
+                offer["provider"].get(hidden).is_none(),
+                "offer.provider.{hidden} leaked"
+            );
+        }
+    }
+    assert!(
+        state["safety"].get("blocked_actor_ids").is_none(),
+        "duplicated safety internals must not be sent"
+    );
+    for group in ["actors", "items", "locations"] {
+        for card in state["cards"][group]
+            .as_object()
+            .expect("public card group")
+            .values()
+        {
+            for hidden in [
+                "pack_id",
+                "source",
+                "asset_status",
+                "profile_id",
+                "subject",
+                "chain_image_uri",
+                "generation_policy",
+            ] {
+                assert!(card.get(hidden).is_none(), "card.{hidden} leaked");
+            }
+        }
+    }
+
+    let sparse_event = serde_json::to_value(EventView {
+        seq: 1,
+        type_name: "world.bootstrapped".to_string(),
+        success: true,
+        ..EventView::default()
+    })
+    .expect("serialize sparse public event");
+    for absent in ["actor_id", "content", "clock_id", "tag_id"] {
+        assert!(
+            sparse_event.get(absent).is_none(),
+            "absent event field {absent} must not be serialized as null"
+        );
+    }
 }
 
 #[tokio::test]

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -124,7 +124,10 @@ impl Serialize for RankedActionOffer {
         out.serialize_field("kind", &self.kind)?;
         out.serialize_field("intention", &self.intention)?;
         if let Some(source) = &self.source_collectible {
-            out.serialize_field("source_collectible", source)?;
+            out.serialize_field(
+                "source_collectible",
+                &PublicActionSourceCollectibleView(source),
+            )?;
         }
         if let Some(method) = &self.threshold_method {
             out.serialize_field("threshold_method", &PublicThresholdMethodView(method))?;
@@ -202,14 +205,16 @@ impl Serialize for PublicDiscoveryOfferView<'_> {
     }
 }
 
-impl Serialize for ActionSourceCollectibleView {
+struct PublicActionSourceCollectibleView<'a>(&'a ActionSourceCollectibleView);
+
+impl Serialize for PublicActionSourceCollectibleView<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         let mut out = serializer.serialize_struct("ActionSourceCollectibleView", 2)?;
-        out.serialize_field("kind", &self.kind)?;
-        out.serialize_field("instance_id", &self.instance_id)?;
+        out.serialize_field("kind", &self.0.kind)?;
+        out.serialize_field("instance_id", &self.0.instance_id)?;
         out.end()
     }
 }
@@ -2576,6 +2581,7 @@ impl Serialize for BondView {
 pub(super) struct InspectorView {
     pub(super) location_id: u64,
     pub(super) practice: Option<ActorPracticeView>,
+    pub(super) first_tale_question: Option<String>,
     pub(super) room: RoomInspectorView,
     pub(super) suggested_action: Option<ActionInspectorView>,
     pub(super) actions: Vec<ActionInspectorView>,
@@ -5004,6 +5010,9 @@ impl RuntimeWorld {
         InspectorView {
             location_id,
             practice: actor_id.and_then(|id| self.actor_practice_view(id)),
+            first_tale_question: actor_id
+                .and_then(|id| self.first_tale_view(id))
+                .map(|first_tale| first_tale.question),
             room: RoomInspectorView {
                 name: self
                     .location_name(location_id)

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -226,9 +226,10 @@ impl Serialize for PublicActionProviderView<'_> {
     where
         S: serde::Serializer,
     {
-        let mut out = serializer.serialize_struct("ActionProviderView", 3)?;
+        let mut out = serializer.serialize_struct("ActionProviderView", 4)?;
         out.serialize_field("kind", &self.0.kind)?;
         out.serialize_field("id", &self.0.id)?;
+        out.serialize_field("reason", &self.0.reason)?;
         out.serialize_field("priority", &self.0.priority)?;
         out.end()
     }

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -1,4 +1,344 @@
 use super::*;
+use serde::ser::SerializeStruct;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct EventView {
+    #[serde(default = "official_world_id")]
+    pub(super) world_id: String,
+    #[serde(default = "official_world_epoch")]
+    pub(super) world_epoch: u64,
+    pub(super) seq: u64,
+    #[serde(rename = "type")]
+    pub(super) type_name: String,
+    pub(super) success: bool,
+    pub(super) reason: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) actor_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) actor_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) target_actor_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) target_actor_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) location_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) location_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) destination_location_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) destination_location_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) content_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) item_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) item_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) target_item_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) target_item_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) raw_roll: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) modifier: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) total: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) dc: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) damage: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) current_hp: Option<i16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) combat_method: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) ability: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) clock_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) clock_scope: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) clock_scope_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) clock_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) clock_label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) clock_filled: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) clock_segments: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) clock_delta: Option<i16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) tag_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) tag_scope: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) tag_scope_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) tag_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) tag_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) caused_by_event_seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) source_world_tick: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) observed_through_seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) source_location_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "content_reference_context_is_empty")]
+    pub(super) content_context: ContentReferenceContext,
+}
+
+impl Serialize for RoomMemoryView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("RoomMemoryView", 4)?;
+        out.serialize_field("summary", &self.summary)?;
+        if let Some(latest) = &self.latest {
+            out.serialize_field("latest", latest)?;
+        }
+        out.serialize_field("recent", &self.recent)?;
+        if let Some(latest_seq) = &self.latest_seq {
+            out.serialize_field("latest_seq", latest_seq)?;
+        }
+        out.end()
+    }
+}
+
+impl Serialize for RankedActionOffer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("RankedActionOffer", 22)?;
+        out.serialize_field("id", &self.id)?;
+        out.serialize_field("offer_id", &self.offer_id)?;
+        out.serialize_field("composition_id", &self.composition_id)?;
+        out.serialize_field("kind", &self.kind)?;
+        out.serialize_field("intention", &self.intention)?;
+        if let Some(source) = &self.source_collectible {
+            out.serialize_field("source_collectible", source)?;
+        }
+        if let Some(method) = &self.threshold_method {
+            out.serialize_field("threshold_method", &PublicThresholdMethodView(method))?;
+        }
+        if let Some(discovery) = &self.discovery {
+            out.serialize_field("discovery", &PublicDiscoveryOfferView(discovery))?;
+        }
+        out.serialize_field("verb", &self.verb)?;
+        out.serialize_field("label", &self.label)?;
+        out.serialize_field("accessible_label", &self.accessible_label)?;
+        out.serialize_field("command", &self.command)?;
+        out.serialize_field("rank", &self.rank)?;
+        out.serialize_field("disabled", &self.disabled)?;
+        if let Some(reason) = &self.disabled_reason {
+            out.serialize_field("disabled_reason", reason)?;
+        }
+        out.serialize_field("provider", &PublicActionProviderView(&self.provider))?;
+        if let Some(target) = &self.target {
+            out.serialize_field("target", target)?;
+        }
+        if let Some(project) = &self.project {
+            out.serialize_field("project", &PublicActionProjectView(project))?;
+        }
+        if let Some(cost) = &self.cost {
+            out.serialize_field("cost", &PublicActionCostView(cost))?;
+        }
+        if let Some(risk) = &self.risk {
+            out.serialize_field("risk", risk)?;
+        }
+        if let Some(effect) = &self.effect {
+            out.serialize_field("effect", effect)?;
+        }
+        if let Some(progress) = &self.progress {
+            out.serialize_field("progress", progress)?;
+        }
+        out.end()
+    }
+}
+
+struct PublicThresholdMethodView<'a>(&'a ThresholdMethodOfferView);
+
+impl Serialize for PublicThresholdMethodView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut out = serializer.serialize_struct("ThresholdMethodOfferView", 7)?;
+        out.serialize_field("descriptor_id", &value.descriptor_id)?;
+        out.serialize_field("method_id", &value.method_id)?;
+        out.serialize_field("method", &value.method)?;
+        out.serialize_field("requirement", &value.requirement)?;
+        out.serialize_field("economy", &value.economy)?;
+        out.serialize_field("effect", &value.effect)?;
+        out.serialize_field("consequence", &value.consequence)?;
+        out.end()
+    }
+}
+
+struct PublicDiscoveryOfferView<'a>(&'a DiscoveryOfferView);
+
+impl Serialize for PublicDiscoveryOfferView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut out = serializer.serialize_struct("DiscoveryOfferView", 5)?;
+        out.serialize_field("procedure", &value.procedure)?;
+        out.serialize_field("slot_id", &value.slot_id)?;
+        out.serialize_field("receipt_id", &value.receipt_id)?;
+        out.serialize_field("target_kind", &value.target_kind)?;
+        out.serialize_field("resolution", &value.resolution)?;
+        out.end()
+    }
+}
+
+impl Serialize for ActionSourceCollectibleView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ActionSourceCollectibleView", 2)?;
+        out.serialize_field("kind", &self.kind)?;
+        out.serialize_field("instance_id", &self.instance_id)?;
+        out.end()
+    }
+}
+
+struct PublicActionProviderView<'a>(&'a ActionProviderView);
+
+impl Serialize for PublicActionProviderView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ActionProviderView", 3)?;
+        out.serialize_field("kind", &self.0.kind)?;
+        out.serialize_field("id", &self.0.id)?;
+        out.serialize_field("priority", &self.0.priority)?;
+        out.end()
+    }
+}
+
+impl Serialize for ActionHandView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ActionHandView", 3)?;
+        out.serialize_field("generation", &self.generation)?;
+        out.serialize_field("pass", &self.pass)?;
+        out.serialize_field("entries", &self.entries)?;
+        out.end()
+    }
+}
+
+impl Serialize for ActionHandPassView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ActionHandPassView", 4)?;
+        out.serialize_field("offer_id", &self.offer_id)?;
+        out.serialize_field("label", &self.label)?;
+        out.serialize_field("state_revision", &self.state_revision)?;
+        out.serialize_field("scene_key", &self.scene_key)?;
+        out.end()
+    }
+}
+
+impl Serialize for ActionHandEntryView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct ProviderIdentity<'a> {
+            kind: &'a str,
+            id: &'a str,
+        }
+
+        let mut out = serializer.serialize_struct("ActionHandEntryView", 4)?;
+        out.serialize_field("offer_id", &self.offer_id)?;
+        out.serialize_field("kind", &self.kind)?;
+        out.serialize_field("intention", &self.intention)?;
+        out.serialize_field(
+            "provider",
+            &ProviderIdentity {
+                kind: self.provider.kind.as_str(),
+                id: self.provider.id.as_str(),
+            },
+        )?;
+        out.end()
+    }
+}
+
+struct PublicActionProjectView<'a>(&'a ActionProjectView);
+
+impl Serialize for PublicActionProjectView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut out = serializer.serialize_struct("ActionProjectView", 8)?;
+        out.serialize_field("id", &value.id)?;
+        out.serialize_field("verb", &value.verb)?;
+        out.serialize_field("label", &value.label)?;
+        out.serialize_field("summary", &value.summary)?;
+        out.serialize_field("progress_clock_id", &value.progress_clock_id)?;
+        if let Some(strategy_id) = &value.strategy_id {
+            out.serialize_field("strategy_id", strategy_id)?;
+        }
+        if let Some(strategy_label) = &value.strategy_label {
+            out.serialize_field("strategy_label", strategy_label)?;
+        }
+        if let Some(resolution) = &value.resolution {
+            out.serialize_field("resolution", resolution)?;
+        }
+        out.end()
+    }
+}
+
+impl Serialize for ActionTargetView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ActionTargetView", 3)?;
+        out.serialize_field("kind", &self.kind)?;
+        if let Some(id) = &self.id {
+            out.serialize_field("id", id)?;
+        }
+        if let Some(label) = &self.label {
+            out.serialize_field("label", label)?;
+        }
+        out.end()
+    }
+}
+
+struct PublicActionCostView<'a>(&'a ActionCostView);
+
+impl Serialize for PublicActionCostView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ActionCostView", 2)?;
+        out.serialize_field("orbs", &self.0.orbs)?;
+        out.serialize_field("reason", &self.0.reason)?;
+        out.end()
+    }
+}
 
 pub(super) fn event_current_hp(event: &CwEvent) -> Option<i16> {
     match event.type_ {
@@ -133,7 +473,8 @@ pub(super) struct JourneyView {
     pub(super) next_location_name: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct FirstTaleView {
     pub(super) schema_version: u8,
     pub(super) phase: String,
@@ -157,7 +498,34 @@ pub(super) struct FirstTaleView {
     pub(super) continuation: Option<FirstTaleContinuationView>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+impl Serialize for FirstTaleView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("FirstTaleView", 15)?;
+        out.serialize_field("phase", &self.phase)?;
+        out.serialize_field("phase_exposure_id", &self.phase_exposure_id)?;
+        out.serialize_field("state_revision", &self.state_revision)?;
+        out.serialize_field("lead_location_id", &self.lead_location_id)?;
+        out.serialize_field("destination_location_id", &self.destination_location_id)?;
+        out.serialize_field("job_id", &self.job_id)?;
+        out.serialize_field("progress_clock_id", &self.progress_clock_id)?;
+        out.serialize_field("required_location_id", &self.required_location_id)?;
+        out.serialize_field("advancing_offer_id", &self.advancing_offer_id)?;
+        out.serialize_field("instruction", &self.instruction)?;
+        out.serialize_field("completion_memory", &self.completion_memory)?;
+        out.serialize_field("next_invitation", &self.next_invitation)?;
+        out.serialize_field("trace_event_seq", &self.trace_event_seq)?;
+        if let Some(continuation) = &self.continuation {
+            out.serialize_field("continuation", continuation)?;
+        }
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct FirstTaleContinuationView {
     pub(super) destination_location_id: u64,
     pub(super) target_actor_id: u64,
@@ -166,6 +534,22 @@ pub(super) struct FirstTaleContinuationView {
     pub(super) instruction: String,
     pub(super) required_location_id: Option<u64>,
     pub(super) advancing_offer_id: Option<String>,
+}
+
+impl Serialize for FirstTaleContinuationView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("FirstTaleContinuationView", 6)?;
+        out.serialize_field("destination_location_id", &self.destination_location_id)?;
+        out.serialize_field("target_actor_id", &self.target_actor_id)?;
+        out.serialize_field("phase", &self.phase)?;
+        out.serialize_field("instruction", &self.instruction)?;
+        out.serialize_field("required_location_id", &self.required_location_id)?;
+        out.serialize_field("advancing_offer_id", &self.advancing_offer_id)?;
+        out.end()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -263,7 +647,8 @@ const JOURNAL_BEAT_POLICIES: &[(&str, JournalBeatCategory)] = &[
     ("magic.spell_cast", JournalBeatCategory::Consequence),
 ];
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct JournalBeatView {
     pub(super) id: String,
     pub(super) source_event_seqs: Vec<u64>,
@@ -271,18 +656,43 @@ pub(super) struct JournalBeatView {
     pub(super) headline: String,
     pub(super) location_id: u64,
     pub(super) ordering_seq: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) world_beat_exposure_id: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for JournalBeatView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("JournalBeatView", 5)?;
+        out.serialize_field("source_event_seqs", &self.source_event_seqs)?;
+        out.serialize_field("category", &self.category)?;
+        out.serialize_field("headline", &self.headline)?;
+        out.serialize_field("ordering_seq", &self.ordering_seq)?;
+        if let Some(exposure_id) = &self.world_beat_exposure_id {
+            out.serialize_field("world_beat_exposure_id", exposure_id)?;
+        }
+        out.end()
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct CommandContextView {
+    pub(super) actor_ref: String,
+    pub(super) actor_version: u64,
+    pub(super) location_version: u64,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct StateResponse {
     pub(super) world_id: String,
     pub(super) world_epoch: u64,
     pub(super) world_seq: u64,
+    pub(super) room_event_seq: u64,
     pub(super) state_revision: u64,
+    pub(super) command_context: Option<CommandContextView>,
     pub(super) rules_context: Option<SceneRulesContextView>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) spatial_scene: Option<SpatialSceneView>,
     pub(super) location: LocationView,
     pub(super) exits: Vec<ExitView>,
@@ -291,7 +701,6 @@ pub(super) struct StateResponse {
     // These internal projections remain available to Rust-side invariant tests;
     // clients receive the explicitly named visible projection below.
     #[allow(dead_code)]
-    #[serde(skip_serializing)]
     pub(super) factions: Vec<FactionView>,
     pub(super) room_features: Vec<RoomFeatureView>,
     pub(super) scene_notices: Vec<DiscoverySceneNoticeView>,
@@ -312,7 +721,6 @@ pub(super) struct StateResponse {
     pub(super) chat_bond_claimed_target_ids: Vec<u64>,
     pub(super) cards: CardRegistryView,
     #[allow(dead_code)]
-    #[serde(skip_serializing)]
     pub(super) card_transactions: Vec<CardTransactionView>,
     pub(super) account: AccountView,
     pub(super) economy: EconomyView,
@@ -321,24 +729,94 @@ pub(super) struct StateResponse {
     pub(super) turn: RoomTurnView,
     pub(super) branch: Option<BranchView>,
     pub(super) safety: ActorSafetyView,
+    // The current-state endpoint must not resend room history on every
+    // projection refresh. Keep it available for server-side memory assembly;
+    // clients load the same bounded, visibility-filtered history from /events.
     pub(super) recent_events: Vec<EventView>,
     pub(super) journal_beats: Vec<JournalBeatView>,
     pub(super) room_memory: RoomMemoryView,
     #[allow(dead_code)]
-    #[serde(skip_serializing)]
     pub(super) primary_action: PrimaryAction,
-    #[serde(rename = "primary_action")]
     pub(super) visible_primary_action: PrimaryAction,
     #[allow(dead_code)]
-    #[serde(skip_serializing)]
     pub(super) action_offers: Vec<RankedActionOffer>,
-    #[serde(rename = "action_offers")]
     pub(super) visible_action_offers: Vec<RankedActionOffer>,
     pub(super) action_hand: ActionHandView,
-    #[serde(skip_serializing)]
     pub(super) inspector: InspectorView,
     pub(super) character_creation: Vec<CharacterCreationProfileView>,
     pub(super) character_identity: Option<CharacterIdentityView>,
+}
+
+// `/state` is a browser capability, not a dump of RuntimeWorld's projections.
+// Keep this allowlist explicit: adding an internal field above must never make
+// it public unless it is deliberately added here as something the UI renders
+// or submits.
+impl Serialize for StateResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("StateResponse", 36)?;
+        out.serialize_field("world_id", &self.world_id)?;
+        out.serialize_field("world_epoch", &self.world_epoch)?;
+        out.serialize_field("world_seq", &self.world_seq)?;
+        out.serialize_field("room_event_seq", &self.room_event_seq)?;
+        out.serialize_field("state_revision", &self.state_revision)?;
+        if let Some(value) = &self.command_context {
+            out.serialize_field("command_context", value)?;
+        }
+        if let Some(value) = &self.spatial_scene {
+            out.serialize_field("spatial_scene", value)?;
+        }
+        out.serialize_field("location", &self.location)?;
+        out.serialize_field("exits", &self.exits)?;
+        out.serialize_field("actors", &self.actors)?;
+        out.serialize_field("items", &self.items)?;
+        out.serialize_field("room_features", &self.room_features)?;
+        out.serialize_field("scene_notices", &self.scene_notices)?;
+        out.serialize_field("search_available", &self.search_available)?;
+        out.serialize_field("clocks", &self.clocks)?;
+        out.serialize_field("shared_questions", &self.shared_questions)?;
+        out.serialize_field("tags", &self.tags)?;
+        out.serialize_field("jobs", &self.jobs)?;
+        out.serialize_field("fronts", &self.fronts)?;
+        if let Some(value) = &self.room_sheet {
+            out.serialize_field("room_sheet", &PublicRoomSheetView(value))?;
+        }
+        if let Some(value) = &self.journey {
+            out.serialize_field("journey", value)?;
+        }
+        if let Some(value) = &self.first_tale {
+            out.serialize_field("first_tale", value)?;
+        }
+        if let Some(value) = &self.calling {
+            out.serialize_field("calling", value)?;
+        }
+        out.serialize_field("skills", &self.skills)?;
+        out.serialize_field("ledger", &self.ledger)?;
+        out.serialize_field("bonds", &self.bonds)?;
+        out.serialize_field("cards", &self.cards)?;
+        out.serialize_field("economy", &self.economy)?;
+        out.serialize_field("deck", &self.deck)?;
+        if let Some(value) = &self.combat {
+            out.serialize_field("combat", value)?;
+        }
+        out.serialize_field("turn", &self.turn)?;
+        if let Some(value) = &self.branch {
+            out.serialize_field("branch", value)?;
+        }
+        out.serialize_field("safety", &PublicActorSafetyView(&self.safety))?;
+        out.serialize_field("journal_beats", &self.journal_beats)?;
+        out.serialize_field("room_memory", &self.room_memory)?;
+        out.serialize_field("primary_action", &self.visible_primary_action)?;
+        out.serialize_field("action_offers", &self.visible_action_offers)?;
+        out.serialize_field("action_hand", &self.action_hand)?;
+        out.serialize_field("character_creation", &self.character_creation)?;
+        if let Some(value) = &self.character_identity {
+            out.serialize_field("character_identity", value)?;
+        }
+        out.end()
+    }
 }
 
 fn semantic_receipt_journal_category(narration_key: &str) -> JournalBeatCategory {
@@ -925,7 +1403,8 @@ pub(super) struct CombatParticipantView {
     pub(super) escaped: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct EconomyView {
     pub(super) orbs: i32,
     pub(super) chat_cost_orbs: i32,
@@ -944,7 +1423,22 @@ pub(super) struct EconomyView {
     pub(super) chat_payer: String,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for EconomyView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("EconomyView", 4)?;
+        out.serialize_field("orbs", &self.orbs)?;
+        out.serialize_field("carried_weight_tenths", &self.carried_weight_tenths)?;
+        out.serialize_field("carrying_capacity_tenths", &self.carrying_capacity_tenths)?;
+        out.serialize_field("listen_attempted_here", &self.listen_attempted_here)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct DeckView {
     pub(super) actor_id: Option<u64>,
     pub(super) carried_cards: Vec<ItemView>,
@@ -969,6 +1463,39 @@ pub(super) struct DeckView {
     pub(super) bag_previews: Vec<String>,
 }
 
+impl Serialize for DeckView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("DeckView", 20)?;
+        out.serialize_field("actor_id", &self.actor_id)?;
+        out.serialize_field("carried_cards", &self.carried_cards)?;
+        out.serialize_field("carried_weight_tenths", &self.carried_weight_tenths)?;
+        out.serialize_field(
+            "base_carrying_capacity_tenths",
+            &self.base_carrying_capacity_tenths,
+        )?;
+        out.serialize_field("container_capacity_tenths", &self.container_capacity_tenths)?;
+        out.serialize_field("carrying_capacity_tenths", &self.carrying_capacity_tenths)?;
+        out.serialize_field("bracelet_slots", &self.bracelet_slots)?;
+        out.serialize_field("equipped_charms", &self.equipped_charms)?;
+        out.serialize_field("available_charms", &self.available_charms)?;
+        out.serialize_field("charm_slot_expansion", &self.charm_slot_expansion)?;
+        out.serialize_field("spell_cards", &self.spell_cards)?;
+        out.serialize_field("prepared_spell_cards", &self.prepared_spell_cards)?;
+        out.serialize_field("exhausted_spell_cards", &self.exhausted_spell_cards)?;
+        out.serialize_field("exhausted_cards", &self.exhausted_cards)?;
+        out.serialize_field("spell_deck_slots", &self.spell_deck_slots)?;
+        out.serialize_field("equipped_weapon", &self.equipped_weapon)?;
+        out.serialize_field("equipped_containers", &self.equipped_containers)?;
+        out.serialize_field("containers", &self.containers)?;
+        out.serialize_field("validation_errors", &self.validation_errors)?;
+        out.serialize_field("bag_previews", &self.bag_previews)?;
+        out.end()
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub(super) struct CharmSlotExpansionView {
     pub(super) charm: ItemView,
@@ -977,7 +1504,8 @@ pub(super) struct CharmSlotExpansionView {
     pub(super) advancement_cost: u8,
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct ContainerDeckView {
     pub(super) container: ItemView,
     pub(super) contents: Vec<ItemView>,
@@ -985,6 +1513,20 @@ pub(super) struct ContainerDeckView {
     pub(super) allowed_contents: Vec<String>,
     pub(super) equipped: bool,
     pub(super) active_capacity_tenths: u16,
+}
+
+impl Serialize for ContainerDeckView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ContainerDeckView", 4)?;
+        out.serialize_field("container", &self.container)?;
+        out.serialize_field("contents", &self.contents)?;
+        out.serialize_field("opening_size", &self.opening_size)?;
+        out.serialize_field("equipped", &self.equipped)?;
+        out.end()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1009,7 +1551,8 @@ pub(super) struct WorldSimulationView {
     pub(super) recent_history: Vec<EventView>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct LocationSimulationView {
     pub(super) weather: String,
     pub(super) weather_intensity: u8,
@@ -1019,6 +1562,22 @@ pub(super) struct LocationSimulationView {
     pub(super) conflict_pressure: u8,
     pub(super) faction_influence: Vec<FactionInfluenceView>,
     pub(super) last_pulse_tick: u64,
+}
+
+impl Serialize for LocationSimulationView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("LocationSimulationView", 6)?;
+        out.serialize_field("weather", &self.weather)?;
+        out.serialize_field("trade_pressure", &self.trade_pressure)?;
+        out.serialize_field("imports", &self.imports)?;
+        out.serialize_field("conflict_pressure", &self.conflict_pressure)?;
+        out.serialize_field("faction_influence", &self.faction_influence)?;
+        out.serialize_field("last_pulse_tick", &self.last_pulse_tick)?;
+        out.end()
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1048,7 +1607,6 @@ pub(super) struct WorldLocationView {
     pub(super) description: String,
     pub(super) persona: String,
     pub(super) memory: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) interior_view: Option<InteriorViewMode>,
     pub(super) factions: Vec<FactionRefView>,
     pub(super) simulation: LocationSimulationView,
@@ -1068,7 +1626,8 @@ pub(super) struct WorldLocationView {
     pub(super) exits: Vec<ExitView>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct LocationView {
     pub(super) id: u64,
     pub(super) canonical_ref: String,
@@ -1079,10 +1638,23 @@ pub(super) struct LocationView {
     pub(super) description: String,
     pub(super) persona: String,
     pub(super) memory: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) interior_view: Option<InteriorViewMode>,
     pub(super) factions: Vec<FactionRefView>,
     pub(super) simulation: LocationSimulationView,
+}
+
+impl Serialize for LocationView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("LocationView", 4)?;
+        out.serialize_field("id", &self.id)?;
+        out.serialize_field("name", &self.name)?;
+        out.serialize_field("description", &self.description)?;
+        out.serialize_field("simulation", &self.simulation)?;
+        out.end()
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1109,7 +1681,7 @@ pub(super) struct FactionView {
     pub(super) member_actor_ids: Vec<u64>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub(super) struct ExitView {
     pub(super) route_id: String,
     pub(super) route_version: u64,
@@ -1120,8 +1692,23 @@ pub(super) struct ExitView {
     pub(super) distance: u8,
     pub(super) locked: bool,
     pub(super) accessible: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) threshold: Option<ThresholdOfferBinding>,
+}
+
+impl Serialize for ExitView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ExitView", 6)?;
+        out.serialize_field("destination_location_id", &self.destination_location_id)?;
+        out.serialize_field("destination_location_name", &self.destination_location_name)?;
+        out.serialize_field("route_label", &self.route_label)?;
+        out.serialize_field("distance", &self.distance)?;
+        out.serialize_field("locked", &self.locked)?;
+        out.serialize_field("accessible", &self.accessible)?;
+        out.end()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -1131,7 +1718,8 @@ pub(super) struct ExpeditionRingView {
     pub(super) needs_rest: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct ActorView {
     pub(super) id: u64,
     pub(super) canonical_ref: String,
@@ -1148,15 +1736,43 @@ pub(super) struct ActorView {
     pub(super) muted_by_you: bool,
     pub(super) blocked_by_you: bool,
     pub(super) location_id: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) relationship: Option<RelationshipPreviewView>,
     pub(super) factions: Vec<FactionRefView>,
-    #[serde(rename = "economy")]
     pub(super) resident_economy: Option<ResidentEconomyView>,
     pub(super) expedition_ring: ExpeditionRingView,
     pub(super) hp: i16,
     pub(super) bloodied: bool,
     pub(super) stats: StatView,
+}
+
+impl Serialize for ActorView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ActorView", 16)?;
+        out.serialize_field("id", &self.id)?;
+        out.serialize_field("name", &self.name)?;
+        out.serialize_field("title", &self.title)?;
+        out.serialize_field("description", &self.description)?;
+        out.serialize_field("practice", &self.practice)?;
+        out.serialize_field("control_mode", &self.control_mode)?;
+        out.serialize_field("kind", &self.kind)?;
+        out.serialize_field("status", &self.status)?;
+        out.serialize_field("muted_by_you", &self.muted_by_you)?;
+        out.serialize_field("blocked_by_you", &self.blocked_by_you)?;
+        out.serialize_field("location_id", &self.location_id)?;
+        if let Some(value) = &self.relationship {
+            out.serialize_field("relationship", value)?;
+        }
+        if let Some(value) = &self.resident_economy {
+            out.serialize_field("economy", value)?;
+        }
+        out.serialize_field("expedition_ring", &self.expedition_ring)?;
+        out.serialize_field("hp", &self.hp)?;
+        out.serialize_field("stats", &PublicStatView(&self.stats))?;
+        out.end()
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -1166,6 +1782,40 @@ pub(super) struct ActorSafetyView {
     pub(super) incoming_offers: Vec<TransferOfferView>,
     pub(super) outgoing_offers: Vec<TransferOfferView>,
     pub(super) gift_auto_accepts: Vec<GiftAutoAcceptView>,
+}
+
+struct PublicActorSafetyView<'a>(&'a ActorSafetyView);
+
+impl Serialize for PublicActorSafetyView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let incoming = self
+            .0
+            .incoming_offers
+            .iter()
+            .map(PublicTransferOfferView)
+            .collect::<Vec<_>>();
+        let outgoing = self
+            .0
+            .outgoing_offers
+            .iter()
+            .map(PublicTransferOfferView)
+            .collect::<Vec<_>>();
+        let gift_auto_accepts = self
+            .0
+            .gift_auto_accepts
+            .iter()
+            .map(PublicGiftAutoAcceptView)
+            .collect::<Vec<_>>();
+        let mut out = serializer.serialize_struct("ActorSafetyView", 4)?;
+        out.serialize_field("muted_actor_ids", &self.0.muted_actor_ids)?;
+        out.serialize_field("incoming_offers", &incoming)?;
+        out.serialize_field("outgoing_offers", &outgoing)?;
+        out.serialize_field("gift_auto_accepts", &gift_auto_accepts)?;
+        out.end()
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1186,6 +1836,26 @@ pub(super) struct TransferOfferView {
     pub(super) can_withdraw: bool,
 }
 
+struct PublicTransferOfferView<'a>(&'a TransferOfferView);
+
+impl Serialize for PublicTransferOfferView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("TransferOfferView", 6)?;
+        out.serialize_field("id", &self.0.id)?;
+        out.serialize_field("kind", &self.0.kind)?;
+        out.serialize_field("offered_by_actor_id", &self.0.offered_by_actor_id)?;
+        out.serialize_field("offered_to_actor_id", &self.0.offered_to_actor_id)?;
+        out.serialize_field("offered_item_name", &self.0.offered_item_name)?;
+        if let Some(item_name) = &self.0.requested_item_name {
+            out.serialize_field("requested_item_name", item_name)?;
+        }
+        out.end()
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub(super) struct GiftAutoAcceptView {
     pub(super) id: String,
@@ -1196,7 +1866,22 @@ pub(super) struct GiftAutoAcceptView {
     pub(super) expires_tick: u64,
 }
 
-#[derive(Clone, Debug, Serialize)]
+struct PublicGiftAutoAcceptView<'a>(&'a GiftAutoAcceptView);
+
+impl Serialize for PublicGiftAutoAcceptView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("GiftAutoAcceptView", 2)?;
+        out.serialize_field("offered_by_actor_id", &self.0.offered_by_actor_id)?;
+        out.serialize_field("item_id", &self.0.item_id)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct ResidentEconomyView {
     pub(super) held_item_ids: Vec<u64>,
     pub(super) held_items: Vec<ResidentHeldItemView>,
@@ -1217,7 +1902,33 @@ pub(super) struct ResidentEconomyView {
     pub(super) motive: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+impl Serialize for ResidentEconomyView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ResidentEconomyView", 9)?;
+        out.serialize_field("held_items", &self.held_items)?;
+        out.serialize_field("inventory_count", &self.inventory_count)?;
+        out.serialize_field("carried_weight_tenths", &self.carried_weight_tenths)?;
+        out.serialize_field("carrying_capacity_tenths", &self.carrying_capacity_tenths)?;
+        out.serialize_field("sought_items", &self.sought_items)?;
+        if let Some(value) = &self.request {
+            out.serialize_field("request", value)?;
+        }
+        if let Some(value) = &self.trade_offer {
+            out.serialize_field("trade_offer", value)?;
+        }
+        if let Some(value) = &self.trade_stance {
+            out.serialize_field("trade_stance", value)?;
+        }
+        out.serialize_field("motive", &self.motive)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct ResidentHeldItemView {
     pub(super) item_id: u64,
     pub(super) disposition: String,
@@ -1226,7 +1937,22 @@ pub(super) struct ResidentHeldItemView {
     pub(super) available_actions: Vec<String>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+impl Serialize for ResidentHeldItemView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ResidentHeldItemView", 4)?;
+        out.serialize_field("item_id", &self.item_id)?;
+        out.serialize_field("disposition", &self.disposition)?;
+        out.serialize_field("reason", &self.reason)?;
+        out.serialize_field("available_actions", &self.available_actions)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct ResidentSoughtItemView {
     pub(super) item_id: u64,
     pub(super) source: String,
@@ -1244,14 +1970,45 @@ pub(super) struct ResidentSoughtItemView {
     pub(super) salience: Option<u8>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+impl Serialize for ResidentSoughtItemView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ResidentSoughtItemView", 7)?;
+        out.serialize_field("item_id", &self.item_id)?;
+        out.serialize_field("world_status", &self.world_status)?;
+        out.serialize_field("world_location_name", &self.world_location_name)?;
+        out.serialize_field("world_holder_actor_id", &self.world_holder_actor_id)?;
+        out.serialize_field("world_holder_actor_name", &self.world_holder_actor_name)?;
+        out.serialize_field("memory_location_name", &self.memory_location_name)?;
+        out.serialize_field("holder_actor_name", &self.holder_actor_name)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct ResidentRequestView {
     pub(super) item_id: u64,
     pub(super) holder_actor_id: u64,
     pub(super) reason: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+impl Serialize for ResidentRequestView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ResidentRequestView", 2)?;
+        out.serialize_field("item_id", &self.item_id)?;
+        out.serialize_field("reason", &self.reason)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct ResidentTradeOfferView {
     pub(super) offered_item_id: u64,
     pub(super) requested_item_id: u64,
@@ -1259,13 +2016,42 @@ pub(super) struct ResidentTradeOfferView {
     pub(super) reason: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+impl Serialize for ResidentTradeOfferView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ResidentTradeOfferView", 4)?;
+        out.serialize_field("offered_item_id", &self.offered_item_id)?;
+        out.serialize_field("requested_item_id", &self.requested_item_id)?;
+        out.serialize_field("willingness", &self.willingness)?;
+        out.serialize_field("reason", &self.reason)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
 pub(super) struct ResidentTradeStanceView {
     pub(super) offered_item_id: u64,
     pub(super) requested_item_id: u64,
     pub(super) willingness: String,
     pub(super) reason: String,
     pub(super) accepted: bool,
+}
+
+impl Serialize for ResidentTradeStanceView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ResidentTradeStanceView", 4)?;
+        out.serialize_field("offered_item_id", &self.offered_item_id)?;
+        out.serialize_field("requested_item_id", &self.requested_item_id)?;
+        out.serialize_field("willingness", &self.willingness)?;
+        out.serialize_field("reason", &self.reason)?;
+        out.end()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1280,7 +2066,22 @@ pub(super) struct StatView {
     pub(super) level: u8,
 }
 
-#[derive(Debug, Serialize)]
+struct PublicStatView<'a>(&'a StatView);
+
+impl Serialize for PublicStatView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("StatView", 2)?;
+        out.serialize_field("hp_base", &self.0.hp_base)?;
+        out.serialize_field("level", &self.0.level)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct ItemView {
     pub(super) id: u64,
     pub(super) canonical_ref: String,
@@ -1304,6 +2105,31 @@ pub(super) struct ItemView {
     pub(super) charges: u8,
 }
 
+impl Serialize for ItemView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ItemView", 15)?;
+        out.serialize_field("id", &self.id)?;
+        out.serialize_field("name", &self.name)?;
+        out.serialize_field("description", &self.description)?;
+        out.serialize_field("kind", &self.kind)?;
+        out.serialize_field("role", &self.role)?;
+        out.serialize_field("weight_tenths", &self.weight_tenths)?;
+        out.serialize_field("size", &self.size)?;
+        out.serialize_field("container_capacity_tenths", &self.container_capacity_tenths)?;
+        out.serialize_field("skill_id", &self.skill_id)?;
+        out.serialize_field("skill_bonus", &self.skill_bonus)?;
+        out.serialize_field("zone", &self.zone)?;
+        out.serialize_field("container_item_id", &self.container_item_id)?;
+        out.serialize_field("location_id", &self.location_id)?;
+        out.serialize_field("holder_actor_id", &self.holder_actor_id)?;
+        out.serialize_field("charges", &self.charges)?;
+        out.end()
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub(super) struct RoomFeatureView {
     pub(super) key: String,
@@ -1324,7 +2150,8 @@ pub(super) struct RoomFeatureUseView {
     pub(super) effect: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct ClockView {
     pub(super) id: String,
     pub(super) scope: String,
@@ -1335,6 +2162,20 @@ pub(super) struct ClockView {
     pub(super) segments: u8,
     pub(super) filled: u8,
     pub(super) status: String,
+}
+
+impl Serialize for ClockView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("ClockView", 4)?;
+        out.serialize_field("id", &self.id)?;
+        out.serialize_field("kind", &self.kind)?;
+        out.serialize_field("segments", &self.segments)?;
+        out.serialize_field("filled", &self.filled)?;
+        out.end()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1351,7 +2192,8 @@ pub(super) struct SharedQuestionStrategyView {
     pub(super) availability_reason: String,
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct SharedQuestionContributionView {
     pub(super) actor_id: u64,
     pub(super) actor_name: String,
@@ -1359,6 +2201,17 @@ pub(super) struct SharedQuestionContributionView {
     pub(super) target_label: String,
     pub(super) progress: u8,
     pub(super) event_seq: u64,
+}
+
+impl Serialize for SharedQuestionContributionView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("SharedQuestionContributionView", 1)?;
+        out.serialize_field("event_seq", &self.event_seq)?;
+        out.end()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1380,7 +2233,8 @@ pub(super) struct SharedQuestionSuggestionView {
     pub(super) risk: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct SharedQuestionView {
     pub(super) id: String,
     pub(super) provenance: String,
@@ -1414,6 +2268,33 @@ pub(super) struct SharedQuestionView {
     pub(super) updated_event_seq: Option<u64>,
 }
 
+impl Serialize for SharedQuestionView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("SharedQuestionView", 14)?;
+        out.serialize_field("id", &self.id)?;
+        out.serialize_field("question", &self.question)?;
+        out.serialize_field("presentation_state", &self.presentation_state)?;
+        out.serialize_field("promoted", &self.promoted)?;
+        if let Some(rank) = &self.promotion_rank {
+            out.serialize_field("promotion_rank", rank)?;
+        }
+        out.serialize_field("situation", &self.situation)?;
+        out.serialize_field("progress_clock_id", &self.progress_clock_id)?;
+        out.serialize_field("filled", &self.filled)?;
+        out.serialize_field("segments", &self.segments)?;
+        out.serialize_field("danger_filled", &self.danger_filled)?;
+        out.serialize_field("danger_segments", &self.danger_segments)?;
+        out.serialize_field("recent_contributions", &self.recent_contributions)?;
+        if let Some(event_seq) = &self.updated_event_seq {
+            out.serialize_field("updated_event_seq", event_seq)?;
+        }
+        out.end()
+    }
+}
+
 fn shared_question_attention_rank(attention: &str) -> u8 {
     match attention {
         "immediate" => 4,
@@ -1434,7 +2315,8 @@ fn shared_question_state_rank(state: &str) -> u8 {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct TagView {
     pub(super) id: String,
     pub(super) scope: String,
@@ -1444,7 +2326,22 @@ pub(super) struct TagView {
     pub(super) expires: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for TagView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("TagView", 4)?;
+        out.serialize_field("id", &self.id)?;
+        out.serialize_field("scope", &self.scope)?;
+        out.serialize_field("scope_id", &self.scope_id)?;
+        out.serialize_field("label", &self.label)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct JobView {
     pub(super) id: String,
     pub(super) premise: String,
@@ -1461,7 +2358,21 @@ pub(super) struct JobView {
     pub(super) narrated_thresholds: Vec<JobNarratedThreshold>,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for JobView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("JobView", 3)?;
+        out.serialize_field("id", &self.id)?;
+        out.serialize_field("status", &self.status)?;
+        out.serialize_field("progress_clock_id", &self.progress_clock_id)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct FrontView {
     pub(super) id: String,
     pub(super) premise: String,
@@ -1476,6 +2387,20 @@ pub(super) struct FrontView {
     pub(super) portent_clock_id: String,
     pub(super) job_ids: Vec<String>,
     pub(super) impending_outcome: String,
+}
+
+impl Serialize for FrontView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("FrontView", 4)?;
+        out.serialize_field("premise", &self.premise)?;
+        out.serialize_field("presentation_state", &self.presentation_state)?;
+        out.serialize_field("outcome_statement", &self.outcome_statement)?;
+        out.serialize_field("stakes_questions", &self.stakes_questions)?;
+        out.end()
+    }
 }
 
 fn front_presentation(
@@ -1515,7 +2440,6 @@ pub(super) struct RoomSheetView {
     pub(super) hooks: Vec<String>,
     pub(super) resources: BTreeMap<String, i16>,
     pub(super) natural_features: Vec<NaturalFeatureState>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) generated_place: Option<GeneratedPlaceView>,
     pub(super) eligible_building_archetypes: Vec<String>,
     pub(super) governance_decisions: Vec<GovernanceDecisionView>,
@@ -1525,10 +2449,38 @@ pub(super) struct RoomSheetView {
     pub(super) projects: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+struct PublicRoomSheetView<'a>(&'a RoomSheetView);
+
+impl Serialize for PublicRoomSheetView<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut out = serializer.serialize_struct("RoomSheetView", 3)?;
+        out.serialize_field("safety", &value.safety)?;
+        out.serialize_field("zone", &value.zone)?;
+        out.serialize_field("hooks", &value.hooks)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct CallingView {
     pub(super) actor_id: u64,
     pub(super) statement: String,
+}
+
+impl Serialize for CallingView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("CallingView", 1)?;
+        out.serialize_field("statement", &self.statement)?;
+        out.end()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1540,7 +2492,8 @@ pub(super) struct SkillView {
     pub(super) bonus: i16,
 }
 
-#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct VisitLedgerView {
     pub(super) journal_ref: Option<String>,
     pub(super) entity_version: u64,
@@ -1552,7 +2505,21 @@ pub(super) struct VisitLedgerView {
     pub(super) unbanked_marks: Vec<VisitLedgerMarkView>,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for VisitLedgerView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("VisitLedgerView", 3)?;
+        out.serialize_field("unbanked_count", &self.unbanked_count)?;
+        out.serialize_field("advancement_points", &self.advancement_points)?;
+        out.serialize_field("unbanked_marks", &self.unbanked_marks)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct VisitLedgerMarkView {
     pub(super) id: String,
     pub(super) category: String,
@@ -1560,7 +2527,20 @@ pub(super) struct VisitLedgerMarkView {
     pub(super) source_event_seq: u64,
 }
 
-#[derive(Debug, Serialize)]
+impl Serialize for VisitLedgerMarkView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("VisitLedgerMarkView", 2)?;
+        out.serialize_field("category", &self.category)?;
+        out.serialize_field("label", &self.label)?;
+        out.end()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(super) struct BondView {
     pub(super) id: String,
     pub(super) canonical_ref: String,
@@ -1575,6 +2555,21 @@ pub(super) struct BondView {
     pub(super) updated_event_seq: Option<u64>,
     pub(super) dialogue_status: String,
     pub(super) dialogue_event_seq: Option<u64>,
+}
+
+impl Serialize for BondView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut out = serializer.serialize_struct("BondView", 5)?;
+        out.serialize_field("target_actor_id", &self.target_actor_id)?;
+        out.serialize_field("target_actor_name", &self.target_actor_name)?;
+        out.serialize_field("statement", &self.statement)?;
+        out.serialize_field("strength", &self.strength)?;
+        out.serialize_field("status", &self.status)?;
+        out.end()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -2834,6 +3829,16 @@ impl RuntimeWorld {
             .map(|actor| self.actor_view_for_client(actor, projection_viewer_id))
             .collect();
         let visible_actor_ids = actors.iter().map(|actor| actor.id).collect::<BTreeSet<_>>();
+        let command_context = client_actor_id.and_then(|id| {
+            actors
+                .iter()
+                .find(|candidate| candidate.id == id)
+                .map(|actor| CommandContextView {
+                    actor_ref: actor.canonical_ref.clone(),
+                    actor_version: actor.entity_version,
+                    location_version: location.entity_version,
+                })
+        });
 
         let items: Vec<ItemView> = self.world.items[..self.world.item_count]
             .iter()
@@ -2937,7 +3942,12 @@ impl RuntimeWorld {
             .take(80)
             .cloned()
             .collect::<Vec<_>>();
-        let journal_beats = journal_beat_views(&recent_events, location_id);
+        let room_event_seq = recent_events.first().map(|event| event.seq).unwrap_or(0);
+        let mut journal_beats = journal_beat_views(&recent_events, location_id);
+        if journal_beats.len() > 60 {
+            let excess = journal_beats.len() - 60;
+            journal_beats.drain(0..excess);
+        }
         let room_memory = fallback_room_memory_view(&location, &recent_events);
         let spatial_scene = self.spatial_scene_view(
             client_actor_id,
@@ -2951,7 +3961,9 @@ impl RuntimeWorld {
             world_id: OFFICIAL_WORLD_ID.to_string(),
             world_epoch: OFFICIAL_WORLD_EPOCH,
             world_seq: self.world.next_event_seq.saturating_sub(1),
+            room_event_seq,
             state_revision: self.current_state_revision(),
+            command_context,
             rules_context: self
                 .scene_rules_context(location_id, self.world.next_event_seq.saturating_sub(1)),
             spatial_scene,

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -259,4 +259,4 @@
 # main as a thin async entry point without changing boot or shutdown order.
 # 67709 -> 67675: move canonical entity-version conflict coverage beside the
 # canonical identity seam while adding typed stale-observation responses.
-67675
+67616

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -105,8 +105,10 @@ async function assertSignedWalletSession() {
     .then((response) => response.json());
   const world = await fetch(`${baseUrl}/world?wallet_session=${encodeURIComponent(session.wallet_session)}`)
     .then((response) => response.json());
-  assert(state.account?.linked_wallet_address === signedSmokeWalletAddress, "signed wallet link did not round-trip");
+  assert(state.account === undefined, "ordinary state must not expose account identity");
+  assert(!JSON.stringify(state).includes(signedSmokeWalletAddress), "ordinary state echoed a wallet identity");
   assert(state.access === undefined, `ordinary state must not expose wallet access: ${JSON.stringify(state.access)}`);
+  assert(state.recent_events === undefined, "ordinary state must not duplicate the /events history feed");
   assert((world.locations || []).every((location) => location.public && location.accessible), `wallet linking must not gate world locations: ${JSON.stringify(world.locations)}`);
   assert(!JSON.stringify(state).match(/owned_card_ids|owned_box_ids|unopened_pack_ids|materialization_receipts/), `ordinary state must omit retired ownership projections: ${JSON.stringify(state.account)}`);
   return {
@@ -2378,11 +2380,26 @@ async function main() {
         }))),
         `two same-kind current offers must remain two distinct exact cards: ${JSON.stringify(family)}`,
       );
+      for (const submission of family.submissions) {
+        for (const internal of [
+          "rules_action",
+          "operation",
+          "rules_profile",
+          "state_revision",
+          "route",
+          "target",
+          "cost",
+        ]) {
+          assert(
+            !Object.hasOwn(submission.payload, internal),
+            `browser submission must not echo internal offer field ${internal}: ${JSON.stringify(submission)}`,
+          );
+        }
+      }
       assert(
         JSON.stringify(family.submissions.map((submission) => ({
           path: submission.path,
           offerId: submission.payload.offer_id,
-          target: submission.payload.target,
           payload: {
             actor_id: submission.payload.payload.actor_id,
             ...(submission.payload.payload.item_id !== undefined ? { item_id: submission.payload.payload.item_id } : {}),
@@ -2395,7 +2412,6 @@ async function main() {
         }))) === JSON.stringify(expected.map((entry) => ({
           path: entry.path,
           offerId: entry.offerId,
-          target: entry.target,
           payload: entry.payload,
         }))),
         `each exact card must submit its own certificate and payload target tuple: ${JSON.stringify(family)}`,
@@ -7775,10 +7791,10 @@ async function main() {
         ]);
         const afterReplayReset = logEvents.map((event) => ({ seq: event.seq, content: event.content }));
         const detectsServerTimelineRewind = transcriptTimelineRewound({
-          recent_events: [message(83, 5000, "Moss Stitch", "rebuilt history")],
+          room_event_seq: 83,
         }, 92);
         const acceptsForwardTimeline = !transcriptTimelineRewound({
-          recent_events: [message(93, 5000, "Moss Stitch", "new history")],
+          room_event_seq: 93,
         }, 92);
         const oldRoomLine = message(300, 5000, "Moss Stitch", "old room history");
         const newRoomLine = {

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -9619,7 +9619,7 @@ async function main() {
         && refreshInFlight === null
         && document.querySelector("#action-modal")?.hidden === true
     ), null, { timeout: 35_000 });
-    const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
+    const deckSize = await fetchInspectableDeckSize();
     let candidates = [];
     for (let draw = 0; draw < Math.min(attempts, deckSize); draw += 1) {
       if (stopWhen && await stopWhen()) return null;
@@ -9663,7 +9663,7 @@ async function main() {
         && document.querySelector("#action-modal")?.hidden === true
     ), null, { timeout: 35_000 });
     const normalizedNeedles = needles.map((needle) => needle.toLowerCase());
-    const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
+    const deckSize = await fetchInspectableDeckSize();
     let result = null;
     for (let draw = 0; draw < deckSize; draw += 1) {
       if (stopWhen && await stopWhen()) return null;
@@ -9848,7 +9848,7 @@ async function main() {
     ));
     if (!inspectIsLegal) return null;
 
-    const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
+    const deckSize = await fetchInspectableDeckSize();
     const drawLimit = deckSize;
     let lastHand = [];
     for (let draw = 0; draw < drawLimit; draw += 1) {
@@ -9997,7 +9997,7 @@ async function main() {
       };
     }, needle);
     let last = null;
-    const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
+    const deckSize = await fetchInspectableDeckSize();
     for (let attempt = 1; attempt <= deckSize; attempt += 1) {
       const result = await focus();
       const primary = String(result?.text || "");
@@ -10401,7 +10401,7 @@ async function main() {
     let lastHand = [];
     let lastScene = {};
     let staleAttempts = 0;
-    const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 8)));
+    const deckSize = await fetchInspectableDeckSize();
     for (let draw = 0; draw < deckSize;) {
       await page.waitForFunction(() => (
         actionBusy === false
@@ -10560,6 +10560,29 @@ async function main() {
     });
   }
 
+  async function fetchInspectableDeckSize() {
+    const result = await page.evaluate(async () => {
+      const actorId = localStorage.getItem("cosyworld.actorId");
+      const actorSession = localStorage.getItem("cosyworld.actorSession");
+      const params = new URLSearchParams({
+        actor_id: actorId,
+        actor_session: actorSession,
+      });
+      const response = await fetch(`/inspect?${params}`);
+      const inspection = await response.json();
+      return {
+        ok: response.ok,
+        status: response.status,
+        deckSize: (inspection.actions || []).length,
+      };
+    });
+    assert(
+      result.ok && result.deckSize > 0,
+      `inspector should expose the bounded developer action deck: ${JSON.stringify(result)}`,
+    );
+    return result.deckSize;
+  }
+
   async function reconcileActionHand() {
     await page.waitForFunction(() => (
       actionBusy === false && refreshInFlight === null
@@ -10712,9 +10735,7 @@ async function main() {
         await page.evaluate(() => refresh());
         continue;
       }
-      const journeyDeckSize = await page.evaluate(() => (
-        Math.max(1, Number(state?.action_hand?.deck_size || 1))
-      ));
+      const journeyDeckSize = await fetchInspectableDeckSize();
       for (let draw = 1; !focusedJourneyStep && draw < journeyDeckSize; draw += 1) {
         await passCertifiedHandForDraw(`continue journey toward ${nextName}`);
         focusedJourneyStep = await focusJourneyStep();
@@ -11204,8 +11225,8 @@ async function main() {
           return { kind: "loose", location: location.name };
         }
         const holder = (location.actors || []).find((actor) => (
-          (actor.economy?.held_item_ids || []).some((heldId) => (
-            Number(heldId) === Number(expectedId)
+          (actor.economy?.held_items || []).some((heldItem) => (
+            Number(heldItem.item_id) === Number(expectedId)
           ))
         ));
         if (holder) {
@@ -11399,7 +11420,7 @@ async function main() {
         && refreshInFlight === null
         && document.querySelector("#action-modal")?.hidden === true
     ), null, { timeout: 35_000 });
-    const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
+    const deckSize = await fetchInspectableDeckSize();
     let result = null;
     for (let draw = 0; draw < deckSize; draw += 1) {
       result = await page.evaluate((residentName) => {
@@ -11483,7 +11504,9 @@ async function main() {
       const world = await fetch(`/world?${params}`).then((worldResponse) => worldResponse.json());
       const target = (world.locations || []).flatMap((location) => location.actors || [])
         .find((actor) => Number(actor.id || 0) === Number(targetActorId));
-      return (target?.economy?.held_item_ids || []).some((heldId) => Number(heldId) === Number(itemId));
+      return (target?.economy?.held_items || []).some((heldItem) => (
+        Number(heldItem.item_id) === Number(itemId)
+      ));
     }, submission);
     if (!transferVerified) {
       steps.push({
@@ -11683,10 +11706,16 @@ async function main() {
       holder: transferReceipt.target_actor_name || `actor:${transferReceipt.target_actor_id}`,
     });
     await page.evaluate(() => refresh());
-    const settledPlacement = await worldItemPlacement(itemName, placement.targetItemId);
+    const stillHeldByPlayer = await page.evaluate(({ expectedName, expectedId }) => {
+      const currentActorId = Number(actorId || 0);
+      const projected = (state?.items || []).find((item) => (
+        Number(item.id || 0) === Number(expectedId) || item.name === expectedName
+      ));
+      return Number(projected?.holder_actor_id || 0) === currentActorId;
+    }, { expectedName: itemName, expectedId: placement.targetItemId });
     assert(
-      settledPlacement && settledPlacement.kind !== "player",
-      `${itemName} should leave the player's hand after its item.given receipt: ${JSON.stringify(settledPlacement)}`,
+      !stillHeldByPlayer,
+      `${itemName} should leave the player's public inventory after its item.given receipt`,
     );
   }
 
@@ -11718,7 +11747,9 @@ async function main() {
             for (const item of expected) {
               if (
                 resident.kind === "npc"
-                && (resident.economy?.held_item_ids || []).includes(item.itemId)
+                && (resident.economy?.held_items || []).some((heldItem) => (
+                  Number(heldItem.item_id) === Number(item.itemId)
+                ))
               ) {
                 const claim = { ...item, actualResidentName: resident.name, location: location.name };
                 if (resident.name === item.residentName) held.push(claim);
@@ -11851,7 +11882,9 @@ async function main() {
             (location.actors || []).some((resident) => (
               expected.some((item) => (
                 resident.name === item.residentName
-                  && (resident.economy?.held_item_ids || []).includes(Number(item.itemId))
+                  && (resident.economy?.held_items || []).some((heldItem) => (
+                    Number(heldItem.item_id) === Number(item.itemId)
+                  ))
               ))
             ))
           ));
@@ -12170,10 +12203,9 @@ async function main() {
         await queueRefresh();
         while (refreshInFlight) await refreshInFlight;
         const target = actorForId(targetActorId);
-        const reporter = actorForId(actorId);
         return {
           targetName: target?.name || "",
-          reporterVersion: Number(reporter?.entity_version || 0),
+          reporterVersion: Number(state?.command_context?.actor_version || 0),
         };
       }, nearbyActor.id);
       assert(
@@ -12305,7 +12337,7 @@ async function main() {
       assert(firstTaleStart.primary.toLowerCase().startsWith("notice"), `second player should enter through a welcoming Notice: ${JSON.stringify(firstTaleStart)}`);
       await playOtherPrimary("second-player Notice", () => (
         state?.first_tale?.phase === "follow_lead"
-        && state?.first_tale?.public_trace_created === false
+        && state?.first_tale?.trace_event_seq == null
         && actionBusy === false
         && document.querySelector("#action-modal")?.hidden === true
       ));
@@ -14610,7 +14642,6 @@ async function main() {
     return {
       phase: continuation.phase || "",
       destinationLocationId: Number(continuation.destination_location_id || 0),
-      jobId: String(continuation.job_id || ""),
       instruction: String(continuation.instruction || ""),
       advancingOfferId: String(continuation.advancing_offer_id || ""),
       guideActionKey: String(guide?.actionKey || ""),
@@ -14621,7 +14652,6 @@ async function main() {
   assert(
     lanternHandoff.phase === "travel"
       && lanternHandoff.destinationLocationId === 800
-      && lanternHandoff.jobId === "lantern-keeper:rekindle-the-beacon"
       && /Wayside Lantern Inn/i.test(lanternHandoff.instruction)
       && lanternHandoff.advancingOfferId
       && lanternHandoff.handOfferIds.includes(lanternHandoff.advancingOfferId)
@@ -14791,7 +14821,7 @@ async function main() {
         const loose = (location.items || []).find((item) => item.name === "Hearthstone Tag");
         if (loose) return { location: location.name, holder: "" };
         const holder = (location.actors || []).find((actor) => (
-          (actor.economy?.held_item_ids || []).includes(2006)
+          (actor.economy?.held_items || []).some((heldItem) => Number(heldItem.item_id) === 2006)
         ));
         if (holder) return { location: location.name, holder: holder.name };
       }
@@ -14862,7 +14892,7 @@ async function main() {
           && document.querySelector("#action-modal")?.hidden === true
       ), null, { timeout: 35_000 });
       const normalizedNeedles = needles.map((needle) => needle.toLowerCase());
-      const deckSize = await page.evaluate(() => Math.max(1, Number(state?.action_hand?.deck_size || 1)));
+      const deckSize = await fetchInspectableDeckSize();
       let lastHand = [];
       let combatResets = 0;
       for (let draw = 0; draw < deckSize; draw += 1) {
@@ -15209,9 +15239,7 @@ async function main() {
           }
         }
         if (!featureUseCommitted) {
-          const primerDeckSize = await page.evaluate(() => (
-            Math.max(1, Number(state?.action_hand?.deck_size || 1))
-          ));
+          const primerDeckSize = await fetchInspectableDeckSize();
           for (let draw = 1; draw <= primerDeckSize && !featureUseCommitted; draw += 1) {
             const beforePass = await moonlitProjectStatus();
             featureUseCommitted = beforePass.completed
@@ -15623,7 +15651,7 @@ async function main() {
       const world = await fetch(`/world?${params}`).then((response) => response.json());
       for (const location of world.locations || []) {
         const holder = (location.actors || []).find((actor) => (
-          (actor.economy?.held_item_ids || []).includes(2004)
+          (actor.economy?.held_items || []).some((heldItem) => Number(heldItem.item_id) === 2004)
         ));
         if (holder) return { name: holder.name, location: location.name };
       }
@@ -15771,7 +15799,9 @@ async function main() {
         for (const item of expectedItems) {
           if (
             resident.name === item.resident
-              && (resident.economy?.held_item_ids || []).includes(item.itemId)
+              && (resident.economy?.held_items || []).some((heldItem) => (
+                Number(heldItem.item_id) === Number(item.itemId)
+              ))
           ) {
             residentItemState.push({
               type: "item.held",

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -263,12 +263,47 @@ function stateUrl(baseUrl, actorId, actorSession) {
   return `${baseUrl}/state?${query}`;
 }
 
+function inspectUrl(baseUrl, actorId, actorSession) {
+  const query = new URLSearchParams({
+    actor_id: String(actorId),
+    actor_session: actorSession,
+  });
+  return `${baseUrl}/inspect?${query}`;
+}
+
+async function fetchInspectableState(baseUrl, actorId, actorSession) {
+  const [state, inspection] = await Promise.all([
+    fetchJson(stateUrl(baseUrl, actorId, actorSession)),
+    fetchJson(inspectUrl(baseUrl, actorId, actorSession)),
+  ]);
+  const internalActions = new Map(
+    (inspection.actions || []).map((action) => [action.offer_id, action]),
+  );
+  return {
+    ...state,
+    action_offers: (state.action_offers || []).map((offer) => ({
+      ...(internalActions.get(offer.offer_id) || {}),
+      ...offer,
+    })),
+    action_hand: {
+      ...(state.action_hand || {}),
+      deck_size: (inspection.actions || []).length,
+    },
+    __inspection: inspection,
+  };
+}
+
+function inspectedRulesContext(state) {
+  return (state?.__inspection?.actions || [])
+    .map((action) => action.composition_trace?.rules_context)
+    .find((context) => context !== undefined) ?? null;
+}
+
 function offerEnvelope(state, actorId, offerId) {
-  const actor = state.actors?.find((candidate) => candidate.id === actorId) ?? {};
   return {
     world_id: state.world_id ?? "world://cosyworld/official",
     intent_id: `smoke:offer:${actorId}:${createHash("sha256").update(offerId).digest("hex")}`,
-    actor_ref: actor.canonical_ref ?? "",
+    actor_ref: state.command_context?.actor_ref ?? "",
     observed: {},
     last_world_seq: Number(state.world_seq ?? 0),
   };
@@ -278,7 +313,7 @@ async function passCurrentHand(baseUrl, actorId, actorSession, initialState) {
   let state = initialState;
   for (let attempt = 0; attempt < 5; attempt += 1) {
     if (!state || attempt > 0) {
-      state = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+      state = await fetchInspectableState(baseUrl, actorId, actorSession);
     }
     const pass = state.action_hand?.pass;
     assert(pass?.offer_id, `a bounded deal must expose Think: ${JSON.stringify(state.action_hand)}`);
@@ -306,7 +341,7 @@ async function passCurrentHand(baseUrl, actorId, actorSession, initialState) {
 }
 
 async function drawExactOffer(baseUrl, actorId, actorSession, predicate, label) {
-  let state = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  let state = await fetchInspectableState(baseUrl, actorId, actorSession);
   const deckSize = Math.max(1, Number(state.action_hand?.deck_size) || 1);
   for (let attempt = 0; attempt < deckSize; attempt += 1) {
     const dealtIds = new Set((state.action_hand?.entries || []).map((entry) => entry.offer_id));
@@ -314,7 +349,7 @@ async function drawExactOffer(baseUrl, actorId, actorSession, predicate, label) 
       dealtIds.has(candidate.offer_id) && predicate(candidate));
     if (offer) return offer;
     await passCurrentHand(baseUrl, actorId, actorSession, state);
-    state = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+    state = await fetchInspectableState(baseUrl, actorId, actorSession);
   }
   throw new Error(`${label} was not dealt in one bounded rotation: ${JSON.stringify(state.action_hand)}`);
 }
@@ -394,7 +429,7 @@ async function submitOffer(
 async function discoverExit(baseUrl, actorId, actorSession, destinationLocationId) {
   await commandExactOffer(baseUrl, actorId, actorSession, "listen");
   for (let attempt = 0; attempt < 32; attempt += 1) {
-    const state = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+    const state = await fetchInspectableState(baseUrl, actorId, actorSession);
     if (state.exits?.some((exit) =>
       exit.destination_location_id === destinationLocationId
       && exit.accessible === true
@@ -415,11 +450,12 @@ async function assertContext(baseUrl, actorId, actorSession, state, {
   sourceCard,
 }) {
   assert(state.location?.name === location, `expected ${location}: ${JSON.stringify(state.location)}`);
+  const rulesContext = inspectedRulesContext(state);
   assert(
-    state.rules_context?.location_pack_id === locationPack
-      && state.rules_context?.selected_by_pack_id === selectedBy
-      && state.rules_context?.capability_id === capability,
-    `wrong rules context at ${location}: ${JSON.stringify(state.rules_context)}`,
+    rulesContext?.location_pack_id === locationPack
+      && rulesContext?.selected_by_pack_id === selectedBy
+      && rulesContext?.capability_id === capability,
+    `wrong rules context at ${location}: ${JSON.stringify(rulesContext)}`,
   );
   const contextOffer = await drawExactOffer(
     baseUrl,
@@ -472,7 +508,7 @@ async function main() {
     assert(created.ok && created.actor?.id && created.actor_session, JSON.stringify(created));
     const actorId = created.actor.id;
     const actorSession = created.actor_session;
-    const sourceCottage = await fetchJson(stateUrl(source.baseUrl, actorId, actorSession));
+    const sourceCottage = await fetchInspectableState(source.baseUrl, actorId, actorSession);
     await assertContext(source.baseUrl, actorId, actorSession, sourceCottage, {
       location: "The Cosy Cottage",
       locationPack: "cosyworld.core",
@@ -524,7 +560,7 @@ async function main() {
       `wrong mounted packs: ${JSON.stringify(first.meta.worldpack?.packs)}`,
     );
 
-    const cottage = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
+    const cottage = await fetchInspectableState(first.baseUrl, actorId, actorSession);
     await assertContext(first.baseUrl, actorId, actorSession, cottage, {
       location: "The Cosy Cottage",
       locationPack: "cosyworld.core",
@@ -571,7 +607,7 @@ async function main() {
           && event.content?.includes("scene composition changed")),
       `tampered composition certificate did not fail closed: ${JSON.stringify(rejectedTravel)}`,
     );
-    const afterRejectedTravel = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
+    const afterRejectedTravel = await fetchInspectableState(first.baseUrl, actorId, actorSession);
     assert(
       afterRejectedTravel.location?.id === cottage.location.id
         && afterRejectedTravel.world_seq === travelOffer.state_revision,
@@ -601,7 +637,7 @@ async function main() {
       `wrong Core → Ruby transition: ${firstTransition.content}`,
     );
 
-    const homeroom = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
+    const homeroom = await fetchInspectableState(first.baseUrl, actorId, actorSession);
     await assertContext(first.baseUrl, actorId, actorSession, homeroom, {
       location: "Homeroom",
       locationPack: "ruby-high.first-bell",
@@ -619,7 +655,7 @@ async function main() {
       second.output.some((line) => line.includes("loaded journal checkpoint")),
       `restart did not use the journal checkpoint: ${second.output.slice(-40).join("")}`,
     );
-    const replayed = await fetchJson(stateUrl(second.baseUrl, actorId, actorSession));
+    const replayed = await fetchInspectableState(second.baseUrl, actorId, actorSession);
     await assertContext(second.baseUrl, actorId, actorSession, replayed, {
       location: "Homeroom",
       locationPack: "ruby-high.first-bell",
@@ -649,7 +685,7 @@ async function main() {
       returnedCore.events?.some((event) => event.type === "rules_context.changed"),
       `Ruby → Core transition missing: ${JSON.stringify(returnedCore.events)}`,
     );
-    const returned = await fetchJson(stateUrl(second.baseUrl, actorId, actorSession));
+    const returned = await fetchInspectableState(second.baseUrl, actorId, actorSession);
     await assertContext(second.baseUrl, actorId, actorSession, returned, {
       location: "The Cosy Cottage",
       locationPack: "cosyworld.core",
@@ -716,7 +752,7 @@ async function main() {
           || pack.id === "cosyworld.composition.core-ruby"),
       `Ruby or its bridge remained mounted: ${JSON.stringify(coreOnly.meta.worldpack)}`,
     );
-    const whileUnmounted = await fetchJson(stateUrl(coreOnly.baseUrl, actorId, actorSession));
+    const whileUnmounted = await fetchInspectableState(coreOnly.baseUrl, actorId, actorSession);
     await assertContext(coreOnly.baseUrl, actorId, actorSession, whileUnmounted, {
       location: "The Cosy Cottage",
       locationPack: "cosyworld.core",
@@ -778,7 +814,7 @@ async function main() {
       remounted.output.some((line) => line.includes("loaded journal checkpoint")),
       `remounted restart did not use the journal checkpoint: ${remounted.output.slice(-40).join("")}`,
     );
-    const afterRemount = await fetchJson(stateUrl(remounted.baseUrl, actorId, actorSession));
+    const afterRemount = await fetchInspectableState(remounted.baseUrl, actorId, actorSession);
     await assertContext(remounted.baseUrl, actorId, actorSession, afterRemount, {
       location: "The Cosy Cottage",
       locationPack: "cosyworld.core",
@@ -804,7 +840,7 @@ async function main() {
       "remount did not restore the discovered Ruby bridge identity",
     );
     await move(remounted.baseUrl, actorId, actorSession, 11);
-    const restoredHomeroom = await fetchJson(stateUrl(remounted.baseUrl, actorId, actorSession));
+    const restoredHomeroom = await fetchInspectableState(remounted.baseUrl, actorId, actorSession);
     await assertContext(remounted.baseUrl, actorId, actorSession, restoredHomeroom, {
       location: "Homeroom",
       locationPack: "ruby-high.first-bell",

--- a/v2/scripts/smoke-standalone-compositions.mjs
+++ b/v2/scripts/smoke-standalone-compositions.mjs
@@ -392,6 +392,42 @@ function stateUrl(baseUrl, actorId, actorSession) {
   return `${baseUrl}/state?${query}`;
 }
 
+function inspectUrl(baseUrl, actorId, actorSession) {
+  const query = new URLSearchParams({
+    actor_id: String(actorId),
+    actor_session: actorSession,
+  });
+  return `${baseUrl}/inspect?${query}`;
+}
+
+async function fetchInspectableState(baseUrl, actorId, actorSession) {
+  const [state, inspection] = await Promise.all([
+    fetchJson(stateUrl(baseUrl, actorId, actorSession)),
+    fetchJson(inspectUrl(baseUrl, actorId, actorSession)),
+  ]);
+  const internalActions = new Map(
+    (inspection.actions || []).map((action) => [action.offer_id, action]),
+  );
+  return {
+    ...state,
+    action_offers: (state.action_offers || []).map((offer) => ({
+      ...(internalActions.get(offer.offer_id) || {}),
+      ...offer,
+    })),
+    action_hand: {
+      ...(state.action_hand || {}),
+      deck_size: (inspection.actions || []).length,
+    },
+    __inspection: inspection,
+  };
+}
+
+function inspectedRulesContext(state) {
+  return (state?.__inspection?.actions || [])
+    .map((action) => action.composition_trace?.rules_context)
+    .find((context) => context !== undefined) ?? null;
+}
+
 async function fetchAllActorEvents(baseUrl, actorId, actorSession) {
   const events = [];
   let after = 0;
@@ -428,11 +464,10 @@ function readDurableWorldEvents(eventDbPath) {
 }
 
 function offerEnvelope(state, actorId, offerId) {
-  const actor = state.actors?.find((candidate) => candidate.id === actorId) ?? {};
   return {
     world_id: state.world_id ?? "world://cosyworld/official",
     intent_id: `smoke:offer:${actorId}:${createHash("sha256").update(offerId).digest("hex")}`,
-    actor_ref: actor.canonical_ref ?? "",
+    actor_ref: state.command_context?.actor_ref ?? "",
     observed: {},
     last_world_seq: Number(state.world_seq ?? 0),
   };
@@ -450,7 +485,7 @@ async function dealOffer(baseUrl, actorId, actorSession, predicate, description)
   const maxWriteAuthorityRefreshes = 12;
   let writeAuthorityRefreshes = 0;
   while (true) {
-    state = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+    state = await fetchInspectableState(baseUrl, actorId, actorSession);
     offer = state.action_offers?.find((candidate) => !candidate.disabled && predicate(candidate));
     if (offer) break;
     if (maxPassAttempts === 0) {
@@ -533,7 +568,7 @@ async function command(baseUrl, actorId, actorSession, value) {
 }
 
 async function passCurrentHand(baseUrl, actorId, actorSession) {
-  const state = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const state = await fetchInspectableState(baseUrl, actorId, actorSession);
   const passOffer = state.action_hand?.pass;
   assert(passOffer?.offer_id, `a bounded deal must expose Think: ${JSON.stringify(state.action_hand)}`);
   const passed = await postJsonWithStatus(`${baseUrl}/commands`, {
@@ -580,24 +615,22 @@ function assertLanternSuggestions(state, label) {
   const question = state.shared_questions?.find((candidate) =>
     candidate.id === "lantern-keeper:rekindle-the-beacon");
   assert(question, `${label} lost the Lantern Keeper shared question`);
-  if (question.resolution !== "active") {
-    assert(
-      question.suggested_actions?.length === 0,
-      `${label} retained suggestions after resolution: ${JSON.stringify(question.suggested_actions)}`,
-    );
-    return;
-  }
+  if (question.presentation_state !== "active") return;
+  const suggestions = state.action_offers || [];
   assert(
-    question.suggested_actions?.length === 2
-      && question.suggested_actions.every((suggestion) =>
+    suggestions.length === 2
+      && suggestions.every((suggestion) =>
         suggestion.offer_id
-          && suggestion.state_revision === state.world_seq
-          && suggestion.label
-          && suggestion.target_label
-          && suggestion.source
-          && suggestion.likely_effect?.includes("current progress is")
-          && suggestion.likely_effect?.includes("danger is")),
-    `${label} did not expose exactly two accessible truthful suggestions: ${JSON.stringify(question.suggested_actions)}`,
+          && suggestion.accessible_label
+          && (suggestion.target?.label || suggestion.project?.label || state.location?.name)
+          && suggestion.provider?.id
+          && suggestion.effect)
+      && Number.isFinite(Number(question.filled))
+      && Number.isFinite(Number(question.danger_filled)),
+    `${label} did not expose exactly two accessible truthful suggestions: ${JSON.stringify({
+      suggestions,
+      question,
+    })}`,
   );
 }
 
@@ -644,7 +677,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     `Lantern Keeper Cottage Notice did not bank its first useful lead: ${JSON.stringify(listened)}`,
   );
 
-  let taleState = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  let taleState = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     taleState.first_tale?.phase === "follow_lead"
       && taleState.first_tale?.required_location_id === 2,
@@ -653,7 +686,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   for (let step = 0; step < 4 && taleState.first_tale?.phase !== "contribute"; step += 1) {
     const offer = firstTaleAdvancingOffer(taleState, `lantern Garden step ${step + 1}`);
     await command(baseUrl, actorId, actorSession, offer.command);
-    taleState = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+    taleState = await fetchInspectableState(baseUrl, actorId, actorSession);
   }
   assert(
     taleState.location?.id === 2 && taleState.first_tale?.phase === "contribute",
@@ -666,7 +699,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     if (result.events?.some((event) => event.type === "job.contribution.resolved")) {
       firstContribution = result;
     } else {
-      taleState = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+      taleState = await fetchInspectableState(baseUrl, actorId, actorSession);
     }
   }
   const contributionEvent = firstContribution?.events?.find((event) =>
@@ -679,12 +712,11 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
       && traceEvents[0].caused_by_event_seq === contributionEvent.seq,
     `Lantern Keeper first contribution did not emit one explicit replay-safe public trace: ${JSON.stringify(firstContribution)}`,
   );
-  taleState = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  taleState = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     taleState.first_tale?.phase === "complete"
       && taleState.first_tale?.continuation?.destination_location_id === 800
       && taleState.first_tale?.continuation?.target_actor_id === 8301
-      && taleState.first_tale?.continuation?.job_id === "lantern-keeper:rekindle-the-beacon"
       && taleState.first_tale?.continuation?.phase === "travel",
     `Lantern Keeper completion did not expose its structured Lantern continuation: ${JSON.stringify(taleState.first_tale)}`,
   );
@@ -714,7 +746,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     duplicate.ok === false && duplicate.status === 409,
     `Lantern Keeper allowed Class selection to be replayed: ${JSON.stringify(duplicate)}`,
   );
-  const classed = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const classed = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     classed.character_identity?.level === 1
       && classed.character_identity?.class_id === "lantern-warden"
@@ -725,7 +757,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   for (let step = 0; step < 8 && taleState.location?.id !== 800; step += 1) {
     const offer = firstTaleAdvancingOffer(taleState, `lantern continuation step ${step + 1}`);
     await command(baseUrl, actorId, actorSession, offer.command);
-    taleState = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+    taleState = await fetchInspectableState(baseUrl, actorId, actorSession);
   }
   assert(
     taleState.location?.id === 800
@@ -761,7 +793,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     `Lantern Keeper could not equip its public camp-shelter tool: ${JSON.stringify(equippedCampKit)}`,
   );
 
-  const readyForMara = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const readyForMara = await fetchInspectableState(baseUrl, actorId, actorSession);
   traceLantern("lantern ready for Mara", readyForMara);
   const maraOffer = firstTaleAdvancingOffer(readyForMara, "lantern Mara continuation");
   assert(
@@ -776,7 +808,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
         event.type === "relationship.beat" && event.content?.includes("empty key hook")),
     `Lantern Keeper did not commit Mara's corrected authored relationship beat: ${JSON.stringify(metMara)}`,
   );
-  const acceptedMara = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const acceptedMara = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     acceptedMara.first_tale?.continuation?.phase === "accepted"
       && acceptedMara.first_tale?.continuation?.target_actor_id === 8301
@@ -791,7 +823,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     `Lantern Keeper did not reveal the route to Mothwood exactly once: ${JSON.stringify(scouted)}`,
   );
   await command(baseUrl, actorId, actorSession, "go Mothwood Path");
-  const mothwood = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const mothwood = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     mothwood.location?.id === 801 && mothwood.location?.name === "Mothwood Path",
     `Lantern Keeper did not reach Mothwood through legal travel: ${JSON.stringify(lanternJourneySummary(mothwood))}`,
@@ -815,7 +847,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   );
   await command(baseUrl, actorId, actorSession, "scout Saint Orra's Ruin");
   await command(baseUrl, actorId, actorSession, "go Saint Orra's Ruin");
-  const saintOrra = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const saintOrra = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     saintOrra.location?.id === 802
       && saintOrra.items?.some((item) => item.id === 8401 && item.name === "Keeper's Brass Key")
@@ -851,7 +883,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   );
   await command(baseUrl, actorId, actorSession, "scout Flooded Barrow");
   await command(baseUrl, actorId, actorSession, "go Flooded Barrow");
-  const barrow = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const barrow = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     barrow.location?.id === 803
       && barrow.location?.name === "Flooded Barrow"
@@ -875,7 +907,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
           && event.total === 1).length === 1,
     `Lantern Keeper did not resolve the Barrow through its authored Dawn Oil choice: ${JSON.stringify(litOil)}`,
   );
-  const barrowResolved = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const barrowResolved = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     !barrowResolved.combat
       && !barrowResolved.action_offers?.some((offer) => offer.kind === "attack"),
@@ -885,7 +917,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
 
   await command(baseUrl, actorId, actorSession, "scout Lantern Tower");
   await command(baseUrl, actorId, actorSession, "go Lantern Tower");
-  const tower = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const tower = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
     tower.location?.id === 804
       && tower.location?.name === "Lantern Tower"
@@ -912,7 +944,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
       `Lantern Keeper could not fit ${itemName} into the Great Lantern Lens: ${JSON.stringify(assembled)}`,
     );
   }
-  let towerReady = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  let towerReady = await fetchInspectableState(baseUrl, actorId, actorSession);
   if (towerReady.tags?.some((tag) => tag.tag_label === "tired" || tag.label === "tired")) {
     await dealOffer(
       baseUrl,
@@ -927,7 +959,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
         event.type === "tag.cleared" && event.tag_label === "tired"),
       `Lantern Keeper could not recover before the finale authority check: ${JSON.stringify(recovered)}`,
     );
-    towerReady = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+    towerReady = await fetchInspectableState(baseUrl, actorId, actorSession);
   }
   const initialWorkDeal = await dealOffer(baseUrl, actorId, actorSession, (offer) =>
     offer.kind === "work" && matchesProjectOffer(offer, "lantern-keeper:rekindle-the-beacon"), "the finale Work card");
@@ -976,7 +1008,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
       event.type === "tag.applied" && event.tag_label === "tired"),
     `Lantern Keeper repeat frontier action did not create a meaningful Rest choice: ${JSON.stringify(repeatedListen)}`,
   );
-  const tiredAtTower = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const tiredAtTower = await fetchInspectableState(baseUrl, actorId, actorSession);
   await dealOffer(baseUrl, actorId, actorSession, (offer) => offer.kind === "rest", "the Rest card");
   const rested = await command(baseUrl, actorId, actorSession, "rest");
   assert(
@@ -988,7 +1020,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
           && event.clock_filled === dangerBeforeMeaningfulRest + 1),
     `Lantern Keeper Rest did not trade recovery for authored danger: ${JSON.stringify(rested)}`,
   );
-  towerReady = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  towerReady = await fetchInspectableState(baseUrl, actorId, actorSession);
   const freshWorkDeal = await dealOffer(baseUrl, actorId, actorSession, (offer) =>
     offer.kind === "work" && matchesProjectOffer(offer, "lantern-keeper:rekindle-the-beacon"), "the refreshed finale Work card");
   towerReady = freshWorkDeal.state;
@@ -1038,15 +1070,14 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     `Lantern Keeper accepted a conflicting finale retry: ${JSON.stringify(conflictingRetry)}`,
   );
 
-  const completedAtTower = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const completedAtTower = await fetchInspectableState(baseUrl, actorId, actorSession);
   const completedQuestion = completedAtTower.shared_questions?.find((question) =>
     question.id === "lantern-keeper:rekindle-the-beacon");
   assert(
     completedQuestion?.presentation_state === "completed_memory"
-      && completedQuestion?.resolution === "completed"
       && completedQuestion?.filled === 6
       && completedQuestion?.danger_filled === dangerBeforeMeaningfulRest + 1
-      && completedQuestion?.completion_memory?.includes("Mothwood beacon")
+      && completedQuestion?.situation?.includes("Mothwood beacon")
       && completedAtTower.tags?.some((tag) => tag.id === "room:804:beacon_rekindled")
       && completedAtTower.economy?.orbs === beforeFinaleOrbs + 2
       && !completedAtTower.action_offers?.some((offer) => matchesContributionKind(offer.kind)),
@@ -1073,12 +1104,11 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     `Lantern Keeper did not pay off Mara's authored relationship exactly once: ${JSON.stringify(trustedMara)}`,
   );
   await command(baseUrl, actorId, actorSession, "go Mothwood Path");
-  const completed = await fetchJson(stateUrl(baseUrl, actorId, actorSession));
+  const completed = await fetchInspectableState(baseUrl, actorId, actorSession);
   const afterTravelQuestion = completed.shared_questions?.find((question) =>
     question.id === "lantern-keeper:rekindle-the-beacon");
   assert(
     afterTravelQuestion?.presentation_state === "completed_memory"
-      && afterTravelQuestion?.resolution === "completed"
       && afterTravelQuestion?.filled === 6
       && afterTravelQuestion?.danger_filled === dangerBeforeMeaningfulRest + 1,
     `Lantern Keeper's post-finale travel reset completion before restart: ${JSON.stringify(lanternJourneySummary(completed))}`,
@@ -1090,7 +1120,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
       orbs: completed.economy?.orbs,
       progress: 6,
       danger: dangerBeforeMeaningfulRest + 1,
-      dangerSituation: completedQuestion.danger_situation,
+      completionSituation: completedQuestion.situation,
       finalePayload,
       finaleResponse: finale,
     },
@@ -1179,10 +1209,9 @@ function assertLanternGoldenReplay(state, events, expected) {
   );
   assert(
     question?.presentation_state === "completed_memory"
-      && question?.resolution === "completed"
       && question?.filled === expected.progress
       && question?.danger_filled === expected.danger
-      && question?.danger_situation === expected.dangerSituation
+      && question?.situation === expected.completionSituation
       && state.economy?.orbs === expected.orbs
       && events.filter((event) =>
         event.type === "job.contribution.resolved"
@@ -1203,8 +1232,7 @@ function assertLanternGoldenReplay(state, events, expected) {
     beacon: eventText.includes("beacon"),
     road: eventText.includes("road"),
     unresolvedFront: state.fronts?.some((front) =>
-      front.id === "lantern-keeper:hollow-light"
-        && front.presentation_state === "persisted"
+      front.presentation_state === "persisted"
         && front.outcome_statement?.includes("remains unresolved")),
   };
   assert(
@@ -1244,18 +1272,19 @@ function assertMountedComposition(meta, spec, addedActorCount = 0, addedLocation
 
 function assertScene(state, spec, { requireOffer = true } = {}) {
   assert(state.location?.name === spec.location, JSON.stringify(state.location));
+  const rulesContext = inspectedRulesContext(state);
   if (spec.selectedBy) {
     assert(
-      state.rules_context?.location_pack_id === spec.locationPack
-        && state.rules_context?.selected_by_pack_id === spec.selectedBy
-        && state.rules_context?.capability_id === spec.capability,
-      `${spec.label} selected the wrong rules context: ${JSON.stringify(state.rules_context)}`,
+      rulesContext?.location_pack_id === spec.locationPack
+        && rulesContext?.selected_by_pack_id === spec.selectedBy
+        && rulesContext?.capability_id === spec.capability,
+      `${spec.label} selected the wrong rules context: ${JSON.stringify(rulesContext)}`,
     );
   } else {
     assert(
-      state.rules_context == null,
+      rulesContext == null,
       `${spec.label} unexpectedly selected a pack-local rules context: ${
-        JSON.stringify(state.rules_context)
+        JSON.stringify(rulesContext)
       }`,
     );
   }
@@ -1282,8 +1311,10 @@ function assertScene(state, spec, { requireOffer = true } = {}) {
   }
   if (spec.firstTaleQuestionIncludes) {
     assert(
-      state.first_tale?.question?.includes(spec.firstTaleQuestionIncludes),
-      `${spec.label} exposed the wrong first-tale question: ${JSON.stringify(state.first_tale)}`,
+      state.__inspection?.first_tale_question?.includes(spec.firstTaleQuestionIncludes),
+      `${spec.label} exposed the wrong first-tale question: ${JSON.stringify(
+        state.__inspection?.first_tale_question,
+      )}`,
     );
   }
 }
@@ -1331,7 +1362,7 @@ async function runWorldLoop(spec) {
     let finalLocationName = spec.location;
     let finalLocationPack = spec.locationPack;
     let goldenJourney = null;
-    let initial = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
+    let initial = await fetchInspectableState(first.baseUrl, actorId, actorSession);
     assertScene(initial, spec, { requireOffer: false });
     if (spec.offerVerb) {
       const dealt = await dealOffer(
@@ -1352,7 +1383,8 @@ async function runWorldLoop(spec) {
         initial,
       );
       finalLocationName = goldenJourney.state.location?.name || finalLocationName;
-      finalLocationPack = goldenJourney.state.rules_context?.location_pack_id || finalLocationPack;
+      finalLocationPack = inspectedRulesContext(goldenJourney.state)?.location_pack_id
+        || finalLocationPack;
     }
     if (spec.localSeedActorCount !== undefined) {
       const localSeedActors = initial.actors?.filter((actor) => actor.id !== actorId) ?? [];
@@ -1398,7 +1430,7 @@ async function runWorldLoop(spec) {
           `scout ${spec.scoutDestination}`,
         );
         discoveryEventCount += scouted.events?.filter(routeDiscoveryEvent).length ?? 0;
-        discovered = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
+        discovered = await fetchInspectableState(first.baseUrl, actorId, actorSession);
         if (!discovered.action_offers?.some((offer) =>
           offer.kind === "explore_path" && offer.target?.label === spec.scoutDestination)) break;
       }
@@ -1448,16 +1480,15 @@ async function runWorldLoop(spec) {
           actorSession,
           `go ${revealedMoveTarget}`,
         );
-        const atWaypoint = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
+        const atWaypoint = await fetchInspectableState(first.baseUrl, actorId, actorSession);
         const activeConnection = atWaypoint.shared_questions?.find((question) =>
           question.question?.includes(spec.connectionItem)
             && question.question.includes(spec.location));
         assert(
-          activeConnection?.resolution === "active"
+          ["active", "quiet"].includes(activeConnection?.presentation_state)
             && activeConnection.filled === 0
-            && activeConnection.strategies?.some((strategy) =>
-              strategy.label?.includes(spec.connectionItem)
-                && strategy.availability_reason?.includes(spec.connectionItem)),
+            && activeConnection.situation?.includes(spec.connectionItem)
+            && activeConnection.situation.includes(spec.location),
           `${spec.label} did not expose its exact physical Connection: ${JSON.stringify(atWaypoint.shared_questions)}`,
         );
 
@@ -1472,19 +1503,18 @@ async function runWorldLoop(spec) {
             && dropped.events?.filter((event) => event.type === "world.logistics.completed").length === 1,
           `${spec.label} exact Connection did not commit one causal completion: ${JSON.stringify(dropped)}`,
         );
-        const connected = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
+        const connected = await fetchInspectableState(first.baseUrl, actorId, actorSession);
         const completedConnection = connected.shared_questions?.find((question) =>
           question.id === activeConnection.id);
         assert(
-          completedConnection?.resolution === "completed"
-            && completedConnection.presentation_state === "completed_memory"
+          completedConnection?.presentation_state === "completed_memory"
             && completedConnection.filled === completedConnection.segments
-            && completedConnection.completion_memory?.includes(spec.connectionItem)
-            && completedConnection.completion_memory.includes(spec.location),
+            && completedConnection.situation?.includes(spec.connectionItem)
+            && completedConnection.situation.includes(spec.location),
           `${spec.label} exact Connection was not visible as completed history: ${JSON.stringify(completedConnection)}`,
         );
         finalLocationName = connected.location?.name || finalLocationName;
-        finalLocationPack = connected.rules_context?.location_pack_id || finalLocationPack;
+        finalLocationPack = inspectedRulesContext(connected)?.location_pack_id || finalLocationPack;
         exactConnection = {
           jobId: activeConnection.id,
           itemName: spec.connectionItem,
@@ -1510,7 +1540,7 @@ async function runWorldLoop(spec) {
       replayMarkerSeq > 0,
       `${spec.label} Think produced no actor-owned durable replay marker: ${JSON.stringify(replayMarker)}`,
     );
-    const committed = await fetchJson(stateUrl(first.baseUrl, actorId, actorSession));
+    const committed = await fetchInspectableState(first.baseUrl, actorId, actorSession);
     assert(
       committed.world_seq > initial.world_seq,
       `${spec.label} action loop did not advance world sequence`,
@@ -1570,7 +1600,7 @@ async function runWorldLoop(spec) {
         `${spec.label} rejected or bypassed its compacted production checkpoint: ${JSON.stringify(restarted.meta.persistence)}`,
       );
     }
-    let replayed = await fetchJson(stateUrl(restarted.baseUrl, actorId, actorSession));
+    let replayed = await fetchInspectableState(restarted.baseUrl, actorId, actorSession);
     assertScene(
       replayed,
       { ...spec, location: finalLocationName, locationPack: finalLocationPack },
@@ -1607,10 +1637,9 @@ async function runWorldLoop(spec) {
       const completedConnection = replayed.shared_questions?.find((question) =>
         question.id === exactConnection.jobId);
       assert(
-        completedConnection?.resolution === "completed"
-          && completedConnection.presentation_state === "completed_memory"
-          && completedConnection.completion_memory?.includes(exactConnection.itemName)
-          && completedConnection.completion_memory.includes(exactConnection.originName),
+        completedConnection?.presentation_state === "completed_memory"
+          && completedConnection.situation?.includes(exactConnection.itemName)
+          && completedConnection.situation.includes(exactConnection.originName),
         `${spec.label} restart lost its exact Connection memory: ${JSON.stringify(completedConnection)}`,
       );
       events = await fetchAllActorEvents(restarted.baseUrl, actorId, actorSession);
@@ -1663,7 +1692,7 @@ async function runWorldLoop(spec) {
           actual: restartedFinale,
         })}`,
       );
-      const afterRestartRetry = await fetchJson(stateUrl(restarted.baseUrl, actorId, actorSession));
+      const afterRestartRetry = await fetchInspectableState(restarted.baseUrl, actorId, actorSession);
       assert(
         afterRestartRetry.world_seq === replayed.world_seq
           && afterRestartRetry.economy?.orbs === replayed.economy?.orbs,


### PR DESCRIPTION
## Summary

- replace the broad `/state` serialization with an explicit browser-facing allowlist
- remove account/wallet identity, internal rule bindings, resolver/provenance traces, and duplicated room history from ordinary state
- load bounded room history through `/events` only when the client needs to hydrate or recover
- submit opaque action certificates and reconstruct/validate route, target, cost, and rule details on the server
- keep legacy expanded submissions compatible while rejecting altered certified payloads
- route developer-only composition diagnostics through the explicit `/inspect` endpoint

## Why

The browser state response was derived from server-rich projections, so fields added for runtime logic could become client-visible by default. That made the response larger than necessary and weakened the boundary between public presentation data and authoritative server state.

This change makes exposure opt-in: the frontend receives only fields it renders or needs for concurrency/certificate checks.

## Impact

- guest `/state` payload measured at 14.0 KB, down from about 22.9 KB (about 39%)
- ordinary state no longer includes wallet/account identity or the duplicated `recent_events` feed
- action execution no longer trusts browser-echoed internal bindings
- event responses omit absent optional fields and journal hydration is bounded
- current-main integration advances the release to 1.0.23

## Validation

- full required pre-push suite passed on the final reviewed commit
- 178 JavaScript tests passed
- worldpack, proof-world, and kernel checks passed
- 1,157 Rust runtime tests, 5 interaction-profile tests, and doc tests passed
- standalone composition matrix and Core/Ruby composition loop passed
- fresh-seed browser journey and living-world stress journey passed
- architecture guard passed at 67,588 `main.rs` lines with clippy warnings held at the existing ceiling
- JavaScript and Python syntax checks passed
- focused public-state boundary test passed
- the integrated gift-handoff regression passed