### PR TITLE
Make travel cards destination-first and minimal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -27,7 +27,8 @@ describe("three-slot Story Hand", () => {
     expect(browser).toMatch(/function usesInlineStoryHand\(\) \{\s+return false;\s+\}/);
     expect(browser).toContain('openActionModal(action, { handCard: true });');
     expect(browser).toContain('dialog.classList.add("hand-card-mode", actionCardAccentClass(action).className);');
-    expect(browser).toContain('$("action-modal-confirm").textContent = handCard ? "play"');
+    expect(browser).toContain('$("action-modal-confirm").textContent = handCard && !action.minimalTravelPresentation');
+    expect(browser).toContain('? "play"\n        : actionConfirmLabel(action);');
     expect(browser).toContain('cancelButton.textContent = handCard ? "close"');
     expect(browser).toContain('cancelButton.hidden = false;');
     expect(browser).toContain('handCard ? `Close ${label} card`');
@@ -76,14 +77,17 @@ describe("three-slot Story Hand", () => {
     );
 
     expect(routeBlock).toContain(
-      "? (firstPathwayDirection?.endpointName || firstExit.destination_location_name)",
+      "const routeDestinationName = firstPathwayDirection?.endpointName || firstExit.destination_location_name",
     );
     expect(routeBlock).toContain("destinationOnlyCardAriaLabel: destinationOnlyCardLabel");
+    expect(routeBlock).toContain("`Begin route to ${routeDestinationName}`");
+    expect(routeBlock).toContain("minimalTravelPresentation: onePath && !searchingPathway && !fleeing");
     expect(routeBlock).not.toContain("conciseRouteLabel");
     expect(cardRenderBlock).toContain(
       'String(action?.intention || "").toLowerCase() === "travel"',
     );
     expect(cardRenderBlock).toContain('? "Travel"');
+    expect(cardRenderBlock).toContain('const visibleCostText = minimalTravelCard && !orbCost ? "" : costText');
   });
 
   it("shows suit emojis instead of suit names on action cards", () => {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.46"
+version = "1.0.47"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.46"
+version = "1.0.47"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2636,6 +2636,23 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    .cmd-symbols {
+      display: flex;
+      min-height: 11px;
+      align-items: center;
+      gap: 4px;
+      color: var(--dim);
+    }
+    .cmd-symbol {
+      display: inline-flex;
+      align-items: center;
+      color: var(--red);
+      line-height: 1;
+    }
+    .cmd-symbol .ui-icon {
+      width: 11px;
+      height: 11px;
+    }
     .collectible-mark {
       position: absolute;
       right: 7px;
@@ -2859,6 +2876,10 @@
     .action-dialog.hand-card-mode .action-art img {
       min-height: min(42dvh, 330px);
       aspect-ratio: 4 / 3;
+    }
+    .action-dialog.hand-card-mode.travel-card-mode .action-art img {
+      min-height: 0;
+      aspect-ratio: 16 / 7;
     }
     .action-art.avatar img,
     .action-art.item img {
@@ -8544,8 +8565,20 @@
             : (fleeing ? "" : (routeVerbLower.endsWith(" to") ? "" : "to "));
           const routeLabel = String(firstExit.route_label || "").trim();
           const routeWayName = routeLabel.replace(/\s+from\s+.+\s+to\s+.+$/i, "").trim();
+          const routeWayDetail = /^(?:route|path|way)$/i.test(routeWayName) ? "" : routeWayName;
+          const routeDestinationName = firstPathwayDirection?.endpointName || firstExit.destination_location_name;
+          const routeViaName = firstPathwayDirection
+            && String(firstExit.destination_location_name || "") !== String(routeDestinationName || "")
+            ? firstExit.destination_location_name
+            : routeWayDetail;
+          const routeSupplement = firstPathwayDirection && routeWayDetail !== routeViaName
+            ? routeWayDetail
+            : "";
+          const minimalRouteSummary = [routeViaName ? `via ${routeViaName}` : "", routeSupplement]
+            .filter(Boolean)
+            .join(" · ");
           const destinationOnlyCardLabel = onePath && !searchingPathway && !fleeing
-            ? (firstPathwayDirection?.endpointName || firstExit.destination_location_name)
+            ? routeDestinationName
             : "";
           const routeTargetLabel = targetBearingLabel(routeIntention, routeVerb, firstExit.destination_location_name);
           const routeAccessibleLabel = firstPathwayDirection
@@ -8586,24 +8619,29 @@
             shape: "location",
             priority: Number(routeOffer?.rank || (searchingPathway ? 55 : (fleeing ? 50 : 80))),
             modalEyebrow: onePath
-              ? (firstPathwayDirection ? "On the road" : (fleeing ? "Way out" : (searchingPathway ? "Pathway scout" : "Destination")))
+              ? (fleeing ? "Way out" : (searchingPathway ? "Pathway scout" : "Travel"))
               : (fleeing ? "Way out" : (searchingPathway ? "Pathway scout" : "Travel")),
             modalTitle: onePath
-              ? (firstPathwayDirection?.endpointName || firstExit.destination_location_name)
+              ? (fleeing || searchingPathway
+                ? routeDestinationName
+                : `Begin route to ${routeDestinationName}`)
               : (fleeing ? "Choose a way out" : "Choose a destination"),
             modalSummary: onePath
               ? (firstPathwayDirection
-                ? `Take the next stretch${routeWayName ? ` via ${routeWayName}` : ""}.`
+                ? (fleeing || searchingPathway
+                  ? `Take the next stretch${routeWayName ? ` via ${routeWayName}` : ""}.`
+                  : minimalRouteSummary)
                 : fleeing
                 ? `Leave the danger behind${routeWayName ? ` via ${routeWayName}` : ""}.`
                 : (searchingPathway
                   ? "Reveal the first adjacent stretch without moving."
-                  : `${view.location?.name ? `From ${view.location.name}` : "From here"}${routeWayName ? ` via ${routeWayName}` : ""}.`))
+                  : minimalRouteSummary))
               : (fleeing
                 ? "Leave the danger behind."
                 : (searchingPathway
                   ? "Reveal its next adjacent route segment without moving."
                   : `${view.location?.name ? `From ${view.location.name}.` : "Choose where the road leads next."}`)),
+            minimalTravelPresentation: onePath && !searchingPathway && !fleeing,
             effect: onePath
               ? (firstPathwayDirection
                 ? (Number(firstExit.destination_location_id) === Number(firstPathwayDirection.endpointId)
@@ -16096,6 +16134,7 @@
 
     function actionIconName(action) {
       const label = String(action?.label || action?.command || "").trim().toLowerCase();
+      if (String(action?.intention || "").toLowerCase() === "travel" || label === "travel") return "travel";
       if (label === "dodge") return "shield";
       if (label === "escape" || label === "flee") return "travel";
       const bySuit = {
@@ -16474,6 +16513,7 @@
     }
 
     function actionSummary(action) {
+      if (action?.minimalTravelPresentation) return String(action?.modalSummary || "");
       if (action?.modalSummary) return String(action.modalSummary);
       if (["nudge", "ping"].includes(String(action?.label || "").toLowerCase())) {
         return "Give them a moment. If they're away, the room passes the next choice to someone who's here.";
@@ -16507,7 +16547,7 @@
         return String(action?.project?.verb || "contribute").toLowerCase();
       }
       if (String(action?.intention || "") === "travel") {
-        return action?.choices?.length ? "travel" : "travel there";
+        return action?.choices?.length ? "travel" : "begin route";
       }
       if (["notice", "inspect", "scout"].includes(String(action?.intention || ""))) {
         return label || String(action.intention);
@@ -16733,9 +16773,10 @@
       }
       actionConfirmAction = action;
       const dialog = $("action-modal").querySelector(".action-dialog");
-      dialog.classList.remove("hand-card-mode", ...actionCardAccentClasses);
+      dialog.classList.remove("hand-card-mode", "travel-card-mode", ...actionCardAccentClasses);
       if (handCard) {
         dialog.classList.add("hand-card-mode", actionCardAccentClass(action).className);
+        if (action.minimalTravelPresentation) dialog.classList.add("travel-card-mode");
       }
       const label = action.modalTitle || actionTitle(action);
       const selectedChoice = Array.isArray(action?.choices)
@@ -16743,9 +16784,11 @@
         : null;
       syncActionChoicePreview(action, selectedChoice);
       const eyebrow = handCard
-        ? [actionCardSuitEmoji(actionCardSuit(action)), String(action?.presentation?.verb || action?.label || "play").trim()]
-          .filter(Boolean)
-          .join(" · ")
+        ? (action.minimalTravelPresentation
+          ? String(action?.presentation?.verb || action?.label || "travel").trim()
+          : [actionCardSuitEmoji(actionCardSuit(action)), String(action?.presentation?.verb || action?.label || "play").trim()]
+            .filter(Boolean)
+            .join(" · "))
         : String(action.modalEyebrow || "").trim();
       $("action-modal-eyebrow").textContent = eyebrow;
       $("action-modal-eyebrow").hidden = !eyebrow;
@@ -16755,7 +16798,9 @@
       else renderActionModalRows(action);
       renderActionChoices(action);
       renderRoomAvatarRail();
-      $("action-modal-confirm").textContent = handCard ? "play" : actionConfirmLabel(action);
+      $("action-modal-confirm").textContent = handCard && !action.minimalTravelPresentation
+        ? "play"
+        : actionConfirmLabel(action);
       const cancelButton = $("action-modal-cancel");
       cancelButton.textContent = handCard ? "close" : actionCancelLabel(action);
       cancelButton.hidden = false;
@@ -16847,7 +16892,7 @@
       closeModal("action-modal");
       $("action-modal-image").removeAttribute("src");
       $("action-modal").querySelector(".action-art")?.classList.remove("avatar", "item", "location");
-      $("action-modal").querySelector(".action-dialog")?.classList.remove("hand-card-mode", ...actionCardAccentClasses);
+      $("action-modal").querySelector(".action-dialog")?.classList.remove("hand-card-mode", "travel-card-mode", ...actionCardAccentClasses);
       $("action-modal-meta").innerHTML = "";
       $("action-modal-choices").hidden = true;
       $("action-modal-choices").innerHTML = "";
@@ -17381,6 +17426,11 @@
         button.classList.remove("dealt");
       }
       const presentation = action.presentation || {};
+      const destinationOnlyCardLabel = String(action.destinationOnlyCardLabel || "").trim();
+      const minimalTravelCard = Boolean(
+        destinationOnlyCardLabel
+        && String(action?.intention || "").toLowerCase() === "travel"
+      );
       const exactVerb = String(
         String(action?.intention || "").toLowerCase() === "travel"
           ? "Travel"
@@ -17399,12 +17449,13 @@
       const riskText = friendlyActionText(presentation.risk || action.risk);
       const orbCost = Number(presentation.cost?.orbs || action.orbCost || 0);
       const costText = orbCost ? `${orbCost} Orb${orbCost === 1 ? "" : "s"}` : "free";
+      const visibleCostText = minimalTravelCard && !orbCost ? "" : costText;
       const sourceText = handProviderReason(action);
       const title = [
         suitEmoji ? `${suitEmoji} · ${exactVerb}` : exactVerb,
         cardTitle,
         effectText,
-        [costText, riskText].filter(Boolean).join(" · "),
+        [visibleCostText, riskText].filter(Boolean).join(" · "),
         sourceText,
       ].filter(Boolean).join("; ");
       if (title) button.title = title;
@@ -17418,7 +17469,6 @@
         ? (typeof action.busyDetail === "function" ? action.busyDetail() : action.busyDetail)
         : "";
       const detail = friendlyActionText(pendingDetail || action.detail);
-      const destinationOnlyCardLabel = String(action.destinationOnlyCardLabel || "").trim();
       button.setAttribute(
         "aria-label",
         [
@@ -17426,7 +17476,7 @@
           exactVerb,
           action.destinationOnlyCardAriaLabel || action.accessibleLabel || cardTitle,
           destinationOnlyCardLabel ? "" : effectText,
-          [costText, riskText].filter(Boolean).join(", "),
+          [visibleCostText, riskText].filter(Boolean).join(", "),
           destinationOnlyCardLabel ? "" : sourceText,
           storyGuideLabel,
           count ? `suggestion ${count}` : "",
@@ -17455,11 +17505,14 @@
         ? `<span class="action-progress" role="progressbar" aria-label="Action in progress" aria-valuetext="in progress"></span>`
         : "";
       const kicker = suitEmoji ? `${suitEmoji} · ${exactVerb}` : exactVerb;
-      const economy = [costText, riskText].filter(Boolean).join(" · ");
+      const economy = [visibleCostText, minimalTravelCard ? "" : riskText].filter(Boolean).join(" · ");
+      const mechanicsHtml = minimalTravelCard && riskText
+        ? `<span class="cmd-symbols"><span class="cmd-symbol" title="${escapeAttr(riskText)}" aria-label="${escapeAttr(riskText)}">${iconSvg("danger")}</span></span>`
+        : (economy ? `<span class="cmd-meta">${escapeHtml(economy)}</span>` : "");
       const rarityMark = suit
         ? `<span class="collectible-mark" title="${escapeAttr(`${rarity} · ${presentation.provenance || "core"}`)}" aria-hidden="true">◇</span>`
         : "";
-      button.innerHTML = `${thumb}<span class="cmd-copy"><span class="cmd-kicker">${escapeHtml(kicker)}</span><span class="cmd-label">${iconSvg(actionIconName(action))}<span class="cmd-label-text">${escapeHtml(labelText)}</span></span>${detailHtml}<span class="cmd-meta">${escapeHtml(economy)}</span>${providerHtml}${storyHtml}</span>${rarityMark}${busyHtml}`;
+      button.innerHTML = `${thumb}<span class="cmd-copy"><span class="cmd-kicker">${escapeHtml(kicker)}</span><span class="cmd-label">${iconSvg(actionIconName(action))}<span class="cmd-label-text">${escapeHtml(labelText)}</span></span>${detailHtml}${mechanicsHtml}${providerHtml}${storyHtml}</span>${rarityMark}${busyHtml}`;
     }
 
     function actionBarActions() {

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -1924,8 +1924,8 @@ async function main() {
     assert(locationSearch?.summary === "Inspect The Cosy Cottage for one hidden thing.", `room Inspect should promise one meaningful discovery in story language: ${JSON.stringify(result)}`);
     assert(locationSearch?.rows?.some((row) => row[1] === "one hidden thing in The Cosy Cottage comes to light"), `room Search outcome should promise concrete progress: ${JSON.stringify(result)}`);
     assert(!/searches .*; can reveal|\b(?:progress|clock|tag)\b/i.test(JSON.stringify(locationSearch)), `room Search confirmation should hide resolver jargon: ${JSON.stringify(result)}`);
-    assert(travel?.title === "Rain-Soft Garden", `Travel confirmation should use the destination as its heading: ${JSON.stringify(result)}`);
-    assert(travel?.summary === "From The Cosy Cottage.", `Travel confirmation should add origin context without repeating the destination: ${JSON.stringify(result)}`);
+    assert(travel?.title === "Begin route to Rain-Soft Garden", `Travel confirmation should lead with the route action and destination: ${JSON.stringify(result)}`);
+    assert(!travel?.summary, `Travel confirmation should omit redundant origin prose when no waypoint needs naming: ${JSON.stringify(result)}`);
     assert(travel?.rows?.some((row) => row[1] === "you arrive in Rain-Soft Garden"), `Travel confirmation should explain where the player ends up: ${JSON.stringify(result)}`);
   }
 
@@ -3813,6 +3813,14 @@ async function main() {
           story: singleButton?.querySelector(".story-call")?.textContent?.trim() || "",
           aria: singleButton?.getAttribute("aria-label") || "",
         };
+        openActionModal(single, { handCard: true });
+        const singleModal = {
+          title: document.querySelector("#action-modal-title")?.textContent?.trim() || "",
+          summary: document.querySelector("#action-modal-summary")?.textContent?.trim() || "",
+          confirm: document.querySelector("#action-modal-confirm")?.textContent?.trim() || "",
+          rows: document.querySelectorAll("#action-modal-meta .action-row").length,
+        };
+        closeActionModal();
         return {
           count: routes.length,
           detail: route?.detail || "",
@@ -3827,6 +3835,7 @@ async function main() {
           modal,
           selectedPreview,
           singleCard,
+          singleModal,
           single: single ? {
             accessibleLabel: single.accessibleLabel,
             detail: single.detail,
@@ -3910,8 +3919,15 @@ async function main() {
         && !result.singleCard?.detail
         && !result.singleCard?.provider
         && !result.singleCard?.story
-        && result.singleCard?.aria === "control, Travel, Rain-Silver Crossing, free",
+        && result.singleCard?.aria === "control, Travel, Rain-Silver Crossing",
       `a synthetic Travel offer without server presentation should show its exact verb and target while failing closed to a control: ${JSON.stringify(result)}`,
+    );
+    assert(
+      result.singleModal?.title === "Begin route to Rain-Silver Crossing"
+        && !result.singleModal?.summary
+        && result.singleModal?.confirm === "begin route"
+        && result.singleModal?.rows === 0,
+      `single-route confirmation should keep only the destination and route action: ${JSON.stringify(result)}`,
     );
     assert(result.single?.choices?.length === 0 && result.single?.payload?.destination_location_id === 2, `single-path Travel should not add an unnecessary choice: ${JSON.stringify(result)}`);
   }
@@ -9402,6 +9418,7 @@ async function main() {
         exits: [{
           destination_location_id: 100001,
           destination_location_name: "Cedar Hollow",
+          route_label: "Cairn path from Rain-Soft Garden to Moonlit Trail",
           direction: "east",
           distance: 1,
           accessible: true,
@@ -9653,6 +9670,9 @@ async function main() {
           effect: travelling?.effect,
           command: travelling?.command,
           accessibleLabel: travelling?.accessibleLabel,
+          destinationOnlyCardLabel: travelling?.destinationOnlyCardLabel,
+          modalTitle: travelling?.modalTitle,
+          modalSummary: travelling?.modalSummary,
           direction: travelling?.pathwayDirection,
         },
         backtracking: {
@@ -9706,6 +9726,9 @@ async function main() {
       result.travelling.label === "travel"
         && result.travelling.detail === "toward Moonlit Trail"
         && result.travelling.accessibleLabel === "Travel toward Moonlit Trail"
+        && result.travelling.destinationOnlyCardLabel === "Moonlit Trail"
+        && result.travelling.modalTitle === "Begin route to Moonlit Trail"
+        && result.travelling.modalSummary === "via Cedar Hollow · Cairn path"
         && result.travelling.direction?.side === "forward"
         && result.travelling.direction?.endpointName === "Moonlit Trail"
         && result.travellingActionCount > 1,


### PR DESCRIPTION
## Summary

- Lead one-path Travel cards with the final destination, including pathway endpoints such as `Void 012`, instead of foregrounding an intermediate waypoint.
- Replace the verbose confirmation with `Begin route to …`, an optional compact `via waypoint · path` line, and a `begin route` action.
- Hide redundant zero-cost copy, keep route risks accessible behind a warning glyph, and use a shallower travel-art crop.
- Update browser and source-contract coverage, and bump the application/runtime release to `1.0.47`.

The root cause was that the presentation reused route metadata and general-purpose action-card prose as primary UI, so the actual destination was demoted beneath waypoint, cost, source, effect, and risk copy. This change makes the player's destination the dominant game choice while preserving route mechanics and accessibility context.

## Validation

- `npm run v2:check`
- `npm test`
- `npm run check:version`
- `git diff --check`
- Repository pre-push hook: `npm run check`

## Notes

- Draft PR for UX review.
- Rebased onto the latest `main`.
- No issue linked.