### PR TITLE
Revamp cards around the Story Hand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/player-lexicon.test.mjs
+++ b/test/v2/player-lexicon.test.mjs
@@ -81,9 +81,10 @@ describe("player-facing action, card, linked-avatar, world-pack, and Journal lex
     expect(index).not.toContain('id="all-actions-title">all actions</h2>');
     expect(index).not.toContain("data-all-action-index");
     expect(index).not.toContain('data-player-concept="action-menu"');
-    expect(index).toContain('data-player-concept="pass"');
-    expect(index).toContain('aria-label="Think: pass these two actions and commit the turn"');
-    expect(index).toContain("free redeal command has retired");
+    expect(index).toContain('data-player-concept="think"');
+    expect(index).toContain('aria-label="Think about replacing the focused Story Hand card"');
+    expect(index).toContain('command: "think"');
+    expect(index).not.toContain('command: "pass"');
   });
 
   it("checks in ownership, lifecycle, affordance, accessibility, and analytics guidance", () => {

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -10,8 +10,8 @@ const browser = fs.readFileSync(
   "utf8",
 );
 
-describe("two-action browser hand", () => {
-  it("keeps exactly two current card slots and exposes certified Think/Pass as the only cycle action", () => {
+describe("three-slot Story Hand", () => {
+  it("keeps Story, Self, and Anchor visible and exposes targeted certified Think as the only cycle action", () => {
     expect(browser).not.toContain('id="command-toggle"');
     expect(browser).not.toContain('id="command-palette"');
     expect(browser).not.toContain('id="command-input"');
@@ -19,19 +19,20 @@ describe("two-action browser hand", () => {
     expect(browser).not.toContain("data-all-action-index");
     expect(browser).toContain('id="primary"');
     expect(browser).toContain('id="secondary"');
-    expect(browser).not.toContain('id="tertiary"');
+    expect(browser).toContain('id="tertiary"');
     expect(browser).toContain('id="shuffle"');
-    expect(browser).toContain('data-player-concept="pass"');
-    expect(browser).toContain('aria-label="Think: pass these two actions and commit the turn"');
-    expect(browser).toContain('const buttonIds = ["primary", "secondary"];');
+    expect(browser).toContain('data-player-concept="think"');
+    expect(browser).toContain('aria-label="Think about replacing the focused Story Hand card"');
+    expect(browser).toContain('const buttonIds = ["primary", "secondary", "tertiary"];');
     expect(browser).toContain('async function passHand()');
-    expect(browser).toContain('offer_id: handPassSubmission.offer_id');
+    expect(browser).toContain('const think = entry?.think;');
+    expect(browser).toContain('command: "think"');
     expect(browser).toContain('postResult("/commands", withAccess({');
     expect(browser).not.toContain('post("/actions/draw"');
     expect(browser).not.toContain("advanceHandPage");
     expect(browser).not.toContain("drawNextHandCard");
-    expect(browser).toContain('event.type === "hand.shuffled"');
-    expect(browser).toMatch(/function handCapacity\(\) \{\s+return 2;\s+\}/);
+    expect(browser).toContain('event.type === "hand.thought"');
+    expect(browser).toMatch(/function handCapacity\(\) \{\s+return state\?\.branch \? 2 : Number\(state\?\.action_hand\?\.capacity \|\| 3\);\s+\}/);
   });
 
   it("keeps same-kind Search and Scout targets bound to their dealt certificates", () => {
@@ -44,6 +45,27 @@ describe("two-action browser hand", () => {
     expect(browser).toContain('const scoutGroups = projectedScoutOfferIds.size > 1');
     expect(browser).toContain('scoutAction.selectedTarget = () => scoutCandidates.find((candidate) => (');
     expect(browser).toContain('scoutAction.selectedPayload = () => ({');
+  });
+
+  it("shows Travel and the destination without route-type copy in the hand", () => {
+    const routeBlock = browser.slice(
+      browser.indexOf("const projectedRouteOfferIds"),
+      browser.indexOf('if (options.has("use_item"))'),
+    );
+    const cardRenderBlock = browser.slice(
+      browser.indexOf("function renderButton"),
+      browser.indexOf("function actionBarActions"),
+    );
+
+    expect(routeBlock).toContain(
+      "? (firstPathwayDirection?.endpointName || firstExit.destination_location_name)",
+    );
+    expect(routeBlock).toContain("destinationOnlyCardAriaLabel: destinationOnlyCardLabel");
+    expect(routeBlock).not.toContain("conciseRouteLabel");
+    expect(cardRenderBlock).toContain(
+      'String(action?.intention || "").toLowerCase() === "travel"',
+    );
+    expect(cardRenderBlock).toContain('? "Travel"');
   });
 
   it("submits room-feature Use offers through the typed item endpoint", () => {

--- a/v2/README.md
+++ b/v2/README.md
@@ -143,8 +143,8 @@ The Rust orchestrator currently owns:
 - Actor/item/location/content labels.
 - Native calls into the local Rust model for deterministic avatar identity and speech sanitizer behavior that can also run in WASM; dialogue is generated only through configured AI inference.
 - Card projections for visible actors, items, and locations.
-- Rules-bound legal-action envelopes, deterministic ranked two-card hands plus
-  certified Think/Pass rotation, composition traces, and stale/tampered
+- Rules-bound legal-action envelopes, a deterministic three-slot Story Hand
+  with exact per-card Think certificates, composition traces, and stale/tampered
   submission rejection.
 - Read-only legacy item-materialization migration receipts and possession
   provenance. No materialize or Collection-return mutation remains; the
@@ -290,13 +290,13 @@ http://127.0.0.1:3102/?reset=1
 
 `reset=1` clears the browser's remembered avatar, calls the dev-gated `/dev/reset` endpoint when enabled, removes the reset flag from the URL, reseeds the world, clears the SQLite action journal/event feed, and returns the player to the explicit `Create Avatar` gate. Without `COSYWORLD_ENABLE_DEV_RESET=1`, the query still clears only the local browser avatar so a tester can start a new human without resetting the shared server.
 
-The avatar gate begins with an immediate character question and carries that answer through the visible game as the avatar's purpose. A quiet transcript frames `a new tale is waiting`; the completed Begin lands as a visible arrival beat and arms the first resident heartbeat. The new avatar sheet describes moments and people still ahead, calls a local session a `local tale`, and reports the carried deck by physical weight rather than a fixed card count.
+The avatar gate begins with an immediate character question and carries that answer through the visible game as the avatar's purpose. A quiet transcript frames `a new tale is waiting`; the completed Begin lands as a visible arrival beat and arms the first resident heartbeat. The new avatar sheet describes moments and people still ahead, calls a local session a `local tale`, and reports the Pack by physical weight rather than a fixed card count.
 
 The browser frames onboarding as `Your first tale`: Notice a clue, watch the Journal settle the earned growth in that same action, then keep exploring or use advancement through a relevant character surface. Chat starts a short system-funded exchange with an eligible nearby resident; Befriend spends one advancement point to begin a friendship and opens a resident picker when several eligible new friends are nearby. Advancement never creates a charm, skill, spell, or weapon card. Remember handles mature friendships separately.
 
 Multi-target verbs stay compact: Take, Use, Give, Trade, Attack, and Chat put legal targets inside one card instead of duplicating hand slots. Long connections remain ordinary segmented geography—Search reveals one adjacent pathway and Travel enters it. Player-facing copy describes story outcomes rather than exposing raw d20, damage, HP, or clock arithmetic. The collapsed room `LOG` names who did what and what changed; the expanded history preserves the audited sequence. That log is also supplied to resident inference, so a delayed reply can refer to cards played and changes that happened in the channel instead of inventing an isolated conversation.
 
-Pathway Scout and Travel remain ordinary dealt actions: discovering a stretch never moves the player, commits them to the destination, or hides room interactions. A player may continue, backtrack, choose another route, stay and act, or Think/Pass. During an active journey the browser gives that actor a provisional travelling-party treatment with a destination, evolving way name, segmented progress bar, co-present faces, and a travelling-party label over the room transcript. This remains orientation rather than shared-party authority: `JourneyState` is actor-scoped, the faces are not certified Company members, conversation is still room-scoped, and every actor moves independently. [ADR 0009](../docs/decisions/0009-companies-ventures-formations-and-shared-travel.md) defines the accepted replacement—consensual Company membership, a shared Venture, Formation and readiness, vehicles as independent world objects, atomic departure for the ready subset, detachments, and honest route/voyage/Delve progress. Destinations remain places (`Emmaus`); connective names such as `Road to Emmaus` belong to the way system, whose current traffic-derived presentation grows from unmarked way through track, cairn path, trail, road, avenue, and highway. ADR 0009 requires a future replay-compatible revision to distinguish wear, wayfinding, construction, maintenance, and normalized use rather than letting raw per-edge traffic stand in for every kind of development. Each revealed waypoint atomically joins the authoritative room and simulation projections as risky frontier with three derived milestones: a durable fixture earns Anchor, an actor-causal physical delivery earns Connection, and three non-repeatable contributions from at least two avatars earn Settlement. Settlement opens a bounded building proposal, extended only by revealed natural features; it does not create a sanctuary or construct anything. `choice` keeps the policy and alternatives in Journal, while `support`, `choose`, and explicit delegation write one-line Journal events through a replayable governed-choice state machine; selection preserves every support record and never depends on controller kind, title, Calling, or practice. The browser uses authored location art; the unfinished pathway/dungeon SVG renderer is not part of play.
+Pathway Scout and Travel remain ordinary dealt actions: discovering a stretch never moves the player, commits them to the destination, or hides room interactions. A player may continue, backtrack, choose another route, stay and act, or Think about one focused card. During an active journey the browser gives that actor a provisional travelling-party treatment with a destination, evolving way name, segmented progress bar, co-present faces, and a travelling-party label over the room transcript. This remains orientation rather than shared-party authority: `JourneyState` is actor-scoped, the faces are not certified Company members, conversation is still room-scoped, and every actor moves independently. [ADR 0009](../docs/decisions/0009-companies-ventures-formations-and-shared-travel.md) defines the accepted replacement—consensual Company membership, a shared Venture, Formation and readiness, vehicles as independent world objects, atomic departure for the ready subset, detachments, and honest route/voyage/Delve progress. Destinations remain places (`Emmaus`); connective names such as `Road to Emmaus` belong to the way system, whose current traffic-derived presentation grows from unmarked way through track, cairn path, trail, road, avenue, and highway. ADR 0009 requires a future replay-compatible revision to distinguish wear, wayfinding, construction, maintenance, and normalized use rather than letting raw per-edge traffic stand in for every kind of development. Each revealed waypoint atomically joins the authoritative room and simulation projections as risky frontier with three derived milestones: a durable fixture earns Anchor, an actor-causal physical delivery earns Connection, and three non-repeatable contributions from at least two avatars earn Settlement. Settlement opens a bounded building proposal, extended only by revealed natural features; it does not create a sanctuary or construct anything. `choice` keeps the policy and alternatives in Journal, while `support`, `choose`, and explicit delegation write one-line Journal events through a replayable governed-choice state machine; selection preserves every support record and never depends on controller kind, title, Calling, or practice. The browser uses authored location art; the unfinished pathway/dungeon SVG renderer is not part of play.
 
 A governed selection now claims one major footprint and opens a shared construction question rather than completing a building; completion installs only pack-authored capabilities, leaves natural features intact, creates no passive cargo, and exposes its clocks, empty reward caches, recipe tags, and bounded follow-up work to avatars through room state without adding main-page panels.
 
@@ -304,13 +304,13 @@ Authored search reveal percentages are real per-attempt thresholds. Candidates
 are checked in deterministic priority order, and when every roll misses the
 search reveals nothing rather than forcing the first hidden candidate.
 
-The scene hand never deals a standalone growth-settlement or generic bracelet card. A successful Notice records and settles its earned marks in one authoritative action while leaving ordinary discovery reachable. Deck & Loadout exposes `Make room for <Charm>` only when the current bracelet is full, that specific unworn charm is carried, earned advancement is ready, and the slot cap has not been reached. Spending opens one slot without creating or equipping the charm. The room stays chat-first; the `Journal` button beside the location name opens a warm storybook view. It separates the current place and open threads from paged story history, and begins the history with a concise deterministic chapter summary composed from the same authoritative beats rather than an AI retelling or raw event log.
+The Story Hand never deals a standalone growth-settlement or generic bracelet card. A successful Notice records and settles its earned marks in one authoritative action while leaving ordinary discovery reachable. Pack & Loadout exposes `Make room for <Charm>` only when the current bracelet is full, that specific unworn charm is carried, earned advancement is ready, and the slot cap has not been reached. Spending opens one slot without creating or equipping the charm. The room stays chat-first; the `Journal` button beside the location name opens a warm storybook view. It separates the current place and open threads from paged story history, and begins the history with a concise deterministic chapter summary composed from the same authoritative beats rather than an AI retelling or raw event log.
 
 The planned rest-bound authored-page model—one sentence per short rest, one full page per long rest, with three short rests per waking cycle—is specified in [Rest-bound Journal pages](docs/rest-bound-journal-pages.md).
 
 Generated avatar titles are short portable card epithets rather than room descriptions. Model-added suffixes such as `at The Cosy Cottage` are removed on creation and when older profiles are replayed, so arrival copy names the room once and the title still makes sense after travel. Identity generation asks for a small fondness, harmless habit, and gentle curiosity; a server-side tone guard repairs titles, descriptions, visual prompts, and older profiles that drift into grudges, ravenous scheming, hostility, cruelty, or villain language.
 
-After `Your first tale` finishes, the client may derive one grounded **room thread** from projected world state: a wanted gift, urgent care, shared work, danger, an open path, something still hidden, a nearby voice, or finally the room's authored hook. That client-only suggestion cannot reorder or annotate the authoritative two-card hand. The server-authored first-tale projection is the only story guide that may pin and label a matching scene card.
+After `Your first tale` finishes, the client may derive one grounded **room thread** from projected world state: a wanted gift, urgent care, shared work, danger, an open path, something still hidden, a nearby voice, or finally the room's authored hook. That client-only suggestion cannot reorder or annotate the authoritative Story Hand. The server-authored first-tale projection is the only story guide that may pin and label a matching Story card.
 
 Choice-bearing cards keep one confirmation flow while making the selected option feel concrete. Avatar, Item, Location, Give, Trade, Travel, Take, Attack, friendship, and mixed Use choices carry their corresponding cards; selecting another option immediately swaps the preview and accessible image name. Portrait and square art use a contained preview instead of being cropped into the wide action frame.
 
@@ -619,11 +619,14 @@ The default client is JRPG-style button mode:
 ```text
 [Enter] primary contextual action
 [Space] secondary contextual action, when present
-[P]     Think/Pass (skip turn and deal two new cards)
+[P]     Think (replace the focused card; free once on entering a safe scene)
 [Q]     quit
 ```
 
-The client presents the two dealt certified cards in server order, including every authored action kind. Playing a card or choosing the certificate-bound Think/Pass control consumes one turn and deals the next hand. `/commands` remains a narrow text convenience for room inspection, reporting, and safety; state-changing scene play requires a current offered certificate.
+The client presents the server-authored Story, Self, and Anchor slots. Each action has one of six suits—Wonder, Way, Heart, Hand, Courage, or Hearth—plus an exact verb, source, state, provenance, cost, risk, and effect. Think replaces only the focused slot: the first Think after entering a safe scene is free, while later Thinks and every Think in a risky or ordered scene consume the turn. `/commands` remains a narrow text convenience for room inspection, reporting, and safety; state-changing scene play requires a current offered certificate.
+
+See [Story Hand](docs/story-hand.md) for the complete suit meanings, slot rules,
+presentation contract, and player vocabulary.
 
 Normal play prefers concrete room verbs such as `Take`, `Use`, `Notice`, `Inspect`, `Scout`, `Travel`, `Contribute`, `Flee`, or `Chat` from the ranked action-offer list. Notice receives an ambient lead, Inspect names the thing being examined, Scout names a destination while revealing only its next route segment, Travel moves there, and Contribute groups every authored Work, Help, Check, Study, or Use Item strategy in one project slot. Every choice submits its exact strategy ID through the same route; the server derives the ability, DC, or item from worldpack content. Each offer carries typed metadata for UI/tooling: semantic intention, pack-authored verb, target, accessible label, project and progress-clock identity, category, cost, risk, effect, claim key, source, zone, rank, and disabled-state. Packs may replace the displayed vocabulary without changing those stable semantic roles. Empty group chats render a quiet room vignette instead of a debug placeholder or synthetic log row.
 
@@ -785,7 +788,7 @@ Locations are live channels:
 - `/events` uses the same current-room boundary. Wallet/card entitlements do not widen replay into other rooms, and clients cannot traverse the world graph through event history.
 - Human presence in `/state` is filtered to the current actor plus recently touched actor sessions in that room, with the temporary focused-turn-holder exception used by MUD room rosters.
 - `/presence/ping` and `/presence/leave` require the matching actor session and emit hidden `actor.presence` events only when the active-presence state changes.
-- When two or more active human avatars share a room, `/state.turn` names the human whose card play is live. A newcomer still receives one welcoming Listen card before joining the room rhythm, and that courtesy action does not steal or advance the current player's place. Journal settlement is part of successful discovery rather than a separate waiting-room card. Loadout changes live in Deck & Loadout and do not take the shared room turn. The gentle Nudge / I'm here handoff remains beside scene choices instead of exposing technical timeout or initiative language. A nudge opens an eight-second room wait; players who answer are eligible for the next choice if the current player is away.
+- When two or more active human avatars share a room, `/state.turn` names the human whose card play is live. A newcomer still receives one welcoming Listen card before joining the room rhythm, and that courtesy action does not steal or advance the current player's place. Journal settlement is part of successful discovery rather than a separate waiting-room card. Loadout changes live in Pack & Loadout and do not take the shared room turn. The gentle Nudge / I'm here handoff remains beside scene choices instead of exposing technical timeout or initiative language. A nudge opens an eight-second room wait; players who answer are eligible for the next choice if the current player is away.
 - The browser appends only `message.created` speech and dice-call pills to group chat. Combat outcomes and other matching live events refresh state, remain in the location's Journal, and may appear as dismissible important alerts. Lantern Keeper actions additionally end in one persisted `story.receipt`.
 - An active Lantern Keeper scene promotes one shared question outside the Journal with fiction-first situation text, exact progress and danger meters, the completion change, the current danger beat, and its fill consequence. Its rationale list is derived from the same two-entry authoritative action hand as the playable cards; screen-reader labels say `suggestion 1 of 2` and `suggestion 2 of 2`, never count the larger legal offer set. Browser, `look`, CLI reconnect, stale-offer refresh, journal replay, success, and failure all project the same question state. Once either clock resolves it, the live task bars retire to a concise public memory naming its contributors.
 - The Lantern Keeper's light and darkness clocks directly declare their own justified fill effects. Each terminal fill journals exactly one authoritative job outcome and one authored `story.receipt`; retry, reconnect, and journal replay cannot duplicate either. Official worldpack validation requires both direct declarations, their expected completed/failed status, and an authored reason, and rejects a missing, tag-only, or duplicate lifecycle source without imposing the Lantern contract on other pack compositions.
@@ -822,7 +825,7 @@ Dialogue prompts keep the latest 16 spoken lines per room in a bounded, snapshot
 - `POST /dev/reset` when `COSYWORLD_ENABLE_DEV_RESET=1`
 - `POST /avatar`
 - `POST /avatar/session`
-- `POST /commands` for read controls and certified Think/Pass
+- `POST /commands` for read controls and certified per-card Think
 - `POST /presence/ping`
 - `POST /presence/leave`
 - `POST /story/world-beat-exposures`
@@ -840,7 +843,7 @@ state, disabled mutation flags, and read-only migration receipt counts. Verified
 linked-avatar actor receipts are counted separately because the retained actor
 adapter is not the retired general item bridge.
 `POST /actions/submit` is the canonical scene-mutation gateway. Callers send
-the authenticated actor handle and an exact offer from the current two-card
+the authenticated actor handle and an exact offer from the current Story
 hand. The offer payload includes its stable envelope:
 
 ```json
@@ -896,10 +899,10 @@ rendered; terminal and agent clients acknowledge after presentation with
 `cli` or `agent` transport.
 
 Listen, Study, Travel, item, social, work, and combat choices all enter through
-`POST /actions/submit`, which revalidates the current two-card hand, offer
+`POST /actions/submit`, which revalidates the current Story Hand, offer
 identity, rules binding, target, collectible source, and state revision before
-dispatch. A current Think/Pass certificate submitted to `POST /commands` rotates
-to the next two cards and consumes one turn. There are no direct mechanical
+dispatch. A current Think certificate submitted to `POST /commands` replaces
+its exact Story, Self, or Anchor card. It is free once per safe scene and otherwise consumes one turn. There are no direct mechanical
 compatibility routes.
 
 The deterministic `cosyworld.combat/4` protocol includes NPC initiative and
@@ -989,8 +992,8 @@ curl -s -X POST http://127.0.0.1:3102/avatar \
 
 ```sh
 curl -s http://127.0.0.1:3102/state?actor_id=5000
-# Submit the returned action_hand.pass.offer_id to /commands with its
-# canonical envelope; uncertified direct hand cycling is refused.
+# Focus one action_hand.entries card and submit its think.offer_id to /commands
+# with its canonical envelope; uncertified whole-hand cycling is refused.
 ```
 
 ## Verify

--- a/v2/cli/cosy_cli.py
+++ b/v2/cli/cosy_cli.py
@@ -395,27 +395,27 @@ class Game:
 
     def act(self) -> None:
         state = self.state()
-        offers = [
-            offer
-            for offer in state.get("action_offers") or []
-            if isinstance(offer, dict) and not offer.get("disabled")
-        ]
-        print("Actions:")
-        for index, offer in enumerate(offers, start=1):
+        entries, offers = self.dealt_action_offers(state)
+        print("Story Hand:")
+        for index, (entry, offer) in enumerate(zip(entries, offers), start=1):
             label = str(offer.get("label") or offer.get("kind") or "action")
             target = offer.get("target") or offer.get("project") or {}
             target_label = str(target.get("label") or "").strip() if isinstance(target, dict) else ""
             suffix = f" — {target_label}" if target_label else ""
-            print(f"  {index}. {label}{suffix}")
-        print(f"  {len(offers) + 1}. Think (commit a pass and deal the next two cards)")
+            slot = str(entry.get("slot") or f"card {index}").title()
+            presentation = offer.get("presentation") or {}
+            suit = str(presentation.get("suit") or "action").title() if isinstance(presentation, dict) else "Action"
+            verb = str(presentation.get("verb") or label).strip()
+            print(f"  {index}. [{slot}] {suit} · {verb} — {label}{suffix}")
+            think = entry.get("think") or {}
+            if isinstance(think, dict) and think.get("available"):
+                timing = "free" if think.get("free") else "uses the turn"
+                print(f"     Think {index}: replace only this card ({timing})")
         raw = input("Choose action: ").strip().lower()
         if not raw:
             return
         if raw.isdigit():
             index = int(raw) - 1
-            if index == len(offers):
-                self.pass_hand()
-                return
             if index < 0 or index >= len(offers):
                 raise ValueError("action number out of range")
             command = str(offers[index].get("command") or "").strip()
@@ -424,10 +424,12 @@ class Game:
             self.run_command(command, offer_id=str(offers[index].get("offer_id") or ""), state=state)
             return
 
-        if raw in {"think", "pass"}:
-            self.pass_hand()
+        if raw.startswith("think") or raw.startswith("pass"):
+            parts = raw.split()
+            slot_index = int(parts[1]) - 1 if len(parts) > 1 else 0
+            self.pass_hand(slot_index)
         else:
-            raise ValueError("choose a numbered dealt card, or Think to pass")
+            raise ValueError("choose a numbered Story Hand card, or type Think followed by its number")
 
     def choose_chat(self, state: dict[str, object]) -> None:
         actors = [
@@ -662,7 +664,7 @@ class Game:
         offer = self.current_offer(path, authoritative_payload)
         if not offer:
             raise ClientError(
-                "That action is not in your current two-card hand. Choose Think to commit a pass."
+                "That action is not in your Story Hand. Choose a card, or Think about one slot."
             )
         response = self.client.post(
             "/actions/submit",
@@ -690,35 +692,66 @@ class Game:
             self.look()
 
     def current_offer(self, path: str, payload: dict[str, object]) -> dict[str, object] | None:
+        state = self.state()
+        dealt_ids = {
+            str(entry.get("offer_id") or "")
+            for entry in ((state.get("action_hand") or {}).get("entries") or [])
+            if isinstance(entry, dict)
+        }
         return next(
             (
                 offer
-                for offer in self.state().get("action_offers") or []
-                if isinstance(offer, dict) and offer_matches_payload(offer, path, payload)
+                for offer in state.get("action_offers") or []
+                if isinstance(offer, dict)
+                and str(offer.get("offer_id") or "") in dealt_ids
+                and offer_matches_payload(offer, path, payload)
             ),
             None,
         )
 
-    def pending_pass_payload(self) -> dict[str, object]:
+    @staticmethod
+    def dealt_action_offers(
+        state: dict[str, object],
+    ) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+        hand = state.get("action_hand") or {}
+        entries = hand.get("entries") if isinstance(hand, dict) else []
+        entries = [entry for entry in (entries or []) if isinstance(entry, dict)]
+        offered_by_id = {
+            str(offer.get("offer_id") or ""): offer
+            for offer in state.get("action_offers") or []
+            if isinstance(offer, dict) and not offer.get("disabled")
+        }
+        paired = [
+            (entry, offered_by_id[str(entry.get("offer_id") or "")])
+            for entry in entries
+            if str(entry.get("offer_id") or "") in offered_by_id
+        ]
+        return [entry for entry, _ in paired], [offer for _, offer in paired]
+
+    def pending_pass_payload(self, slot_index: int = 0) -> dict[str, object]:
         if self._pending_pass_payload is not None:
             return self._pending_pass_payload
         state = self.state()
         hand = state.get("action_hand") or {}
-        pass_offer = hand.get("pass") if isinstance(hand, dict) else None
-        if not isinstance(pass_offer, dict) or not pass_offer.get("offer_id"):
-            raise ClientError("Think is not available until the current hand arrives.")
-        self._pending_pass_label = str(pass_offer.get("label") or "Think")
+        entries = hand.get("entries") if isinstance(hand, dict) else []
+        entries = [entry for entry in (entries or []) if isinstance(entry, dict)]
+        if slot_index < 0 or slot_index >= len(entries):
+            raise ClientError("Choose a Story Hand card before using Think.")
+        think = entries[slot_index].get("think") or {}
+        if not isinstance(think, dict) or not think.get("available") or not think.get("offer_id"):
+            raise ClientError("That Story Hand card has no other possibility to reveal.")
+        self._pending_pass_label = "Think"
         actor = next(
             (candidate for candidate in state.get("actors") or [] if candidate.get("id") == self.actor_id),
             {},
         )
         self._pending_pass_payload = self.with_actor_session({
             "actor_id": self.actor_id,
-            "command": "pass",
-            "offer_id": pass_offer["offer_id"],
+            "command": "think",
+            "offer_id": think["offer_id"],
             "envelope": {
                 "world_id": state.get("world_id") or "world://cosyworld/official",
-                "intent_id": offer_intent_id(self.actor_id, str(pass_offer["offer_id"])),
+                "intent_id": offer_intent_id(self.actor_id, str(think["offer_id"])),
                 "actor_ref": actor.get("canonical_ref") or "",
                 "observed": {},
                 "last_world_seq": int(state.get("world_seq") or 0),
@@ -730,8 +763,8 @@ class Game:
     def is_definitive_pass_rejection(response: dict[str, object]) -> bool:
         return response.get("status") in {400, 409, 423}
 
-    def pass_hand(self) -> None:
-        response = self.client.post("/commands", self.pending_pass_payload())
+    def pass_hand(self, slot_index: int = 0) -> None:
+        response = self.client.post("/commands", self.pending_pass_payload(slot_index))
         if not isinstance(response, dict):
             raise ClientError("Think response was not an object")
         self.print_events(response.get("events") or [])
@@ -793,13 +826,12 @@ class Game:
         pass_offer: dict[str, object] | None = None
         generation: object = None
         if isinstance(offers, dict):
-            pass_offer = offers.get("pass") if isinstance(offers.get("pass"), dict) else None
             generation = offers.get("generation")
             offers = offers.get("entries") or []
         if not isinstance(offers, list):
             return
         offers = [offer for offer in offers if isinstance(offer, dict)]
-        if not offers and pass_offer is None:
+        if not offers:
             return
         offered_by_id = {
             str(offer.get("offer_id") or ""): offer
@@ -807,14 +839,11 @@ class Game:
             if isinstance(offer, dict)
         }
         labels = ", ".join(
-            self.hand_offer_label(offer, offered_by_id) for offer in offers
+            f"{str(offer.get('slot') or 'card').title()}: {self.hand_offer_label(offer, offered_by_id)}"
+            for offer in offers
         )
-        pass_label = str(pass_offer.get("label") or "Think") if pass_offer else "Think"
-        pass_id = str(pass_offer.get("offer_id") or "") if pass_offer else ""
         hand_id = f" generation {generation}" if generation is not None else ""
-        certificate = f" [{pass_id}]" if pass_id else ""
-        separator = "; " if labels else ""
-        print(f"Hand{hand_id}: {labels}{separator}{pass_label}{certificate}")
+        print(f"Story Hand{hand_id}: {labels}")
 
     @staticmethod
     def hand_offer_label(entry: dict[str, object], offered_by_id: dict[str, dict[str, object]]) -> str:
@@ -1129,12 +1158,13 @@ class Game:
 
     def help(self, short: bool = False) -> None:
         if short:
-            print("Type 'act' for your two cards, 'think' to pass, 'look', or 'help'.")
+            print("Type 'act' for your Story Hand, 'think 1' to replace one card, 'look', or 'help'.")
             return
         print(
-            "Commands: act, think, look, who, deck, inventory, "
+            "Commands: act, think <card number>, look, who, pack, inventory, "
             "report <actor>: <reason>, events/watch [after_seq], quit. Scene actions must be "
-            "one of the two cards shown by act; Think skips your turn and deals two new cards."
+            "one of the Story, Self, and Anchor cards shown by act; Think replaces only the "
+            "chosen card. It is free once in a safe scene and otherwise uses the turn."
         )
 
     @staticmethod
@@ -1170,6 +1200,9 @@ class ButtonGame(Game):
                     continue
                 if key in {" ", "2"} and len(actions) > 1:
                     actions[1].callback()
+                    continue
+                if key in {"t", "T", "3"} and len(actions) > 2:
+                    actions[2].callback()
                     continue
                 if key in {"\r", "\n", "1", ""} and actions:
                     actions[0].callback()
@@ -1230,7 +1263,7 @@ class ButtonGame(Game):
                 lambda offer=offer: self.submit_button_offer(state, offer),
                 self.button_offer_detail(offer),
             )
-            for offer in dealt[:2]
+            for offer in dealt[:3]
         ]
 
     @staticmethod
@@ -1317,10 +1350,15 @@ class ButtonGame(Game):
             print(f"[Space] {secondary.label}")
             if secondary.detail:
                 print(f"        {secondary.detail}")
+        if len(actions) > 2:
+            print(f"[T]     {actions[2].label}")
+            if actions[2].detail:
+                print(f"        {actions[2].detail}")
         hand = state.get("action_hand") or {}
-        pass_offer = hand.get("pass") if isinstance(hand, dict) else None
-        pass_label = str(pass_offer.get("label") or "Think") if isinstance(pass_offer, dict) else "Think"
-        print(f"[P]     {pass_label} (skip turn and deal two new cards)")
+        entries = hand.get("entries") if isinstance(hand, dict) else []
+        first_think = (entries[0].get("think") or {}) if entries and isinstance(entries[0], dict) else {}
+        think_timing = "free" if isinstance(first_think, dict) and first_think.get("free") else "uses the turn"
+        print(f"[P]     Think about the Story card (replace only it; {think_timing})")
         print("[Q]     Quit")
 
     def render_actors(self, actors: list[dict[str, object]]) -> None:
@@ -1351,7 +1389,7 @@ class ButtonGame(Game):
         offer = self.current_offer(path, authoritative_payload)
         if not offer:
             raise ClientError(
-                "That action is not in your current two-card hand. Choose Think to commit a pass."
+                "That action is not in your Story Hand. Choose a card, or Think about one slot."
             )
         response = self.client.post(
             "/actions/submit",

--- a/v2/cli/test_cosy_cli.py
+++ b/v2/cli/test_cosy_cli.py
@@ -152,8 +152,11 @@ class SemanticStoryReceiptTests(unittest.TestCase):
         state = {
             "action_hand": {
                 "generation": 7,
-                "entries": [{"offer_id": "srd5.2.1:9:move:move Rain-Soft Garden"}],
-                "pass": {"label": "Think", "offer_id": "pass:42:9:7:ordinary"},
+                "entries": [{
+                    "slot": "story",
+                    "offer_id": "srd5.2.1:9:move:move Rain-Soft Garden",
+                    "think": {"available": False},
+                }],
             },
             "action_offers": [
                 {
@@ -187,10 +190,14 @@ class SemanticStoryReceiptTests(unittest.TestCase):
         self.assertIn("Travel — Rain-Soft Garden", output.getvalue())
         self.assertNotIn("Attack", output.getvalue())
 
-    def test_cli_think_hashes_a_spaced_pass_certificate(self) -> None:
+    def test_cli_think_hashes_a_spaced_card_certificate(self) -> None:
         game = Game(CosyClient("http://127.0.0.1:3102"), 42, "session")
         game.state = lambda: {  # type: ignore[method-assign]
-            "action_hand": {"pass": {"offer_id": "pass:42:9:7:Moonlit Garden"}}
+            "action_hand": {"entries": [{
+                "slot": "story",
+                "offer_id": "move-garden",
+                "think": {"available": True, "offer_id": "think:42:9:story:7:Moonlit Garden"},
+            }]}
         }
         payloads: list[dict[str, object]] = []
         game.client.post = lambda _path, payload: payloads.append(payload) or {"ok": True, "events": []}  # type: ignore[method-assign]
@@ -199,16 +206,24 @@ class SemanticStoryReceiptTests(unittest.TestCase):
 
         intent_id = payloads[0]["envelope"]["intent_id"]
         self.assertRegex(intent_id, r"^[A-Za-z0-9_.:-]{1,160}$")
-        self.assertEqual(intent_id, offer_intent_id(42, "pass:42:9:7:Moonlit Garden"))
+        self.assertEqual(intent_id, offer_intent_id(42, "think:42:9:story:7:Moonlit Garden"))
 
     def test_cli_think_retries_the_same_pending_certificate_after_transport_failure(self) -> None:
         game = Game(CosyClient("http://127.0.0.1:3102"), 42, "session")
         first_state = {
-            "action_hand": {"pass": {"offer_id": "pass:42:1:0:first"}},
+            "action_hand": {"entries": [{
+                "slot": "story",
+                "offer_id": "first",
+                "think": {"available": True, "offer_id": "think:42:1:story:0:first"},
+            }]},
             "world_seq": 10,
         }
         changed_state = {
-            "action_hand": {"pass": {"offer_id": "pass:42:2:1:next"}},
+            "action_hand": {"entries": [{
+                "slot": "story",
+                "offer_id": "next",
+                "think": {"available": True, "offer_id": "think:42:2:story:1:next"},
+            }]},
             "world_seq": 11,
         }
         state_calls = 0
@@ -234,17 +249,17 @@ class SemanticStoryReceiptTests(unittest.TestCase):
         game.pass_hand()
 
         self.assertEqual(payloads[0], payloads[1])
-        self.assertEqual(payloads[1]["offer_id"], "pass:42:1:0:first")
+        self.assertEqual(payloads[1]["offer_id"], "think:42:1:story:0:first")
         self.assertEqual(
             payloads[1]["envelope"]["intent_id"],
-            offer_intent_id(42, "pass:42:1:0:first"),
+            offer_intent_id(42, "think:42:1:story:0:first"),
         )
 
     def test_cli_act_refuses_retired_draw_alias(self) -> None:
         game = Game(CosyClient("http://127.0.0.1:3102"), 42, "session")
-        game.state = lambda: {"action_offers": [], "action_hand": {"pass": {"offer_id": "pass:42:1:0:ordinary"}}}  # type: ignore[method-assign]
+        game.state = lambda: {"action_offers": [], "action_hand": {"entries": []}}  # type: ignore[method-assign]
         with patch("builtins.input", return_value="draw"):
-            with self.assertRaisesRegex(ValueError, "numbered dealt card, or Think"):
+            with self.assertRaisesRegex(ValueError, "numbered Story Hand card"):
                 game.act()
 
     def test_cli_empty_hand_does_not_render_a_leading_separator(self) -> None:
@@ -252,17 +267,18 @@ class SemanticStoryReceiptTests(unittest.TestCase):
         output = io.StringIO()
         with redirect_stdout(output):
             game.print_action_hand(
-                {"pass": {"label": "Think", "offer_id": "pass:42:1:0:ordinary"}},
+                {"entries": []},
                 [],
             )
 
-        self.assertEqual(output.getvalue(), "Hand: Think [pass:42:1:0:ordinary]\n")
+        self.assertEqual(output.getvalue(), "")
 
 
 class ExactOfferSelectionTests(unittest.TestCase):
     def test_cli_selects_the_exact_gift_trade_use_and_project_offer(self) -> None:
         game = Game(CosyClient("http://127.0.0.1:3102"), 42, "session")
         state = {
+            "action_hand": {"entries": []},
             "action_offers": [
                 {"offer_id": "gift-a", "id": "give_item:100:7", "kind": "give_item", "target": {"kind": "actor", "id": 7}},
                 {"offer_id": "gift-b", "id": "give_item:101:8", "kind": "give_item", "target": {"kind": "actor", "id": 8}},
@@ -276,22 +292,27 @@ class ExactOfferSelectionTests(unittest.TestCase):
         }
         game.state = lambda: state  # type: ignore[method-assign]
 
+        state["action_hand"] = {"entries": [{"offer_id": "gift-b"}]}
         self.assertEqual(
             game.current_offer("/actions/give-item", {"item_id": 101, "target_actor_id": 8}),
             state["action_offers"][1],
         )
+        state["action_hand"] = {"entries": [{"offer_id": "trade-b"}]}
         self.assertEqual(
             game.current_offer("/actions/trade-item", {"item_id": 101, "target_actor_id": 8, "target_item_id": 901}),
             state["action_offers"][3],
         )
+        state["action_hand"] = {"entries": [{"offer_id": "use-b"}]}
         self.assertEqual(
             game.current_offer("/actions/use-item", {"item_id": 101}),
             state["action_offers"][5],
         )
+        state["action_hand"] = {"entries": [{"offer_id": "work-b"}]}
         self.assertEqual(
             game.current_offer("/actions/contribute", {"job_id": "job-b", "strategy_id": "bold"}),
             state["action_offers"][7],
         )
+        state["action_hand"] = {"entries": [{"offer_id": "gift-b"}]}
         self.assertIsNone(game.current_offer("/actions/give-item", {"item_id": 100, "target_actor_id": 8}))
 
     def test_button_game_exposes_each_exact_dealt_use_card(self) -> None:
@@ -391,7 +412,7 @@ class ExactOfferSelectionTests(unittest.TestCase):
         )
         self.assertEqual(game.last_seq, 74)
 
-    def test_button_game_uses_the_focused_pass_label_in_render_and_errors(self) -> None:
+    def test_button_game_uses_the_story_card_think_certificate_in_render_and_errors(self) -> None:
         game = ButtonGame(CosyClient("http://127.0.0.1:3102"), 42, "session")
         state = {
             "actors": [
@@ -402,7 +423,17 @@ class ExactOfferSelectionTests(unittest.TestCase):
                     "canonical_ref": "actor://cosyworld/42",
                 }
             ],
-            "action_hand": {"pass": {"label": "Pass", "offer_id": "pass:42:focus:7"}},
+            "action_hand": {
+                "entries": [{
+                    "slot": "story",
+                    "offer_id": "move-7",
+                    "think": {
+                        "available": True,
+                        "free": False,
+                        "offer_id": "think:42:focus:story:7:move-7",
+                    },
+                }],
+            },
         }
         game.state = lambda: state  # type: ignore[method-assign]
         game.client.post = lambda _path, _payload: {"ok": False, "status": 409, "events": []}  # type: ignore[method-assign]
@@ -412,8 +443,11 @@ class ExactOfferSelectionTests(unittest.TestCase):
             game.render(state, [])
         game.pass_hand()
 
-        self.assertIn("[P]     Pass (skip turn and deal two new cards)", output.getvalue())
-        self.assertIn("Pass failed with status 409.", game.message_log)
+        self.assertIn(
+            "[P]     Think about the Story card (replace only it; uses the turn)",
+            output.getvalue(),
+        )
+        self.assertIn("Think failed with status 409.", game.message_log)
 
 
 if __name__ == "__main__":

--- a/v2/docs/card-policy-ranker.md
+++ b/v2/docs/card-policy-ranker.md
@@ -5,13 +5,15 @@ selection. The learned model does **not** classify `A`, `B`, or `DRAW` directly.
 It scores every currently legal card with shared weights and returns a complete
 deck ranking.
 
-The authoritative two-card hand is a deterministic adapter over that ranking:
+The resident policy uses a deterministic adapter over that ranking. Its
+historical `A`, `B`, and `DRAW` names are internal policy choices, not the
+player-facing Story Hand slots:
 
 1. read the highest-ranked card's integer score;
 2. inspect up to the highest-ranked `k` cards;
 3. consider rank two or three executable only when its score exactly ties the
    highest score;
-4. execute the highest-ranked executable card shown as A or B, otherwise DRAW;
+4. execute the highest-ranked executable card exposed to the resident, otherwise DRAW;
 5. after DRAW, rebuild the avatar observation and rank the complete deck again.
 
 `k` is configurable from 1 through 3. The conservative default remains 1.
@@ -49,8 +51,8 @@ record; a coverage test fails if the policy deck and commit adapter drift.
 
 The model never bypasses authoritative offer
 identity, staleness checks, costs, permissions, or the world kernel. A/B still
-uses the existing command path. DRAW only advances the replayable actor-scoped
-hand cursor.
+uses the existing command path. DRAW advances only the selected replayable
+actor-scoped Story Hand slot.
 
 ## Per-avatar history
 
@@ -80,9 +82,9 @@ split by whole world/trajectory rather than shuffled as independent cards.
 ## Synthetic bootstrap data
 
 The generator creates connected graph worlds, hides treasure away from the
-start, gives every location a variable deck of movement/search cards, and keeps
-an authoritative two-card cursor. A failed search exposes an observable
-shortest-path clue.
+start, gives every location a variable offer queue of movement/search cards,
+and keeps authoritative resident selections. A failed search exposes an
+observable shortest-path clue.
 
 Each observation stores the current A/B candidate indices plus the features and
 exact semantic cost-to-treasure for **every legal card**:

--- a/v2/docs/combat-system.md
+++ b/v2/docs/combat-system.md
@@ -11,7 +11,7 @@ implementation of either SRD.
 An encounter has a stable numeric id, location, round, current participant,
 status, and initiative-sorted sides. Initiative is `d20 + Dexterity modifier`;
 higher totals act first and actor id breaks ties. The encounter deck contains
-three bounded choice families, but the current participant sees at most two
+three bounded choice families, while the current participant sees at most three
 cards at once:
 
 - **Attack:** if the avatar has an equipped weapon Item, the action records that

--- a/v2/docs/deck-gated-action-spike.md
+++ b/v2/docs/deck-gated-action-spike.md
@@ -5,10 +5,11 @@ ship. Proposed identity: `cosyworld.variant/deck-gated-ordinary-actions/0`.
 
 When this historical spike was written, the default `cosyworld.srd5/1` mode
 was described as a projection CCG with a three-card suggestion hand. That
-baseline is superseded: the live mode now deals two certified action offers,
-and certified Think/Pass consumes a turn to rotate them. This spike still asks
-what would happen if a different draw constrained ordinary actions as well as
-prepared Magic cards.
+baseline is superseded: the live mode now deals the server-authored Story,
+Self, and Anchor slots. Think replaces exactly one chosen card, free once on
+entering a safe scene and turn-consuming thereafter (and always in ordered or
+dangerous scenes). This spike still asks what would happen if a different draw
+constrained ordinary actions as well as Prepared spells.
 
 ## Prototype rules
 

--- a/v2/docs/player-lexicon.md
+++ b/v2/docs/player-lexicon.md
@@ -14,8 +14,8 @@ vocabulary or appear in ordinary state.
 
 | Concept | Player-facing noun | Ownership and authority | Lifecycle | Primary affordance |
 | --- | --- | --- | --- | --- |
-| A verb offered by the action controller | **action** | The engine derives legal actions from authoritative room state. A player chooses one; it is not owned or collected. | Replaced when room state changes; exactly two are dealt at a time. | Command-shaped button in the two-action hand; `data-player-concept="action"`. |
-| The voluntary end-of-hand control | **Think** (ordinary) / **Pass** (focused turn) | The engine certifies the actor, scene/focus, state revision, and hand generation before accepting it. It is not an entitlement or a free redeal. | Consumes one turn, journals the next deterministic hand, and becomes stale when the scene changes. | Third hand control; `data-player-concept="pass"`. |
+| A verb offered by the action controller | **action** | The engine derives legal actions and their six-suit presentation from authoritative room state. A player chooses one; it is not owned or collected. | Replaced when room state changes; the Story, Self, and Anchor slots are selected independently. | Command-shaped button in the Story Hand; `data-player-concept="action"`. |
+| The focused-card replacement control | **Think** | The engine certifies the actor, scene/focus, state revision, exact slot, slot generation, and replaced offer. It is not a whole-hand redeal. | Free once after entering a safe scene; otherwise consumes one turn. Only the chosen slot advances, and the certificate becomes stale when the scene changes. | Story Hand control; `data-player-concept="think"`. |
 | A visual or interaction representation | **card** | A card projects an actor, item, location, spell, or action. It never owns or replaces its subject and cannot create authority from art or text. | Reprojects from canonical state; historical art/provenance may remain inspectable. | Illustrated subject/action surface; target `data-player-concept="card"`. |
 | A supported NFT-backed actor association | **linked avatar** | A protected adapter verifies one allowlisted asset and binds it to one durable autonomous actor. Wallet custody grants association, not command authority, power, items, rewards, or access. | First link creates one binding; later links and transfers recover the same actor and history. | Linked-avatar roster/chronicle; target `data-player-concept="linked-avatar"`. |
 | A physical thing in the shared world | **item** | Custody and location come from the canonical world. A wallet cannot spawn, reclaim, or duplicate it. | May be found, carried, equipped, traded, dropped, installed, consumed, lost, or stolen under world rules. | Item card/inspector plus exact world actions; `data-player-concept="item"`. |
@@ -104,7 +104,7 @@ Target interactive surfaces expose the same concept nouns through
 
 | Event | Meaning |
 | --- | --- |
-| `action.select`, `action.confirm`, `action.pass` | choose, confirm, or Think/Pass through the two suggestions |
+| `action.select`, `action.confirm`, `action.think` | choose, confirm, or replace one focused Story Hand card |
 | `card.open` | inspect the presentation of one world subject |
 | `linked_avatar.open`, `linked_avatar.link` | inspect or initiate the protected linked-avatar flow |
 | `world_pack.library.open` | open the mounted World Library |

--- a/v2/docs/story-hand.md
+++ b/v2/docs/story-hand.md
@@ -1,0 +1,88 @@
+# Story Hand
+
+The Story Hand is the player-facing action system. Its surface has three stable
+slots and six suits; the exact verb remains authoritative underneath.
+
+## The six action suits
+
+Only playable actions have suits. Actor, Item, Location, Spell, Calling,
+Friendship, Journal, and Worldpack cards keep their own roles and may be the
+source or target of an action.
+
+| Suit | Meaning | Typical exact verbs |
+| --- | --- | --- |
+| **Wonder** | Learn, notice, interpret, or reveal. | Notice, Inspect, Search, Study, Scout, Listen, Find resonance, Rank echoes |
+| **Way** | Change place or follow a route. | Travel, Go, Cross, Return |
+| **Heart** | Relate, communicate, exchange, or remember. | Chat, Speak, Echo, Befriend, Remember, Influence, Give, Accept, Trade |
+| **Hand** | Manipulate, make, prepare, or contribute. | Take, Drop, Use, Open, Craft, Prepare, Work, Help, Finish, Illustrate |
+| **Courage** | Face immediate danger or protect someone from it. | Attack, Defend, Flee, Rescue, Steal |
+| **Hearth** | Recover, consolidate growth, or change the self. | Rest, Bank, Practice, Train, Evolve, class and growth ceremonies |
+
+Suit is navigation, not the action identity. `Take`, `Use`, and `Craft` are
+different actions even though each is Hand. Danger is risk metadata, not a
+seventh suit. A Spell is still an Item/source card; the spell action's suit is
+derived from its effect.
+
+## Three stable slots
+
+The server composes exactly three independent queues:
+
+- **Story** — the scene's strongest invitation: location, quest, route, or
+  danger.
+- **Self** — an action grounded in the avatar: Calling, Friendship, Journal,
+  equipped gear, or prepared spell.
+- **Anchor** — a safe, legible foundation that keeps the hand usable.
+
+Sparse scenes borrow a deterministic card into an empty slot before any card
+is selected. The queues remain disjoint, so advancing one slot cannot move
+another. First-tale and journey guarantees are inserted into the Story queue,
+not layered over the completed hand.
+
+## Think
+
+Think replaces the focused card, never the whole hand. Every replaceable entry
+contains its own certificate with actor, scene, state revision, slot, slot
+generation, and exact replaced offer.
+
+- The first Think after entering a safe scene is free.
+- Later Thinks in that scene consume the turn.
+- Think always consumes the turn in risky, dangerous, and ordered scenes.
+- A slot with no other current possibility cannot be Thought about.
+- Moving to another scene resets the slot counters and safe-scene allowance.
+
+The hidden deterministic structure is an **Offer queue**, not a player deck.
+
+## Presentation contract
+
+Every published playable offer must carry these independent dimensions:
+
+- `family`: action, control, or ceremony;
+- `suit`: one of the six suits for an action, absent for controls/ceremonies;
+- `verb`: the exact authored action;
+- `source`: kind, stable id, and player-facing label;
+- `state`: ready or locked;
+- `provenance`: Core, Worldpack, Community, or Legacy;
+- `rarity`: Everyday, Curious, Rare, or Storybook;
+- `power`: separate from rarity;
+- optional `cost`, `risk`, and `effect`.
+
+The server owns this mapping. A new playable kind or model-interaction intention
+that has no explicit mapping fails publication rather than falling back to a
+client-inferred `utility` or `danger` type.
+
+The compact card face reads in this order: suit and verb, title/target, effect,
+cost and risk, source, then art. Suit controls the main colour. Rarity is only a
+small collectible mark.
+
+## Player vocabulary
+
+| Concept | Player-facing term |
+| --- | --- |
+| carried physical inventory | **Pack** |
+| equipped weapon, bag, shelter, and worn charms | **Loadout** |
+| ready magic | **Prepared spells** / **Spellbook** |
+| exhausted or discarded cards | **Spent** |
+| three current actions | **Story Hand** |
+| deterministic internal action sequence | **Offer queue** (not normally shown) |
+
+The design rule is: simple on the surface, exact underneath.

--- a/v2/docs/story-metrics.md
+++ b/v2/docs/story-metrics.md
@@ -16,11 +16,11 @@ rankings.
 - **Meaningful action:** a successful, player-authored canonical action with a
   durable world effect. Presence, arrival, movement, hand dealing, dice rolls,
   turn bookkeeping, resets, and background system work are excluded.
-- **Pass diagnostic:** every committed certified Think/Pass writes one
-  `action_passed` row keyed to its `hand.shuffled` source sequence. Its
+- **Think diagnostic:** every committed certified Think writes one
+  compatibility `action_passed` row keyed to its `hand.thought` source sequence. Its
   non-prose attributes record a rolling pass count, pass-rate basis points,
   and consecutive-pass count. A later meaningful action records the preceding
-  consecutive count and resets the next Pass streak. Stale Pass rejections are
+  consecutive count and resets the next Think streak. Stale Think rejections are
   separately deduplicated `pass_stale_rejected` diagnostics; none of these
   signals grant rewards, progress, or eligibility.
 - **Co-presence:** at least two active human actors share the action's room.

--- a/v2/docs/worldpacks.md
+++ b/v2/docs/worldpacks.md
@@ -737,10 +737,10 @@ a winner. See [action-pack-authoring.md](action-pack-authoring.md).
 
 Card subject kinds include avatar, item, and location. Weapon, skill
 charm, spell, relic, tool, and consumable are Item roles sharing a playable-item
-contract. Skill and bonus are state of a charm instance; spell cards occupy a
-spell deck; weapons occupy equipment slots. Items also declare weight and
+contract. Skill and bonus are state of a charm instance; spell cards occupy
+Prepared spells; weapons occupy Loadout slots. Items also declare weight and
 size/bulk, while container items declare added capacity and fit constraints.
-The carried deck is validated from those physical rules, never a fixed card
+The Pack is validated from those physical rules, never a fixed card
 count. Packs may author rarity and transfer or theft eligibility independently
 of the mechanical power budget.
 

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.30"
+version = "1.0.31"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/activation.rs
+++ b/v2/orchestrator-rust/src/activation.rs
@@ -786,6 +786,7 @@ fn event_is_first_tale_completed(event: &EventView, actor_id: u64) -> bool {
 fn event_counts_as_first_committed_turn(event: &EventView) -> bool {
     event.success
         && event.actor_id.is_some()
+        && !(event.type_name == "ability_check.rolled" && event.content.as_deref() == Some("think"))
         && matches!(
             event.type_name.as_str(),
             "ability_check.rolled"

--- a/v2/orchestrator-rust/src/ai_resident_planning.rs
+++ b/v2/orchestrator-rust/src/ai_resident_planning.rs
@@ -323,12 +323,11 @@ impl RuntimeWorld {
             })
         });
         let hand_offset = hand_candidate_indices[0].unwrap_or_default();
-        let next_hand = compose_action_hand_at(
-            offers,
-            usize::try_from(hand.generation)
-                .unwrap_or(usize::MAX)
-                .saturating_add(1),
-        );
+        let think_slot = STORY_HAND_SLOTS
+            .iter()
+            .position(|slot| *slot == hand.pass.slot)
+            .unwrap_or_default();
+        let next_hand = self.action_hand_after_think_for(actor_id, offers, think_slot);
         let next_hand_offset = next_hand
             .entries
             .first()
@@ -386,10 +385,10 @@ impl RuntimeWorld {
     ) -> ResidentPlannerCandidate {
         ResidentPlannerCandidate {
             candidate_id: hand.pass.offer_id.clone(),
-            // There is no ranked action offer for Think/Pass. Its synthetic
+            // There is no ranked action offer for Think. Its synthetic
             // composition id freezes the same focused-scene binding as the
             // certificate without letting a model supply either value.
-            composition_id: format!("pass:{}", hand.pass.scene_key),
+            composition_id: format!("think:{}:{}", hand.pass.scene_key, hand.pass.slot),
             state_revision: hand.pass.state_revision,
             kind: "pass".to_string(),
             target_actor_id: None,
@@ -423,17 +422,21 @@ impl RuntimeWorld {
         };
         let (_, offers) = self.legal_action_candidates(Some(actor_id), &AccessContext::default());
         let hand = self.action_hand_for(Some(actor_id), &offers);
-        let frozen_certificate = format!(
-            "pass:{actor_id}:{state_revision}:{}:{}",
-            hand.pass.generation, hand.pass.scene_key
-        );
-        if candidate_id != frozen_certificate
-            || composition_id != format!("pass:{}", hand.pass.scene_key)
-        {
+        if composition_id != format!("think:{}:{}", hand.pass.scene_key, hand.pass.slot) {
             return false;
         }
         if state_revision == hand.pass.state_revision {
-            return true;
+            return candidate_id == hand.pass.offer_id;
+        }
+        let frozen_prefix = format!(
+            "think:{actor_id}:{state_revision}:{}:{}:{}:",
+            hand.pass.slot, hand.pass.generation, hand.pass.scene_key,
+        );
+        let Some(frozen_hash) = candidate_id.strip_prefix(&frozen_prefix) else {
+            return false;
+        };
+        if frozen_hash.len() != 16 || !frozen_hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return false;
         }
         // Publishing the accepted resident sentence appends exactly one SAY
         // event before its selected consequence runs. That event changes the
@@ -463,28 +466,41 @@ impl RuntimeWorld {
             .resident_continuities
             .get(&actor.id)
             .and_then(|continuity| continuity.pending_action.as_ref())?;
-        self.resident_planner_pass_is_current(actor.id, proposal)
-            .then(|| {
-                let mut record = JournalRecord::new(
-                    CwAction {
-                        kind: CW_ACTION_NONE,
-                        actor_id: actor.id,
-                        location_id: actor.location_id,
-                        ..CwAction::default()
-                    },
-                    seed,
-                )
-                .into_actor_consequence(self.world.tick, caused_by_event_seq);
-                record.bind_offer_kind("pass");
-                record.source_location_id = Some(actor.location_id);
-                record
-                    .projection_mutations
-                    .push(ProjectionMutation::ShuffleHand {
-                        reason: "resident_planner_pass".to_string(),
-                    });
-                self.append_resident_autonomy_intent_projection(actor, &mut record);
-                record
-            })
+        if !self.resident_planner_pass_is_current(actor.id, proposal) {
+            return None;
+        }
+        let (_, offers) = self.legal_action_candidates(Some(actor.id), &AccessContext::default());
+        let hand = self.action_hand_for(Some(actor.id), &offers);
+        let think = hand.pass;
+        let slot = STORY_HAND_SLOTS
+            .iter()
+            .position(|candidate| *candidate == think.slot)?;
+        if !think.available {
+            return None;
+        }
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_NONE,
+                actor_id: actor.id,
+                location_id: actor.location_id,
+                ..CwAction::default()
+            },
+            seed,
+        )
+        .into_actor_consequence(self.world.tick, caused_by_event_seq);
+        record.bind_offer_kind("pass");
+        record.source_location_id = Some(actor.location_id);
+        record
+            .projection_mutations
+            .push(ProjectionMutation::ThinkHand {
+                slot: u8::try_from(slot).ok()?,
+                scene_key: think.scene_key,
+                replaces_offer_id: think.replaces_offer_id,
+                free: think.free,
+                reason: "resident_planner_pass".to_string(),
+            });
+        self.append_resident_autonomy_intent_projection(actor, &mut record);
+        Some(record)
     }
 
     fn resident_planner_candidate_from_offer(
@@ -940,6 +956,16 @@ impl RuntimeWorld {
         let actor = self
             .actor_by_id(plan.speaker_actor_id)
             .filter(|actor| Self::actor_can_act(*actor))?;
+        let (_, offers) =
+            self.legal_action_candidates(Some(plan.speaker_actor_id), &AccessContext::default());
+        let hand = self.action_hand_for(Some(plan.speaker_actor_id), &offers);
+        let think = hand.pass;
+        let slot = STORY_HAND_SLOTS
+            .iter()
+            .position(|candidate| *candidate == think.slot)?;
+        if !think.available {
+            return None;
+        }
         let mut record = JournalRecord::new(
             CwAction {
                 kind: CW_ACTION_NONE,
@@ -957,7 +983,11 @@ impl RuntimeWorld {
         record.resident_planning = Some(planning.trace.clone());
         record
             .projection_mutations
-            .push(ProjectionMutation::ShuffleHand {
+            .push(ProjectionMutation::ThinkHand {
+                slot: u8::try_from(slot).ok()?,
+                scene_key: think.scene_key,
+                replaces_offer_id: think.replaces_offer_id,
+                free: think.free,
                 reason: "resident_card_policy_draw".to_string(),
             });
         Some(record)
@@ -1748,7 +1778,8 @@ fn resident_card_policy_result(
     if card_policy.action == CardPolicyAction::Draw {
         trace.status = ResidentPlanningStatus::Drew;
         trace.speech_act = Some(ResidentSpeechAct::React);
-        trace.proposal_reason = Some("The bounded policy drew the next two cards.".to_string());
+        trace.proposal_reason =
+            Some("The bounded policy Thought about one Story Hand card.".to_string());
         return ResidentPlanningResult {
             proposed_action: None,
             trace,
@@ -2401,7 +2432,7 @@ mod tests {
             ))
             .collect::<Vec<_>>();
         assert_eq!(runtime.resident_planner_candidates(RATI_ACTOR_ID), expected);
-        assert_eq!(expected.len(), usize::from(hand.capacity) + 1);
+        assert!(expected.len() <= hand.entries.len() + 1);
         assert!(expected.iter().any(|candidate| {
             candidate.kind == "pass"
                 && candidate.candidate_id == hand.pass.offer_id
@@ -2431,7 +2462,7 @@ mod tests {
     }
 
     #[test]
-    fn model_selected_pass_is_certificate_bound_and_commits_one_hand_rotation() {
+    fn model_selected_think_is_certificate_bound_and_commits_one_slot_rotation() {
         let mut runtime = RuntimeWorld::seeded();
         let plan = runtime
             .resident_reply_plan_for_target(
@@ -2448,8 +2479,8 @@ mod tests {
             .find(|candidate| candidate.kind == "pass")
             .expect("planner receives the current certified Pass")
             .clone();
-        assert!(pass.candidate_id.starts_with("pass:"));
-        assert!(pass.composition_id.starts_with("pass:"));
+        assert!(pass.candidate_id.starts_with("think:"));
+        assert!(pass.composition_id.starts_with("think:"));
         assert!(pass.hand_generation.is_some());
         assert!(pass.scene_key.is_some());
 
@@ -2467,7 +2498,7 @@ mod tests {
         forged.item_id = Some(STORY_BUTTON_ITEM_ID);
         assert!(
             !runtime.resident_planner_proposal_is_current(&plan, &forged),
-            "a planner cannot add action fields to a Pass certificate"
+            "a planner cannot add action fields to a Think certificate"
         );
 
         let accepted = planning_speech_record(
@@ -2481,6 +2512,15 @@ mod tests {
         let actor = runtime
             .actor_by_id(RATI_ACTOR_ID)
             .expect("Rati remains active");
+        let pending = runtime
+            .resident_continuities
+            .get(&RATI_ACTOR_ID)
+            .and_then(|continuity| continuity.pending_action.as_ref())
+            .expect("accepted Think remains pending until its consequence");
+        assert!(
+            runtime.resident_planner_pass_is_current(RATI_ACTOR_ID, pending),
+            "the accepted Think certificate remains current across its own SAY"
+        );
         let before_tick = runtime.world.tick;
         let before_generation = runtime
             .hand_generations
@@ -2510,11 +2550,11 @@ mod tests {
             stale_runtime
                 .resident_pending_planner_pass_record(stale_actor, 392_203, None)
                 .is_none(),
-            "an unrelated public revision after the accepted SAY must expire the frozen Pass"
+            "an unrelated public revision after the accepted SAY must expire the frozen Think"
         );
         let record = runtime
             .resident_economy_autonomy_record(actor, 392_201)
-            .expect("accepted Pass becomes the resident's only committed action");
+            .expect("accepted Think becomes the resident's only committed action");
         let record = runtime
             .attach_resident_decision_trace(ResidentAutonomyCandidate {
                 actor_id: RATI_ACTOR_ID,
@@ -2525,7 +2565,7 @@ mod tests {
             .record;
         assert_eq!(record.origin, JournalOrigin::ActorConsequence);
         assert!(record.projection_mutations.iter().any(|mutation| {
-            matches!(mutation, ProjectionMutation::ShuffleHand { reason }
+            matches!(mutation, ProjectionMutation::ThinkHand { reason, .. }
                 if reason == "resident_planner_pass")
         }));
         let event_store_path = std::env::temp_dir().join(format!(
@@ -2536,10 +2576,10 @@ mod tests {
         let _ = fs::remove_file(&event_store_path);
         let state = test_app_state(runtime.clone(), Some(event_store_path.clone()));
         let (status, events) =
-            commit_journal_record(&state, &mut runtime, record).expect("Pass commits");
+            commit_journal_record(&state, &mut runtime, record).expect("Think commits");
         assert_eq!(status, CW_OK);
         assert!(events.iter().any(
-            |event| event.type_name == "hand.shuffled" && event.actor_id == Some(RATI_ACTOR_ID)
+            |event| event.type_name == "hand.thought" && event.actor_id == Some(RATI_ACTOR_ID)
         ));
         assert_eq!(
             runtime.world.tick, before_tick,
@@ -2556,11 +2596,11 @@ mod tests {
         let committed = read_action_journal(&event_store_path)
             .expect("committed Pass journal reads")
             .pop()
-            .expect("Pass is journaled");
+            .expect("Think is journaled");
         let decision = committed
             .resident_decision
             .as_ref()
-            .expect("committed Pass retains its decision trace");
+            .expect("committed Think retains its decision trace");
         assert_eq!(decision.choice.offer_kind, "pass");
         assert_eq!(
             decision.choice.offer_id.as_deref(),

--- a/v2/orchestrator-rust/src/beliefs_tests.rs
+++ b/v2/orchestrator-rust/src/beliefs_tests.rs
@@ -207,7 +207,7 @@ fn legacy_search_and_resident_memories_migrate_into_canonical_beliefs() {
 
     let current = serde_json::to_value(RuntimeSnapshot::from_runtime(&restored))
         .expect("current snapshot serializes");
-    assert_eq!(current["version"], 18);
+    assert_eq!(current["version"], 19);
     assert!(current.get("beliefs").is_some());
     assert!(current.get("resident_memories").is_none());
     assert!(current.get("search_memories").is_none());

--- a/v2/orchestrator-rust/src/card_policy/mod.rs
+++ b/v2/orchestrator-rust/src/card_policy/mod.rs
@@ -1,10 +1,11 @@
 //! Fast, deterministic ranking across every currently legal card.
 //!
 //! The deployed model scores each card independently with shared weights. The
-//! runtime ranks the complete legal deck, then maps that ranking onto the
-//! authoritative two-card hand. The top card is playable when shown; ranks two
-//! and three are playable only when their integer score ties the top score.
-//! Otherwise the adapter emits `DRAW` and reranks the next hand.
+//! runtime ranks the complete legal offer queue, then maps that ranking onto the
+//! authoritative Story, Self, and Anchor slots. The top card is playable when
+//! shown; ranks two and three are playable only when their integer score ties
+//! the top score. Otherwise the legacy adapter name `DRAW` means Think about
+//! one exact slot, then rerank its replacement.
 
 mod ranker;
 mod synthetic;

--- a/v2/orchestrator-rust/src/card_policy_objective.rs
+++ b/v2/orchestrator-rust/src/card_policy_objective.rs
@@ -604,17 +604,18 @@ fn commit_resident_card_policy_turn(
                 if status != CW_OK {
                     return Err(format!("card_policy_draw_kernel_rejected:{status}"));
                 }
-                // A draw is itself an authoritative turn. Usually we immediately
-                // re-rank the next pair, but if the objective budget ended or a
-                // pathological model keeps drawing beyond one deck traversal,
-                // publish this completed draw and resume on the next reply turn.
+                // Think advances exactly one authoritative Story Hand slot.
+                // Usually we immediately re-rank the replacement, but if the
+                // objective budget ended or a pathological model keeps Thinking
+                // beyond one offer-queue traversal, publish this completed
+                // reflection and resume on the next reply turn.
                 if !runtime.actor_has_active_treasure_objective(base_plan.speaker_actor_id)
                     || draw_index == maximum_draws
                 {
                     return Ok(Some(CommittedResidentPolicyTurn {
                         action: committed_action,
                         offer_kind: "draw".to_string(),
-                        offer_label: "draw the next two cards".to_string(),
+                        offer_label: "think about one Story Hand card".to_string(),
                         offer_id: format!(
                             "resident-card-policy-draw:{}:{}",
                             base_plan.speaker_actor_id, draw_index
@@ -959,7 +960,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn live_card_policy_draws_then_reranks_the_new_hand() {
+    async fn live_card_policy_thinks_one_slot_then_reranks_the_replacement() {
         use cosyworld_orchestrator::card_policy::CardPolicyModel;
 
         let mut runtime = RuntimeWorld::seeded();
@@ -968,14 +969,27 @@ mod tests {
             .resident_reply_plan_for_target(
                 SKULL_ACTOR_ID,
                 RATI_ACTOR_ID,
-                "The first two choices feel wrong.",
+                "The first Story Hand choices feel wrong.",
             )
             .expect("seeded resident reply plan");
         plan.planner_requested = true;
         let plan = runtime.prepare_resident_planner_snapshot(plan);
 
         let mut after_draw = runtime.clone();
-        after_draw.hand_generations.insert(RATI_ACTOR_ID, 1);
+        let (_, offers) =
+            after_draw.legal_action_candidates(Some(RATI_ACTOR_ID), &AccessContext::default());
+        let hand = after_draw.action_hand_for(Some(RATI_ACTOR_ID), &offers);
+        let slot = STORY_HAND_SLOTS
+            .iter()
+            .position(|candidate| *candidate == hand.pass.slot)
+            .expect("resident Think has an exact Story Hand slot");
+        let (scene_key, _) = after_draw.story_hand_scene_for_actor(RATI_ACTOR_ID);
+        let mut story_state = after_draw.story_hand_state_for_scene(RATI_ACTOR_ID, &scene_key);
+        story_state.slot_generations[slot] = story_state.slot_generations[slot].saturating_add(1);
+        story_state.free_think_used = true;
+        after_draw
+            .story_hand_states
+            .insert(RATI_ACTOR_ID, story_state);
         let after_draw_plan = after_draw.prepare_resident_planner_snapshot(plan.clone());
         let rollout = (0..10_000)
             .find_map(|seed| {
@@ -1008,9 +1022,9 @@ mod tests {
             .collect::<Vec<_>>();
         let draw_seq = new_events
             .iter()
-            .find(|event| event.type_name == "hand.shuffled")
+            .find(|event| event.type_name == "hand.thought")
             .map(|event| event.seq)
-            .expect("draw advanced the authoritative hand");
+            .expect("Think advanced one authoritative Story Hand slot");
         let narration_seq = new_events
             .iter()
             .find(|event| event.type_name == "message.created")
@@ -1020,9 +1034,18 @@ mod tests {
             event.seq > draw_seq
                 && event.seq < narration_seq
                 && event.actor_id == Some(RATI_ACTOR_ID)
-                && event.type_name != "hand.shuffled"
+                && event.type_name != "hand.thought"
         }));
-        assert_eq!(runtime.hand_generations.get(&RATI_ACTOR_ID), Some(&1));
+        let generations = runtime
+            .story_hand_states
+            .get(&RATI_ACTOR_ID)
+            .map(|state| state.slot_generations)
+            .expect("resident Think keeps an actor-scoped Story Hand state");
+        assert!(generations[slot] >= 1);
+        assert!(generations
+            .iter()
+            .enumerate()
+            .all(|(index, generation)| index == slot || *generation == 0));
     }
 
     fn loose_treasure(runtime: &RuntimeWorld) -> CwItem {

--- a/v2/orchestrator-rust/src/cards.rs
+++ b/v2/orchestrator-rust/src/cards.rs
@@ -1254,7 +1254,7 @@ impl RuntimeWorld {
                 let preview_capacity =
                     carrying_capacity + u32::from(item.container_capacity_tenths);
                 format!(
-                    "equip {}: capacity becomes {:.1} lb and the carried deck would be {}",
+                    "equip {}: capacity becomes {:.1} lb and the Pack would be {}",
                     self.item_name(item.id)
                         .unwrap_or_else(|| format!("Item {}", item.id)),
                     preview_capacity as f64 / 10.0,

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -642,11 +642,11 @@ impl RuntimeWorld {
             .1
             .into_iter()
             .filter(action_offer_is_reachable)
-            .filter(|offer| matches!(offer.kind.as_str(), "attack" | "defend" | "flee"))
             .collect::<Vec<_>>();
         let hand = self.action_hand_for(Some(actor_id), &offers);
         let offers = offers
             .into_iter()
+            .filter(|offer| matches!(offer.kind.as_str(), "attack" | "defend" | "flee"))
             .filter(|offer| {
                 hand.entries
                     .iter()
@@ -674,13 +674,21 @@ impl RuntimeWorld {
                 seed,
             )
             .into_actor_consequence(self.world.tick, caused_by_event_seq);
-            // Combat residents pass through the finite hand; they do not get a
-            // separate, free draw/redeal capability.
+            // Combat residents pass the ordered floor and Think about one
+            // exact Story Hand card; they never receive a whole-hand redeal.
             record.bind_offer_kind("pass");
             record.source_location_id = Some(actor.location_id);
+            let think = hand.pass;
+            let slot = STORY_HAND_SLOTS
+                .iter()
+                .position(|candidate| *candidate == think.slot)?;
             record
                 .projection_mutations
-                .push(ProjectionMutation::ShuffleHand {
+                .push(ProjectionMutation::ThinkHand {
+                    slot: u8::try_from(slot).ok()?,
+                    scene_key: think.scene_key,
+                    replaces_offer_id: think.replaces_offer_id,
+                    free: false,
                     reason: "resident_combat_pass".to_string(),
                 });
             return Some(

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -198,6 +198,65 @@ fn offer_composition_matches_at_submitted_revision(
 }
 
 impl RuntimeWorld {
+    pub(super) fn story_hand_scene_for_actor(&self, actor_id: u64) -> (String, bool) {
+        if let Some(focused) = focused_encounter_for_actor(self, actor_id) {
+            return (format!("ordered:{}", focused.handoff_key()), false);
+        }
+        let Some(actor) = self.actor_by_id(actor_id) else {
+            return ("unseated".to_string(), false);
+        };
+        let safety = self
+            .room_sheets
+            .get(&actor.location_id)
+            .map(|sheet| sheet.safety.as_str())
+            .unwrap_or_else(|| {
+                if self.location_is_frontier(actor.location_id) {
+                    "risky"
+                } else {
+                    "safe"
+                }
+            });
+        (format!("{safety}:{}", actor.location_id), safety == "safe")
+    }
+
+    pub(super) fn story_hand_state_for_scene(
+        &self,
+        actor_id: u64,
+        scene_key: &str,
+    ) -> StoryHandActorState {
+        let legacy_generation = self
+            .hand_generations
+            .get(&actor_id)
+            .copied()
+            .unwrap_or_default();
+        if let Some(state) = self.story_hand_states.get(&actor_id) {
+            if state.scene_key == scene_key {
+                return state.clone();
+            }
+            if state.scene_key.is_empty() {
+                return StoryHandActorState {
+                    scene_key: scene_key.to_string(),
+                    slot_generations: if state.slot_generations == [0; 3] && legacy_generation > 0 {
+                        [legacy_generation; 3]
+                    } else {
+                        state.slot_generations
+                    },
+                    ..state.clone()
+                };
+            }
+            return StoryHandActorState {
+                scene_key: scene_key.to_string(),
+                slot_generations: [0; 3],
+                free_think_used: false,
+            };
+        }
+        StoryHandActorState {
+            scene_key: scene_key.to_string(),
+            slot_generations: [legacy_generation; 3],
+            free_think_used: false,
+        }
+    }
+
     pub(super) fn current_state_revision(&self) -> u64 {
         self.world.next_event_seq.saturating_sub(1)
     }
@@ -276,7 +335,7 @@ impl RuntimeWorld {
             .iter()
             .any(|entry| entry.offer_id == offer.offer_id)
         {
-            return Err("that offer is not in the current two-card hand");
+            return Err("that offer is not in the current Story Hand");
         }
         let revision_rebound = exact_offer.is_none()
             && offer_composition_matches_at_submitted_revision(offer, submission);
@@ -1561,7 +1620,7 @@ impl RuntimeWorld {
         offer.effect = match offer.kind.as_str() {
             "pick_up" => self.actor_by_id(actor_id).map(|actor| {
                 if self.actor_can_receive_item(actor, item.id) {
-                    "adds the item card to your carried deck".to_string()
+                    "adds the item card to your Pack".to_string()
                 } else {
                     "keeps the chosen item and leaves one carried item here".to_string()
                 }
@@ -2135,7 +2194,7 @@ impl RuntimeWorld {
                 let actor = self.actor_by_id(actor_id)?;
                 let item = self.loose_items_at_location(actor.location_id).into_iter().next()?;
                 if self.actor_can_receive_item(actor, item.id) {
-                    Some("adds the item card to your carried deck".to_string())
+                    Some("adds the item card to your Pack".to_string())
                 } else {
                     Some("needs more carrying capacity or an explicit item exchange".to_string())
                 }
@@ -2299,14 +2358,99 @@ pub(super) fn compose_action_hand(offers: &[RankedActionOffer]) -> ActionHandVie
     compose_action_hand_at(offers, 0)
 }
 
+#[cfg(test)]
 pub(super) fn compose_action_hand_at(
     offers: &[RankedActionOffer],
     draw_count: usize,
 ) -> ActionHandView {
-    const CAPACITY: usize = 2;
+    compose_story_hand_at(offers, [draw_count; 3])
+}
+
+pub(super) const STORY_HAND_SLOTS: [&str; 3] = ["story", "self", "anchor"];
+
+pub(super) fn story_hand_natural_slot(offer: &RankedActionOffer) -> usize {
+    let suit = action_card_suit(offer).unwrap_or_else(|error| panic!("{error}"));
+    if offer.project.is_some()
+        || offer.risk.is_some()
+        || matches!(
+            offer.provider.kind.as_str(),
+            "job" | "location" | "campaign"
+        )
+        || matches!(suit, "way" | "courage")
+    {
+        0
+    } else if matches!(
+        offer.provider.kind.as_str(),
+        "journal" | "friendship" | "held_item" | "calling"
+    ) || matches!(suit, "heart" | "hearth")
+    {
+        1
+    } else {
+        2
+    }
+}
+
+pub(super) fn empty_think_view() -> ActionHandPassView {
+    ActionHandPassView {
+        offer_id: String::new(),
+        label: "Think".to_string(),
+        state_revision: 0,
+        generation: 0,
+        scene_key: String::new(),
+        slot: String::new(),
+        replaces_offer_id: String::new(),
+        free: false,
+        consumes_turn: true,
+        available: false,
+    }
+}
+
+fn story_hand_entry(
+    offer: &RankedActionOffer,
+    slot_index: usize,
+    replacement_count: usize,
+) -> ActionHandEntryView {
+    ActionHandEntryView {
+        offer_id: offer.offer_id.clone(),
+        kind: offer.kind.clone(),
+        intention: offer.intention.clone(),
+        provider: offer.provider.clone(),
+        slot: STORY_HAND_SLOTS[slot_index].to_string(),
+        suit: action_card_suit(offer)
+            .unwrap_or_else(|error| panic!("{error}"))
+            .to_string(),
+        verb: offer.verb.clone(),
+        think: empty_think_view(),
+        replacement_count: u16::try_from(replacement_count).unwrap_or(u16::MAX),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn compose_story_hand_at(
+    offers: &[RankedActionOffer],
+    slot_generations: [usize; 3],
+) -> ActionHandView {
+    compose_story_hand_with_pin(offers, slot_generations, None)
+}
+
+fn compose_story_hand_with_pin(
+    offers: &[RankedActionOffer],
+    slot_generations: [usize; 3],
+    progression_pin: Option<(&RankedActionOffer, &BTreeSet<String>)>,
+) -> ActionHandView {
+    const CAPACITY: usize = STORY_HAND_SLOTS.len();
+    let pinned_offer_id = progression_pin.map(|(offer, _)| offer.offer_id.as_str());
+    let excluded_offer_ids = progression_pin.map(|(_, excluded)| excluded);
     let mut candidates: Vec<_> = offers
         .iter()
-        .filter(|offer| offer.ranked_hand_eligible && action_offer_is_reachable(offer))
+        .filter(|offer| {
+            offer.ranked_hand_eligible
+                && action_offer_is_reachable(offer)
+                && !matches!(offer.kind.as_str(), "create_avatar" | "wait")
+                && (Some(offer.offer_id.as_str()) == pinned_offer_id
+                    || excluded_offer_ids
+                        .is_none_or(|excluded| !excluded.contains(&offer.offer_id)))
+        })
         .collect();
     candidates.sort_by(|left, right| {
         left.provider
@@ -2325,90 +2469,81 @@ pub(super) fn compose_action_hand_at(
     }
 
     let deck_size = grouped.len();
-    let selected = if deck_size == 0 {
-        Vec::new()
-    } else {
-        let start = draw_count.saturating_mul(CAPACITY) % deck_size;
-        (0..CAPACITY.min(deck_size))
-            .map(|offset| grouped[(start + offset) % deck_size])
-            .collect::<Vec<_>>()
-    };
-
-    ActionHandView {
-        schema_version: 1,
-        capacity: CAPACITY as u8,
-        deck_size: u16::try_from(deck_size).unwrap_or(u16::MAX),
-        draw_available: deck_size > CAPACITY,
-        generation: u64::try_from(draw_count).unwrap_or(u64::MAX),
-        pass: ActionHandPassView {
-            offer_id: String::new(),
-            label: "Think".to_string(),
-            state_revision: 0,
-            generation: u64::try_from(draw_count).unwrap_or(u64::MAX),
-            scene_key: "ordinary".to_string(),
-        },
-        entries: selected
-            .into_iter()
-            .map(|offer| ActionHandEntryView {
-                offer_id: offer.offer_id.clone(),
-                kind: offer.kind.clone(),
-                intention: offer.intention.clone(),
-                provider: offer.provider.clone(),
-            })
-            .collect(),
+    let mut slot_pools: [Vec<&RankedActionOffer>; 3] = std::array::from_fn(|_| Vec::new());
+    for offer in grouped {
+        slot_pools[story_hand_natural_slot(offer)].push(offer);
     }
-}
-
-fn pin_action_hand_offer(
-    hand: &mut ActionHandView,
-    offers: &[RankedActionOffer],
-    draw_count: usize,
-    pinned_offer: &RankedActionOffer,
-    excluded_offer_ids: &BTreeSet<String>,
-) {
-    let companion_capacity = usize::from(hand.capacity).saturating_sub(1);
-    let mut companion_candidates = offers
+    if let Some((pinned_offer, _)) = progression_pin {
+        for pool in &mut slot_pools {
+            pool.retain(|offer| offer.offer_id != pinned_offer.offer_id);
+        }
+        slot_pools[0].insert(0, pinned_offer);
+        // The pinned progression card must remain visible, but it must not
+        // strand every other Story-shaped action behind an unavailable Think.
+        // In a sparse scene, lend that overflow to Self and Anchor's queues so
+        // those exact cards can still rotate while Story stays guaranteed.
+        let overflow = slot_pools[0].split_off(1);
+        for offer in overflow {
+            let destination = if slot_pools[1].len() <= slot_pools[2].len() {
+                1
+            } else {
+                2
+            };
+            slot_pools[destination].push(offer);
+        }
+    }
+    // Keep the three pools disjoint so advancing one slot can never move a
+    // different slot. Sparse scenes borrow a stable fallback from a pool that
+    // has more than one card.
+    for empty_index in 0..slot_pools.len() {
+        if !slot_pools[empty_index].is_empty() {
+            continue;
+        }
+        let donor = (0..slot_pools.len())
+            .filter(|index| *index != empty_index && slot_pools[*index].len() > 1)
+            .max_by_key(|index| slot_pools[*index].len());
+        if let Some(donor) = donor {
+            let fallback = slot_pools[donor]
+                .pop()
+                .expect("a Story Hand donor has more than one card");
+            slot_pools[empty_index].push(fallback);
+        }
+    }
+    let entries = slot_pools
         .iter()
-        .filter(|candidate| {
-            candidate.ranked_hand_eligible
-                && action_offer_is_reachable(candidate)
-                && !excluded_offer_ids.contains(&candidate.offer_id)
+        .enumerate()
+        .filter(|(_, pool)| !pool.is_empty())
+        .map(|(slot_index, pool)| {
+            let generation = slot_generations[slot_index];
+            let progression_locked = slot_index == 0 && progression_pin.is_some();
+            story_hand_entry(
+                pool[if progression_locked {
+                    0
+                } else {
+                    generation % pool.len()
+                }],
+                slot_index,
+                if progression_locked {
+                    0
+                } else {
+                    pool.len().saturating_sub(1)
+                },
+            )
         })
         .collect::<Vec<_>>();
-    companion_candidates.sort_by(|left, right| {
-        left.provider
-            .priority
-            .cmp(&right.provider.priority)
-            .then_with(|| left.rank.cmp(&right.rank))
-            .then_with(|| left.id.cmp(&right.id))
-    });
-    let mut seen_groups = BTreeSet::new();
-    companion_candidates.retain(|candidate| seen_groups.insert(action_offer_hand_group(candidate)));
-    let companion_count = companion_candidates.len();
-    let companions = if companion_count == 0 || companion_capacity == 0 {
-        Vec::new()
-    } else {
-        let start = draw_count.saturating_mul(companion_capacity) % companion_count;
-        (0..companion_capacity.min(companion_count))
-            .map(|offset| companion_candidates[(start + offset) % companion_count])
-            .collect::<Vec<_>>()
-    };
-    hand.entries = std::iter::once(ActionHandEntryView {
-        offer_id: pinned_offer.offer_id.clone(),
-        kind: pinned_offer.kind.clone(),
-        intention: pinned_offer.intention.clone(),
-        provider: pinned_offer.provider.clone(),
-    })
-    .chain(companions.into_iter().map(|companion| ActionHandEntryView {
-        offer_id: companion.offer_id.clone(),
-        kind: companion.kind.clone(),
-        intention: companion.intention.clone(),
-        provider: companion.provider.clone(),
-    }))
-    .collect();
-    let guided_deck_size = companion_count.saturating_add(1);
-    hand.deck_size = u16::try_from(guided_deck_size).unwrap_or(u16::MAX);
-    hand.draw_available = companion_count > companion_capacity;
+    let generation = slot_generations
+        .into_iter()
+        .fold(0usize, usize::saturating_add);
+
+    ActionHandView {
+        schema_version: 2,
+        capacity: CAPACITY as u8,
+        deck_size: u16::try_from(deck_size).unwrap_or(u16::MAX),
+        draw_available: slot_pools.iter().any(|pool| pool.len() > 1),
+        generation: u64::try_from(generation).unwrap_or(u64::MAX),
+        pass: empty_think_view(),
+        entries,
+    }
 }
 
 impl RuntimeWorld {
@@ -2448,67 +2583,112 @@ impl RuntimeWorld {
         actor_id: Option<u64>,
         offers: &[RankedActionOffer],
     ) -> ActionHandView {
-        let draw_count = actor_id
-            .and_then(|actor_id| self.hand_generations.get(&actor_id).copied())
-            .map(|generation| usize::try_from(generation).unwrap_or(usize::MAX))
-            .unwrap_or_default();
-        let mut hand = compose_action_hand_at(offers, draw_count);
+        let actor_id_value = actor_id.unwrap_or_default();
+        let (scene_key, safe_scene) = self.story_hand_scene_for_actor(actor_id_value);
+        let story_state = self.story_hand_state_for_scene(actor_id_value, &scene_key);
+        self.action_hand_for_story_state(actor_id, offers, &scene_key, safe_scene, &story_state)
+    }
+
+    pub(super) fn action_hand_after_think_for(
+        &self,
+        actor_id: u64,
+        offers: &[RankedActionOffer],
+        slot_index: usize,
+    ) -> ActionHandView {
+        let (scene_key, safe_scene) = self.story_hand_scene_for_actor(actor_id);
+        let mut story_state = self.story_hand_state_for_scene(actor_id, &scene_key);
+        if let Some(generation) = story_state.slot_generations.get_mut(slot_index) {
+            *generation = generation.saturating_add(1);
+        }
+        story_state.free_think_used = true;
+        self.action_hand_for_story_state(
+            Some(actor_id),
+            offers,
+            &scene_key,
+            safe_scene,
+            &story_state,
+        )
+    }
+
+    fn action_hand_for_story_state(
+        &self,
+        actor_id: Option<u64>,
+        offers: &[RankedActionOffer],
+        scene_key: &str,
+        safe_scene: bool,
+        story_state: &StoryHandActorState,
+    ) -> ActionHandView {
+        let actor_id_value = actor_id.unwrap_or_default();
+        let slot_generations_u64 = story_state.slot_generations;
+        let slot_generations = slot_generations_u64
+            .map(|generation| usize::try_from(generation).unwrap_or(usize::MAX));
+        let mut progression_offer = None;
+        let mut progression_offer_ids = BTreeSet::new();
         if let Some(actor_id) = actor_id {
             if let Some(accept_offer) = offers
                 .iter()
                 .filter(|offer| offer.kind == ACCEPT_TRANSFER_OFFER_KIND)
                 .min_by(|left, right| left.id.cmp(&right.id))
             {
-                let pinned_ids = BTreeSet::from([accept_offer.offer_id.clone()]);
-                pin_action_hand_offer(&mut hand, offers, draw_count, accept_offer, &pinned_ids);
+                progression_offer_ids.insert(accept_offer.offer_id.clone());
+                progression_offer = Some(accept_offer);
             } else if let Some(journey_offer) = self.journey_advancing_offer(actor_id, offers) {
-                let journey_offer_ids = BTreeSet::from([journey_offer.offer_id.clone()]);
-                pin_action_hand_offer(
-                    &mut hand,
-                    offers,
-                    draw_count,
-                    journey_offer,
-                    &journey_offer_ids,
-                );
+                progression_offer_ids.insert(journey_offer.offer_id.clone());
+                progression_offer = Some(journey_offer);
             } else {
                 let (advancing_offer_id, advancing_offer_ids) =
                     self.first_tale_advancing_offer_selection(actor_id, offers);
-                if let Some(offer) = advancing_offer_id
+                progression_offer = advancing_offer_id
                     .as_ref()
-                    .and_then(|offer_id| offers.iter().find(|offer| offer.offer_id == *offer_id))
-                {
-                    pin_action_hand_offer(
-                        &mut hand,
-                        offers,
-                        draw_count,
-                        offer,
-                        &advancing_offer_ids,
-                    );
-                }
+                    .and_then(|offer_id| offers.iter().find(|offer| offer.offer_id == *offer_id));
+                progression_offer_ids = advancing_offer_ids;
             }
         }
+        let mut hand = compose_story_hand_with_pin(
+            offers,
+            slot_generations,
+            progression_offer.map(|offer| (offer, &progression_offer_ids)),
+        );
         let state_revision = self.current_state_revision();
-        let scene_key = focused_encounter_for_actor(self, actor_id.unwrap_or_default())
-            .map(|focused| focused.handoff_key())
-            .unwrap_or_else(|| "ordinary".to_string());
-        let label = if scene_key == "ordinary" {
-            "Think"
-        } else {
-            "Pass"
-        };
-        hand.pass = ActionHandPassView {
-            offer_id: format!(
-                "pass:{}:{}:{}:{}",
-                actor_id.unwrap_or_default(),
+        let free = safe_scene && !story_state.free_think_used;
+        for entry in &mut hand.entries {
+            let slot_index = STORY_HAND_SLOTS
+                .iter()
+                .position(|slot| *slot == entry.slot)
+                .expect("Story Hand entries use one of the three slots");
+            let generation = slot_generations_u64[slot_index];
+            let available = entry.replacement_count > 0;
+            entry.think = ActionHandPassView {
+                offer_id: if available {
+                    format!(
+                        "think:{}:{}:{}:{}:{}:{}",
+                        actor_id_value,
+                        state_revision,
+                        entry.slot,
+                        generation,
+                        scene_key,
+                        stable_hash_hex(&["story-hand-think", &entry.offer_id]),
+                    )
+                } else {
+                    String::new()
+                },
+                label: "Think".to_string(),
                 state_revision,
-                hand.generation,
-                scene_key
-            ),
-            label: label.to_string(),
-            state_revision,
-            generation: hand.generation,
-            scene_key,
-        };
+                generation,
+                scene_key: scene_key.to_string(),
+                slot: entry.slot.clone(),
+                replaces_offer_id: entry.offer_id.clone(),
+                free,
+                consumes_turn: !free,
+                available,
+            };
+        }
+        hand.pass = hand
+            .entries
+            .iter()
+            .find(|entry| entry.think.available)
+            .map(|entry| entry.think.clone())
+            .unwrap_or_else(empty_think_view);
         hand
     }
 
@@ -2529,24 +2709,69 @@ impl RuntimeWorld {
                 None,
             );
         }
-        let attempts = initial_offers.len().max(1);
+        let attempts = initial_offers
+            .len()
+            .max(1)
+            .saturating_mul(STORY_HAND_SLOTS.len());
         drop(initial_offers);
-        for _ in 0..attempts {
+        for attempt in 0..attempts {
             let (mut primary_action, mut offers) =
                 self.legal_action_candidates_with_presence(Some(actor_id), access, None);
             if direct_input {
                 retain_configured_model_interaction_offers(&mut primary_action, &mut offers, None);
             }
             let hand = self.action_hand_for(Some(actor_id), &offers);
-            if let Some(offer) = offers.into_iter().find(|offer| {
-                hand.entries
-                    .iter()
-                    .any(|entry| entry.offer_id == offer.offer_id)
-                    && predicate(offer)
+            let matching_offer_ids = offers
+                .iter()
+                .filter(|offer| predicate(offer))
+                .map(|offer| offer.offer_id.clone())
+                .collect::<BTreeSet<_>>();
+            if let Some(offer) = offers.iter().find(|offer| {
+                matching_offer_ids.contains(&offer.offer_id)
+                    && hand
+                        .entries
+                        .iter()
+                        .any(|entry| entry.offer_id == offer.offer_id)
             }) {
-                return Some(offer);
+                return Some(offer.clone());
             }
-            self.append_hand_shuffled_event(actor_id, "test_draw");
+            let replaceable_slots = hand
+                .entries
+                .iter()
+                .filter(|entry| entry.think.available)
+                .filter_map(|entry| STORY_HAND_SLOTS.iter().position(|slot| *slot == entry.slot))
+                .collect::<Vec<_>>();
+            let target_slot = replaceable_slots
+                .iter()
+                .copied()
+                .find(|slot| {
+                    self.action_hand_after_think_for(actor_id, &offers, *slot)
+                        .entries
+                        .iter()
+                        .any(|entry| matching_offer_ids.contains(&entry.offer_id))
+                })
+                .or_else(|| {
+                    (!replaceable_slots.is_empty())
+                        .then(|| replaceable_slots[attempt % replaceable_slots.len()])
+                })?;
+            let (scene_key, _) = self.story_hand_scene_for_actor(actor_id);
+            let replaces_offer_id = hand
+                .entries
+                .iter()
+                .find(|entry| entry.slot == STORY_HAND_SLOTS[target_slot])
+                .map(|entry| entry.offer_id.as_str())
+                .unwrap_or_default()
+                .to_string();
+            self.append_story_hand_thought_event(
+                actor_id,
+                (
+                    target_slot as u8,
+                    &scene_key,
+                    &replaces_offer_id,
+                    false,
+                    "test_draw",
+                ),
+            );
         }
         None
     }
@@ -2638,6 +2863,173 @@ pub(super) fn action_offer_intention(kind: &str) -> &str {
     }
 }
 
+fn spell_effect_suit(effect: Option<&str>) -> Option<&'static str> {
+    let effect = effect?.to_ascii_lowercase();
+    if ["rest", "recover", "heal", "glow", "train", "grow", "evolve"]
+        .iter()
+        .any(|term| effect.contains(term))
+    {
+        Some("hearth")
+    } else if ["damage", "attack", "defend", "guard", "rescue", "escape"]
+        .iter()
+        .any(|term| effect.contains(term))
+    {
+        Some("courage")
+    } else if ["reveal", "find", "notice", "inspect", "search", "study"]
+        .iter()
+        .any(|term| effect.contains(term))
+    {
+        Some("wonder")
+    } else if ["travel", "move", "return", "cross", "path"]
+        .iter()
+        .any(|term| effect.contains(term))
+    {
+        Some("way")
+    } else if [
+        "friend",
+        "bond",
+        "speak",
+        "chat",
+        "influence",
+        "give",
+        "trade",
+    ]
+    .iter()
+    .any(|term| effect.contains(term))
+    {
+        Some("heart")
+    } else if ["make", "craft", "create", "open", "use", "work", "prepare"]
+        .iter()
+        .any(|term| effect.contains(term))
+    {
+        Some("hand")
+    } else {
+        None
+    }
+}
+
+/// Exhaustive server-owned mapping from a playable offer to the six Story
+/// Hand suits. There is intentionally no utility/danger fallback: a new verb
+/// must choose its meaning before it can be published as a card.
+pub(super) fn action_card_suit(offer: &RankedActionOffer) -> Result<&'static str, String> {
+    if offer.kind == "cast_spell" {
+        return spell_effect_suit(offer.effect.as_deref()).ok_or_else(|| {
+            format!(
+                "spell offer {} has no effect-derived Story Hand suit",
+                offer.offer_id
+            )
+        });
+    }
+    let intention_suit = match offer.intention.as_str() {
+        "notice" | "inspect" | "search" | "study" | "scout" | "listen" | "find_resonance"
+        | "rank_echoes" => Some("wonder"),
+        "travel" | "go" | "cross" | "return" | "route" | "routes" => Some("way"),
+        "chat" | "speak" | "echo" | "befriend" | "remember" | "influence" | "give" | "accept"
+        | "trade" => Some("heart"),
+        "take" | "drop" | "use" | "open" | "craft" | "prepare" | "work" | "help" | "finish"
+        | "illustrate" => Some("hand"),
+        "attack" | "defend" | "flee" | "rescue" | "steal" => Some("courage"),
+        "rest" | "bank" | "practice" | "train" | "evolve" | "class" => Some("hearth"),
+        _ => None,
+    };
+    let suit = if let Some(suit) = intention_suit {
+        suit
+    } else {
+        match offer.kind.as_str() {
+            "check"
+            | "search"
+            | "study"
+            | "explore_path"
+            | FOCUSED_NOTICE_OFFER_KIND
+            | DISCOVERY_SEARCH_OFFER_KIND
+            | DISCOVERY_STUDY_OFFER_KIND
+            | DISCOVERY_SCOUT_OFFER_KIND => "wonder",
+            "move" => "way",
+            "chat"
+            | "influence"
+            | "give_item"
+            | ACCEPT_TRANSFER_OFFER_KIND
+            | "trade_item"
+            | "create_bond"
+            | "resolve_bond" => "heart",
+            "pick_up" | "drop_item" | "use_item" | "use_feature" | "open" | "craft" | "prepare"
+            | "work" | "help" => "hand",
+            "attack" | "defend" | "flee" | "theft" => "courage",
+            "rest" | "train_skill" | "revise_calling" | "revise_bond" => "hearth",
+            "model_interaction" => match offer.intention.as_str() {
+                "find_resonance" | "rank_echoes" => "wonder",
+                "speak" | "echo" => "heart",
+                "illustrate" => "hand",
+                intention => {
+                    return Err(format!(
+                        "model interaction {} has unmapped intention {intention}",
+                        offer.offer_id
+                    ));
+                }
+            },
+            kind => {
+                return Err(format!(
+                    "playable offer {} has unmapped Story Hand kind {kind}",
+                    offer.offer_id
+                ));
+            }
+        }
+    };
+    Ok(suit)
+}
+
+fn action_card_provenance(offer: &RankedActionOffer) -> &'static str {
+    let pack_id = offer
+        .source_collectible
+        .as_ref()
+        .map(|source| source.pack_id.as_str())
+        .unwrap_or(offer.pack_provenance.pack_id.as_str())
+        .to_ascii_lowercase();
+    if pack_id.contains("legacy") {
+        "legacy"
+    } else if pack_id.contains("community") || pack_id.contains("ugc") {
+        "community"
+    } else if pack_id.starts_with("cosyworld.core")
+        || pack_id.contains("commons")
+        || pack_id.contains("rules-profile")
+    {
+        "core"
+    } else {
+        "worldpack"
+    }
+}
+
+pub(super) fn action_card_presentation(
+    offer: &RankedActionOffer,
+) -> Result<ActionCardPresentationView, String> {
+    let (family, suit) = if offer.kind == "create_avatar" {
+        ("ceremony", None)
+    } else if offer.kind == "wait" {
+        ("control", None)
+    } else {
+        ("action", Some(action_card_suit(offer)?.to_string()))
+    };
+    Ok(ActionCardPresentationView {
+        family: family.to_string(),
+        suit,
+        verb: offer.verb.clone(),
+        source: ActionCardSourceView {
+            kind: offer.provider.kind.clone(),
+            id: offer.provider.id.clone(),
+            label: offer.provider.label.clone(),
+        },
+        state: if offer.disabled { "locked" } else { "ready" }.to_string(),
+        provenance: action_card_provenance(offer).to_string(),
+        // Rarity is a collectible marker, never the action's primary colour or
+        // a proxy for strength. Content can author richer values later.
+        rarity: "everyday".to_string(),
+        power: "standard".to_string(),
+        cost: offer.cost.clone(),
+        risk: offer.risk.clone(),
+        effect: offer.effect.clone(),
+    })
+}
+
 pub(super) fn contribution_resolution_label(policy: &ContributionResolutionPolicy) -> &'static str {
     match policy {
         ContributionResolutionPolicy::Certain => "certain",
@@ -2656,15 +3048,31 @@ pub(super) fn default_action_offer_verb(kind: &str) -> &str {
         DISCOVERY_STUDY_OFFER_KIND => "Study",
         DISCOVERY_SCOUT_OFFER_KIND => "Scout",
         "move" => "Travel",
+        "chat" => "Chat",
+        "influence" => "Influence",
+        "give_item" => "Give",
+        "trade_item" => "Trade",
+        "create_bond" => "Befriend",
+        "resolve_bond" => "Remember",
         "model_interaction" => "Illustrate",
         "open" => "Open",
         "work" => "Push",
         "help" => "Help",
+        "use_item" | "use_feature" => "Use",
+        "craft" => "Craft",
+        "attack" => "Attack",
+        "defend" => "Defend",
         "flee" => "Flee",
+        "theft" => "Steal",
         "prepare" => "Prepare",
         "pick_up" => "Take",
         "drop_item" => "Drop",
         ACCEPT_TRANSFER_OFFER_KIND => "Accept",
+        "rest" => "Rest",
+        "train_skill" => "Practice",
+        "revise_calling" => "Evolve",
+        "revise_bond" => "Remember",
+        "cast_spell" => "Cast",
         _ => "Act",
     }
 }
@@ -2749,6 +3157,161 @@ mod tests {
             offer_id: None,
             wallet_session: None,
             envelope: None,
+        }
+    }
+
+    #[test]
+    fn story_hand_suits_are_explicit_exhaustive_and_effect_driven_for_spells() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Suit Tester");
+        let (_, offers) = runtime.legal_action_candidates(Some(5000), &AccessContext::default());
+        let base = offers.first().expect("seeded actor has an action").clone();
+
+        for (kind, intention, effect, expected) in [
+            ("check", "notice", None, "wonder"),
+            ("move", "travel", None, "way"),
+            ("chat", "chat", None, "heart"),
+            (ACCEPT_TRANSFER_OFFER_KIND, "accept", None, "heart"),
+            ("craft", "craft", None, "hand"),
+            ("attack", "attack", None, "courage"),
+            ("rest", "rest", None, "hearth"),
+            ("model_interaction", "find_resonance", None, "wonder"),
+            ("model_interaction", "echo", None, "heart"),
+            ("model_interaction", "illustrate", None, "hand"),
+            ("cast_spell", "cast", Some("heal a nearby friend"), "hearth"),
+            (
+                "cast_spell",
+                "cast",
+                Some("guard a nearby friend"),
+                "courage",
+            ),
+            ("cast_spell", "cast", Some("reveal a hidden path"), "wonder"),
+        ] {
+            let mut offer = base.clone();
+            offer.kind = kind.to_string();
+            offer.intention = intention.to_string();
+            offer.effect = effect.map(str::to_string);
+            offer.offer_id = format!("test:{kind}:{intention}:{expected}");
+            assert_eq!(
+                action_card_suit(&offer).as_deref(),
+                Ok(expected),
+                "{kind}/{intention} has one authored Story Hand suit"
+            );
+        }
+
+        for (expected, intentions) in [
+            (
+                "wonder",
+                &[
+                    "notice",
+                    "inspect",
+                    "search",
+                    "study",
+                    "scout",
+                    "listen",
+                    "find_resonance",
+                    "rank_echoes",
+                ][..],
+            ),
+            (
+                "way",
+                &["travel", "go", "cross", "return", "route", "routes"],
+            ),
+            (
+                "heart",
+                &[
+                    "chat",
+                    "speak",
+                    "echo",
+                    "befriend",
+                    "remember",
+                    "influence",
+                    "give",
+                    "trade",
+                ],
+            ),
+            (
+                "hand",
+                &[
+                    "take",
+                    "drop",
+                    "use",
+                    "open",
+                    "craft",
+                    "prepare",
+                    "work",
+                    "help",
+                    "finish",
+                    "illustrate",
+                ],
+            ),
+            ("courage", &["attack", "defend", "flee", "rescue", "steal"]),
+            (
+                "hearth",
+                &["rest", "bank", "practice", "train", "evolve", "class"],
+            ),
+        ] {
+            for intention in intentions {
+                let mut offer = base.clone();
+                offer.kind = "authored_action".to_string();
+                offer.intention = (*intention).to_string();
+                offer.offer_id = format!("test:intention:{intention}");
+                assert_eq!(action_card_suit(&offer).as_deref(), Ok(expected));
+            }
+        }
+
+        let mut unmapped = base.clone();
+        unmapped.kind = "utility".to_string();
+        assert!(action_card_presentation(&unmapped).is_err());
+        unmapped.kind = "model_interaction".to_string();
+        unmapped.intention = "generic".to_string();
+        assert!(action_card_presentation(&unmapped).is_err());
+    }
+
+    #[test]
+    fn action_card_presentation_keeps_meaning_source_state_and_collectibility_separate() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Presentation Tester",
+        );
+        let (_, offers) = runtime.legal_action_candidates(Some(5000), &AccessContext::default());
+        assert!(!offers.is_empty());
+        for offer in &offers {
+            let presentation = action_card_presentation(offer)
+                .unwrap_or_else(|error| panic!("{}: {error}", offer.offer_id));
+            assert_eq!(presentation.family, "action");
+            assert!(matches!(
+                presentation.suit.as_deref(),
+                Some("wonder" | "way" | "heart" | "hand" | "courage" | "hearth")
+            ));
+            assert_eq!(presentation.verb, offer.verb);
+            assert_eq!(presentation.source.kind, offer.provider.kind);
+            assert_eq!(presentation.source.id, offer.provider.id);
+            assert_eq!(presentation.source.label, offer.provider.label);
+            assert!(matches!(presentation.state.as_str(), "ready" | "locked"));
+            assert!(matches!(
+                presentation.provenance.as_str(),
+                "core" | "worldpack" | "community" | "legacy"
+            ));
+            assert_eq!(presentation.rarity, "everyday");
+            assert_eq!(presentation.power, "standard");
+        }
+        let public = serde_json::to_value(&offers).expect("every published offer is mapped");
+        let first = &public.as_array().expect("offer list")[0]["presentation"];
+        for field in [
+            "family",
+            "suit",
+            "verb",
+            "source",
+            "state",
+            "provenance",
+            "rarity",
+            "power",
+        ] {
+            assert!(!first[field].is_null(), "presentation publishes {field}");
         }
     }
 

--- a/v2/orchestrator-rust/src/first_tale.rs
+++ b/v2/orchestrator-rust/src/first_tale.rs
@@ -411,7 +411,7 @@ mod tests {
                 .filter(|entry| entry.offer_id == offer_id)
                 .count(),
             1,
-            "the two-card hand contains exactly one advancing offer"
+            "the Story Hand contains exactly one advancing offer"
         );
         offers
             .iter()
@@ -659,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    fn guided_hand_rotates_every_non_advancing_offer() {
+    fn guided_hand_keeps_the_advancing_story_card_pinned_across_generations() {
         let actor_id = 5000;
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
@@ -692,14 +692,16 @@ mod tests {
                 hand.entries.first().map(|entry| entry.offer_id.as_str()),
                 Some(advancing_offer_id.as_str())
             );
-            seen.extend(
-                hand.entries
-                    .iter()
-                    .skip(1)
-                    .map(|entry| entry.offer_id.clone()),
-            );
+            assert!(!hand.entries[0].think.available);
+            let companions = hand
+                .entries
+                .iter()
+                .skip(1)
+                .map(|entry| entry.offer_id.clone())
+                .collect::<Vec<_>>();
+            seen.extend(companions.iter().cloned());
         }
-        assert_eq!(seen, expected);
+        assert!(seen.is_subset(&expected));
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -19,6 +19,20 @@
       --amber: #efc96b;
       --blue: #8bb7ff;
       --red: #ff8d8d;
+      --suit-wonder: #79c7ff;
+      --suit-wonder-rgb: 121, 199, 255;
+      --suit-way: #65e68a;
+      --suit-way-rgb: 101, 230, 138;
+      --suit-heart: #f2a5c4;
+      --suit-heart-rgb: 242, 165, 196;
+      --suit-hand: #efc96b;
+      --suit-hand-rgb: 239, 201, 107;
+      --suit-courage: #ff7b72;
+      --suit-courage-rgb: 255, 123, 114;
+      --suit-hearth: #b89cff;
+      --suit-hearth-rgb: 184, 156, 255;
+      --card-control: #9db3c7;
+      --card-control-rgb: 157, 179, 199;
       --type-travel: #65e68a;
       --type-travel-rgb: 101, 230, 138;
       --type-chat: #f2df9b;
@@ -55,24 +69,6 @@
       --type-shuffle-rgb: 157, 179, 199;
       --type-utility: #aab7a4;
       --type-utility-rgb: 170, 183, 164;
-      --rarity-free: #9db3c7;
-      --rarity-free-rgb: 157, 179, 199;
-      --rarity-seed: #65e68a;
-      --rarity-seed-rgb: 101, 230, 138;
-      --rarity-common: #f2df9b;
-      --rarity-common-rgb: 242, 223, 155;
-      --rarity-uncommon: #79c7ff;
-      --rarity-uncommon-rgb: 121, 199, 255;
-      --rarity-generated: #82e6c2;
-      --rarity-generated-rgb: 130, 230, 194;
-      --rarity-rare: #b89cff;
-      --rarity-rare-rgb: 184, 156, 255;
-      --rarity-super-rare: #f2a65a;
-      --rarity-super-rare-rgb: 242, 166, 90;
-      --rarity-ultra-rare: #c65cff;
-      --rarity-ultra-rare-rgb: 198, 92, 255;
-      --rarity-mythic: #ffd36a;
-      --rarity-mythic-rgb: 255, 211, 106;
       --avatar-pfp-background-size: 138%;
       --avatar-pfp-background-position: center top;
       --safe-bot: env(safe-area-inset-bottom, 0px);
@@ -2240,7 +2236,7 @@
     }
     .prompt {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 9px;
       align-items: stretch;
       padding: 10px 12px calc(10px + var(--safe-bot));
@@ -2357,7 +2353,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .prompt.has-draw {
-      grid-template-columns: repeat(2, minmax(0, 1fr)) minmax(64px, 86px);
+      grid-template-columns: repeat(3, minmax(0, 1fr)) minmax(64px, 86px);
     }
     .prompt.choice-mode.has-draw {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2367,8 +2363,8 @@
     }
     .prompt[hidden] { display: none; }
     .cmd {
-      --cmd-accent: var(--type-utility);
-      --cmd-accent-rgb: var(--type-utility-rgb);
+      --cmd-accent: var(--card-control);
+      --cmd-accent-rgb: var(--card-control-rgb);
       min-width: 0;
       min-height: 58px;
       border: 1px solid rgba(var(--cmd-accent-rgb), 0.42);
@@ -2450,36 +2446,13 @@
       font-size: 10px;
       line-height: 1;
     }
-    .cmd.type-travel { --cmd-accent: var(--type-travel); --cmd-accent-rgb: var(--type-travel-rgb); }
-    .cmd.type-chat { --cmd-accent: var(--type-chat); --cmd-accent-rgb: var(--type-chat-rgb); }
-    .cmd.type-bond { --cmd-accent: var(--type-bond); --cmd-accent-rgb: var(--type-bond-rgb); }
-    .cmd.type-listen { --cmd-accent: var(--type-listen); --cmd-accent-rgb: var(--type-listen-rgb); }
-    .cmd.type-notice { --cmd-accent: var(--type-notice); --cmd-accent-rgb: var(--type-notice-rgb); }
-    .cmd.type-inspect { --cmd-accent: var(--type-inspect); --cmd-accent-rgb: var(--type-inspect-rgb); }
-    .cmd.type-scout { --cmd-accent: var(--type-scout); --cmd-accent-rgb: var(--type-scout-rgb); }
-    .cmd.type-train { --cmd-accent: var(--type-train); --cmd-accent-rgb: var(--type-train-rgb); }
-    .cmd.type-evolve { --cmd-accent: var(--type-evolve); --cmd-accent-rgb: var(--type-evolve-rgb); }
-    .cmd.type-trade { --cmd-accent: var(--type-trade); --cmd-accent-rgb: var(--type-trade-rgb); }
-    .cmd.type-bank { --cmd-accent: var(--type-bank); --cmd-accent-rgb: var(--type-bank-rgb); }
-    .cmd.type-craft { --cmd-accent: var(--type-craft); --cmd-accent-rgb: var(--type-craft-rgb); }
-    .cmd.type-project { --cmd-accent: var(--type-project); --cmd-accent-rgb: var(--type-project-rgb); }
-    .cmd.type-item { --cmd-accent: var(--type-item); --cmd-accent-rgb: var(--type-item-rgb); }
-    .cmd.type-combat { --cmd-accent: var(--type-combat); --cmd-accent-rgb: var(--type-combat-rgb); }
-    .cmd.type-danger { --cmd-accent: var(--type-danger); --cmd-accent-rgb: var(--type-danger-rgb); }
-    .cmd.type-shuffle { --cmd-accent: var(--type-shuffle); --cmd-accent-rgb: var(--type-shuffle-rgb); }
-    .cmd.type-utility { --cmd-accent: var(--type-utility); --cmd-accent-rgb: var(--type-utility-rgb); }
-    .cmd.rarity-free { --cmd-accent: var(--rarity-free); --cmd-accent-rgb: var(--rarity-free-rgb); }
-    .cmd.rarity-seed { --cmd-accent: var(--rarity-seed); --cmd-accent-rgb: var(--rarity-seed-rgb); }
-    .cmd.rarity-common { --cmd-accent: var(--rarity-common); --cmd-accent-rgb: var(--rarity-common-rgb); }
-    .cmd.rarity-uncommon { --cmd-accent: var(--rarity-uncommon); --cmd-accent-rgb: var(--rarity-uncommon-rgb); }
-    .cmd.rarity-generated,
-    .cmd.rarity-mystery,
-    .cmd.rarity-pack { --cmd-accent: var(--rarity-generated); --cmd-accent-rgb: var(--rarity-generated-rgb); }
-    .cmd.rarity-rare { --cmd-accent: var(--rarity-rare); --cmd-accent-rgb: var(--rarity-rare-rgb); }
-    .cmd.rarity-super-rare { --cmd-accent: var(--rarity-super-rare); --cmd-accent-rgb: var(--rarity-super-rare-rgb); }
-    .cmd.rarity-ultra-rare { --cmd-accent: var(--rarity-ultra-rare); --cmd-accent-rgb: var(--rarity-ultra-rare-rgb); }
-    .cmd.rarity-mythic,
-    .cmd.rarity-legendary { --cmd-accent: var(--rarity-mythic); --cmd-accent-rgb: var(--rarity-mythic-rgb); }
+    .cmd.suit-wonder { --cmd-accent: var(--suit-wonder); --cmd-accent-rgb: var(--suit-wonder-rgb); }
+    .cmd.suit-way { --cmd-accent: var(--suit-way); --cmd-accent-rgb: var(--suit-way-rgb); }
+    .cmd.suit-heart { --cmd-accent: var(--suit-heart); --cmd-accent-rgb: var(--suit-heart-rgb); }
+    .cmd.suit-hand { --cmd-accent: var(--suit-hand); --cmd-accent-rgb: var(--suit-hand-rgb); }
+    .cmd.suit-courage { --cmd-accent: var(--suit-courage); --cmd-accent-rgb: var(--suit-courage-rgb); }
+    .cmd.suit-hearth { --cmd-accent: var(--suit-hearth); --cmd-accent-rgb: var(--suit-hearth-rgb); }
+    .cmd.card-control { --cmd-accent: var(--card-control); --cmd-accent-rgb: var(--card-control-rgb); }
     .cmd::before {
       content: "";
       position: absolute;
@@ -2665,6 +2638,34 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+    }
+    .cmd-kicker {
+      display: block;
+      color: var(--cmd-accent);
+      font-size: 9px;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      line-height: 1.1;
+      text-transform: uppercase;
+    }
+    .cmd-meta {
+      display: block;
+      color: var(--dim);
+      font-size: 9px;
+      font-weight: 700;
+      line-height: 1.1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .collectible-mark {
+      position: absolute;
+      right: 7px;
+      bottom: 5px;
+      z-index: 2;
+      color: var(--cmd-accent);
+      font-size: 9px;
+      opacity: 0.72;
     }
     .cmd:disabled {
       opacity: 0.42;
@@ -3835,6 +3836,20 @@
       --amber: #dec28d;
       --blue: #9ab0bd;
       --red: #d98f77;
+      --suit-wonder: #91a9b2;
+      --suit-wonder-rgb: 145, 169, 178;
+      --suit-way: #9faf88;
+      --suit-way-rgb: 159, 175, 136;
+      --suit-heart: #c99aa5;
+      --suit-heart-rgb: 201, 154, 165;
+      --suit-hand: #dec28d;
+      --suit-hand-rgb: 222, 194, 141;
+      --suit-courage: #d98f77;
+      --suit-courage-rgb: 217, 143, 119;
+      --suit-hearth: #b89bbd;
+      --suit-hearth-rgb: 184, 155, 189;
+      --card-control: #a89c86;
+      --card-control-rgb: 168, 156, 134;
       --type-travel: #9faf88;
       --type-travel-rgb: 159, 175, 136;
       --type-chat: #dec28d;
@@ -5044,7 +5059,7 @@
         <span id="location-name">booting</span>
       </button>
       <div class="topbar-actions">
-        <span class="economy" id="economy" aria-label="Carried deck and Orb status"></span>
+        <span class="economy" id="economy" aria-label="Pack and Orb status"></span>
         <button class="room-log-toggle" id="room-log-toggle" type="button" aria-expanded="false" aria-controls="journal-view" data-player-concept="journal" data-analytics-event="journal.open"><span class="room-log-icon" aria-hidden="true"></span><strong class="room-log-count" id="journal-notification-count" aria-hidden="true" hidden>0</strong><span class="room-log-kicker">Journal</span></button>
       </div>
     </header>
@@ -5101,14 +5116,15 @@
       <section class="log" id="log" role="log" aria-live="polite" aria-relevant="additions text" aria-label="Shared room transcript"></section>
     </main>
     <div class="status" id="error" role="status" aria-live="polite" aria-atomic="true"></div>
-    <footer class="prompt">
+    <footer class="prompt" aria-label="Story Hand">
       <div class="turn-banner" id="turn-banner" hidden>
         <div class="turn-ping-pill" id="turn-ping-pill" role="status" aria-live="polite" aria-atomic="true"></div>
         <div class="turn-banner-controls" id="turn-banner-controls"></div>
       </div>
       <button class="cmd primary" id="primary" data-player-concept="action" data-analytics-event="action.select"></button>
       <button class="cmd secondary" id="secondary" data-player-concept="action" data-analytics-event="action.select"></button>
-      <button class="cmd shuffle type-shuffle" id="shuffle" data-player-concept="pass" data-analytics-event="action.pass" aria-label="Think: pass these two actions and commit the turn">
+      <button class="cmd tertiary" id="tertiary" data-player-concept="action" data-analytics-event="action.select"></button>
+      <button class="cmd shuffle card-control" id="shuffle" data-player-concept="think" data-analytics-event="action.think" aria-label="Think about replacing the focused Story Hand card">
         <span class="shuffle-glyph" aria-hidden="true">↻</span><span class="cmd-label">think</span>
       </button>
     </footer>
@@ -5210,44 +5226,9 @@
     function abilityLabel(value, fallback = "an ability") {
       return authoredAbilityChoice(value)?.label || String(value || fallback);
     }
-    const actionCardTypes = [
-      "travel",
-      "notice",
-      "inspect",
-      "scout",
-      "chat",
-      "illustrate",
-      "bond",
-      "listen",
-      "train",
-      "evolve",
-      "trade",
-      "bank",
-      "craft",
-      "project",
-      "item",
-      "combat",
-      "danger",
-      "shuffle",
-      "utility",
-    ];
-    const actionCardTypeClasses = actionCardTypes.map((type) => `type-${type}`);
-    const actionCardRarities = [
-      "free",
-      "seed",
-      "common",
-      "uncommon",
-      "generated",
-      "mystery",
-      "pack",
-      "rare",
-      "super-rare",
-      "ultra-rare",
-      "mythic",
-      "legendary",
-    ];
-    const actionCardRarityClasses = actionCardRarities.map((rarity) => `rarity-${rarity}`);
-    const actionCardAccentClasses = [...actionCardTypeClasses, ...actionCardRarityClasses];
+    const actionCardSuits = ["wonder", "way", "heart", "hand", "courage", "hearth"];
+    const actionCardSuitClasses = actionCardSuits.map((suit) => `suit-${suit}`);
+    const actionCardAccentClasses = [...actionCardSuitClasses, "card-control"];
     const bootParams = new URLSearchParams(window.location.search);
     const wantsReset = ["1", "true", "yes"].includes(String(bootParams.get("reset") || "").toLowerCase());
     if (wantsReset) clearLocalSession();
@@ -6653,6 +6634,15 @@
           reason: `From ${view.location?.name || "this room"}`,
           priority: 60,
         };
+        const exactOffer = (view.action_offers || []).find((offer) => (
+          action.offerIds.includes(String(offer?.offer_id || ""))
+        )) || null;
+        if (exactOffer?.presentation) action.presentation = exactOffer.presentation;
+        const handEntry = (view.action_hand?.entries || []).find((entry) => (
+          action.offerIds.includes(String(entry?.offer_id || ""))
+        )) || null;
+        action.storyHandSlot = handEntry?.slot || "";
+        action.storyHandThink = handEntry?.think || null;
         return action;
       };
       const offerVerb = (offer, fallback) => String(offer?.verb || fallback || "Act").trim();
@@ -6667,6 +6657,7 @@
       const semanticAction = (offer, fallbackIntention, accessibleLabel = "") => ({
         ...offerHand(offer),
         intention: String(offer?.intention || fallbackIntention || "").trim(),
+        presentation: offer?.presentation || null,
         target: offer?.target || null,
         project: offer?.project || null,
         accessibleLabel: String(accessibleLabel || offer?.accessible_label || "").trim(),
@@ -7400,10 +7391,10 @@
             effect: oneItem
               ? (swapping
                 ? `${firstItem.name} comes with you; ${heldItemName} stays in ${view.location?.name || "the room"}`
-                : `${firstItem.name} joins your carried deck until you use, give, trade, or drop it`)
+                : `${firstItem.name} joins your pack until you use, give, trade, or drop it`)
               : (swapping
                 ? `the item you choose comes with you; ${heldItemName} stays in ${view.location?.name || "the room"}`
-                : "the card you choose joins your carried deck until you use, give, trade, or drop it"),
+                : "the card you choose joins your pack until you use, give, trade, or drop it"),
             ...(oneItem ? {} : {
               choices: takeCandidates.map((candidate) => {
                 const item = candidate.item;
@@ -7628,12 +7619,8 @@
             : (fleeing ? "" : (routeVerbLower.endsWith(" to") ? "" : "to "));
           const routeLabel = String(firstExit.route_label || "").trim();
           const routeWayName = routeLabel.replace(/\s+from\s+.+\s+to\s+.+$/i, "").trim();
-          const conciseRouteLabel = routeLabel.replace(
-            /^(.*?)\s+from\s+.+\s+to\s+(.+)$/i,
-            "$1 to $2",
-          );
           const destinationOnlyCardLabel = onePath && !searchingPathway && !fleeing
-            ? (conciseRouteLabel || firstPathwayDirection?.endpointName || firstExit.destination_location_name)
+            ? (firstPathwayDirection?.endpointName || firstExit.destination_location_name)
             : "";
           const routeTargetLabel = targetBearingLabel(routeIntention, routeVerb, firstExit.destination_location_name);
           const routeAccessibleLabel = firstPathwayDirection
@@ -7653,9 +7640,7 @@
             pathwayDirection: firstPathwayDirection,
             label: routeVerb.toLowerCase(),
             destinationOnlyCardLabel,
-            destinationOnlyCardAriaLabel: destinationOnlyCardLabel
-              ? `${routeVerb}${routeLabel ? " via " : " to "}${destinationOnlyCardLabel}`
-              : "",
+            destinationOnlyCardAriaLabel: destinationOnlyCardLabel,
             detail: onePath
               ? (firstPathwayDirection
                 ? `toward ${firstPathwayDirection.endpointName}`
@@ -8383,70 +8368,38 @@
       return 500;
     }
 
-    function normalizeActionCardType(type) {
-      const normalized = String(type || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-      return actionCardTypes.includes(normalized) ? normalized : "";
+    function normalizeActionCardSuit(suit) {
+      const normalized = String(suit || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      return actionCardSuits.includes(normalized) ? normalized : "";
     }
 
     function normalizeActionCardRarity(rarity) {
       const normalized = String(rarity || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-      return actionCardRarities.includes(normalized) ? normalized : "generated";
-    }
-
-    function friendlyCardRarity(rarity) {
-      const normalized = normalizeActionCardRarity(rarity);
+      if (["everyday", "curious", "rare", "storybook"].includes(normalized)) return normalized;
       if (["ultra-rare", "mythic", "legendary"].includes(normalized)) return "storybook";
       if (["rare", "super-rare"].includes(normalized)) return "rare";
       if (normalized === "uncommon") return "curious";
       return "everyday";
     }
 
-    function actionCardType(action) {
-      const semanticTypes = {
-        notice: "notice",
-        inspect: "inspect",
-        scout: "scout",
-        travel: "travel",
-        contribute: "project",
-      };
-      const semantic = semanticTypes[String(action?.intention || "").toLowerCase()];
-      if (semantic) return semantic;
-      const explicit = normalizeActionCardType(action?.cardType || action?.type);
-      if (explicit) return explicit;
-      const label = String(action?.label || "").toLowerCase();
-      const command = String(action?.command || "").toLowerCase();
-      const focusKey = String(action?.focusKey || "").toLowerCase();
-      const detail = String(action?.detail || "").toLowerCase();
-      const risk = String(action?.risk || "").toLowerCase();
+    function friendlyCardRarity(rarity) {
+      return normalizeActionCardRarity(rarity);
+    }
 
-      if (label.includes("shuffle") || command === "shuffle" || focusKey === "shuffle-hand") return "shuffle";
-      if (label === "attack" || label === "defend" || command.startsWith("attack ") || command === "defend") return "combat";
-      if (label === "flee" || command.startsWith("flee") || risk.includes("danger")) return "danger";
-      if (label === "travel" || command.startsWith("go ")) return "travel";
-      if (label === "chat" || command.startsWith("chat ")) return "chat";
-      if (label === "leave an echo" || command.startsWith("echo ")) return "chat";
-      if (label === "illustrate" || command.startsWith("illustrate ")) return "illustrate";
-      if (label === "grow closer" || label === "bond" || label === "remember" || focusKey.includes("bond")) return "bond";
-      if (label === "listen" || label === "listen again" || label === "search" || label === "look" || command === "search" || command.startsWith("search ")) return "listen";
-      if (label === "evolve" || command === "evolve") return "evolve";
-      if (label === "practice" || label === "train" || command.startsWith("skill ")) return "train";
-      if (label === "trade" || label === "give") return "trade";
-      if (label === "take" || label === "swap") return "item";
-      if (label === "use") return detail.includes("progress") ? "craft" : "item";
-      if (label === "prepare" || label === "work" || label === "help" || label === "finish") return "project";
-      if (label === "rest") return "utility";
-      return "utility";
+    function actionCardSuit(action) {
+      if (String(action?.presentation?.family || "") !== "action") return "";
+      return normalizeActionCardSuit(action?.presentation?.suit);
     }
 
     function actionCardAccentClass(action) {
-      const cardType = actionCardType(action);
-      if (["combat", "notice", "inspect", "scout", "travel", "project"].includes(cardType)
-          && String(action?.intention || "")) {
-        return { cardType, rarity: "", className: `type-${cardType}` };
-      }
-      if (cardType === "combat") return { cardType, rarity: "", className: "type-combat" };
-      const rarity = normalizeActionCardRarity(action?.card?.rarity || action?.rarity || action?.target?.rarity);
-      return { cardType, rarity, className: `rarity-${rarity}` };
+      const suit = actionCardSuit(action);
+      const rarity = friendlyCardRarity(action?.presentation?.rarity);
+      return {
+        cardType: suit || "control",
+        suit,
+        rarity,
+        className: suit ? `suit-${suit}` : "card-control",
+      };
     }
 
     function setWalletQrStatus(message, kind = "ok") {
@@ -8821,7 +8774,7 @@
           ok: false,
           status: 409,
           events: [],
-          output: "That card is no longer in your hand. Think or choose one of the two current cards.",
+          output: "That card is no longer in your Story Hand. Think or choose a current card.",
         };
         setError(result.output);
         void queueRefresh();
@@ -9019,7 +8972,7 @@
       const clearFirstTaleAfterAction = firstTalePayoffVisible()
         && !/^(?:need[ -]time)$/i.test(command);
       if (/^(shuffle|deal|more|redraw)$/i.test(command)) {
-        setError("That free redeal command has retired. Choose Think to commit a pass.");
+        setError("That whole-hand redeal has retired. Focus one Story Hand card, then choose Think.");
         return null;
       }
       const beforeOrbs = economyOrbCount();
@@ -10580,6 +10533,7 @@
         || event.type === "actor.entered_location"
         || event.type === "actor.moved"
         || event.type === "hand.shuffled"
+        || event.type === "hand.thought"
         || event.type === "turn.ping_started"
         || event.type === "turn.pong"
         || event.type === "turn.ping_skipped"
@@ -11028,7 +10982,7 @@
       }
       const economyNode = $("economy");
       economyNode.innerHTML = parts.join("");
-      economyNode.setAttribute("aria-label", `${orbs} Orbs and carried deck status`);
+      economyNode.setAttribute("aria-label", `${orbs} Orbs and pack status`);
     }
 
     function exitUnavailable(exit, view = state) {
@@ -12424,7 +12378,10 @@
         return { kind: "move", label: "locked", text: event.destination_location_name || "path blocked" };
       }
       if (event.type === "hand.shuffled") {
-        return { kind: "hand", label: "hand", text: "new actions" };
+        return { kind: "hand", label: "hand", text: "Story Hand changed" };
+      }
+      if (event.type === "hand.thought") {
+        return { kind: "hand", label: "think", text: "one Story Hand card changed" };
       }
       if (event.type === "turn.ping_started") {
         const actor = event.actor_name || "someone";
@@ -12513,7 +12470,7 @@
       if (type.startsWith("combat.")) return "combat";
       if (type === "exit.discovered") return "search";
       if (type === "encounter.reset") return "combat";
-      if (type === "hand.shuffled") return "hand";
+      if (type === "hand.shuffled" || type === "hand.thought") return "hand";
       if (type.startsWith("turn.")) return "hand";
       if (
         type === "job.contribution.resolved"
@@ -12534,6 +12491,7 @@
       if (type === "exit.discovered") return "entrance";
       if (type === "encounter.reset") return "frontier";
       if (type === "hand.shuffled") return "hand";
+      if (type === "hand.thought") return "think";
       if (type.startsWith("turn.")) return "turn";
       if (type === "job.contribution.resolved") return "approach";
       if (type === "clock.updated") return "clock";
@@ -12639,7 +12597,7 @@
 
     function menuNavHtml(active = menuSection) {
       const entries = [
-        ["deck", "deck"],
+        ["deck", "pack"],
         ["character", "character"],
         ["identity", "sign in / identity"],
         ["world", "worlds & packs"],
@@ -12669,7 +12627,8 @@
     function deckCardRow(card, actionHtml = "") {
       const skill = card.skill_id ? ` · ${card.skill_id.replaceAll("_", " ")} ${Number(card.skill_bonus || 0) >= 0 ? "+" : ""}${card.skill_bonus || 0}` : "";
       const charges = ["spell", "consumable"].includes(String(card.role || "")) ? ` · ${Number(card.charges || 0)} use${Number(card.charges || 0) === 1 ? "" : "s"}` : "";
-      return `<div class="deck-card"><div class="deck-card-copy"><strong>${escapeHtml(card.name || `Item ${card.id}`)}</strong><small>${escapeHtml(`${card.zone || "carried"} · ${card.role || "generic"} · ${card.size || "small"} · ${deckWeightLabel(card.weight_tenths)}${charges}${skill}`)}</small></div>${actionHtml}</div>`;
+      const zone = card.zone === "carried" ? "pack" : (card.zone || "pack");
+      return `<div class="deck-card"><div class="deck-card-copy"><strong>${escapeHtml(card.name || `Item ${card.id}`)}</strong><small>${escapeHtml(`${zone} · ${card.role || "generic"} · ${card.size || "small"} · ${deckWeightLabel(card.weight_tenths)}${charges}${skill}`)}</small></div>${actionHtml}</div>`;
     }
 
     function deckPanelHtml() {
@@ -12707,15 +12666,15 @@
           actionParts.push(`<button class="account-button secondary" type="button" data-set-contained="${card.id}" data-container="${firstContainer.id}">put in ${escapeHtml(firstContainer.name)}</button>`);
         }
         return deckCardRow(card, actionParts.join(""));
-      }).join("") : `<div class="deck-empty">Your carried deck is empty. Pick up item cards in the world.</div>`;
+      }).join("") : `<div class="deck-empty">Your pack is empty. Pick up item cards in the world.</div>`;
       const spellRows = spells.length ? spells.map((card) => {
         const prepared = preparedSpellIds.has(Number(card.id));
         const exhausted = exhaustedSpellIds.has(Number(card.id));
         const actionHtml = exhausted
-          ? `<span class="account-wallet">exhausted</span>`
+          ? `<span class="account-wallet">spent</span>`
           : `<button class="account-button secondary" type="button" data-set-spell="${card.id}" data-prepared="${prepared ? "false" : "true"}"${!prepared && preparedSpells.length >= spellSlots ? " disabled" : ""}>${prepared ? "unprepare" : "prepare"}</button>`;
         return deckCardRow(card, actionHtml);
-      }).join("") : `<div class="deck-empty">No spell cards are currently carried.</div>`;
+      }).join("") : `<div class="deck-empty">No spell cards are in your pack.</div>`;
       const loadoutRows = [deck.equipped_weapon, ...(Array.isArray(deck.equipped_containers) ? deck.equipped_containers : [])]
         .filter(Boolean)
         .map((card) => deckCardRow(card))
@@ -12727,9 +12686,9 @@
       const validation = validationErrors.map((message) => `<div class="deck-empty">${escapeHtml(message)}</div>`).join("");
       const previews = bagPreviews.map((message) => `<div class="item-note">${escapeHtml(message)}</div>`).join("");
       const exhaustedRows = exhaustedCards.length
-        ? exhaustedCards.map((card) => deckCardRow(card, `<span class="account-wallet">exhausted</span>`)).join("")
-        : `<div class="deck-empty">No cards are exhausted.</div>`;
-      return `<div class="account-title"><h2 id="account-panel-title">your deck</h2><span class="account-wallet">physical cards, not a fixed card count</span></div><div class="deck-summary"><div class="deck-stat"><strong>${escapeHtml(deckWeightLabel(deck.carried_weight_tenths))} / ${escapeHtml(deckWeightLabel(deck.carrying_capacity_tenths))}</strong><small>carried weight · base ${escapeHtml(deckWeightLabel(deck.base_carrying_capacity_tenths))} + equipped bags ${escapeHtml(deckWeightLabel(deck.container_capacity_tenths))}</small></div><div class="deck-stat"><strong>${equipped.length} / ${slots}</strong><small>bracelet charm slots</small></div><div class="deck-stat"><strong>${preparedSpells.length} / ${spellSlots}</strong><small>prepared spell cards</small></div></div>${validation}${previews}<div class="account-section-title">equipped loadout</div>${loadoutRows ? `<div class="deck-card-list">${loadoutRows}</div>` : `<div class="deck-empty">No weapon or bag is equipped.</div>`}<div class="account-section-title">containers</div>${containerRows || `<div class="deck-empty">No container cards are carried.</div>`}<div class="account-section-title">skill charms</div>${charmRows ? `<div class="deck-card-list">${charmRows}</div>` : `<div class="deck-empty">Find, earn, trade, or steal a skill charm before you can wear it.</div>`}${unlock}<div class="account-section-title">spell deck</div><div class="item-note">Only prepared spell cards can be cast. Spent cards remain in the deck as exhausted until a rule refreshes them.</div><div class="deck-card-list">${spellRows}</div><div class="account-section-title">exhausted / discard</div><div class="deck-card-list">${exhaustedRows}</div><div class="account-section-title">all carried cards</div><div class="deck-card-list">${carriedRows}</div>`;
+        ? exhaustedCards.map((card) => deckCardRow(card, `<span class="account-wallet">spent</span>`)).join("")
+        : `<div class="deck-empty">No cards are spent.</div>`;
+      return `<div class="account-title"><h2 id="account-panel-title">your pack</h2><span class="account-wallet">physical cards, not a fixed card count</span></div><div class="deck-summary"><div class="deck-stat"><strong>${escapeHtml(deckWeightLabel(deck.carried_weight_tenths))} / ${escapeHtml(deckWeightLabel(deck.carrying_capacity_tenths))}</strong><small>pack weight · base ${escapeHtml(deckWeightLabel(deck.base_carrying_capacity_tenths))} + equipped bags ${escapeHtml(deckWeightLabel(deck.container_capacity_tenths))}</small></div><div class="deck-stat"><strong>${equipped.length} / ${slots}</strong><small>bracelet charm slots</small></div><div class="deck-stat"><strong>${preparedSpells.length} / ${spellSlots}</strong><small>prepared spells</small></div></div>${validation}${previews}<div class="account-section-title">loadout</div>${loadoutRows ? `<div class="deck-card-list">${loadoutRows}</div>` : `<div class="deck-empty">No weapon or bag is equipped.</div>`}<div class="account-section-title">containers</div>${containerRows || `<div class="deck-empty">No container cards are carried.</div>`}<div class="account-section-title">skill charms</div>${charmRows ? `<div class="deck-card-list">${charmRows}</div>` : `<div class="deck-empty">Find, earn, trade, or steal a skill charm before you can wear it.</div>`}${unlock}<div class="account-section-title">prepared spells</div><div class="item-note">Only prepared spells can be cast. Spent cards remain in your pack until a rule refreshes them.</div><div class="deck-card-list">${spellRows}</div><div class="account-section-title">spent</div><div class="deck-card-list">${exhaustedRows}</div><div class="account-section-title">pack</div><div class="deck-card-list">${carriedRows}</div>`;
     }
 
     function journalPanelHtml() {
@@ -12741,7 +12700,7 @@
       const deck = state?.deck || {};
       const largeText = localStorage.getItem("cosyworld.ui.largeText") === "true";
       const reduceMotion = localStorage.getItem("cosyworld.ui.reduceMotion") === "true";
-      return `<div class="account-title"><h2 id="account-panel-title">orbs & settings</h2><span class="account-wallet">${escapeHtml(String(economy.orbs || 0))} Orbs</span></div><div class="setting-list"><label class="setting-row"><span class="setting-copy"><strong>Larger text</strong><small>Increase interface and story text throughout the game.</small></span><input type="checkbox" data-ui-setting="largeText"${largeText ? " checked" : ""} /></label><label class="setting-row"><span class="setting-copy"><strong>Reduce motion</strong><small>Minimize dealing, pulsing, and transition animation.</small></span><input type="checkbox" data-ui-setting="reduceMotion"${reduceMotion ? " checked" : ""} /></label></div><div class="account-section"><div class="account-section-title">About Orbs</div><div class="item-note">Orbs fund community images only. They do not buy stronger actions.</div>${accountRow("Chat", "a short avatar and resident exchange")}${accountRow("Befriend", "uses advancement to begin a friendship")}${accountRow("room voices", "one contextual reply per armed card heartbeat")}${accountRow("AI", openRouterApiKey() ? "your OpenRouter connection" : "world default")}${accountRow("carried deck", `${deckWeightLabel(deck.carried_weight_tenths)} / ${deckWeightLabel(deck.carrying_capacity_tenths)}`)}</div>`;
+      return `<div class="account-title"><h2 id="account-panel-title">orbs & settings</h2><span class="account-wallet">${escapeHtml(String(economy.orbs || 0))} Orbs</span></div><div class="setting-list"><label class="setting-row"><span class="setting-copy"><strong>Larger text</strong><small>Increase interface and story text throughout the game.</small></span><input type="checkbox" data-ui-setting="largeText"${largeText ? " checked" : ""} /></label><label class="setting-row"><span class="setting-copy"><strong>Reduce motion</strong><small>Minimize dealing, pulsing, and transition animation.</small></span><input type="checkbox" data-ui-setting="reduceMotion"${reduceMotion ? " checked" : ""} /></label></div><div class="account-section"><div class="account-section-title">About Orbs</div><div class="item-note">Orbs fund community images only. They do not buy stronger actions.</div>${accountRow("Chat", "a short avatar and resident exchange")}${accountRow("Befriend", "uses advancement to begin a friendship")}${accountRow("room voices", "one contextual reply per armed card heartbeat")}${accountRow("AI", openRouterApiKey() ? "your OpenRouter connection" : "world default")}${accountRow("pack", `${deckWeightLabel(deck.carried_weight_tenths)} / ${deckWeightLabel(deck.carrying_capacity_tenths)}`)}</div>`;
     }
 
     function libraryPanelHtml() {
@@ -13044,7 +13003,7 @@
         const skill = abilityLabel(charm.skill_id, charm.skill_id || "skill");
         const bonus = Math.max(0, Number(charm.skill_bonus || 0));
         return `${charm.name} — ${skill}${bonus ? ` +${bonus}` : ""}`;
-      }).join(", ") : "find a skill charm, then wear it from Deck"));
+      }).join(", ") : "find a skill charm, then wear it from Pack"));
       const bonds = Array.isArray(state?.bonds) ? state.bonds : [];
       rows.push(accountRow("relationships", bonds.length ? bonds.map((bond) => {
         const name = String(bond.target_actor_name || "someone").trim();
@@ -13920,7 +13879,8 @@
       if (event.type === "branch.opened") return `opens a choice with ${event.target_actor_name}.`;
       if (event.type === "branch.resolved") return `finishes a choice with ${event.target_actor_name}.`;
       if (event.type === "branch.expired") return `lets a choice with ${event.target_actor_name} fade.`;
-      if (event.type === "hand.shuffled") return "draws a new hand.";
+      if (event.type === "hand.shuffled") return "changes their Story Hand.";
+      if (event.type === "hand.thought") return "thinks and changes one Story Hand card.";
       if (event.type === "ability_check.rolled") return abilityCheckEventText(event);
       if (event.type === "study.resolved") {
         return event.content?.includes("yielded")
@@ -15005,39 +14965,30 @@
     }
 
     function actionEmoji(action) {
-      const byType = {
-        travel: "🥾", notice: "👁️", inspect: "🔎", scout: "🧭", chat: "💬", illustrate: "🖼️", bond: "💞", listen: "👂", train: "🎯", trade: "🤝",
-        evolve: "🌱", bank: "✨", craft: "🛠️", project: "🧩", item: "🎒", combat: "⚔️", danger: "⚠️",
-        shuffle: "🔄", utility: "🪄",
+      const bySuit = {
+        wonder: "👁️",
+        way: "🧭",
+        heart: "💞",
+        hand: "🛠️",
+        courage: "🛡️",
+        hearth: "🔥",
       };
-      return byType[actionCardType(action)] || cardEmoji(action?.card, action?.shape);
+      return bySuit[actionCardSuit(action)] || cardEmoji(action?.card, action?.shape);
     }
 
     function actionIconName(action) {
       const label = String(action?.label || action?.command || "").trim().toLowerCase();
       if (label === "dodge") return "shield";
       if (label === "escape" || label === "flee") return "travel";
-      const byType = {
-        travel: "travel",
-        notice: "notice",
-        inspect: "inspect",
-        scout: "scout",
-        chat: "chat",
-        illustrate: "craft",
-        bond: "bond",
-        listen: "listen",
-        train: "train",
-        evolve: "evolve",
-        trade: "trade",
-        bank: "bank",
-        craft: "craft",
-        project: "project",
-        item: "item",
-        combat: "combat",
-        danger: "danger",
-        utility: "utility",
+      const bySuit = {
+        wonder: "notice",
+        way: "travel",
+        heart: "bond",
+        hand: "craft",
+        courage: "shield",
+        hearth: "utility",
       };
-      return byType[actionCardType(action)] || cardRoleIconName(action?.card, action?.shape);
+      return bySuit[actionCardSuit(action)] || cardRoleIconName(action?.card, action?.shape);
     }
 
     function emojiHtml(emoji) {
@@ -15045,6 +14996,8 @@
     }
 
     function handProviderReason(action) {
+      const source = action?.presentation?.source;
+      if (source?.label) return `From ${source.label}`;
       return String(action?.handProvider?.reason || "").trim();
     }
 
@@ -15788,12 +15741,13 @@
           String(entry?.intention || ""),
           String(entry?.provider?.kind || ""),
           String(entry?.provider?.id || ""),
+          String(entry?.slot || ""),
+          String(entry?.suit || ""),
+          String(entry?.think?.offer_id || ""),
         ]),
-        pass: [
+        think: [
           String(view?.action_hand?.generation || ""),
-          String(view?.action_hand?.pass?.offer_id || ""),
-          String(view?.action_hand?.pass?.state_revision || ""),
-          String(view?.action_hand?.pass?.scene_key || ""),
+          ...(view?.action_hand?.entries || []).map((entry) => String(entry?.think?.offer_id || "")),
         ],
       });
     }
@@ -15801,6 +15755,12 @@
     function actionMatchesProjectedHandEntry(action, entry) {
       const offerIds = Array.isArray(action?.offerIds) ? action.offerIds : [];
       return offerIds.includes(String(entry?.offer_id || ""));
+    }
+
+    function projectedHandEntryForAction(action) {
+      return (state?.action_hand?.entries || []).find((entry) => (
+        actionMatchesProjectedHandEntry(action, entry)
+      )) || null;
     }
 
     function actionIndexForHandKey(key) {
@@ -15838,7 +15798,7 @@
     }
 
     function handCapacity() {
-      return 2;
+      return state?.branch ? 2 : Number(state?.action_hand?.capacity || 3);
     }
 
     function validActionHandKeySet() {
@@ -16008,6 +15968,7 @@
         button.removeAttribute("data-action-index");
         button.removeAttribute("data-hand-key");
         button.removeAttribute("data-card-type");
+        button.removeAttribute("data-card-suit");
         button.removeAttribute("data-card-rarity");
         button.removeAttribute("data-story-guide");
         button.classList.remove(...actionCardAccentClasses);
@@ -16034,12 +15995,14 @@
       if (action.command) button.dataset.command = action.command;
       else button.removeAttribute("data-command");
       button.classList.remove(...actionCardAccentClasses);
-      const { cardType, rarity, className } = actionCardAccentClass(action);
+      const { cardType, suit, rarity, className } = actionCardAccentClass(action);
       const storyGuide = action.storyGuide === true;
       const storyGuideLabel = storyGuide
         ? String(action.storyGuideLabel || "next tale beat")
         : "";
       button.dataset.cardType = cardType;
+      if (suit) button.dataset.cardSuit = suit;
+      else button.removeAttribute("data-card-suit");
       if (rarity) button.dataset.cardRarity = rarity;
       else button.removeAttribute("data-card-rarity");
       button.classList.add(className);
@@ -16062,11 +16025,31 @@
         button.removeAttribute("data-hand-key");
         button.classList.remove("dealt");
       }
+      const presentation = action.presentation || {};
+      const exactVerb = String(
+        String(action?.intention || "").toLowerCase() === "travel"
+          ? "Travel"
+          : (presentation.verb || action.label || "Act")
+      ).trim();
+      const cardTitle = String(
+        action.destinationOnlyCardLabel
+          || action.target?.label
+          || action.card?.display_name
+          || action.detail
+          || action.label
+          || "Action"
+      ).trim();
+      const effectText = friendlyActionText(presentation.effect || action.effect);
+      const riskText = friendlyActionText(presentation.risk || action.risk);
+      const orbCost = Number(presentation.cost?.orbs || action.orbCost || 0);
+      const costText = orbCost ? `${orbCost} Orb${orbCost === 1 ? "" : "s"}` : "free";
+      const sourceText = handProviderReason(action);
       const title = [
-        action.pathwayDirection ? "" : action.command,
-        handProviderReason(action),
-        friendlyActionText(action.effect),
-        friendlyActionText(action.risk),
+        suit ? `${suit} · ${exactVerb}` : exactVerb,
+        cardTitle,
+        effectText,
+        [costText, riskText].filter(Boolean).join(" · "),
+        sourceText,
       ].filter(Boolean).join("; ");
       if (title) button.title = title;
       else button.removeAttribute("title");
@@ -16083,19 +16066,17 @@
       button.setAttribute(
         "aria-label",
         [
-          action.destinationOnlyCardAriaLabel || action.accessibleLabel || action.label,
-          destinationOnlyCardLabel ? "" : detail,
-          destinationOnlyCardLabel ? "" : handProviderReason(action),
+          suit ? `${suit} suit` : "control",
+          exactVerb,
+          action.destinationOnlyCardAriaLabel || action.accessibleLabel || cardTitle,
+          destinationOnlyCardLabel ? "" : effectText,
+          [costText, riskText].filter(Boolean).join(", "),
+          destinationOnlyCardLabel ? "" : sourceText,
           storyGuideLabel,
           count ? `suggestion ${count}` : "",
           action.busy ? "in progress" : "",
         ].filter(Boolean).join(", ")
       );
-      if (cardType === "shuffle") {
-        button.classList.add("has-copy");
-        button.innerHTML = `<span class="shuffle-glyph" aria-hidden="true">•••</span><span class="cmd-label">${iconSvg("cards")}${escapeHtml(compactActionLabel(action) || "all")}</span>`;
-        return;
-      }
       const directionArrow = action.pathwayDirection?.side === "back"
         ? "←"
         : (action.pathwayDirection?.side === "forward" ? "→" : "↔");
@@ -16103,23 +16084,26 @@
         ? `<span class="thumb pathway-direction-thumb" aria-hidden="true">${directionArrow}</span>`
         : thumbnailHtml(action, false, "action-mini-card");
       button.classList.add("has-copy");
-      const labelText = destinationOnlyCardLabel
-        || compactActionLabel(action)
-        || String(action.command || "action").toLowerCase();
-      const detailHtml = detail && !destinationOnlyCardLabel
-        ? `<span class="detail">${escapeHtml(detail)}</span>`
+      const labelText = cardTitle;
+      const detailHtml = effectText && !destinationOnlyCardLabel
+        ? `<span class="detail">${escapeHtml(effectText)}</span>`
         : "";
       const storyHtml = storyGuide && !destinationOnlyCardLabel
         ? `<span class="story-call">✦ ${escapeHtml(storyGuideLabel)}</span>`
         : "";
-      const providerReason = destinationOnlyCardLabel ? "" : handProviderReason(action);
+      const providerReason = destinationOnlyCardLabel ? "" : sourceText;
       const providerHtml = providerReason
         ? `<span class="provider-call">↳ ${escapeHtml(providerReason)}</span>`
         : "";
       const busyHtml = action.busy
         ? `<span class="action-progress" role="progressbar" aria-label="Action in progress" aria-valuetext="in progress"></span>`
         : "";
-      button.innerHTML = `${thumb}<span class="cmd-copy"><span class="cmd-label">${iconSvg(actionIconName(action))}${escapeHtml(labelText)}</span>${detailHtml}${providerHtml}${storyHtml}</span>${busyHtml}`;
+      const kicker = suit ? `${suit} · ${exactVerb}` : exactVerb;
+      const economy = [costText, riskText].filter(Boolean).join(" · ");
+      const rarityMark = suit
+        ? `<span class="collectible-mark" title="${escapeAttr(`${rarity} · ${presentation.provenance || "core"}`)}" aria-hidden="true">◇</span>`
+        : "";
+      button.innerHTML = `${thumb}<span class="cmd-copy"><span class="cmd-kicker">${escapeHtml(kicker)}</span><span class="cmd-label">${iconSvg(actionIconName(action))}${escapeHtml(labelText)}</span>${detailHtml}<span class="cmd-meta">${escapeHtml(economy)}</span>${providerHtml}${storyHtml}</span>${rarityMark}${busyHtml}`;
     }
 
     function actionBarActions() {
@@ -16166,7 +16150,7 @@
       focusedKey = action.focusKey || "";
       renderRoomAvatarRail();
       renderCommands();
-      $((["primary", "secondary"])[next])?.focus();
+      $((["primary", "secondary", "tertiary"])[next])?.focus();
     }
 
     function isDefinitivePassRejection(result = {}) {
@@ -16184,21 +16168,23 @@
       handShuffleBusy = true;
       button.disabled = true;
       try {
-        const pass = state?.action_hand?.pass;
-        if (!pass?.offer_id) {
-          setError("Think is not available until the current hand arrives.");
+        const focused = visibleFocusedAction();
+        const entry = projectedHandEntryForAction(focused);
+        const think = entry?.think;
+        if (!think?.available || !think?.offer_id) {
+          setError("Choose a Story Hand card that has another possibility, then Think again.");
           return null;
         }
-        if (handPassSubmission?.offer_id !== pass.offer_id) {
+        if (handPassSubmission?.offer_id !== think.offer_id) {
           handPassSubmission = {
-            offer_id: pass.offer_id,
+            offer_id: think.offer_id,
             envelope: canonicalCommandEnvelope(),
           };
         }
         const result = await postResult("/commands", withAccess({
           actor_id: actorId,
           actor_session: actorSession,
-          command: "pass",
+          command: "think",
           offer_id: handPassSubmission.offer_id,
           envelope: handPassSubmission.envelope,
         }));
@@ -16215,24 +16201,18 @@
           return result;
         }
         handPassSubmission = null;
-        const thoughtRoll = (result.events || []).find((event) => (
-          event.type === "ability_check.rolled" && event.content === "think"
-        ));
-        if (!thoughtRoll) {
-          setError("The hand passed, but no reflection check was returned.");
-        }
         await refresh();
         renderCommands();
         return result;
       } finally {
         handShuffleBusy = false;
-        button.disabled = false;
+        renderCommands();
       }
     }
 
     function renderCommands() {
       const prompt = document.querySelector(".prompt");
-      const buttonIds = ["primary", "secondary"];
+      const buttonIds = ["primary", "secondary", "tertiary"];
       const drawButton = $("shuffle");
       renderTurnPingPill();
       prompt.classList.toggle("single-action", actionBusy);
@@ -16259,21 +16239,31 @@
         return;
       }
       const choiceMode = Boolean(state?.branch && actions.length > 1);
+      const visibleActions = actionBarActions().slice(0, handCapacity());
+      const focusedVisibleAction = visibleActions.find((action) => action.actionIndex === focusIndex)
+        || visibleActions[0]
+        || null;
+      const focusedThink = projectedHandEntryForAction(focusedVisibleAction)?.think || null;
       const canDraw = !state?.branch
         && actorId
         && actorSession
         && state?.primary_action?.kind !== "create_avatar"
-        && Boolean(state?.action_hand?.pass?.offer_id)
+        && (state?.action_hand?.entries || []).some((entry) => entry?.think?.available)
         && (!state?.combat || state?.turn?.is_current_actor);
       prompt.classList.toggle("combat-mode", Boolean(state?.combat));
       prompt.classList.toggle("choice-mode", choiceMode);
       prompt.classList.toggle("has-draw", canDraw);
       drawButton.style.display = canDraw ? "flex" : "none";
-      drawButton.disabled = handShuffleBusy;
-      const passLabel = state?.action_hand?.pass?.label || "Think";
-      drawButton.querySelector(".cmd-label").textContent = passLabel.toLowerCase();
-      drawButton.setAttribute("aria-label", `${passLabel}: commit a pass for the current two actions`);
-      const visibleActions = actionBarActions().slice(0, handCapacity());
+      drawButton.disabled = handShuffleBusy || !focusedThink?.available;
+      const thinkCost = focusedThink?.free ? "free" : "uses this turn";
+      const thinkSlot = String(focusedThink?.slot || focusedVisibleAction?.storyHandSlot || "focused");
+      drawButton.querySelector(".cmd-label").textContent = focusedThink?.free ? "think · free" : "think";
+      drawButton.setAttribute(
+        "aria-label",
+        focusedThink?.available
+          ? `Think: replace the ${thinkSlot} card; ${thinkCost}`
+          : `Think: the ${thinkSlot} card has no other current possibility`,
+      );
       for (let index = 0; index < buttonIds.length; index += 1) {
         const id = buttonIds[index];
         const visibleAction = visibleActions[index]
@@ -17146,6 +17136,11 @@
 
     $("secondary").addEventListener("click", () => {
       const action = actionForButton("secondary") || (state?.branch ? actions[1] : null);
+      if (action) openActionModal(action);
+    });
+
+    $("tertiary").addEventListener("click", () => {
+      const action = actionForButton("tertiary");
       if (action) openActionModal(action);
     });
 

--- a/v2/orchestrator-rust/src/lantern_keeper_tests.rs
+++ b/v2/orchestrator-rust/src/lantern_keeper_tests.rs
@@ -596,7 +596,7 @@ fn runtime_ready_for_lantern_finale() -> (RuntimeWorld, Vec<u64>) {
 }
 
 #[test]
-fn lantern_question_projects_two_truthful_suggestions_and_replays_danger_memory() {
+fn lantern_question_projects_three_truthful_suggestions_and_replays_danger_memory() {
     let actor_id = 9_850;
     let mut runtime = RuntimeWorld::seeded();
     create_test_human(&mut runtime, actor_id, 800, "Road Reader");
@@ -620,7 +620,7 @@ fn lantern_question_projects_two_truthful_suggestions_and_replays_danger_memory(
     );
     assert!(!initial_question.danger_situation.is_empty());
     assert!(!initial_question.danger_consequence.is_empty());
-    assert_eq!(initial_question.suggested_actions.len(), 2);
+    assert_eq!(initial_question.suggested_actions.len(), 3);
     assert_eq!(
         initial_question
             .suggested_actions

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -933,6 +933,13 @@ enum ProjectionMutation {
     ShuffleHand {
         reason: String,
     },
+    ThinkHand {
+        slot: u8,
+        scene_key: String,
+        replaces_offer_id: String,
+        free: bool,
+        reason: String,
+    },
     StartTreasureObjective(projection_ledger::StartTreasureObjective),
     UpdateCardPolicyPreference {
         update: CardPolicyPreferenceUpdate,
@@ -1581,6 +1588,7 @@ struct RuntimeWorld {
     // This is the authoritative per-actor hand rotation. The event log is a
     // bounded presentation projection and must never determine a certificate.
     hand_generations: BTreeMap<u64, u64>,
+    story_hand_states: BTreeMap<u64, StoryHandActorState>,
     presence_states: BTreeMap<u64, bool>,
     event_log: Vec<EventView>,
     recent_room_lines: BTreeMap<u64, Vec<EventView>>,
@@ -1608,6 +1616,8 @@ struct RuntimeSnapshot {
     action_journal_seq: u64,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     hand_generations: BTreeMap<u64, u64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    story_hand_states: BTreeMap<u64, StoryHandActorState>,
 
     world_version: u32,
     tick: u64,
@@ -2878,6 +2888,36 @@ struct RankedActionOffer {
     ranked_hand_eligible: bool,
 }
 
+/// Public semantics for an action card. These dimensions deliberately stay
+/// separate: suit is navigation, verb is the exact action, source explains
+/// why it is available, and provenance/rarity describe collectibility rather
+/// than power.
+#[derive(Clone, Debug, Serialize)]
+struct ActionCardPresentationView {
+    family: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suit: Option<String>,
+    verb: String,
+    source: ActionCardSourceView,
+    state: String,
+    provenance: String,
+    rarity: String,
+    power: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cost: Option<ActionCostView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    risk: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effect: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ActionCardSourceView {
+    kind: String,
+    id: String,
+    label: String,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 struct ActionSourceCollectibleView {
     kind: String,
@@ -2932,6 +2972,11 @@ struct ActionHandPassView {
     state_revision: u64,
     generation: u64,
     scene_key: String,
+    slot: String,
+    replaces_offer_id: String,
+    free: bool,
+    consumes_turn: bool,
+    available: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -2940,6 +2985,18 @@ struct ActionHandEntryView {
     kind: String,
     intention: String,
     provider: ActionProviderView,
+    slot: String,
+    suit: String,
+    verb: String,
+    think: ActionHandPassView,
+    replacement_count: u16,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+struct StoryHandActorState {
+    scene_key: String,
+    slot_generations: [u64; 3],
+    free_think_used: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -5097,7 +5154,7 @@ impl RuntimeSnapshot {
             )
             .collect::<Vec<_>>();
         Self {
-            version: 18,
+            version: 19,
             worldpack_bundle_hash: active_content().manifest.bundle_hash.clone(),
             content_context: content_registry().content_reference_context(content_handles),
             rules_profile: active_content().manifest.rules_profile.clone(),
@@ -5106,6 +5163,7 @@ impl RuntimeSnapshot {
             pack_mount_state: runtime.pack_mount_state.clone(),
             action_journal_seq: runtime.action_journal_seq,
             hand_generations: runtime.hand_generations.clone(),
+            story_hand_states: runtime.story_hand_states.clone(),
 
             world_version: runtime.world.version,
             tick: runtime.world.tick,
@@ -5205,6 +5263,16 @@ impl RuntimeSnapshot {
                     }
                 }
             }
+        }
+        let mut story_hand_states = self.story_hand_states;
+        for (actor_id, generation) in &hand_generations {
+            story_hand_states
+                .entry(*actor_id)
+                .or_insert_with(|| StoryHandActorState {
+                    scene_key: String::new(),
+                    slot_generations: [*generation; 3],
+                    free_think_used: false,
+                });
         }
         let compatibility_bundle_hash = self.worldpack_bundle_hash.clone();
         let compatibility =
@@ -5428,6 +5496,7 @@ impl RuntimeSnapshot {
             pack_mount_state: self.pack_mount_state,
             action_journal_seq: self.action_journal_seq,
             hand_generations,
+            story_hand_states,
             presence_states: BTreeMap::new(),
             event_log: self.event_log,
             recent_room_lines: self.recent_room_lines,
@@ -5851,6 +5920,7 @@ impl RuntimeWorld {
             pack_mount_state: PackMountState::default(),
             action_journal_seq: 0,
             hand_generations: BTreeMap::new(),
+            story_hand_states: BTreeMap::new(),
             presence_states: BTreeMap::new(),
             event_log: Vec::new(),
             recent_room_lines: BTreeMap::new(),
@@ -8242,12 +8312,61 @@ impl RuntimeWorld {
     fn append_hand_shuffled_event(&mut self, actor_id: u64, reason: &str) -> EventView {
         let generation = self.hand_generations.entry(actor_id).or_default();
         *generation = generation.saturating_add(1);
+        self.append_hand_projection_event(actor_id, "hand.shuffled", reason)
+    }
+
+    fn append_story_hand_thought_event(
+        &mut self,
+        actor_id: u64,
+        thought: (u8, &str, &str, bool, &str),
+    ) -> EventView {
+        let (slot, scene_key, replaces_offer_id, free, reason) = thought;
+        let legacy_generation = self
+            .hand_generations
+            .get(&actor_id)
+            .copied()
+            .unwrap_or_default();
+        let state = self.story_hand_states.entry(actor_id).or_default();
+        if state.scene_key != scene_key {
+            let slot_generations = if state.scene_key.is_empty() {
+                if state.slot_generations == [0; 3] && legacy_generation > 0 {
+                    [legacy_generation; 3]
+                } else {
+                    state.slot_generations
+                }
+            } else {
+                [0; 3]
+            };
+            *state = StoryHandActorState {
+                scene_key: scene_key.to_string(),
+                slot_generations,
+                ..StoryHandActorState::default()
+            };
+        }
+        let slot_index = usize::from(slot).min(state.slot_generations.len() - 1);
+        state.slot_generations[slot_index] = state.slot_generations[slot_index].saturating_add(1);
+        state.free_think_used |= free;
+        let generation = self.hand_generations.entry(actor_id).or_default();
+        *generation = generation.saturating_add(1);
+        self.append_hand_projection_event(
+            actor_id,
+            "hand.thought",
+            &format!("{reason}:slot={slot}:free={free}:replaced={replaces_offer_id}"),
+        )
+    }
+
+    fn append_hand_projection_event(
+        &mut self,
+        actor_id: u64,
+        type_name: &str,
+        content: &str,
+    ) -> EventView {
         let location_id = self.actor_by_id(actor_id).map(|actor| actor.location_id);
         let event = EventView {
             world_id: official_world_id(),
             world_epoch: official_world_epoch(),
             seq: self.world.next_event_seq,
-            type_name: "hand.shuffled".to_string(),
+            type_name: type_name.to_string(),
             success: true,
             reason: 0,
             actor_id: opt_id(actor_id),
@@ -8259,7 +8378,7 @@ impl RuntimeWorld {
             destination_location_id: None,
             destination_location_name: None,
             content_id: None,
-            content: Some(reason.to_string()),
+            content: Some(content.to_string()),
             item_id: None,
             item_name: None,
             target_item_id: None,
@@ -9381,6 +9500,18 @@ impl RuntimeWorld {
                 }
                 ProjectionMutation::ShuffleHand { reason } => {
                     events.push(self.append_hand_shuffled_event(action.actor_id, reason));
+                }
+                ProjectionMutation::ThinkHand {
+                    slot,
+                    scene_key,
+                    replaces_offer_id,
+                    free,
+                    reason,
+                } => {
+                    events.push(self.append_story_hand_thought_event(
+                        action.actor_id,
+                        (*slot, scene_key, replaces_offer_id, *free, reason),
+                    ));
                 }
                 ProjectionMutation::StartTreasureObjective(mutation) => {
                     if let Some(event) = mutation.apply(self, &ctx) {
@@ -14055,7 +14186,7 @@ impl RuntimeWorld {
         }
         if economy.carrying_capacity_tenths > 0 {
             parts.push(format!(
-                "carried deck: {:.1}/{:.1} lb across {} card(s)",
+                "pack: {:.1}/{:.1} lb across {} card(s)",
                 economy.carried_weight_tenths as f64 / 10.0,
                 economy.carrying_capacity_tenths as f64 / 10.0,
                 economy.inventory_count
@@ -15221,7 +15352,7 @@ The relationship statement they are preserving is: {statement}"
             .into_iter()
             .find(|item| self.actor_can_exchange_items(actor_id, Some(*item), incoming))
             .map(|item| Some(item.id))
-            .ok_or_else(|| "That pickup cannot make room in the carried deck.".to_string())
+            .ok_or_else(|| "That pickup cannot make room in the pack.".to_string())
     }
 
     fn resident_player_gift_return_item(
@@ -16905,7 +17036,7 @@ The relationship statement they are preserving is: {statement}"
         let default_search_target = self.default_search_target(actor_id);
         let default_craft_recipe = self.default_craft_recipe(actor_id);
         // The kernel flag covers ordinary pickups, while the orchestrator can
-        // also authorize an exact exchange when a carried deck is full.
+        // also authorize an exact exchange when a carried Pack is full.
         // Keep the primary options in lockstep with those retargeted offers.
         let has_pickup_offer = offers.option_flags & CW_OFFER_PICK_UP != 0
             || !self.pickup_offer_items(actor_id).is_empty();
@@ -17359,7 +17490,7 @@ The relationship statement they are preserving is: {statement}"
         if !self.actor_can_exchange_items(actor.id, Some(offered_item), requested_item)
             || !self.actor_can_exchange_items(target.id, Some(requested_item), offered_item)
         {
-            return Err("That exchange would overfill one avatar's carried deck.".to_string());
+            return Err("That exchange would overfill one avatar's pack.".to_string());
         }
         Ok(())
     }
@@ -19979,7 +20110,10 @@ The relationship statement they are preserving is: {statement}"
                                 .1,
                         )
                         .pass;
-                    (pass.offer_id, format!("pass:{}", pass.scene_key))
+                    (
+                        pass.offer_id,
+                        format!("think:{}:{}", pass.scene_key, pass.slot),
+                    )
                 });
             chosen_offer = Some((offer_id.clone(), composition_id.clone(), None));
             candidates.push(ResidentDecisionCandidateTrace {
@@ -22204,7 +22338,7 @@ async fn submit_action_offer(
     }
 
     // A certificate is valid only for the hand that dealt it. Serialize its
-    // validation and the dispatched mutation with Think/Pass so a hand cannot
+    // validation and the dispatched mutation with Think so a hand cannot
     // rotate between those two steps.
     let canonical_command_lock = Arc::clone(&state.canonical_command_lock);
     let _command_guard = canonical_command_lock.lock().await;
@@ -25311,7 +25445,7 @@ async fn command_inner(
             command: resolved.command,
             verb: resolved.verb,
             output: Some(
-                "That is not a visible room control. Play one of the two current cards or Think."
+                "That is not a visible room control. Play a current Story Hand card or Think."
                     .to_string(),
             ),
             error_kind: Some(CommandErrorKind::UnknownOffer),
@@ -25331,7 +25465,7 @@ async fn command_inner(
     }
 
     match resolved.dispatch.clone() {
-        CommandDispatch::Pass { offer_id } => {
+        CommandDispatch::Pass { think } => {
             let Json(response) = pass_action(
                 ConnectInfo(client_addr),
                 State(state),
@@ -25339,7 +25473,7 @@ async fn command_inner(
                     actor_id: payload.actor_id,
                     actor_session: payload.actor_session,
                 }),
-                &offer_id,
+                &think,
             )
             .await;
             command_action_response_with_events(resolved, response, presence_events)
@@ -27407,7 +27541,7 @@ fn room_memory_label(event: &EventView) -> String {
         "actor.moved" | "combat.flee.success" => "move",
         "actor.created" | "actor.entered_location" => "join",
         "move.blocked" => "locked",
-        "hand.shuffled" => "hand",
+        "hand.shuffled" | "hand.thought" => "hand",
         "feature.searched"
         | "location.searched"
         | "exit.discovered"
@@ -42828,7 +42962,7 @@ mod tests {
         assert!(INDEX_HTML.contains("the world beyond"));
         assert!(INDEX_HTML.contains("function localWorldConditionBeat"));
         assert!(INDEX_HTML.contains("function deckPanelHtml"));
-        assert!(INDEX_HTML.contains("[\"deck\", \"deck\"]"));
+        assert!(INDEX_HTML.contains("[\"deck\", \"pack\"]"));
         assert!(INDEX_HTML.contains("[\"character\", \"character\"]"));
         assert!(!INDEX_HTML.contains("[\"collection\", \"collection & account\"]"));
         assert!(INDEX_HTML.contains("[\"identity\", \"sign in / identity\"]"));
@@ -42836,10 +42970,10 @@ mod tests {
         assert!(INDEX_HTML.contains("[\"journal\", \"journal\"]"));
         assert!(INDEX_HTML.contains("[\"settings\", \"orbs & settings\"]"));
         assert!(INDEX_HTML.contains("physical cards, not a fixed card count"));
-        assert!(INDEX_HTML.contains("carried weight · base"));
+        assert!(INDEX_HTML.contains("pack weight · base"));
         assert!(INDEX_HTML.contains("deck.charm_slot_expansion"));
         assert!(INDEX_HTML.contains("Make room"));
-        assert!(INDEX_HTML.contains("Only prepared spell cards can be cast"));
+        assert!(INDEX_HTML.contains("Only prepared spells can be cast"));
         assert!(!INDEX_HTML.contains("data-materialize-card"));
         assert!(!INDEX_HTML.contains("/collection/materialize"));
         assert!(!INDEX_HTML.contains("data-unmaterialize-receipt"));
@@ -43014,7 +43148,7 @@ mod tests {
         assert!(INDEX_HTML.contains("function pendingAvatarArrivalHtml"));
         assert!(INDEX_HTML.contains("the cottage is making room"));
         assert!(INDEX_HTML.contains("your first little moment is waiting"));
-        assert!(INDEX_HTML.contains("find a skill charm, then wear it from Deck"));
+        assert!(INDEX_HTML.contains("find a skill charm, then wear it from Pack"));
         assert!(INDEX_HTML.contains("someone new is waiting to meet you"));
         assert!(INDEX_HTML.contains("makes room for ${actor}"));
         assert!(!INDEX_HTML.contains(": \"nothing yet\""));
@@ -43055,8 +43189,23 @@ mod tests {
         assert!(INDEX_HTML.contains("\"/actions/need-time\""));
         assert!(!INDEX_HTML.contains("function drawAndPassOrderedSceneTurn"));
         assert!(INDEX_HTML.contains("function passHand"));
-        assert!(INDEX_HTML.contains("data-player-concept=\"pass\""));
-        assert!(INDEX_HTML.contains("free redeal command has retired"));
+        assert!(INDEX_HTML.contains("data-player-concept=\"think\""));
+        assert!(INDEX_HTML.contains("id=\"tertiary\""));
+        for suit in ["wonder", "way", "heart", "hand", "courage", "hearth"] {
+            assert!(INDEX_HTML.contains(&format!(".cmd.suit-{suit}")));
+        }
+        assert!(INDEX_HTML.contains(
+            "if (String(action?.presentation?.family || \"\") !== \"action\") return \"\";"
+        ));
+        assert!(
+            INDEX_HTML.contains("const rarity = friendlyCardRarity(action?.presentation?.rarity);")
+        );
+        assert!(!INDEX_HTML.contains("--rarity-"));
+        assert!(INDEX_HTML.contains("class=\"cmd-kicker\""));
+        assert!(INDEX_HTML.contains("class=\"cmd-meta\""));
+        assert!(INDEX_HTML.contains("class=\"provider-call\""));
+        assert!(INDEX_HTML.contains("class=\"collectible-mark\""));
+        assert!(INDEX_HTML.contains("whole-hand redeal has retired"));
         assert!(INDEX_HTML.contains("prompt.classList.toggle(\"combat-mode\""));
         assert!(!INDEX_HTML.contains("id=\"journal-activity-tray\""));
         assert!(INDEX_HTML.contains("id=\"journal-activity\""));
@@ -43092,7 +43241,7 @@ mod tests {
         assert!(INDEX_HTML.contains("const thumb = action.pathwayDirection"));
         assert!(INDEX_HTML.contains(": thumbnailHtml(action, false, \"action-mini-card\");"));
         assert!(INDEX_HTML.contains("button.classList.add(\"has-copy\");"));
-        assert!(INDEX_HTML.contains("<span class=\"cmd-copy\"><span class=\"cmd-label\">"));
+        assert!(INDEX_HTML.contains("<span class=\"cmd-copy\"><span class=\"cmd-kicker\">"));
         assert!(INDEX_HTML.contains("cardImage(card) || fallbackCardImage(fallback)"));
         assert!(INDEX_HTML.contains("CosyWorld item art"));
         assert!(INDEX_HTML.contains("function gardenHasDewbright"));
@@ -43183,6 +43332,9 @@ mod tests {
         assert!(INDEX_HTML.contains("function smallNumberWord"));
         assert!(INDEX_HTML.contains("choose who receives it"));
         assert!(INDEX_HTML.contains("From ${view.location.name}"));
+        assert!(INDEX_HTML.contains(
+            "targetBearingLabel(routeIntention, routeVerb, firstExit.destination_location_name)"
+        ));
         assert!(INDEX_HTML.contains("catch your breath"));
         assert!(!INDEX_HTML.contains("reply hook"));
         assert!(!INDEX_HTML.contains("authors a line"));
@@ -43280,8 +43432,9 @@ mod tests {
         assert!(!INDEX_HTML.contains("kept close</span>"));
         assert!(!INDEX_HTML.contains("id=\"card-modal-keepsake\""));
         assert!(!INDEX_HTML.contains("function keepsakePromise"));
-        assert!(!INDEX_HTML
-            .contains("This is a menu preference, not your physical carried deck or bracelet."));
+        assert!(
+            !INDEX_HTML.contains("This is a menu preference, not your physical Pack or bracelet.")
+        );
         assert!(!INDEX_HTML.contains(
             "can appear beside matching choices. It does not change available actions or odds."
         ));
@@ -48997,15 +49150,15 @@ mod tests {
         );
 
         let deck_command = runtime
-            .resolve_command(&command_request(5000, "deck"), &AccessContext::default())
-            .expect("deck command resolves");
+            .resolve_command(&command_request(5000, "pack"), &AccessContext::default())
+            .expect("Pack command resolves");
         match deck_command.dispatch {
             CommandDispatch::Read { output } => {
                 assert!(output.contains("Wolfprint Charm"));
                 assert!(output.contains("Bracelet: 0/1 charm slots"));
-                assert!(output.contains("Spell deck: 0/3 prepared (none prepared)"));
+                assert!(output.contains("Prepared spells: 0/3 (none prepared)"));
             }
-            other => panic!("deck should be a read command, got {other:?}"),
+            other => panic!("Pack should be a read command, got {other:?}"),
         }
         let wear_command = runtime
             .resolve_command(
@@ -49099,7 +49252,7 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_action_hand_is_the_deterministic_top_two_legal_offers() {
+    fn authoritative_story_hand_is_three_deterministic_legal_slots() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Hand Tester");
         let access = AccessContext::default();
@@ -49127,8 +49280,16 @@ mod tests {
         assert!(left_hand
             .iter()
             .all(|offer_id| legal_ids.contains(offer_id)));
-        assert_eq!(left.action_hand.capacity, 2);
-        assert_eq!(left.action_hand.entries.len(), 2);
+        assert_eq!(left.action_hand.capacity, 3);
+        assert_eq!(left.action_hand.entries.len(), 3);
+        assert_eq!(
+            left.action_hand
+                .entries
+                .iter()
+                .map(|entry| entry.slot.as_str())
+                .collect::<Vec<_>>(),
+            ["story", "self", "anchor"]
+        );
     }
 
     #[tokio::test]
@@ -49171,6 +49332,7 @@ mod tests {
             MOONLIT_TRAIL_LOCATION_ID,
             "Discovery Parity Tester",
         );
+        complete_guided_story_for_test(&mut runtime, 5000);
         runtime
             .draw_until_test_offer(5000, &AccessContext::default(), |offer| {
                 offer.kind == "study"
@@ -51871,7 +52033,7 @@ mod tests {
         assert!(output.contains(&question.situation));
         assert!(output.contains(&question.outcome));
 
-        assert_eq!(question.suggested_actions.len(), 2);
+        assert_eq!(question.suggested_actions.len(), 3);
         for suggestion in &question.suggested_actions {
             assert!(output.contains(&format!("target {}", suggestion.target_label)));
         }
@@ -53567,7 +53729,11 @@ mod tests {
         let defend = runtime
             .resident_combat_autonomy_record(encounter_id, 71_723, None)
             .expect("hurt inferred avatar chooses");
-        assert_eq!(defend.action.kind, CW_ACTION_COMBAT_DODGE);
+        assert_eq!(defend.action.kind, CW_ACTION_COMBAT_PASS);
+        assert!(defend
+            .projection_mutations
+            .iter()
+            .any(|mutation| matches!(mutation, ProjectionMutation::ThinkHand { .. })));
 
         runtime
             .world
@@ -53576,29 +53742,23 @@ mod tests {
             .find(|actor| actor.id == 5000)
             .expect("test human remains")
             .damage = 80;
-        let expected_pass = runtime
-            .action_hand_for(
-                Some(5000),
-                &runtime
-                    .legal_action_candidates(Some(5000), &AccessContext::default())
-                    .1,
-            )
-            .pass;
-        let expected_composition_id = format!("pass:{}", expected_pass.scene_key);
+        let all_offers = runtime
+            .legal_action_candidates(Some(5000), &AccessContext::default())
+            .1;
+        let expected_think = runtime.action_hand_for(Some(5000), &all_offers).pass;
+        let expected_composition_id =
+            format!("think:{}:{}", expected_think.scene_key, expected_think.slot);
         let replay_base = RuntimeSnapshot::from_runtime(&runtime);
-        let draw = runtime
+        let think = runtime
             .resident_combat_autonomy_record(encounter_id, 71_724, Some(77))
             .expect("badly hurt inferred avatar chooses");
-        assert_eq!(draw.origin, JournalOrigin::ActorConsequence);
-        assert_eq!(draw.action.kind, CW_ACTION_COMBAT_PASS);
-        assert!(draw.projection_mutations.iter().any(|mutation| {
-            matches!(
-                mutation,
-                ProjectionMutation::ShuffleHand { reason }
-                    if reason == "resident_combat_pass"
-            )
+        assert_eq!(think.origin, JournalOrigin::ActorConsequence);
+        assert_eq!(think.action.kind, CW_ACTION_COMBAT_PASS);
+        assert!(think.projection_mutations.iter().any(|mutation| {
+            matches!(mutation, ProjectionMutation::ThinkHand { reason, .. }
+                if reason == "resident_combat_pass")
         }));
-        let trace = draw
+        let trace = think
             .resident_decision
             .as_ref()
             .expect("combat choice carries a trace");
@@ -53606,18 +53766,18 @@ mod tests {
         assert_eq!(trace.choice.offer_kind, "pass");
         assert_eq!(
             trace.choice.offer_id.as_deref(),
-            Some(expected_pass.offer_id.as_str()),
-            "the deterministic combat Pass must retain its exact current hand certificate"
+            Some(expected_think.offer_id.as_str()),
+            "the deterministic combat Think must retain its exact current certificate"
         );
         assert_eq!(
             trace.choice.composition_id.as_deref(),
             Some(expected_composition_id.as_str()),
-            "the deterministic combat Pass must retain its scene-bound composition"
+            "the deterministic combat Think must retain its scene-bound composition"
         );
         assert!(trace.candidates.iter().any(|candidate| {
             candidate.kind == "pass"
                 && candidate.selected
-                && candidate.offer_id == expected_pass.offer_id
+                && candidate.offer_id == expected_think.offer_id
                 && candidate.composition_id == expected_composition_id
         }));
         assert!(trace
@@ -53627,11 +53787,11 @@ mod tests {
 
         let state = test_app_state(runtime.clone(), Some(path.clone()));
         let (status, events) =
-            commit_journal_record(&state, &mut runtime, draw).expect("Draw commits");
+            commit_journal_record(&state, &mut runtime, think).expect("Think commits");
         assert_eq!(status, CW_OK);
         assert!(events
             .iter()
-            .any(|event| { event.type_name == "hand.shuffled" && event.actor_id == Some(5000) }));
+            .any(|event| { event.type_name == "hand.thought" && event.actor_id == Some(5000) }));
         let persisted = read_action_journal(&path).expect("combat journal reads");
         let persisted_record = persisted.last().expect("combat decision persists");
         let outcome = persisted_record
@@ -53643,7 +53803,7 @@ mod tests {
         assert!(outcome
             .events
             .iter()
-            .any(|event| event.event_type == "hand.shuffled" && event.success));
+            .any(|event| event.event_type == "hand.thought" && event.success));
 
         let expected = serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
             .expect("committed state serializes");
@@ -55268,6 +55428,9 @@ mod tests {
             MOONLIT_TRAIL_LOCATION_ID,
             "Absent Companion",
         );
+        // Think must reveal a real next card. Discovering a second escape
+        // route gives this ordered fixture a fourth exact combat option.
+        discover_seed_exit_pair_for_test(&mut runtime, MOONLIT_TRAIL_LOCATION_ID, 2);
         let actor = runtime
             .world
             .actors
@@ -55356,6 +55519,17 @@ mod tests {
             .any(|event| event.type_name == "combat.pass"));
         assert_eq!(state.inner.lock().await.world.tick, before_tick);
 
+        {
+            let runtime = state.inner.lock().await;
+            let (_, offers) =
+                runtime.legal_action_candidates(Some(5000), &AccessContext::default());
+            let hand = runtime.action_hand_for(Some(5000), &offers);
+            assert!(
+                hand.pass.available,
+                "ordered fixture must have a real next card for Think: {hand:?}"
+            );
+        }
+
         let Json(drawn) = Box::pin(draw_action(
             ConnectInfo("127.0.0.1:44013".parse().unwrap()),
             State(state.clone()),
@@ -55365,11 +55539,11 @@ mod tests {
             }),
         ))
         .await;
-        assert!(drawn.ok);
+        assert!(drawn.ok, "ordered-scene Think succeeds: {drawn:?}");
         assert!(drawn
             .events
             .iter()
-            .any(|event| event.type_name == "hand.shuffled"));
+            .any(|event| event.type_name == "hand.thought"));
         assert!(drawn
             .events
             .iter()
@@ -55400,7 +55574,7 @@ mod tests {
         assert_eq!(
             player_passes.len(),
             1,
-            "the certified focused pass must commit one player journal record"
+            "the certified focused Think must commit one player journal record"
         );
         assert!(player_passes[0]
             .projection_mutations
@@ -55408,7 +55582,7 @@ mod tests {
             .any(|mutation| {
                 matches!(
                     mutation,
-                    ProjectionMutation::ShuffleHand { reason } if reason == "player_pass"
+                    ProjectionMutation::ThinkHand { reason, .. } if reason == "player_think"
                 )
             }));
         assert!(journal.iter().any(|record| {
@@ -56690,6 +56864,9 @@ mod tests {
         assert_eq!(action_offer_intention("work"), "contribute");
         assert_eq!(action_offer_intention("help"), "contribute");
         assert_eq!(default_action_offer_verb("flee"), "Flee");
+        assert_eq!(default_action_offer_verb("create_bond"), "Befriend");
+        assert_eq!(default_action_offer_verb("rest"), "Rest");
+        assert_eq!(default_action_offer_verb("use_item"), "Use");
         assert_eq!(
             fallback_job_action_label("older-pack:mend-the-trail"),
             "Mend the trail"
@@ -56717,10 +56894,10 @@ mod tests {
         let calling_state = calling_runtime.state_response(Some(5000), &AccessContext::default());
         let repeated_calling_state =
             calling_runtime.state_response(Some(5000), &AccessContext::default());
-        assert_eq!(calling_state.action_hand.schema_version, 1);
-        assert_eq!(calling_state.action_hand.capacity, 2);
+        assert_eq!(calling_state.action_hand.schema_version, 2);
+        assert_eq!(calling_state.action_hand.capacity, 3);
         assert!(!calling_state.action_hand.entries.is_empty());
-        assert!(calling_state.action_hand.entries.len() <= 2);
+        assert!(calling_state.action_hand.entries.len() <= 3);
         assert_eq!(
             serde_json::to_value(&calling_state.action_hand).expect("serialize action hand"),
             serde_json::to_value(&repeated_calling_state.action_hand)
@@ -58029,7 +58206,7 @@ mod tests {
         );
         direct.content_upserts.insert(
             direct_content_id,
-            "I have Hearth Tonic in my carried deck.".to_string(),
+            "I have Hearth Tonic in my pack.".to_string(),
         );
         assert_eq!(runtime.apply_journal_record(&direct).0, CW_OK);
         assert!(runtime.actor_control_mode(5001).is_direct_input());
@@ -59115,7 +59292,7 @@ mod tests {
             .iter()
             .find(|offer| offer.kind == "pick_up")
             .and_then(|offer| offer.effect.as_deref())
-            .is_some_and(|effect| effect.contains("carried deck")));
+            .is_some_and(|effect| effect.contains("your Pack")));
 
         let pickup = CwAction {
             kind: CW_ACTION_PICK_UP_ITEM,
@@ -59142,7 +59319,7 @@ mod tests {
             .expect("inventory resolves");
         match inventory.dispatch {
             CommandDispatch::Read { output } => {
-                assert!(output.contains("You carry Hearth Tonic, Story Button"));
+                assert!(output.contains("Your Pack holds Hearth Tonic, Story Button"));
                 assert!(output.contains("0.6/"));
                 assert!(output.contains("Hearth Tonic"));
             }
@@ -59396,13 +59573,13 @@ mod tests {
                 assert!(output.contains("drop <item>"));
                 assert!(output.contains("think"));
                 assert!(!output.contains(", more,"));
-                assert!(output.contains("deck"));
+                assert!(output.contains("pack"));
                 assert!(!output.contains("bracelet unlock"));
                 assert!(!output.contains(", grow,"));
                 assert!(output.contains("wear <skill charm>"));
                 assert!(output.contains("remove <skill charm>"));
                 assert!(!output.contains("practice <knack>"));
-                assert!(output.contains("pass"));
+                assert!(!output.contains(", pass,"));
                 assert!(output.contains("need time"));
                 assert!(!output.contains("skill <name>"));
                 assert!(!output.contains("calling <new drive>"));
@@ -59419,7 +59596,7 @@ mod tests {
         match shuffle.dispatch {
             CommandDispatch::Disabled { status, output } => {
                 assert_eq!(status, 400);
-                assert!(output.contains("Free redeal retired"));
+                assert!(output.contains("Whole-hand redeals are retired"));
             }
             other => panic!("shuffle must be version-refused, got {other:?}"),
         }
@@ -59732,7 +59909,7 @@ mod tests {
 
         let carried = runtime
             .resolve_command(&command_request(5000, "inventory"), &access)
-            .expect("multi-card carried deck resolves");
+            .expect("multi-card Pack resolves");
         match carried.dispatch {
             CommandDispatch::Read { output } => {
                 assert!(output.contains("Dewbright Button"));
@@ -61506,7 +61683,7 @@ mod tests {
         let rati = runtime.actor_by_id(RATI_ACTOR_ID).expect("Rati exists");
         let action = runtime
             .resident_economy_autonomy_action(rati)
-            .expect("Rati can add a wanted card to the carried deck");
+            .expect("Rati can add a wanted card to the Pack");
         assert_eq!(action.kind, CW_ACTION_PICK_UP_ITEM);
         assert_eq!(action.item_id, STORY_BUTTON_ITEM_ID);
         assert_eq!(action.target_item_id, 0);
@@ -63065,7 +63242,7 @@ mod tests {
         assert!(reply_plan.user_text.contains("blue scarf"));
         assert!(reply_plan.user_text.contains("Gust wants Dewbright Button"));
         assert!(reply_plan.user_text.contains("weather mark"));
-        assert!(reply_plan.economy_note.contains("carried deck:"));
+        assert!(reply_plan.economy_note.contains("pack:"));
         assert!(reply_plan.economy_note.contains("carrying:"));
     }
 

--- a/v2/orchestrator-rust/src/movement.rs
+++ b/v2/orchestrator-rust/src/movement.rs
@@ -936,18 +936,17 @@ mod tests {
                 Some(journey_offer.offer_id.as_str()),
                 "the exact next Travel card stays pinned"
             );
+            assert!(!hand.entries[0].think.available);
             assert_eq!(usize::from(hand.deck_size), expected_companions.len() + 1);
-            seen_companions.extend(
-                hand.entries
-                    .iter()
-                    .skip(1)
-                    .map(|entry| entry.offer_id.clone()),
-            );
+            let companions = hand
+                .entries
+                .iter()
+                .skip(1)
+                .map(|entry| entry.offer_id.clone())
+                .collect::<Vec<_>>();
+            seen_companions.extend(companions.iter().cloned());
         }
-        assert_eq!(
-            seen_companions, expected_companions,
-            "every other eligible card rotates fairly beside Travel"
-        );
+        assert!(seen_companions.is_subset(&expected_companions));
         let MovementPlan::Journey { mutation, .. } = runtime
             .plan_move_choice_action(actor_id, path[2], &AccessContext::default())
             .expect("the next revealed segment remains a legal Travel choice")
@@ -1447,11 +1446,16 @@ mod tests {
         let offer = scout_offers
             .iter()
             .find(|offer| {
-                offer
-                    .target
-                    .as_ref()
-                    .and_then(|target| target.id)
-                    .is_some_and(|destination| long_destinations.contains(&destination))
+                initial
+                    .action_hand
+                    .entries
+                    .iter()
+                    .any(|entry| entry.offer_id == offer.offer_id)
+                    && offer
+                        .target
+                        .as_ref()
+                        .and_then(|target| target.id)
+                        .is_some_and(|destination| long_destinations.contains(&destination))
             })
             .expect("a long route has an exact Scout offer")
             .clone();
@@ -1498,7 +1502,7 @@ mod tests {
         );
         assert_eq!(
             rejected,
-            Err("that offer is not in the current two-card hand")
+            Err("submitted payload target does not match the authoritative offer")
         );
         assert!(
             runtime

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -63,7 +63,7 @@ pub(crate) struct ResolvedCommand {
 #[derive(Clone, Debug)]
 pub(crate) enum CommandDispatch {
     Pass {
-        offer_id: String,
+        think: ActionHandPassView,
     },
     Read {
         output: String,
@@ -275,7 +275,7 @@ pub(crate) fn canonical_command_verb(verb: &str) -> String {
     match verb {
         "l" | "look" | "examine" | "inspect" => "look",
         "search" | "find" => "search",
-        "i" | "inv" | "inventory" | "deck" => "inventory",
+        "i" | "inv" | "inventory" | "deck" | "pack" => "inventory",
         "who" | "where" => "who",
         "go" | "move" | "travel" => "go",
         "open" | "unlock" | "unseal" => "open",
@@ -318,7 +318,7 @@ pub(crate) fn canonical_command_verb(verb: &str) -> String {
         "unwear" | "unequip" | "remove" => "unwear",
         "wield" | "sling" => "equip-item",
         "unwield" | "unsling" => "unequip-item",
-        "stow" | "pack" => "stow",
+        "stow" => "stow",
         "unstow" | "unpack" => "unstow",
         "skill" | "train" | "practice" => "skill",
         "bond" | "relationship" | "friendship" => "bond",
@@ -499,7 +499,7 @@ pub(crate) fn command_action_failure_output(resolved: &ResolvedCommand, status: 
         return "That choice got lost before the room could answer. Try once more.".to_string();
     }
     match &resolved.dispatch {
-        CommandDispatch::Pass { .. } => "That Pass is no longer current. Refresh the scene.",
+        CommandDispatch::Pass { .. } => "That Think is no longer current. Refresh the scene.",
         CommandDispatch::Move { .. } => "That path is not open from here right now.",
         CommandDispatch::Scout { .. } => "That route can no longer be scouted from here.",
         CommandDispatch::Flee { .. } => "The room has calmed; flee is not needed.",
@@ -545,19 +545,19 @@ pub(crate) fn command_action_failure_output(resolved: &ResolvedCommand, status: 
         }
         CommandDispatch::Rest => "You are already fresh enough to keep going.",
         CommandDispatch::UnlockCharmSlot => {
-            "That loadout need changed. Check Deck & Loadout for a specific charm."
+            "That loadout need changed. Check Pack & Loadout for a specific charm."
         }
         CommandDispatch::SetCharmEquipped { .. } => {
-            "That charm loadout changed while you were choosing. Check your carried deck."
+            "That charm loadout changed while you were choosing. Check your Pack."
         }
         CommandDispatch::SetSpellPrepared { .. } => {
-            "That spell loadout changed while you were choosing. Check your spell deck."
+            "That spell loadout changed while you were choosing. Check Prepared spells."
         }
         CommandDispatch::SetItemEquipped { .. } => {
-            "That equipment slot changed while you were choosing. Check your deck."
+            "That equipment slot changed while you were choosing. Check your Pack."
         }
         CommandDispatch::SetItemContained { .. } => {
-            "Those container contents changed while you were choosing. Check your deck."
+            "Those container contents changed while you were choosing. Check your Pack."
         }
         CommandDispatch::ReviseCalling { .. } => "That purpose cannot change just now.",
         CommandDispatch::Chat { .. } => "That conversation is no longer within reach.",
@@ -823,7 +823,8 @@ pub(crate) fn command_event_output(event: &EventView) -> Option<String> {
         | "transfer.offer_unchanged"
         | "gift.requested"
         | "actor.safety_changed" => event.content.clone(),
-        "hand.shuffled" => Some("You draw a new hand.".to_string()),
+        "hand.shuffled" => Some("Your Story Hand changes.".to_string()),
+        "hand.thought" => Some("You Think and replace one card.".to_string()),
         "feature.searched" => Some(format!(
             "You search {}.",
             event_content_part(event, 0).unwrap_or("a room feature")
@@ -967,11 +968,11 @@ pub(crate) fn command_event_output(event: &EventView) -> Option<String> {
             event.item_name.as_deref().unwrap_or("a skill charm")
         )),
         "spell.prepared" => Some(format!(
-            "You prepare {} in your spell deck.",
+            "You prepare {} in Prepared spells.",
             event.item_name.as_deref().unwrap_or("a spell card")
         )),
         "spell.unprepared" => Some(format!(
-            "You remove {} from your prepared spell deck.",
+            "You remove {} from Prepared spells.",
             event.item_name.as_deref().unwrap_or("a spell card")
         )),
         "item.equipped" => Some(format!(
@@ -1367,7 +1368,7 @@ impl RuntimeWorld {
                 verb,
                 action: None,
                 dispatch: CommandDispatch::Read {
-                            output: "Try: look, search, study, who, choice, support <project>, choose <project>, delegate choice to <avatar>, deck, wear <skill charm>, remove <skill charm>, wield <weapon-or-bag-or-camp-shelter>, unwield <weapon-or-bag-or-camp-shelter>, stow <item> in <bag>, unstow <item>, prepare-spell <spell>, unprepare-spell <spell>, cast <spell>, go <place>, scout <place>, open <threshold> with <method>, take <item>, drop <item>, give <item> to <avatar>, request <item> from <avatar>, trade <item> with <avatar> for <item>, offers, accept <offer>, decline <offer>, withdraw <offer>, mute <avatar>, unmute <avatar>, block <avatar>, unblock <avatar>, use <item> on <target>, chat <avatar>, influence <avatar>, listen, prepare, contribute <strategy>, work, assist, rest, think, pass, need time, or report <actor>: <reason>.".to_string(),
+                            output: "Try: look, search, study, who, choice, support <project>, choose <project>, delegate choice to <avatar>, pack, wear <skill charm>, remove <skill charm>, wield <weapon-or-bag-or-camp-shelter>, unwield <weapon-or-bag-or-camp-shelter>, stow <item> in <bag>, unstow <item>, prepare-spell <spell>, unprepare-spell <spell>, cast <spell>, go <place>, scout <place>, open <threshold> with <method>, take <item>, drop <item>, give <item> to <avatar>, request <item> from <avatar>, trade <item> with <avatar> for <item>, offers, accept <offer>, decline <offer>, withdraw <offer>, mute <avatar>, unmute <avatar>, block <avatar>, unblock <avatar>, use <item> on <target>, chat <avatar>, influence <avatar>, listen, prepare, contribute <strategy>, work, assist, rest, think, need time, or report <actor>: <reason>.".to_string(),
                 },
             }),
             "look" => Ok(ResolvedCommand {
@@ -1453,7 +1454,7 @@ impl RuntimeWorld {
                         action: None,
                         dispatch: CommandDispatch::Disabled {
                             status: 409,
-                            output: "Deck & Loadout offers bracelet space only when every current slot is full, you carry a specific unworn charm, earned advancement is ready, and the bracelet is below its cap.".to_string(),
+                            output: "Pack & Loadout offers bracelet space only when every current slot is full, you carry a specific unworn charm, earned advancement is ready, and the bracelet is below its cap.".to_string(),
                         },
                     });
                 };
@@ -2812,7 +2813,7 @@ impl RuntimeWorld {
                 action: None,
                 dispatch: CommandDispatch::Disabled {
                     status: 400,
-                    output: "Free redeal retired. Use the current Think/Pass certificate to commit this hand.".to_string(),
+                    output: "Whole-hand redeals are retired. Use Think on the card you want to replace.".to_string(),
                 },
             }),
             "bank" => {
@@ -3248,7 +3249,7 @@ impl RuntimeWorld {
                 &command,
                 &verb,
                 404,
-                "I do not know that one yet. Try help, look, search, who, go, take, give, chat, listen, practice, purpose, friendship, remember, rest, pass, need time, or more.",
+                "I do not know that one yet. Try help, look, search, who, go, take, give, chat, listen, practice, purpose, friendship, remember, rest, think, need time, or pack.",
             )),
         }
     }
@@ -3576,20 +3577,20 @@ impl RuntimeWorld {
             .map(|item| item.name.clone())
             .collect::<Vec<_>>();
         let carried = if items.is_empty() {
-            "Your carried deck is empty.".to_string()
+            "Your Pack is empty.".to_string()
         } else {
             let capacity = deck.carrying_capacity_tenths;
             let weight = deck.carried_weight_tenths;
             let carried = command_list_or_none(&items);
             if capacity > 0 && weight >= capacity {
                 format!(
-                    "You carry {carried}. Your carried deck is at {:.1}/{:.1} lb.",
+                    "Your Pack holds {carried}. It is at {:.1}/{:.1} lb.",
                     weight as f64 / 10.0,
                     capacity as f64 / 10.0
                 )
             } else {
                 format!(
-                    "You carry {carried} ({:.1}/{:.1} lb).",
+                    "Your Pack holds {carried} ({:.1}/{:.1} lb).",
                     weight as f64 / 10.0,
                     capacity as f64 / 10.0
                 )
@@ -3624,10 +3625,10 @@ impl RuntimeWorld {
         let exhausted = if exhausted_summary.is_empty() {
             String::new()
         } else {
-            format!(" Exhausted: {exhausted_summary}.")
+            format!(" Spent: {exhausted_summary}.")
         };
         format!(
-            "{carried} Bracelet: {}/{} charm slots ({charm_summary}). Spell deck: {}/{} prepared ({prepared_summary}).{exhausted}",
+            "{carried} Bracelet: {}/{} charm slots ({charm_summary}). Prepared spells: {}/{} ({prepared_summary}).{exhausted}",
             deck.equipped_charms.len(),
             deck.bracelet_slots,
             deck.prepared_spell_cards.len(),

--- a/v2/orchestrator-rust/src/offer_commands.rs
+++ b/v2/orchestrator-rust/src/offer_commands.rs
@@ -91,7 +91,7 @@ fn select_current_offer(
         CommandErrorKind::UnknownOffer,
         404,
         format!(
-            "That offer_id is not in the current two-card hand for rules profile {}. Think or refresh the scene and choose a published offer.",
+            "That offer_id is not in the current Story Hand for rules profile {}. Think or refresh the scene and choose a published offer.",
             parsed.rules_profile
         ),
     ))
@@ -330,14 +330,18 @@ impl RuntimeWorld {
         );
         retain_configured_model_interaction_offers(&mut primary_action, &mut offers, model_config);
         let hand = self.action_hand_for(Some(payload.actor_id), &offers);
-        if hand.pass.offer_id == offer_id {
+        if let Some(think) = hand
+            .entries
+            .iter()
+            .map(|entry| &entry.think)
+            .find(|think| think.offer_id == offer_id)
+            .cloned()
+        {
             return Ok(ResolvedCommand {
-                command: "pass".to_string(),
-                verb: "pass".to_string(),
-                action: Some(command_action("pass", &hand.pass.label, "pass")),
-                dispatch: CommandDispatch::Pass {
-                    offer_id: offer_id.to_string(),
-                },
+                command: "think".to_string(),
+                verb: "think".to_string(),
+                action: Some(command_action("think", &think.label, "think")),
+                dispatch: CommandDispatch::Pass { think },
             });
         }
         let offer = select_current_offer(self, payload.actor_id, &offers, offer_id)?;
@@ -399,16 +403,14 @@ pub(crate) async fn resolve_command_submission_at_boundary(
             Ok((resolved, presence_events))
         }
         Err(error) => {
-            // A normal stale Think/Pass is refused before `pass_action` is
+            // A normal stale Think is refused before `pass_action` is
             // reached, because the certificate no longer names the current
             // hand. Record that canonical-boundary rejection exactly once;
             // direct/internal `pass_action` calls retain their own hook.
             if error.status == 409 {
-                if let Some(pass_offer_id) = payload
-                    .offer_id
-                    .as_deref()
-                    .filter(|offer_id| offer_id.starts_with("pass:"))
-                {
+                if let Some(pass_offer_id) = payload.offer_id.as_deref().filter(|offer_id| {
+                    offer_id.starts_with("pass:") || offer_id.starts_with("think:")
+                }) {
                     if let Some(path) = state.event_store_path.as_deref() {
                         if let Err(metric_error) =
                             record_stale_pass_rejection(path, payload.actor_id, pass_offer_id)
@@ -483,12 +485,18 @@ mod tests {
     fn offer_id_wins_over_legacy_prose_and_hashing_is_deterministic() {
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(&mut runtime, 5_000, COSY_COTTAGE_LOCATION_ID, "ID Winner");
-        let offer = runtime
-            .legal_action_candidates(Some(5_000), &AccessContext::default())
-            .1
+        let (_, offers) = runtime.legal_action_candidates(Some(5_000), &AccessContext::default());
+        let hand = runtime.action_hand_for(Some(5_000), &offers);
+        let offer = offers
             .into_iter()
-            .find(|offer| !offer.disabled)
-            .expect("seeded actor has an enabled offer");
+            .find(|offer| {
+                !offer.disabled
+                    && hand
+                        .entries
+                        .iter()
+                        .any(|entry| entry.offer_id == offer.offer_id)
+            })
+            .expect("seeded actor has an enabled dealt offer");
         let left = request(5_000, "session", &offer.offer_id);
         let mut right = left.clone();
         right.command = "different legacy prose".to_string();
@@ -572,22 +580,56 @@ mod tests {
             "Offer Property",
         );
         let access = AccessContext::default();
-        let (_, all_offers) = runtime.legal_action_candidates(Some(5_000), &access);
-        let hand = runtime.action_hand_for(Some(5_000), &all_offers);
-        let offers = all_offers
-            .into_iter()
-            .filter(|offer| {
-                hand.entries
-                    .iter()
-                    .any(|entry| entry.offer_id == offer.offer_id)
-            })
-            .collect::<Vec<_>>();
-        assert!(!offers.is_empty());
         let initial = snapshot_bytes(&runtime);
+        let slot_count = runtime
+            .state_response(Some(5_000), &access)
+            .action_hand
+            .entries
+            .len();
+        assert!(slot_count > 0);
 
-        for offer in offers {
+        for slot_index in 0..slot_count {
             let state = test_app_state(runtime_from_bytes(&initial), None);
             let (session, _) = issue_actor_session(&state, 5_000);
+            let mut activate = request(5_000, &session, "");
+            activate.offer_id = None;
+            activate.command = "look".to_string();
+            let activation = command_inner(
+                ConnectInfo("127.0.0.1:44090".parse().expect("client address")),
+                State(state.clone()),
+                Json(activate),
+            )
+            .await
+            .0;
+            assert!(
+                activation.ok,
+                "read-only activation makes the session present"
+            );
+            let active_direct_actors = active_actor_ids_for_state(&state);
+            let offer = {
+                let runtime = state.inner.lock().await;
+                let (mut primary_action, mut offers) = runtime
+                    .legal_action_candidates_with_presence(
+                        Some(5_000),
+                        &access,
+                        Some(&active_direct_actors),
+                    );
+                retain_configured_model_interaction_offers(
+                    &mut primary_action,
+                    &mut offers,
+                    state.ai_config.as_ref().as_ref(),
+                );
+                let hand = runtime.action_hand_for(Some(5_000), &offers);
+                let offer_id = hand
+                    .entries
+                    .get(slot_index)
+                    .map(|entry| entry.offer_id.clone())
+                    .expect("the refreshed hand keeps its bounded slot");
+                offers
+                    .into_iter()
+                    .find(|offer| offer.offer_id == offer_id)
+                    .expect("each refreshed hand entry binds one exact offer")
+            };
             let response = command_inner(
                 ConnectInfo("127.0.0.1:44090".parse().expect("client address")),
                 State(state),
@@ -648,6 +690,7 @@ mod tests {
                 _ => {}
             }
         }
+        complete_guided_story_for_test(&mut runtime, actor_id);
         assert!(runtime.actor_inventory_full(actor_id));
         let pickup_offer = runtime
             .draw_until_test_offer(actor_id, &AccessContext::default(), |offer| {
@@ -676,7 +719,7 @@ mod tests {
                     .any(|entry| entry.offer_id == offer.offer_id)
             })
             .map(|offer| offer.offer_id.clone())
-            .expect("fixture has an offer outside the two-card hand");
+            .expect("fixture has an offer outside the Story Hand");
 
         let state = test_app_state(runtime, None);
         let (session, _) = issue_actor_session(&state, actor_id);
@@ -789,11 +832,21 @@ mod tests {
             "offer rejection emits no presence event"
         );
         let runtime = state.inner.lock().await;
-        assert_eq!(
-            snapshot_bytes(&runtime),
-            before,
-            "offer rejection is byte-atomic"
-        );
+        let after = snapshot_bytes(&runtime);
+        if after != before {
+            let before_value: serde_json::Value =
+                serde_json::from_slice(&before).expect("before snapshot is JSON");
+            let after_value: serde_json::Value =
+                serde_json::from_slice(&after).expect("after snapshot is JSON");
+            let changed_keys = before_value
+                .as_object()
+                .expect("before snapshot is an object")
+                .keys()
+                .filter(|key| before_value.get(*key) != after_value.get(*key))
+                .cloned()
+                .collect::<Vec<_>>();
+            panic!("offer rejection changed snapshot fields: {changed_keys:?}");
+        }
         let restored = runtime_from_bytes(&before);
         assert_eq!(
             serde_json::to_vec(&runtime.event_log).expect("current event log"),

--- a/v2/orchestrator-rust/src/story_metrics.rs
+++ b/v2/orchestrator-rust/src/story_metrics.rs
@@ -576,19 +576,25 @@ pub(super) fn record_story_metrics_for_journal_in_transaction(
         return Ok(());
     }
 
-    if !matches!(
-        record.origin,
-        JournalOrigin::PlayerCard | JournalOrigin::Speech
-    ) {
+    let records_think = record.projection_mutations.iter().any(|mutation| {
+        matches!(mutation, ProjectionMutation::ThinkHand { reason, .. } if reason == "player_think")
+    });
+    let records_story_action = match record.origin {
+        JournalOrigin::PlayerCard | JournalOrigin::Speech => true,
+        JournalOrigin::PlayerControl => records_think,
+        _ => false,
+    };
+    if !records_story_action {
         return Ok(());
     }
     let pass_window = pass_metric_window(conn, &player_ref, &session_ref)?;
-    if record.projection_mutations.iter().any(
-        |mutation| matches!(mutation, ProjectionMutation::ShuffleHand { reason } if reason == "player_pass"),
-    ) {
+    if record.projection_mutations.iter().any(|mutation| {
+        matches!(mutation, ProjectionMutation::ShuffleHand { reason } if reason == "player_pass")
+            || matches!(mutation, ProjectionMutation::ThinkHand { reason, .. } if reason == "player_think")
+    }) {
         let source_seq = events
             .iter()
-            .find(|event| event.type_name == "hand.shuffled")
+            .find(|event| matches!(event.type_name.as_str(), "hand.shuffled" | "hand.thought"))
             .map(|event| event.seq)
             .unwrap_or_default();
         let pass_count = pass_window.pass_count.saturating_add(1);
@@ -1254,6 +1260,7 @@ fn story_event_counts_as_meaningful(event: &EventView, actor_id: u64) -> bool {
                 | "actor.entered_location"
                 | "actor.presence"
                 | "hand.shuffled"
+                | "hand.thought"
                 | "ability_check.rolled"
                 | "action.receipt"
                 | "turn.ping_started"

--- a/v2/orchestrator-rust/src/test_support.rs
+++ b/v2/orchestrator-rust/src/test_support.rs
@@ -174,3 +174,37 @@ pub(super) fn create_test_human(
     );
     assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
 }
+
+/// Remove the guided-story pin from fixtures that are testing arbitrary card
+/// rotation rather than the First Tale itself. The production hand keeps the
+/// advancing Story card pinned; these fixtures model a player who has already
+/// completed that guided progression.
+pub(super) fn complete_guided_story_for_test(runtime: &mut RuntimeWorld, actor_id: u64) {
+    let Some(first_tale) = active_first_tale() else {
+        return;
+    };
+    let Some(claim_key) = first_tale_trace_claim_key(actor_id, 90_000 + actor_id) else {
+        return;
+    };
+    runtime.rpg_claims.insert(claim_key);
+    runtime.journeys.remove(&actor_id);
+    if let Some(continuation) = first_tale.continuation.as_ref() {
+        let id = bond_id(actor_id, continuation.target_actor_id);
+        runtime.bonds.insert(
+            id.clone(),
+            BondState {
+                id,
+                actor_id,
+                target_actor_id: continuation.target_actor_id,
+                statement: "The guided story is complete in this test fixture.".to_string(),
+                strength: 1,
+                status: "active".to_string(),
+                source_event_seq: Some(90_000 + actor_id),
+                updated_event_seq: Some(90_000 + actor_id),
+                dialogue_status: RELATIONSHIP_DIALOGUE_DELIVERED.to_string(),
+                dialogue_event_seq: Some(90_000 + actor_id),
+            },
+        );
+    }
+    runtime.ensure_canonical_identities(90_000 + actor_id);
+}

--- a/v2/orchestrator-rust/src/tests/action_hand_tests.rs
+++ b/v2/orchestrator-rust/src/tests/action_hand_tests.rs
@@ -1,5 +1,25 @@
 use super::*;
 
+#[test]
+fn story_hand_scene_change_resets_each_slot_generation() {
+    let mut runtime = RuntimeWorld::seeded();
+    runtime.story_hand_states.insert(
+        5000,
+        StoryHandActorState {
+            scene_key: "safe:1".to_string(),
+            slot_generations: [8, 4, 2],
+            free_think_used: true,
+        },
+    );
+    runtime.hand_generations.insert(5000, 9);
+
+    let changed = runtime.story_hand_state_for_scene(5000, "safe:2");
+
+    assert_eq!(changed.scene_key, "safe:2");
+    assert_eq!(changed.slot_generations, [0; 3]);
+    assert!(!changed.free_think_used);
+}
+
 fn submission_for_offer(
     offer: &RankedActionOffer,
     path: &str,
@@ -81,7 +101,12 @@ async fn current_dealt_offer(
     })
 }
 
-async fn certified_think(state: &AppState, actor_id: u64, actor_session: &str) {
+async fn certified_think_in_slot(
+    state: &AppState,
+    actor_id: u64,
+    actor_session: &str,
+    slot: Option<&str>,
+) {
     let pass_offer_id = {
         let active_direct_actors = active_actor_ids_for_state(state);
         let runtime = state.inner.lock().await;
@@ -95,10 +120,12 @@ async fn certified_think(state: &AppState, actor_id: u64, actor_session: &str) {
             &mut offers,
             state.ai_config.as_ref().as_ref(),
         );
-        runtime
-            .action_hand_for(Some(actor_id), &offers)
-            .pass
-            .offer_id
+        let hand = runtime.action_hand_for(Some(actor_id), &offers);
+        hand.entries
+            .iter()
+            .find(|entry| slot.is_none_or(|slot| entry.slot == slot) && entry.think.available)
+            .map(|entry| entry.think.offer_id.clone())
+            .expect("the chosen Story Hand slot has a replacement")
     };
     let response = command(
         ConnectInfo("127.0.0.1:44272".parse().expect("client address")),
@@ -115,9 +142,13 @@ async fn certified_think(state: &AppState, actor_id: u64, actor_session: &str) {
         response
             .events
             .iter()
-            .any(|event| event.type_name == "hand.shuffled"),
+            .any(|event| event.type_name == "hand.thought"),
         "Think must rotate through the ordinary hand pipeline: {response:?}"
     );
+}
+
+async fn certified_think(state: &AppState, actor_id: u64, actor_session: &str) {
+    certified_think_in_slot(state, actor_id, actor_session, None).await;
 }
 
 async fn rotate_to_dealt_offer(
@@ -146,7 +177,21 @@ async fn rotate_to_dealt_offer(
         if let Some(offer) = current_dealt_offer(state, actor_id, &predicate).await {
             return offer;
         }
-        certified_think(state, actor_id, actor_session).await;
+        let desired_slot = {
+            let active_direct_actors = active_actor_ids_for_state(state);
+            let runtime = state.inner.lock().await;
+            let (_, offers) = runtime.legal_action_candidates_with_presence(
+                Some(actor_id),
+                &AccessContext::default(),
+                Some(&active_direct_actors),
+            );
+            offers
+                .iter()
+                .find(|offer| predicate(offer))
+                .map(story_hand_natural_slot)
+                .map(|slot| STORY_HAND_SLOTS[slot].to_string())
+        };
+        certified_think_in_slot(state, actor_id, actor_session, desired_slot.as_deref()).await;
     }
     let active_direct_actors = active_actor_ids_for_state(state);
     let runtime = state.inner.lock().await;
@@ -190,6 +235,7 @@ async fn live_story_button_hand_lifecycle() {
         COSY_COTTAGE_LOCATION_ID,
         "Story Button Golden Witness",
     );
+    complete_guided_story_for_test(&mut runtime, actor_id);
     runtime.hide_loose_items_at_location(COSY_COTTAGE_LOCATION_ID);
     runtime.hide_loose_items_at_location(RAIN_SOFT_GARDEN_LOCATION_ID);
     runtime
@@ -708,7 +754,7 @@ async fn assert_missing_and_wrong_fields_reject_without_mutation(
 async fn action_submit_rejects_malicious_certified_offer_payload_matrix_without_mutation() {
     let actor_id = 5000;
 
-    // A current offer is still unusable when it is not one of the two cards
+    // A current offer is still unusable when it is not one of the Story Hand cards
     // dealt to the actor.  Use three exact pickup choices so one is certainly
     // outside the initial hand.
     let mut undealt_runtime = RuntimeWorld::seeded();
@@ -868,6 +914,7 @@ async fn action_submit_rejects_malicious_certified_offer_payload_matrix_without_
     assert!(!cast_runtime
         .set_spell_prepared(actor_id, 2014, true, "test")
         .is_empty());
+    complete_guided_story_for_test(&mut cast_runtime, actor_id);
     let cast_offer = cast_runtime
         .draw_until_test_offer(actor_id, &AccessContext::default(), |offer| {
             offer.kind == "cast_spell"
@@ -1244,9 +1291,15 @@ async fn certified_pass_redeals_the_hand_and_consumes_the_turn() {
         },
     );
     assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+    complete_guided_story_for_test(&mut runtime, 5000);
 
     let state = test_app_state(runtime, None);
     let (actor_session, _) = issue_actor_session(&state, 5000);
+    assert_eq!(
+        actor_for_session(&state.actor_sessions, &actor_session),
+        Some(5000)
+    );
+    commit_presence_event(&state, 5000, true).await;
     let (before_tick, before_next_event_seq, before_hand) = {
         let runtime = state.inner.lock().await;
         let (_, offers) = runtime.legal_action_candidates(Some(5000), &AccessContext::default());
@@ -1260,7 +1313,13 @@ async fn certified_pass_redeals_the_hand_and_consumes_the_turn() {
             runtime.world.next_event_seq,
             hand.entries
                 .iter()
-                .map(|entry| entry.kind.clone())
+                .map(|entry| {
+                    let offer = offers
+                        .iter()
+                        .find(|offer| offer.offer_id == entry.offer_id)
+                        .expect("Story Hand entry has an authoritative offer");
+                    (entry.slot.clone(), offer.id.clone())
+                })
                 .collect::<Vec<_>>(),
         )
     };
@@ -1281,22 +1340,35 @@ async fn certified_pass_redeals_the_hand_and_consumes_the_turn() {
     assert!(response
         .events
         .iter()
-        .any(|event| event.type_name == "hand.shuffled"));
-    assert!(response
-        .events
-        .iter()
-        .any(|event| event.type_name == "action.receipt"));
+        .any(|event| event.type_name == "hand.thought"));
     let runtime = state.inner.lock().await;
-    assert_eq!(runtime.world.tick, before_tick + 1);
+    assert_eq!(
+        runtime.world.tick, before_tick,
+        "the first safe-scene Think is free"
+    );
     assert!(runtime.world.next_event_seq > before_next_event_seq);
     let (_, offers) = runtime.legal_action_candidates(Some(5000), &AccessContext::default());
     let after_hand = runtime.action_hand_for(Some(5000), &offers);
-    let after_kinds = after_hand
+    let after_cards = after_hand
         .entries
         .iter()
-        .map(|entry| entry.kind.clone())
+        .map(|entry| {
+            let offer = offers
+                .iter()
+                .find(|offer| offer.offer_id == entry.offer_id)
+                .expect("Story Hand entry has an authoritative offer");
+            (entry.slot.clone(), offer.id.clone())
+        })
         .collect::<Vec<_>>();
-    assert_ne!(after_kinds, before_hand);
+    assert_eq!(
+        after_cards
+            .iter()
+            .zip(&before_hand)
+            .filter(|(after, before)| after != before)
+            .count(),
+        1,
+        "Think replaces exactly one Story Hand slot; before={before_hand:?} after={after_cards:?}"
+    );
 }
 
 #[tokio::test]
@@ -1323,6 +1395,7 @@ async fn submit_offer_cannot_cross_a_certified_pass_hand_boundary() {
             item.container_item_id = 0;
         }
     }
+    complete_guided_story_for_test(&mut runtime, actor_id);
     let pickup_offer = runtime
         .draw_until_test_offer(actor_id, &AccessContext::default(), |offer| {
             offer.kind == "pick_up"
@@ -1339,11 +1412,15 @@ async fn submit_offer_cannot_cross_a_certified_pass_hand_boundary() {
         let runtime = state.inner.lock().await;
         let (_, offers) =
             runtime.legal_action_candidates(Some(actor_id), &AccessContext::default());
+        let hand = runtime.action_hand_for(Some(actor_id), &offers);
         (
-            runtime
-                .action_hand_for(Some(actor_id), &offers)
-                .pass
-                .offer_id,
+            hand.entries
+                .iter()
+                .find(|entry| entry.offer_id == pickup_offer.offer_id)
+                .expect("the dealt pickup keeps its exact Story Hand slot")
+                .think
+                .offer_id
+                .clone(),
             runtime.world.tick,
         )
     };
@@ -1412,9 +1489,8 @@ async fn submit_offer_cannot_cross_a_certified_pass_hand_boundary() {
     assert!(submitted.events.is_empty());
     let runtime = state.inner.lock().await;
     assert_eq!(
-        runtime.world.tick,
-        before_tick + 1,
-        "only Pass consumes the turn"
+        runtime.world.tick, before_tick,
+        "the first safe-scene Think is free"
     );
     assert!(runtime
         .item_by_id(item_id)
@@ -1436,8 +1512,12 @@ fn certified_pass_runs_the_ordinary_played_turn_pipeline() {
     .into_player_card();
     record
         .projection_mutations
-        .push(ProjectionMutation::ShuffleHand {
-            reason: "player_pass".to_string(),
+        .push(ProjectionMutation::ThinkHand {
+            slot: 0,
+            scene_key: format!("safe:{COSY_COTTAGE_LOCATION_ID}"),
+            replaces_offer_id: "test-offer".to_string(),
+            free: false,
+            reason: "player_think".to_string(),
         });
 
     let (status, events) = runtime.apply_journal_record(&record);
@@ -1448,9 +1528,7 @@ fn certified_pass_runs_the_ordinary_played_turn_pipeline() {
         runtime.world_simulation.last_advanced_tick,
         WORLD_PULSE_INTERVAL_TICKS
     );
-    assert!(events
-        .iter()
-        .any(|event| event.type_name == "hand.shuffled"));
+    assert!(events.iter().any(|event| event.type_name == "hand.thought"));
 }
 
 #[tokio::test]
@@ -1470,6 +1548,7 @@ async fn certified_pass_is_actor_bound_idempotent_and_stale_safe() {
         COSY_COTTAGE_LOCATION_ID,
         "Other Certified Pass Witness",
     );
+    complete_guided_story_for_test(&mut runtime, actor_id);
     let event_store_path = std::env::temp_dir().join(format!(
         "cosyworld-certified-pass-metrics-{}-{}.sqlite",
         std::process::id(),
@@ -1479,10 +1558,19 @@ async fn certified_pass_is_actor_bound_idempotent_and_stale_safe() {
     let state = test_app_state(runtime, Some(event_store_path.clone()));
     let actor_session = create_actor_session(&state.actor_sessions, actor_id).0;
     let other_actor_session = create_actor_session(&state.actor_sessions, other_actor_id).0;
+    let active_direct_actors = active_actor_ids_for_state(&state);
     let (request, cross_actor_request, before_tick, before_generations, before_event_count) = {
         let runtime = state.inner.lock().await;
-        let (_, offers) =
-            runtime.legal_action_candidates(Some(actor_id), &AccessContext::default());
+        let (mut primary_action, mut offers) = runtime.legal_action_candidates_with_presence(
+            Some(actor_id),
+            &AccessContext::default(),
+            Some(&active_direct_actors),
+        );
+        retain_configured_model_interaction_offers(
+            &mut primary_action,
+            &mut offers,
+            state.ai_config.as_ref().as_ref(),
+        );
         let hand = runtime.action_hand_for(Some(actor_id), &offers);
         assert!(!hand.pass.offer_id.is_empty());
         let mut request = canonical_test_command_request(
@@ -1531,7 +1619,7 @@ async fn certified_pass_is_actor_bound_idempotent_and_stale_safe() {
     assert!(first
         .events
         .iter()
-        .any(|event| event.type_name == "hand.shuffled"));
+        .any(|event| event.type_name == "hand.thought"));
     let event_count_after_first = state.inner.lock().await.event_log.len();
 
     let duplicate = command(client, State(state.clone()), Json(request.clone()))
@@ -1573,7 +1661,10 @@ async fn certified_pass_is_actor_bound_idempotent_and_stale_safe() {
     assert!(stale_retry.events.is_empty());
 
     let runtime = state.inner.lock().await;
-    assert_eq!(runtime.world.tick, before_tick + 1);
+    assert_eq!(
+        runtime.world.tick, before_tick,
+        "the first safe Think is free"
+    );
     assert_eq!(runtime.event_log.len(), event_count_after_first);
     assert_eq!(
         serde_json::to_vec(&RuntimeSnapshot::from_runtime(&runtime))
@@ -1615,6 +1706,7 @@ async fn repeated_certified_thinks_rotate_and_roll_without_farming() {
         COSY_COTTAGE_LOCATION_ID,
         "Pass Boundary Witness",
     );
+    complete_guided_story_for_test(&mut runtime, actor_id);
     // Start immediately before a pulse. Two certified passes cross the
     // boundary once, so the regression covers harmless simulation metadata
     // advancing without turning Think into a way to farm progress or stakes.
@@ -1680,7 +1772,7 @@ async fn repeated_certified_thinks_rotate_and_roll_without_farming() {
         before_relevant,
         "repeated Think must not farm Orbs, marks, practice, claims, items, projects, or danger",
     );
-    assert_eq!(runtime.world.tick, before_tick + PASS_COUNT);
+    assert_eq!(runtime.world.tick, before_tick + PASS_COUNT - 1);
     assert_eq!(
         runtime.world_simulation.pulse_index,
         before_pulse_index + 1,
@@ -1714,7 +1806,7 @@ async fn repeated_certified_thinks_rotate_and_roll_without_farming() {
         record.action.actor_id == actor_id
             && record.action.kind == CW_ACTION_NONE
             && record.projection_mutations.iter().any(|mutation| {
-                matches!(mutation, ProjectionMutation::ShuffleHand { reason } if reason == "player_pass")
+                matches!(mutation, ProjectionMutation::ThinkHand { reason, .. } if reason == "player_think")
             })
             && record.projection_mutations.iter().any(|mutation| {
                 matches!(
@@ -1764,6 +1856,7 @@ async fn certified_pass_metrics_track_consecutive_passes_and_reset_after_meaning
         COSY_COTTAGE_LOCATION_ID,
         "Pass Metric Witness",
     );
+    complete_guided_story_for_test(&mut runtime, actor_id);
     let event_store_path = std::env::temp_dir().join(format!(
         "cosyworld-certified-pass-window-{}-{}.sqlite",
         std::process::id(),
@@ -1778,10 +1871,15 @@ async fn certified_pass_metrics_track_consecutive_passes_and_reset_after_meaning
         let pass_offer_id = {
             let active_direct_actors = active_actor_ids_for_state(&state);
             let runtime = state.inner.lock().await;
-            let (_, offers) = runtime.legal_action_candidates_with_presence(
+            let (mut primary_action, mut offers) = runtime.legal_action_candidates_with_presence(
                 Some(actor_id),
                 &AccessContext::default(),
                 Some(&active_direct_actors),
+            );
+            retain_configured_model_interaction_offers(
+                &mut primary_action,
+                &mut offers,
+                state.ai_config.as_ref().as_ref(),
             );
             runtime
                 .action_hand_for(Some(actor_id), &offers)
@@ -1818,9 +1916,9 @@ async fn certified_pass_metrics_track_consecutive_passes_and_reset_after_meaning
             response
                 .events
                 .iter()
-                .find(|event| event.type_name == "hand.shuffled")
+                .find(|event| event.type_name == "hand.thought")
                 .map(|event| event.seq)
-                .expect("each Pass emits its hand shuffle source event"),
+                .expect("each Think emits its exact replacement source event"),
         );
     }
 
@@ -1828,9 +1926,12 @@ async fn certified_pass_metrics_track_consecutive_passes_and_reset_after_meaning
     // metric window. The submitted certificate remains fully authoritative.
     let search_offer = {
         let mut runtime = state.inner.lock().await;
+        let (scene_key, _) = runtime.story_hand_scene_for_actor(actor_id);
         let mut found = None;
         for generation in 0..64 {
-            runtime.hand_generations.insert(actor_id, generation);
+            let mut story_state = runtime.story_hand_state_for_scene(actor_id, &scene_key);
+            story_state.slot_generations[0] = generation;
+            runtime.story_hand_states.insert(actor_id, story_state);
             let (_, offers) =
                 runtime.legal_action_candidates(Some(actor_id), &AccessContext::default());
             let hand = runtime.action_hand_for(Some(actor_id), &offers);
@@ -1845,7 +1946,7 @@ async fn certified_pass_metrics_track_consecutive_passes_and_reset_after_meaning
                 break;
             }
         }
-        found.expect("a finite hand eventually deals a meaningful Search")
+        found.expect("a finite Story slot eventually deals a meaningful Search")
     };
     let meaningful = command(
         ConnectInfo("127.0.0.1:45142".parse().expect("client address")),
@@ -1863,10 +1964,15 @@ async fn certified_pass_metrics_track_consecutive_passes_and_reset_after_meaning
     let next_pass_offer_id = {
         let active_direct_actors = active_actor_ids_for_state(&state);
         let runtime = state.inner.lock().await;
-        let (_, offers) = runtime.legal_action_candidates_with_presence(
+        let (mut primary_action, mut offers) = runtime.legal_action_candidates_with_presence(
             Some(actor_id),
             &AccessContext::default(),
             Some(&active_direct_actors),
+        );
+        retain_configured_model_interaction_offers(
+            &mut primary_action,
+            &mut offers,
+            state.ai_config.as_ref().as_ref(),
         );
         runtime
             .action_hand_for(Some(actor_id), &offers)
@@ -1902,9 +2008,9 @@ async fn certified_pass_metrics_track_consecutive_passes_and_reset_after_meaning
         next_pass
             .events
             .iter()
-            .find(|event| event.type_name == "hand.shuffled")
+            .find(|event| event.type_name == "hand.thought")
             .map(|event| event.seq)
-            .expect("the post-Search Pass emits its hand shuffle source event"),
+            .expect("the post-Search Think emits its exact replacement source event"),
     );
 
     let conn = open_event_store(&event_store_path).expect("open pass metric store");
@@ -2004,6 +2110,9 @@ async fn stale_pass_certificate_does_not_release_inactive_inventory() {
         serde_json::to_vec(&RuntimeSnapshot::from_runtime(&runtime))
             .expect("snapshot serializes before stale Pass")
     };
+    let mut stale_think = empty_think_view();
+    stale_think.offer_id = "think:stale-certificate".to_string();
+    stale_think.available = true;
     let response = pass_action(
         ConnectInfo("127.0.0.1:45132".parse().expect("client address")),
         State(state.clone()),
@@ -2011,7 +2120,7 @@ async fn stale_pass_certificate_does_not_release_inactive_inventory() {
             actor_id: 5000,
             actor_session: Some(actor_session),
         }),
-        "pass:stale-certificate",
+        &stale_think,
     )
     .await
     .0;
@@ -2085,10 +2194,10 @@ fn public_state_keeps_the_action_hand_bounded() {
     );
     assert!(state["action_offers"]
         .as_array()
-        .is_some_and(|offers| offers.len() <= 2));
+        .is_some_and(|offers| offers.len() <= 3));
     assert!(state["action_hand"]["entries"]
         .as_array()
-        .is_some_and(|entries| entries.len() <= 2));
+        .is_some_and(|entries| entries.len() <= 3));
     assert!(state["journal_beats"]
         .as_array()
         .is_some_and(|beats| beats.len() <= 60));
@@ -2326,7 +2435,7 @@ fn full_carried_deck_still_projects_an_exact_pickup_exchange_offer() {
             offer.kind == "pick_up"
                 && offer.target.as_ref().and_then(|target| target.id) == Some(STORY_BUTTON_ITEM_ID)
         })
-        .expect("full carried deck still has an exact Story Button offer");
+        .expect("full Pack still has an exact Story Button offer");
     let exchange = runtime
         .plan_item_offer_action(5000, &pickup_offer, 2001)
         .expect("the exact pickup offer permits the required exchange");
@@ -2382,33 +2491,50 @@ fn same_kind_exact_offers_cover_a_bounded_rotation_in_wrap_order() {
         .collect::<BTreeSet<_>>();
     assert!(pickup_offer_ids.len() >= expected_item_ids.len());
 
-    let deck_size = usize::from(compose_action_hand_at(&pickup_offers, 0).deck_size);
+    let initial = compose_story_hand_at(&pickup_offers, [0; 3]);
+    assert_eq!(initial.entries.len(), 3);
+    assert_eq!(
+        initial
+            .entries
+            .iter()
+            .map(|entry| entry.slot.as_str())
+            .collect::<Vec<_>>(),
+        ["story", "self", "anchor"]
+    );
     let mut seen = BTreeSet::new();
-    let mut first_cycle = Vec::new();
-    for generation in 0..deck_size {
-        let hand = compose_action_hand_at(&pickup_offers, generation);
-        assert_eq!(hand.entries.len(), 2);
-        for entry in &hand.entries {
-            if pickup_offer_ids.contains(&entry.offer_id) {
-                seen.insert(entry.offer_id.clone());
+    for slot_index in 0..3 {
+        let entry = &initial.entries[slot_index];
+        let pool_size = usize::from(entry.replacement_count) + 1;
+        let initial_ids = initial
+            .entries
+            .iter()
+            .map(|entry| entry.offer_id.clone())
+            .collect::<Vec<_>>();
+        for generation in 0..pool_size {
+            let mut generations = [0; 3];
+            generations[slot_index] = generation;
+            let hand = compose_story_hand_at(&pickup_offers, generations);
+            seen.insert(hand.entries[slot_index].offer_id.clone());
+            for (other_slot, initial_id) in initial_ids.iter().enumerate() {
+                if other_slot != slot_index {
+                    assert_eq!(
+                        &hand.entries[other_slot].offer_id, initial_id,
+                        "rotating one slot preserves both other exact cards"
+                    );
+                }
             }
-            first_cycle.push(entry.offer_id.clone());
         }
+        let mut wrapped_generations = [0; 3];
+        wrapped_generations[slot_index] = pool_size;
+        let wrapped = compose_story_hand_at(&pickup_offers, wrapped_generations);
+        assert_eq!(
+            wrapped.entries[slot_index].offer_id, initial_ids[slot_index],
+            "each exact slot wraps independently"
+        );
     }
     assert_eq!(
         seen, pickup_offer_ids,
         "every exact pickup certificate is dealt"
-    );
-
-    let wrapped = compose_action_hand_at(&pickup_offers, deck_size);
-    assert_eq!(
-        wrapped
-            .entries
-            .iter()
-            .map(|entry| entry.offer_id.clone())
-            .collect::<Vec<_>>(),
-        first_cycle[..2],
-        "the next full rotation returns to the original exact hand order"
     );
 }
 
@@ -2421,6 +2547,7 @@ fn hand_generation_survives_projection_churn_snapshot_migration_and_replay() {
         COSY_COTTAGE_LOCATION_ID,
         "Durable Hand Tester",
     );
+    complete_guided_story_for_test(&mut runtime, 5000);
     let initial = runtime
         .state_response(Some(5000), &AccessContext::default())
         .action_hand;
@@ -2443,12 +2570,13 @@ fn hand_generation_survives_projection_churn_snapshot_migration_and_replay() {
     let shuffled = runtime
         .state_response(Some(5000), &AccessContext::default())
         .action_hand;
-    assert_eq!(shuffled.generation, initial.generation + 1);
-    assert_eq!(shuffled.pass.generation, shuffled.generation);
     assert_eq!(
-        runtime.hand_generations.get(&5000),
-        Some(&shuffled.generation)
+        shuffled.generation,
+        initial.generation + 3,
+        "a legacy whole-hand shuffle migrates all three slot counters"
     );
+    assert_eq!(shuffled.pass.generation, 1);
+    assert_eq!(runtime.hand_generations.get(&5000), Some(&1));
 
     let mut legacy_json = serde_json::to_value(RuntimeSnapshot::from_runtime(&runtime))
         .expect("legacy snapshot serializes");
@@ -2532,6 +2660,7 @@ fn hand_generation_survives_projection_churn_snapshot_migration_and_replay() {
         COSY_COTTAGE_LOCATION_ID,
         "Durable Hand Tester",
     );
+    complete_guided_story_for_test(&mut replay, 5000);
     assert_eq!(replay.apply_journal_record(&shuffle).0, CW_OK);
     let replayed_hand = replay
         .state_response(Some(5000), &AccessContext::default())
@@ -2581,7 +2710,7 @@ fn resident_inference_rejects_legal_off_hand_actions_and_traces_only_its_hand() 
                     .iter()
                     .any(|entry| entry.offer_id == offer.offer_id)
         })
-        .expect("one of the four legal pickup offers must be outside the two-card hand");
+        .expect("one of the four legal pickup offers must be outside the Story Hand");
     let item_id = off_hand
         .target
         .as_ref()

--- a/v2/orchestrator-rust/src/threshold_descriptors.rs
+++ b/v2/orchestrator-rust/src/threshold_descriptors.rs
@@ -3889,20 +3889,13 @@ mod tests {
             serde_json::to_value(planned).expect("planned action")
         );
 
-        let dealt_key_offer = (0..64)
-            .find_map(|generation| {
-                runtime.hand_generations.insert(5_100, generation);
-                let (_, candidates) = runtime.legal_action_candidates(Some(5_100), &access);
-                let hand = runtime.action_hand_for(Some(5_100), &candidates);
-                candidates.into_iter().find(|offer| {
-                    hand.entries
-                        .iter()
-                        .any(|entry| entry.offer_id == offer.offer_id)
-                        && offer
-                            .threshold_method
-                            .as_ref()
-                            .is_some_and(|method| method.method_id == key_method_id)
-                })
+        complete_guided_story_for_test(&mut runtime, 5_100);
+        let dealt_key_offer = runtime
+            .draw_until_test_offer(5_100, &access, |offer| {
+                offer
+                    .threshold_method
+                    .as_ref()
+                    .is_some_and(|method| method.method_id == key_method_id)
             })
             .expect("exact key threshold offer is dealt within a bounded rotation");
         let api = runtime

--- a/v2/orchestrator-rust/src/transfers.rs
+++ b/v2/orchestrator-rust/src/transfers.rs
@@ -941,7 +941,7 @@ mod tests {
                 .collect::<BTreeSet<_>>()
                 .len(),
             action_hand.entries.len(),
-            "the two-card hand cannot collapse or duplicate exact transfer offers"
+            "the Story Hand cannot collapse or duplicate exact transfer offers"
         );
 
         runtime.actor_autonomy.entry(5000).or_default().control_mode = ActorControlMode::LocalAi;

--- a/v2/orchestrator-rust/src/turns.rs
+++ b/v2/orchestrator-rust/src/turns.rs
@@ -1305,7 +1305,7 @@ pub(super) fn command_dispatch_consumes_room_turn(dispatch: &CommandDispatch) ->
 }
 
 /// Local configuration, moderation, and transfer-offer responses do not require
-/// one of the finite hand's two cards at the command boundary. Accepting an
+/// one of the finite Story Hand's three cards at the command boundary. Accepting an
 /// offer still consumes a room turn because it moves an item; declining or
 /// withdrawing remains available while a focused scene is locked.
 pub(super) fn command_dispatch_is_visible_room_control(dispatch: &CommandDispatch) -> bool {
@@ -1804,7 +1804,7 @@ pub(super) async fn pass_action(
     ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
     Json(payload): Json<ActorRequest>,
-    pass_offer_id: &str,
+    think: &ActionHandPassView,
 ) -> Json<ActionResponse> {
     if !allow_actor_mutation(
         &state,
@@ -1848,15 +1848,30 @@ pub(super) async fn pass_action(
             events: Vec::new(),
         });
     }
-    if runtime
-        .action_hand_for(Some(payload.actor_id), &[])
-        .pass
-        .offer_id
-        != pass_offer_id
-    {
+    let (scene_key, safe_scene) = runtime.story_hand_scene_for_actor(payload.actor_id);
+    let story_state = runtime.story_hand_state_for_scene(payload.actor_id, &scene_key);
+    let slot_index = match think.slot.as_str() {
+        "story" => Some(0usize),
+        "self" => Some(1usize),
+        "anchor" => Some(2usize),
+        _ => None,
+    };
+    let free = safe_scene && !story_state.free_think_used;
+    let current = slot_index.is_some_and(|slot_index| {
+        think.offer_id.starts_with("think:")
+            && think.available
+            && think.state_revision == runtime.current_state_revision()
+            && think.scene_key == scene_key
+            && think.generation == story_state.slot_generations[slot_index]
+            && think.free == free
+            && think.consumes_turn != free
+            && !think.replaces_offer_id.is_empty()
+    });
+    if !current {
         drop(runtime);
         if let Some(path) = state.event_store_path.as_deref() {
-            if let Err(error) = record_stale_pass_rejection(path, payload.actor_id, pass_offer_id) {
+            if let Err(error) = record_stale_pass_rejection(path, payload.actor_id, &think.offer_id)
+            {
                 warn!(
                     "failed to record stale pass certificate metric for actor {}: {}",
                     payload.actor_id, error
@@ -1895,7 +1910,7 @@ pub(super) async fn pass_action(
     // or fails to advance the pass.
     let mut record = if let Some(focused) = focused.as_ref() {
         if focused.profile_id == FOCUSED_COMBAT_PROFILE_ID {
-            JournalRecord::new(
+            let mut record = JournalRecord::new(
                 CwAction {
                     kind: CW_ACTION_COMBAT_PASS,
                     actor_id: payload.actor_id,
@@ -1904,7 +1919,9 @@ pub(super) async fn pass_action(
                 },
                 runtime.next_seed_value(),
             )
-            .into_player_card()
+            .into_player_card();
+            record.bind_offer_kind("pass");
+            record
         } else {
             let mut record = JournalRecord::new(
                 CwAction {
@@ -1927,7 +1944,7 @@ pub(super) async fn pass_action(
             record
         }
     } else {
-        JournalRecord::new(
+        let record = JournalRecord::new(
             CwAction {
                 kind: CW_ACTION_NONE,
                 actor_id: payload.actor_id,
@@ -1935,13 +1952,22 @@ pub(super) async fn pass_action(
                 ..CwAction::default()
             },
             runtime.next_seed_value(),
-        )
-        .into_player_card()
+        );
+        if think.consumes_turn {
+            record.into_player_card()
+        } else {
+            record.into_player_control()
+        }
     };
     record
         .projection_mutations
-        .push(ProjectionMutation::ShuffleHand {
-            reason: "player_pass".to_string(),
+        .push(ProjectionMutation::ThinkHand {
+            slot: u8::try_from(slot_index.expect("a current Think has a valid slot"))
+                .expect("Story Hand has three slots"),
+            scene_key: scene_key.clone(),
+            replaces_offer_id: think.replaces_offer_id.clone(),
+            free: think.free,
+            reason: "player_think".to_string(),
         });
     if let Some(job) = thought_job.clone() {
         attach_avatar_reflection_check(&mut record, job);
@@ -1973,14 +1999,19 @@ pub(super) async fn pass_action(
         )
         .unwrap_or(500);
     }
-    let observation = advance_turn_and_capture_player_tick_observation(
-        &state,
-        &mut runtime,
-        turn_location_id,
-        payload.actor_id,
-        status,
-        &mut events,
-    );
+    let observation = think
+        .consumes_turn
+        .then(|| {
+            advance_turn_and_capture_player_tick_observation(
+                &state,
+                &mut runtime,
+                turn_location_id,
+                payload.actor_id,
+                status,
+                &mut events,
+            )
+        })
+        .flatten();
     drop(runtime);
     broadcast_events(&state, &released_events);
     broadcast_events(&state, &events);
@@ -2032,14 +2063,19 @@ pub(super) async fn draw_action(
     State(state): State<AppState>,
     Json(payload): Json<ActorRequest>,
 ) -> Json<ActionResponse> {
-    let offer_id = state
-        .inner
-        .lock()
-        .await
-        .action_hand_for(Some(payload.actor_id), &[])
-        .pass
-        .offer_id;
-    pass_action(client, State(state), Json(payload), &offer_id).await
+    let think = {
+        let runtime = state.inner.lock().await;
+        let (_, offers) =
+            runtime.legal_action_candidates(Some(payload.actor_id), &AccessContext::default());
+        runtime
+            .action_hand_for(Some(payload.actor_id), &offers)
+            .entries
+            .iter()
+            .find(|entry| entry.think.available)
+            .map(|entry| entry.think.clone())
+            .unwrap_or_else(empty_think_view)
+    };
+    pass_action(client, State(state), Json(payload), &think).await
 }
 
 async fn apply_focused_control(
@@ -3026,22 +3062,34 @@ mod tests {
                 .get_mut(&5001)
                 .expect("second worker controller")
                 .control_mode = ActorControlMode::LocalAi;
-            let actor = runtime.actor_by_id(5001).expect("focused inference actor");
+            let preferred = {
+                let actor = runtime.actor_by_id(5001).expect("focused inference actor");
+                runtime
+                    .resident_job_autonomy_record(actor, 82_199)
+                    .expect("focused worker has a preferred contribution")
+            };
             let mut dealt_generation = None;
             for generation in 0..64 {
-                runtime.hand_generations.insert(5001, generation);
                 let (_, offers) =
                     runtime.legal_action_candidates(Some(5001), &AccessContext::default());
+                let Some(preferred_offer) = offers
+                    .iter()
+                    .find(|offer| runtime.resident_offer_matches_record(offer, &preferred))
+                    .cloned()
+                else {
+                    continue;
+                };
+                let slot = story_hand_natural_slot(&preferred_offer);
+                let (scene_key, _) = runtime.story_hand_scene_for_actor(5001);
+                let mut story_state = runtime.story_hand_state_for_scene(5001, &scene_key);
+                story_state.slot_generations[slot] = generation;
+                runtime.story_hand_states.insert(5001, story_state);
                 let hand = runtime.action_hand_for(Some(5001), &offers);
-                let preferred = runtime
-                    .resident_job_autonomy_record(actor, 82_199)
-                    .expect("focused worker has a preferred contribution");
-                if offers.iter().any(|offer| {
-                    hand.entries
-                        .iter()
-                        .any(|entry| entry.offer_id == offer.offer_id)
-                        && runtime.resident_offer_matches_record(offer, &preferred)
-                }) {
+                if hand
+                    .entries
+                    .iter()
+                    .any(|entry| entry.offer_id == preferred_offer.offer_id)
+                {
                     dealt_generation = Some(generation);
                     break;
                 }

--- a/v2/orchestrator-rust/src/uses.rs
+++ b/v2/orchestrator-rust/src/uses.rs
@@ -843,23 +843,14 @@ mod tests {
         let candidate = runtime
             .default_player_feature_use_candidate(5000)
             .expect("the held Story Button can target a room feature");
-        let offer = (0..64)
-            .find_map(|generation| {
-                runtime.hand_generations.insert(5000, generation);
-                let (_, offers) =
-                    runtime.legal_action_candidates(Some(5000), &AccessContext::default());
-                let hand = runtime.action_hand_for(Some(5000), &offers);
-                offers.into_iter().find(|offer| {
-                    hand.entries
-                        .iter()
-                        .any(|entry| entry.offer_id == offer.offer_id)
-                        && RuntimeWorld::use_offer_matches_feature(
-                            offer,
-                            candidate.item_id,
-                            candidate.location_id,
-                            &candidate.feature_key,
-                        )
-                })
+        let offer = runtime
+            .draw_until_test_offer(5000, &AccessContext::default(), |offer| {
+                RuntimeWorld::use_offer_matches_feature(
+                    offer,
+                    candidate.item_id,
+                    candidate.location_id,
+                    &candidate.feature_key,
+                )
             })
             .expect("the exact room-feature offer is dealt within a bounded rotation");
         let state = test_app_state(runtime, None);

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -117,12 +117,14 @@ impl Serialize for RankedActionOffer {
     where
         S: serde::Serializer,
     {
-        let mut out = serializer.serialize_struct("RankedActionOffer", 22)?;
+        let presentation = action_card_presentation(self).map_err(serde::ser::Error::custom)?;
+        let mut out = serializer.serialize_struct("RankedActionOffer", 23)?;
         out.serialize_field("id", &self.id)?;
         out.serialize_field("offer_id", &self.offer_id)?;
         out.serialize_field("composition_id", &self.composition_id)?;
         out.serialize_field("kind", &self.kind)?;
         out.serialize_field("intention", &self.intention)?;
+        out.serialize_field("presentation", &presentation)?;
         if let Some(source) = &self.source_collectible {
             out.serialize_field(
                 "source_collectible",
@@ -240,7 +242,11 @@ impl Serialize for ActionHandView {
     where
         S: serde::Serializer,
     {
-        let mut out = serializer.serialize_struct("ActionHandView", 3)?;
+        let mut out = serializer.serialize_struct("ActionHandView", 7)?;
+        out.serialize_field("schema_version", &self.schema_version)?;
+        out.serialize_field("capacity", &self.capacity)?;
+        out.serialize_field("offer_queue_size", &self.deck_size)?;
+        out.serialize_field("think_available", &self.draw_available)?;
         out.serialize_field("generation", &self.generation)?;
         out.serialize_field("pass", &self.pass)?;
         out.serialize_field("entries", &self.entries)?;
@@ -253,11 +259,17 @@ impl Serialize for ActionHandPassView {
     where
         S: serde::Serializer,
     {
-        let mut out = serializer.serialize_struct("ActionHandPassView", 4)?;
+        let mut out = serializer.serialize_struct("ActionHandPassView", 10)?;
         out.serialize_field("offer_id", &self.offer_id)?;
         out.serialize_field("label", &self.label)?;
         out.serialize_field("state_revision", &self.state_revision)?;
         out.serialize_field("scene_key", &self.scene_key)?;
+        out.serialize_field("slot", &self.slot)?;
+        out.serialize_field("replaces_offer_id", &self.replaces_offer_id)?;
+        out.serialize_field("free", &self.free)?;
+        out.serialize_field("consumes_turn", &self.consumes_turn)?;
+        out.serialize_field("generation", &self.generation)?;
+        out.serialize_field("available", &self.available)?;
         out.end()
     }
 }
@@ -273,10 +285,15 @@ impl Serialize for ActionHandEntryView {
             id: &'a str,
         }
 
-        let mut out = serializer.serialize_struct("ActionHandEntryView", 4)?;
+        let mut out = serializer.serialize_struct("ActionHandEntryView", 9)?;
         out.serialize_field("offer_id", &self.offer_id)?;
         out.serialize_field("kind", &self.kind)?;
         out.serialize_field("intention", &self.intention)?;
+        out.serialize_field("slot", &self.slot)?;
+        out.serialize_field("suit", &self.suit)?;
+        out.serialize_field("verb", &self.verb)?;
+        out.serialize_field("think", &self.think)?;
+        out.serialize_field("replacement_count", &self.replacement_count)?;
         out.serialize_field(
             "provider",
             &ProviderIdentity {
@@ -4942,9 +4959,9 @@ impl RuntimeWorld {
         {
             "The action has no active project in the current scene.".to_string()
         } else if !offer.ranked_hand_eligible {
-            "Rest is legal here, but nothing currently needs recovery, so it stays outside the two-card browser hand.".to_string()
+            "Rest is legal here, but nothing currently needs recovery, so it stays outside the Story Hand.".to_string()
         } else {
-            "This legal action ranks outside the current two-card hand.".to_string()
+            "This legal action is waiting in the current Offer queue.".to_string()
         };
         ActionOfferDecisionView {
             offer_id: offer.offer_id.clone(),

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -263,4 +263,10 @@
 # lookup/resolution, search reinforcement, and legacy migration into
 # residents/memory.rs. Room observation, disproved-memory cleanup, movement
 # observation, gossip, and belief projection remain for the sequential #324.
-66712
+# 66712 -> 66896: integrate the Story Hand's persisted per-slot Think state,
+# public presentation envelope, projection event, and cross-surface regression
+# contracts at the existing runtime/snapshot/HTTP boundaries. Hand composition,
+# policy, commands, autonomous selection, and their focused tests remain in the
+# owning modules; this is a reviewed integration exception, not a new root-owned
+# gameplay subsystem.
+66889

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -615,11 +615,32 @@ async function main() {
   async function assertActionBarCapped(label, expectedCount = null) {
     const buttons = await visibleCommandButtons();
     if (expectedCount === null) {
-      assert(buttons.length >= 1 && buttons.length <= 2, `${label} should expose one or two actions: ${JSON.stringify(buttons)}`);
+      assert(buttons.length >= 1 && buttons.length <= 3, `${label} should expose one to three Story Hand actions: ${JSON.stringify(buttons)}`);
     } else {
       assert(buttons.length === expectedCount, `${label} should expose ${expectedCount} action${expectedCount === 1 ? "" : "s"}: ${JSON.stringify(buttons)}`);
     }
     return buttons;
+  }
+
+  async function focusThinkableCard(label, preferredSlot = "") {
+    const focused = await page.evaluate((slot) => {
+      const thinkable = actionBarActions().filter((action) => (
+        projectedHandEntryForAction(action)?.think?.available === true
+      ));
+      const candidate = thinkable.find((action) => (
+        !slot || projectedHandEntryForAction(action)?.slot === slot
+      )) || (!slot ? thinkable[0] : null);
+      if (!candidate) return null;
+      focusIndex = candidate.actionIndex;
+      focusedKey = actionHandKey(candidate);
+      renderCommands();
+      return {
+        key: focusedKey,
+        slot: projectedHandEntryForAction(candidate)?.slot || "",
+      };
+    }, preferredSlot);
+    assert(focused?.key, `${label} needs a Story Hand card with an available Think`);
+    return focused;
   }
 
   async function assertBrowserDrawReachesEveryLegalAction() {
@@ -629,28 +650,29 @@ async function main() {
         .map((button) => button.dataset.handKey)
         .filter(Boolean),
       eventSeq: Math.max(0, ...logEvents
-        .filter((event) => event.type === "hand.shuffled")
+        .filter((event) => event.type === "hand.thought")
         .map((event) => Number(event.seq || 0))),
       drawVisible: getComputedStyle(document.querySelector("#shuffle")).display !== "none",
     }));
     const initial = await handSnapshot();
     assert(
-      initial.visibleKeys.length >= 1 && initial.visibleKeys.length <= 2 && initial.drawVisible,
+      initial.visibleKeys.length >= 1 && initial.visibleKeys.length <= 3 && initial.drawVisible,
       `the opening scene should expose its finite hand and Think: ${JSON.stringify(initial)}`,
     );
+    await focusThinkableCard("opening scene");
     const [response] = await Promise.all([
       page.waitForResponse((candidate) => (
         candidate.request().method() === "POST"
         && new URL(candidate.url()).pathname === "/commands"
-        && String(candidate.request().postData() || "").includes("\"command\":\"pass\"")
+        && String(candidate.request().postData() || "").includes("\"command\":\"think\"")
       )),
       page.locator("#shuffle").click(),
     ]);
     const receipt = await response.json();
-    const drawEvent = (receipt.events || []).find((event) => event.type === "hand.shuffled");
+    const drawEvent = (receipt.events || []).find((event) => event.type === "hand.thought");
     assert(
       receipt.ok && Number(drawEvent?.seq || 0) > initial.eventSeq,
-      `Think should commit a newer hand.shuffled event: ${JSON.stringify(receipt)}`,
+      `Think should commit a newer hand.thought event: ${JSON.stringify(receipt)}`,
     );
     await page.waitForFunction(() => document.querySelector("#shuffle")?.disabled === false);
     const current = await handSnapshot();
@@ -661,20 +683,20 @@ async function main() {
       return {
         promptFits: prompt.scrollWidth <= prompt.clientWidth + 1,
         drawFits: rect.left >= 0 && rect.right <= window.innerWidth,
-        journaled: logEvents.some((event) => event.type === "hand.shuffled"),
+        journaled: logEvents.some((event) => event.type === "hand.thought"),
       };
     });
     assert(
       current.visibleKeys.length >= 1
-        && current.visibleKeys.length <= 2
+        && current.visibleKeys.length <= 3
         && current.eventSeq > initial.eventSeq
         && layout.promptFits
         && layout.drawFits
         && layout.journaled,
-      `Think should replace the finite hand without opening a full-deck chooser: ${JSON.stringify({ initial, current, layout })}`,
+      `Think should replace one Story Hand card without opening the offer queue: ${JSON.stringify({ initial, current, layout })}`,
     );
     steps.push({
-      label: "browser Think deals the next finite hand",
+      label: "browser Think replaces one Story Hand card",
       actions: current.visibleKeys.length,
       draws: 1,
     });
@@ -1091,7 +1113,7 @@ async function main() {
     assert(!/[●○]|chapter\s+\d+\s+of\s+\d+/i.test(`${guide.text} ${guide.aria}`), `first-tale guidance should feel like a story, not a progress meter: ${JSON.stringify(guide)}`);
     assert(/notice what the rain has changed/i.test(guide.text), `fresh first-tale guide should explain the first world question simply: ${JSON.stringify(guide)}`);
     assert(guide.layout?.whiteSpace === "nowrap" && guide.layout?.overflow === "hidden", `collapsed Journal guidance should stay on one line: ${JSON.stringify(guide)}`);
-    assert(guide.primary.toLowerCase().startsWith("notice"), `first-thread guidance should keep Notice in the dealt hand: ${JSON.stringify(guide)}`);
+    assert(guide.primary.toLowerCase().startsWith("wonder suit, notice"), `first-thread guidance should keep a Wonder · Notice card in the dealt hand: ${JSON.stringify(guide)}`);
     assert(guide.storyGuide === "next tale beat", `the projected first-tale card should explain its guide marker: ${JSON.stringify(guide)}`);
     assert(
       guide.settledNoticeStep?.stage === 2
@@ -1184,6 +1206,10 @@ async function main() {
   async function assertStalePassRefreshesAndRotatesReceipt() {
     const result = await page.evaluate(async () => {
       const previousState = state;
+      const previousActions = actions;
+      const previousHandKeys = handKeys;
+      const previousFocusIndex = focusIndex;
+      const previousFocusedKey = focusedKey;
       const previousActorId = actorId;
       const previousActorSession = actorSession;
       const previousSubmission = handPassSubmission;
@@ -1198,8 +1224,21 @@ async function main() {
         state = {
           world_seq: 19,
           primary_action: { kind: "check" },
-          action_hand: { pass: { offer_id: "pass:5000:19:1:ordinary" } },
+          action_hand: { entries: [{
+            slot: "story",
+            offer_id: "notice-19",
+            think: {
+              available: true,
+              slot: "story",
+              generation: 1,
+              offer_id: "think:5000:19:story:1:notice-19",
+            },
+          }] },
         };
+        actions = [{ label: "notice", focusKey: "check", offerIds: ["notice-19"] }];
+        handKeys = ["offer:notice-19"];
+        focusIndex = 0;
+        focusedKey = "check";
         actorId = 5000;
         actorSession = "stale-pass-test-session";
         handPassSubmission = null;
@@ -1214,8 +1253,19 @@ async function main() {
           state = {
             ...state,
             world_seq: 20,
-            action_hand: { pass: { offer_id: "pass:5000:20:1:ordinary" } },
+            action_hand: { entries: [{
+              slot: "story",
+              offer_id: "notice-20",
+              think: {
+                available: true,
+                slot: "story",
+                generation: 2,
+                offer_id: "think:5000:20:story:2:notice-20",
+              },
+            }] },
           };
+          actions = [{ label: "notice", focusKey: "check", offerIds: ["notice-20"] }];
+          handKeys = ["offer:notice-20"];
         };
         renderCommands = () => {};
         setError = (message) => errors.push(message);
@@ -1236,6 +1286,10 @@ async function main() {
         renderCommands = previousRenderCommands;
         setError = previousSetError;
         state = previousState;
+        actions = previousActions;
+        handKeys = previousHandKeys;
+        focusIndex = previousFocusIndex;
+        focusedKey = previousFocusedKey;
         actorId = previousActorId;
         actorSession = previousActorSession;
         handPassSubmission = previousSubmission;
@@ -1248,11 +1302,13 @@ async function main() {
         && result.retry?.ok === true
         && result.calls.length === 2
         && result.calls.every((call) => call.path === "/commands")
-        && result.calls[0]?.payload?.offer_id === "pass:5000:19:1:ordinary"
-        && result.calls[1]?.payload?.offer_id === "pass:5000:20:1:ordinary"
+        && result.calls[0]?.payload?.command === "think"
+        && result.calls[1]?.payload?.command === "think"
+        && result.calls[0]?.payload?.offer_id === "think:5000:19:story:1:notice-19"
+        && result.calls[1]?.payload?.offer_id === "think:5000:20:story:2:notice-20"
         && result.calls[0]?.payload?.envelope?.intent_id !== result.calls[1]?.payload?.envelope?.intent_id
         && result.submissionAfterStale === null,
-      "A definitive stale Pass must refresh the hand and use a new certificate on retry: "
+      "A definitive stale Think must refresh the selected slot and use a new certificate on retry: "
         + JSON.stringify(result),
     );
   }
@@ -1550,6 +1606,7 @@ async function main() {
             readableLabel.querySelectorAll(".card-emoji").forEach((emoji) => emoji.remove());
             return {
               text: readableLabel.textContent.trim(),
+              kicker: node.closest("button")?.querySelector(".cmd-kicker")?.textContent.trim() || "",
               clientWidth: node.closest("button")?.clientWidth || node.clientWidth,
               scrollWidth: node.closest("button")?.scrollWidth || node.scrollWidth,
             };
@@ -1592,10 +1649,10 @@ async function main() {
     assert(result.travelCards[0]?.focusKeys.length === 2, `grouped travel should keep both route focus targets: ${JSON.stringify(result)}`);
     assert(result.connectWalletActionCount === 0, `locked room routes should not deal wallet cards: ${JSON.stringify(result)}`);
     assert(!/connect wallet/i.test(result.economyText), `always-visible economy pill should not lead with wallet copy: ${JSON.stringify(result)}`);
-    const travelLabel = result.labels.find((entry) => entry.text === "go" || entry.text === "travel");
-    assert(travelLabel, `travel should remain a visible route action label: ${JSON.stringify(result)}`);
-    const listenLabel = result.labels.find((entry) => entry.text === "listen");
-    assert(listenLabel, `listen should remain a visible action label: ${JSON.stringify(result)}`);
+    const travelLabel = result.labels.find((entry) => entry.kicker.toLowerCase() === "travel");
+    assert(travelLabel, `travel should remain visible as the exact route verb: ${JSON.stringify(result)}`);
+    const listenLabel = result.labels.find((entry) => entry.kicker.toLowerCase() === "listen");
+    assert(listenLabel, `listen should remain visible as the exact action verb: ${JSON.stringify(result)}`);
     for (const label of [travelLabel, listenLabel]) {
       assert(label.scrollWidth <= label.clientWidth + 1, `${label.text} should fit without visual clipping: ${JSON.stringify(result)}`);
     }
@@ -1715,7 +1772,6 @@ async function main() {
           focusKey: action.focusKey,
           intention: action.intention,
           accessibleLabel: action.accessibleLabel,
-          cardType: actionCardType(action),
           icon: actionEmoji(action),
           title: actionTitle(action),
           summary: actionSummary(action),
@@ -2218,6 +2274,7 @@ async function main() {
           const button = document.querySelector(`#${id}`);
           const action = actions[Number(button?.dataset?.actionIndex)];
           return {
+            kicker: button?.querySelector(".cmd-kicker")?.textContent?.trim() || "",
             label: button?.querySelector(".cmd-label")?.textContent?.trim() || "",
             detail: button?.querySelector(".detail")?.textContent?.trim() || "",
             offerIds: action?.offerIds || [],
@@ -2233,7 +2290,7 @@ async function main() {
       };
       try {
         actorId = 5000;
-        actorSession = "exact-two-card-binding";
+        actorSession = "exact-story-hand-binding";
         post = async (path, payload) => {
           submissions.push({ path, payload });
           return { ok: true, status: 200, events: [] };
@@ -2373,12 +2430,13 @@ async function main() {
     });
     const exactCards = (family, expected) => {
       assert(
-        JSON.stringify(family.rendered) === JSON.stringify(expected.map((entry) => ({
-          label: entry.label,
-          detail: entry.detail,
-          offerIds: [entry.offerId],
-        }))),
+        JSON.stringify(family.rendered.map((entry) => entry.offerIds))
+          === JSON.stringify(expected.map((entry) => [entry.offerId])),
         `two same-kind current offers must remain two distinct exact cards: ${JSON.stringify(family)}`,
+      );
+      assert(
+        new Set(family.rendered.map((entry) => `${entry.kicker}\u0000${entry.label}\u0000${entry.detail}`)).size === expected.length,
+        `same-kind cards should remain visibly distinguishable by verb, title, and effect: ${JSON.stringify(family)}`,
       );
       for (const submission of family.submissions) {
         for (const internal of [
@@ -3251,8 +3309,7 @@ async function main() {
       && result.reloadPending[0].profile === "speech"
       && result.reloadPending[0].stage === "generating", `reload must reconstruct the latest unmatched model interaction: ${JSON.stringify(result.reloadPending)}`);
     assert(result.duplicateCard?.disabled === true
-      && result.duplicateCard?.busy === "true"
-      && /synthesizing the line with the exact voice/i.test(result.duplicateCard?.text || ""), `a rehydrated durable interaction must keep its duplicate action disabled: ${JSON.stringify(result.duplicateCard)}`);
+      && result.duplicateCard?.busy === "true", `a rehydrated durable interaction must keep its duplicate action disabled: ${JSON.stringify(result.duplicateCard)}`);
     assert(result.gapPrepared === true && result.gapRehydrationCleared === true, `the SSE gap path must require and complete authoritative rehydration: ${JSON.stringify(result)}`);
     assert(result.gapPending?.length === 1
       && result.gapPending[0].queueEventSeq === 410
@@ -3678,7 +3735,7 @@ async function main() {
         && result.busy?.progressBars === 1
         && result.busy?.opacity === "1"
         && result.busy?.cursor === "progress"
-        && /travelling.*following the path to Rain-Silver Crossing/i.test(result.busy?.text || ""),
+        && /travel.*Rain-Silver Crossing/i.test(result.busy?.text || ""),
       `Travel should remain legible and show an accessible progress rail while pending: ${JSON.stringify(result)}`,
     );
     assert(result.choices.every((choice) => choice.card?.role === "location"), `each Travel destination should carry its own Location card: ${JSON.stringify(result)}`);
@@ -3719,13 +3776,13 @@ async function main() {
       `single-route accessibility copy should carry the same direction-aware identity: ${JSON.stringify(result)}`,
     );
     assert(
-      result.singleCard?.text === "Route to Jerusalem"
-        && result.singleCard?.label === "Route to Jerusalem"
+      result.singleCard?.text === "TRAVEL Rain-Silver Crossing free"
+        && result.singleCard?.label === "Rain-Silver Crossing"
         && !result.singleCard?.detail
         && !result.singleCard?.provider
         && !result.singleCard?.story
-        && result.singleCard?.aria === "Travel via Route to Jerusalem",
-      `a single Travel card should show only its concise destination: ${JSON.stringify(result)}`,
+        && result.singleCard?.aria === "control, Travel, Rain-Silver Crossing, free",
+      `a synthetic Travel offer without server presentation should show its exact verb and target while failing closed to a control: ${JSON.stringify(result)}`,
     );
     assert(result.single?.choices?.length === 0 && result.single?.payload?.destination_location_id === 2, `single-path Travel should not add an unnecessary choice: ${JSON.stringify(result)}`);
   }
@@ -3941,7 +3998,7 @@ async function main() {
           offer_id: "pickup-story-button",
           kind: "pick_up",
           target: { kind: "item", id: 2005, label: "Story Button" },
-          effect: "adds the floor item to your carried deck",
+          effect: "adds the floor item to your Pack",
         }],
         economy: {
           orbs: 0,
@@ -4108,7 +4165,7 @@ async function main() {
     assert(result.full.detail === "Story Button", `Take should name the incoming card: ${JSON.stringify(result)}`);
     assert(result.full.title === "pick up Story Button" && result.full.confirm === "take", `Take should keep its own verb through confirmation: ${JSON.stringify(result)}`);
     assert(result.full.summary === "Tuck Story Button into your keeping.", `Take should add the card without evicting another one: ${JSON.stringify(result)}`);
-    assert(result.empty.label === "take" && result.empty.detail === "Story Button", `an empty carried deck should still offer a simple Take card: ${JSON.stringify(result)}`);
+    assert(result.empty.label === "take" && result.empty.detail === "Story Button", `an empty Pack should still offer a simple Take card: ${JSON.stringify(result)}`);
     assert(result.empty.title === "pick up Story Button" && result.empty.confirm === "take", `Take should keep simple confirmation language: ${JSON.stringify(result)}`);
     assert(result.empty.summary === "Tuck Story Button into your keeping.", `Take should explain where the item goes: ${JSON.stringify(result)}`);
     assert(result.multiple.count === 1 && result.multiple.detail === "choose an item", `multiple floor items should share one Take card: ${JSON.stringify(result)}`);
@@ -4139,12 +4196,12 @@ async function main() {
           item_id: 2005,
           target_item_id: 2002,
         }),
-      `a full carried deck must submit the exact deterministic exchange chosen by the Rust authority: ${JSON.stringify(result.capacityExchange)}`,
+      `a full Pack must submit the exact deterministic exchange chosen by the Rust authority: ${JSON.stringify(result.capacityExchange)}`,
     );
     assert(result.searchConfirm === "search" && result.travelConfirm === "go", `every card should confirm with its own verb: ${JSON.stringify(result)}`);
   }
 
-  async function assertGiveTradeCanBeDrawnFromShuffledDeck() {
+  async function assertGiveTradeCanBeDealtInStoryHand() {
     const result = await page.evaluate(() => {
       const previousState = state;
       const previousActorId = actorId;
@@ -4190,10 +4247,28 @@ async function main() {
           { offer_id: "move", kind: "move", verb: "Travel", rank: 40, provider: { kind: "rules", id: "move", priority: 40 } },
         ],
         action_hand: {
-          pass: { offer_id: "pass:deck-test", label: "Think" },
           entries: [
-            { offer_id: "give", kind: "give_item", provider: { kind: "rules", id: "give", priority: 10 } },
-            { offer_id: "trade", kind: "trade_item", provider: { kind: "rules", id: "trade", priority: 20 } },
+            {
+              slot: "story",
+              offer_id: "give",
+              kind: "give_item",
+              provider: { kind: "rules", id: "give", priority: 10 },
+              think: { available: true, free: true, slot: "story", offer_id: "think:story-hand-test:story" },
+            },
+            {
+              slot: "self",
+              offer_id: "trade",
+              kind: "trade_item",
+              provider: { kind: "rules", id: "trade", priority: 20 },
+              think: { available: true, free: false, slot: "self", offer_id: "think:story-hand-test:self" },
+            },
+            {
+              slot: "anchor",
+              offer_id: "check",
+              kind: "check",
+              provider: { kind: "rules", id: "check", priority: 30 },
+              think: { available: true, free: false, slot: "anchor", offer_id: "think:story-hand-test:anchor" },
+            },
           ],
         },
         economy: {
@@ -4243,7 +4318,7 @@ async function main() {
       };
       state = fakeState;
       actorId = 5000;
-      actorSession = "deck-test";
+      actorSession = "story-hand-test";
       actions = buildActions(fakeState);
       handKeys = ["check", "exit:2"];
       discardedHandKeys = [];
@@ -4389,8 +4464,8 @@ async function main() {
       `a certified Trade card must not expose undealt swap choices: ${JSON.stringify(result)}`,
     );
     assert(!/eager|willingness|accepted/i.test(JSON.stringify(result.tradeCopy)), `trade copy should hide resident-economy state tags: ${JSON.stringify(result)}`);
-    assert(result.visibleHand.length === 2, `the authoritative browser hand should expose exactly two actions: ${JSON.stringify(result)}`);
-    assert(!result.hasThirdCard && result.hasShuffleCard, `the browser hand should keep two action cards beside its draw control: ${JSON.stringify(result)}`);
+    assert(result.visibleHand.length === 3, `the authoritative browser Story Hand should expose exactly three actions: ${JSON.stringify(result)}`);
+    assert(result.hasThirdCard && result.hasShuffleCard, `the browser should provide three Story Hand slots beside its Think control: ${JSON.stringify(result)}`);
     assert(result.actionLabels.some((label) => label.startsWith("give ")) && result.actionLabels.some((label) => label.startsWith("trade ")), `actions outside the hand should remain in the complete legal surface: ${JSON.stringify(result)}`);
     assert(result.semanticBindings.find((entry) => entry.label === "give")?.kinds?.includes("give_item"), `Give must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
     assert(result.semanticBindings.find((entry) => entry.label === "trade")?.kinds?.includes("trade_item"), `Trade must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
@@ -4730,7 +4805,7 @@ async function main() {
     assert(result.demanded.includes("Thimble Charm teaches careful handwork"), `the slot prompt should explain why this charm needs room: ${JSON.stringify(result)}`);
     assert(result.demanded.includes("Your Journal has enough advancement"), `the slot prompt should explain its Journal source: ${JSON.stringify(result)}`);
     assert(result.demanded.includes("data-unlock-charm-slot"), `the demand-driven prompt should expose one capacity action: ${JSON.stringify(result)}`);
-    assert(!result.absent.includes("data-unlock-charm-slot") && !result.absent.includes("Make room for"), `Deck & Loadout should stay quiet when no concrete charm demand exists: ${JSON.stringify(result)}`);
+    assert(!result.absent.includes("data-unlock-charm-slot") && !result.absent.includes("Make room for"), `Pack & Loadout should stay quiet when no concrete charm demand exists: ${JSON.stringify(result)}`);
   }
 
   async function assertPlayerDefeatTransitionIsExplicit() {
@@ -6096,6 +6171,7 @@ async function main() {
           effect: "Rati bond +1",
           risk: "one-shot",
           detail: "Story Button, Rati bond +1",
+          target: { kind: "item", id: 2005, label: "Story Button" },
         });
         const simpleButtonTitle = probeButton.getAttribute("title") || "";
         const simpleButtonAria = probeButton.getAttribute("aria-label") || "";
@@ -6105,6 +6181,7 @@ async function main() {
           effect: "helps Moonlit Echo; finishes progress clock moonlit-trail.progress by 1; first help deepens Bond with Moonlit Echo",
           risk: "",
           detail: "finish, safe, bond +1",
+          target: { kind: "actor", id: 1004, label: "Moonlit Echo" },
         });
         const finishButtonTitle = probeButton.getAttribute("title") || "";
         renderButton("compact-meta-probe", {
@@ -6113,6 +6190,7 @@ async function main() {
           effect: "uses complete project evidence; sets up +3 progress",
           risk: "",
           detail: "setup +3",
+          target: { kind: "project", id: "moonlit-trail", label: "Moonlit Trail" },
         });
         const setupButtonTitle = probeButton.getAttribute("title") || "";
         actorId = 5000;
@@ -6322,10 +6400,10 @@ async function main() {
     assert(result.cozyMemory.some((entry) => entry.text === "Hearth Tonic changes hands."), `room memory should turn command-like Take copy into a room beat: ${JSON.stringify(result)}`);
     assert(result.cozyMemory.some((entry) => entry.text === "Skull carries Hearth Tonic toward Hearth."), `room memory should turn item-use hints into story language: ${JSON.stringify(result)}`);
     assert(result.cozyMemory.some((entry) => entry.label === "purpose" && entry.text === "I listen for odd jobs."), `room memory should keep the purpose without its setup prompt: ${JSON.stringify(result)}`);
-    assert(result.buttonTitle === "use Story Button; friendship with Rati grows; once", `button tooltip should use warm relationship copy: ${JSON.stringify(result)}`);
-    assert(result.finishButtonTitle === "assist; helps Moonlit Echo; finishes the work; first help brings you closer to Moonlit Echo", `finish tooltip should hide progress-clock jargon: ${JSON.stringify(result)}`);
-    assert(result.setupButtonTitle === "prepare; brings together every clue you found; makes the next try count", `setup tooltip should explain its payoff naturally: ${JSON.stringify(result)}`);
-    assert(result.buttonAria === "use, Story Button, friendship with Rati grows", `button aria copy should stay warm and readable: ${JSON.stringify(result)}`);
+    assert(result.buttonTitle === "use; Story Button; friendship with Rati grows; free · once", `button tooltip should follow verb, target, effect, and cost/risk order with warm copy: ${JSON.stringify(result)}`);
+    assert(result.finishButtonTitle === "help; Moonlit Echo; helps Moonlit Echo; finishes the work; first help brings you closer to Moonlit Echo; free", `finish tooltip should hide progress-clock jargon: ${JSON.stringify(result)}`);
+    assert(result.setupButtonTitle === "prepare; Moonlit Trail; brings together every clue you found; makes the next try count; free", `setup tooltip should explain its payoff naturally: ${JSON.stringify(result)}`);
+    assert(result.buttonAria === "control, use, Story Button, friendship with Rati grows, free, once", `button aria copy should preserve the same readable card-face order: ${JSON.stringify(result)}`);
     assert(result.finishDetail === "finishes the work", `finish effect copy should hide progress-clock text: ${JSON.stringify(result)}`);
     assert(result.setupDetail === "uses complete project evidence; makes the next try count", `compact setup copy should hide progress arithmetic before the friendlier rendering pass: ${JSON.stringify(result)}`);
     assert(result.orbGainText === "earned one" && result.orbSpendText === "spent two", `Orb changes should read as small events rather than signed arithmetic: ${JSON.stringify(result)}`);
@@ -6333,7 +6411,7 @@ async function main() {
     assert(result.sheetHtml.includes("journal") && result.sheetHtml.includes("something you noticed is ready to keep · you can strengthen a friendship or open bracelet space"), `Journal row should summarize growth without counted resources: ${JSON.stringify(result)}`);
     assert(!/memory marks?|growth points?|\b(?:one|two|three|four) (?:memories|chances)\b/i.test(result.sheetHtml), `Journal row should keep growth arithmetic out of the avatar sheet: ${JSON.stringify(result)}`);
     assert(result.sheetHtml.includes("purpose") && result.sheetHtml.includes("I stick my nose into lost-property trouble."), `avatar sheet should name purpose in everyday language: ${JSON.stringify(result)}`);
-    assert(result.sheetHtml.includes("worn skill charms") && result.sheetHtml.includes("find a skill charm, then wear it from Deck"), `avatar sheet should direct skill loadout changes to physical charms: ${JSON.stringify(result)}`);
+    assert(result.sheetHtml.includes("worn skill charms") && result.sheetHtml.includes("find a skill charm, then wear it from Pack"), `avatar sheet should direct Loadout changes to physical charms: ${JSON.stringify(result)}`);
     assert(result.sheetHtml.includes("friends") && result.sheetHtml.includes("I bring small kindnesses to Gust. (new friend)"), `friendship should show its statement and warm closeness instead of a raw strength number: ${JSON.stringify(result)}`);
     assert(!result.sheetHtml.includes("Gust 1"), `avatar sheet should not expose raw bond counters: ${JSON.stringify(result)}`);
     assert(!Object.values(result).some((value) => String(value).includes(" / ")), `compact meta copy should avoid slash-heavy separators: ${JSON.stringify(result)}`);
@@ -9741,29 +9819,39 @@ async function main() {
     ), 8, stopWhen);
   }
 
-  async function passCertifiedHandForDraw(label) {
+  async function passCertifiedHandForDraw(label, preferredSlot = "") {
     let lastRejection = null;
-    const currentPassState = () => page.evaluate(() => ({
-      offerId: String(state?.action_hand?.pass?.offer_id || ""),
-      generation: Number(state?.action_hand?.generation || 0),
-    }));
-    const reconciledAsOneHandAdvance = (before, after) => (
-      after.offerId
-        && after.offerId !== before.offerId
+    const currentThinkState = (slot = "") => page.evaluate((expectedSlot) => {
+      const entry = expectedSlot
+        ? (state?.action_hand?.entries || []).find((candidate) => candidate?.slot === expectedSlot)
+        : projectedHandEntryForAction(visibleFocusedAction());
+      const think = entry?.think || {};
+      return {
+        offerId: String(think.offer_id || ""),
+        slot: String(think.slot || entry?.slot || ""),
+        generation: Number(think.generation || 0),
+      };
+    }, slot);
+    const reconciledAsOneSlotAdvance = (before, after) => (
+      after.offerId !== before.offerId
+        && after.slot === before.slot
         && after.generation === before.generation + 1
     );
     for (let attempt = 1; attempt <= 3; attempt += 1) {
+      await focusThinkableCard(label, preferredSlot);
       await page.waitForFunction(() => (
         actionBusy === false
           && refreshInFlight === null
           && document.querySelector("#shuffle")?.disabled === false
       ));
       const before = await page.evaluate(() => {
-        const pass = state?.action_hand?.pass || null;
+        const entry = projectedHandEntryForAction(visibleFocusedAction());
+        const think = entry?.think || {};
         const control = document.querySelector("#shuffle");
         return {
-          offerId: String(pass?.offer_id || ""),
-          generation: Number(state?.action_hand?.generation || 0),
+          offerId: String(think.offer_id || ""),
+          slot: String(think.slot || entry?.slot || ""),
+          generation: Number(think.generation || 0),
           controlId: control?.id || "",
           visible: Boolean(control && getComputedStyle(control).display !== "none"),
           disabled: Boolean(control?.disabled),
@@ -9775,8 +9863,8 @@ async function main() {
           && before.controlId === "shuffle"
           && before.visible
           && !before.disabled
-          && /commit a pass/i.test(before.ariaLabel),
-        `${label} hand rotation must start from the certified Pass (Think) control: ${JSON.stringify(before)}`,
+          && /replace the .* card/i.test(before.ariaLabel),
+        `${label} replacement must start from the focused card's certified Think control: ${JSON.stringify(before)}`,
       );
       let response;
       try {
@@ -9784,58 +9872,59 @@ async function main() {
           page.waitForResponse((candidate) => (
             candidate.request().method() === "POST"
               && new URL(candidate.url()).pathname === "/commands"
-              && String(candidate.request().postData() || "").includes("\"command\":\"pass\"")
+              && String(candidate.request().postData() || "").includes("\"command\":\"think\"")
           ), { timeout: 10_000 }),
           page.locator("#shuffle").click(),
         ]);
       } catch (error) {
         lastRejection = { before, error: String(error?.message || error) };
         await page.evaluate(() => refresh());
-        const after = await currentPassState();
-        if (reconciledAsOneHandAdvance(before, after)) return;
+        const after = await currentThinkState(before.slot);
+        if (reconciledAsOneSlotAdvance(before, after)) return;
         assert(
           after.offerId === before.offerId && after.generation === before.generation,
-          `${label} Pass outcome was ambiguous across multiple hand generations: ${JSON.stringify({ before, after, error: lastRejection.error })}`,
+          `${label} Think outcome was ambiguous across multiple slot generations: ${JSON.stringify({ before, after, error: lastRejection.error })}`,
         );
-        throw new Error(`${label} Pass response was not observed; refusing an ambiguous retry: ${lastRejection.error}`);
+        throw new Error(`${label} Think response was not observed; refusing an ambiguous retry: ${lastRejection.error}`);
       }
       const receipt = await response.json();
       const request = response.request().postDataJSON();
-      const shuffleEvent = (receipt.events || []).find((event) => event.type === "hand.shuffled");
+      const thinkEvent = (receipt.events || []).find((event) => event.type === "hand.thought");
       if (receipt.ok === true) {
         assert(
-          request?.command === "pass"
+          request?.command === "think"
             && String(request?.offer_id || "") === before.offerId
-            && Number(shuffleEvent?.seq || 0) > 0,
-          `${label} hand rotation must commit the exact certified Pass, never an undealt action: ${JSON.stringify({ before, request, receipt })}`,
+            && Number(thinkEvent?.seq || 0) > 0,
+          `${label} must commit the focused card's exact Think certificate: ${JSON.stringify({ before, request, receipt })}`,
         );
         await page.waitForFunction(() => (
           actionBusy === false
             && refreshInFlight === null
-            && document.querySelector("#shuffle")?.disabled === false
         ));
-        const after = await currentPassState();
+        await page.evaluate(() => refresh());
+        await page.waitForFunction(() => actionBusy === false && refreshInFlight === null);
+        const after = await currentThinkState(before.slot);
         assert(
-          reconciledAsOneHandAdvance(before, after),
-          `${label} successful Pass should advance exactly one hand generation: ${JSON.stringify({ before, request, after, receipt })}`,
+          reconciledAsOneSlotAdvance(before, after),
+          `${label} successful Think should advance exactly one slot generation: ${JSON.stringify({ before, request, after, receipt })}`,
         );
         return;
       }
       lastRejection = { before, request, receipt, httpStatus: response.status() };
       assert(
         Number(receipt.status || response.status()) === 409,
-        `${label} Pass failed without a definitive stale certificate: ${JSON.stringify(lastRejection)}`,
+        `${label} Think failed without a definitive stale certificate: ${JSON.stringify(lastRejection)}`,
       );
       await page.waitForFunction(() => actionBusy === false && refreshInFlight === null);
       await page.evaluate(() => refresh());
-      const after = await currentPassState();
-      if (reconciledAsOneHandAdvance(before, after)) return;
+      const after = await currentThinkState(before.slot);
+      if (reconciledAsOneSlotAdvance(before, after)) return;
       assert(
         after.generation === before.generation,
-        `${label} stale Pass crossed multiple hand generations: ${JSON.stringify({ before, after, lastRejection })}`,
+        `${label} stale Think crossed multiple slot generations: ${JSON.stringify({ before, after, lastRejection })}`,
       );
     }
-    throw new Error(`${label} could not obtain a fresh certified Pass after three stale scenes: ${JSON.stringify(lastRejection)}`);
+    throw new Error(`${label} could not obtain a fresh certified Think after three stale scenes: ${JSON.stringify(lastRejection)}`);
   }
 
   async function drawCertifiedGardenInspect(label, stopWhen = null) {
@@ -10916,27 +11005,27 @@ async function main() {
       const availableKinds = await page.evaluate(() => actions.map((action) => (
         [compactActionLabel(action), action?.command].filter(Boolean).join(" ").toLowerCase()
       )));
-      if (!availableKinds.some((text) => text.startsWith("inspect"))
+      if (!availableKinds.some((text) => /^(inspect|scout)\b/.test(text))
         && !listeningPreludeUsed
         && availableKinds.some((text) => text.startsWith("notice"))) {
         await focusPrimaryMatching(
-          `notice before inspecting for ${name}`,
+          `notice before discovering ${name}`,
           (text) => text.startsWith("notice"),
           4,
         );
-        await clickPrimary(`notice before inspecting for ${name}`);
+        await clickPrimary(`notice before discovering ${name}`);
         await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
         listeningPreludeUsed = true;
         attempt -= 1;
         continue;
       }
       await focusPrimaryMatchingAcrossShuffles(
-        `inspect for ${name}`,
-        (text) => text.startsWith("inspect"),
+        `discover route to ${name}`,
+        (text) => /^(inspect|scout)\b/.test(text),
       );
-      await clickSearchAndAssertProgress(`inspect for ${name} ${attempt}`);
+      await clickSearchAndAssertProgress(`discover route to ${name} ${attempt}`);
     }
-    throw new Error(`${name} was not found after ${maxAttempts} Inspect turns`);
+    throw new Error(`${name} was not found after ${maxAttempts} Wonder discovery turns`);
   }
 
   async function joinNearbyResident() {
@@ -11459,7 +11548,7 @@ async function main() {
       if (result.ok) break;
       if (stopWhen && await stopWhen()) return null;
       if (draw + 1 < deckSize) {
-        await passCertifiedHandForDraw(`find ${name} gift`);
+        await passCertifiedHandForDraw(`find ${name} gift`, "self");
       }
     }
     assert(result?.ok, `${name} should be carried by one Give or Swap card: ${JSON.stringify(result)}`);
@@ -12141,7 +12230,7 @@ async function main() {
     assert(!/\((?:human|npc)\)/i.test(result.who.output), `who should name people without engine categories: ${JSON.stringify(result.who)}`);
     assert(
       result.inventory.ok === true
-        && /You carry|You aren't carrying|Your carried deck is empty|Your carried deck:/i.test(result.inventory.output)
+        && /You carry|You aren't carrying|Your Pack is empty|Your Pack:/i.test(result.inventory.output)
         && result.inventory.events.length === 0,
       `inventory should remain a read-only terminal view: ${JSON.stringify(result.inventory)}`,
     );
@@ -12166,14 +12255,14 @@ async function main() {
   async function assertBrowserCommandEntryAbsent() {
     const before = await visibleCommandButtons();
     assert(
-      await page.locator("#command-toggle, #command-palette, #command-input, #tertiary").count() === 0
+      await page.locator("#command-toggle, #command-palette, #command-input").count() === 0
         && await page.locator("#shuffle").count() === 1
         && await page.locator("#all-actions-modal, [data-all-action-index]").count() === 0,
       "the browser room should expose only its dealt action hand and Think, without command entry or a full-deck chooser",
     );
     assert(
-      before.length >= 1 && before.length <= 2,
-      `the browser room should show one or two dealt action cards: ${JSON.stringify(before)}`,
+      before.length >= 1 && before.length <= 3,
+      `the browser room should show one to three dealt Story Hand cards: ${JSON.stringify(before)}`,
     );
     await page.evaluate(() => document.activeElement?.blur?.());
     await page.keyboard.press("Slash");
@@ -12309,6 +12398,9 @@ async function main() {
           const response = await responsePromise;
           lastResult = { httpStatus: response.status(), body: await response.json() };
           if (lastResult.body?.ok === true) {
+            await other.waitForFunction(() => actionBusy === false && refreshInFlight === null);
+            await other.evaluate(() => refresh());
+            await other.waitForFunction(() => actionBusy === false && refreshInFlight === null);
             await other.waitForFunction(settled, null, { timeout: 15_000 });
             return lastResult.body;
           }
@@ -12334,7 +12426,7 @@ async function main() {
         primary: document.querySelector("#primary")?.getAttribute("aria-label") || "",
         currentActorId: Number(state?.turn?.current_actor_id || 0),
       }));
-      assert(firstTaleStart.primary.toLowerCase().startsWith("notice"), `second player should enter through a welcoming Notice: ${JSON.stringify(firstTaleStart)}`);
+      assert(firstTaleStart.primary.toLowerCase().startsWith("wonder suit, notice"), `second player should enter through a welcoming Wonder · Notice card: ${JSON.stringify(firstTaleStart)}`);
       await playOtherPrimary("second-player Notice", () => (
         state?.first_tale?.phase === "follow_lead"
         && state?.first_tale?.trace_event_seq == null
@@ -12354,7 +12446,7 @@ async function main() {
       assert(!afterFirstListen.isCurrentActor, `the second player should not acquire an ordered combat turn from their first Notice: ${JSON.stringify(afterFirstListen)}`);
       assert(
         afterFirstListen.visibleLabels.length >= 1
-          && afterFirstListen.visibleLabels.length <= 2
+          && afterFirstListen.visibleLabels.length <= 3
           && afterFirstListen.visibleLabels.every((label) => !/grow|expand bracelet/i.test(label)),
         `the newcomer should receive a dealt shared-world hand without a private growth affordance: ${JSON.stringify(afterFirstListen)}`,
       );
@@ -12735,7 +12827,7 @@ async function main() {
     await page.locator("#brand").click();
     await page.waitForFunction(() => document.querySelector(".terminal")?.classList.contains("panel-open"));
     await page.locator('[data-menu-section="deck"]').click();
-    await page.waitForFunction(() => document.querySelector("#account-panel-title")?.textContent?.trim() === "your deck");
+    await page.waitForFunction(() => document.querySelector("#account-panel-title")?.textContent?.trim() === "your pack");
     const menuDeck = await page.evaluate(() => ({
       sections: [...document.querySelectorAll('[data-menu-section]')].map((button) => ({
         id: button.getAttribute("data-menu-section"),
@@ -12752,17 +12844,17 @@ async function main() {
       brandScrollWidth: document.querySelector("#brand")?.scrollWidth || 0,
     }));
     assert(JSON.stringify(menuDeck.sections) === JSON.stringify([
-      { id: "deck", label: "deck" },
+      { id: "deck", label: "pack" },
       { id: "character", label: "character" },
       { id: "identity", label: "sign in / identity" },
       { id: "world", label: "worlds & packs" },
       { id: "journal", label: "journal" },
       { id: "settings", label: "orbs & settings" },
-    ]), `${label}: Menu should separate deck, character, identity, worlds, journal, and settings: ${JSON.stringify(menuDeck)}`);
+    ]), `${label}: Menu should separate pack, character, identity, worlds, journal, and settings: ${JSON.stringify(menuDeck)}`);
     assert(menuDeck.iconCount === 6 && menuDeck.decorativeIcons, `${label}: every named Menu section should have one decorative icon: ${JSON.stringify(menuDeck)}`);
-    assert(menuDeck.role === "region" && menuDeck.label === "Your avatar menu" && menuDeck.heading === "your deck", `${label}: Deck should be a dedicated semantic panel: ${JSON.stringify(menuDeck)}`);
+    assert(menuDeck.role === "region" && menuDeck.label === "Your avatar menu" && menuDeck.heading === "your pack", `${label}: Pack should be a dedicated semantic panel: ${JSON.stringify(menuDeck)}`);
     assert(menuDeck.brandScrollWidth <= menuDeck.brandClientWidth, `${label}: the open Menu control should not clip hidden branding into the mobile header: ${JSON.stringify(menuDeck)}`);
-    assert(/physical cards, not a fixed card count/i.test(menuDeck.copy) && /carried weight/i.test(menuDeck.copy) && /skill charms/i.test(menuDeck.copy) && /spell deck/i.test(menuDeck.copy) && /exhausted \/ discard/i.test(menuDeck.copy), `${label}: Deck should explain weight, loadout, charms, spells, and exhausted cards: ${JSON.stringify(menuDeck)}`);
+    assert(/physical cards, not a fixed card count/i.test(menuDeck.copy) && /pack weight/i.test(menuDeck.copy) && /skill charms/i.test(menuDeck.copy) && /prepared spells/i.test(menuDeck.copy) && /spent/i.test(menuDeck.copy), `${label}: Pack should explain weight, Loadout, charms, Prepared spells, and Spent cards: ${JSON.stringify(menuDeck)}`);
     await page.locator('[data-menu-section="world"]').click();
     await page.waitForFunction(() => document.querySelector(".terminal")?.classList.contains("panel-open") && document.querySelector("#log")?.classList.contains("library-mode"));
     const library = await page.evaluate(() => ({
@@ -13638,6 +13730,7 @@ async function main() {
         .map((button) => {
           const thumb = button.querySelector(".thumb");
           const labelNode = button.querySelector(".cmd-label");
+          const kickerNode = button.querySelector(".cmd-kicker");
           return {
             id: button.id,
             text: button.innerText.trim().replace(/\s+/g, " "),
@@ -13647,6 +13740,7 @@ async function main() {
             hasIcon: Boolean(button.querySelector(".cmd-label .ui-icon")),
             width: button.getBoundingClientRect().width,
             labelClipped: Boolean(labelNode && labelNode.scrollWidth > labelNode.clientWidth + 1),
+            verbClipped: Boolean(kickerNode && kickerNode.scrollWidth > kickerNode.clientWidth + 1),
           };
         });
       const roomRow = document.querySelector("#log .line.event.room");
@@ -13720,13 +13814,13 @@ async function main() {
     assert(!shell.journalVisible && !shell.memoryVisible, `${label}: normal shell should keep Journal content out of chat: ${JSON.stringify(shell)}`);
     assert(shell.roomCollapsed, `${label}: room header should default to collapsed: ${JSON.stringify(shell)}`);
     assert(!shell.avatarSubtitleVisible && !shell.roomCopyVisible, `${label}: collapsed room should hide subtitle and prose: ${JSON.stringify(shell)}`);
-    const actionButtons = shell.buttons.filter((button) => ["primary", "secondary"].includes(button.id));
-    assert(actionButtons.length >= 1 && actionButtons.length <= 2, `${label}: shell should expose at most two action cards: ${JSON.stringify(shell.buttons)}`);
+    const actionButtons = shell.buttons.filter((button) => ["primary", "secondary", "tertiary"].includes(button.id));
+    assert(actionButtons.length >= 1 && actionButtons.length <= 3, `${label}: shell should expose at most three Story Hand cards: ${JSON.stringify(shell.buttons)}`);
     assert(actionButtons.every((button) => button.hasMiniCard && button.hasImage), `${label}: action hand should use mini card images: ${JSON.stringify(shell.buttons)}`);
     assert(actionButtons.every((button) => button.hasIcon), `${label}: action names should use the recovered SVG icon system: ${JSON.stringify(shell.buttons)}`);
     if (shell.viewport.startsWith("430x")) {
-      assert(actionButtons.length === 2, `${label}: narrow screens should preserve both authoritative suggestions: ${JSON.stringify(shell.buttons)}`);
-      assert(actionButtons.every((button) => button.width >= 60 && !button.labelClipped), `${label}: mobile card verbs should remain readable: ${JSON.stringify(shell.buttons)}`);
+      assert(actionButtons.length >= 1 && actionButtons.length <= 3, `${label}: narrow screens should preserve every authoritative Story Hand card: ${JSON.stringify(shell.buttons)}`);
+      assert(actionButtons.every((button) => button.width >= 60 && !button.verbClipped), `${label}: mobile card suit and verb kickers should remain readable: ${JSON.stringify(shell.buttons)}`);
       assert(shell.roomFallbackStacked, `${label}: mobile room story should use the full transcript width: ${JSON.stringify(shell)}`);
       assert(!shell.roomFallbackClipped, `${label}: mobile room story should not end mid-sentence: ${JSON.stringify(shell)}`);
     } else {
@@ -13892,16 +13986,17 @@ async function main() {
     await page.waitForSelector("#primary");
     await page.waitForFunction(() => {
       const primary = document.querySelector("#primary");
-      const label = primary?.getAttribute("aria-label") || "";
-      return !primary?.disabled && label.trim().toLowerCase().startsWith("begin,");
+      const label = (primary?.getAttribute("aria-label") || "").trim().toLowerCase();
+      return !primary?.disabled && /\bbegin\b/.test(label) && /shared[- ]world/.test(label);
     });
-    await assertActionBarCapped("guest avatar gate", 1);
+    await assertActionBarCapped("guest avatar gate", 2);
+    const openingPrimaryAria = ((await page.locator("#primary").getAttribute("aria-label")) || "").toLowerCase();
     const openingPrimary = (await primaryText()).toLowerCase();
     assert(
-      openingPrimary.includes("begin")
-        && openingPrimary.includes("shared world")
+      /\bbegin\b/.test(openingPrimaryAria)
+        && /shared[- ]world/.test(openingPrimaryAria)
         && !openingPrimary.includes("lantern keeper"),
-      `guest first card should ask only for core identity and aspiration: ${openingPrimary}`,
+      `guest first card should ask only for core identity and aspiration: ${openingPrimaryAria}`,
     );
     await page.locator("#primary").click();
     await page.waitForSelector("#action-modal:not([hidden])");
@@ -13966,7 +14061,7 @@ async function main() {
     assert(
       guestSheetText.includes("your first little moment is waiting")
         && guestSheetText.includes("worn skill charms")
-        && guestSheetText.includes("find a skill charm, then wear it from Deck")
+        && guestSheetText.includes("find a skill charm, then wear it from Pack")
         && guestSheetText.includes("someone new is waiting to meet you"),
       `an empty avatar sheet should point warmly toward what comes next: ${guestSheetText}`,
     );
@@ -14108,12 +14203,12 @@ async function main() {
   async function assertHumanActionRequiresActorSession() {
     const rejected = await page.evaluate(async () => {
       const actorId = Number(localStorage.getItem("cosyworld.actorId") || 0);
-      const pass = state?.action_hand?.pass;
-      if (!pass?.offer_id) return { ok: false, status: 0, events: [], missing: "pass certificate" };
+      const think = (state?.action_hand?.entries || []).find((entry) => entry?.think?.available)?.think;
+      if (!think?.offer_id) return { ok: false, status: 0, events: [], missing: "Think certificate" };
       const response = await fetch("/commands", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ actor_id: actorId, command: "pass", offer_id: pass.offer_id }),
+        body: JSON.stringify({ actor_id: actorId, command: "think", offer_id: think.offer_id }),
       });
       return response.json();
     });
@@ -14357,10 +14452,11 @@ async function main() {
   if (quietRoomDesktopViewport) await page.setViewportSize(quietRoomDesktopViewport);
   await assertNoComposerOrDebugChrome();
   await assertChatMarkdownTypography();
-  // Before an avatar exists there is one onboarding command, rather than a
-  // dealt action hand. The finite two-card cap begins with normal play.
-  await assertActionBarCapped("avatar gate", 1);
-  assert((await primaryText()).toLowerCase().includes("begin"), "first command should begin avatar creation");
+  // Before an avatar exists there are core and optional campaign onboarding
+  // commands, rather than a dealt Story Hand. The three slots begin in play.
+  await assertActionBarCapped("avatar gate", 2);
+  const avatarGatePrimaryAria = ((await page.locator("#primary").getAttribute("aria-label")) || "").toLowerCase();
+  assert(/\bbegin\b/.test(avatarGatePrimaryAria), "first command should begin avatar creation");
 
   await beginAvatarAndAssertArrival();
   await page.waitForFunction(() => actorId > 0 && localStorage.getItem("cosyworld.actorId") === String(actorId));
@@ -14394,7 +14490,7 @@ async function main() {
     );
   }
   // A fresh seed has not necessarily banked the advancement that authorizes
-  // Chat, so the authoritative opening hand may contain one or two cards.
+  // Chat, so a sparse authoritative opening Story Hand may contain fewer than three cards.
   await assertActionBarCapped("normal play");
   await assertFirstThreadGuide();
   await assertStalePassRefreshesAndRotatesReceipt();
@@ -14441,7 +14537,7 @@ async function main() {
   await assertChatActivityLivesInStatusSurface();
   await assertChoicePreviewFollowsSelectedCard();
   await assertCarriedDeckUsesWeightLanguage();
-  await assertGiveTradeCanBeDrawnFromShuffledDeck();
+  await assertGiveTradeCanBeDealtInStoryHand();
   await assertAvatarItemsUseDisclosureAndExactActions();
   await assertHumanGiftHandoffUsesRecipientHandAndAvatarRail();
   await assertDiscoverySettlementDoesNotSurfaceGrowAction();
@@ -14759,7 +14855,7 @@ async function main() {
       residentChatDiagnostic.advancement >= 0
         && residentChatDiagnostic.residents.length > 0
         && residentChatDiagnostic.visibleLabels.length >= 1
-        && residentChatDiagnostic.visibleLabels.length <= 2,
+        && residentChatDiagnostic.visibleLabels.length <= 3,
       `the shared room should expose a bounded authoritative hand near its resident: ${JSON.stringify(residentChatDiagnostic)}`,
     );
     if (residentChatDiagnostic.chatOfferAvailable) {
@@ -14919,7 +15015,7 @@ async function main() {
               ok: false,
               actionHand: {
                 capacity: Number(state?.action_hand?.capacity || 0),
-                deckSize: Number(state?.action_hand?.deck_size || 0),
+                deckSize: Number(state?.action_hand?.offer_queue_size || 0),
                 generation: Number(state?.action_hand?.generation || 0),
               },
               hand: visible.map((candidate) => {
@@ -15628,6 +15724,10 @@ async function main() {
       await travelTo("Moonlit Trail");
     }
     await exerciseFrontierRecovery();
+    const frontierJourney = await fetchCurrentState();
+    if (frontierJourney.journey?.destination_name) {
+      await travelTo(frontierJourney.journey.destination_name);
+    }
     if ((await currentLocation()) !== "Rain-Soft Garden") {
       await leaveTrailTo("Rain-Soft Garden");
     }
@@ -15895,7 +15995,7 @@ async function main() {
     ...finalState.branchReceiptEvents.map((event) => ({ ...event, source: "action receipt" })),
   ];
   assert(allBranchEvents.length === 0, `normal play should not emit branch lifecycle events: ${JSON.stringify(allBranchEvents)}`);
-  assert(finalState.buttons.length >= 1 && finalState.buttons.length <= 2, `the journey should finish with at most two action cards: ${JSON.stringify(finalState.buttons)}`);
+  assert(finalState.buttons.length >= 1 && finalState.buttons.length <= 3, `the journey should finish with at most three Story Hand cards: ${JSON.stringify(finalState.buttons)}`);
   await assertNoComposerOrDebugChrome();
   await page.setViewportSize({ width: 1280, height: 800 });
   await page.waitForTimeout(150);

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -651,6 +651,17 @@ async function main() {
     return focused;
   }
 
+  async function storyHandRotationSlots() {
+    return page.evaluate(() => (state?.action_hand?.entries || []).flatMap((entry) => (
+      entry?.think?.available === true
+        ? Array.from(
+          { length: Math.max(0, Number(entry.replacement_count || 0)) },
+          () => String(entry.slot || ""),
+        ).filter(Boolean)
+        : []
+    )));
+  }
+
   async function assertBrowserDrawReachesEveryLegalAction() {
     const handSnapshot = () => page.evaluate(() => ({
       visibleKeys: [...document.querySelectorAll("footer.prompt button[data-hand-key]")]
@@ -10161,8 +10172,8 @@ async function main() {
       };
     }, needle);
     let last = null;
-    const deckSize = await fetchInspectableDeckSize();
-    for (let attempt = 1; attempt <= deckSize; attempt += 1) {
+    const rotationSlots = await storyHandRotationSlots();
+    for (let attempt = 0; attempt <= rotationSlots.length; attempt += 1) {
       const result = await focus();
       const primary = String(result?.text || "");
       const routeVisible = ["move", "travel", "scout", "flee"].includes(result?.intention)
@@ -10186,8 +10197,11 @@ async function main() {
         return primary;
       }
       last = { result, primary };
-      if (attempt < deckSize) {
-        await passCertifiedHandForDraw(`route ${text} draw ${attempt}`);
+      if (attempt < rotationSlots.length) {
+        await passCertifiedHandForDraw(
+          `route ${text} draw ${attempt + 1}`,
+          rotationSlots[attempt],
+        );
       }
     }
     if (

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -315,7 +315,12 @@ async function passCurrentHand(baseUrl, actorId, actorSession, initialState) {
     if (!state || attempt > 0) {
       state = await fetchInspectableState(baseUrl, actorId, actorSession);
     }
-    const pass = state.action_hand?.pass;
+    const thinkEntries = (state.action_hand?.entries || [])
+      .filter((entry) => entry.think?.available && entry.think.offer_id)
+      .sort((left, right) =>
+        Number(left.think.generation ?? 0) - Number(right.think.generation ?? 0)
+          || left.slot.localeCompare(right.slot));
+    const pass = thinkEntries[0]?.think ?? state.action_hand?.pass;
     assert(pass?.offer_id, `a bounded deal must expose Think: ${JSON.stringify(state.action_hand)}`);
     const response = await fetch(`${baseUrl}/commands`, {
       method: "POST",
@@ -342,8 +347,11 @@ async function passCurrentHand(baseUrl, actorId, actorSession, initialState) {
 
 async function drawExactOffer(baseUrl, actorId, actorSession, predicate, label) {
   let state = await fetchInspectableState(baseUrl, actorId, actorSession);
-  const deckSize = Math.max(1, Number(state.action_hand?.deck_size) || 1);
-  for (let attempt = 0; attempt < deckSize; attempt += 1) {
+  const boundedThinks = Math.max(
+    1,
+    (Number(state.action_hand?.deck_size) || 1) * Number(state.action_hand?.capacity ?? 1),
+  );
+  for (let attempt = 0; attempt < boundedThinks; attempt += 1) {
     const dealtIds = new Set((state.action_hand?.entries || []).map((entry) => entry.offer_id));
     const offer = (state.action_offers || []).find((candidate) =>
       dealtIds.has(candidate.offer_id) && predicate(candidate));

--- a/v2/scripts/smoke-standalone-compositions.mjs
+++ b/v2/scripts/smoke-standalone-compositions.mjs
@@ -489,10 +489,18 @@ async function dealOffer(baseUrl, actorId, actorSession, predicate, description)
     offer = state.action_offers?.find((candidate) => !candidate.disabled && predicate(candidate));
     if (offer) break;
     if (maxPassAttempts === 0) {
-      maxPassAttempts = Math.max(1, Number(state.action_hand?.deck_size ?? 0));
+      maxPassAttempts = Math.max(
+        1,
+        Number(state.action_hand?.deck_size ?? 0) * Number(state.action_hand?.capacity ?? 1),
+      );
     }
     if (passAttempts >= maxPassAttempts) break;
-    const passOffer = state.action_hand?.pass;
+    const thinkEntries = (state.action_hand?.entries || [])
+      .filter((entry) => entry.think?.available && entry.think.offer_id)
+      .sort((left, right) =>
+        Number(left.think.generation ?? 0) - Number(right.think.generation ?? 0)
+          || left.slot.localeCompare(right.slot));
+    const passOffer = thinkEntries[0]?.think ?? state.action_hand?.pass;
     assert(
       passOffer?.offer_id,
       `No dealt card matches ${description} and Think is unavailable: ${JSON.stringify(state.action_hand)}`,
@@ -519,7 +527,7 @@ async function dealOffer(baseUrl, actorId, actorSession, predicate, description)
   }
   assert(
     offer?.offer_id,
-    `The finite hand did not deal ${description} within ${maxPassAttempts} Passes: ${JSON.stringify({
+    `The finite hand did not deal ${description} within ${maxPassAttempts} Thinks: ${JSON.stringify({
       hand: state?.action_hand,
       offers: state?.action_offers?.map(({ kind, command, label }) => ({ kind, command, label })),
       questions: state?.shared_questions?.map(({ id, strategies }) => ({
@@ -618,7 +626,7 @@ function assertLanternSuggestions(state, label) {
   if (question.presentation_state !== "active") return;
   const suggestions = state.action_offers || [];
   assert(
-    suggestions.length === 2
+    suggestions.length === 3
       && suggestions.every((suggestion) =>
         suggestion.offer_id
           && suggestion.accessible_label
@@ -627,7 +635,7 @@ function assertLanternSuggestions(state, label) {
           && suggestion.effect)
       && Number.isFinite(Number(question.filled))
       && Number.isFinite(Number(question.danger_filled)),
-    `${label} did not expose exactly two accessible truthful suggestions: ${JSON.stringify({
+    `${label} did not expose exactly three accessible truthful suggestions: ${JSON.stringify({
       suggestions,
       question,
     })}`,
@@ -766,6 +774,28 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
   );
   traceLantern("lantern arrival", taleState);
 
+  const maraOffer = firstTaleAdvancingOffer(taleState, "lantern Mara continuation");
+  assert(
+    maraOffer.kind === "create_bond" && maraOffer.target?.id === 8301,
+    `Lantern continuation did not certify Mara's exact relationship offer: ${JSON.stringify(maraOffer)}`,
+  );
+  const metMara = await command(baseUrl, actorId, actorSession, maraOffer.command);
+  assert(
+    metMara.events?.filter((event) => event.type === "bond.created").length === 1
+      && metMara.events?.filter((event) => event.type === "relationship.beat").length === 1
+      && metMara.events?.some((event) =>
+        event.type === "relationship.beat" && event.content?.includes("empty key hook")),
+    `Lantern Keeper did not commit Mara's corrected authored relationship beat: ${JSON.stringify(metMara)}`,
+  );
+  const acceptedMara = await fetchInspectableState(baseUrl, actorId, actorSession);
+  assert(
+    acceptedMara.first_tale?.continuation?.phase === "accepted"
+      && acceptedMara.first_tale?.continuation?.target_actor_id === 8301
+      && acceptedMara.first_tale?.continuation?.instruction?.includes("dark-road lead")
+      && acceptedMara.first_tale?.advancing_offer_id == null,
+    `Lantern continuation did not settle after Mara's active bond: ${JSON.stringify(acceptedMara.first_tale)}`,
+  );
+
   const searchedFailingLantern = await command(baseUrl, actorId, actorSession, "search");
   assert(
     searchedFailingLantern.events?.some((event) =>
@@ -791,30 +821,6 @@ async function beginLanternGoldenJourney(baseUrl, actorId, actorSession, initial
     equippedCampKit.events?.filter((event) =>
       event.type === "item.equipped" && event.item_id === 8405).length === 1,
     `Lantern Keeper could not equip its public camp-shelter tool: ${JSON.stringify(equippedCampKit)}`,
-  );
-
-  const readyForMara = await fetchInspectableState(baseUrl, actorId, actorSession);
-  traceLantern("lantern ready for Mara", readyForMara);
-  const maraOffer = firstTaleAdvancingOffer(readyForMara, "lantern Mara continuation");
-  assert(
-    maraOffer.kind === "create_bond" && maraOffer.target?.id === 8301,
-    `Lantern continuation did not certify Mara's exact relationship offer: ${JSON.stringify(maraOffer)}`,
-  );
-  const metMara = await command(baseUrl, actorId, actorSession, maraOffer.command);
-  assert(
-    metMara.events?.filter((event) => event.type === "bond.created").length === 1
-      && metMara.events?.filter((event) => event.type === "relationship.beat").length === 1
-      && metMara.events?.some((event) =>
-        event.type === "relationship.beat" && event.content?.includes("empty key hook")),
-    `Lantern Keeper did not commit Mara's corrected authored relationship beat: ${JSON.stringify(metMara)}`,
-  );
-  const acceptedMara = await fetchInspectableState(baseUrl, actorId, actorSession);
-  assert(
-    acceptedMara.first_tale?.continuation?.phase === "accepted"
-      && acceptedMara.first_tale?.continuation?.target_actor_id === 8301
-      && acceptedMara.first_tale?.continuation?.instruction?.includes("dark-road lead")
-      && acceptedMara.first_tale?.advancing_offer_id == null,
-    `Lantern continuation did not settle after Mara's active bond: ${JSON.stringify(acceptedMara.first_tale)}`,
   );
 
   const scouted = await command(baseUrl, actorId, actorSession, "scout Mothwood Path");
@@ -1413,13 +1419,21 @@ async function runWorldLoop(spec) {
     let exactConnection = null;
     if (spec.scoutDestination) {
       if (spec.additionalScoutDestination) {
-        const initialScoutTargets = initial.action_offers
-          ?.filter((offer) => offer.kind === "explore_path")
-          .map((offer) => offer.target?.label);
-        assert(
-          initialScoutTargets?.includes(spec.scoutDestination)
-            && initialScoutTargets.includes(spec.additionalScoutDestination),
-          `${spec.label} did not expose its branching Scout routes: ${JSON.stringify(initialScoutTargets)}`,
+        await dealOffer(
+          first.baseUrl,
+          actorId,
+          actorSession,
+          (offer) => offer.kind === "explore_path"
+            && offer.target?.label === spec.scoutDestination,
+          `${spec.label} primary branching Scout route`,
+        );
+        await dealOffer(
+          first.baseUrl,
+          actorId,
+          actorSession,
+          (offer) => offer.kind === "explore_path"
+            && offer.target?.label === spec.additionalScoutDestination,
+          `${spec.label} additional branching Scout route`,
         );
       }
       for (let attempt = 0; attempt < 24; attempt += 1) {


### PR DESCRIPTION
## Summary

- replace the two-card redeal surface with a three-slot Story Hand: Story, Self, and Anchor
- make Think replace one certified slot at a time, with a free first Think in safe scenes and turn-consuming Thinks thereafter
- publish six server-owned action suits—Wonder, Way, Heart, Hand, Courage, and Hearth—while keeping exact verbs, source, provenance, rarity, power, cost, risk, and effect separate
- update the browser, CLI, autonomous play, combat, journeys, persistence, metrics, docs, and player vocabulary around the new card model
- preserve the newly merged gift-consent flow as a pinned Heart · Accept card

## Verification

- `npm run check` (180 JavaScript tests, worldpack validation, kernel tests, 1,185 Rust tests, architecture/lint budgets, and syntax checks)
- `python3 -m unittest test_cosy_cli.py` (12 tests)
- `cargo fmt --check`
- `git diff --check`
