### PR TITLE
Make actor Notice truthful

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.30"
+version = "1.0.31"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_resident_planning.rs
+++ b/v2/orchestrator-rust/src/ai_resident_planning.rs
@@ -25,6 +25,7 @@ const RESIDENT_PLANNER_ELIGIBLE_KINDS: &[&str] = &[
     "search",
     "craft",
     "influence",
+    NOTICE_ACTOR_OFFER_KIND,
     "check",
     "explore_path",
     "prepare",
@@ -582,6 +583,7 @@ impl RuntimeWorld {
                         | "search"
                         | "craft"
                         | "influence"
+                        | NOTICE_ACTOR_OFFER_KIND
                         | "check"
                         | "explore_path"
                         | "prepare"
@@ -610,6 +612,7 @@ impl RuntimeWorld {
                 self.resident_card_policy_job_record(actor, &offer, seed)?
             }
             "rest"
+            | NOTICE_ACTOR_OFFER_KIND
             | "check"
             | FOCUSED_NOTICE_OFFER_KIND
             | DISCOVERY_SEARCH_OFFER_KIND
@@ -1468,6 +1471,7 @@ fn resident_card_kind_is_search(kind: &str) -> bool {
         kind,
         "search"
             | "check"
+            | NOTICE_ACTOR_OFFER_KIND
             | "study"
             | FOCUSED_NOTICE_OFFER_KIND
             | DISCOVERY_SEARCH_OFFER_KIND
@@ -1491,6 +1495,7 @@ fn resident_event_matches_card_kind(event_type: &str, kind: &str) -> bool {
             event_type,
             "location.searched" | "feature.searched" | "discovery.resolved"
         ),
+        NOTICE_ACTOR_OFFER_KIND => event_type == "notice.actor_observed",
         DISCOVERY_STUDY_OFFER_KIND | "study" => {
             matches!(event_type, "location.studied" | "discovery.resolved")
         }
@@ -2302,6 +2307,11 @@ mod tests {
     #[test]
     fn current_snapshot_rejects_forged_fields_and_newer_revision() {
         let mut runtime = RuntimeWorld::seeded();
+        let executable_offer = runtime
+            .draw_until_test_offer(RATI_ACTOR_ID, &AccessContext::default(), |offer| {
+                offer.kind == "pick_up"
+            })
+            .expect("the seeded resident can draw a kernel-executable card");
         let plan = runtime
             .resident_reply_plan_for_target(
                 SKULL_ACTOR_ID,
@@ -2313,7 +2323,8 @@ mod tests {
         let plan = runtime.prepare_resident_planner_snapshot(plan);
         let candidate = plan
             .planner_candidates
-            .first()
+            .iter()
+            .find(|candidate| candidate.candidate_id == executable_offer.offer_id)
             .expect("seeded Rati has a legal planner candidate")
             .clone();
         let proposal = AvatarProposedAction {
@@ -2666,6 +2677,12 @@ mod tests {
     #[test]
     fn accepted_rejected_committed_lifecycle_replays_without_a_gateway() {
         let mut runtime = RuntimeWorld::seeded();
+        let executable_offer = runtime
+            .draw_until_test_offer(RATI_ACTOR_ID, &AccessContext::default(), |offer| {
+                offer.kind == "pick_up"
+            })
+            .expect("the seeded resident can draw a kernel-executable card");
+        let replay_base = RuntimeSnapshot::from_runtime(&runtime);
         let plan = runtime
             .resident_reply_plan_for_target(
                 SKULL_ACTOR_ID,
@@ -2677,7 +2694,8 @@ mod tests {
         let plan = runtime.prepare_resident_planner_snapshot(plan);
         let candidate = plan
             .planner_candidates
-            .first()
+            .iter()
+            .find(|candidate| candidate.candidate_id == executable_offer.offer_id)
             .expect("seeded Rati has an executable planner candidate")
             .clone();
         let mut accepted_trace = ResidentPlanningTrace::absent(&plan);
@@ -2813,7 +2831,9 @@ mod tests {
         let encoded = serde_json::to_string(&records).expect("records serialize");
         let replay_records: Vec<JournalRecord> =
             serde_json::from_str(&encoded).expect("records deserialize");
-        let mut replayed = RuntimeWorld::seeded();
+        let mut replayed = replay_base
+            .into_runtime()
+            .expect("the pre-lifecycle snapshot restores");
         for record in &replay_records {
             assert_eq!(replayed.apply_journal_record(record).0, CW_OK);
         }

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -11,6 +11,7 @@ fn submitted_payload_target_key(path: &str, target: &ActionTargetView) -> Option
         ("/actions/use-item", "feature") => "location_id",
         (
             "/actions/chat"
+            | "/actions/notice"
             | "/actions/model-interaction"
             | "/actions/attack"
             | "/actions/give-item"
@@ -166,6 +167,7 @@ fn action_offer_kind_requires_actor_target(kind: &str) -> bool {
     matches!(
         kind,
         "chat"
+            | NOTICE_ACTOR_OFFER_KIND
             | "model_interaction"
             | "influence"
             | "attack"
@@ -744,6 +746,8 @@ impl RuntimeWorld {
         offers = self.expand_route_action_offers(actor_id, access, offers);
         offers.extend(self.threshold_method_action_offers(actor_id, access));
         offers.extend(self.discovery_action_offers(actor_id));
+        offers.retain(|offer| offer.kind != "check" || offer.project.is_some());
+        offers.extend(self.notice_actor_action_offers(actor_id));
         if let Some(reason) = self.rest_offer_unavailable_reason(actor_id) {
             let mut unavailable = self.ranked_offer_from_parts(
                 "rest",
@@ -929,6 +933,73 @@ impl RuntimeWorld {
             return 84;
         }
         action_offer_rank(kind)
+    }
+
+    fn notice_actor_action_offers(&self, actor_id: u64) -> Vec<RankedActionOffer> {
+        self.notice_actor_facts(actor_id)
+            .into_iter()
+            .map(|fact| {
+                let target = ActionTargetView {
+                    kind: "actor".to_string(),
+                    id: Some(fact.target_actor_id),
+                    label: Some(fact.target_name.clone()),
+                };
+                let mut offer = self.ranked_offer_from_parts(
+                    NOTICE_ACTOR_OFFER_KIND,
+                    "Notice",
+                    &format!("notice {}", fact.target_name),
+                    action_offer_rank(NOTICE_ACTOR_OFFER_KIND),
+                    false,
+                    None,
+                    Some(target),
+                    None,
+                    None,
+                    Some(format!(
+                        "reveals one disclosure-safe observable fact about {}",
+                        fact.target_name
+                    )),
+                    Some(fact.fact_id.clone()),
+                    "one nearby visible actor has one unresolved disclosure-safe fact",
+                );
+                let legacy_id = format!("notice_actor_v1:{}", fact.fact_id);
+                offer.id = legacy_id.clone();
+                offer.offer_id = format!(
+                    "{}:{}:{}",
+                    offer.rules_profile, offer.state_revision, legacy_id
+                );
+                let binding = resolved_action_binding(NOTICE_ACTOR_OFFER_KIND)
+                    .expect("notice_actor must resolve through the SRD search binding");
+                let location_id = self.actor_by_id(actor_id).map(|actor| actor.location_id);
+                let source_collectible = self.location_source_collectible(actor_id);
+                offer.composition_trace = self.action_composition_trace(
+                    location_id,
+                    offer.state_revision,
+                    &binding,
+                    ActionCompositionContributions {
+                        source_card_instances: source_collectible.clone().into_iter().collect(),
+                        target: offer.target.clone(),
+                        applied_reskins: Vec::new(),
+                        contextual_offers: Vec::new(),
+                    },
+                );
+                offer.source_collectible = source_collectible;
+                offer.source = "visible_actor+observable_fact".to_string();
+                offer.accessible_label = self.action_offer_accessible_label(
+                    NOTICE_ACTOR_OFFER_KIND,
+                    &offer.verb,
+                    &offer.label,
+                    offer.target.as_ref(),
+                    None,
+                );
+                offer.provider = self.action_offer_provider(
+                    NOTICE_ACTOR_OFFER_KIND,
+                    actor_id,
+                    offer.target.as_ref(),
+                    None,
+                );
+                offer
+            })
+            .collect()
     }
 
     pub(super) fn ranked_offer_from_parts(
@@ -1134,7 +1205,7 @@ impl RuntimeWorld {
 
         if let Some(calling) = self.callings.get(&actor_id) {
             let calling_matches = match kind {
-                "check" => calling_matches_listen(&calling.statement),
+                "check" | NOTICE_ACTOR_OFFER_KIND => calling_matches_listen(&calling.statement),
                 "search" => calling_matches_inspect(&calling.statement),
                 "explore_path" | "move" => calling_statement_is_explorer(&calling.statement),
                 _ => false,
@@ -1158,6 +1229,21 @@ impl RuntimeWorld {
                 format!("From {}", project.label),
                 50,
             );
+        }
+
+        if kind == NOTICE_ACTOR_OFFER_KIND {
+            if let Some(target_actor_id) = target.and_then(|target| target.id) {
+                let target_name = self
+                    .actor_name(target_actor_id)
+                    .unwrap_or_else(|| format!("Actor {target_actor_id}"));
+                return action_provider(
+                    "actor",
+                    format!("actor:{target_actor_id}"),
+                    target_name,
+                    "One nearby visible actor has a detail you can truthfully observe",
+                    40,
+                );
+            }
         }
 
         if let Some(actor) = actor {
@@ -2227,6 +2313,7 @@ pub(super) fn action_offer_requires_target(kind: &str) -> bool {
     matches!(
         kind,
         "chat"
+            | NOTICE_ACTOR_OFFER_KIND
             | "model_interaction"
             | "influence"
             | "attack"
@@ -2282,6 +2369,7 @@ pub(super) fn action_offer_is_generally_useful(offer: &RankedActionOffer) -> boo
     matches!(
         offer.kind.as_str(),
         "check"
+            | NOTICE_ACTOR_OFFER_KIND
             | "search"
             | FOCUSED_NOTICE_OFFER_KIND
             | DISCOVERY_SEARCH_OFFER_KIND
@@ -2568,6 +2656,7 @@ pub(super) fn action_offer_rank(kind: &str) -> u16 {
         "help" => 49,
         "flee" => 50,
         FOCUSED_NOTICE_OFFER_KIND => 52,
+        NOTICE_ACTOR_OFFER_KIND => 52,
         DISCOVERY_SEARCH_OFFER_KIND => 53,
         DISCOVERY_STUDY_OFFER_KIND => 54,
         "explore_path" | DISCOVERY_SCOUT_OFFER_KIND => 55,
@@ -2594,6 +2683,7 @@ pub(super) fn practice_category_matches_offer(category: &str, kind: &str) -> boo
                 | "search"
                 | "check"
                 | FOCUSED_NOTICE_OFFER_KIND
+                | NOTICE_ACTOR_OFFER_KIND
                 | DISCOVERY_SEARCH_OFFER_KIND
                 | DISCOVERY_SCOUT_OFFER_KIND
                 | "open"
@@ -2626,6 +2716,7 @@ pub(super) fn action_offer_intention(kind: &str) -> &str {
         "search" => "inspect",
         "explore_path" => "scout",
         FOCUSED_NOTICE_OFFER_KIND => "notice",
+        NOTICE_ACTOR_OFFER_KIND => "notice",
         DISCOVERY_SEARCH_OFFER_KIND => "inspect",
         DISCOVERY_STUDY_OFFER_KIND => "study",
         DISCOVERY_SCOUT_OFFER_KIND => "scout",
@@ -2652,6 +2743,7 @@ pub(super) fn default_action_offer_verb(kind: &str) -> &str {
         "search" => "Inspect",
         "explore_path" => "Scout",
         FOCUSED_NOTICE_OFFER_KIND => "Notice",
+        NOTICE_ACTOR_OFFER_KIND => "Notice",
         DISCOVERY_SEARCH_OFFER_KIND => "Search",
         DISCOVERY_STUDY_OFFER_KIND => "Study",
         DISCOVERY_SCOUT_OFFER_KIND => "Scout",
@@ -2725,6 +2817,7 @@ pub(super) fn action_offer_category(kind: &str) -> &'static str {
         "craft" => "craft",
         "chat" | "model_interaction" | "help" | "create_bond" | "resolve_bond" => "social",
         "check"
+        | NOTICE_ACTOR_OFFER_KIND
         | "search"
         | FOCUSED_NOTICE_OFFER_KIND
         | DISCOVERY_SEARCH_OFFER_KIND

--- a/v2/orchestrator-rust/src/first_tale.rs
+++ b/v2/orchestrator-rust/src/first_tale.rs
@@ -246,9 +246,14 @@ impl RuntimeWorld {
         };
         match stage {
             FirstTaleStage::Notice => {
-                offer.intention == "notice"
-                    && offer.target.as_ref().and_then(|target| target.id)
-                        == Some(first_tale.lead_location_id)
+                offer.kind == NOTICE_ACTOR_OFFER_KIND
+                    && offer.target.as_ref().is_some_and(|target| {
+                        target.kind == "actor"
+                            && target
+                                .id
+                                .and_then(|target_actor_id| self.actor_by_id(target_actor_id))
+                                .is_some_and(|target| target.location_id == actor.location_id)
+                    })
             }
             FirstTaleStage::ReturnToLead => route_toward(first_tale.lead_location_id),
             FirstTaleStage::FollowLead | FirstTaleStage::ReturnToDestination => {
@@ -265,7 +270,7 @@ impl RuntimeWorld {
                             && project.progress_clock_id == first_tale.progress_clock_id
                     }))
                     || (shared_question_complete
-                        && offer.intention == "notice"
+                        && offer.intention == "inspect"
                         && offer.target.as_ref().and_then(|target| target.id)
                             == Some(first_tale.destination_location_id))
             }
@@ -724,7 +729,7 @@ mod tests {
         let (offers, hand, view) = first_tale_action_state(&runtime, actor_id);
         assert_eq!(view.phase, "contribute");
         let fallback = advancing_offer(&offers, &hand, &view);
-        assert_eq!(fallback.intention, "notice");
+        assert_eq!(fallback.intention, "inspect");
         assert_eq!(
             fallback.target.as_ref().and_then(|target| target.id),
             Some(RAIN_SOFT_GARDEN_LOCATION_ID)

--- a/v2/orchestrator-rust/src/first_tale.rs
+++ b/v2/orchestrator-rust/src/first_tale.rs
@@ -170,7 +170,13 @@ impl RuntimeWorld {
         if let Some(claim_key) = first_tale_trace_claim_key(action.actor_id, trace.seq) {
             self.rpg_claims.insert(claim_key);
         }
-        vec![trace]
+        let mut projected = vec![trace];
+        // Truthful actor Notice does not touch growth; completing the tale is
+        // the authored reward that funds its relationship continuation.
+        if let Some(settlement) = self.bank_visit_ledger(action.actor_id, "first_tale") {
+            projected.push(settlement);
+        }
+        projected
     }
 
     pub(super) fn first_tale_stage(&self, actor_id: u64) -> Option<FirstTaleStage> {

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -6932,6 +6932,30 @@
           }),
         });
       }
+      for (const offer of exactOfferVariants("notice_actor").filter(Boolean)) {
+        const targetId = Number(offer?.target?.id || 0);
+        const targetLabel = String(offer?.target?.label || "a nearby actor").trim();
+        if (!targetId) continue;
+        const noticeVerb = offerVerb(offer, "Notice");
+        built.push({
+          ...semanticAction(offer, "notice", `${noticeVerb} ${targetLabel}`),
+          label: noticeVerb.toLowerCase(),
+          detail: targetLabel,
+          command: offer.command || `notice ${targetLabel}`,
+          focusKey: `actor:${targetId}`,
+          focusKeys: [`actor:${targetId}`],
+          card: cardForActor(targetId),
+          shape: "avatar",
+          priority: Number(offer.rank || 52),
+          modalTitle: `${noticeVerb.toLowerCase()} ${targetLabel}`,
+          modalSummary: "Notice one disclosure-safe fact that is visibly true right now.",
+          effect: offer.effect,
+          run: () => action("/actions/notice", {
+            actor_id: actorId,
+            target_actor_id: targetId,
+          }),
+        });
+      }
       const journey = view.journey || null;
       const pathwayJourney = activePathwayJourney(view);
       const scoutOffers = (view.action_offers || []).filter((offer) => (
@@ -8055,39 +8079,6 @@
           });
         }
       });
-      const listenAttemptedHere = economy.listen_attempted_here === true;
-      const ambientCheckOffer = (view.action_offers || []).find((offer) => (
-        offer.kind === "check" && !offer.project
-      )) || null;
-      const listenHasFreshOutcome = !listenAttemptedHere
-        || Boolean(ambientCheckOffer)
-        || options.has("check");
-      const listenKnownUnattempted = economy.listen_attempted_here === false;
-      if ((options.has("check") || listenKnownUnattempted)
-          && listenHasFreshOutcome) {
-        const listenOffer = ambientCheckOffer;
-        const noticeVerb = offerVerb(listenOffer, "Notice");
-        built.push({
-          ...semanticAction(listenOffer, "notice"),
-          label: listenAttemptedHere ? `${noticeVerb.toLowerCase()} again` : noticeVerb.toLowerCase(),
-          detail: listenAttemptedHere ? "free" : "for a clue",
-          command: "listen",
-          focusKey: "check",
-          card: cardForLocation(view.location?.id),
-          shape: "location",
-          priority: listenAttemptedHere ? 82 : Number(listenOffer?.rank || 60),
-          orbCost: 0,
-          modalTitle: listenAttemptedHere ? `${noticeVerb.toLowerCase()} once more` : noticeVerb.toLowerCase(),
-          modalSummary: listenAttemptedHere
-            ? "Notice another ambient lead. The room may have nothing new yet."
-            : "Receive one ambient lead from the room.",
-          effect: listenAttemptedHere
-            ? "the room may share another clue"
-            : "the room shares one clue it is ready to tell",
-          risk: listenAttemptedHere ? listenOffer?.risk : undefined,
-          run: () => action("/actions/check", { actor_id: actorId, ability: "wisdom", dc: 12 })
-        });
-      }
       if (options.has("influence")) {
         for (const influenceOffer of exactOfferVariants("influence")) {
           const targetId = Number(influenceOffer?.target?.id || 0);
@@ -8651,6 +8642,7 @@
         "/actions/move": ["move"],
         "/actions/explore-path": ["explore_path"],
         "/actions/flee": ["flee"],
+        "/actions/notice": ["notice_actor"],
         "/actions/open": ["open"],
         "/actions/check": ["check"],
         "/actions/study": ["study"],
@@ -8695,6 +8687,7 @@
       "/actions/move",
       "/actions/explore-path",
       "/actions/flee",
+      "/actions/notice",
       "/actions/open",
       "/actions/check",
       "/actions/study",
@@ -8734,7 +8727,7 @@
         return Number(payload.item_id || 0);
       }
       if (["/actions/trade-item", "/actions/theft"].includes(path) && targetKind === "item") return Number(payload.target_item_id || 0);
-      if (["/actions/chat", "/actions/model-interaction", "/actions/attack", "/actions/give-item", "/actions/create-bond", "/actions/resolve-bond", "/actions/cast-spell", "/actions/influence", "/actions/use-item"].includes(path)
+      if (["/actions/chat", "/actions/notice", "/actions/model-interaction", "/actions/attack", "/actions/give-item", "/actions/create-bond", "/actions/resolve-bond", "/actions/cast-spell", "/actions/influence", "/actions/use-item"].includes(path)
           && targetKind === "actor") {
         return Number(payload.target_actor_id || 0);
       }
@@ -14692,7 +14685,6 @@
       if (!actor || Number(actor.id || 0) === Number(actorId || 0)) return "";
       const actorNumericId = Number(actor.id || 0);
       const downed = actorIsDownedForRail(actor);
-      const economyKnown = Boolean(actor?.economy);
       const giftAvailable = !downed && Boolean(transferActionForActor("give", actorNumericId));
       const careAvailable = actorNeedsHealing(actor) && Boolean(careActionForActor(actorNumericId));
       const incoming = (state?.safety?.incoming_offers || [])
@@ -14719,16 +14711,13 @@
       ].join("");
       const muteVerb = actor.muted_by_you ? "unmute" : "mute";
       const blockVerb = actor.blocked_by_you ? "unblock" : "block";
-      const noticeButton = economyKnown || downed
-        ? ""
-        : `<button class="account-button avatar-icon-action" type="button" data-avatar-notice="${actorNumericId}">${iconSvg("notice")}<span>notice</span></button>`;
       const giftButton = giftAvailable
         ? `<button class="account-button avatar-icon-action" type="button" data-avatar-transfer="give" data-avatar-id="${actorNumericId}">${iconSvg("gift")}<span>gift</span></button>`
         : "";
       const careButton = careAvailable
         ? `<button class="account-button avatar-icon-action" type="button" data-avatar-care="${actorNumericId}">${iconSvg("utility")}<span>help</span></button>`
         : "";
-      const primaryActions = `${careButton}${noticeButton}${giftButton}`;
+      const primaryActions = `${careButton}${giftButton}`;
       return `${offerHtml}<div class="avatar-interactions" aria-label="Interactions with ${escapeAttr(actorLabel(actor))}">${primaryActions ? `<div class="avatar-action-strip">${primaryActions}</div>` : ""}${avatarKnownItemsHtml(actor, giftRequests)}<div class="avatar-safety-strip" aria-label="Safety controls"><button class="account-button avatar-icon-action" type="button" data-avatar-safety="${muteVerb}" data-avatar-id="${actorNumericId}">${iconSvg("mute")}<span>${muteVerb}</span></button><button class="account-button avatar-icon-action" type="button" data-avatar-safety="${blockVerb}" data-avatar-id="${actorNumericId}">${iconSvg("block")}<span>${blockVerb}</span></button><button class="account-button avatar-icon-action" type="button" data-avatar-report="${actorNumericId}">${iconSvg("report")}<span>report</span></button></div></div>`;
     }
 
@@ -16867,25 +16856,6 @@
         if (targetChoice) careAction.selectedChoice = targetChoice;
         closeCardModal();
         openActionModal(careAction);
-        return;
-      }
-      const notice = event.target.closest("[data-avatar-notice]");
-      if (notice) {
-        event.preventDefault();
-        event.stopPropagation();
-        const targetActorId = Number(notice.getAttribute("data-avatar-notice") || 0);
-        if (!targetActorId) return;
-        notice.disabled = true;
-        action("/actions/check", {
-          actor_id: actorId,
-          target_actor_id: targetActorId,
-          ability: "wisdom",
-          dc: 12,
-        }).then(async () => {
-          await refresh();
-          const updated = cardForActor(targetActorId);
-          if (updated) openCardModal(updated);
-        });
         return;
       }
       const transfer = event.target.closest("[data-avatar-transfer]");

--- a/v2/orchestrator-rust/src/keys.rs
+++ b/v2/orchestrator-rust/src/keys.rs
@@ -17,6 +17,17 @@ pub(super) fn economy_disclosure_claim_key(viewer_actor_id: u64, target_actor_id
     format!("economy_disclosed:{viewer_actor_id}:{target_actor_id}")
 }
 
+pub(super) fn notice_actor_fact_claim_key(
+    viewer_actor_id: u64,
+    target_actor_id: u64,
+    item_id: u64,
+    held_since_tick: u64,
+) -> String {
+    format!(
+        "notice_actor:v1:{viewer_actor_id}:{target_actor_id}:carried_item:{item_id}:{held_since_tick}"
+    )
+}
+
 pub(super) fn listen_attempt_claim_key(actor_id: u64, location_id: u64) -> String {
     format!("listen_attempt:{actor_id}:{location_id}")
 }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -70,6 +70,7 @@ mod moderation;
 mod movement;
 mod mud;
 mod natural_affordances;
+mod notice;
 mod offer_commands;
 mod ownership;
 #[cfg(test)]
@@ -180,6 +181,7 @@ use moderation::*;
 use movement::*;
 use mud::*;
 use natural_affordances::*;
+use notice::*;
 use offer_commands::*;
 use ownership::*;
 use projection_cache::*;
@@ -930,6 +932,12 @@ enum ProjectionMutation {
     },
     SetGiftAutoAccept(projection_ledger::SetGiftAutoAccept),
     ConsumeGiftAutoAccept(projection::ConsumeGiftAutoAccept),
+    RecordNoticeActorFact {
+        fact_id: String,
+        target_actor_id: u64,
+        item_id: u64,
+        held_since_tick: u64,
+    },
     ShuffleHand {
         reason: String,
     },
@@ -1347,6 +1355,7 @@ impl ActorControlMode {
 
 const TRANSFER_OFFER_TTL_TICKS: u64 = 24;
 const ACCEPT_TRANSFER_OFFER_KIND: &str = "accept_transfer";
+const NOTICE_ACTOR_OFFER_KIND: &str = "notice_actor";
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -4947,6 +4956,7 @@ fn resolved_action_binding(kind: &str) -> Option<ResolvedActionBinding> {
         ACCEPT_TRANSFER_OFFER_KIND => "give_item",
         "explore_path" | DISCOVERY_SCOUT_OFFER_KIND | DISCOVERY_SEARCH_OFFER_KIND => "search",
         FOCUSED_NOTICE_OFFER_KIND => "check",
+        NOTICE_ACTOR_OFFER_KIND => "check",
         DISCOVERY_STUDY_OFFER_KIND => "study",
         "open" => "use_item",
         other => other,
@@ -9379,6 +9389,32 @@ impl RuntimeWorld {
                 ProjectionMutation::ConsumeGiftAutoAccept(mutation) => {
                     mutation.apply(self, &ctx);
                 }
+                ProjectionMutation::RecordNoticeActorFact {
+                    fact_id,
+                    target_actor_id,
+                    item_id: _,
+                    held_since_tick: _,
+                } => {
+                    if self.rpg_claims.insert(fact_id.clone()) {
+                        if action.location_id != 0 {
+                            self.listen_attempt_claims.insert(listen_attempt_claim_key(
+                                action.actor_id,
+                                action.location_id,
+                            ));
+                        }
+                        let target_name = self
+                            .actor_name(*target_actor_id)
+                            .unwrap_or_else(|| format!("Avatar {target_actor_id}"));
+                        events.push(self.append_async_job_event(
+                            "notice.actor_observed",
+                            action.actor_id,
+                            Some(*target_actor_id),
+                            Some(format!(
+                                "A private observable detail about {target_name} became known."
+                            )),
+                        ));
+                    }
+                }
                 ProjectionMutation::ShuffleHand { reason } => {
                     events.push(self.append_hand_shuffled_event(action.actor_id, reason));
                 }
@@ -13197,8 +13233,8 @@ impl RuntimeWorld {
             .actor_by_id(actor_id)
             .filter(|actor| Self::actor_can_act(*actor))
             .ok_or_else(|| "Notice requires an active avatar.".to_string())?;
-        if target_actor_id != 0 && !self.economy_notice_target_is_valid(actor_id, target_actor_id) {
-            return Err("That avatar is not close enough to notice.".to_string());
+        if target_actor_id != 0 {
+            return Err("Actor Notice now requires a certified notice_actor_v1 offer.".to_string());
         }
         Ok((
             CwAction {
@@ -19272,6 +19308,21 @@ The relationship statement they are preserving is: {statement}"
                 record.projection_mutations.extend(mutations);
                 record
             }
+            NOTICE_ACTOR_OFFER_KIND => {
+                let target_actor_id = offer
+                    .target
+                    .as_ref()
+                    .filter(|target| target.kind == "actor")
+                    .and_then(|target| target.id)?;
+                let (action, mutation, _) = self
+                    .plan_notice_actor_action(actor.id, target_actor_id)
+                    .ok()?;
+                let mut record =
+                    JournalRecord::new(action, seed).into_actor_consequence(self.world.tick, None);
+                record.bind_offer_kind(NOTICE_ACTOR_OFFER_KIND);
+                record.projection_mutations.push(mutation);
+                record
+            }
             "check" => {
                 if self.event_log.iter().rev().any(|event| {
                     event.seq >= min_seq
@@ -19635,6 +19686,18 @@ The relationship statement they are preserving is: {statement}"
                             intent.strategy.strategy_label.trim_end_matches('.')
                         ))
                     }
+                    ProjectionMutation::RecordNoticeActorFact {
+                        target_actor_id, ..
+                    } => {
+                        proposed_action.kind = NOTICE_ACTOR_OFFER_KIND.to_string();
+                        proposed_action.target_actor_id = Some(*target_actor_id);
+                        let target = self
+                            .actor_name(*target_actor_id)
+                            .unwrap_or_else(|| format!("Avatar {target_actor_id}"));
+                        Some(format!(
+                            "{actor_name} intends to notice one visible detail about {target}."
+                        ))
+                    }
                     ProjectionMutation::ClearTag { reason, .. } if reason == "rest" => {
                         proposed_action.kind = "rest".to_string();
                         Some(format!("{actor_name} intends to rest."))
@@ -19806,6 +19869,24 @@ The relationship statement they are preserving is: {statement}"
             return offer.target.as_ref().is_some_and(|target| {
                 target.kind == "location" && target.id == Some(destination_location_id)
             });
+        }
+        if let Some((fact_id, target_actor_id)) =
+            record
+                .projection_mutations
+                .iter()
+                .find_map(|mutation| match mutation {
+                    ProjectionMutation::RecordNoticeActorFact {
+                        fact_id,
+                        target_actor_id,
+                        ..
+                    } => Some((fact_id.as_str(), *target_actor_id)),
+                    _ => None,
+                })
+        {
+            return offer.claim_key.as_deref() == Some(fact_id)
+                && offer.target.as_ref().is_some_and(|target| {
+                    target.kind == "actor" && target.id == Some(target_actor_id)
+                });
         }
         if action.kind == CW_ACTION_RULES_SEARCH && offer.kind == "check" {
             return offer.target.as_ref().is_some_and(|target| {
@@ -22302,6 +22383,14 @@ async fn submit_action_offer(
                 ConnectInfo(client_addr),
                 State(state),
                 Json(parsed!(CheckRequest)),
+            )
+            .await
+        }
+        "/actions/notice" => {
+            notice_actor(
+                ConnectInfo(client_addr),
+                State(state),
+                Json(parsed!(NoticeActorRequest)),
             )
             .await
         }
@@ -25417,6 +25506,19 @@ async fn command_inner(
         CommandDispatch::OpenThreshold { action } => {
             let Json(response) =
                 apply_and_broadcast(state.clone(), *action, payload.actor_session.as_deref()).await;
+            command_action_response_with_events(resolved, response, presence_events)
+        }
+        CommandDispatch::NoticeActor { target_actor_id } => {
+            let Json(response) = notice_actor(
+                ConnectInfo(client_addr),
+                State(state),
+                Json(NoticeActorRequest {
+                    actor_id: payload.actor_id,
+                    actor_session: payload.actor_session,
+                    target_actor_id,
+                }),
+            )
+            .await;
             command_action_response_with_events(resolved, response, presence_events)
         }
         CommandDispatch::Check => {
@@ -36989,7 +37091,8 @@ mod tests {
     #[test]
     fn avatar_inspector_and_hand_expose_room_bound_transfer_consent() {
         for contract in [
-            "data-avatar-notice=",
+            "exactOfferVariants(\"notice_actor\")",
+            "/actions/notice",
             "Nothing known yet.",
             "data-avatar-transfer=\"give\"",
             "data-avatar-item-toggle=",
@@ -42997,7 +43100,9 @@ mod tests {
         assert!(INDEX_HTML.contains("function quietRoomSceneHtml"));
         assert!(INDEX_HTML.contains("Chat with someone here or explore the room."));
         assert!(INDEX_HTML.contains("discover the room through play"));
-        assert!(INDEX_HTML.contains("options.has(\"check\") || listenKnownUnattempted"));
+        assert!(INDEX_HTML.contains("exactOfferVariants(\"notice_actor\")"));
+        assert!(INDEX_HTML.contains("/actions/notice"));
+        assert!(!INDEX_HTML.contains("data-avatar-notice"));
         assert!(!INDEX_HTML.contains("hasCheckContribution"));
         assert!(INDEX_HTML.contains("data-story-guide"));
         assert!(INDEX_HTML.contains("const storyGuideLabel"));
@@ -43041,7 +43146,9 @@ mod tests {
         assert!(!INDEX_HTML.contains("rules:ordered-scene-pass"));
         assert!(!INDEX_HTML.contains("rules:ordered-scene-need-time"));
         assert!(!INDEX_HTML.contains("shows the current combat order without taking an action"));
-        assert!(INDEX_HTML.contains("Receive one ambient lead from the room."));
+        assert!(
+            INDEX_HTML.contains("Notice one disclosure-safe fact that is visibly true right now.")
+        );
         assert!(!INDEX_HTML.contains("temporary Dex priority boost"));
         assert!(INDEX_HTML.contains("class=\"roll-symbol\""));
         assert!(INDEX_HTML.contains("class=\"roll-result\""));
@@ -43155,13 +43262,12 @@ mod tests {
         assert!(INDEX_HTML.contains("/ai/openrouter/verify"));
         assert!(!INDEX_HTML.contains("/api/v1/auth/keys"));
         assert!(INDEX_HTML.contains("listenHintForLocation"));
-        assert!(INDEX_HTML.contains("listen_attempted_here"));
-        assert!(INDEX_HTML.contains("listen again"));
-        assert!(INDEX_HTML.contains("The room may have nothing new yet."));
-        assert!(INDEX_HTML.contains("the room may share another clue"));
+        assert!(!INDEX_HTML.contains("listen_attempted_here"));
+        assert!(INDEX_HTML.contains("exactOfferVariants(\"notice_actor\")"));
+        assert!(INDEX_HTML.contains("target_actor_id: targetId"));
         assert!(INDEX_HTML.contains("[\"Costs\", orbCost ?"));
         assert!(!INDEX_HTML.contains("to listen again"));
-        assert!(INDEX_HTML.contains("Receive one ambient lead from the room."));
+        assert!(!INDEX_HTML.contains("Receive one ambient lead from the room."));
         assert!(INDEX_HTML.contains("one Orb"));
         assert!(INDEX_HTML.contains("function orbChangeText"));
         assert!(!INDEX_HTML.contains("flashEconomy(`+${delta}`"));
@@ -47738,63 +47844,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn targeted_notice_endpoint_reveals_only_after_a_successful_check() {
-        let mut runtime = RuntimeWorld::seeded();
-        create_test_human(
-            &mut runtime,
-            5000,
-            COSY_COTTAGE_LOCATION_ID,
-            "Endpoint Observer",
-        );
-        runtime
-            .world
-            .actors
-            .iter_mut()
-            .find(|actor| actor.id == 5000)
-            .expect("observer exists")
-            .stats
-            .wisdom = i8::MAX;
-        let state = test_app_state(runtime, None);
-        let (actor_session, _) = issue_actor_session(&state, 5000);
-
-        let response = ability_check(
-            ConnectInfo("127.0.0.1:43110".parse().expect("client address")),
-            State(state.clone()),
-            Json(CheckRequest {
-                actor_id: 5000,
-                actor_session: Some(actor_session),
-                ability: "wisdom".to_string(),
-                dc: Some(LISTEN_DC),
-                target_actor_id: Some(RATI_ACTOR_ID),
-            }),
-        )
-        .await
-        .0;
-
-        assert!(response.ok);
-        let notice = response
-            .events
-            .iter()
-            .find(|event| event.type_name == "ability_check.rolled")
-            .expect("targeted notice event");
-        assert!(notice.success);
-        assert_eq!(notice.content.as_deref(), Some("notice"));
-        assert_eq!(notice.target_actor_id, Some(RATI_ACTOR_ID));
-        assert!(!response
-            .events
-            .iter()
-            .any(|event| event.type_name == "job.contribution.resolved"));
-        let runtime = state.inner.lock().await;
-        assert!(runtime.economy_known_by(5000, RATI_ACTOR_ID));
-        assert!(runtime
-            .state_response(Some(5000), &AccessContext::default())
-            .actors
-            .iter()
-            .find(|actor| actor.id == RATI_ACTOR_ID)
-            .is_some_and(|actor| actor.resident_economy.is_some()));
-    }
-
-    #[tokio::test]
     async fn ability_check_endpoint_rejects_noncanonical_dc_and_ability() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
@@ -48823,7 +48872,7 @@ mod tests {
             .primary_action
             .options
             .iter()
-            .any(|option| option.kind == "check"));
+            .all(|option| option.kind != "check"));
 
         let bank_command = runtime
             .resolve_command(&command_request(5000, "grow"), &AccessContext::default())
@@ -51945,7 +51994,7 @@ mod tests {
         let baseline_notice = baseline
             .action_offers
             .iter()
-            .find(|offer| offer.kind == "check")
+            .find(|offer| offer.kind == NOTICE_ACTOR_OFFER_KIND)
             .expect("Notice is already legal before practice recognition");
 
         for seq in 1..=5 {
@@ -51982,7 +52031,7 @@ mod tests {
         let recognized_notice = recognized
             .action_offers
             .iter()
-            .find(|offer| offer.kind == "check")
+            .find(|offer| offer.kind == NOTICE_ACTOR_OFFER_KIND)
             .expect("Notice remains legal after practice recognition");
 
         assert_eq!(recognized_kinds, baseline_kinds);
@@ -56781,7 +56830,7 @@ mod tests {
             .action_hand
             .entries
             .iter()
-            .any(|entry| entry.kind == "check"));
+            .any(|entry| entry.kind == NOTICE_ACTOR_OFFER_KIND));
         assert!(calling_runtime
             .bank_visit_ledger(5000, "action_hand_fixture")
             .is_some());
@@ -56950,10 +56999,10 @@ mod tests {
         assert_eq!(state.primary_action.kind, "pick_up");
         assert_eq!(state.primary_action.label, "Take");
         assert!(state
-            .primary_action
-            .options
+            .action_offers
             .iter()
-            .any(|option| option.kind == "check" && option.command == "listen"));
+            .filter(|offer| offer.kind == "check")
+            .all(|offer| offer.project.is_some()));
         assert!(state
             .primary_action
             .options
@@ -56964,33 +57013,11 @@ mod tests {
             .options
             .iter()
             .any(|option| option.kind == "help" && option.command == "assist"));
-        let listen_offer = state
+        assert!(state
             .action_offers
             .iter()
-            .find(|offer| offer.kind == "check")
-            .expect("listen offer is exposed");
-        assert_eq!(listen_offer.category, "discovery");
-        assert_eq!(listen_offer.intention, "notice");
-        assert_eq!(listen_offer.verb, "Notice");
-        assert_eq!(listen_offer.label, "Notice");
-        assert_eq!(listen_offer.accessible_label, "Notice at Moonlit Trail");
-        assert!(listen_offer.target.as_ref().is_some_and(|target| {
-            target.kind == "location"
-                && target.id == Some(MOONLIT_TRAIL_LOCATION_ID)
-                && target.label.as_deref() == Some("Moonlit Trail")
-        }));
-        assert_eq!(listen_offer.zone, ZONE_FRONTIER);
-        assert!(listen_offer
-            .effect
-            .as_deref()
-            .is_some_and(|effect| effect.contains("one useful clue")
-                && effect.contains("shared work")
-                && !effect.contains(MOONLIT_PROGRESS_CLOCK_ID)));
-        assert_eq!(listen_offer.progress, Some(1));
-        assert!(listen_offer
-            .risk
-            .as_deref()
-            .is_some_and(|risk| risk.contains("out here may tire you")));
+            .filter(|offer| offer.kind == "check")
+            .all(|offer| offer.project.is_some()));
         assert_complete_offer_inspector(&state);
         let help_offer = state
             .action_offers
@@ -57084,9 +57111,7 @@ mod tests {
             .room
             .listen_reason
             .as_deref()
-            .is_some_and(|reason| reason.contains("one useful clue")
-                && reason.contains("shared work")
-                && !reason.contains(MOONLIT_PROGRESS_CLOCK_ID)));
+            .is_some_and(|reason| !reason.contains("ambient lead")));
         assert!(
             inspector
                 .jobs
@@ -57865,97 +57890,6 @@ mod tests {
             revealed.items.iter().any(|item| item.id == 2001),
             "disclosure reveals held item cards through the same viewer-target fact"
         );
-    }
-
-    #[test]
-    fn notice_disclosure_is_success_gated_and_survives_snapshot_and_replay() {
-        std::thread::Builder::new()
-            .name("economy-disclosure-replay".to_string())
-            .stack_size(16 * 1024 * 1024)
-            .spawn(|| {
-                let mut runtime = RuntimeWorld::seeded();
-                create_test_human(
-                    &mut runtime,
-                    5000,
-                    COSY_COTTAGE_LOCATION_ID,
-                    "Careful Observer",
-                );
-                let target_actor_id = RATI_ACTOR_ID;
-                assert!(runtime
-                    .resident_economy_view(
-                        runtime.actor_by_id(target_actor_id).expect("Rati exists"),
-                        Some(5000),
-                    )
-                    .is_none());
-
-                let failed_record = JournalRecord::new(
-                    CwAction {
-                        kind: CW_ACTION_RULES_SEARCH,
-                        actor_id: 5000,
-                        target_actor_id,
-                        ability: LISTEN_ABILITY,
-                        dc: LISTEN_DC,
-                        modifier: -100,
-                        ..CwAction::default()
-                    },
-                    86_001,
-                );
-                let (status, failed_events) = runtime.apply_journal_record(&failed_record);
-                assert_eq!(status, CW_OK);
-                let failed = failed_events
-                    .iter()
-                    .find(|event| event.type_name == "ability_check.rolled")
-                    .expect("notice check event");
-                assert_eq!(failed.content.as_deref(), Some("notice"));
-                assert_eq!(failed.target_actor_id, Some(target_actor_id));
-                assert!(!runtime.economy_known_by(5000, target_actor_id));
-
-                let replay_base = RuntimeSnapshot::from_runtime(&runtime);
-                let successful_record = JournalRecord::new(
-                    CwAction {
-                        kind: CW_ACTION_RULES_SEARCH,
-                        actor_id: 5000,
-                        target_actor_id,
-                        ability: LISTEN_ABILITY,
-                        dc: LISTEN_DC,
-                        modifier: 100,
-                        ..CwAction::default()
-                    },
-                    86_002,
-                );
-                let (status, successful_events) = runtime.apply_journal_record(&successful_record);
-                assert_eq!(status, CW_OK);
-                let successful = successful_events
-                    .iter()
-                    .find(|event| event.type_name == "ability_check.rolled")
-                    .expect("successful notice event");
-                assert!(successful.success);
-                assert_eq!(successful.content.as_deref(), Some("notice"));
-                assert!(runtime.economy_known_by(5000, target_actor_id));
-                assert!(runtime
-                    .resident_economy_view(
-                        runtime.actor_by_id(target_actor_id).expect("Rati exists"),
-                        Some(5000),
-                    )
-                    .is_some());
-
-                let persisted = RuntimeSnapshot::from_runtime(&runtime);
-                drop(runtime);
-                let restored = persisted
-                    .into_runtime()
-                    .expect("economy disclosure snapshot restores");
-                assert!(restored.economy_known_by(5000, target_actor_id));
-                drop(restored);
-
-                let mut replayed = replay_base
-                    .into_runtime()
-                    .expect("pre-disclosure snapshot restores");
-                assert_eq!(replayed.apply_journal_record(&successful_record).0, CW_OK);
-                assert!(replayed.economy_known_by(5000, target_actor_id));
-            })
-            .expect("spawn economy disclosure replay test")
-            .join()
-            .expect("economy disclosure replay test completes");
     }
 
     #[test]
@@ -60497,8 +60431,8 @@ mod tests {
             .find(|offer| offer.kind == "search")
             .expect("the player candidate surface offers Search");
         let record = runtime
-            .resident_economy_autonomy_record(actor, seed)
-            .expect("the resident selects the same Search offer");
+            .resident_record_for_shared_offer(actor, &offer, seed)
+            .expect("the resident can execute the same Search offer");
         assert_eq!(record.origin, JournalOrigin::ActorConsequence);
         assert_eq!(record.rules_action, offer.rules_action);
         assert_eq!(record.operation, offer.operation);
@@ -60706,7 +60640,7 @@ mod tests {
     }
 
     #[test]
-    fn resident_notice_uses_the_player_offer_and_replays_the_roll() {
+    fn resident_notice_uses_the_player_fact_offer_and_replays_the_projection() {
         let mut runtime = RuntimeWorld::seeded();
         runtime
             .actor_autonomy
@@ -60714,16 +60648,40 @@ mod tests {
             .or_default()
             .control_mode = ActorControlMode::LocalAi;
         let actor = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
+        let target_actor_id = 1002;
+        runtime
+            .world
+            .actors
+            .iter_mut()
+            .take(runtime.world.actor_count)
+            .find(|target| target.id == target_actor_id)
+            .expect("target resident exists")
+            .location_id = actor.location_id;
+        let item = runtime
+            .world
+            .items
+            .iter_mut()
+            .take(runtime.world.item_count)
+            .find(|item| item.id == STORY_BUTTON_ITEM_ID)
+            .expect("story button exists");
+        item.location_id = 0;
+        item.holder_actor_id = target_actor_id;
+        item.container_item_id = 0;
+        item.zone = CW_CARD_ZONE_CARRIED;
+        item.held_since_tick = 98;
         let inference_offers = runtime
             .legal_action_candidates(Some(actor.id), &AccessContext::default())
             .1;
         let offer = inference_offers
             .iter()
-            .find(|offer| offer.kind == "check")
+            .find(|offer| {
+                offer.kind == NOTICE_ACTOR_OFFER_KIND
+                    && offer.target.as_ref().and_then(|target| target.id) == Some(target_actor_id)
+            })
             .cloned()
             .expect("the resident sees the player-facing Notice offer");
         assert!(offer.target.as_ref().is_some_and(|target| {
-            target.kind == "location" && target.id == Some(actor.location_id)
+            target.kind == "actor" && target.id == Some(target_actor_id)
         }));
 
         runtime
@@ -60739,8 +60697,8 @@ mod tests {
             serde_json::to_value(&inference_offers).expect("inference offers serialize"),
             "controller mode cannot change legal Notice enumeration"
         );
-        let (player_action, player_mutations) = runtime
-            .plan_notice_action(actor.id, 0)
+        let (player_action, player_mutation, _) = runtime
+            .plan_notice_actor_action(actor.id, target_actor_id)
             .expect("the player Notice planner accepts the current offer");
 
         runtime
@@ -60750,14 +60708,20 @@ mod tests {
             .control_mode = ActorControlMode::LocalAi;
         runtime
             .draw_until_test_offer(actor.id, &AccessContext::default(), |candidate| {
-                candidate.kind == "check"
+                candidate.kind == NOTICE_ACTOR_OFFER_KIND
+                    && candidate.target.as_ref().and_then(|target| target.id)
+                        == Some(target_actor_id)
             })
             .expect("the exact Notice offer is dealt before LocalAI selects it");
         let offer = runtime
             .legal_action_candidates(Some(actor.id), &AccessContext::default())
             .1
             .into_iter()
-            .find(|candidate| candidate.kind == "check")
+            .find(|candidate| {
+                candidate.kind == NOTICE_ACTOR_OFFER_KIND
+                    && candidate.target.as_ref().and_then(|target| target.id)
+                        == Some(target_actor_id)
+            })
             .expect("the dealt Notice offer remains current");
         let record = runtime
             .resident_record_for_shared_offer(actor, &offer, 98_101)
@@ -60778,7 +60742,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             serde_json::to_value(resident_mutations).expect("resident mutations serialize"),
-            serde_json::to_value(player_mutations).expect("player mutations serialize")
+            serde_json::to_value([player_mutation]).expect("player mutation serializes")
         );
         let (rank, score) = runtime.resident_autonomy_record_priority(actor, &record);
         let record = runtime
@@ -60793,7 +60757,7 @@ mod tests {
             .resident_decision
             .as_ref()
             .expect("Notice selection carries a decision trace");
-        assert_eq!(trace.choice.offer_kind, "check");
+        assert_eq!(trace.choice.offer_kind, NOTICE_ACTOR_OFFER_KIND);
         assert_eq!(
             trace.choice.offer_id.as_deref(),
             Some(offer.offer_id.as_str())
@@ -60803,9 +60767,9 @@ mod tests {
         let (status, events) = runtime.apply_journal_record(&record);
         assert_eq!(status, CW_OK);
         assert!(events.iter().any(|event| {
-            event.type_name == "ability_check.rolled"
+            event.type_name == "notice.actor_observed"
                 && event.actor_id == Some(actor.id)
-                && event.location_id == Some(actor.location_id)
+                && event.target_actor_id == Some(target_actor_id)
         }));
         assert!(runtime
             .resident_record_for_shared_offer(actor, &offer, 98_102)

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -37656,13 +37656,7 @@ mod tests {
         kind: &str,
     ) -> CommandRequest {
         let offer_id = if kind == "*" {
-            runtime
-                .state_response(Some(actor_id), &AccessContext::default())
-                .visible_action_offers
-                .into_iter()
-                .find(|offer| !offer.disabled && offer.kind != "chat")
-                .map(|offer| offer.offer_id)
-                .unwrap_or_else(|| runtime.action_hand_for(Some(actor_id), &[]).pass.offer_id)
+            runtime.action_hand_for(Some(actor_id), &[]).pass.offer_id
         } else {
             runtime
                 .draw_until_test_offer(actor_id, &AccessContext::default(), |offer| {

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -84,6 +84,9 @@ pub(crate) enum CommandDispatch {
     OpenThreshold {
         action: Box<CwAction>,
     },
+    NoticeActor {
+        target_actor_id: u64,
+    },
     Check,
     Study,
     Discover {
@@ -505,6 +508,9 @@ pub(crate) fn command_action_failure_output(resolved: &ResolvedCommand, status: 
         CommandDispatch::Flee { .. } => "The room has calmed; flee is not needed.",
         CommandDispatch::OpenThreshold { .. } => {
             "That threshold method changed while you were choosing. Look again."
+        }
+        CommandDispatch::NoticeActor { .. } => {
+            "That observable fact changed while you were choosing. Look again."
         }
         CommandDispatch::Check => "The room did not catch that Listen. Try once more.",
         CommandDispatch::Study => "There is no authored subject to Study here now.",
@@ -995,6 +1001,7 @@ pub(crate) fn command_event_output(event: &EventView) -> Option<String> {
             event.item_name.as_deref().unwrap_or("the prepared spell")
         )),
         "influence.committed" => event.content.clone(),
+        "notice.fact_revealed" => event.content.clone(),
         "study.resolved" => Some(
             if event
                 .content
@@ -2619,6 +2626,50 @@ impl RuntimeWorld {
                     verb,
                     action: Some(command_action("check", "Listen", "listen")),
                     dispatch: CommandDispatch::Check,
+                })
+            }
+            "notice" => {
+                let target = self
+                    .resolve_room_actor(
+                        actor,
+                        rest,
+                        CommandActorFilter::ActiveActor,
+                        active_direct_actor_ids,
+                    )
+                    .map_err(|output| command_error(&command, "notice", 404, output))?;
+                let target_name = self.actor_view(target).name;
+                let canonical = format!("notice {target_name}");
+                if self
+                    .notice_actor_fact_for_target(actor.id, target.id)
+                    .is_none()
+                {
+                    return Ok(ResolvedCommand {
+                        command: canonical.clone(),
+                        verb,
+                        action: Some(command_action(
+                            NOTICE_ACTOR_OFFER_KIND,
+                            "Notice",
+                            &canonical,
+                        )),
+                        dispatch: CommandDispatch::Disabled {
+                            status: 409,
+                            output: format!(
+                                "There is no unresolved observable fact about {target_name}."
+                            ),
+                        },
+                    });
+                }
+                Ok(ResolvedCommand {
+                    command: canonical.clone(),
+                    verb,
+                    action: Some(command_action(
+                        NOTICE_ACTOR_OFFER_KIND,
+                        "Notice",
+                        &canonical,
+                    )),
+                    dispatch: CommandDispatch::NoticeActor {
+                        target_actor_id: target.id,
+                    },
                 })
             }
             "contribute" => {

--- a/v2/orchestrator-rust/src/notice.rs
+++ b/v2/orchestrator-rust/src/notice.rs
@@ -1,0 +1,599 @@
+use super::*;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct NoticeActorFact {
+    pub(super) fact_id: String,
+    pub(super) target_actor_id: u64,
+    pub(super) target_name: String,
+    pub(super) item_id: u64,
+    pub(super) item_name: String,
+    pub(super) held_since_tick: u64,
+    pub(super) content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct NoticeActorRequest {
+    pub(super) actor_id: u64,
+    pub(super) actor_session: Option<String>,
+    pub(super) target_actor_id: u64,
+}
+
+impl RuntimeWorld {
+    pub(super) fn notice_actor_fact_for_target(
+        &self,
+        viewer_actor_id: u64,
+        target_actor_id: u64,
+    ) -> Option<NoticeActorFact> {
+        if !self.economy_notice_target_is_valid(viewer_actor_id, target_actor_id)
+            || self.economy_known_by(viewer_actor_id, target_actor_id)
+        {
+            return None;
+        }
+        let target_name = self.actor_name(target_actor_id)?;
+        let mut visible_items = self
+            .actor_held_items(target_actor_id)
+            .into_iter()
+            .filter(|item| {
+                item.container_item_id == 0
+                    && matches!(item.zone, CW_CARD_ZONE_CARRIED | CW_CARD_ZONE_EQUIPPED)
+            })
+            .collect::<Vec<_>>();
+        visible_items.sort_by_key(|item| item.id);
+        let has_visible_items = !visible_items.is_empty();
+        if let Some(fact) = visible_items.into_iter().find_map(|item| {
+            let fact_id = notice_actor_fact_claim_key(
+                viewer_actor_id,
+                target_actor_id,
+                item.id,
+                item.held_since_tick,
+            );
+            (!self.rpg_claims.contains(&fact_id)).then(|| NoticeActorFact {
+                fact_id,
+                target_actor_id,
+                target_name: target_name.clone(),
+                item_id: item.id,
+                item_name: self
+                    .item_name(item.id)
+                    .unwrap_or_else(|| format!("Item {}", item.id)),
+                held_since_tick: item.held_since_tick,
+                content: String::new(),
+            })
+        }) {
+            let mut fact = fact;
+            fact.content = format!(
+                "You notice that {} is visibly carrying {}.",
+                fact.target_name, fact.item_name
+            );
+            return Some(fact);
+        }
+        if has_visible_items {
+            return None;
+        }
+
+        let target = self.actor_by_id(target_actor_id)?;
+        let title = self.actor_view(target).title.trim().to_string();
+        if title.is_empty() {
+            return None;
+        }
+        let title_signature = stable_hash_u64(&[
+            "notice-actor-public-title",
+            &target_actor_id.to_string(),
+            &title,
+        ]);
+        let fact_id = format!(
+            "notice_actor:v1:{viewer_actor_id}:{target_actor_id}:public_title:{title_signature}"
+        );
+        (!self.rpg_claims.contains(&fact_id)).then(|| NoticeActorFact {
+            fact_id,
+            target_actor_id,
+            target_name: target_name.clone(),
+            item_id: 0,
+            item_name: String::new(),
+            held_since_tick: 0,
+            content: format!("You notice that {target_name} is {title}."),
+        })
+    }
+
+    pub(super) fn notice_actor_facts(&self, viewer_actor_id: u64) -> Vec<NoticeActorFact> {
+        let Some(viewer) = self
+            .actor_by_id(viewer_actor_id)
+            .filter(|actor| Self::actor_can_act(*actor))
+        else {
+            return Vec::new();
+        };
+        let mut target_ids = self.world.actors[..self.world.actor_count]
+            .iter()
+            .copied()
+            .filter(|target| {
+                target.id != viewer_actor_id
+                    && target.location_id == viewer.location_id
+                    && Self::actor_can_act(*target)
+                    && self.actor_visible_in_projection(*target, Some(viewer_actor_id), None)
+            })
+            .map(|target| target.id)
+            .collect::<Vec<_>>();
+        target_ids.sort_unstable();
+        target_ids
+            .into_iter()
+            .filter_map(|target_actor_id| {
+                self.notice_actor_fact_for_target(viewer_actor_id, target_actor_id)
+            })
+            .collect()
+    }
+
+    pub(super) fn noticed_actor_items(
+        &self,
+        viewer_actor_id: u64,
+        target_actor_id: u64,
+    ) -> Vec<CwItem> {
+        let mut items = self
+            .actor_held_items(target_actor_id)
+            .into_iter()
+            .filter(|item| {
+                item.container_item_id == 0
+                    && matches!(item.zone, CW_CARD_ZONE_CARRIED | CW_CARD_ZONE_EQUIPPED)
+                    && self.rpg_claims.contains(&notice_actor_fact_claim_key(
+                        viewer_actor_id,
+                        target_actor_id,
+                        item.id,
+                        item.held_since_tick,
+                    ))
+            })
+            .collect::<Vec<_>>();
+        items.sort_by_key(|item| item.id);
+        items
+    }
+
+    pub(super) fn plan_notice_actor_action(
+        &self,
+        actor_id: u64,
+        target_actor_id: u64,
+    ) -> Result<(CwAction, ProjectionMutation, NoticeActorFact), String> {
+        let actor = self
+            .actor_by_id(actor_id)
+            .filter(|actor| Self::actor_can_act(*actor))
+            .ok_or_else(|| "Notice requires an active avatar.".to_string())?;
+        let fact = self
+            .notice_actor_fact_for_target(actor_id, target_actor_id)
+            .ok_or_else(|| "That actor has no unresolved observable fact.".to_string())?;
+        let action = CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id,
+            target_actor_id,
+            item_id: fact.item_id,
+            location_id: actor.location_id,
+            ..CwAction::default()
+        };
+        let mutation = ProjectionMutation::RecordNoticeActorFact {
+            fact_id: fact.fact_id.clone(),
+            target_actor_id,
+            item_id: fact.item_id,
+            held_since_tick: fact.held_since_tick,
+        };
+        Ok((action, mutation, fact))
+    }
+}
+
+pub(super) async fn notice_actor(
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    Json(payload): Json<NoticeActorRequest>,
+) -> Json<ActionResponse> {
+    if !allow_actor_mutation(
+        &state,
+        client_addr,
+        payload.actor_id,
+        "action-actor",
+        GENERAL_ACTION_LIMIT,
+    ) {
+        return action_rate_limited_response();
+    }
+    let was_active = payload
+        .actor_session
+        .as_deref()
+        .and_then(|token| {
+            actor_session_active_for_actor(&state.actor_sessions, payload.actor_id, token)
+        })
+        .unwrap_or(false);
+    let mut runtime = state.inner.lock().await;
+    if !client_actor_authorized_for_state(
+        &runtime,
+        &state,
+        payload.actor_id,
+        payload.actor_session.as_deref(),
+    ) {
+        return client_actor_rejected_response();
+    }
+    let released_events = release_inactive_direct_inventory_locked(&state, &mut runtime);
+    let (action, mutation, fact) =
+        match runtime.plan_notice_actor_action(payload.actor_id, payload.target_actor_id) {
+            Ok(plan) => plan,
+            Err(reason) => {
+                drop(runtime);
+                if !released_events.is_empty() {
+                    broadcast_events(&state, &released_events);
+                }
+                return action_offer_rejected(reason);
+            }
+        };
+    if let Some(response) =
+        actor_offer_turn_rejection(&runtime, payload.actor_id, NOTICE_ACTOR_OFFER_KIND)
+    {
+        drop(runtime);
+        if !released_events.is_empty() {
+            broadcast_events(&state, &released_events);
+        }
+        return response;
+    }
+    let turn_location_id = Some(action.location_id);
+    let mut record = JournalRecord::new(action, runtime.next_seed_value()).into_player_card();
+    record.bind_offer_kind(NOTICE_ACTOR_OFFER_KIND);
+    record.projection_mutations.push(mutation);
+    let Ok((status, mut events)) = commit_journal_record(&state, &mut runtime, record) else {
+        drop(runtime);
+        if !released_events.is_empty() {
+            broadcast_events(&state, &released_events);
+        }
+        return Json(ActionResponse {
+            ok: false,
+            status: 500,
+            events: Vec::new(),
+        });
+    };
+    let observation = advance_turn_and_capture_player_tick_observation(
+        &state,
+        &mut runtime,
+        turn_location_id,
+        payload.actor_id,
+        status,
+        &mut events,
+    );
+    let actor_name = runtime.actor_name(payload.actor_id);
+    drop(runtime);
+    if !released_events.is_empty() {
+        broadcast_events(&state, &released_events);
+    }
+    broadcast_events(&state, &events);
+    if let Some(observation) = observation {
+        schedule_player_tick_observation(&state, observation);
+    }
+    let mut response_events = events;
+    if status == CW_OK {
+        let mut private_fact = private_actor_event(
+            "notice.fact_revealed",
+            payload.actor_id,
+            Some(fact.target_actor_id),
+            fact.content,
+        );
+        private_fact.actor_name = actor_name;
+        private_fact.target_actor_name = Some(fact.target_name);
+        if fact.item_id != 0 {
+            private_fact.item_id = Some(fact.item_id);
+            private_fact.item_name = Some(fact.item_name);
+        }
+        response_events.push(private_fact);
+    }
+    if !was_active {
+        response_events.extend(commit_presence_event(&state, payload.actor_id, true).await);
+    }
+    Json(ActionResponse {
+        ok: status == CW_OK,
+        status,
+        events: response_events,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arrange_visible_story_button(runtime: &mut RuntimeWorld, held_since_tick: u64) {
+        let item = runtime
+            .world
+            .items
+            .iter_mut()
+            .take(runtime.world.item_count)
+            .find(|item| item.id == STORY_BUTTON_ITEM_ID)
+            .expect("story button exists");
+        item.location_id = 0;
+        item.holder_actor_id = RATI_ACTOR_ID;
+        item.container_item_id = 0;
+        item.zone = CW_CARD_ZONE_CARRIED;
+        item.held_since_tick = held_since_tick;
+    }
+
+    #[tokio::test]
+    async fn actor_notice_endpoint_reveals_exactly_one_private_fact_without_a_roll() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Endpoint Observer",
+        );
+        let held_since_tick = runtime.world.tick;
+        arrange_visible_story_button(&mut runtime, held_since_tick);
+        let offer = runtime
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| {
+                offer.kind == NOTICE_ACTOR_OFFER_KIND
+                    && offer.target.as_ref().and_then(|target| target.id) == Some(RATI_ACTOR_ID)
+            })
+            .expect("one actor Notice offer is published");
+        assert!(offer.id.starts_with("notice_actor_v1:"));
+        assert!(offer.claim_key.is_some());
+        let state = test_app_state(runtime, None);
+        let (actor_session, _) = issue_actor_session(&state, 5000);
+        let mut broadcasts = state.tx.subscribe();
+
+        let response = notice_actor(
+            ConnectInfo("127.0.0.1:43110".parse().expect("client address")),
+            State(state.clone()),
+            Json(NoticeActorRequest {
+                actor_id: 5000,
+                actor_session: Some(actor_session),
+                target_actor_id: RATI_ACTOR_ID,
+            }),
+        )
+        .await
+        .0;
+
+        assert!(response.ok);
+        assert!(!response
+            .events
+            .iter()
+            .any(|event| event.type_name == "ability_check.rolled"));
+        let notice = response
+            .events
+            .iter()
+            .find(|event| event.type_name == "notice.fact_revealed")
+            .expect("private exact fact response");
+        assert_eq!(notice.target_actor_id, Some(RATI_ACTOR_ID));
+        assert_eq!(notice.item_id, Some(STORY_BUTTON_ITEM_ID));
+        assert!(notice
+            .content
+            .as_deref()
+            .is_some_and(|content| content.contains("visibly carrying Story Button")));
+        assert!(!response
+            .events
+            .iter()
+            .any(|event| event.type_name == "job.contribution.resolved"));
+        let emitted = std::iter::from_fn(|| broadcasts.try_recv().ok()).collect::<Vec<_>>();
+        assert!(emitted
+            .iter()
+            .any(|event| event.type_name == "notice.actor_observed"));
+        assert!(!emitted
+            .iter()
+            .any(|event| event.type_name == "notice.fact_revealed"));
+        let runtime = state.inner.lock().await;
+        assert!(!runtime.economy_known_by(5000, RATI_ACTOR_ID));
+        let state_view = runtime.state_response(Some(5000), &AccessContext::default());
+        let projected = state_view
+            .actors
+            .iter()
+            .find(|actor| actor.id == RATI_ACTOR_ID)
+            .and_then(|actor| actor.resident_economy.as_ref())
+            .expect("the viewer receives the noticed fact projection");
+        assert_eq!(projected.held_item_ids, vec![STORY_BUTTON_ITEM_ID]);
+        assert!(projected.sought_item_ids.is_empty());
+        assert!(runtime
+            .notice_actor_fact_for_target(5000, RATI_ACTOR_ID)
+            .is_none());
+        assert!(!runtime
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1
+            .iter()
+            .any(|candidate| {
+                candidate.kind == NOTICE_ACTOR_OFFER_KIND
+                    && candidate.target.as_ref().and_then(|target| target.id) == Some(RATI_ACTOR_ID)
+            }));
+    }
+
+    #[test]
+    fn actor_notice_fact_is_stable_replayable_and_does_not_touch_growth_or_currency() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Replay Observer",
+        );
+        arrange_visible_story_button(&mut runtime, 77);
+
+        let before_orbs = runtime.orb_balance(5000);
+        let before_marks = runtime.ledger_marks.len();
+        let (action, mutation, fact) = runtime
+            .plan_notice_actor_action(5000, RATI_ACTOR_ID)
+            .expect("one exact fact can be planned");
+        let mut record = JournalRecord::new(action, 86_003).into_player_card();
+        record.bind_offer_kind(NOTICE_ACTOR_OFFER_KIND);
+        record.projection_mutations.push(mutation);
+        let replay_base = RuntimeSnapshot::from_runtime(&runtime);
+
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert!(events
+            .iter()
+            .any(|event| event.type_name == "notice.actor_observed"));
+        assert!(runtime.rpg_claims.contains(&fact.fact_id));
+        assert_eq!(runtime.orb_balance(5000), before_orbs);
+        assert_eq!(runtime.ledger_marks.len(), before_marks);
+        assert!(runtime
+            .notice_actor_fact_for_target(5000, RATI_ACTOR_ID)
+            .is_none());
+
+        let restored = RuntimeSnapshot::from_runtime(&runtime)
+            .into_runtime()
+            .expect("noticed fact snapshot restores");
+        assert!(restored.rpg_claims.contains(&fact.fact_id));
+        assert_eq!(restored.noticed_actor_items(5000, RATI_ACTOR_ID).len(), 1);
+
+        let mut replayed = replay_base
+            .into_runtime()
+            .expect("pre-Notice snapshot restores");
+        assert_eq!(replayed.apply_journal_record(&record).0, CW_OK);
+        assert!(replayed.rpg_claims.contains(&fact.fact_id));
+        assert_eq!(
+            replayed.noticed_actor_items(5000, RATI_ACTOR_ID),
+            runtime.noticed_actor_items(5000, RATI_ACTOR_ID)
+        );
+        assert!(replayed.event_log.iter().any(|event| {
+            event.type_name == "notice.actor_observed"
+                && event.actor_id == Some(5000)
+                && event.target_actor_id == Some(RATI_ACTOR_ID)
+        }));
+    }
+
+    #[test]
+    fn stale_actor_notice_certificate_rejects_without_world_mutation() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Stale Notice Observer",
+        );
+        arrange_visible_story_button(&mut runtime, 91);
+        let offer = runtime
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1
+            .into_iter()
+            .find(|offer| {
+                offer.kind == NOTICE_ACTOR_OFFER_KIND
+                    && offer.target.as_ref().and_then(|target| target.id) == Some(RATI_ACTOR_ID)
+            })
+            .expect("the exact item fact is certified");
+
+        let item = runtime
+            .world
+            .items
+            .iter_mut()
+            .take(runtime.world.item_count)
+            .find(|item| item.id == STORY_BUTTON_ITEM_ID)
+            .expect("story button remains present");
+        item.holder_actor_id = 0;
+        item.location_id = COSY_COTTAGE_LOCATION_ID;
+        item.held_since_tick = 0;
+        let before = serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
+            .expect("serialize pre-submission state");
+
+        let rejected = runtime.validate_action_offer_submission(
+            5000,
+            &AccessContext::default(),
+            &ActionOfferSubmissionRequest {
+                path: "/actions/notice".to_string(),
+                offer_id: offer.offer_id,
+                composition_id: offer.composition_id,
+                kind: offer.kind,
+                rules_action: offer.rules_action,
+                operation: offer.operation,
+                rules_profile: offer.rules_profile,
+                state_revision: offer.state_revision,
+                route: offer.route,
+                target: offer.target,
+                cost: offer.cost,
+                payload: serde_json::json!({
+                    "actor_id": 5000,
+                    "target_actor_id": RATI_ACTOR_ID,
+                }),
+            },
+        );
+        assert!(rejected.is_err());
+        assert_eq!(
+            serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
+                .expect("serialize post-rejection state"),
+            before
+        );
+    }
+
+    #[test]
+    fn legacy_targeted_notice_disclosure_still_replays_unchanged() {
+        std::thread::Builder::new()
+            .name("economy-disclosure-replay".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let mut runtime = RuntimeWorld::seeded();
+                create_test_human(
+                    &mut runtime,
+                    5000,
+                    COSY_COTTAGE_LOCATION_ID,
+                    "Careful Observer",
+                );
+                let target_actor_id = RATI_ACTOR_ID;
+                assert!(runtime
+                    .resident_economy_view(
+                        runtime.actor_by_id(target_actor_id).expect("Rati exists"),
+                        Some(5000),
+                    )
+                    .is_none());
+
+                let failed_record = JournalRecord::new(
+                    CwAction {
+                        kind: CW_ACTION_RULES_SEARCH,
+                        actor_id: 5000,
+                        target_actor_id,
+                        ability: LISTEN_ABILITY,
+                        dc: LISTEN_DC,
+                        modifier: -100,
+                        ..CwAction::default()
+                    },
+                    86_001,
+                );
+                let (status, failed_events) = runtime.apply_journal_record(&failed_record);
+                assert_eq!(status, CW_OK);
+                let failed = failed_events
+                    .iter()
+                    .find(|event| event.type_name == "ability_check.rolled")
+                    .expect("notice check event");
+                assert_eq!(failed.content.as_deref(), Some("notice"));
+                assert_eq!(failed.target_actor_id, Some(target_actor_id));
+                assert!(!runtime.economy_known_by(5000, target_actor_id));
+
+                let replay_base = RuntimeSnapshot::from_runtime(&runtime);
+                let successful_record = JournalRecord::new(
+                    CwAction {
+                        kind: CW_ACTION_RULES_SEARCH,
+                        actor_id: 5000,
+                        target_actor_id,
+                        ability: LISTEN_ABILITY,
+                        dc: LISTEN_DC,
+                        modifier: 100,
+                        ..CwAction::default()
+                    },
+                    86_002,
+                );
+                let (status, successful_events) = runtime.apply_journal_record(&successful_record);
+                assert_eq!(status, CW_OK);
+                let successful = successful_events
+                    .iter()
+                    .find(|event| event.type_name == "ability_check.rolled")
+                    .expect("successful notice event");
+                assert!(successful.success);
+                assert_eq!(successful.content.as_deref(), Some("notice"));
+                assert!(runtime.economy_known_by(5000, target_actor_id));
+                assert!(runtime
+                    .resident_economy_view(
+                        runtime.actor_by_id(target_actor_id).expect("Rati exists"),
+                        Some(5000),
+                    )
+                    .is_some());
+
+                let persisted = RuntimeSnapshot::from_runtime(&runtime);
+                let restored = persisted
+                    .into_runtime()
+                    .expect("economy disclosure snapshot restores");
+                assert!(restored.economy_known_by(5000, target_actor_id));
+
+                let mut replayed = replay_base
+                    .into_runtime()
+                    .expect("pre-disclosure snapshot restores");
+                assert_eq!(replayed.apply_journal_record(&successful_record).0, CW_OK);
+                assert!(replayed.economy_known_by(5000, target_actor_id));
+            })
+            .expect("spawn economy disclosure replay test")
+            .join()
+            .expect("economy disclosure replay test completes");
+    }
+}

--- a/v2/orchestrator-rust/src/offer_commands.rs
+++ b/v2/orchestrator-rust/src/offer_commands.rs
@@ -158,6 +158,9 @@ fn dispatch_for_offer(
                 action: Box::new(action),
             })
             .map_err(|_| invalid()),
+        NOTICE_ACTOR_OFFER_KIND => Ok(CommandDispatch::NoticeActor {
+            target_actor_id: required_target_id(offer, "actor")?,
+        }),
         "check" => Ok(CommandDispatch::Check),
         "study" => Ok(CommandDispatch::Study),
         FOCUSED_NOTICE_OFFER_KIND

--- a/v2/orchestrator-rust/src/resident_offer_scoring.rs
+++ b/v2/orchestrator-rust/src/resident_offer_scoring.rs
@@ -15,6 +15,7 @@ impl RuntimeWorld {
                     "search"
                         | "craft"
                         | "influence"
+                        | NOTICE_ACTOR_OFFER_KIND
                         | "check"
                         | "explore_path"
                         | "open"
@@ -164,6 +165,7 @@ impl RuntimeWorld {
                 "move" => (60, RESIDENT_DEFAULT_ITEM_SCORE),
                 "open" => (55, RESIDENT_DEFAULT_ITEM_SCORE),
                 "search" => (65, 0),
+                NOTICE_ACTOR_OFFER_KIND => (64, 0),
                 FOCUSED_NOTICE_OFFER_KIND => (64, 0),
                 DISCOVERY_SEARCH_OFFER_KIND => (65, 0),
                 DISCOVERY_STUDY_OFFER_KIND => (66, 0),

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -21,6 +21,7 @@ pub(super) fn action_path_accepts_kind(path: &str, kind: &str) -> bool {
                 | DISCOVERY_SCOUT_OFFER_KIND
         ),
         "/actions/flee" => kind == "flee",
+        "/actions/notice" => kind == NOTICE_ACTOR_OFFER_KIND,
         "/actions/check" => kind == "check",
         "/actions/study" => kind == "study",
         "/actions/influence" => kind == "influence",
@@ -243,6 +244,7 @@ pub(super) fn app_router(state: AppState) -> Router {
             post(legacy_action_requires_certificate),
         )
         .route("/actions/check", post(legacy_action_requires_certificate))
+        .route("/actions/notice", post(legacy_action_requires_certificate))
         .route("/actions/study", post(legacy_action_requires_certificate))
         .route(
             "/actions/influence",

--- a/v2/orchestrator-rust/src/rules_context.rs
+++ b/v2/orchestrator-rust/src/rules_context.rs
@@ -422,7 +422,7 @@ mod tests {
             .legal_action_candidates(Some(5000), &AccessContext::default())
             .1
             .into_iter()
-            .find(|offer| offer.kind == "check")
+            .find(|offer| offer.kind == NOTICE_ACTOR_OFFER_KIND)
             .expect("the cottage exposes Notice");
         runtime.pack_mount_state = PackMountState(serde_json::json!({
             "schema_version": 1,

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -488,6 +488,7 @@ pub(super) fn command_concurrency_policy(dispatch: &CommandDispatch) -> Concurre
             ConcurrencyPolicy::TargetSerialized
         }
         CommandDispatch::PickUp { .. }
+        | CommandDispatch::NoticeActor { .. }
         | CommandDispatch::OpenThreshold { .. }
         | CommandDispatch::Drop { .. }
         | CommandDispatch::UseItem { .. }
@@ -1333,6 +1334,7 @@ pub(super) fn command_actor_turn_rejection(
         CommandDispatch::Defend => "defend",
         CommandDispatch::Flee { .. } => "flee",
         CommandDispatch::OpenThreshold { .. } => "open",
+        CommandDispatch::NoticeActor { .. } => NOTICE_ACTOR_OFFER_KIND,
         CommandDispatch::Check => "check",
         CommandDispatch::Study => "study",
         CommandDispatch::Discover { procedure, .. } => match procedure.as_str() {

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -3557,7 +3557,48 @@ impl RuntimeWorld {
         }
         if let Some(viewer_actor_id) = client_actor_id {
             if !self.economy_known_by(viewer_actor_id, resident.id) {
-                return None;
+                let noticed_items = self.noticed_actor_items(viewer_actor_id, resident.id);
+                if noticed_items.is_empty() {
+                    return None;
+                }
+                let resident_name = self
+                    .actor_name(resident.id)
+                    .unwrap_or_else(|| format!("Avatar {}", resident.id));
+                let held_item_ids = noticed_items.iter().map(|item| item.id).collect::<Vec<_>>();
+                let held_items = noticed_items
+                    .into_iter()
+                    .map(|item| {
+                        let item_name = self
+                            .item_name(item.id)
+                            .unwrap_or_else(|| format!("Item {}", item.id));
+                        ResidentHeldItemView {
+                            item_id: item.id,
+                            disposition: "noticed".to_string(),
+                            reason: format!("{resident_name} is visibly carrying {item_name}."),
+                            keep_score: 0,
+                            available_actions: Vec::new(),
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                return Some(ResidentEconomyView {
+                    inventory_count: held_item_ids.len(),
+                    held_item_ids,
+                    held_items,
+                    inventory_capacity: 0,
+                    carried_weight_tenths: 0,
+                    carrying_capacity_tenths: 0,
+                    desired_item_ids: Vec::new(),
+                    sought_item_ids: Vec::new(),
+                    sought_items: Vec::new(),
+                    attached_item_ids: Vec::new(),
+                    seeking_item_id: None,
+                    seeking_location_id: None,
+                    seeking_location_name: None,
+                    request: None,
+                    trade_offer: None,
+                    trade_stance: None,
+                    motive: String::new(),
+                });
             }
         }
         let held_items_raw = self.actor_held_items(resident.id);

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -263,6 +263,7 @@
 # lookup/resolution, search reinforcement, and legacy migration into
 # residents/memory.rs. Room observation, disproved-memory cleanup, movement
 # observation, gossip, and belief projection remain for the sequential #324.
-# 66712 -> 66676: move the complete actor Notice fact contract, endpoint, and
-# focused replay/staleness tests into notice.rs.
-66676
+# 66712 -> 66670: move the complete actor Notice fact contract, endpoint, and
+# focused replay/staleness tests into notice.rs; keep canonical capacity tests
+# on their stable certified Pass card instead of unrelated gameplay offers.
+66670

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -263,4 +263,6 @@
 # lookup/resolution, search reinforcement, and legacy migration into
 # residents/memory.rs. Room observation, disproved-memory cleanup, movement
 # observation, gossip, and belief projection remain for the sequential #324.
-66712
+# 66712 -> 66676: move the complete actor Notice fact contract, endpoint, and
+# focused replay/staleness tests into notice.rs.
+66676

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -1290,22 +1290,32 @@ async function main() {
     }, needles);
   }
 
-  async function zeroOrbActionLabels(listenRewardClaimable) {
-    return page.evaluate((claimable) => {
+  async function zeroOrbActionLabels(factAvailable) {
+    return page.evaluate((available) => {
       const previousState = state;
       const previousActorId = actorId;
       const fakeState = {
         location: { id: 1, name: "The Cosy Cottage" },
         primary_action: {
           kind: "chat",
-          options: [{ kind: "chat" }, { kind: "check" }],
+          options: [{ kind: "chat" }],
+        },
+        action_offers: available ? [{
+          offer_id: "core:1:notice-rati",
+          kind: "notice_actor",
+          command: "notice Rati",
+          target: { kind: "actor", id: 1001, label: "Rati" },
+          provider: { kind: "actor", id: "actor:1001", priority: 40 },
+        }] : [],
+        action_hand: {
+          entries: available ? [{ offer_id: "core:1:notice-rati", kind: "notice_actor" }] : [],
         },
         economy: {
           orbs: 0,
           can_chat_with_orbs: false,
-          listen_cost_orbs: claimable ? 0 : 1,
-          listen_reward_claimable: claimable,
-          listen_attempted_here: !claimable,
+          listen_cost_orbs: available ? 0 : 1,
+          listen_reward_claimable: available,
+          listen_attempted_here: !available,
           openrouter_connected: false,
         },
         actors: [
@@ -1339,7 +1349,7 @@ async function main() {
         state = previousState;
         actorId = previousActorId;
       }
-    }, listenRewardClaimable);
+    }, factAvailable);
   }
 
   async function assertFreeActionsIgnoreOrbBalance() {
@@ -1349,8 +1359,8 @@ async function main() {
     assert(!claimableLabels.includes("connect ai"), `free actions should not offer Connect AI as a command: ${JSON.stringify(claimableActions)}`);
     const exhaustedActions = await zeroOrbActionLabels(false);
     const exhaustedLabels = exhaustedActions.map((action) => action.label);
-    assert(!exhaustedLabels.includes("notice"), `a claimed first clue should become repeat Notice: ${JSON.stringify(exhaustedActions)}`);
-    assert(exhaustedActions.some((action) => action.label === "notice again" && action.detail === "free"), `repeat Notice should ignore a stale legacy cost and remain free at zero Orbs: ${JSON.stringify(exhaustedActions)}`);
+    assert(!exhaustedLabels.includes("notice"), `Notice should disappear when no certified fact remains: ${JSON.stringify(exhaustedActions)}`);
+    assert(!exhaustedLabels.includes("notice again"), `ambient repeat Notice must not be reconstructed from stale economy fields: ${JSON.stringify(exhaustedActions)}`);
     const travelActions = await page.evaluate(() => {
       const previousState = state;
       const previousActorId = actorId;
@@ -1538,11 +1548,11 @@ async function main() {
           shape: "location",
         });
         renderButton("secondary", {
-          label: "listen",
-          detail: "Homeroom",
-          command: "listen",
-          card: cardForLocation(11),
-          shape: "location",
+          label: "notice",
+          detail: "Rati",
+          command: "notice Rati",
+          card: cardForActor(1001),
+          shape: "avatar",
         });
         const labels = [...document.querySelectorAll("footer.prompt .cmd-label")]
           .map((node) => {
@@ -1594,9 +1604,9 @@ async function main() {
     assert(!/connect wallet/i.test(result.economyText), `always-visible economy pill should not lead with wallet copy: ${JSON.stringify(result)}`);
     const travelLabel = result.labels.find((entry) => entry.text === "go" || entry.text === "travel");
     assert(travelLabel, `travel should remain a visible route action label: ${JSON.stringify(result)}`);
-    const listenLabel = result.labels.find((entry) => entry.text === "listen");
-    assert(listenLabel, `listen should remain a visible action label: ${JSON.stringify(result)}`);
-    for (const label of [travelLabel, listenLabel]) {
+    const noticeLabel = result.labels.find((entry) => entry.text === "notice");
+    assert(noticeLabel, `actor Notice should remain a visible action label: ${JSON.stringify(result)}`);
+    for (const label of [travelLabel, noticeLabel]) {
       assert(label.scrollWidth <= label.clientWidth + 1, `${label.text} should fit without visual clipping: ${JSON.stringify(result)}`);
     }
   }
@@ -1608,13 +1618,9 @@ async function main() {
       const baseState = {
         location: { id: 1, name: "The Cosy Cottage" },
         primary_action: {
-          kind: "check",
-          options: [{ kind: "chat" }, { kind: "check" }, { kind: "move" }],
+          kind: "chat",
+          options: [{ kind: "chat" }, { kind: "move" }],
         },
-        action_offers: [{
-          kind: "check",
-          risk: "repeat listening on the frontier can leave you tired",
-        }],
         economy: {
           orbs: 0,
           can_chat_with_orbs: true,
@@ -1631,10 +1637,20 @@ async function main() {
         cards: { actors: {}, items: {}, locations: {} },
         access: {},
       };
-      const actionsFor = (attempted, economyPatch = {}) => {
+      const actionsFor = (available, economyPatch = {}) => {
         const fakeState = {
           ...baseState,
-          economy: { ...baseState.economy, listen_attempted_here: attempted, ...economyPatch },
+          action_offers: available ? [{
+            offer_id: "core:1:notice-rati",
+            kind: "notice_actor",
+            command: "notice Rati",
+            target: { kind: "actor", id: 1001, label: "Rati" },
+            provider: { kind: "actor", id: "actor:1001", priority: 40 },
+          }] : [],
+          action_hand: {
+            entries: available ? [{ offer_id: "core:1:notice-rati", kind: "notice_actor" }] : [],
+          },
+          economy: { ...baseState.economy, listen_attempted_here: !available, ...economyPatch },
         };
         state = fakeState;
         actorId = 5000;
@@ -1651,30 +1667,20 @@ async function main() {
       };
       try {
         return {
-          fresh: actionsFor(false),
-          repeat: actionsFor(true),
-          stalePaidRepeat: actionsFor(true, { orbs: 1, listen_cost_orbs: 1, listen_reward_claimable: false }),
+          fresh: actionsFor(true),
+          exhausted: actionsFor(false),
+          staleLegacy: actionsFor(false, { orbs: 1, listen_cost_orbs: 1, listen_reward_claimable: false }),
         };
       } finally {
         state = previousState;
         actorId = previousActorId;
       }
     });
-    assert(result.fresh[0]?.label === "notice", `fresh room clue should still lead the first action: ${JSON.stringify(result)}`);
-    assert(result.repeat[0]?.label !== "notice again", `repeat Notice should not stay the default action: ${JSON.stringify(result)}`);
-    assert(result.repeat.some((action) => action.label === "chat"), `free Chat should remain available beside repeat Notice when the server exposes an eligible resident: ${JSON.stringify(result)}`);
-    const repeatIndex = result.repeat.findIndex((action) => action.label === "notice again");
-    assert(repeatIndex > 0 && result.repeat[repeatIndex]?.detail === "free", `free repeat Notice should remain available without hijacking the primary action: ${JSON.stringify(result)}`);
-    const stalePaidRepeat = result.stalePaidRepeat.find((action) => action.label === "notice again");
-    assert(stalePaidRepeat?.detail === "free" && stalePaidRepeat?.compactLabel === "notice again", `repeat Notice should stay free even when stale state reports a legacy cost: ${JSON.stringify(result)}`);
-    assert(stalePaidRepeat?.title === "notice once more", `repeat confirmation should keep the Notice verb: ${JSON.stringify(result)}`);
-    assert(stalePaidRepeat?.summary === "Notice another ambient lead. The room may have nothing new yet.", `repeat confirmation should explain its uncertain outcome without an Orb charge: ${JSON.stringify(result)}`);
-    assert(!stalePaidRepeat?.rows?.some((row) => row[0] === "Costs"), `repeat Notice should never display an Orb cost: ${JSON.stringify(result)}`);
-    assert(stalePaidRepeat?.rows?.some((row) => row[0] === "What may happen" && row[1] === "the room may share another clue"), `repeat confirmation should describe its possible reward plainly: ${JSON.stringify(result)}`);
-    assert(stalePaidRepeat?.rows?.some((row) => row[0] === "Watch for" && row[1] === "listening again may tire you"), `repeat confirmation should preserve its gentle fatigue warning: ${JSON.stringify(result)}`);
-    assert(stalePaidRepeat?.confirm === "notice again", `repeat confirmation button should match the card: ${JSON.stringify(result)}`);
-    assert(!JSON.stringify(stalePaidRepeat).includes("to listen again"), `repeat listen should not repeat its own verb: ${JSON.stringify(result)}`);
-    assert(!stalePaidRepeat?.detail.includes("/"), `repeat listen should avoid slash shorthand: ${JSON.stringify(result)}`);
+    const freshNotice = result.fresh.find((action) => action.label === "notice");
+    assert(freshNotice?.detail === "Rati" && freshNotice?.command === "notice Rati", `certified actor Notice should name its exact target: ${JSON.stringify(result)}`);
+    assert(result.exhausted.some((action) => action.label === "chat"), `free Chat should remain when no Notice fact is eligible: ${JSON.stringify(result)}`);
+    assert(!result.exhausted.some((action) => action.label === "notice" || action.label === "notice again"), `Notice should disappear after its certified fact is exhausted: ${JSON.stringify(result)}`);
+    assert(!result.staleLegacy.some((action) => action.label === "notice" || action.label === "notice again"), `stale legacy cost and attempt fields must not recreate Notice: ${JSON.stringify(result)}`);
   }
 
   async function assertCalmRoomSearchDoesNotHijackPrimary() {
@@ -1858,7 +1864,7 @@ async function main() {
     const travelIndex = result.findIndex((action) => action.label === "travel");
     const chatIndex = result.findIndex((action) => action.label === "chat");
     assert(chatIndex >= 0, `optional feature fixtures with an eligible resident should retain free Chat: ${JSON.stringify(result)}`);
-    assert(listenAgainIndex > travelIndex && result[listenAgainIndex]?.detail === "free", `repeat Notice should remain available without outranking concrete travel: ${JSON.stringify(result)}`);
+    assert(listenAgainIndex === -1, `ambient repeat Notice must stay absent from the feature surface: ${JSON.stringify(result)}`);
     assert(useIndex === -1 || useIndex > travelIndex, `optional feature use should stay behind travel unless focused: ${JSON.stringify(result)}`);
     if (useIndex >= 0) {
       assert(result[useIndex]?.command === "use Story Button on Scarf Basket", `feature use should remain focusable when the server exposes it: ${JSON.stringify(result)}`);
@@ -4497,7 +4503,7 @@ async function main() {
     });
     assert(result.direct.chips === 1 && result.direct.requests === 1 && result.direct.trades === 1, `a disclosed direct-player item should become one icon with exact consent actions: ${JSON.stringify(result)}`);
     assert(result.inference.chips === 1 && result.inference.requests === 0 && result.inference.steals === 1, `an inference-held item must not expose the invalid direct-player request route: ${JSON.stringify(result)}`);
-    assert(result.unknown.chips === 0 && result.unknown.requests === 0 && result.unknown.notices === 1, `unknown holdings must stay hidden behind Notice: ${JSON.stringify(result)}`);
+    assert(result.unknown.chips === 0 && result.unknown.requests === 0 && result.unknown.notices === 0, `unknown holdings must stay hidden without an inspector Notice shortcut: ${JSON.stringify(result)}`);
     assert(result.direct.safety === 3 && result.inference.safety === 3, `safety controls should stay separate from item actions: ${JSON.stringify(result)}`);
     assert(result.direct.itemText.includes("Keeper's Brass Key") && !result.direct.itemText.includes("request Keeper's Brass Key"), `the item picker should keep names in the selected detail instead of giant verb buttons: ${JSON.stringify(result)}`);
     assert(result.nearby.chips === 1 && result.nearby.target.includes("garden"), `current location details should expose adjacent items for image-workshop access: ${JSON.stringify(result)}`);

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -723,7 +723,7 @@ async function main() {
             lead_location_id: 1,
             instruction: "Notice what the rain has changed; the first useful lead is guaranteed.",
           },
-        }, [{ label: "notice", intention: "notice", target: { id: 1 }, focusKey: "check", command: "listen" }]),
+        }, [{ label: "notice", intention: "notice", target: { id: 1001, label: "Rati" }, focusKey: "actor:1001", command: "notice Rati" }]),
         missedListenWithOtherAdvancementStep: firstThreadModel({
           primary_action: { kind: "search" },
           first_tale: {
@@ -841,6 +841,16 @@ async function main() {
         welcomingListenWithoutOption: buildActions({
           location: { id: 1, name: "The Cosy Cottage" },
           primary_action: { options: [{ kind: "search" }] },
+          action_offers: [{
+            offer_id: "core:1:notice-rati",
+            kind: "notice_actor",
+            command: "notice Rati",
+            target: { kind: "actor", id: 1001, label: "Rati" },
+            provider: { kind: "actor", id: "actor:1001", priority: 40 },
+          }],
+          action_hand: {
+            entries: [{ offer_id: "core:1:notice-rati", kind: "notice_actor" }],
+          },
           economy: { listen_attempted_here: false },
           ledger: { unbanked_count: 1, unbanked_marks: [{ category: "witness" }] },
           turn: { enabled: false, is_current_actor: true },
@@ -1158,7 +1168,7 @@ async function main() {
     // The floor is preserved by dealing a waiting player no bypass action at
     // all, which is stricter than the previous single observational card.
     assert(guide.arrivalActions.length === 0, `an explicitly ordered scene should remain authoritative while the newcomer's first-tale Notice waits, dealing no bypass card: ${JSON.stringify(guide)}`);
-    assert(guide.welcomingListenWithoutOption.some((action) => action.label === "notice" && action.focusKey === "check"), `the welcoming Notice should remain playable when ordinary room options rotate: ${JSON.stringify(guide)}`);
+    assert(guide.welcomingListenWithoutOption.some((action) => action.label === "notice" && action.focusKey === "actor:1001"), `the welcoming Notice should remain playable when ordinary room options rotate: ${JSON.stringify(guide)}`);
     assert(guide.waitingWelcomeWithoutOption.length === 0, `another player's explicit combat turn should not be bypassed by first-tale guidance: ${JSON.stringify(guide)}`);
     assert(guide.waitingActions.length === 0, `ordinary ordered-scene waiting should preserve the combat floor without a timer card: ${JSON.stringify(guide)}`);
     assert(
@@ -1693,12 +1703,27 @@ async function main() {
           kind: "chat",
           options: [{ kind: "chat" }, { kind: "check" }, { kind: "move" }],
         },
-        action_offers: [{
-          offer_id: "move:rain-soft-garden",
-          kind: "move",
-          target: { kind: "location", id: 2, label: "Rain-Soft Garden" },
-          provider: { kind: "location", id: "location:1", label: "The Cosy Cottage" },
-        }],
+        action_offers: [
+          {
+            offer_id: "core:1:notice-rati",
+            kind: "notice_actor",
+            command: "notice Rati",
+            target: { kind: "actor", id: 1001, label: "Rati" },
+            provider: { kind: "actor", id: "actor:1001", priority: 40 },
+          },
+          {
+            offer_id: "move:rain-soft-garden",
+            kind: "move",
+            target: { kind: "location", id: 2, label: "Rain-Soft Garden" },
+            provider: { kind: "location", id: "location:1", label: "The Cosy Cottage" },
+          },
+        ],
+        action_hand: {
+          entries: [
+            { offer_id: "core:1:notice-rati", kind: "notice_actor" },
+            { offer_id: "move:rain-soft-garden", kind: "move" },
+          ],
+        },
         economy: { orbs: 1, can_chat_with_orbs: true, listen_cost_orbs: 0, listen_reward_claimable: true },
         search_available: true,
         room_features: [{ key: "hearth", name: "Hearth", searched: false, uses: [] }],
@@ -11079,71 +11104,55 @@ async function main() {
     });
   }
 
-  async function exerciseFrontierRecovery() {
-    assert((await currentLocation()) === "Moonlit Trail", "frontier recovery should begin on Moonlit Trail");
-    const startingState = await fetchCurrentState();
-    if ((startingState.tags || []).some((tag) => tag.label === "tired")) {
-      const startingRestAvailable = await page.evaluate(() => (
-        actions.some((action) => String(action.label || "").toLowerCase() === "rest")
-      ));
-      if (!startingRestAvailable) {
-        await leaveTrailTo("Rain-Soft Garden");
-      }
-      const startingRest = await drawPrimaryMatching("pre-existing frontier rest", ["rest", "feel fresh"]);
-      steps.push({ label: "pre-existing frontier rest", primary: startingRest, location: await currentLocation() });
-      await clickPrimary("pre-existing frontier rest");
-      await page.waitForFunction(() => !(state?.tags || []).some((tag) => tag.label === "tired"));
-      if ((await currentLocation()) !== "Moonlit Trail") await travelTo("Moonlit Trail");
-    }
-    let firstListenCommitted = startingState.economy?.listen_attempted_here === true;
-    if (firstListenCommitted) {
-      steps.push({
-        label: "frontier notice already attempted",
-        location: await currentLocation(),
-      });
-    }
-    for (let attempt = 1; attempt <= 3 && !firstListenCommitted; attempt += 1) {
-      const firstListen = await drawPrimaryMatching("first frontier notice", ["notice", "for a clue"]);
-      steps.push({ label: "first frontier notice", primary: firstListen, location: await currentLocation(), attempt });
-      await clickPrimary("first frontier notice");
-      await page.waitForFunction(() => actionBusy === false && refreshInFlight === null);
-      firstListenCommitted = (await fetchCurrentState()).economy?.listen_attempted_here === true;
-    }
-    assert(firstListenCommitted, "the first frontier Notice should commit before drawing its free repeat");
-    const repeatNotice = await drawPrimaryMatching("tiring frontier notice", ["notice", "free"]);
-    steps.push({ label: "tiring frontier notice", primary: repeatNotice, location: await currentLocation() });
-    await clickActionMatching("tiring frontier notice", ["notice", "free"]);
+  async function exerciseFrontierObservation() {
+    assert((await currentLocation()) === "Moonlit Trail", "frontier observation should begin on Moonlit Trail");
+    const noticeCard = await drawPrimaryMatching(
+      "frontier actor notice",
+      ["notice", "reveals one disclosure-safe observable fact"],
+    );
+    const before = await page.evaluate(() => ({
+      actorId: Number(actorId || 0),
+      eventSeq: logEvents.reduce((latest, event) => Math.max(latest, Number(event.seq) || 0), 0),
+      ledger: {
+        banked: Number(state?.ledger?.banked_count || 0),
+        unbanked: Number(state?.ledger?.unbanked_count || 0),
+      },
+      tired: (state?.tags || []).some((tag) => tag.label === "tired"),
+    }));
+    assert(!before.tired, `frontier Notice should begin from a fresh actor: ${JSON.stringify(before)}`);
+    steps.push({ label: "frontier actor notice", primary: noticeCard, location: await currentLocation() });
+    await clickPrimary("frontier actor notice");
     await page.waitForFunction(() => (
       actionBusy === false
         && refreshInFlight === null
         && document.querySelector("#action-modal")?.hidden === true
     ), null, { timeout: 35_000 });
-    const tiredState = await fetchCurrentState();
-    if (!(tiredState.tags || []).some((tag) => tag.label === "tired")) {
-      steps.push({ label: "frontier notice stayed fresh", location: await currentLocation() });
-      return;
-    }
-    const restAlreadyAvailable = await page.evaluate(() => (
-      actions.some((action) => String(action.label || "").toLowerCase() === "rest")
-    ));
-    if (!restAlreadyAvailable) {
-      await leaveTrailTo("Rain-Soft Garden");
-      steps.push({ label: "frontier recovery walk", location: await currentLocation() });
-    }
-
-    const restCard = await drawPrimaryMatching("frontier rest", ["rest", "feel fresh"]);
-    steps.push({ label: "immediate frontier recovery", primary: restCard, location: await currentLocation() });
+    const after = await page.evaluate((starting) => {
+      const events = logEvents.filter((event) => Number(event.seq || 0) > starting.eventSeq);
+      return {
+        observations: events.filter((event) => (
+          event.type === "notice.actor_observed"
+            && Number(event.actor_id || 0) === starting.actorId
+        )).length,
+        rolled: events.some((event) => event.type === "ability_check.rolled"),
+        touchedGrowth: events.some((event) => (
+          event.type === "ledger.marked" || event.type === "ledger.banked"
+        )),
+        ledger: {
+          banked: Number(state?.ledger?.banked_count || 0),
+          unbanked: Number(state?.ledger?.unbanked_count || 0),
+        },
+        tired: (state?.tags || []).some((tag) => tag.label === "tired"),
+      };
+    }, before);
     assert(
-      restCard.toLowerCase().startsWith("rest feel fresh"),
-      `Rest should become the first card as soon as frontier listening leaves you tired: ${restCard}`,
-    );
-    steps.push({ label: "frontier rest", primary: restCard, location: await currentLocation() });
-    await clickPrimary("frontier rest");
-    await page.waitForFunction(() => !(state?.tags || []).some((tag) => tag.label === "tired"));
-    const rested = await fetchCurrentState();
-    assert(
-      !(rested.tags || []).some((tag) => tag.label === "tired"),
-      `Rest should leave the avatar feeling fresh again: ${JSON.stringify(rested.tags)}`,
+      after.observations === 1
+        && after.rolled === false
+        && after.touchedGrowth === false
+        && after.ledger.banked === before.ledger.banked
+        && after.ledger.unbanked === before.ledger.unbanked
+        && after.tired === false,
+      `frontier Notice should remain one truthful, non-tiring observation: ${JSON.stringify({ before, after })}`,
     );
   }
 
@@ -11293,15 +11302,14 @@ async function main() {
       const handOfferIds = new Set((state?.action_hand?.entries || [])
         .map((entry) => String(entry?.offer_id || ""))
         .filter(Boolean));
-      const previousRollSeq = Math.max(0, ...roomMemoryModel().recent
-        .filter((entry) => (
-          entry.kind === "roll"
-            && Number(entry.actorId || 0) === currentActorId
-        ))
-        .map((entry) => Number(entry.seq || 0)));
+      const exactOffer = (state?.action_offers || []).find((offer) =>
+        (focused?.offerIds || []).includes(offer.offer_id)) || null;
       return {
         actorId: currentActorId,
-        previousRollSeq,
+        targetActorId: Number(exactOffer?.target?.id || 0),
+        previousEventSeq: logEvents.reduce((latest, event) => (
+          Math.max(latest, Number(event.seq) || 0)
+        ), 0),
         focused: focused && {
           label: compactActionLabel(focused),
           intention: focused.intention,
@@ -11313,75 +11321,42 @@ async function main() {
     });
     assert(
       noticeBefore.actorId > 0
+        && noticeBefore.targetActorId > 0
         && noticeBefore.focused?.intention === "notice"
         && noticeBefore.focused?.isCertified === true,
       `Notice must remain an exact currently dealt hand action before it is played: ${JSON.stringify(noticeBefore)}`,
     );
     await clickPrimary("notice");
-    await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
-    await page.waitForFunction(({ actorId: currentActorId, previousRollSeq }) => (
-      roomMemoryModel().recent.some((entry) => (
-        entry.kind === "roll"
-          && Number(entry.actorId || 0) === Number(currentActorId)
-          && Number(entry.seq || 0) > Number(previousRollSeq)
-          && String(entry.text || "").trim().length > 0
-      ))
-    ), noticeBefore);
-    if (!runLivingWorldStress && runtimeMeta.features?.ai_enabled) {
-      // A resident reply is asynchronous: intent inference, then dialogue
-      // inference, then the authored chat delay. Re-enabling the primary button
-      // does not mean the line has landed, so wait for it rather than sampling
-      // the log the instant the action completes.
-      await page
-        .waitForFunction(() => [...document.querySelectorAll("#log > *")].some((node) => (
-          node.classList.contains("chat")
-          && node.classList.contains("avatar")
-          && !node.classList.contains("you")
-        )), { timeout: 45000 })
-        .catch(() => {});
-    }
-    const scene = await page.evaluate(({ actorId: currentActorId, previousRollSeq }) => {
+    await page.waitForFunction(() => (
+      actionBusy === false
+        && refreshInFlight === null
+        && state?.first_tale?.phase === "follow_lead"
+    ));
+    const scene = await page.evaluate(({ actorId: currentActorId, targetActorId, previousEventSeq }) => {
       const rows = [...document.querySelectorAll("#log > *")];
-      // Chat rows are classified you/avatar/world; there is no longer an "npc"
-      // class. A resident reply is any avatar row that is not the player's.
-      const reply = rows.findLast((node) => (
-        node.classList.contains("chat")
-        && node.classList.contains("avatar")
-        && !node.classList.contains("you")
-      ));
-      const noticeRoll = roomMemoryModel().recent
-        .filter((entry) => (
-          entry.kind === "roll"
-            && Number(entry.actorId || 0) === Number(currentActorId)
-            && Number(entry.seq || 0) > Number(previousRollSeq)
-        ))
-        .sort((left, right) => Number(left.seq || 0) - Number(right.seq || 0))
-        .at(-1) || null;
+      const newEvents = logEvents.filter((event) => Number(event.seq || 0) > Number(previousEventSeq));
       return {
-        residentReply: reply?.textContent?.trim().replace(/\s+/g, " ") || "",
-        roomLatest: document.querySelector("#room-log-latest")?.textContent?.trim().replace(/\s+/g, " ") || "",
-        noticeRoll: noticeRoll && {
-          seq: Number(noticeRoll.seq || 0),
-          actorId: Number(noticeRoll.actorId || 0),
-          kind: noticeRoll.kind,
-          label: noticeRoll.label,
-          text: noticeRoll.text,
-        },
+        observed: newEvents.some((event) =>
+          event.type === "notice.actor_observed"
+            && Number(event.actor_id || 0) === Number(currentActorId)
+            && Number(event.target_actor_id || 0) === Number(targetActorId)),
+        rolled: newEvents.some((event) => event.type === "ability_check.rolled"),
+        touchedGrowth: newEvents.some((event) =>
+          event.type === "ledger.marked" || event.type === "ledger.banked"),
+        ledger: state?.ledger || {},
         eventRows: document.querySelectorAll("#log .line.event, #log .roll-line").length,
         nonChatRows: rows.filter((node) => node.classList.contains("line") && !node.classList.contains("chat")).length,
       };
     }, noticeBefore);
     assert(scene.eventRows === 0 && scene.nonChatRows === 0, `Notice outcomes should stay out of group chat: ${JSON.stringify(scene)}`);
     assert(
-      scene.noticeRoll?.seq > noticeBefore.previousRollSeq
-        && scene.noticeRoll?.actorId === noticeBefore.actorId
-        && scene.noticeRoll?.kind === "roll"
-        && String(scene.noticeRoll?.text || "").trim().length > 0,
-      `the room Log should retain this actor's new Notice roll without depending on success or failure prose: ${JSON.stringify({ noticeBefore, scene })}`,
+      scene.observed === true
+        && scene.rolled === false
+        && scene.touchedGrowth === false
+        && Number(scene.ledger?.banked_count || 0) === 0
+        && Number(scene.ledger?.unbanked_count || 0) === 0,
+      `actor Notice should record one generic observation without a roll or growth mutation: ${JSON.stringify({ noticeBefore, scene })}`,
     );
-    if (!runLivingWorldStress && runtimeMeta.features?.ai_enabled) {
-      assert(scene.residentReply.length > 0, `group chat should retain the resident's spoken reply: ${JSON.stringify(scene)}`);
-    }
     await assertActionBarCapped("notice action bar");
   }
 
@@ -12364,14 +12339,19 @@ async function main() {
           && afterFirstListen.visibleLabels.every((label) => !/grow|expand bracelet/i.test(label)),
         `the newcomer should receive a dealt shared-world hand without a private growth affordance: ${JSON.stringify(afterFirstListen)}`,
       );
-      assert(/earned one/i.test(afterFirstListen.economy) && !/\+1/.test(afterFirstListen.economy), `the Listen reward should read as a small event rather than arithmetic: ${JSON.stringify(afterFirstListen)}`);
+      assert(
+        !/earned one|\+1/i.test(afterFirstListen.economy)
+          && Number(afterFirstListen.ledger?.banked_count || 0) === 0
+          && Number(afterFirstListen.ledger?.unbanked_count || 0) === 0,
+        `actor Notice should advance the lead without mutating growth: ${JSON.stringify(afterFirstListen)}`,
+      );
       const sharedTurnOwner = firstTaleStart.currentActorId;
       assert(
         afterFirstListen.currentActorId === sharedTurnOwner
           && afterFirstListen.firstTale?.phase === "follow_lead"
           && /Rain-Soft Garden/i.test(afterFirstListen.guide)
           && !/your first tale is yours/i.test(afterFirstListen.guide),
-        `automatic discovery settlement should reveal the shared-world lead without taking the shared room turn: ${JSON.stringify(afterFirstListen)}`,
+        `truthful observation should reveal the shared-world lead without taking the shared room turn: ${JSON.stringify(afterFirstListen)}`,
       );
       steps.push({
         label: "waiting player shared-world lead",
@@ -15633,7 +15613,7 @@ async function main() {
       );
       await travelTo("Moonlit Trail");
     }
-    await exerciseFrontierRecovery();
+    await exerciseFrontierObservation();
     if ((await currentLocation()) !== "Rain-Soft Garden") {
       await leaveTrailTo("Rain-Soft Garden");
     }

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -427,7 +427,6 @@ async function submitOffer(
 }
 
 async function discoverExit(baseUrl, actorId, actorSession, destinationLocationId) {
-  await commandExactOffer(baseUrl, actorId, actorSession, "listen");
   for (let attempt = 0; attempt < 32; attempt += 1) {
     const state = await fetchInspectableState(baseUrl, actorId, actorSession);
     if (state.exits?.some((exit) =>
@@ -643,7 +642,7 @@ async function main() {
       locationPack: "ruby-high.first-bell",
       selectedBy: "ruby-high.first-bell",
       capability: "ruby-high.first-bell/rules",
-      offerVerb: "Tune in",
+      offerVerb: "Notice",
       sourceCard: "location-homeroom",
     });
     const worldSeqBeforeRestart = homeroom.world_seq;
@@ -661,7 +660,7 @@ async function main() {
       locationPack: "ruby-high.first-bell",
       selectedBy: "ruby-high.first-bell",
       capability: "ruby-high.first-bell/rules",
-      offerVerb: "Tune in",
+      offerVerb: "Notice",
       sourceCard: "location-homeroom",
     });
     assert(
@@ -846,7 +845,7 @@ async function main() {
       locationPack: "ruby-high.first-bell",
       selectedBy: "ruby-high.first-bell",
       capability: "ruby-high.first-bell/rules",
-      offerVerb: "Tune in",
+      offerVerb: "Notice",
       sourceCard: "location-homeroom",
     });
     console.log(JSON.stringify({

--- a/v2/scripts/smoke-standalone-compositions.mjs
+++ b/v2/scripts/smoke-standalone-compositions.mjs
@@ -96,7 +96,7 @@ const worldCases = [
     locationPack: "ruby-high.first-bell",
     selectedBy: "ruby-high.first-bell",
     capability: "ruby-high.first-bell/rules",
-    offerVerb: "Tune in",
+    offerVerb: "Notice",
     firstTaleAbsent: true,
   },
   {
@@ -139,6 +139,7 @@ const worldCases = [
     localSeedActorCount: 1,
     localSeedActorControlMode: "local_ai",
     localItemCount: 1,
+    noticeAbsent: true,
     scoutDestination: "Void 002",
     additionalScoutDestination: "Void 003",
     multiStepScoutPath: true,
@@ -672,9 +673,9 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   const noticeOffer = firstTaleAdvancingOffer(initial, "lantern Cottage notice");
   const listened = await command(baseUrl, actorId, actorSession, noticeOffer.command);
   assert(
-    listened.events?.some((event) => event.type === "ability_check.rolled")
-      && listened.events?.some((event) => event.type === "ledger.banked"),
-    `Lantern Keeper Cottage Notice did not bank its first useful lead: ${JSON.stringify(listened)}`,
+    listened.events?.some((event) => event.type === "notice.actor_observed")
+      && listened.events?.some((event) => event.type === "notice.fact_revealed"),
+    `Lantern Keeper Cottage Notice did not reveal its first useful lead: ${JSON.stringify(listened)}`,
   );
 
   let taleState = await fetchInspectableState(baseUrl, actorId, actorSession);
@@ -709,8 +710,9 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   assert(
     contributionEvent
       && traceEvents.length === 1
-      && traceEvents[0].caused_by_event_seq === contributionEvent.seq,
-    `Lantern Keeper first contribution did not emit one explicit replay-safe public trace: ${JSON.stringify(firstContribution)}`,
+      && traceEvents[0].caused_by_event_seq === contributionEvent.seq
+      && firstContribution.events?.some((event) => event.type === "ledger.banked"),
+    `Lantern Keeper first contribution did not emit one replay-safe trace and settle its reward: ${JSON.stringify(firstContribution)}`,
   );
   taleState = await fetchInspectableState(baseUrl, actorId, actorSession);
   assert(
@@ -970,7 +972,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     `Lantern Keeper did not expose the authoritative finale offer: ${JSON.stringify(lanternJourneySummary(towerReady))}`,
   );
   traceLantern("lantern Tower ready", towerReady);
-  const dangerBeforeMeaningfulRest = Number(towerReady.shared_questions?.find((question) =>
+  const dangerBeforeFinale = Number(towerReady.shared_questions?.find((question) =>
     question.id === "lantern-keeper:rekindle-the-beacon")?.danger_filled || 0);
 
   const tamperedOffer = await postJsonExpectingStatus(`${baseUrl}/commands`, {
@@ -987,7 +989,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     `Lantern Keeper accepted a tampered finale offer: ${JSON.stringify(tamperedOffer)}`,
   );
 
-  const firstTowerListen = await command(baseUrl, actorId, actorSession, "listen");
+  await passCurrentHand(baseUrl, actorId, actorSession);
   const staleOffer = await postJsonExpectingStatus(`${baseUrl}/commands`, {
     actor_id: actorId,
     actor_session: actorSession,
@@ -1002,24 +1004,6 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     `Lantern Keeper accepted a stale finale offer: ${JSON.stringify(staleOffer)}`,
   );
 
-  const repeatedListen = await command(baseUrl, actorId, actorSession, "listen");
-  assert(
-    repeatedListen.events?.some((event) =>
-      event.type === "tag.applied" && event.tag_label === "tired"),
-    `Lantern Keeper repeat frontier action did not create a meaningful Rest choice: ${JSON.stringify(repeatedListen)}`,
-  );
-  const tiredAtTower = await fetchInspectableState(baseUrl, actorId, actorSession);
-  await dealOffer(baseUrl, actorId, actorSession, (offer) => offer.kind === "rest", "the Rest card");
-  const rested = await command(baseUrl, actorId, actorSession, "rest");
-  assert(
-    rested.events?.some((event) =>
-      event.type === "tag.cleared" && event.tag_label === "tired")
-      && rested.events?.some((event) =>
-        event.type === "clock.updated"
-          && event.clock_id === "lantern-keeper.darkness"
-          && event.clock_filled === dangerBeforeMeaningfulRest + 1),
-    `Lantern Keeper Rest did not trade recovery for authored danger: ${JSON.stringify(rested)}`,
-  );
   towerReady = await fetchInspectableState(baseUrl, actorId, actorSession);
   const freshWorkDeal = await dealOffer(baseUrl, actorId, actorSession, (offer) =>
     offer.kind === "work" && matchesProjectOffer(offer, "lantern-keeper:rekindle-the-beacon"), "the refreshed finale Work card");
@@ -1029,11 +1013,9 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     question.id === "lantern-keeper:rekindle-the-beacon");
   assert(
     readyQuestion?.filled === 0
-      && readyQuestion?.danger_filled === dangerBeforeMeaningfulRest + 1
-      && freshWorkOffer?.offer_id
-      && rested.receipt?.world_id
-      && rested.receipt?.actor_ref,
-    `Lantern Keeper lost its finale after the meaningful Rest choice: ${JSON.stringify(lanternJourneySummary(towerReady))}`,
+      && readyQuestion?.danger_filled === dangerBeforeFinale
+      && freshWorkOffer?.offer_id,
+    `Lantern Keeper lost its finale after refreshing the hand: ${JSON.stringify(lanternJourneySummary(towerReady))}`,
   );
 
   const finalePayload = {
@@ -1076,7 +1058,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   assert(
     completedQuestion?.presentation_state === "completed_memory"
       && completedQuestion?.filled === 6
-      && completedQuestion?.danger_filled === dangerBeforeMeaningfulRest + 1
+      && completedQuestion?.danger_filled === dangerBeforeFinale
       && completedQuestion?.situation?.includes("Mothwood beacon")
       && completedAtTower.tags?.some((tag) => tag.id === "room:804:beacon_rekindled")
       && completedAtTower.economy?.orbs === beforeFinaleOrbs + 2
@@ -1110,7 +1092,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   assert(
     afterTravelQuestion?.presentation_state === "completed_memory"
       && afterTravelQuestion?.filled === 6
-      && afterTravelQuestion?.danger_filled === dangerBeforeMeaningfulRest + 1,
+      && afterTravelQuestion?.danger_filled === dangerBeforeFinale,
     `Lantern Keeper's post-finale travel reset completion before restart: ${JSON.stringify(lanternJourneySummary(completed))}`,
   );
   traceLantern("lantern completed", completed);
@@ -1119,7 +1101,7 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     expected: {
       orbs: completed.economy?.orbs,
       progress: 6,
-      danger: dangerBeforeMeaningfulRest + 1,
+      danger: dangerBeforeFinale,
       completionSituation: completedQuestion.situation,
       finalePayload,
       finaleResponse: finale,
@@ -1523,11 +1505,18 @@ async function runWorldLoop(spec) {
       }
     }
 
-    if (!spec.goldenJourney) {
-      const listened = await command(first.baseUrl, actorId, actorSession, "listen");
+    if (!spec.goldenJourney && !spec.noticeAbsent) {
+      const noticeDeal = await dealOffer(
+        first.baseUrl,
+        actorId,
+        actorSession,
+        (offer) => offer.kind === "notice_actor",
+        `${spec.label} actor Notice`,
+      );
+      const noticed = await command(first.baseUrl, actorId, actorSession, noticeDeal.offer.command);
       assert(
-        listened.events?.length > 0,
-        `${spec.label} Listen produced no committed events: ${JSON.stringify(listened)}`,
+        noticed.events?.some((event) => event.type === "notice.actor_observed"),
+        `${spec.label} Notice produced no committed observation: ${JSON.stringify(noticed)}`,
       );
     }
     const replayMarker = await passCurrentHand(first.baseUrl, actorId, actorSession);


### PR DESCRIPTION
## Summary

- replace ambient and repeat Notice with an exact `notice_actor_v1` offer for one nearby visible actor and one stable viewer-scoped observable fact
- keep the exact result private to the viewer while the public receipt remains generic; Notice has no roll, currency, readiness, or unrelated growth settlement
- withhold exhausted offers, reject stale certificates without mutation, preserve historical Notice replay, and align browser, terminal, API, resident, and composition paths
- settle the authored First Tale reward when its public trace completes so its Mara relationship continuation remains reachable without coupling growth back to Notice
- extract the contract into `notice.rs` and bump the release version to 1.0.31
- keep canonical capacity/failover coverage on its stable certified Pass card so unrelated gameplay offer order cannot move the fixture out of the partition under test

## Verification

- `npm run check` via the pre-push gate
  - 179 JavaScript tests
  - official and composed worldpack validation
  - kernel checks
  - 1,184 Rust tests, including `hot_room_and_regional_chaos_preserve_one_committed_world`
  - exact `main.rs` and clippy budgets
  - JavaScript and Python syntax checks
- `npm run v2:composition:smoke:standalone`
  - seven-world matrix, Lantern golden journey, restart, and replay
- `npm run v2:composition:smoke:core-ruby`
  - mount, transition, checkpoint replay, soft unmount, tombstone inspection, and remount
- targeted canonical concurrency fixture passed repeatedly outside the sandbox

Closes #774