### PR TITLE
Unify avatar portrait crops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.28"
+version = "1.0.29"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.28"
+version = "1.0.29"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -73,6 +73,8 @@
       --rarity-ultra-rare-rgb: 198, 92, 255;
       --rarity-mythic: #ffd36a;
       --rarity-mythic-rgb: 255, 211, 106;
+      --avatar-pfp-background-size: 138%;
+      --avatar-pfp-background-position: center top;
       --safe-bot: env(safe-area-inset-bottom, 0px);
     }
     * { box-sizing: border-box; }
@@ -1044,8 +1046,8 @@
     }
     .room-avatar-pfp {
       padding: 0;
-      background-size: 138%;
-      background-position: center top;
+      background-size: var(--avatar-pfp-background-size);
+      background-position: var(--avatar-pfp-background-position);
       cursor: zoom-in;
       pointer-events: auto;
     }
@@ -1635,8 +1637,8 @@
       background:
         linear-gradient(135deg, rgba(216, 247, 220, 0.14), rgba(139, 183, 255, 0.12)),
         rgba(13, 20, 15, 0.92);
-      background-size: cover;
-      background-position: center;
+      background-size: var(--avatar-pfp-background-size);
+      background-position: var(--avatar-pfp-background-position);
       color: var(--text);
       display: inline-flex;
       align-items: center;


### PR DESCRIPTION
## Summary

- centralize the avatar portrait crop size and focal position
- apply the top-rail crop to chat portraits
- bump the root package version to 1.0.29

## Why

The room avatar rail used a 138% crop anchored at the top, while chat portraits used a generic centered cover crop. The same character could therefore be framed differently between the top and bottom UI surfaces.

## Impact

Top-rail and chat portraits now share the same crop configuration, so avatar framing remains consistent across both locations.

## Validation

- verified the computed browser styles resolve to `138%` and `center top` for both selectors
- `git diff --check`
- `npm run check:version`
- `cargo check --manifest-path v2/orchestrator-rust/Cargo.toml`
- Vitest: 18 files, 179 tests passed
- worldpack, proof-world, and C kernel gates passed
- the full local pre-push gate reached the Rust test stage but the macOS loader timed out twice after 120 seconds while starting the orchestrator test binary; no compile or assertion failure was reported