### PR TITLE
End stale chats cleanly after movement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.43",
+      "version": "1.0.44",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.43"
+version = "1.0.44"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.43"
+version = "1.0.44"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/chat_action.rs
+++ b/v2/orchestrator-rust/src/chat_action.rs
@@ -97,6 +97,138 @@ pub(super) fn orb_chat_attempt_stage(stage: &str, attempt: u32) -> String {
     format!("{stage}:attempt:{}", attempt.max(1))
 }
 
+pub(super) async fn commit_chat_status(
+    state: &AppState,
+    actor_id: u64,
+    target_actor_id: u64,
+    status: &str,
+    reason: &str,
+    caused_by_event_seq: Option<u64>,
+    source_world_tick: Option<u64>,
+    observed_through_seq: Option<u64>,
+    source_location_id: Option<u64>,
+) -> Vec<EventView> {
+    let mut runtime = state.inner.lock().await;
+    let mut record = JournalRecord::new(
+        CwAction {
+            kind: CW_ACTION_NONE,
+            actor_id,
+            ..CwAction::default()
+        },
+        runtime.next_seed_value(),
+    );
+    record.caused_by_event_seq = caused_by_event_seq;
+    record.source_world_tick = source_world_tick;
+    record.observed_through_seq = observed_through_seq;
+    record.source_location_id = source_location_id;
+    record
+        .projection_mutations
+        .push(ProjectionMutation::ChatStatus {
+            target_actor_id,
+            status: status.to_string(),
+            reason: reason.to_string(),
+        });
+    let Ok((commit_status, events)) = commit_journal_record(state, &mut runtime, record) else {
+        return Vec::new();
+    };
+    drop(runtime);
+    if commit_status == CW_OK {
+        broadcast_events(state, &events);
+        events
+    } else {
+        Vec::new()
+    }
+}
+
+pub(super) async fn announce_chat_typing(
+    state: &AppState,
+    speaker_actor_id: u64,
+    listener_actor_id: u64,
+    caused_by_event_seq: Option<u64>,
+    source_world_tick: Option<u64>,
+    observed_through_seq: Option<u64>,
+    source_location_id: Option<u64>,
+) {
+    let _ = commit_chat_status(
+        state,
+        speaker_actor_id,
+        listener_actor_id,
+        "typing",
+        "the next line is being composed",
+        caused_by_event_seq,
+        source_world_tick,
+        observed_through_seq,
+        source_location_id,
+    )
+    .await;
+}
+
+async fn complete_queued_orb_chat(
+    state: &AppState,
+    actor_id: u64,
+    target_actor_id: u64,
+    plan: AvatarChatPlan,
+    queue_event_id: Option<u64>,
+    source_world_tick: Option<u64>,
+    observed_through_seq: Option<u64>,
+) -> Result<(), String> {
+    complete_queued_orb_chat_attempt(
+        state,
+        actor_id,
+        target_actor_id,
+        plan,
+        queue_event_id,
+        source_world_tick,
+        observed_through_seq,
+        1,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn complete_chat_after_context_change(
+    state: &AppState,
+    actor_id: u64,
+    target_actor_id: u64,
+    queue_event_id: Option<u64>,
+    source_world_tick: Option<u64>,
+    observed_through_seq: Option<u64>,
+    source_location_id: u64,
+) -> Result<(), String> {
+    let completed_already = {
+        let runtime = state.inner.lock().await;
+        orb_chat_status_already_committed(
+            &runtime,
+            actor_id,
+            target_actor_id,
+            "completed",
+            source_location_id,
+            queue_event_id,
+            source_world_tick,
+            observed_through_seq,
+        )
+    };
+    if completed_already {
+        return Ok(());
+    }
+
+    let events = commit_chat_status(
+        state,
+        actor_id,
+        target_actor_id,
+        "completed",
+        "the conversation moved out of reach",
+        queue_event_id,
+        source_world_tick,
+        observed_through_seq,
+        Some(source_location_id),
+    )
+    .await;
+    (!events.is_empty())
+        .then_some(())
+        .ok_or_else(|| "the ended conversation status could not be committed".to_string())
+}
+
 fn orb_chat_event_matches_job(
     event: &EventView,
     queue_event_id: Option<u64>,
@@ -1404,6 +1536,120 @@ mod tests {
             .event_log
             .iter()
             .any(|event| event.type_name == "message.created"));
+    }
+
+    #[tokio::test]
+    async fn moving_during_opening_inference_completes_chat_without_a_false_failure() {
+        let inference_started = Arc::new(Notify::new());
+        let inference_released = Arc::new(Notify::new());
+        let released = Arc::new(AtomicU8::new(0));
+        let app = Router::new().route(
+            "/chat/completions",
+            post({
+                let inference_started = inference_started.clone();
+                let inference_released = inference_released.clone();
+                let released = released.clone();
+                move |Json(_request): Json<serde_json::Value>| {
+                    let inference_started = inference_started.clone();
+                    let inference_released = inference_released.clone();
+                    let released = released.clone();
+                    async move {
+                        inference_started.notify_one();
+                        while released.load(AtomicOrdering::SeqCst) == 0 {
+                            inference_released.notified().await;
+                        }
+                        Json(serde_json::json!({
+                            "model": "test-chat-model",
+                            "choices": [{
+                                "finish_reason": "stop",
+                                "message": {
+                                    "content": "I found a quiet minute. How is the cottage treating you?"
+                                }
+                            }]
+                        }))
+                    }
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind moving Chat inference server");
+        let address = listener
+            .local_addr()
+            .expect("moving Chat inference server address");
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let mut state = test_app_state(RuntimeWorld::seeded(), None);
+        state.ai_config = Arc::new(Some(AiConfig {
+            api_key: "test".to_string(),
+            base_url: format!("http://{address}"),
+            model: "test-chat-model".to_string(),
+            ..AiConfig::default()
+        }));
+        let plan = {
+            let mut runtime = state.inner.lock().await;
+            create_test_human(
+                &mut runtime,
+                5000,
+                COSY_COTTAGE_LOCATION_ID,
+                "Inference Tester",
+            );
+            runtime
+                .avatar_chat_plan_for(5000, RATI_ACTOR_ID)
+                .expect("co-present inference resident is a Chat target")
+        };
+
+        let worker_state = state.clone();
+        let worker = tokio::spawn(async move {
+            complete_queued_orb_chat(
+                &worker_state,
+                5000,
+                RATI_ACTOR_ID,
+                plan,
+                Some(71),
+                Some(10),
+                Some(70),
+            )
+            .await
+        });
+        tokio::time::timeout(Duration::from_secs(2), inference_started.notified())
+            .await
+            .expect("opening inference starts");
+        {
+            let mut runtime = state.inner.lock().await;
+            let actor_count = runtime.world.actor_count;
+            runtime.world.actors[..actor_count]
+                .iter_mut()
+                .find(|actor| actor.id == 5000)
+                .expect("Chat initiator exists")
+                .location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
+        }
+        released.store(1, AtomicOrdering::SeqCst);
+        inference_released.notify_waiters();
+
+        tokio::time::timeout(Duration::from_secs(10), worker)
+            .await
+            .expect("moved Chat worker finishes")
+            .expect("moved Chat worker joins")
+            .expect("moving ends the queued Chat cleanly");
+
+        let runtime = state.inner.lock().await;
+        assert!(runtime.event_log.iter().any(|event| {
+            event.type_name == "chat.completed"
+                && event.caused_by_event_seq == Some(71)
+                && event.content.as_deref() == Some("the conversation moved out of reach")
+        }));
+        assert!(!runtime.event_log.iter().any(|event| {
+            matches!(event.type_name.as_str(), "chat.retrying" | "chat.failed")
+                && event.caused_by_event_seq == Some(71)
+        }));
+        assert!(!runtime.event_log.iter().any(|event| {
+            event.type_name == "message.created" && event.caused_by_event_seq == Some(71)
+        }));
+        drop(runtime);
+        server.abort();
     }
 
     /// The scripted exchange the fake provider plays back, in order. Turn

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -23029,94 +23029,6 @@ async fn fund_community_image(
     FundCommunityImageResponse::action(true, CW_OK, events)
 }
 
-async fn commit_chat_status(
-    state: &AppState,
-    actor_id: u64,
-    target_actor_id: u64,
-    status: &str,
-    reason: &str,
-    caused_by_event_seq: Option<u64>,
-    source_world_tick: Option<u64>,
-    observed_through_seq: Option<u64>,
-    source_location_id: Option<u64>,
-) -> Vec<EventView> {
-    let mut runtime = state.inner.lock().await;
-    let mut record = JournalRecord::new(
-        CwAction {
-            kind: CW_ACTION_NONE,
-            actor_id,
-            ..CwAction::default()
-        },
-        runtime.next_seed_value(),
-    );
-    record.caused_by_event_seq = caused_by_event_seq;
-    record.source_world_tick = source_world_tick;
-    record.observed_through_seq = observed_through_seq;
-    record.source_location_id = source_location_id;
-    record
-        .projection_mutations
-        .push(ProjectionMutation::ChatStatus {
-            target_actor_id,
-            status: status.to_string(),
-            reason: reason.to_string(),
-        });
-    let Ok((commit_status, events)) = commit_journal_record(state, &mut runtime, record) else {
-        return Vec::new();
-    };
-    drop(runtime);
-    if commit_status == CW_OK {
-        broadcast_events(state, &events);
-        events
-    } else {
-        Vec::new()
-    }
-}
-
-async fn announce_chat_typing(
-    state: &AppState,
-    speaker_actor_id: u64,
-    listener_actor_id: u64,
-    caused_by_event_seq: Option<u64>,
-    source_world_tick: Option<u64>,
-    observed_through_seq: Option<u64>,
-    source_location_id: Option<u64>,
-) {
-    let _ = commit_chat_status(
-        state,
-        speaker_actor_id,
-        listener_actor_id,
-        "typing",
-        "the next line is being composed",
-        caused_by_event_seq,
-        source_world_tick,
-        observed_through_seq,
-        source_location_id,
-    )
-    .await;
-}
-
-async fn complete_queued_orb_chat(
-    state: &AppState,
-    actor_id: u64,
-    target_actor_id: u64,
-    plan: AvatarChatPlan,
-    queue_event_id: Option<u64>,
-    source_world_tick: Option<u64>,
-    observed_through_seq: Option<u64>,
-) -> Result<(), String> {
-    complete_queued_orb_chat_attempt(
-        state,
-        actor_id,
-        target_actor_id,
-        plan,
-        queue_event_id,
-        source_world_tick,
-        observed_through_seq,
-        1,
-    )
-    .await
-}
-
 #[allow(clippy::too_many_arguments)]
 async fn complete_queued_orb_chat_attempt(
     state: &AppState,
@@ -23153,6 +23065,28 @@ async fn complete_queued_orb_chat_attempt(
         )?
     };
     if committed_lines.is_empty() {
+        let participants_can_continue = {
+            let runtime = state.inner.lock().await;
+            chat_participants_can_continue(&runtime, actor_id, target_actor_id, plan.location_id)
+        };
+        if !participants_can_continue {
+            tracing::info!(
+                actor_id,
+                target_actor_id,
+                location_id = plan.location_id,
+                "avatar chat ended cleanly before inference because a participant left the room"
+            );
+            return complete_chat_after_context_change(
+                state,
+                actor_id,
+                target_actor_id,
+                queue_event_id,
+                source_world_tick,
+                observed_through_seq,
+                plan.location_id,
+            )
+            .await;
+        }
         announce_chat_typing(
             state,
             actor_id,
@@ -23209,7 +23143,7 @@ async fn complete_queued_orb_chat_attempt(
         };
         let reasoning_trace = certified.reasoning_trace().map(ToString::to_string);
         let (content, publication_receipt) = into_recorded_speech_parts(state, certified);
-        let committed = {
+        let (context_changed, committed) = {
             let mut runtime = state.inner.lock().await;
             if !chat_participants_can_continue(
                 &runtime,
@@ -23217,7 +23151,7 @@ async fn complete_queued_orb_chat_attempt(
                 target_actor_id,
                 plan.location_id,
             ) {
-                None
+                (true, None)
             } else {
                 let content_id = runtime.next_content_id_value();
                 let mut record = JournalRecord::new(
@@ -23241,12 +23175,44 @@ async fn complete_queued_orb_chat_attempt(
                     plan.location_id,
                     reasoning_trace.as_deref(),
                 );
-                match commit_journal_record(state, &mut runtime, record) {
+                let committed = match commit_journal_record(state, &mut runtime, record) {
                     Ok((CW_OK, events)) if !events.is_empty() => Some((content_id, events)),
                     _ => None,
-                }
+                };
+                (false, committed)
             }
         };
+
+        if context_changed {
+            tracing::info!(
+                actor_id,
+                target_actor_id,
+                location_id = plan.location_id,
+                "avatar chat ended cleanly after a participant left during inference"
+            );
+            record_ai_usage(
+                state,
+                Some(actor_id),
+                "avatar_chat",
+                "cosyworld_system",
+                usage_config.as_ref(),
+                "ok",
+                queue_event_id,
+                0,
+                None,
+                started_at.elapsed(),
+            );
+            return complete_chat_after_context_change(
+                state,
+                actor_id,
+                target_actor_id,
+                queue_event_id,
+                source_world_tick,
+                observed_through_seq,
+                plan.location_id,
+            )
+            .await;
+        }
 
         let Some((content_id, events)) = committed else {
             commit_chat_status(
@@ -23312,18 +23278,16 @@ async fn complete_queued_orb_chat_attempt(
                 location_id = plan.location_id,
                 "avatar chat ended cleanly after a participant left the room"
             );
-            let _ = commit_chat_status(
+            complete_chat_after_context_change(
                 state,
                 actor_id,
                 target_actor_id,
-                "completed",
-                "the conversation moved out of reach",
                 queue_event_id,
                 source_world_tick,
                 observed_through_seq,
-                Some(plan.location_id),
+                plan.location_id,
             )
-            .await;
+            .await?;
             return Ok(());
         }
         let config = state.ai_config.as_ref().as_ref();

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -276,4 +276,4 @@
 # combat.rs while separating declaration from the first attack.
 # 66856 -> 66855: route authored actor control-mode defaults through the
 # content loader while keeping avatar-session handoff persistence in its module.
-66855
+66819


### PR DESCRIPTION
## Summary

- end a queued Chat cleanly when either participant leaves the source room before or during opening inference
- discard stale generated speech without retrying the impossible room-scoped exchange into a misleading `chat.failed` event
- preserve successful provider-usage accounting when inference completed but the conversation context moved
- add a regression test that pauses opening inference, moves the initiator, and verifies a terminal `chat.completed` event with no speech, retry, or failure
- move the shared Chat status helpers into the existing chat module and lower the `main.rs` line ceiling by 36 lines

Root cause: the opening commit path represented both “participants moved” and “journal commit failed” with the same empty result. Durable workers therefore treated a stale room context as a retryable failure and regenerated the conversation until the attempt budget was exhausted.

User impact: moving during a delayed reply now ends the stale conversation as “the conversation moved out of reach” without publishing out-of-room speech, repeating inference, or showing a false failure.

## Validation

- `git diff --check` — passed
- `npm run check:version` — passed
- `cargo test --manifest-path v2/orchestrator-rust/Cargo.toml moving_during_opening_inference_completes_chat_without_a_false_failure -- --nocapture` — passed
- `env COSYWORLD_CARGO_TIMEOUT_SECS=300 npm run v2:rust:test` — passed
- `env COSYWORLD_CARGO_TIMEOUT_SECS=300 npm run v2:check` — passed, including production-profile persistence, multiplayer, browser, accessibility, and visual smoke checks
- pre-push `npm run check` — passed: 183 Node tests, all worldpack/composition checks, kernel, 1,196 Rust tests, architecture/lint, and syntax

No migration, deployment configuration, compatibility behavior, or generated worldpack artifact changed. Release version is bumped to `1.0.44`.

## Review checklist

- [x] Regression covers movement during opening inference
- [x] Stale speech is not published
- [x] Context changes terminate without retry/failure amplification
- [x] Generated/runtime artifacts and secrets are absent from the diff
- [x] Package and Rust runtime versions remain aligned
- [x] Required local gates pass
