### PR TITLE
Show suit emojis on Story Hand cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -76,6 +76,22 @@ describe("three-slot Story Hand", () => {
     expect(cardRenderBlock).toContain('? "Travel"');
   });
 
+  it("shows suit emojis instead of suit names on action cards", () => {
+    const cardRenderBlock = browser.slice(
+      browser.indexOf("function renderButton"),
+      browser.indexOf("function actionBarActions"),
+    );
+
+    expect(browser).toContain('head: "🧠"');
+    expect(browser).toContain('heart: "❤️"');
+    expect(browser).toContain('honor: "🛡️"');
+    expect(browser).toContain('hustle: "🛠️"');
+    expect(cardRenderBlock).toContain("const suitEmoji = actionCardSuitEmoji(suit);");
+    expect(cardRenderBlock).toContain('suitEmoji ? `${suitEmoji} · ${exactVerb}` : exactVerb');
+    expect(cardRenderBlock).not.toContain('suit ? `${suit} · ${exactVerb}` : exactVerb');
+    expect(cardRenderBlock).toContain('suit ? `${suit} suit` : "control"');
+  });
+
   it("submits room-feature Use offers through the typed item endpoint", () => {
     const featureUseBlock = browser.slice(
       browser.indexOf('if (options.has("use_feature"))'),

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.37"
+version = "1.0.38"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5459,6 +5459,12 @@
       return authoredAbilityChoice(value)?.label || String(value || fallback);
     }
     const actionCardSuits = ["head", "heart", "honor", "hustle"];
+    const actionCardSuitEmojis = {
+      head: "🧠",
+      heart: "❤️",
+      honor: "🛡️",
+      hustle: "🛠️",
+    };
     const actionCardSuitClasses = actionCardSuits.map((suit) => `suit-${suit}`);
     const actionCardAccentClasses = [...actionCardSuitClasses, "card-control"];
     const bootParams = new URLSearchParams(window.location.search);
@@ -8607,6 +8613,10 @@
     function normalizeActionCardSuit(suit) {
       const normalized = String(suit || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
       return actionCardSuits.includes(normalized) ? normalized : "";
+    }
+
+    function actionCardSuitEmoji(suit) {
+      return actionCardSuitEmojis[normalizeActionCardSuit(suit)] || "";
     }
 
     function normalizeActionCardRarity(rarity) {
@@ -15303,13 +15313,7 @@
     }
 
     function actionEmoji(action) {
-      const bySuit = {
-        head: "🧠",
-        heart: "❤️",
-        honor: "🛡️",
-        hustle: "🛠️",
-      };
-      return bySuit[actionCardSuit(action)] || cardEmoji(action?.card, action?.shape);
+      return actionCardSuitEmoji(actionCardSuit(action)) || cardEmoji(action?.card, action?.shape);
     }
 
     function actionIconName(action) {
@@ -16393,13 +16397,14 @@
           || action.label
           || "Action"
       ).trim();
+      const suitEmoji = actionCardSuitEmoji(suit);
       const effectText = friendlyActionText(presentation.effect || action.effect);
       const riskText = friendlyActionText(presentation.risk || action.risk);
       const orbCost = Number(presentation.cost?.orbs || action.orbCost || 0);
       const costText = orbCost ? `${orbCost} Orb${orbCost === 1 ? "" : "s"}` : "free";
       const sourceText = handProviderReason(action);
       const title = [
-        suit ? `${suit} · ${exactVerb}` : exactVerb,
+        suitEmoji ? `${suitEmoji} · ${exactVerb}` : exactVerb,
         cardTitle,
         effectText,
         [costText, riskText].filter(Boolean).join(" · "),
@@ -16452,7 +16457,7 @@
       const busyHtml = action.busy
         ? `<span class="action-progress" role="progressbar" aria-label="Action in progress" aria-valuetext="in progress"></span>`
         : "";
-      const kicker = suit ? `${suit} · ${exactVerb}` : exactVerb;
+      const kicker = suitEmoji ? `${suitEmoji} · ${exactVerb}` : exactVerb;
       const economy = [costText, riskText].filter(Boolean).join(" · ");
       const rarityMark = suit
         ? `<span class="collectible-mark" title="${escapeAttr(`${rarity} · ${presentation.provenance || "core"}`)}" aria-hidden="true">◇</span>`


### PR DESCRIPTION
## What changed

- render Head, Heart, Honor, and Hustle as 🧠, ❤️, 🛡️, and 🛠️ on Story Hand cards
- reuse the existing suit emoji mapping for card icons, kickers, and tooltips
- keep full suit names in accessible labels for screen readers
- add regression coverage for all four suit mappings and visible card rendering
- bump the project and orchestrator version to `1.0.38`, as required by the release gate

## Why

The suit is a compact visual category on the card face. Showing the full suit word duplicates that category and makes the Story Hand denser than necessary.

## Impact

Players see the suit emoji beside the action verb, while assistive technology still announces the descriptive suit name.

## Validation

- `npx vitest run test/v2/two-action-hand.test.mjs` passed locally
- the PR was rebuilt on the latest `main` and all version manifests report `1.0.38`
- GitHub Actions CI passed, including version, lint, Node/content/kernel, Rust, architecture, release, composition, and fresh-seed browser checks
- Documentation publication passed
- unrelated local worktree changes were not included