### PR TITLE
Make Hoppycat avatars chattable and lock portraits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.39",
+      "version": "1.0.40",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.39"
+version = "1.0.40"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.39"
+version = "1.0.40"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_interaction_profiles.rs
+++ b/v2/orchestrator-rust/src/actor_interaction_profiles.rs
@@ -386,6 +386,35 @@ pub(super) fn exact_actor_interaction_profile_for_model(
     exact_profile_at(registry, index, kind)
 }
 
+/// Resolve an operational profile for an authored actor binding without
+/// weakening the exact-model contract. The capability snapshot is generated
+/// from one canonical actor per OpenRouter model, while worldpacks may bind
+/// that same audited model to their own actor ids. An actor-id match remains
+/// authoritative; model lookup is only allowed when the authored actor is not
+/// present in the snapshot, and the complete route identity must still match.
+pub(super) fn exact_actor_interaction_profile_for_binding(
+    actor_id: u64,
+    requested_model_id: &str,
+    canonical_slug: &str,
+    kind: ActorInteractionKind,
+) -> Result<Option<ExactActorInteractionProfile<'static>>, String> {
+    let registry = profile_registry()?;
+    let index = registry.by_actor_id.get(&actor_id).copied().or_else(|| {
+        registry
+            .by_requested_model_id
+            .get(requested_model_id)
+            .copied()
+    });
+    let Some(index) = index else {
+        return Ok(None);
+    };
+    Ok(exact_profile_at(registry, index, kind)?.filter(|exact| {
+        exact.binding.requested_model_id == requested_model_id
+            && exact.binding.route_model_id == requested_model_id
+            && exact.binding.canonical_slug == canonical_slug
+    }))
+}
+
 fn exact_profile_at(
     registry: &'static ActorInteractionProfileRegistry,
     index: usize,
@@ -463,6 +492,41 @@ mod tests {
         assert!(exact_actor_interaction_profile_for_actor(
             trinity.binding.actor_id,
             ActorInteractionKind::Illustrate,
+        )
+        .expect("profile registry")
+        .is_none());
+    }
+
+    #[test]
+    fn world_specific_actor_ids_can_reuse_only_an_exact_catalog_profile() {
+        let canonical = exact_actor_interaction_profile_for_binding(
+            u64::MAX,
+            "~anthropic/claude-fable-latest",
+            "~anthropic/claude-fable-latest",
+            ActorInteractionKind::Talk,
+        )
+        .expect("profile registry")
+        .expect("world-specific Fable Talk profile");
+        assert_eq!(
+            canonical.binding.requested_model_id,
+            "~anthropic/claude-fable-latest"
+        );
+        assert!(canonical.profile.ready_before_policy());
+
+        assert!(exact_actor_interaction_profile_for_binding(
+            u64::MAX,
+            "~anthropic/claude-fable-latest",
+            "anthropic/changed-canonical-slug",
+            ActorInteractionKind::Talk,
+        )
+        .expect("profile registry")
+        .is_none());
+
+        assert!(exact_actor_interaction_profile_for_binding(
+            canonical.binding.actor_id,
+            "openai/gpt-chat-latest",
+            "openai/gpt-chat-latest-20260505",
+            ActorInteractionKind::Talk,
         )
         .expect("profile registry")
         .is_none());

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -1863,14 +1863,11 @@ mod tests {
         }
     }
 
-    fn hoppycat_fable_binding() -> crate::content_load::SeedActorModelBinding {
+    fn hoppycat_bindings() -> Vec<crate::content_load::SeedActorModelBinding> {
         serde_json::from_str::<Vec<crate::content_load::SeedActorModelBinding>>(include_str!(
             "../../content/hoppycat-archive/actor_model_bindings.json"
         ))
         .expect("Hoppycat actor model bindings")
-        .into_iter()
-        .find(|binding| binding.actor_id == 771_100)
-        .expect("Fable actor model binding")
     }
 
     fn gate(key: &str) -> SpeechGateContext {
@@ -1994,7 +1991,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_exact_actor_binding_never_falls_back_to_the_generic_pool() {
+    async fn hoppycat_exact_actor_bindings_never_fall_back_to_the_generic_pool() {
         let mut config = three_candidates(VoiceRoutingConfig {
             max_attempts: 3,
             hedge_width: 1,
@@ -2002,31 +1999,42 @@ mod tests {
             ..VoiceRoutingConfig::default()
         });
         config.base_url = "https://openrouter.ai/api/v1".to_string();
-        let binding = hoppycat_fable_binding();
-        let expected_model = binding.requested_model_id.clone();
-        let backend = MockBackend::with_outputs([
-            ("~anthropic/claude-fable-latest", "unanchored one", 0),
-            ("~anthropic/claude-fable-latest", "unanchored two", 0),
-            ("~anthropic/claude-fable-latest", "unanchored three", 0),
-        ]);
-        let mut exact_request = request("dialogue_resident_raw");
-        exact_request.model_binding = Some(binding);
-        let mut exact_gate = gate("hoppycat-fable-exhausted");
-        exact_gate.mode = SpeechMode::Raw;
-        exact_gate.anchors = vec!["teapot".to_string()];
+        let bindings = hoppycat_bindings();
+        assert_eq!(bindings.len(), 7);
+        for binding in bindings {
+            let expected_model = binding.requested_model_id.clone();
+            let backend = MockBackend::default();
+            backend.outputs.lock().unwrap().insert(
+                expected_model.clone(),
+                ["unanchored one", "unanchored two", "unanchored three"]
+                    .into_iter()
+                    .map(|text| MockOutput {
+                        text: text.to_string(),
+                        reasoning_trace: None,
+                        delay: Duration::ZERO,
+                        finish_reason: "stop".to_string(),
+                    })
+                    .collect(),
+            );
+            let mut exact_request = request("dialogue_resident_raw");
+            exact_request.model_binding = Some(binding);
+            let mut exact_gate = gate("hoppycat-exact-model-exhausted");
+            exact_gate.mode = SpeechMode::Raw;
+            exact_gate.anchors = vec!["teapot".to_string()];
 
-        let error = route_certified_voice_with(
-            &config,
-            None,
-            exact_request,
-            exact_gate,
-            Arc::new(backend.clone()),
-        )
-        .await
-        .expect_err("the exact model exhausts without substitution");
+            let error = route_certified_voice_with(
+                &config,
+                None,
+                exact_request,
+                exact_gate,
+                Arc::new(backend.clone()),
+            )
+            .await
+            .expect_err("the exact model exhausts without substitution");
 
-        assert_eq!(error.code(), "voice_candidates_exhausted");
-        assert_eq!(backend.requested_models(), vec![expected_model; 3]);
+            assert_eq!(error.code(), "voice_candidates_exhausted");
+            assert_eq!(backend.requested_models(), vec![expected_model; 3]);
+        }
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/model_interaction.rs
+++ b/v2/orchestrator-rust/src/model_interaction.rs
@@ -810,10 +810,15 @@ fn binding_has_ready_profile(
     } else {
         profile.interaction_kind()
     };
-    let exact = exact_actor_interaction_profile_for_actor(binding.actor_id, interaction_kind)
-        .ok()
-        .flatten()
-        .filter(|exact| exact.profile.ready_before_policy());
+    let exact = exact_actor_interaction_profile_for_binding(
+        binding.actor_id,
+        &binding.requested_model_id,
+        &binding.canonical_slug,
+        interaction_kind,
+    )
+    .ok()
+    .flatten()
+    .filter(|exact| exact.profile.ready_before_policy());
     let Some(exact) = exact else {
         return false;
     };

--- a/v2/orchestrator-rust/src/resident_image.rs
+++ b/v2/orchestrator-rust/src/resident_image.rs
@@ -160,15 +160,19 @@ pub(super) fn resident_supports_text_reply(actor_id: u64) -> bool {
 }
 
 pub(super) fn binding_supports_text_reply(binding: &SeedActorModelBinding) -> bool {
-    exact_actor_interaction_profile_for_actor(binding.actor_id, ActorInteractionKind::Talk)
-        .ok()
-        .flatten()
-        .is_some_and(|exact| {
-            exact.profile.ready_before_policy()
-                && exact.binding.requested_model_id == binding.requested_model_id
-                && exact.binding.canonical_slug == binding.canonical_slug
-        })
-        && PinnedModelSelection::from_actor_binding(binding, DataPolicyMode::Development).is_ok()
+    exact_actor_interaction_profile_for_binding(
+        binding.actor_id,
+        &binding.requested_model_id,
+        &binding.canonical_slug,
+        ActorInteractionKind::Talk,
+    )
+    .ok()
+    .flatten()
+    .is_some_and(|exact| {
+        exact.profile.ready_before_policy()
+            && exact.binding.requested_model_id == binding.requested_model_id
+            && exact.binding.canonical_slug == binding.canonical_slug
+    }) && PinnedModelSelection::from_actor_binding(binding, DataPolicyMode::Development).is_ok()
 }
 
 fn resident_image_binding(actor_id: u64) -> Option<&'static SeedActorModelBinding> {
@@ -183,16 +187,20 @@ fn resident_image_binding(actor_id: u64) -> Option<&'static SeedActorModelBindin
 }
 
 pub(super) fn binding_supports_image_interaction(binding: &SeedActorModelBinding) -> bool {
-    exact_actor_interaction_profile_for_actor(binding.actor_id, ActorInteractionKind::Illustrate)
-        .ok()
-        .flatten()
-        .is_some_and(|exact| {
-            exact.profile.ready_before_policy()
-                && exact.binding.requested_model_id == binding.requested_model_id
-                && exact.binding.canonical_slug == binding.canonical_slug
-        })
-        && PinnedModelSelection::from_actor_image_binding(binding, DataPolicyMode::Development)
-            .is_ok()
+    exact_actor_interaction_profile_for_binding(
+        binding.actor_id,
+        &binding.requested_model_id,
+        &binding.canonical_slug,
+        ActorInteractionKind::Illustrate,
+    )
+    .ok()
+    .flatten()
+    .is_some_and(|exact| {
+        exact.profile.ready_before_policy()
+            && exact.binding.requested_model_id == binding.requested_model_id
+            && exact.binding.canonical_slug == binding.canonical_slug
+    }) && PinnedModelSelection::from_actor_image_binding(binding, DataPolicyMode::Development)
+        .is_ok()
 }
 
 fn binding_uses_image_reply(binding: &SeedActorModelBinding) -> bool {
@@ -984,6 +992,20 @@ mod tests {
             .output_modalities
             .iter()
             .any(|value| value == "text"));
+    }
+
+    #[test]
+    fn every_hoppycat_model_resident_has_an_exact_text_reply_route() {
+        let bindings = serde_json::from_str::<Vec<SeedActorModelBinding>>(include_str!(
+            "../../content/hoppycat-archive/actor_model_bindings.json"
+        ))
+        .expect("Hoppycat actor model bindings");
+        assert_eq!(bindings.len(), 7);
+        assert!(bindings.iter().all(binding_supports_text_reply));
+
+        let mut changed = bindings[0].clone();
+        changed.canonical_slug = "anthropic/changed-canonical-slug".to_string();
+        assert!(!binding_supports_text_reply(&changed));
     }
 
     #[test]

--- a/v2/scripts/hoppycat-worldpack.test.mjs
+++ b/v2/scripts/hoppycat-worldpack.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -132,6 +133,28 @@ test("Hoppycat uses a locked illustrated card set led by Hoppy Cat", () => {
     const fileName = card.image_url.slice(mount.public_prefix.length + 1);
     const assetPath = path.join(packRoot, mount.directory, fileName);
     assert.ok(fs.statSync(assetPath).size > 10_000, `${card.card_id} has usable art`);
+  }
+
+  const lockedRosterArt = new Map([
+    ["hoppycat-hoppy-cat", "944e1e08e70434a61f93256ed8b25827b83b8c46fbe5d891757d9af86377b52d"],
+    ["hoppycat-fable", "5f059ec1d52994c2fe5adaef78ebf8875910854691f8e1e4cea942e039915c26"],
+    ["hoppycat-phase-two", "15d3976c241f80259beaeb6b911f5b678fba15869c69deb6c0e956145fc2fde8"],
+    ["hoppycat-arc", "2b7d007cf40c9d9d4c08a79e907e7055c3c60c7580de84aa6db2736207fc0b17"],
+    ["hoppycat-staticwashere", "28e7d9ca86684b6d4ae2774ffb057e31b7866f0585266dfb022319617cbc439f"],
+    ["hoppycat-solwashere", "7c9d7a38e03d1cd3b12094eccca95c7df84ce910d7a203ec84fae810d0ae8b5d"],
+    ["hoppycat-ledger-opus", "c8326e4ed53ff2d5dfe931cb38c0e2c91ac5b4e1828d1605012eae5bde6ed0a6"],
+    ["hoppycat-ledger-sonnet", "165527b083ef838a1b6b7f528bbee0857a717a5e059453dc5e26a417fb0ece36"],
+  ]);
+  for (const [cardId, expectedDigest] of lockedRosterArt) {
+    const card = cards.find((candidate) => candidate.card_id === cardId);
+    assert.ok(card, `${cardId} has a card binding`);
+    const fileName = card.image_url.slice(mount.public_prefix.length + 1);
+    const bytes = fs.readFileSync(path.join(packRoot, mount.directory, fileName));
+    assert.equal(
+      crypto.createHash("sha256").update(bytes).digest("hex"),
+      expectedDigest,
+      `${cardId} keeps its approved portrait`,
+    );
   }
 
   assert.equal(


### PR DESCRIPTION
## What changed

- Resolve audited interaction profiles by exact model identity for world-specific actor IDs while preserving actor-ID authority and fail-closed canonical-slug checks.
- Allow all seven Hoppycat model residents through the runtime text-reply and Chat eligibility gate.
- Extend no-fallback coverage from Fable to every Hoppycat OpenRouter binding.
- Pin SHA-256 digests for Hoppy and the seven new roster portraits.
- Merge the repaired deployment baseline and bump the application and orchestrator version to 1.0.41.

## Root cause

Hoppycat correctly authored exact OpenRouter bindings, but the operational capability snapshot was generated from the canonical Elysium actor IDs. The runtime looked up Talk capability only by actor ID, so Hoppycat’s world-specific IDs were filtered out even though their model and canonical route metadata matched the audited catalog exactly.

## Impact

Fable, Phase Two, Arc, staticwashere, solwashere, Ledger (Opus 4.7), and Ledger (Sonnet 4.6) can receive Chat offers and reply through only their assigned exact models. Hoppy remains a direct-input human avatar. Portrait changes now require an explicit digest update.

## Validation

- `npm run v2:worldpack:hoppycat` — 5/5 tests; bundle remains `sha256:51a21c2587473007ba2b16571a1c75a910738792e36cb96de3cbdf3f843aa3c5`
- Vitest: 183/183
- Version alignment and diff checks pass at 1.0.41
- Hoppy exact-profile, text-reply, canonical-tamper, and all-seven no-fallback Rust tests pass
- Kernel, syntax, architecture, formatting, and clippy gates pass
- Full Rust binary: 1,167 tests passed; two unrelated canonical-journal concurrency stress tests flaked only under saturated local parallel build load and both passed individually outside the sandbox

The refreshed macOS binary test link stalled after compilation because of the existing local loader issue, so the pushed Linux CI run remains the authoritative post-merge gate.