### PR TITLE
Fix mobile Story Hand typography

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.36",
+      "version": "1.0.37",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.36"
+version = "1.0.37"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2604,6 +2604,12 @@
       white-space: nowrap;
       text-overflow: ellipsis;
     }
+    .cmd-label-text {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
     .cmd-kicker {
       display: block;
       color: var(--cmd-accent);
@@ -5074,6 +5080,12 @@
       min-height: 44px;
     }
     @media (max-width: 900px) {
+      html,
+      body {
+        font-size: 15px;
+        -webkit-text-size-adjust: 100%;
+        text-size-adjust: 100%;
+      }
       .topbar {
         grid-template-columns: auto minmax(0, 1fr) auto;
         grid-template-areas: "brand location economy";
@@ -5094,7 +5106,7 @@
         justify-self: stretch;
         min-width: 0;
         padding: 0 4px;
-        font-size: 13px;
+        font-size: 14px;
       }
       .economy {
         max-width: none;
@@ -5108,9 +5120,166 @@
         width: 14px;
         height: 14px;
       }
+      .status {
+        padding: 7px 10px;
+        overflow: visible;
+        font-size: 13px;
+        line-height: 1.35;
+        overflow-wrap: anywhere;
+        text-overflow: clip;
+        white-space: normal;
+      }
+      .prompt,
+      .prompt.choice-mode {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 6px;
+        align-items: stretch;
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+        overflow: visible;
+        padding: 8px max(8px, env(safe-area-inset-right, 0px))
+          calc(8px + var(--safe-bot)) max(8px, env(safe-area-inset-left, 0px));
+      }
+      .turn-banner {
+        grid-column: 1 / -1;
+      }
+      .prompt:not(.choice-mode) .cmd.tertiary,
+      .prompt.single-action .cmd.primary {
+        grid-column: 1 / -1;
+        width: 100%;
+      }
+      .cmd {
+        width: 100%;
+        min-width: 0;
+        min-height: 104px;
+        gap: 5px;
+        justify-content: flex-start;
+        padding: 5px;
+        text-align: left;
+      }
+      .cmd-copy {
+        gap: 3px;
+        padding: 0 14px 0 6px;
+      }
+      .cmd-kicker {
+        font-size: 10px;
+        line-height: 1.2;
+      }
+      .cmd-label {
+        display: flex;
+        align-items: flex-start;
+        gap: 5px;
+        overflow: visible;
+        color: var(--text);
+        font-size: 14px;
+        font-weight: 780;
+        line-height: 1.18;
+        text-overflow: clip;
+        white-space: normal;
+      }
+      .cmd-label-text {
+        display: -webkit-box;
+        min-width: 0;
+        overflow: hidden;
+        text-wrap: pretty;
+        text-overflow: clip;
+        white-space: normal;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+      .detail {
+        margin-top: 1px;
+        font-size: 12px;
+        line-height: 1.25;
+        -webkit-line-clamp: 2;
+      }
+      .cmd-meta,
+      .provider-call,
+      .story-call {
+        font-size: 10px;
+        line-height: 1.2;
+      }
+      .cmd-meta {
+        overflow: visible;
+        text-overflow: clip;
+        white-space: normal;
+      }
+      .cmd.has-copy .thumb {
+        width: 46px;
+        height: 46px;
+        flex-basis: 46px;
+      }
+      .cmd.has-copy .thumb.avatar {
+        width: 36px;
+        height: 48px;
+        flex-basis: 36px;
+      }
+      .cmd.has-copy .thumb.location {
+        width: 54px;
+        height: 36px;
+        flex-basis: 54px;
+      }
+      body.large-text .status {
+        font-size: 15px;
+      }
+      body.large-text .cmd-label {
+        font-size: 16px;
+      }
+      body.large-text .detail {
+        font-size: 14px;
+      }
+      body.large-text :is(.cmd-kicker, .cmd-meta, .provider-call, .story-call) {
+        font-size: 12px;
+      }
       .menu-nav button {
         padding-inline: 5px;
         font-size: 12px;
+      }
+    }
+    @media (max-width: 360px) {
+      .location-pill img {
+        display: none;
+      }
+      .cmd-copy {
+        padding-right: 10px;
+        padding-left: 4px;
+      }
+      .cmd-label {
+        font-size: 13px;
+      }
+      .cmd-label .ui-icon {
+        display: none;
+      }
+      .cmd.has-copy .thumb,
+      .cmd.has-copy .thumb.location {
+        width: 40px;
+        height: 40px;
+        flex-basis: 40px;
+      }
+      .cmd.has-copy .thumb.avatar {
+        width: 32px;
+        height: 44px;
+        flex-basis: 32px;
+      }
+      body.large-text .cmd-label {
+        font-size: 15px;
+      }
+    }
+    @media (min-width: 600px) and (max-width: 900px) {
+      .prompt,
+      .prompt:not(.choice-mode) {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+      .prompt.choice-mode {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .prompt:not(.choice-mode) .cmd.tertiary {
+        grid-column: auto;
+      }
+      .cmd {
+        min-height: 96px;
       }
     }
   </style>
@@ -16288,7 +16457,7 @@
       const rarityMark = suit
         ? `<span class="collectible-mark" title="${escapeAttr(`${rarity} · ${presentation.provenance || "core"}`)}" aria-hidden="true">◇</span>`
         : "";
-      button.innerHTML = `${thumb}<span class="cmd-copy"><span class="cmd-kicker">${escapeHtml(kicker)}</span><span class="cmd-label">${iconSvg(actionIconName(action))}${escapeHtml(labelText)}</span>${detailHtml}<span class="cmd-meta">${escapeHtml(economy)}</span>${providerHtml}${storyHtml}</span>${rarityMark}${busyHtml}`;
+      button.innerHTML = `${thumb}<span class="cmd-copy"><span class="cmd-kicker">${escapeHtml(kicker)}</span><span class="cmd-label">${iconSvg(actionIconName(action))}<span class="cmd-label-text">${escapeHtml(labelText)}</span></span>${detailHtml}<span class="cmd-meta">${escapeHtml(economy)}</span>${providerHtml}${storyHtml}</span>${rarityMark}${busyHtml}`;
     }
 
     function actionBarActions() {

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -706,13 +706,27 @@ async function main() {
     const current = await handSnapshot();
     const layout = await page.evaluate(() => {
       const prompt = document.querySelector("footer.prompt");
+      const status = document.querySelector("#error");
+      const statusStyle = getComputedStyle(status);
+      const labels = [...prompt.querySelectorAll(".cmd-label-text")];
       const cards = [...prompt.querySelectorAll("button")]
         .filter((button) => getComputedStyle(button).display !== "none")
         .map((button) => button.getBoundingClientRect());
+      const tertiary = document.querySelector("#tertiary");
+      const tertiaryRect = tertiary?.getBoundingClientRect();
       return {
         promptFits: prompt.scrollWidth <= prompt.clientWidth + 1,
+        promptDisplay: getComputedStyle(prompt).display,
+        promptColumns: getComputedStyle(prompt).gridTemplateColumns.split(" ").filter(Boolean).length,
         cardsFit: cards.length <= 3
           && cards.every((rect) => rect.left >= 0 && rect.right <= window.innerWidth),
+        thirdCardSpansRow: cards.length < 3
+          || Boolean(tertiaryRect && tertiaryRect.width >= prompt.clientWidth - 17),
+        documentFits: document.documentElement.scrollWidth <= window.innerWidth,
+        primaryLabelsFit: labels.every((label) => label.scrollHeight <= label.clientHeight + 1),
+        statusWraps: statusStyle.whiteSpace === "normal"
+          && statusStyle.textOverflow === "clip"
+          && status.scrollHeight <= status.clientHeight + 1,
         journaled: logEvents.some((event) => event.type === "hand.thought"),
       };
     });
@@ -721,7 +735,13 @@ async function main() {
         && current.visibleKeys.length <= 3
         && current.eventSeq > initial.eventSeq
         && layout.promptFits
+        && layout.promptDisplay === "grid"
+        && layout.promptColumns === 2
         && layout.cardsFit
+        && layout.thirdCardSpansRow
+        && layout.documentFits
+        && layout.primaryLabelsFit
+        && layout.statusWraps
         && layout.journaled,
       `Discard should replace one Story Hand card without adding a fourth card: ${JSON.stringify({ initial, current, layout })}`,
     );


### PR DESCRIPTION
## What changed

- replace the squeezed mobile Story Hand row with a two-column phone layout
- let the third card span the second row, while tablets and landscape retain a three-card row
- wrap primary card titles and story notices; tune narrow-phone and Larger Text typography
- add browser regression checks for overflow, wrapping, and card placement
- bump release version to 1.0.37

## Why

At narrow widths the three cards were compressed enough that primary titles such as “Circle of the Moon” and the story notice appeared accidentally cut off. The fixed single-line typography and flex layout did not give mobile copy enough readable space.

## Impact

Mobile players can read the current story cue and all primary action titles without horizontal scrolling. Tablet and landscape layouts remain compact.

## Validation

- in-app browser: 320×568, 375×667, 390×844, 430×860, 768×1024, and 844×390
- Larger Text at 390×844
- full pre-push `npm run check` (181 JS tests, worldpack/proof/kernel gates, 1,187 Rust tests, architecture and syntax checks)
- no browser console warnings or errors
