### PR TITLE
Resolve Notice, place durability, and resident voice contracts

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -16,6 +16,14 @@ player is waiting on — consolidation, identity refinement, journals, and
 objectives — runs in batch off the tick, per
 [ADR 0011](docs/decisions/0011-reflective-work-runs-in-batch.md).
 
+Durable generated resident voice profiles follow the same batch boundary.
+[ADR 0014](docs/decisions/0014-resident-voice-profile-refresh.md) admits an
+initial profile after durable identity refinement and refreshes only after a
+committed avatar evolution, with exact replay-safe identities and hard
+resident/world attempt ceilings. Authored voices remain permanent unless their
+owning pack explicitly opts into a versioned drift policy; rejection always
+keeps the prior profile or authored fallback.
+
 `Chat` is the player-facing friendship action. It appears only when the avatar
 has banked advancement and a nearby resident is eligible for a new Bond; playing
 it spends one advancement point, creates that friendship, and passes the room

--- a/PRD.md
+++ b/PRD.md
@@ -87,6 +87,15 @@ Adopted direction (2026-07-19), superseding the one-hand/one-floor simplificatio
 5. **Items persist and crafting grows the world.** Use, craft, and evolution may exhaust, attune, rename, tag, recharge, unlock, mint, transform, or create cards, but authored inputs are not silently deleted. A crafted key can open a doorway, a lantern can wake a route, and a relic can anchor a location or project. Recipes declare both their card output and the world capacity, desire, route, or story possibility they add.
 6. **Evolution is public arrangement.** Evolution requirements are placement patterns across explicit zones: a charm equipped by Skull, a thread left at the Silver Milepost, a bell carried into the Garden. Patterns compile from a closed vocabulary of existing cards, reachable places, valid zones, and present residents; the kernel checks them against real shared state. Completion is a public ceremony, and placers and witnesses earn Journal credit.
 
+Player-established places are durable for the life of the current canonical
+world. Restart, replay, recovery, and return visits do not remove them. A
+deliberate world renewal starts a new world and does not silently restore the
+prior world's generated places or fixtures; historical records may remain
+readable but grant no live authority.
+[ADR 0013](docs/decisions/0013-generated-places-are-world-scoped.md) records
+this boundary, so current copy says **establish** rather than promising an
+unqualified “lasting” fixture.
+
 The old phrases “one hand” and “one floor” may survive as scene copy or a deliberately constrained rules variant. They are not storage, ownership, or composition laws. Scarcity comes from authored supply, carrying constraints, typed slots, exhaustion, access, and meaningful placement—not from pretending a deck contains one card.
 
 ## Users

--- a/docs/decisions/0005-thresholds-trails-and-strict-referee.md
+++ b/docs/decisions/0005-thresholds-trails-and-strict-referee.md
@@ -76,8 +76,9 @@ pack-specific reskin, but the binding below cannot change.
 | Procedure | Player verb | Contract |
 | --- | --- | --- |
 | `scene_notice_v1` | no button; the scene simply shows it | Free on arrival or relevant state change. Publish obvious exits, creatures, objects, landmark cues, sensory Signs, and perceivable Hazard tells. Never roll and never consume played time. |
-| `focused_notice_v2` | **Notice** | Spend one turn to resolve one broad, authored sensory Lead or stateful safety/environment result. Offer it only while an unresolved result exists. Under Pressure, a check avoids a named consequence; it never decides whether stocked truth exists. |
-| `search_v2` | **Search** | Spend one turn exhaustively examining one named local physical target. A safe Search is certain. It may reveal a frozen item, mechanism, secret feature, actor trace, or evidence, but never opens, Takes, equips, or moves through the result. |
+| `focused_notice_v2` | legacy **Notice** only | Preserve broad environmental Notice records for replay and compatibility. New offers do not use this procedure. |
+| `notice_actor_v1` | **Notice** | Spend one turn observing one nearby visible actor. Reveal exactly one eligible unresolved viewer-scoped observable fact; otherwise withhold the offer. |
+| `search_v2` | **Search** | Spend one turn exhaustively examining the current location or one named local physical feature. A safe Search is certain. It may reveal a frozen item, mechanism, trace, or evidence, but never a route, actor profile, Open, Take, equip, or Travel result. |
 | `study_v2` | **Study** | Spend one turn interpreting an already perceived target. Reveal requirements, operation, provenance, meaning, or a better method. Study cannot materialize physical truth. |
 | `scout_v2` | **Scout** | Spend played time pursuing one exact geographic Lead from a legal Anchor or along its active foray. Reveal only the authorized next segment or target. Scout never moves the actor; **Travel** is a separate commit. |
 | `travel_v1` | **Travel** | Move through one revealed route whose Gate permits this actor or expedition. Travel does not stock, reveal, or secure a destination. |
@@ -87,7 +88,9 @@ pack-specific reskin, but the binding below cannot change.
 
 `Inspect` is approved copy only when it binds to `search_v2` for physical
 examination or `study_v2` for interpretation. It is not a third resolver.
-`Listen` and `Tune In` may reskin focused Notice. `Head To` may reskin Travel.
+`Head To` may reskin Travel. Observe and Survey are not additional actions.
+[ADR 0012](0012-notice-search-and-scout-targets.md) is authoritative for the
+Notice, Search, Scout, and empty-result contracts.
 
 The currently journaled route procedure is named `scout_v1`: it uses the
 legacy Search action and an `explore_path` projection mutation to reveal one
@@ -96,8 +99,10 @@ the honest no-movement result but adds an exact Lead, Anchor/active-foray
 evidence, descriptor versions, and no-null-commit law. New code must use a new
 append-only action or procedure version rather than reinterpret `scout_v1`.
 
-The `discovery-procedure-v2` runtime implements `focused_notice_v2`,
-`search_v2`, `study_v2`, and `scout_v2` as one slot-bound pipeline. A pack
+The shipped `discovery-procedure-v2` runtime implements `focused_notice_v2`,
+`search_v2`, `study_v2`, and `scout_v2` as one slot-bound pipeline. Under ADR
+0012, `focused_notice_v2` becomes compatibility-only and new actor Notice uses
+`notice_actor_v1` after the #725 fact contract lands. A pack
 catalog freezes the receipt, claim scope, stocked result, and any pressure
 consequence before an offer is projected. Browser, terminal, API, and
 inference controllers select that same offer and receipt. A safe Search
@@ -105,8 +110,8 @@ commits without an ability roll; under Pressure the roll only avoids the
 already-frozen consequence. The discovery projection records a Lead or Reveal
 and cannot Open, Travel, Take, equip, materialize, or award the result.
 Snapshots and journal records preserve the frozen claim, and exact retries or
-replay cannot roll or publish it twice. Legacy Search, Study, and `scout_v1`
-records retain their original meanings.
+replay cannot roll or publish it twice. Legacy Search, Study, broad Notice, and
+`scout_v1` records retain their original meanings.
 
 ### Shared discovery progression
 

--- a/docs/decisions/0012-notice-search-and-scout-targets.md
+++ b/docs/decisions/0012-notice-search-and-scout-targets.md
@@ -1,0 +1,103 @@
+# ADR 0012: Notice observes actors, Search examines places, and Scout follows leads
+
+- Status: Accepted
+- Date: 2026-08-13
+- Decision owners: CosyWorld maintainers
+- Related: #693, #725–#729, #774, #783, ADR 0005
+
+## Context
+
+CosyWorld currently uses **Notice** for two different promises. The discovery
+pipeline presents a broad room-focused Notice, while avatar inspection can
+offer a targeted Notice that reveals something about a nearby resident. Search
+has also revealed routes in historical records even though Scout is the
+route-facing verb.
+
+That overlap is difficult for people and agents to learn. A label must identify
+one target class and one authoritative result before the action is offered. An
+action that can truthfully do nothing is not a useful promise.
+
+## Decision
+
+The disputed discovery vocabulary settles on three verbs: Notice, Search, and
+Scout. Obvious scene facts remain automatic and **Study** keeps its separate
+interpretation role. There is no additional Observe or Survey action.
+
+| Surface                                    | Exact target class                                                               | Bounded authoritative promise                                                                                                                               | Empty result                                                                              |
+| ------------------------------------------ | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| automatic scene notice (`scene_notice_v1`) | the actor's current location                                                     | Project every currently obvious exit, present subject, sensory sign, and perceivable hazard tell. This is presentation, not a played action.                | Show the scene without an extra message or action.                                        |
+| **Notice** (`notice_actor_v1`)             | one nearby, visible actor                                                        | Reveal exactly one eligible unresolved viewer-scoped observable fact about that actor.                                                                      | Do not offer the action. An already-open actor inspector may say “Nothing new to notice.” |
+| **Search** (`search_v2`)                   | one local searchable physical subject: the current location or one named feature | Reveal exactly one eligible unresolved physical-evidence fact bound to that subject. Search never reveals a route or an actor profile.                      | Do not offer the action. A named inspector may say “Nothing new to search here.”          |
+| **Scout** (`scout_v2`)                     | one active geographic Lead or eligible route edge                                | Reveal exactly the authorized next route segment or geographic target. Scout never moves the actor.                                                         | Do not offer the action. Preserve the Lead's current state without a no-change event.     |
+| **Study** (`study_v2`)                     | one already perceived subject                                                    | Reveal exactly one eligible unresolved interpretive fact about operation, provenance, meaning, or a better method. Study never materializes physical truth. | Do not offer the action.                                                                  |
+
+A room with non-obvious ambient truth authors the current location as a Search
+target. A room with no such target has no played ambient-discovery action;
+automatic scene notice still presents everything obvious. This avoids adding a
+fourth verb merely to provide a button in every room.
+
+Notice is an ordinary repeatable exploration action, not rest-bound readiness.
+It has no charge, cooldown, or rest refresh. A successful reveal exhausts only
+that fact for that viewer. A later authoritative change or newly eligible fact
+may make Notice available again.
+
+### Labels and transport identity
+
+Every transport preserves the same action identity and target.
+
+| Action | Browser                                         | Terminal                    | Agent/API                                                                |
+| ------ | ----------------------------------------------- | --------------------------- | ------------------------------------------------------------------------ |
+| Notice | `Notice` on an eligible actor card or inspector | `notice <actor>`            | intention `notice`, procedure `notice_actor_v1`, exact `target_actor_id` |
+| Search | `Search` on the room or a named feature         | `search <place-or-feature>` | intention `search`, procedure `search_v2`, exact physical-subject target |
+| Scout  | `Scout` on an eligible Lead or route            | `scout <lead-or-route>`     | intention `scout`, procedure `scout_v2`, exact Lead/edge target          |
+| Study  | `Study` on a perceived subject                  | `study <subject>`           | intention `study`, procedure `study_v2`, exact perceived-subject target  |
+
+Clients and inference controllers select one server-authored offer certificate.
+They cannot substitute a target, choose a fact, or request an empty result.
+
+### Knowledge and replay
+
+#725 owns the viewer-scoped fact and provenance schema. These verbs consume
+that contract but do not create a second knowledge store. The selected fact and
+its reveal method commit before any optional prose. Generated dialogue can
+describe the result but cannot choose or enlarge it.
+
+Historical records keep their original meaning:
+
+- legacy Search records that revealed routes remain Search in historical
+  Journal and snapshot replay;
+- `scout_v1` remains the legacy no-movement route procedure;
+- `focused_notice_v2` remains a broad environmental Notice for replay and
+  compatibility, but new offers do not use it;
+- targeted `CW_ACTION_ABILITY_CHECK` records whose content is `notice` retain
+  their historical success-gated disclosure; and
+- migration may add compatibility projections, but never rewrites old action,
+  event, target, or result identities.
+
+New records use `notice_actor_v1`, `search_v2`, `study_v2`, and `scout_v2`.
+Browser copy, terminal output, the Journal, and agent-facing responses derive
+their labels from those committed identities.
+
+## Rejected alternatives
+
+- **Broad Notice over rooms and actors.** Rejected because one verb would still
+  promise two target classes and compete with Search.
+- **Survey or Observe as a fourth played verb.** Rejected because Search can
+  target the current location and automatic scene notice already owns obvious
+  ambient truth.
+- **Rest-bound Notice charges.** Rejected because rest should recover actor
+  readiness, not manufacture unresolved facts. The Deck therefore does not
+  display a Notice charge.
+- **Truthful no-change events.** Rejected for these discovery verbs. Absence is
+  projected before selection, so a successful played action always keeps its
+  promised reveal.
+
+## Consequences
+
+- #774 implements truthful actor-only Notice rather than room-or-inhabitant
+  Notice.
+- #726 keeps Search physical and Scout geographic.
+- #727 uses one fact per actor Notice rather than an observable-profile bundle.
+- #728 remains fact transfer through Chat and does not compete with Notice.
+- #729 migrates presentation and compatibility without reinterpretation.
+- #785 may show recovery readiness, but not a Notice charge or rest refresh.

--- a/docs/decisions/0013-generated-places-are-world-scoped.md
+++ b/docs/decisions/0013-generated-places-are-world-scoped.md
@@ -1,0 +1,84 @@
+# ADR 0013: player-established places last for the current world
+
+- Status: Accepted
+- Date: 2026-08-13
+- Decision owners: CosyWorld maintainers
+- Related: #289, #470, #471, ADR 0003, ADR 0005
+
+## Context
+
+The generated-place lifecycle asks a player to place a “lasting fixture,” but a
+bundle-hash mismatch deliberately starts a new world epoch. The new world does
+not restore actors, Bonds, completed Jobs, clocks, or generated places from the
+prior epoch. Calling a fixture lasting without naming that boundary promises
+more than the canonical world currently guarantees.
+
+Three meanings were considered: durability for the current world, automatic
+promotion into reviewed pack content, and restoration from a separate
+cross-world authority.
+
+## Decision
+
+Player-established places are **world-scoped**. Establishment is a monotonic,
+replay-safe ratchet for the life of the current canonical world. Ordinary
+restart, snapshot recovery, journal replay, pack remount, and repeat visits do
+not remove or un-establish the place.
+
+A deliberate reseed begins a new canonical world. It removes the prior world's
+generated places and fixtures from live authority. Historical journals and
+operator archives may remain readable as records of the ended world, but they
+are never silently rehydrated into the new world and grant it no topology,
+access, building, item, or progression state.
+
+Player-facing copy therefore uses **establish** and names the current-world
+scope in explanatory text. The generic action must not promise an unqualified
+“lasting fixture.” A pack may present the operation as **Build a cairn**, **Scan
+the sector**, or another validated ritual under #471, while the shared detail
+states:
+
+> Establish this place in the current world. It survives return visits and
+> restarts; a deliberate world renewal begins a new world.
+
+“World epoch,” bundle hash, snapshot, and reseed remain implementation language
+and do not appear in ordinary action labels.
+
+## Rejected alternatives
+
+### Automatic authored promotion
+
+Rejected. A player action cannot write generated output into
+`v2/content/official/**` or another mounted pack. Maintainers may separately
+author a future pack version inspired by play, but that is a reviewed content
+change with new pack-owned identity, not continuation of the live generated
+entity.
+
+### Cross-world restoration authority
+
+Rejected. A second durable authority would have to decide which old topology,
+items, actors, projects, and dependencies enter a new world. Restoring only the
+fixture would create orphaned state; restoring the whole subgraph would turn a
+reseed into an undeclared merge. Neither behavior exists, and no player-facing
+promise depends on it.
+
+## Compatibility and migration
+
+- Existing generated-place journal and snapshot records replay unchanged inside
+  their recorded world identity and epoch.
+- Historical “lasting fixture” copy remains readable as historical copy; it is
+  not reinterpreted as cross-world durability.
+- New establishment records freeze the pack-authored ritual presentation and
+  the current world identity/epoch.
+- A future change to cross-world restoration requires a new ADR, an explicit
+  migration authority, and new player-facing wording. It cannot reinterpret
+  this decision.
+
+## Consequences
+
+- #471 can make establishment pack-authored while keeping one host-owned,
+  world-scoped lifecycle.
+- Within one world, damage, maintenance, dormancy, or forgotten beliefs never
+  un-establish a place unless a later explicit lifecycle contract says what
+  happens to the fixture. A reseed is outside that lifecycle because it starts
+  a new world.
+- Authored promotion and cross-world restoration are closed rather than hidden
+  future requirements of establishment.

--- a/docs/decisions/0014-resident-voice-profile-refresh.md
+++ b/docs/decisions/0014-resident-voice-profile-refresh.md
@@ -1,0 +1,120 @@
+# ADR 0014: resident voice profiles refresh on durable identity events
+
+- Status: Accepted
+- Date: 2026-08-13
+- Decision owners: CosyWorld maintainers
+- Related: #547, #548, #554, #796, ADR 0011
+
+## Context
+
+Resident replies already use committed continuity, but generated avatars share
+one generic fallback voice arm. A durable generated voice profile can make each
+resident's interior register reflect their own history without adding a model
+call to every line.
+
+Persisting such a profile requires exact refresh triggers, an authored-character
+policy, and hard cost ceilings. A vague cadence would make replay and provider
+spend depend on scheduling rather than world events.
+
+## Decision
+
+### Refresh trigger and generation identity
+
+A voice-profile job may be admitted only after one of these committed events:
+
+1. the generated actor's first durable identity refinement; or
+2. a successful `avatar.evolved` event for that actor.
+
+The initial profile and each level refresh read continuity only through the
+triggering event's committed sequence. Unrelated continuity changes do not
+schedule work. Retries reuse the same generation identity:
+
+```text
+resident-voice-profile-v1
+  / {world_id}
+  / {world_epoch}
+  / {actor_id}
+  / {trigger_kind}
+  / {trigger_event_seq}
+  / {continuity_through_seq}
+```
+
+One identity can publish at most one accepted profile. Snapshot restore,
+journal replay, reconnect, duplicate scheduling, and concurrent workers recover
+the existing job or result rather than generating again. Replay never calls a
+model.
+
+### Authored actors
+
+Hand-written actor voices are permanent by default. An authored actor may use
+generated refresh only when its owning world pack declares a versioned
+`generated_voice_policy` opt-in. The hand-written voice remains the immutable
+seed and fallback; generated output may refine register from continuity but may
+not erase named structural constraints, change identity, or become world fact.
+
+Adding, removing, or changing that opt-in is a declared pack migration. Existing
+accepted profiles keep their frozen policy and source voice. A host default or
+provider configuration can never opt an authored actor into drift.
+
+### Cost and retry ceilings
+
+The following ceilings are product law for `resident-voice-profile-v1`:
+
+| Scope                           | Accepted profiles | Provider attempts |
+| ------------------------------- | ----------------: | ----------------: |
+| one resident in one world epoch |                 4 |                 8 |
+| the complete world epoch        |               512 |             1,024 |
+| one generation identity         |                 1 |                 2 |
+
+The initial identity profile consumes one resident slot. Later
+`avatar.evolved` triggers consume the remaining slots in event order. Once a
+resident or world ceiling is reached, newer triggers retain the latest accepted
+profile or the authored fallback and do not queue deferred work for a later
+wall-clock window.
+
+The normal server-paid daily admission limit and capability registry remain
+additional gates. The required capability is `WorldContent` through the
+reviewed metacognitive lane. Missing capability, disabled generation, budget
+exhaustion, timeout, provider failure, or validation rejection never falls
+through to an unreviewed model.
+
+### Failure and validation
+
+Generated profiles are private candidates until validation accepts their
+bounded first-person register. They may describe preferences, attention,
+hesitation, and social habits grounded in supplied continuity. They may not add
+possessions, relationships, memories, actions, secrets, authority, catchphrases,
+speaker labels, signpost habits, model language, or facts absent from the
+committed context.
+
+A failed or rejected job:
+
+- leaves the previous accepted profile unchanged;
+- otherwise uses the existing authored or deterministic fallback arm;
+- does not mutate continuity, identity, facts, or progression;
+- persists only bounded attempt status, check codes, hashes, attribution, cost,
+  and timing; and
+- never delays or blocks the resident's next legal action or reply.
+
+## Rejected alternatives
+
+- **Refresh after an arbitrary continuity-change threshold.** Rejected because
+  a large class of events would need to become hidden cost triggers and minor
+  tuning changes could alter replay scheduling.
+- **Refresh on every line or room heartbeat.** Rejected for latency, cost, and
+  replay nondeterminism.
+- **Implicit drift for authored actors.** Rejected because a host setting could
+  silently replace pack-authored character identity.
+- **Unlimited retries under the daily spend cap.** Rejected because repeated
+  invalid output can starve other world features even when total spend is
+  bounded.
+
+## Implementation slices for #554
+
+1. Add the versioned policy, generation identity, job/result persistence, and
+   the resident/world admission counters.
+2. Build the continuity-through-sequence prompt and fail-closed validator while
+   preserving the current fallback arms.
+3. Commit accepted profiles, consume them in the resident context spine, and
+   prove snapshot, journal replay, retry, authored opt-in migration, and cost
+   ceilings.

--- a/docs/location-development.md
+++ b/docs/location-development.md
@@ -39,7 +39,7 @@ swapped instantly.
 
 | Term | Meaning |
 | --- | --- |
-| **Cairn / Anchor** | Durable navigation fixture that permits a founding proposal at its location. It is not a building slot or a rest entitlement. |
+| **Cairn / Anchor** | Navigation fixture that remains durable for the life of the current canonical world and permits a founding proposal at its location. It is not a building slot, cross-world restoration promise, or rest entitlement. |
 | **Unsettled** | A cairned location with no completed identity building. It has no numbered development level or class. |
 | **Location class** | The class family derived from the completed identity building. Initial families are Pathway, Hearth, Garden, and Shrine. |
 | **Building archetype** | A pack-authored structure or durable civic work with class affinities, slot kind, prerequisites, and installed capabilities. |

--- a/docs/worldpacks/construction-and-routing-discovery.md
+++ b/docs/worldpacks/construction-and-routing-discovery.md
@@ -86,6 +86,15 @@ authorize a legal founding proposal; Connection and Settlement may remain
 separate projects or archetype prerequisites without being universal gates on
 originating that proposal.
 
+Generated-place establishment is durable within the current canonical world,
+as decided by [ADR 0013](../decisions/0013-generated-places-are-world-scoped.md).
+Restart, snapshot recovery, journal replay, pack remount, and repeat visits do
+not un-establish it. A deliberate world renewal starts a new world and does not
+restore the prior generated subgraph. Generic player copy therefore says
+**establish this place** and explains the current-world boundary; it does not
+promise an unqualified “lasting fixture.” Pack-authored ritual vocabulary under
+#471 must preserve that same lifecycle.
+
 Generated-place Connection jobs freeze one exact, movable item represented at
 the connected source when the job is created. Their public question names that
 item and source. Completion requires the same item identity, the recorded

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/player-lexicon.md
+++ b/v2/docs/player-lexicon.md
@@ -73,6 +73,25 @@ accessibility concepts, routes, state projections, or worldpack requirements.
 - Never expose dotted event keys, source sequence numbers, payload delimiters,
   arrow movement, or “Something changed” as Journal copy.
 
+## Exploration action verbs
+
+[ADR 0012](../../docs/decisions/0012-notice-search-and-scout-targets.md)
+gives each exploration verb one target and one promise. These are actions, not
+new nouns in the player vocabulary.
+
+| Verb | Player target | Promise |
+| --- | --- | --- |
+| **Notice** | one nearby actor | reveal one new observable fact about that actor |
+| **Search** | the current place or one named physical feature | reveal one new physical-evidence fact; never a route or actor profile |
+| **Scout** | one geographic Lead or route | reveal the next authorized geographic step; never move |
+| **Study** | one already perceived subject | reveal one new interpretive fact |
+
+If no promised result exists, the server does not offer the action. Browser,
+terminal, and agent/API clients use the same server-authored offer and exact
+target. Obvious scene facts appear automatically; **Observe** and **Survey** are
+not separate actions. Notice is repeatable when a new fact becomes eligible and
+is never charged or refreshed by Rest.
+
 The public API keeps card presentation (`cards`, `card_id`) but has no
 `required_card_id`, Box/pack inventory, owned-card projection, NFT burn/open,
 or collection-materialization route. Related database names remain unchanged

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.29"
+version = "1.0.30"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- add ADR 0012: Notice targets one nearby actor, Search targets one physical place/feature, Scout targets one geographic Lead/route, and empty discovery actions are withheld
- add ADR 0013: player-established places are durable for the current canonical world but are not silently restored after a deliberate world renewal
- add ADR 0014: resident voice profiles refresh only after durable identity/evolution events, authored voices drift only by explicit pack opt-in, and generation/retry spend is capped
- align the player lexicon, threshold/discovery contract, product requirements, generated-place documentation, and AI design
- bump the release contract to 1.0.30

## Why

These are the three implementation-free decision tickets in the ready queue. Settling them together removes contradictory contracts before implementation and unblocks the next bounded slices without pulling intentionally parked work into the current horizon.

Closes #783.
Closes #470.
Closes #796.

Unblocks #774, #471, and #554, and aligns the downstream #725–#729 exploration sequence.

## Impact

This PR changes product and compatibility contracts only. It does not change runtime behavior. Historical Notice/Search/Scout records keep their original replay meaning, generated places retain their current-world durability, and failed resident voice generation continues to use the existing fallback.

## Validation

- documentation renderer completed successfully
- version enforcement and diff whitespace checks passed
- full `npm run check` pre-push gate passed
- 179 JavaScript tests passed
- official and composed worldpack checks plus strict proof-world validation passed
- C-kernel tests passed
- 1,182 Rust unit/integration tests passed
- architecture guard passed at 66,712 `main.rs` lines with clippy warnings held at the existing ceiling
- JavaScript and Python syntax checks passed
