### PR TITLE
Redesign combat as a dedicated activity dock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.41",
+      "version": "1.0.42",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/combat-system.md
+++ b/v2/docs/combat-system.md
@@ -87,11 +87,14 @@ There are no direct attack, defend, flee, or uncertified pass endpoints. `/state
 exposes protocol, round, participants, current actor, and only the two current
 offers. `/meta` advertises protocol and kernel versions.
 
-The combat footer contains only those cards. Discard lives in the selected
-card's detail modal. Group chat renders
-speech and dice-call pills; outcomes such as hits, misses, defence, knockout,
-escape, and resolution remain in Journal and may appear as dismissible
-important alerts.
+The combat footer contains only those cards and Pass. Group chat remains a
+speech channel; it never renders attack rolls, damage, defence, knockout,
+escape, or resolution rows. During an active encounter, a compact combat dock
+beside the room scene shows the round, current actor, and latest outcome. Its
+player-opened history groups an attack attempt with its hit, miss, damage, and
+knockout outcome, preserving exact arithmetic without turning the room into a
+wall of system prose. Journal remains the durable post-encounter archive, and
+rare state changes may also appear as dismissible important alerts.
 
 Combat offer traces name the stable action, target, active profile, resolver,
 source location, and—when present—the equipped weapon's item/card/pack

--- a/v2/docs/writing-style.md
+++ b/v2/docs/writing-style.md
@@ -153,9 +153,10 @@ it lands
 - Damage, HP, and recovery keep their existing prose treatment. This section
   governs the roll, not its consequences: "Gust looks steadier" is still right,
   and zero-HP language is still banned.
-- The same roll may appear in both the transcript and the Log. That is
-  deliberate: the transcript carries the beat you read, the Log the row you
-  scan. They render from `detail` and `story` on the same event.
+- The same roll may appear in the active combat dock and the Journal. That is
+  deliberate: the dock carries the result you scan while playing, and the
+  Journal keeps the durable story record. Combat arithmetic never enters the
+  room's speech transcript.
 
 This reverses an earlier stance under which combat hid its arithmetic while
 ordinary checks exposed theirs — the same kernel roll with two opposite rules.

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.41"
+version = "1.0.42"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.41"
+version = "1.0.42"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5583,6 +5583,208 @@
         transition: none;
       }
     }
+    /* Combat is a live game state, not a kind of chat. Keep the immediate
+       result beside the encounter and disclose the deeper ledger on demand. */
+    .combat-dock {
+      min-width: 0;
+      margin: 0 0 9px;
+      overflow: hidden;
+      border: 1px solid rgba(var(--type-combat-rgb), 0.34);
+      border-radius: 5px;
+      background:
+        linear-gradient(90deg, rgba(var(--type-combat-rgb), 0.09), transparent 44%),
+        rgba(14, 12, 10, 0.82);
+    }
+    .combat-dock[hidden] { display: none; }
+    .combat-dock-head {
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 6px 8px 5px 10px;
+      border-bottom: 1px solid rgba(var(--type-combat-rgb), 0.18);
+    }
+    .combat-dock-state {
+      min-width: 0;
+      display: flex;
+      align-items: baseline;
+      gap: 7px;
+      overflow: hidden;
+    }
+    .combat-dock-round {
+      flex: 0 0 auto;
+      color: var(--red);
+      font-size: 10px;
+      font-weight: 900;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .combat-dock-turn {
+      min-width: 0;
+      overflow: hidden;
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 820;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .combat-history-toggle {
+      flex: 0 0 auto;
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      border: 0;
+      border-bottom: 1px solid var(--line-strong);
+      border-radius: 0;
+      background: transparent;
+      color: var(--dim);
+      padding: 4px 2px;
+      font: inherit;
+      font-size: 10px;
+      font-weight: 800;
+      cursor: pointer;
+    }
+    .combat-history-toggle:hover,
+    .combat-history-toggle:focus-visible,
+    .combat-history-toggle[aria-expanded="true"] {
+      border-bottom-color: var(--red);
+      color: var(--text);
+      outline: 0;
+    }
+    .combat-history-toggle-count {
+      min-width: 17px;
+      height: 17px;
+      display: grid;
+      place-items: center;
+      border: 1px solid rgba(var(--type-combat-rgb), 0.42);
+      border-radius: 999px;
+      color: var(--red);
+      font-size: 9px;
+    }
+    .combat-latest,
+    .combat-latest-inner,
+    .combat-history-row {
+      min-width: 0;
+      display: grid;
+      grid-template-columns: 24px minmax(0, 1fr) auto;
+      gap: 8px;
+      align-items: center;
+    }
+    .combat-latest {
+      min-height: 46px;
+      padding: 7px 10px;
+    }
+    .combat-latest-inner { display: contents; }
+    .combat-beat-icon {
+      width: 24px;
+      height: 24px;
+      display: grid;
+      place-items: center;
+      border: 1px solid rgba(var(--type-combat-rgb), 0.42);
+      border-radius: 999px;
+      background: rgba(var(--type-combat-rgb), 0.1);
+      color: var(--red);
+      font-size: 11px;
+      font-weight: 900;
+    }
+    .combat-beat-copy {
+      min-width: 0;
+      display: grid;
+      gap: 1px;
+    }
+    .combat-beat-summary,
+    .combat-beat-detail {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .combat-beat-summary {
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 780;
+    }
+    .combat-beat-detail {
+      color: var(--dim);
+      font-size: 10px;
+    }
+    .combat-beat-result {
+      max-width: none;
+      overflow: hidden;
+      border: 1px solid rgba(var(--type-combat-rgb), 0.34);
+      border-radius: 999px;
+      background: rgba(var(--type-combat-rgb), 0.09);
+      color: var(--red);
+      padding: 3px 7px;
+      font-size: 9px;
+      font-weight: 900;
+      text-overflow: ellipsis;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .combat-beat-result.miss,
+    .combat-beat-result.wait {
+      border-color: var(--line-strong);
+      background: rgba(255, 255, 255, 0.025);
+      color: var(--dim);
+    }
+    .combat-beat-result.critical {
+      border-color: rgba(var(--type-combat-rgb), 0.7);
+      background: rgba(var(--type-combat-rgb), 0.2);
+      color: #fff;
+    }
+    .combat-history {
+      max-height: min(28vh, 230px);
+      overflow: auto;
+      overscroll-behavior: contain;
+      border-top: 1px solid rgba(var(--type-combat-rgb), 0.18);
+      background: rgba(6, 6, 5, 0.46);
+      scrollbar-width: thin;
+    }
+    .combat-history[hidden] { display: none; }
+    .combat-history-row {
+      min-height: 42px;
+      align-items: start;
+      padding: 6px 10px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+    }
+    .combat-history-row .combat-beat-icon,
+    .combat-history-row .combat-beat-result { margin-top: 1px; }
+    .combat-history-row .combat-beat-detail {
+      display: -webkit-box;
+      overflow: hidden;
+      line-height: 1.25;
+      white-space: normal;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
+    .combat-history-row:last-child { border-bottom: 0; }
+    .combat-history-empty {
+      margin: 0;
+      padding: 12px;
+      color: var(--dim);
+      font-size: 11px;
+      text-align: center;
+    }
+    @media (max-width: 900px) {
+      .combat-dock { margin-bottom: 7px; }
+      .combat-dock-head { min-height: 44px; padding-inline: 8px; }
+      .combat-latest { padding-inline: 8px; }
+      .combat-history-row { padding-inline: 8px; }
+    }
+    body.large-text .combat-dock-turn,
+    body.large-text .combat-beat-summary { font-size: 1rem; }
+    body.large-text .combat-dock-round,
+    body.large-text .combat-beat-detail,
+    body.large-text .combat-history-toggle { font-size: 0.82rem; }
+    @media (max-width: 360px) {
+      .combat-dock-state { gap: 5px; }
+      .combat-dock-turn { font-size: 11px; }
+      .combat-history-toggle { font-size: 0; }
+      .combat-history-toggle::before { content: "log"; font-size: 10px; }
+    }
   </style>
 </head>
 <body>
@@ -5612,6 +5814,14 @@
             <div class="spatial-caption"><strong id="spatial-title"></strong><span class="spatial-hand-key"><span>first card</span><span>second card</span></span></div>
           </div>
         </div>
+        <section class="combat-dock" id="combat-dock" aria-label="Combat status" hidden>
+          <header class="combat-dock-head">
+            <div class="combat-dock-state"><span class="combat-dock-round" id="combat-dock-round"></span><strong class="combat-dock-turn" id="combat-dock-turn"></strong></div>
+            <button class="combat-history-toggle" id="combat-history-toggle" type="button" aria-expanded="false" aria-controls="combat-history">History <span class="combat-history-toggle-count" id="combat-history-count" aria-hidden="true">0</span></button>
+          </header>
+          <div class="combat-latest" id="combat-latest" role="status" aria-live="polite" aria-atomic="true"></div>
+          <div class="combat-history" id="combat-history" role="log" aria-label="Combat history" hidden></div>
+        </section>
         <button class="room-log-latest" id="room-log-latest" type="button" aria-controls="journal-view" data-player-concept="journal" data-analytics-event="journal.open" hidden><span class="room-log-latest-track" id="room-log-latest-track"></span></button>
         <div class="room-copy" id="location-copy"></div>
       </section>
@@ -5872,6 +6082,8 @@
     let openRouterConnection = loadOpenRouterConnection();
     let roomCopyExpanded = false;
     let journalOpen = false;
+    let combatHistoryOpen = false;
+    let combatHistoryEncounterId = 0;
     let journalPageIndex = -1;
     let roomLogTickerFrame = null;
     let journalRowOverflowFrame = null;
@@ -9737,24 +9949,30 @@
         && Number(attempt.content_id || 0) === Number(outcome.content_id || 0);
     }
 
-    function sharedRoomTranscriptEvents(events) {
+    function combatEventsForPresentation(events) {
       const visible = [];
       let combatActive = Boolean(state?.combat);
       const currentLocationId = Number(state?.location?.id || 0);
-      for (let index = 0; index < (events || []).length; index += 1) {
-        const event = events[index];
+      const localEvents = (events || []).filter((event) => {
         const eventLocationId = Number(event?.location_id || 0);
-        if (currentLocationId && eventLocationId && eventLocationId !== currentLocationId) continue;
-        if (["message.created", "image.created", "model_interaction.output"].includes(event?.type)) {
-          visible.push(event);
-          continue;
+        return !(currentLocationId && eventLocationId && eventLocationId !== currentLocationId);
+      });
+      let encounterStart = -1;
+      for (let index = localEvents.length - 1; index >= 0; index -= 1) {
+        if (localEvents[index]?.type === "combat.encounter.started") {
+          encounterStart = index;
+          break;
         }
+      }
+      const encounterEvents = encounterStart >= 0 ? localEvents.slice(encounterStart) : localEvents;
+      for (let index = 0; index < encounterEvents.length; index += 1) {
+        const event = encounterEvents[index];
         if (event?.type === "combat.encounter.started") combatActive = true;
         if (event?.type === "combat.attack.attempt") {
           const grouped = { ...event };
           let lastSeq = Number(event.seq || 0);
-          for (let cursor = index + 1; cursor < events.length; cursor += 1) {
-            const outcome = events[cursor];
+          for (let cursor = index + 1; cursor < encounterEvents.length; cursor += 1) {
+            const outcome = encounterEvents[cursor];
             if (!combatAttackEventsShareBeat(event, outcome)) break;
             if (outcome.type === "combat.knockout") grouped.combat_knockout = outcome;
             else grouped.combat_outcome = outcome;
@@ -9773,8 +9991,16 @@
         }
         if (event?.type === "combat.encounter.resolved") combatActive = false;
       }
-      // The source log remains append-only and substantially deeper. This
-      // bound limits mounted DOM without dropping speech when combat begins.
+      return visible.slice(-24);
+    }
+
+    function sharedRoomTranscriptEvents(events) {
+      const currentLocationId = Number(state?.location?.id || 0);
+      const visible = (events || []).filter((event) => {
+        const eventLocationId = Number(event?.location_id || 0);
+        return eventIsChatTranscriptEvent(event)
+          && !(currentLocationId && eventLocationId && eventLocationId !== currentLocationId);
+      });
       return visible.slice(-40);
     }
 
@@ -9946,18 +10172,22 @@
     }
 
     const importantNotificationTypes = new Set([
-      "combat.encounter.started",
-      "combat.attack.hit",
-      "combat.attack.miss",
-      "combat.defend",
-      "combat.dodge",
-      "combat.pass",
       "combat.knockout",
       "combat.flee.success",
       "combat.encounter.resolved",
       "clock.threshold",
       "relationship.advanced",
       "world.conflict.escalated",
+    ]);
+    const dockOwnedCombatNotificationTypes = new Set([
+      "combat.encounter.started",
+      "combat.attack.attempt",
+      "combat.attack.hit",
+      "combat.attack.miss",
+      "combat.defend",
+      "combat.dodge",
+      "combat.pass",
+      "combat.need_time",
     ]);
 
     function enqueueImportantNotification(event) {
@@ -9984,6 +10214,7 @@
     function enqueueJournalNotification(event) {
       if (!sceneCardEventTypes.has(String(event?.type || ""))) return;
       if (["ability_check.rolled", "avatar.thought", "avatar.dream"].includes(event.type)) return;
+      if (dockOwnedCombatNotificationTypes.has(event.type)) return;
       const key = String(event?.seq || `${event.type}:${Date.now()}`);
       if (journalNotifications.some((notification) => notification.key === key)) return;
       const meta = statusUpdateMeta(event);
@@ -11868,6 +12099,140 @@
       $("room-hero")?.classList.toggle("has-rescue-row", Boolean(rescueHtml));
     }
 
+    function combatBeatPresentation(event) {
+      const type = String(event?.type || "");
+      const actor = event?.actor_name || "Someone";
+      const target = event?.target_actor_name || event?.combat_outcome?.target_actor_name || "their opponent";
+      const base = {
+        icon: "⚔",
+        summary: "The clash continues",
+        detail: "",
+        result: "",
+        resultKind: "wait",
+      };
+      if (type === "combat.attack.attempt") {
+        const outcome = event.combat_outcome || null;
+        const knockout = event.combat_knockout || null;
+        const method = event.combat_method || event.item_name || "Unarmed strike";
+        const mechanics = combatAttackMechanics(event).replace(/\s*·\s*$/g, "");
+        const damageValue = outcome?.damage ?? knockout?.damage;
+        const damage = Number.isFinite(Number(damageValue)) ? Math.max(0, Number(damageValue)) : null;
+        const missed = outcome?.type === "combat.attack.miss" || (!outcome && event.success === false);
+        return {
+          icon: missed ? "◇" : knockout ? "!" : "✦",
+          summary: actor + " → " + target,
+          detail: [method, mechanics].filter(Boolean).join(" · "),
+          result: missed ? "miss" : knockout ? "knockout" : damage > 0 ? damage + " harm" : "hit",
+          resultKind: missed ? "miss" : knockout ? "critical" : "hit",
+        };
+      }
+      if (type === "combat.encounter.started") {
+        return { ...base, icon: "⚔", summary: actor + " faces " + target, detail: "The encounter begins", result: "start" };
+      }
+      if (type === "combat.attack.hit") {
+        const damage = Math.max(0, Number(event.damage || 0));
+        return { ...base, icon: "✦", summary: actor + " hits " + target, detail: event.combat_method || event.item_name || "Attack", result: damage ? damage + " harm" : "hit", resultKind: "hit" };
+      }
+      if (type === "combat.attack.miss") {
+        return { ...base, icon: "◇", summary: target + " evades " + actor, detail: event.combat_method || event.item_name || "Attack", result: "miss", resultKind: "miss" };
+      }
+      if (type === "combat.knockout") {
+        return { ...base, icon: "!", summary: target + " is knocked out", detail: event.combat_method || event.item_name || actor + "'s attack", result: "knockout", resultKind: "critical" };
+      }
+      if (type === "combat.dodge") {
+        return { ...base, icon: "↝", summary: actor + " prepares to dodge", detail: "Attacks have Disadvantage", result: "dodge" };
+      }
+      if (type === "combat.defend") {
+        return { ...base, icon: "◇", summary: actor + " holds their guard", detail: "Waiting for an opening", result: "guard" };
+      }
+      if (type === "combat.pass") {
+        return { ...base, icon: "→", summary: actor + " passes", detail: "The combat floor moves on", result: "pass" };
+      }
+      if (type === "combat.need_time") {
+        return { ...base, icon: "…", summary: actor + " needs more time", detail: "The turn stays with them", result: "pause" };
+      }
+      if (type === "combat.flee.success") {
+        return { ...base, icon: "↗", summary: actor + " escapes", detail: "To " + (event.destination_location_name || "safety"), result: "away" };
+      }
+      if (type === "combat.encounter.resolved") {
+        return { ...base, icon: "✦", summary: "The clash is over", detail: "The room settles again", result: "resolved", resultKind: "hit" };
+      }
+      if (type === "item.used") {
+        const recovery = Number(event.damage || 0) < 0 ? Math.abs(Number(event.damage || 0)) : 0;
+        return { ...base, icon: "+", summary: actor + " uses " + (event.item_name || "an item"), detail: event.target_actor_name ? "On " + event.target_actor_name : "In the clash", result: recovery ? "+" + recovery + " HP" : "used", resultKind: recovery ? "hit" : "wait" };
+      }
+      if (type === "magic.spell_cast") {
+        return { ...base, icon: "✧", summary: actor + " casts " + (event.item_name || "a spell"), detail: event.target_actor_name ? "Toward " + event.target_actor_name : "Its effect takes hold", result: "cast", resultKind: "hit" };
+      }
+      return {
+        ...base,
+        summary: cleanStatusText(sceneCardEventText(event) || eventText(event)) || base.summary,
+      };
+    }
+
+    function combatBeatHtml(event, className) {
+      const beat = combatBeatPresentation(event);
+      const result = beat.result
+        ? '<span class="combat-beat-result ' + escapeAttr(beat.resultKind) + '">' + escapeHtml(beat.result) + "</span>"
+        : "";
+      const detail = beat.detail
+        ? '<span class="combat-beat-detail">' + escapeHtml(beat.detail) + "</span>"
+        : "";
+      const aria = [beat.summary, beat.detail, beat.result].filter(Boolean).join(". ");
+      return '<div class="' + escapeAttr(className) + '" data-combat-history-seq="' + Number(event?.transcript_tail_seq || event?.seq || 0) + '" aria-label="' + escapeAttr(aria) + '"><span class="combat-beat-icon" aria-hidden="true">' + escapeHtml(beat.icon) + '</span><span class="combat-beat-copy"><span class="combat-beat-summary">' + escapeHtml(beat.summary) + "</span>" + detail + "</span>" + result + "</div>";
+    }
+
+    function renderCombatDock(view = state) {
+      const dock = $("combat-dock");
+      const history = $("combat-history");
+      const toggle = $("combat-history-toggle");
+      if (!dock || !history || !toggle) return;
+      const combat = view?.combat || null;
+      if (!combat) {
+        dock.hidden = true;
+        combatHistoryOpen = false;
+        combatHistoryEncounterId = 0;
+        history.hidden = true;
+        toggle.setAttribute("aria-expanded", "false");
+        return;
+      }
+      const encounterId = Number(combat.encounter_id || 0);
+      if (encounterId !== combatHistoryEncounterId) {
+        combatHistoryEncounterId = encounterId;
+        combatHistoryOpen = false;
+      }
+      const beats = combatEventsForPresentation(logEvents);
+      const historicalBeats = beats.slice(0, -1);
+      const currentActor = combat.current_actor_name
+        || actorForId(combat.current_actor_id)?.name
+        || "The next combatant";
+      const round = Math.max(1, Number(combat.round || 1));
+      const turnCopy = combat.is_current_actor || Number(combat.current_actor_id) === Number(actorId)
+        ? "Your turn"
+        : currentActor + "'s turn";
+      $("combat-dock-round").textContent = "Round " + round;
+      $("combat-dock-turn").textContent = turnCopy;
+      $("combat-history-count").textContent = String(beats.length);
+      const latest = beats.at(-1);
+      $("combat-latest").innerHTML = latest
+        ? combatBeatHtml(latest, "combat-latest-inner")
+        : '<span class="combat-beat-icon" aria-hidden="true">…</span><span class="combat-beat-copy"><span class="combat-beat-summary">' + escapeHtml(currentActor) + ' is choosing</span><span class="combat-beat-detail">The encounter state is up to date</span></span><span class="combat-beat-result wait">waiting</span>';
+      history.innerHTML = historicalBeats.length
+        ? historicalBeats.map((event) => combatBeatHtml(event, "combat-history-row")).join("")
+        : '<p class="combat-history-empty">No earlier combat actions yet.</p>';
+      history.hidden = !combatHistoryOpen;
+      toggle.setAttribute("aria-expanded", combatHistoryOpen ? "true" : "false");
+      toggle.setAttribute("aria-label", (combatHistoryOpen ? "Hide" : "Show") + " combat history, " + beats.length + " " + (beats.length === 1 ? "event" : "events"));
+      const latestBeat = latest ? combatBeatPresentation(latest) : null;
+      dock.setAttribute("aria-label", [
+        "Combat, round " + round,
+        turnCopy,
+        latestBeat ? "Latest: " + latestBeat.summary + ", " + (latestBeat.result || latestBeat.detail) : "No actions resolved yet",
+      ].join(". "));
+      dock.hidden = false;
+      if (combatHistoryOpen) history.scrollTop = history.scrollHeight;
+    }
+
     function journalSentence(value) {
       const text = cleanStatusText(value);
       if (!text) return "";
@@ -11983,6 +12348,7 @@
       renderJournalActivity();
       renderRoomMemory();
       renderJournalLog();
+      renderCombatDock();
       renderLog();
       syncJournalRegions();
       syncJournalMode();
@@ -13565,7 +13931,9 @@
 
     function quietRoomSceneHtml() {
       const hasAvatar = Boolean(actorId && state?.primary_action?.kind !== "create_avatar");
-      const cue = state?.journey
+      const cue = state?.combat
+        ? "The clash has the floor. Choose from your combat hand."
+        : state?.journey
         ? "The road is quiet for a moment. Chat with the travelling party or choose how to press on."
         : hasAvatar
           ? "Chat with someone here or explore the room."
@@ -17745,6 +18113,10 @@
     });
     $("room-log-latest").addEventListener("click", () => {
       setJournalOpen(!journalOpen);
+    });
+    $("combat-history-toggle").addEventListener("click", () => {
+      combatHistoryOpen = !combatHistoryOpen;
+      renderCombatDock();
     });
 
     $("card-modal").addEventListener("click", (event) => {

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -8030,6 +8030,182 @@ async function main() {
     );
   }
 
+  async function assertCombatUsesDedicatedDockOutsideChat() {
+    const result = await page.evaluate(() => {
+      const previous = {
+        logEvents: logEvents.slice(),
+        seenSeq: [...seenSeq],
+        actorId,
+        state,
+        accountPanelPinned,
+        libraryPanelPinned,
+        pendingChats: pendingChats.slice(),
+        renderedChatTailKey,
+        defeatTransition,
+        combatHistoryOpen,
+        combatHistoryEncounterId,
+      };
+      const message = (seq, content) => ({
+        seq,
+        type: "message.created",
+        actor_id: 1001,
+        actor_name: "Rati",
+        location_id: 3,
+        location_name: "Moonlit Trail",
+        content,
+      });
+      const combatEvent = (seq, type, extra = {}) => ({
+        seq,
+        type,
+        actor_id: 5000,
+        actor_name: "Lantern Stitch",
+        target_actor_id: 1004,
+        target_actor_name: "Coach",
+        location_id: 3,
+        location_name: "Moonlit Trail",
+        content_id: 77,
+        ...extra,
+      });
+      const events = [
+        message(990600001, "Keep the lantern between you and the dark."),
+        combatEvent(990600002, "combat.encounter.started"),
+        combatEvent(990600003, "combat.attack.attempt", {
+          success: true,
+          combat_method: "Ashwood Practice Blade",
+          item_name: "Ashwood Practice Blade",
+          ability: "Strength",
+          raw_roll: 14,
+          modifier: 3,
+          total: 17,
+          dc: 13,
+        }),
+        combatEvent(990600004, "combat.attack.hit", {
+          success: true,
+          combat_method: "Ashwood Practice Blade",
+          item_name: "Ashwood Practice Blade",
+          ability: "Strength",
+          damage: 4,
+          current_hp: 1,
+        }),
+        message(990600005, "I am still here. Breathe."),
+        combatEvent(990600006, "combat.dodge"),
+        combatEvent(990600007, "combat.flee.success", {
+          destination_location_name: "The Cosy Cottage",
+        }),
+        combatEvent(990600008, "combat.encounter.resolved"),
+      ];
+      const signature = (entries) => entries.map((event) => ({
+        type: event.type,
+        seq: Number(event.seq || 0),
+        tail: Number(event.transcript_tail_seq || event.seq || 0),
+        outcome: event.combat_outcome?.type || "",
+      }));
+      try {
+        actorId = 5000;
+        state = {
+          ...state,
+          location: { ...(state?.location || {}), id: 3, name: "Moonlit Trail" },
+          actors: [
+            { id: 5000, name: "Lantern Stitch", status: "active", control_mode: "direct_input" },
+            { id: 1001, name: "Rati", status: "active", control_mode: "local_ai" },
+            { id: 1004, name: "Coach", status: "active", control_mode: "local_ai" },
+          ],
+          combat: {
+            encounter_id: 77,
+            round: 2,
+            current_actor_id: 5000,
+            current_actor_name: "Lantern Stitch",
+            is_current_actor: true,
+            participants: [],
+          },
+        };
+        accountPanelPinned = false;
+        libraryPanelPinned = false;
+        pendingChats = [];
+        defeatTransition = null;
+        logEvents = events.slice();
+        seenSeq.clear();
+        for (const event of events) seenSeq.add(event.seq);
+        renderedChatTailKey = "";
+        combatHistoryOpen = true;
+        combatHistoryEncounterId = 77;
+        const beforeReconnect = signature(combatEventsForPresentation(logEvents));
+        renderCombatDock();
+        renderLog();
+        const transcript = $("log");
+        const dock = $("combat-dock");
+        const history = $("combat-history");
+        const rendered = {
+          label: transcript.getAttribute("aria-label") || "",
+          chat: [...transcript.querySelectorAll(".line.chat")].map((row) => row.textContent.trim().replace(/\s+/g, " ")),
+          combatBeatCount: transcript.querySelectorAll("[data-combat-beat]").length,
+          eventText: [...transcript.querySelectorAll(".line.event")].map((row) => row.textContent.trim().replace(/\s+/g, " ")).join(" "),
+          dockHidden: dock.hidden,
+          dockRound: $("combat-dock-round").textContent.trim(),
+          dockTurn: $("combat-dock-turn").textContent.trim(),
+          dockLatest: $("combat-latest").textContent.trim().replace(/\s+/g, " "),
+          historyHidden: history.hidden,
+          historyRows: history.querySelectorAll(".combat-history-row").length,
+          historyText: history.textContent.trim().replace(/\s+/g, " "),
+        };
+        rebuildLog(events);
+        const afterReconnect = signature(combatEventsForPresentation(logEvents));
+
+        logEvents = Array.from({ length: 40 }, (_, index) => message(
+          990601000 + index,
+          "A deliberately long transcript line " + (index + 1) + " keeps the reader's chosen place stable while another public beat arrives.",
+        ));
+        renderedChatTailKey = "";
+        renderLog();
+        const overflow = transcript.scrollHeight > transcript.clientHeight + 28;
+        transcript.scrollTop = 0;
+        logEvents.push(combatEvent(990601100, "combat.dodge"));
+        renderCombatDock();
+        renderLog();
+        const preservedReaderPosition = !overflow || transcript.scrollTop <= 1;
+
+        return {
+          beforeReconnect,
+          afterReconnect,
+          rendered,
+          preservedReaderPosition,
+        };
+      } finally {
+        logEvents = previous.logEvents;
+        seenSeq.clear();
+        for (const seq of previous.seenSeq) seenSeq.add(seq);
+        actorId = previous.actorId;
+        state = previous.state;
+        accountPanelPinned = previous.accountPanelPinned;
+        libraryPanelPinned = previous.libraryPanelPinned;
+        pendingChats = previous.pendingChats;
+        renderedChatTailKey = previous.renderedChatTailKey;
+        defeatTransition = previous.defeatTransition;
+        combatHistoryOpen = previous.combatHistoryOpen;
+        combatHistoryEncounterId = previous.combatHistoryEncounterId;
+        renderTimelines();
+      }
+    });
+    assert(result.rendered.label === "Shared room transcript", "combat should keep the ordinary speech transcript mounted: " + JSON.stringify(result));
+    assert(result.rendered.chat.length === 2 && result.rendered.chat[0].includes("Keep the lantern") && result.rendered.chat[1].includes("still here"), "speech from before and during combat should remain ordered and visible: " + JSON.stringify(result));
+    assert(result.rendered.combatBeatCount === 0 && result.rendered.eventText === "", "combat system output must not be rendered as dialogue: " + JSON.stringify(result));
+    assert(!result.rendered.dockHidden
+      && result.rendered.dockRound === "Round 2"
+      && result.rendered.dockTurn === "Your turn"
+      && !result.rendered.historyHidden
+      && result.rendered.historyRows === 4, "active combat should expose one compact latest result with optional bounded earlier history: " + JSON.stringify(result));
+    assert(
+      result.rendered.historyText.includes("Ashwood Practice Blade")
+        && result.rendered.historyText.includes("Strength attack · d20 14 +3 = 17 vs AC 13")
+        && result.rendered.historyText.includes("4 harm"),
+      "the grouped dock beat should retain method, Attribute, arithmetic, harm, and outcome: " + JSON.stringify(result),
+    );
+    assert(/prepares to dodge/.test(result.rendered.historyText), "Dodge needs compact combat-history feedback: " + JSON.stringify(result));
+    assert(/clash is over/i.test(result.rendered.dockLatest) && /Cosy Cottage/.test(result.rendered.historyText), "escape and resolution need immediate combat feedback: " + JSON.stringify(result));
+    assert(JSON.stringify(result.beforeReconnect) === JSON.stringify(result.afterReconnect), "reconnect should reconstruct the same grouped combat-history ordering: " + JSON.stringify(result));
+    assert(result.preservedReaderPosition, "new combat beats must not move a reader's chosen place in chat: " + JSON.stringify(result));
+  }
+
   async function assertWorldResetClearsTranscriptAndResidentRepeatsCollapse() {
     const result = await page.evaluate(() => {
       const previousLogEvents = logEvents.slice();
@@ -8215,186 +8391,6 @@ async function main() {
     assert(result.detectsServerTimelineRewind && result.acceptsForwardTimeline, `a reconnect should replace rewound server history without mistaking a forward timeline for a reset: ${JSON.stringify(result)}`);
     assert(result.afterTravelReceipt?.applied && result.afterTravelReceipt.pendingCount === 0 && result.afterTravelReceipt.events.length === 1 && result.afterTravelReceipt.events[0]?.content === "new room history", `a live travel receipt should clear pending chat and replace the old room transcript: ${JSON.stringify(result)}`);
     assert(result.afterCompactReceipt?.applied && result.afterCompactReceipt.worldTick === 13 && result.afterCompactReceipt.stateRevision === 35 && result.afterCompactReceipt.locationId === 2, `a compact action receipt should advance revision metadata without replacing the current state projection: ${JSON.stringify(result)}`);
-  }
-
-  async function assertCombatStaysInSharedRoomTranscript() {
-    const result = await page.evaluate(() => {
-      const previous = {
-        logEvents: logEvents.slice(),
-        seenSeq: [...seenSeq],
-        actorId,
-        state,
-        accountPanelPinned,
-        libraryPanelPinned,
-        pendingChats: pendingChats.slice(),
-        renderedChatTailKey,
-        defeatTransition,
-      };
-      const message = (seq, actorIdValue, actorName, content) => ({
-        seq,
-        type: "message.created",
-        actor_id: actorIdValue,
-        actor_name: actorName,
-        location_id: 3,
-        location_name: "Moonlit Trail",
-        content,
-      });
-      const combatEvent = (seq, type, extra = {}) => ({
-        seq,
-        type,
-        actor_id: 5000,
-        actor_name: "Lantern Stitch",
-        target_actor_id: 1004,
-        target_actor_name: "Coach",
-        location_id: 3,
-        location_name: "Moonlit Trail",
-        content_id: 77,
-        ...extra,
-      });
-      const events = [
-        message(990600001, 1001, "Rati", "Keep the lantern between you and the dark."),
-        combatEvent(990600002, "combat.encounter.started"),
-        combatEvent(990600003, "combat.attack.attempt", {
-          success: true,
-          combat_method: "Ashwood Practice Blade",
-          item_name: "Ashwood Practice Blade",
-          ability: "Strength",
-        }),
-        combatEvent(990600004, "combat.attack.hit", {
-          success: true,
-          combat_method: "Ashwood Practice Blade",
-          item_name: "Ashwood Practice Blade",
-          ability: "Strength",
-          damage: 4,
-          current_hp: 1,
-        }),
-        combatEvent(990600005, "combat.knockout", {
-          success: true,
-          combat_method: "Ashwood Practice Blade",
-          item_name: "Ashwood Practice Blade",
-          ability: "Strength",
-          damage: 4,
-          current_hp: 1,
-        }),
-        message(990600006, 1001, "Rati", "I am still here. Breathe."),
-        combatEvent(990600007, "combat.dodge"),
-        combatEvent(990600008, "combat.defend"),
-        combatEvent(990600009, "item.used", {
-          item_name: "Hearth Tonic",
-          target_actor_name: "Lantern Stitch",
-          damage: -2,
-        }),
-        combatEvent(990600010, "magic.spell_cast", {
-          item_name: "Mothlight",
-          target_actor_name: "Coach",
-        }),
-        combatEvent(990600011, "combat.flee.success", {
-          destination_location_name: "The Cosy Cottage",
-        }),
-        combatEvent(990600012, "combat.encounter.resolved"),
-      ];
-      const signature = (entries) => entries.map((event) => ({
-        type: event.type,
-        seq: Number(event.seq || 0),
-        tail: Number(event.transcript_tail_seq || event.seq || 0),
-        outcome: event.combat_outcome?.type || "",
-        knockout: event.combat_knockout?.type || "",
-      }));
-      try {
-        actorId = 5000;
-        state = {
-          ...state,
-          location: { ...(state?.location || {}), id: 3, name: "Moonlit Trail" },
-          actors: [
-            { id: 5000, name: "Lantern Stitch", status: "active", control_mode: "direct_input" },
-            { id: 1001, name: "Rati", status: "active", control_mode: "local_ai" },
-            { id: 1004, name: "Coach", status: "knocked_out", control_mode: "local_ai" },
-          ],
-        };
-        accountPanelPinned = false;
-        libraryPanelPinned = false;
-        pendingChats = [];
-        defeatTransition = null;
-        logEvents = events.slice();
-        seenSeq.clear();
-        for (const event of events) seenSeq.add(event.seq);
-        renderedChatTailKey = "";
-        const beforeReconnect = signature(sharedRoomTranscriptEvents(logEvents));
-        renderLog();
-        const transcript = $("log");
-        const rendered = {
-          label: transcript.getAttribute("aria-label") || "",
-          chat: [...transcript.querySelectorAll(".line.chat")].map((row) => row.textContent.trim().replace(/\s+/g, " ")),
-          combatBeatCount: transcript.querySelectorAll("[data-combat-beat]").length,
-          combatBeat: transcript.querySelector("[data-combat-beat]")?.textContent?.trim().replace(/\s+/g, " ") || "",
-          eventText: [...transcript.querySelectorAll(".line.event")].map((row) => row.textContent.trim().replace(/\s+/g, " ")).join(" "),
-        };
-        defeatTransition = {
-          actorName: "Lantern Stitch",
-          opponentName: "Coach",
-          kind: "combat.knockout",
-          eventSeq: 990600005,
-        };
-        renderLog();
-        rendered.defeatKeepsTranscript = transcript.querySelectorAll(".line.chat").length === 2
-          && transcript.querySelectorAll("[data-combat-beat]").length === 1
-          && Boolean(transcript.querySelector(".defeat-scene"));
-        defeatTransition = null;
-
-        rebuildLog(events);
-        const afterReconnect = signature(sharedRoomTranscriptEvents(logEvents));
-
-        logEvents = Array.from({ length: 40 }, (_, index) => message(
-          990601000 + index,
-          index % 2 ? 1001 : 5000,
-          index % 2 ? "Rati" : "Lantern Stitch",
-          `A deliberately long transcript line ${index + 1} keeps the reader's chosen place stable while another public beat arrives.`,
-        ));
-        renderedChatTailKey = "";
-        renderLog();
-        const overflow = transcript.scrollHeight > transcript.clientHeight + 28;
-        transcript.scrollTop = 0;
-        logEvents.push(combatEvent(990601100, "combat.defend"));
-        renderLog();
-        const preservedReaderPosition = !overflow || transcript.scrollTop <= 1;
-
-        return {
-          beforeReconnect,
-          afterReconnect,
-          rendered,
-          overflow,
-          preservedReaderPosition,
-        };
-      } finally {
-        logEvents = previous.logEvents;
-        seenSeq.clear();
-        for (const seq of previous.seenSeq) seenSeq.add(seq);
-        actorId = previous.actorId;
-        state = previous.state;
-        accountPanelPinned = previous.accountPanelPinned;
-        libraryPanelPinned = previous.libraryPanelPinned;
-        pendingChats = previous.pendingChats;
-        renderedChatTailKey = previous.renderedChatTailKey;
-        defeatTransition = previous.defeatTransition;
-        renderTimelines();
-      }
-    });
-    assert(result.rendered.label === "Shared room transcript", `combat should keep the ordinary shared transcript mounted: ${JSON.stringify(result)}`);
-    assert(result.rendered.chat.length === 2 && result.rendered.chat[0].includes("Keep the lantern") && result.rendered.chat[1].includes("still here"), `speech from before and during combat should remain ordered and visible: ${JSON.stringify(result)}`);
-    assert(result.rendered.defeatKeepsTranscript, `a player Knockout transition should append without replacing room speech or the grouped combat beat: ${JSON.stringify(result)}`);
-    assert(result.rendered.combatBeatCount === 1, `attempt, hit, harm, and Knockout should render as one combat beat: ${JSON.stringify(result)}`);
-    assert(
-      result.rendered.combatBeat.includes("Ashwood Practice Blade")
-        && result.rendered.combatBeat.includes("Strength")
-        && result.rendered.combatBeat.includes("4 harm")
-        && result.rendered.combatBeat.includes("knocked out"),
-      `the grouped combat beat should retain method, Attribute, harm, and outcome: ${JSON.stringify(result)}`,
-    );
-    assert(/ready to slip clear/.test(result.rendered.eventText) && /plants their feet/.test(result.rendered.eventText), `Dodge and Defend need authored transcript text: ${JSON.stringify(result)}`);
-    assert(/Hearth Tonic/.test(result.rendered.eventText) && /Mothlight/.test(result.rendered.eventText), `item and spell actions need authored transcript text: ${JSON.stringify(result)}`);
-    assert(/clash is over/.test(result.rendered.eventText) && /Cosy Cottage/.test(result.rendered.eventText), `escape and resolution need authored transcript text: ${JSON.stringify(result)}`);
-    assert(JSON.stringify(result.beforeReconnect) === JSON.stringify(result.afterReconnect), `reconnect should reconstruct the same grouped transcript ordering: ${JSON.stringify(result)}`);
-    assert(result.preservedReaderPosition, `new combat beats must not force-follow when the reader moved upward: ${JSON.stringify(result)}`);
   }
 
   async function assertCardBeatsStayInSceneAndBookkeepingStaysOut() {
@@ -14869,7 +14865,7 @@ async function main() {
   await assertWorldBeatExposureFollowsVisibleAuthoredProse();
   await assertFactionInfluenceEventNameStaysInternal();
   await assertWorldResetClearsTranscriptAndResidentRepeatsCollapse();
-  await assertCombatStaysInSharedRoomTranscript();
+  await assertCombatUsesDedicatedDockOutsideChat();
   await assertCardBeatsStayInSceneAndBookkeepingStaysOut();
   await assertLanternKeeperSemanticStoryReceipt();
   await assertLanternQuestionAndTwoSuggestionAccessibility();


### PR DESCRIPTION
## Summary

- move deterministic combat output out of the shared room transcript and into a compact dock beside the scene
- show round, current turn, and the latest resolved beat at a glance, with a player-opened bounded history
- group attack attempts with hit, miss, damage, and knockout outcomes while preserving exact roll arithmetic
- keep chat speech-only, reserve Journal notifications for consequential combat milestones, and document the surface contract
- update the browser regression and align the release version at 1.0.42

## Why

The mobile combat display mixed dialogue, mechanics, damage, and repeated event rows in one scrolling surface. That made the transcript overlap, obscured the current encounter state, and forced players to parse a wall of prose during time-sensitive play.

This separates the two reading modes: chat remains conversation, while the combat dock owns live state and optional mechanical history.

## Verification

- `npm run check` through the mandatory pre-push hook
  - 18 Vitest files / 183 tests
  - official and composed worldpack checks plus strict proof world
  - C kernel tests
  - 1,167 Rust orchestrator tests plus supporting binary/integration suites
  - architecture ceiling, Clippy warning ceiling, and syntax checks
- inline browser script parsed with `new Function`
- `git diff --check`

## Browser gate note

`npm run v2:browser:check` compiled the production Rust binary successfully, but this machine did not pass the server readiness precondition because AI inference is not configured. The smoke assertions therefore did not start; the failure was `inference_unconfigured`, not a combat UI assertion.