### PR TITLE
Allow queued Fly snapshots to complete

### DIFF
--- a/docs/deployment/07-deployment.md
+++ b/docs/deployment/07-deployment.md
@@ -217,6 +217,10 @@ bash scripts/backup-fly-v2.sh cosyworld primary
 flyctl deploy --remote-only --config fly.toml --strategy rolling
 ```
 
+The backup command waits up to ten minutes for the exact requested snapshot to
+reach `created`. Do not bypass it when Fly reports a slow `waiting` or `running`
+snapshot; a timeout leaves the current Machine untouched and blocks deployment.
+
 ---
 
 ## Monitoring

--- a/docs/deployment/lonelyforest-fly.md
+++ b/docs/deployment/lonelyforest-fly.md
@@ -77,7 +77,11 @@ configured volume (`cosyworld_data` or `lonelyforest_data`), requires one
 attached volume, requests an on-demand Fly snapshot, and waits for that
 specific snapshot to reach `created`. The script is fail-closed and does not
 detach, replace, or destroy a volume. The resulting snapshot ID is printed in
-the workflow log for the rollback operator.
+the workflow log for the rollback operator. The default wait is ten minutes:
+Fly may accept a snapshot and leave it in `waiting` or `running` for several
+minutes during transient queueing, but a snapshot that never reaches `created`
+still blocks the deploy.
+
 Before Fly replaces the image, the Lonely Forest job runs
 `v2/scripts/check-lonelyforest-worldpacks.mjs`. It reads every
 required tenant's live `https://<host>/meta` identity and compares it with the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.39",
+      "version": "1.0.40",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/scripts/backup-fly-v2.sh
+++ b/scripts/backup-fly-v2.sh
@@ -180,7 +180,10 @@ if [ -z "$snapshot_id" ]; then
   echo "::notice::flyctl snapshot create returned no JSON snapshot id; resolving the exact new snapshot from the verified list"
 fi
 
-timeout_secs="${COSYWORLD_FLY_SNAPSHOT_TIMEOUT_SECS:-180}"
+# Transient Fly queueing can leave a successfully accepted snapshot in
+# `waiting` or `running` for more than three minutes. Keep the deploy
+# fail-closed while allowing that verified snapshot enough time to finish.
+timeout_secs="${COSYWORLD_FLY_SNAPSHOT_TIMEOUT_SECS:-600}"
 poll_secs="${COSYWORLD_FLY_SNAPSHOT_POLL_SECS:-5}"
 if ! [[ "$timeout_secs" =~ ^[0-9]+$ ]] || [ "$timeout_secs" -lt 1 ]; then
   echo "::error::COSYWORLD_FLY_SNAPSHOT_TIMEOUT_SECS must be a positive integer" >&2

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -57,6 +57,7 @@ const volumeGuardPath = fileURLToPath(
 const backupScriptPath = fileURLToPath(
   new URL('../../scripts/backup-fly-v2.sh', import.meta.url)
 );
+const backupScript = readFileSync(backupScriptPath, 'utf8');
 
 const runVolumeGuard = (fakeFlyctl) => {
   const directory = mkdtempSync(join(tmpdir(), 'cosyworld-volume-guard-'));
@@ -290,6 +291,15 @@ describe('deploy workflow', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Verified Fly volume snapshot vs_new');
+  });
+
+  it('allows queued Fly snapshots ten minutes to complete before failing closed', () => {
+    expect(backupScript).toContain(
+      'COSYWORLD_FLY_SNAPSHOT_TIMEOUT_SECS:-600'
+    );
+    expect(backupScript).toContain(
+      'timed out waiting for Fly volume snapshot $snapshot_id to reach created'
+    );
   });
 
   it('recovers a verifiable new snapshot when flyctl create returns an empty successful response', () => {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.39"
+version = "1.0.40"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.39"
+version = "1.0.40"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- extend the fail-closed Fly volume snapshot wait from 180 seconds to 600 seconds
- keep exact snapshot identity and terminal-state verification unchanged
- document the ten-minute deployment boundary and cover the default in the deployment contract
- align the root and Rust runtime release versions at 1.0.40

The two most recent production workflows accepted their rollback snapshots, observed them progress from waiting to running, and timed out at 180 seconds. Fly later reported both exact snapshots as created, so the deploys were blocked by the local wait ceiling rather than a build or snapshot failure.

## Validation

- `npx vitest run test/infrastructure/deploy-workflow.test.mjs --reporter=dot` — 27 passed
- `npm test` — 183 passed
- `npm run check:version` — passed
- `git diff --check` — passed
- release-version alignment check — package, Cargo manifest, and Cargo lock all report 1.0.40
- `npm run check:local` — passed worldpack, kernel, AI-model, WASM, and JavaScript gates; the unchanged Rust orchestrator compile hit the repository's documented 120-second macOS loader timeout
- first GitHub CI run — exposed and confirmed the missing Rust version bump; fixed in f190c19d
- current GitHub CI run — required before merge

## Deployment notes

No persistence format, worldpack identity, or runtime behavior changes. The rollback snapshot remains mandatory and fail-closed; only its bounded wait increases to tolerate transient Fly queueing.

## Review checklist

- [x] Focused deployment contract passes
- [x] Root and Rust release versions align
- [x] Operator documentation updated
- [x] No generated content or secrets changed
- [ ] GitHub CI passes before merge