### PR TITLE
Add passkey recovery UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.42",
+      "version": "1.0.43",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.42"
+version = "1.0.43"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.42"
+version = "1.0.43"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/account_auth.rs
+++ b/v2/orchestrator-rust/src/account_auth.rs
@@ -2433,6 +2433,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn browser_passkey_recovery_requires_an_explicit_replacement_choice() {
+        assert!(INDEX_HTML.contains("function passkeyServerRecordIsMissing(error)"));
+        assert!(INDEX_HTML.contains("Number(error?.status || 0) === 401"));
+        assert!(INDEX_HTML
+            .contains("String(error?.message || \"\") === \"passkey sign-in was not accepted\""));
+        assert!(INDEX_HTML.contains("passkeyRecoveryAvailable = true"));
+        assert!(INDEX_HTML.contains("data-passkey-recover"));
+        assert!(INDEX_HTML.contains("data-passkey-continue>try another passkey"));
+        assert!(INDEX_HTML.contains("Creating a replacement starts a new CosyWorld account"));
+        assert!(INDEX_HTML.contains("does not restore data held only by the missing account"));
+        assert!(INDEX_HTML.contains(
+            "runIdentityTask(\"Creating a replacement passkey.\", recoverWithReplacementPasskey)"
+        ));
+    }
+
+    #[test]
     fn usernames_are_stable_and_conservative() {
         assert_eq!(
             normalize_account_username("  Maple.Rook_7  ").as_deref(),

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -6076,6 +6076,7 @@
     let worldView = null;
     let worldViewAccessKey = "";
     let identity = null;
+    let passkeyRecoveryAvailable = false;
     const openRouterApiKeyStorage = "cosyworld.openrouterApiKey";
     const openRouterConnectionStorage = "cosyworld.openrouterConnection";
     const openRouterOauthVerifierStorage = "cosyworld.openrouterOauthVerifier";
@@ -6442,6 +6443,7 @@
     function applyIdentity(nextIdentity) {
       identity = nextIdentity || { authenticated: false, wallets: [], passkeys: [] };
       if (identity.authenticated) {
+        passkeyRecoveryAvailable = false;
         walletAddress = identity.active_wallet || "";
         walletSession = identity.wallet_session || "";
         localStorage.removeItem("cosyworld.walletSession");
@@ -6513,13 +6515,31 @@
       connectStream();
     }
 
+    function passkeyServerRecordIsMissing(error) {
+      return Number(error?.status || 0) === 401
+        && String(error?.message || "") === "passkey sign-in was not accepted";
+    }
+
     async function continueWithPasskey() {
       try {
         await loginWithPasskey();
       } catch (error) {
-        if (String(error?.name || "") !== "NotAllowedError") throw error;
-        await registerPasskey(false);
+        if (String(error?.name || "") === "NotAllowedError") {
+          await registerPasskey(false);
+          return;
+        }
+        if (passkeyServerRecordIsMissing(error)) {
+          passkeyRecoveryAvailable = true;
+          setStatus("This passkey's server record is missing. Choose a recovery option below.", "notice");
+          return false;
+        }
+        throw error;
       }
+    }
+
+    async function recoverWithReplacementPasskey() {
+      await registerPasskey(false);
+      passkeyRecoveryAvailable = false;
     }
 
     async function logoutAccount() {
@@ -13996,6 +14016,9 @@
 
     function identitySectionHtml() {
       if (!identity?.authenticated) {
+        if (passkeyRecoveryAvailable) {
+          return `<section class="account-section" aria-label="Passkey recovery"><div class="account-section-title">Passkey recovery</div><div class="item-note"><strong>This device has a passkey that CosyWorld no longer recognizes.</strong><br>Try another passkey if you have one. Creating a replacement starts a new CosyWorld account and does not restore data held only by the missing account.</div><div class="account-actions"><button class="account-button" type="button" data-passkey-recover>create replacement passkey</button><button class="account-button secondary" type="button" data-passkey-continue>try another passkey</button></div></section>`;
+        }
         return `<section class="account-section" aria-label="CosyWorld sign in"><div class="account-actions"><button class="account-button" type="button" data-passkey-continue>continue with passkey</button></div></section>`;
       }
       const passkeys = Array.isArray(identity.passkeys) ? identity.passkeys : [];
@@ -18035,6 +18058,12 @@
       if (passkeyContinue) {
         event.preventDefault();
         runIdentityTask("Continue with your passkey.", continueWithPasskey);
+        return;
+      }
+      const passkeyRecover = event.target.closest("[data-passkey-recover]");
+      if (passkeyRecover) {
+        event.preventDefault();
+        runIdentityTask("Creating a replacement passkey.", recoverWithReplacementPasskey);
         return;
       }
       const passkeyAdd = event.target.closest("[data-passkey-add]");


### PR DESCRIPTION
## Summary

- detect the orphaned-passkey response after a discoverable WebAuthn assertion
- show explicit recovery choices to try another passkey or create a replacement
- warn that replacement creates a new account and cannot restore missing account-only data
- bump the coordinated release version to 1.0.43

## Root cause

A browser can retain a `cosyworld.fly.dev` passkey after the server-side account/public-key record is gone. The assertion reaches the server, but the credential cannot be matched, and the previous UI only displayed the generic rejection with no way forward.

## User impact

Affected users can choose another credential or deliberately register a replacement passkey without deleting the orphaned device credential. Replacement is never automatic after a server rejection.

## Validation

- full pre-push `npm run check`
- 183 Vitest tests
- all worldpack, proof-world, and kernel gates
- 1,170 orchestrator tests plus library, binary, integration, and doc tests
- architecture and syntax gates