### PR TITLE
Remove chat chrome and focus hand cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.45",
+      "version": "1.0.46",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -28,6 +28,9 @@ describe("three-slot Story Hand", () => {
     expect(browser).toContain('openActionModal(action, { handCard: true });');
     expect(browser).toContain('dialog.classList.add("hand-card-mode", actionCardAccentClass(action).className);');
     expect(browser).toContain('$("action-modal-confirm").textContent = handCard ? "play"');
+    expect(browser).toContain('cancelButton.textContent = handCard ? "close"');
+    expect(browser).toContain('cancelButton.hidden = false;');
+    expect(browser).toContain('handCard ? `Close ${label} card`');
     expect(browser).toContain('discardButton.textContent = handCard ? "discard"');
     expect(browser).not.toContain("function travellingPartyHeaderHtml");
     expect(browser).not.toContain('writeStatus(`${statusActivity.label} · ${statusActivity.text}`');

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -11,7 +11,7 @@ const browser = fs.readFileSync(
 );
 
 describe("three-slot Story Hand", () => {
-  it("keeps Story, Self, and Anchor visible and puts targeted Discard inside card details", () => {
+  it("keeps Story, Self, and Anchor visible and opens focused cards with Play and Discard", () => {
     expect(browser).not.toContain('id="command-toggle"');
     expect(browser).not.toContain('id="command-palette"');
     expect(browser).not.toContain('id="command-input"');
@@ -24,6 +24,13 @@ describe("three-slot Story Hand", () => {
     expect(browser).not.toContain('data-player-concept="think"');
     expect(browser).toContain('id="action-modal-discard"');
     expect(browser).toContain('data-analytics-event="action.discard"');
+    expect(browser).toMatch(/function usesInlineStoryHand\(\) \{\s+return false;\s+\}/);
+    expect(browser).toContain('openActionModal(action, { handCard: true });');
+    expect(browser).toContain('dialog.classList.add("hand-card-mode", actionCardAccentClass(action).className);');
+    expect(browser).toContain('$("action-modal-confirm").textContent = handCard ? "play"');
+    expect(browser).toContain('discardButton.textContent = handCard ? "discard"');
+    expect(browser).not.toContain("function travellingPartyHeaderHtml");
+    expect(browser).not.toContain('writeStatus(`${statusActivity.label} · ${statusActivity.text}`');
     expect(browser).toContain('const buttonIds = ["primary", "secondary", "tertiary"];');
     expect(browser).toContain('async function discardActionCard(focused = visibleFocusedAction())');
     expect(browser).toContain('const think = entry?.think;');

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.45"
+version = "1.0.46"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.45"
+version = "1.0.46"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2825,6 +2825,20 @@
       padding: 0;
       overflow: hidden auto;
     }
+    .action-dialog.hand-card-mode {
+      --cmd-accent: var(--card-control);
+      --cmd-accent-rgb: var(--card-control-rgb);
+      width: min(390px, calc(100vw - 24px));
+      max-height: calc(100dvh - 24px);
+      border-color: rgba(var(--cmd-accent-rgb), 0.58);
+      background:
+        linear-gradient(180deg, rgba(var(--cmd-accent-rgb), 0.08), transparent 42%),
+        #191611;
+    }
+    .action-dialog.hand-card-mode.suit-head { --cmd-accent: var(--suit-head); --cmd-accent-rgb: var(--suit-head-rgb); }
+    .action-dialog.hand-card-mode.suit-heart { --cmd-accent: var(--suit-heart); --cmd-accent-rgb: var(--suit-heart-rgb); }
+    .action-dialog.hand-card-mode.suit-honor { --cmd-accent: var(--suit-honor); --cmd-accent-rgb: var(--suit-honor-rgb); }
+    .action-dialog.hand-card-mode.suit-hustle { --cmd-accent: var(--suit-hustle); --cmd-accent-rgb: var(--suit-hustle-rgb); }
     .action-art {
       clear: both;
       border: 0;
@@ -2839,6 +2853,13 @@
       object-fit: cover;
       background: rgba(16, 25, 18, 0.72);
     }
+    .action-dialog.hand-card-mode .action-art {
+      border-bottom-color: rgba(var(--cmd-accent-rgb), 0.34);
+    }
+    .action-dialog.hand-card-mode .action-art img {
+      min-height: min(42dvh, 330px);
+      aspect-ratio: 4 / 3;
+    }
     .action-art.avatar img,
     .action-art.item img {
       object-fit: contain;
@@ -2852,6 +2873,20 @@
       display: grid;
       gap: 5px;
       padding: 16px 18px 0;
+    }
+    .action-dialog.hand-card-mode .action-copy {
+      padding-top: 14px;
+    }
+    .action-dialog.hand-card-mode .action-eyebrow {
+      color: var(--cmd-accent);
+    }
+    .action-dialog.hand-card-mode .action-title {
+      color: var(--text);
+      font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+      font-size: clamp(24px, 7vw, 32px);
+    }
+    .action-dialog.hand-card-mode .action-meta {
+      display: none;
     }
     .action-eyebrow {
       color: var(--dim);
@@ -2989,6 +3024,7 @@
       outline: 2px solid var(--amber);
       outline-offset: 2px;
     }
+    .action-cancel[hidden] { display: none; }
     .action-discard {
       border-color: rgba(239, 201, 107, 0.42);
       color: var(--amber);
@@ -3002,6 +3038,20 @@
     }
     .action-actions.has-discard {
       grid-template-columns: auto auto minmax(0, 1fr);
+    }
+    .action-actions.hand-card-actions {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    }
+    .action-dialog.hand-card-mode .action-discard,
+    .action-dialog.hand-card-mode .action-confirm {
+      min-height: 48px;
+      font-size: 15px;
+      text-transform: uppercase;
+    }
+    .action-dialog.hand-card-mode .action-confirm {
+      border-color: rgba(var(--cmd-accent-rgb), 0.58);
+      background: rgba(var(--cmd-accent-rgb), 0.18);
+      color: var(--text);
     }
     .wallet-title {
       clear: both;
@@ -4769,38 +4819,6 @@
       font-size: 12px;
       text-align: center;
     }
-    .party-channel-heading {
-      position: sticky;
-      top: -12px;
-      z-index: 4;
-      min-height: 42px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      margin: -12px -16px 9px;
-      padding: 8px 16px;
-      border-bottom: 1px solid rgba(239, 201, 107, 0.18);
-      background: rgba(8, 15, 10, 0.96);
-    }
-    .party-channel-title {
-      display: inline-flex;
-      align-items: center;
-      gap: 7px;
-      color: var(--text);
-      font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
-      font-size: 15px;
-      font-weight: 650;
-    }
-    .party-channel-title .ui-icon { color: var(--amber); }
-    .party-channel-heading small {
-      min-width: 0;
-      overflow: hidden;
-      color: var(--dim);
-      font-size: 10px;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
     .log.journey-mode.room-mode {
       align-items: stretch;
       justify-content: flex-start;
@@ -4809,11 +4827,6 @@
     .log.journey-mode.room-mode .chat-empty { margin: auto; }
 
     @media (max-width: 900px) {
-      .party-channel-heading {
-        top: -12px;
-        margin-inline: -16px;
-        padding-inline: 12px;
-      }
       .room-log-toggle {
         width: auto;
         min-width: auto;
@@ -5383,7 +5396,7 @@
         padding: 7px 8px 0;
       }
       .hand-header {
-        display: block;
+        display: none;
         border-bottom: 1px solid rgba(216, 247, 220, 0.09);
       }
       .hand-toggle {
@@ -10390,14 +10403,6 @@
       if (!panel) return;
       panel.hidden = activities.length === 0;
       panel.innerHTML = activities.map(journalActivityRowHtml).join("");
-      const latest = activities.at(-1);
-      const statusNode = $("error");
-      const statusActivity = journalOpen ? null : latest;
-      if (statusActivity && (!statusNode.textContent || statusNode.dataset.statusSource === "journal")) {
-        writeStatus(`${statusActivity.label} · ${statusActivity.text}`, "notice", "journal");
-      } else if (!statusActivity && statusNode.dataset.statusSource === "journal") {
-        writeStatus("");
-      }
       syncJournalRegions();
     }
 
@@ -13651,7 +13656,6 @@
       const pendingArrival = pendingAvatarArrivalHtml();
       const defeatScene = defeatTransitionHtml();
       const observerScene = knockedOutObserverHtml();
-      const partyHeading = travellingPartyHeaderHtml();
       const hasTranscript = visibleEvents.length > 0
         || Boolean(pendingConversation)
         || Boolean(pendingChatReplies)
@@ -13693,13 +13697,13 @@
         return;
       }
       if (pendingArrival) {
-        log.innerHTML = `${partyHeading}${pendingArrival}`;
+        log.innerHTML = pendingArrival;
         log.scrollTop = 0;
         return;
       }
       if (!hasTranscript) {
         renderedChatTailKey = "";
-        log.innerHTML = `${partyHeading}${quietRoomSceneHtml()}`;
+        log.innerHTML = quietRoomSceneHtml();
         log.scrollTop = 0;
         return;
       }
@@ -13713,7 +13717,7 @@
       ].join(":");
       const firstTranscriptRender = !renderedChatTailKey;
       renderedChatTailKey = chatTailKey;
-      log.innerHTML = `${partyHeading}${visibleEvents.map(transcriptEventHtml).join("")}${defeatScene}${observerScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;
+      log.innerHTML = `${visibleEvents.map(transcriptEventHtml).join("")}${defeatScene}${observerScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;
       log.scrollTop = firstTranscriptRender || wasAtBottom
         ? log.scrollHeight
         : Math.min(previousScrollTop, Math.max(0, log.scrollHeight - log.clientHeight));
@@ -13999,11 +14003,6 @@
           ? "Chat with someone here or explore the room."
         : "Begin a tale, then discover the room through play.";
       return `<p class="chat-empty" role="note">${escapeHtml(cue)}</p>`;
-    }
-
-    function travellingPartyHeaderHtml(view = state) {
-      if (!view?.journey) return "";
-      return `<header class="party-channel-heading"><span class="party-channel-title">${iconSvg("travel")}Travelling party</span><small>conversation follows the road</small></header>`;
     }
 
     function eventIsChatTranscriptEvent(event) {
@@ -16541,7 +16540,7 @@
     }
 
     function usesInlineStoryHand() {
-      return window.matchMedia("(max-width: 900px)").matches;
+      return false;
     }
 
     function storyHandKey(action) {
@@ -16691,21 +16690,7 @@
 
     function activateStoryHandAction(action) {
       if (!action || actionBusy) return;
-      if (!usesInlineStoryHand()) {
-        openActionModal(action);
-        return;
-      }
-      const visibleActions = actionBarActions();
-      const actionIndex = actions.indexOf(action);
-      const selected = visibleActions.find((candidate) => candidate.actionIndex === actionIndex) || visibleActions[0];
-      if (!selected) return;
-      storyHandExpanded = true;
-      storyHandActiveKey = storyHandKey(selected);
-      focusIndex = selected.actionIndex;
-      focusedKey = action.focusKey || "";
-      actionConfirmAction = action;
-      storyHandScrollPending = true;
-      renderCommands();
+      openActionModal(action, { handCard: true });
     }
 
     function selectStoryHandCardFromScroll() {
@@ -16738,7 +16723,7 @@
       renderStoryHandInspector(action);
     }
 
-    function openActionModal(action) {
+    function openActionModal(action, { handCard = false } = {}) {
       if (!action || actionBusy) return;
       if (action.kind === "orb-chat" && pendingChats.length) {
         setError("Let the current conversation settle before starting another.");
@@ -16746,21 +16731,33 @@
         return;
       }
       actionConfirmAction = action;
+      const dialog = $("action-modal").querySelector(".action-dialog");
+      dialog.classList.remove("hand-card-mode", ...actionCardAccentClasses);
+      if (handCard) {
+        dialog.classList.add("hand-card-mode", actionCardAccentClass(action).className);
+      }
       const label = action.modalTitle || actionTitle(action);
       const selectedChoice = Array.isArray(action?.choices)
         ? (action.choices.find((choice) => String(choice.value || "") === String(action.selectedChoice || "")) || action.choices[0])
         : null;
       syncActionChoicePreview(action, selectedChoice);
-      const eyebrow = String(action.modalEyebrow || "").trim();
+      const eyebrow = handCard
+        ? [actionCardSuitEmoji(actionCardSuit(action)), String(action?.presentation?.verb || action?.label || "play").trim()]
+          .filter(Boolean)
+          .join(" · ")
+        : String(action.modalEyebrow || "").trim();
       $("action-modal-eyebrow").textContent = eyebrow;
       $("action-modal-eyebrow").hidden = !eyebrow;
       $("action-modal-title").textContent = label;
       $("action-modal-summary").textContent = journalSentence(actionSummary(action));
-      renderActionModalRows(action);
+      if (handCard) $("action-modal-meta").innerHTML = "";
+      else renderActionModalRows(action);
       renderActionChoices(action);
       renderRoomAvatarRail();
-      $("action-modal-confirm").textContent = actionConfirmLabel(action);
-      $("action-modal-cancel").textContent = actionCancelLabel(action);
+      $("action-modal-confirm").textContent = handCard ? "play" : actionConfirmLabel(action);
+      const cancelButton = $("action-modal-cancel");
+      cancelButton.textContent = actionCancelLabel(action);
+      cancelButton.hidden = handCard;
       const discardButton = $("action-modal-discard");
       const discardCertificate = projectedHandEntryForAction(action)?.think || null;
       const canDiscard = !state?.branch
@@ -16769,16 +16766,18 @@
         && discardCertificate?.available
         && discardCertificate?.offer_id
         && (!state?.combat || state?.turn?.is_current_actor);
-      discardButton.hidden = !canDiscard;
-      discardButton.disabled = handShuffleBusy;
-      discardButton.textContent = discardCertificate?.free ? "discard · free" : "discard";
+      discardButton.hidden = handCard ? false : !canDiscard;
+      discardButton.disabled = handShuffleBusy || (handCard && !canDiscard);
+      discardButton.textContent = handCard ? "discard" : (discardCertificate?.free ? "discard · free" : "discard");
       discardButton.setAttribute(
         "aria-label",
         canDiscard
           ? `Discard this ${discardCertificate.slot || action.storyHandSlot || "Story Hand"} card; ${discardCertificate.free ? "free" : "uses this turn"}`
           : "This Story Hand card cannot be discarded",
       );
-      discardButton.closest(".action-actions")?.classList.toggle("has-discard", Boolean(canDiscard));
+      const actionButtons = discardButton.closest(".action-actions");
+      actionButtons?.classList.toggle("has-discard", Boolean(canDiscard) && !handCard);
+      actionButtons?.classList.toggle("hand-card-actions", handCard);
       openModal("action-modal", $("action-modal-confirm"));
     }
 
@@ -16846,14 +16845,17 @@
       closeModal("action-modal");
       $("action-modal-image").removeAttribute("src");
       $("action-modal").querySelector(".action-art")?.classList.remove("avatar", "item", "location");
+      $("action-modal").querySelector(".action-dialog")?.classList.remove("hand-card-mode", ...actionCardAccentClasses);
       $("action-modal-meta").innerHTML = "";
       $("action-modal-choices").hidden = true;
       $("action-modal-choices").innerHTML = "";
       $("action-modal-eyebrow").hidden = true;
       $("action-modal-eyebrow").textContent = "";
       $("action-modal-cancel").textContent = "not now";
+      $("action-modal-cancel").hidden = false;
       $("action-modal-discard").hidden = true;
-      $("action-modal-discard").closest(".action-actions")?.classList.remove("has-discard");
+      $("action-modal-discard").disabled = false;
+      $("action-modal-discard").closest(".action-actions")?.classList.remove("has-discard", "hand-card-actions");
       actionConfirmAction = null;
       renderRoomAvatarRail();
     }

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -3040,8 +3040,9 @@
       grid-template-columns: auto auto minmax(0, 1fr);
     }
     .action-actions.hand-card-actions {
-      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
+    .action-dialog.hand-card-mode .action-cancel,
     .action-dialog.hand-card-mode .action-discard,
     .action-dialog.hand-card-mode .action-confirm {
       min-height: 48px;
@@ -16756,8 +16757,9 @@
       renderRoomAvatarRail();
       $("action-modal-confirm").textContent = handCard ? "play" : actionConfirmLabel(action);
       const cancelButton = $("action-modal-cancel");
-      cancelButton.textContent = actionCancelLabel(action);
-      cancelButton.hidden = handCard;
+      cancelButton.textContent = handCard ? "close" : actionCancelLabel(action);
+      cancelButton.hidden = false;
+      cancelButton.setAttribute("aria-label", handCard ? `Close ${label} card` : cancelButton.textContent);
       const discardButton = $("action-modal-discard");
       const discardCertificate = projectedHandEntryForAction(action)?.think || null;
       const canDiscard = !state?.branch
@@ -16853,6 +16855,7 @@
       $("action-modal-eyebrow").textContent = "";
       $("action-modal-cancel").textContent = "not now";
       $("action-modal-cancel").hidden = false;
+      $("action-modal-cancel").removeAttribute("aria-label");
       $("action-modal-discard").hidden = true;
       $("action-modal-discard").disabled = false;
       $("action-modal-discard").closest(".action-actions")?.classList.remove("has-discard", "hand-card-actions");

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -43121,7 +43121,7 @@ mod tests {
         assert!(INDEX_HTML.contains("white-space: normal;"));
         assert!(INDEX_HTML.contains("const visibleEvents = sharedRoomTranscriptEvents(logEvents);"));
         assert!(INDEX_HTML.contains(
-            "log.innerHTML = `${partyHeading}${visibleEvents.map(transcriptEventHtml).join(\"\")}${defeatScene}${observerScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;"
+            "log.innerHTML = `${visibleEvents.map(transcriptEventHtml).join(\"\")}${defeatScene}${observerScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;"
         ));
         assert!(INDEX_HTML.contains(
             "return [\"message.created\", \"image.created\", \"model_interaction.output\", \"avatar.thought\", \"avatar.dream\"].includes(event?.type);"

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -703,6 +703,7 @@ async function main() {
         promptExpanded: prompt.classList.contains("hand-expanded"),
         handHeaderVisible: document.querySelector(".hand-header")?.getClientRects().length > 0,
         inspectorVisible: document.querySelector("#hand-inspector")?.hidden === false,
+        cancel: document.querySelector("#action-modal-cancel")?.textContent?.trim() || "",
         confirm: document.querySelector("#action-modal-confirm")?.textContent?.trim() || "",
         discard: document.querySelector("#action-modal-discard")?.textContent?.trim() || "",
         cancelVisible: document.querySelector("#action-modal-cancel")?.getClientRects().length > 0,
@@ -715,11 +716,12 @@ async function main() {
         && !modalLayout.promptExpanded
         && !modalLayout.handHeaderVisible
         && !modalLayout.inspectorVisible
+        && modalLayout.cancel === "close"
         && modalLayout.confirm === "play"
         && modalLayout.discard === "discard"
-        && !modalLayout.cancelVisible
+        && modalLayout.cancelVisible
         && !modalLayout.metaVisible,
-      `tapping a card should open only a larger card with Play and Discard: ${JSON.stringify(modalLayout)}`,
+      `tapping a card should open a larger card with Close, Play, and Discard: ${JSON.stringify(modalLayout)}`,
     );
     const [response] = await Promise.all([
       page.waitForResponse((candidate) => (
@@ -13864,14 +13866,15 @@ async function main() {
     );
     assert(
       await page.locator("#action-modal-meta:visible").count() === 0
-        && await page.locator("#action-modal-confirm").innerText() === "play"
-        && await page.locator("#action-modal-discard").innerText() === "discard",
+        && await page.locator("#action-modal-cancel").textContent() === "close"
+        && await page.locator("#action-modal-confirm").textContent() === "play"
+        && await page.locator("#action-modal-discard").textContent() === "discard",
       "core arrival should use the focused card surface without a hand dashboard",
     );
-    await page.locator("#action-modal").click({ position: { x: 2, y: 2 } });
+    await page.locator("#action-modal-cancel").click();
     await page.locator("#primary").click();
     await page.waitForSelector("#action-modal:not([hidden]) .action-dialog.hand-card-mode");
-    assert(await page.locator("#action-modal-confirm").innerText() === "play", "the certified core arrival should play the classless traveler card");
+    assert(await page.locator("#action-modal-confirm").textContent() === "play", "the certified core arrival should play the classless traveler card");
     await page.locator("#action-modal-confirm").click();
     await page.waitForTimeout(200);
     await assertNoVisibleOverflow();

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -685,35 +685,41 @@ async function main() {
       button?.click();
     }, focused.key);
     await page.waitForFunction(() => {
-      const prompt = document.querySelector("footer.prompt");
-      const discard = document.querySelector("#hand-discard");
-      return prompt?.classList.contains("hand-expanded")
-        && document.querySelector("#action-modal")?.hidden === true
+      const discard = document.querySelector("#action-modal-discard");
+      return document.querySelector("#action-modal")?.hidden === false
+        && document.querySelector("#action-modal .action-dialog")?.classList.contains("hand-card-mode")
         && discard
         && !discard.hidden
         && !discard.disabled;
     });
-    const expandedLayout = await page.evaluate(() => {
+    const modalLayout = await page.evaluate(() => {
       const prompt = document.querySelector("footer.prompt");
-      const rail = document.querySelector("#hand-rail");
-      const current = rail.querySelector(".cmd[aria-current='true']");
+      const dialog = document.querySelector("#action-modal .action-dialog");
+      const art = document.querySelector("#action-modal-image");
       return {
-        expanded: prompt.classList.contains("hand-expanded"),
-        modalHidden: document.querySelector("#action-modal")?.hidden === true,
+        modalOpen: document.querySelector("#action-modal")?.hidden === false,
+        largeCard: dialog?.classList.contains("hand-card-mode")
+          && art?.getBoundingClientRect().height >= 240,
+        promptExpanded: prompt.classList.contains("hand-expanded"),
+        handHeaderVisible: document.querySelector(".hand-header")?.getClientRects().length > 0,
         inspectorVisible: document.querySelector("#hand-inspector")?.hidden === false,
-        horizontalRail: getComputedStyle(rail).display === "flex"
-          && getComputedStyle(rail).overflowX === "auto"
-          && getComputedStyle(rail).scrollSnapType.includes("x"),
-        focusedCardReadable: Boolean(current && current.getBoundingClientRect().width >= window.innerWidth * 0.75),
+        confirm: document.querySelector("#action-modal-confirm")?.textContent?.trim() || "",
+        discard: document.querySelector("#action-modal-discard")?.textContent?.trim() || "",
+        cancelVisible: document.querySelector("#action-modal-cancel")?.getClientRects().length > 0,
+        metaVisible: document.querySelector("#action-modal-meta")?.getClientRects().length > 0,
       };
     });
     assert(
-      expandedLayout.expanded
-        && expandedLayout.modalHidden
-        && expandedLayout.inspectorVisible
-        && expandedLayout.horizontalRail
-        && expandedLayout.focusedCardReadable,
-      `tapping a compact card should expand a readable swipeable hand without a modal: ${JSON.stringify(expandedLayout)}`,
+      modalLayout.modalOpen
+        && modalLayout.largeCard
+        && !modalLayout.promptExpanded
+        && !modalLayout.handHeaderVisible
+        && !modalLayout.inspectorVisible
+        && modalLayout.confirm === "play"
+        && modalLayout.discard === "discard"
+        && !modalLayout.cancelVisible
+        && !modalLayout.metaVisible,
+      `tapping a card should open only a larger card with Play and Discard: ${JSON.stringify(modalLayout)}`,
     );
     const [response] = await Promise.all([
       page.waitForResponse((candidate) => (
@@ -721,7 +727,7 @@ async function main() {
         && new URL(candidate.url()).pathname === "/commands"
         && String(candidate.request().postData() || "").includes("\"command\":\"think\"")
       )),
-      page.locator("#hand-discard").click(),
+      page.locator("#action-modal-discard").click(),
     ]);
     const receipt = await response.json();
     const drawEvent = (receipt.events || []).find((event) => event.type === "hand.thought");
@@ -732,7 +738,7 @@ async function main() {
     await page.waitForFunction(() => (
       actionBusy === false
         && refreshInFlight === null
-        && !document.querySelector("footer.prompt")?.classList.contains("hand-expanded")
+        && document.querySelector("#action-modal")?.hidden === true
     ));
     const current = await handSnapshot();
     const layout = await page.evaluate(() => {
@@ -747,8 +753,7 @@ async function main() {
       return {
         promptFits: prompt.scrollWidth <= prompt.clientWidth + 1,
         promptDisplay: getComputedStyle(prompt).display,
-        compactHandHeight: document.querySelector(".hand-header").getBoundingClientRect().height
-          + handRail.getBoundingClientRect().height,
+        compactHandHeight: handRail.getBoundingClientRect().height,
         railDisplay: getComputedStyle(handRail).display,
         railColumns: getComputedStyle(handRail).gridTemplateColumns.split(" ").filter(Boolean).length,
         cardsFit: cards.length <= 3
@@ -3909,7 +3914,7 @@ async function main() {
     assert(result.single?.choices?.length === 0 && result.single?.payload?.destination_location_id === 2, `single-path Travel should not add an unnecessary choice: ${JSON.stringify(result)}`);
   }
 
-  async function assertChatActivityLivesInStatusSurface() {
+  async function assertChatActivityStaysOutOfStatusSurface() {
     const result = await page.evaluate(() => {
       const previous = {
         state,
@@ -4014,20 +4019,20 @@ async function main() {
     assert(
       result.initial.topTrayAbsent
         && !result.initial.bottomProgress
-        && result.initial.statusSource === "journal"
-        && result.initial.statusNotice
-        && result.initial.statusText.includes("chat")
+        && result.initial.statusSource === ""
+        && !result.initial.statusNotice
+        && result.initial.statusText === ""
         && result.initial.segments === 2
         && result.initial.filled === 2,
-      `Chat progress should use the shared status surface instead of a top popup: ${JSON.stringify(result)}`,
+      `Chat progress should remain in the Journal without consuming transcript space: ${JSON.stringify(result)}`,
     );
     assert(
       result.initiative.roundHandled
         && result.initiative.passHandled
         && result.initiative.segments === 3
         && result.initiative.filled === 1
-        && result.initiative.text.includes("passed"),
-      `initiative chat/pass events should advance Journal segments: ${JSON.stringify(result)}`,
+        && result.initiative.text === "",
+      `initiative chat/pass events should advance Journal segments without adding status chrome: ${JSON.stringify(result)}`,
     );
     assert(
       result.opened.statusCleared
@@ -9742,8 +9747,8 @@ async function main() {
         && result.journeyPresentation.pathwayMeta === "Road to Emmaus · 2 travellers · next Figshade Bend"
         && /On Road to Emmaus, from the way back to Emmaus\. Stretch 2 of 4\. 2 travellers\. next Figshade Bend\./i.test(result.journeyPresentation.pathwayLabel)
         && result.journeyPresentation.chatLabel === "Travelling party chat"
-        && /Travelling party/i.test(result.journeyPresentation.chatHeading),
-      `an active journey should keep one illustrated tracker with compact way, party, next-step, and chat context: ${JSON.stringify(result)}`,
+        && result.journeyPresentation.chatHeading === "",
+      `an active journey should keep one illustrated tracker without a second chat heading: ${JSON.stringify(result)}`,
     );
     assert(
       result.inspect.count === 1
@@ -10360,10 +10365,7 @@ async function main() {
       await page.locator("#action-modal-confirm").click();
       return true;
     }
-    const handOpen = await page.locator("footer.prompt.hand-expanded #hand-confirm").count();
-    if (!handOpen) return false;
-    await page.locator("#hand-confirm").click();
-    return true;
+    return false;
   }
 
   async function clickPrimary(label, { allowStale = false } = {}) {
@@ -12580,13 +12582,8 @@ async function main() {
           await other.locator("#primary").click();
           await other.waitForFunction(() => (
             !document.querySelector("#action-modal")?.hidden
-              || document.querySelector("footer.prompt")?.classList.contains("hand-expanded")
           ));
-          if (await other.locator("#action-modal:not([hidden])").count()) {
-            await other.locator("#action-modal-confirm").click();
-          } else {
-            await other.locator("#hand-confirm").click();
-          }
+          await other.locator("#action-modal-confirm").click();
           const response = await responsePromise;
           lastResult = { httpStatus: response.status(), body: await response.json() };
           if (lastResult.body?.ok === true) {
@@ -13857,27 +13854,25 @@ async function main() {
       `guest first card should ask only for core identity and aspiration: ${openingPrimaryAria}`,
     );
     await page.locator("#primary").click();
-    await page.waitForSelector("footer.prompt.hand-expanded #hand-inspector:not([hidden])");
-    assert(await page.locator("#hand-title").innerText() === "what draws you in?", "core arrival should ask for aspiration");
-    const coreOpeningSummary = await page.locator("#hand-summary").innerText();
+    await page.waitForSelector("#action-modal:not([hidden]) .action-dialog.hand-card-mode");
+    assert(await page.locator("#action-modal-title").innerText() === "what draws you in?", "core arrival should ask for aspiration");
+    const coreOpeningSummary = await page.locator("#action-modal-summary").innerText();
     assert(
       coreOpeningSummary.includes("Choose an aspiration")
         && coreOpeningSummary.includes("deeds reveal"),
       `core arrival should leave identity to later deeds: ${coreOpeningSummary}`,
     );
-    const coreOpeningRows = await page.locator("#hand-meta .action-row").evaluateAll((nodes) => (
-      nodes.map((node) => node.innerText.trim().replace(/\s+/g, " "))
-    ));
     assert(
-      coreOpeningRows.some((row) => /Choose/i.test(row))
-        && coreOpeningRows.some((row) => /Then/i.test(row)),
-      `core arrival should expose its full choice details inside the expanded hand: ${JSON.stringify(coreOpeningRows)}`,
+      await page.locator("#action-modal-meta:visible").count() === 0
+        && await page.locator("#action-modal-confirm").innerText() === "play"
+        && await page.locator("#action-modal-discard").innerText() === "discard",
+      "core arrival should use the focused card surface without a hand dashboard",
     );
-    await page.locator("#hand-close").click();
+    await page.locator("#action-modal").click({ position: { x: 2, y: 2 } });
     await page.locator("#primary").click();
-    await page.waitForSelector("footer.prompt.hand-expanded #hand-inspector:not([hidden])");
-    assert(await page.locator("#hand-confirm").innerText() === "begin", "the certified core arrival should begin the classless traveler");
-    await page.locator("#hand-confirm").click();
+    await page.waitForSelector("#action-modal:not([hidden]) .action-dialog.hand-card-mode");
+    assert(await page.locator("#action-modal-confirm").innerText() === "play", "the certified core arrival should play the classless traveler card");
+    await page.locator("#action-modal-confirm").click();
     await page.waitForTimeout(200);
     await assertNoVisibleOverflow();
     steps.push({ label: "guest begin avatar", primary: await primaryText(), location: await page.locator("#location-name").innerText() });
@@ -14393,7 +14388,7 @@ async function main() {
   await assertGiftPrimaryUsesCompactVerb();
   await assertGiftChoicesCollapseIntoOneCard();
   await assertTravelChoicesCollapseIntoOneCard();
-  await assertChatActivityLivesInStatusSurface();
+  await assertChatActivityStaysOutOfStatusSurface();
   await assertChoicePreviewFollowsSelectedCard();
   await assertCarriedDeckUsesWeightLanguage();
   await assertGiveTradeCanBeDealtInStoryHand();


### PR DESCRIPTION
## What changed

- Remove the persistent travelling-party banner and routine journal/status chrome so the chat transcript keeps more vertical space.
- Replace the mobile inline hand dashboard with a focused, larger card surface when a card is tapped.
- Put Play and Discard actions directly on that card surface while preserving authoritative discard handling and any choices required by a played card.
- Keep actual system and error status messages visible.
- Update browser, UI-contract, and embedded-HTML coverage, and bump the package version to 1.0.43.

## Why

Journey context and routine journal activity were being duplicated into persistent rows above the transcript. The mobile hand also reused the expanded inline inspector, so opening a card consumed chat space with a dashboard instead of focusing on the selected card and its actions.

## Impact

- More room for chat on small screens.
- A consistent focused-card interaction across breakpoints.
- No change to authoritative play/discard behavior.
- Errors and meaningful system status remain available.

## Verification

- Full pre-push `npm run check` gate passed, including 183 Vitest tests, worldpack/kernel checks, 1,169 Rust tests, architecture limits, and syntax checks.
- `cargo build --manifest-path v2/orchestrator-rust/Cargo.toml`
- `npm run check:version`
- Live browser check at 375×812 with the Hoppycat registry: no hand header/dashboard, routine status, or party heading; tapping a dealt card opened the larger Play/Discard card surface.

## Test-harness note

The default `npm run v2:browser:check` fixture did not reach browser readiness because its existing unconfigured resident AI actors kept retrying during startup. The focused live browser check used the Hoppycat registry to exercise the changed UI directly.
