### PR TITLE
Make chat the core card surface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/player-lexicon.test.mjs
+++ b/test/v2/player-lexicon.test.mjs
@@ -60,7 +60,9 @@ describe("player-facing action, card, linked-avatar, world-pack, and Journal lex
     expect(index).toContain('aria-label="Open current location card"');
     expect(index).toContain('aria-label="Close card details"');
     expect(index).toContain("supported linked avatars");
-    expect(index).toContain("portable account, optional linked avatars");
+    expect(index).toContain('<span>Identity</span>${identityAction}');
+    expect(index).toContain('data-passkey-continue>Sign in</button>');
+    expect(index).toContain('class="minimal-menu-value">Passkey</span>');
   });
 
   it("removes the retired collection and wallet-gate surface", () => {
@@ -83,6 +85,8 @@ describe("player-facing action, card, linked-avatar, world-pack, and Journal lex
     expect(index).not.toContain('data-player-concept="action-menu"');
     expect(index).not.toContain('data-player-concept="think"');
     expect(index).toContain('id="action-modal-discard"');
+    expect(index).toContain('data-hand-discard="primary"');
+    expect(index).toContain('data-hand-play="primary"');
     expect(index).toContain('`Discard this ${discardCertificate.slot || action.storyHandSlot || "Story Hand"} card;');
     expect(index).toContain('command: "think"');
     expect(index).not.toContain('command: "pass"');

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -11,7 +11,7 @@ const browser = fs.readFileSync(
 );
 
 describe("three-slot Story Hand", () => {
-  it("keeps Story, Self, and Anchor visible and opens focused cards with Play and Discard", () => {
+  it("keeps Story, Self, and Anchor visible with inline Play and Discard", () => {
     expect(browser).not.toContain('id="command-toggle"');
     expect(browser).not.toContain('id="command-palette"');
     expect(browser).not.toContain('id="command-input"');
@@ -22,17 +22,18 @@ describe("three-slot Story Hand", () => {
     expect(browser).toContain('id="tertiary"');
     expect(browser).not.toContain('id="shuffle"');
     expect(browser).not.toContain('data-player-concept="think"');
-    expect(browser).toContain('id="action-modal-discard"');
-    expect(browser).toContain('data-analytics-event="action.discard"');
-    expect(browser).toMatch(/function usesInlineStoryHand\(\) \{\s+return false;\s+\}/);
+    expect(browser).toContain('data-hand-play="primary"');
+    expect(browser).toContain('data-hand-discard="primary"');
+    expect(browser).toContain('data-hand-play="secondary"');
+    expect(browser).toContain('data-hand-discard="tertiary"');
+    expect(browser).toContain("function playStoryHandCard(id)");
+    expect(browser).toContain("async function discardStoryHandCard(id)");
+    expect(browser).toContain('prompt.classList.toggle("hand-expanded", expanded);');
+    expect(browser).not.toMatch(/function usesInlineStoryHand\(\) \{\s+return false;\s+\}/);
+    expect(browser).toContain('if (!usesInlineStoryHand()) {');
     expect(browser).toContain('openActionModal(action, { handCard: true });');
-    expect(browser).toContain('dialog.classList.add("hand-card-mode", actionCardAccentClass(action).className);');
-    expect(browser).toContain('$("action-modal-confirm").textContent = handCard && !action.minimalTravelPresentation');
-    expect(browser).toContain('? "play"\n        : actionConfirmLabel(action);');
-    expect(browser).toContain('cancelButton.textContent = handCard ? "close"');
-    expect(browser).toContain('cancelButton.hidden = false;');
-    expect(browser).toContain('handCard ? `Close ${label} card`');
-    expect(browser).toContain('discardButton.textContent = handCard ? "discard"');
+    expect(browser).toContain('setStoryHandExpanded(true, action);');
+    expect(browser).toContain('discardStoryHandCard(discard.getAttribute("data-hand-discard") || "")');
     expect(browser).not.toContain("function travellingPartyHeaderHtml");
     expect(browser).not.toContain('writeStatus(`${statusActivity.label} · ${statusActivity.text}`');
     expect(browser).toContain('const buttonIds = ["primary", "secondary", "tertiary"];');

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.48"
+version = "1.0.49"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.48"
+version = "1.0.49"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5896,6 +5896,518 @@
       .combat-history-toggle { font-size: 0; }
       .combat-history-toggle::before { content: "log"; font-size: 10px; }
     }
+
+    /* Chat is the game table. Supporting controls use square, illustrated
+       card geometry and stay visually quiet beside the transcript. */
+    .location-pill,
+    .location-pill img,
+    .room-hero,
+    .room-hero-card,
+    .room-hero-card img,
+    .chat-empty.play-cue,
+    .prompt,
+    .prompt .cmd,
+    .prompt .thumb,
+    .prompt button,
+    .account-panel.minimal-menu,
+    .account-panel.minimal-menu button,
+    .account-panel.minimal-menu input,
+    .action-dialog,
+    .action-choice,
+    .action-confirm,
+    .action-cancel {
+      border-radius: 0 !important;
+      box-shadow: none !important;
+    }
+    .chat-empty.play-cue {
+      min-height: 0;
+      border: 0;
+      background: transparent;
+      padding: 16px;
+    }
+    .play-cue-kicker,
+    .play-cue strong,
+    .play-cue-direction { display: none; }
+    .play-cue-copy {
+      color: var(--dim);
+      font: 500 13px/1.45 ui-sans-serif, system-ui, sans-serif;
+    }
+    .economy-stat.orbs { gap: 7px; }
+    .minimal-orb-rack {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .minimal-orb-rack i {
+      width: 13px;
+      height: 13px;
+      display: block;
+      border: 1px solid var(--line-strong);
+      background: transparent;
+      transform: rotate(45deg);
+    }
+    .minimal-orb-rack i.filled { background: var(--amber); }
+    .minimal-orb-rack.tier-10 i.filled { background: #9eb6bf; }
+    .minimal-orb-rack.tier-100 i.filled { background: #c3a7d5; }
+    .minimal-orb-rack.tier-1000 i.filled { background: #efc96b; }
+    .minimal-orb-rack.compact { gap: 3px; }
+    .minimal-orb-rack.compact i { width: 8px; height: 8px; }
+
+    .prompt,
+    .prompt.onboarding-mode,
+    .prompt.choice-mode,
+    .prompt.has-draw,
+    .prompt.choice-mode.has-draw {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0;
+      width: 100%;
+      max-width: none;
+      max-height: none;
+      overflow: visible;
+      padding: 0;
+      border-top: 1px solid var(--line-strong);
+      background: #0a0b08;
+    }
+    .turn-banner {
+      grid-column: 1;
+      margin: 6px 8px 0;
+    }
+    .hand-header {
+      width: 100%;
+      min-height: 36px;
+      display: none;
+      border: 0;
+      border-bottom: 1px solid var(--line);
+      background: transparent;
+    }
+    .prompt.hand-expanded .hand-header { display: block; }
+    .hand-toggle {
+      width: 100%;
+      min-height: 36px;
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 8px;
+      border: 0;
+      background: transparent;
+      color: var(--dim);
+      padding: 7px 12px;
+      text-align: left;
+      cursor: pointer;
+    }
+    .hand-toggle:hover,
+    .hand-toggle:focus-visible { color: var(--text); }
+    .hand-toggle-title {
+      color: inherit;
+      font: 800 10px/1.2 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .hand-toggle-status {
+      color: var(--amber);
+      font: 800 10px/1.2 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.06em;
+    }
+    .hand-toggle-chevron {
+      color: var(--amber);
+      font: 800 10px/1.2 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      transform: none !important;
+    }
+    .hand-rail {
+      min-width: 0;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1px;
+      overflow: visible;
+      padding: 7px;
+      background: var(--line);
+    }
+    .story-card-slot {
+      min-width: 0;
+      overflow: hidden;
+      display: grid;
+      grid-template-rows: minmax(0, 1fr);
+      border: 1px solid rgba(var(--cmd-accent-rgb, var(--card-control-rgb)), 0.38);
+      background: #11110d;
+    }
+    .story-card-slot[hidden] { display: none !important; }
+    .story-card-actions {
+      display: none;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      border-top: 1px solid var(--line);
+    }
+    .story-card-actions button {
+      min-width: 0;
+      min-height: 42px;
+      border: 0;
+      background: transparent;
+      color: var(--dim);
+      padding: 7px 4px;
+      font: 750 11px/1 ui-sans-serif, system-ui, sans-serif;
+      cursor: pointer;
+    }
+    .story-card-actions button + button { border-left: 1px solid var(--line); }
+    .story-card-actions .story-card-play { color: var(--amber); }
+    .story-card-actions button:hover,
+    .story-card-actions button:focus-visible {
+      background: rgba(var(--cmd-accent-rgb, var(--card-control-rgb)), 0.1);
+      color: var(--text);
+    }
+    .story-card-actions button:disabled { opacity: 0.32; cursor: default; }
+    .prompt .cmd {
+      width: 100%;
+      min-width: 0;
+      min-height: 58px;
+      height: 100%;
+      display: grid !important;
+      grid-template-columns: 54px minmax(0, 1fr);
+      grid-template-rows: 58px;
+      align-items: stretch;
+      justify-content: stretch;
+      gap: 0;
+      overflow: hidden;
+      border: 0;
+      background: #14140f;
+      padding: 0;
+      text-align: left;
+    }
+    .prompt .cmd[style*="display: none"] { display: none !important; }
+    .prompt .cmd::before,
+    .prompt .cmd::after,
+    .prompt .collectible-mark,
+    .prompt .cmd-symbols,
+    .prompt .cmd-meta,
+    .prompt .provider-call,
+    .prompt .story-call { display: none !important; }
+    .prompt .cmd .thumb,
+    .prompt .cmd .thumb.location,
+    .prompt .cmd .thumb.avatar,
+    .prompt .cmd .thumb.item,
+    .prompt .cmd .thumb.action-mini-card {
+      width: 54px;
+      height: 58px;
+      min-height: 0;
+      align-self: stretch;
+      flex: none;
+      border: 0;
+      border-right: 1px solid var(--line);
+      background-color: #080906;
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: cover !important;
+    }
+    .prompt .cmd-copy {
+      min-width: 0;
+      align-content: center;
+      gap: 2px;
+      padding: 6px 7px;
+    }
+    .prompt .cmd-kicker {
+      color: var(--cmd-accent);
+      font-size: 8px;
+      letter-spacing: 0.12em;
+    }
+    .prompt .cmd-label {
+      display: block;
+      color: var(--text);
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: 12px;
+      font-weight: 600;
+      line-height: 1.12;
+      white-space: normal;
+    }
+    .prompt .cmd-label .ui-icon { display: none; }
+    .prompt .cmd-label-text {
+      display: -webkit-box;
+      overflow: hidden;
+      white-space: normal;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
+    .prompt .detail { display: none; }
+    .prompt.hand-expanded .hand-rail {
+      height: clamp(238px, 34dvh, 330px);
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1px;
+      overflow: visible;
+      padding: 8px;
+    }
+    .prompt.hand-expanded .story-card-slot {
+      grid-template-rows: minmax(0, 1fr) 42px;
+    }
+    .prompt.hand-expanded .story-card-actions { display: grid; }
+    .prompt.hand-expanded .cmd {
+      width: 100%;
+      min-width: 0;
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: minmax(104px, 1.2fr) minmax(86px, 0.8fr);
+      opacity: 1;
+      transition: none;
+    }
+    .prompt.hand-expanded .cmd .thumb,
+    .prompt.hand-expanded .cmd .thumb.location,
+    .prompt.hand-expanded .cmd .thumb.avatar,
+    .prompt.hand-expanded .cmd .thumb.item,
+    .prompt.hand-expanded .cmd .thumb.action-mini-card {
+      width: 100%;
+      height: 100%;
+      border-right: 0;
+      border-bottom: 1px solid var(--line);
+    }
+    .prompt.hand-expanded .cmd-copy {
+      align-content: start;
+      gap: 5px;
+      padding: 9px 8px;
+    }
+    .prompt.hand-expanded .cmd-kicker { font-size: 9px; }
+    .prompt.hand-expanded .cmd-label { font-size: clamp(12px, 1.4vw, 16px); }
+    .prompt.hand-expanded .detail {
+      display: -webkit-box;
+      overflow: hidden;
+      color: var(--dim);
+      font-size: 11px;
+      font-weight: 500;
+      line-height: 1.28;
+      white-space: normal;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
+    .hand-inspector { display: none !important; }
+    .prompt.onboarding-mode .hand-header,
+    .prompt.choice-mode .hand-header { display: none; }
+    .prompt.onboarding-mode .hand-rail,
+    .prompt.choice-mode .hand-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .prompt.onboarding-mode .story-card-actions,
+    .prompt.choice-mode .story-card-actions { display: none; }
+    #shuffle { display: none !important; }
+
+    .account-panel.minimal-menu {
+      width: min(820px, 100%);
+      max-width: 820px;
+      margin: 0 auto;
+      border: 1px solid var(--line-strong);
+      background: #0b0c09;
+      padding: 0;
+      color: var(--text);
+    }
+    .account-panel.minimal-menu * { border-radius: 0 !important; box-shadow: none !important; }
+    .minimal-menu-heading {
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border-bottom: 1px solid var(--line);
+    }
+    .minimal-menu-heading > span {
+      padding: 10px 13px;
+      color: var(--dim);
+      font-size: 10px;
+      font-weight: 850;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .minimal-menu-heading button {
+      align-self: stretch;
+      border: 0;
+      border-left: 1px solid var(--line);
+      background: transparent;
+      color: var(--amber);
+      padding: 8px 13px;
+      font: 750 10px/1 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    .minimal-menu-player {
+      display: grid;
+      grid-template-columns: 52px minmax(0, 1fr) auto;
+      gap: 12px;
+      align-items: center;
+      margin: 0 14px;
+      padding: 14px 0;
+      border-bottom: 1px solid var(--line);
+    }
+    .minimal-menu-player > div { min-width: 0; display: grid; gap: 3px; }
+    .minimal-menu-player strong {
+      overflow: hidden;
+      font: 600 17px/1.15 Georgia, "Times New Roman", serif;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .minimal-menu-player small {
+      overflow: hidden;
+      color: var(--dim);
+      font-size: 11px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .minimal-menu-avatar {
+      width: 52px;
+      height: 64px;
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      border: 1px solid var(--line-strong);
+      background: #11110d;
+      color: var(--amber);
+      font: 600 18px/1 Georgia, "Times New Roman", serif;
+    }
+    .minimal-menu-avatar img { width: 100%; height: 100%; display: block; object-fit: cover; }
+    .minimal-menu-level { color: var(--amber); font: 600 14px/1 Georgia, "Times New Roman", serif; }
+    .minimal-menu-orbs {
+      min-height: 56px;
+      display: grid;
+      grid-template-columns: 56px minmax(0, 1fr) auto;
+      gap: 12px;
+      align-items: center;
+      margin: 0 14px;
+      border-bottom: 1px solid var(--line);
+      color: var(--dim);
+      font-size: 10px;
+      font-weight: 850;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    .minimal-menu-orbs strong { color: var(--amber); font-size: 10px; }
+    .minimal-menu-slots {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 1px;
+      margin: 14px;
+      border: 1px solid var(--line);
+      background: var(--line);
+    }
+    .minimal-menu-slot {
+      position: relative;
+      min-width: 0;
+      min-height: 112px;
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      border: 0;
+      background: #10110d;
+      color: var(--faint);
+      padding: 8px;
+      font: 750 10px/1.2 ui-sans-serif, system-ui, sans-serif;
+      cursor: pointer;
+    }
+    .minimal-menu-slot:disabled { cursor: default; }
+    .minimal-menu-slot img {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+    }
+    .minimal-menu-slot.filled span {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 1;
+      border-top: 1px solid var(--line);
+      background: rgba(7, 8, 5, 0.88);
+      color: var(--text);
+      padding: 5px;
+      text-align: center;
+    }
+    .minimal-menu-slot b { color: var(--line-strong); font: 500 18px/1 Georgia, "Times New Roman", serif; }
+    .minimal-menu-rows { margin: 0 14px; border-top: 1px solid var(--line); }
+    .minimal-menu-row {
+      min-height: 54px;
+      display: grid;
+      grid-template-columns: 74px minmax(0, 1fr);
+      gap: 12px;
+      align-items: center;
+      border-bottom: 1px solid var(--line);
+    }
+    .minimal-menu-row > span:first-child {
+      color: var(--dim);
+      font-size: 10px;
+      font-weight: 850;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    .minimal-menu-row strong,
+    .minimal-menu-value,
+    .minimal-menu-inline-action {
+      overflow: hidden;
+      color: var(--text);
+      font: 600 15px/1.2 Georgia, "Times New Roman", serif;
+      text-align: left;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .minimal-menu-inline-action {
+      width: fit-content;
+      min-height: 36px;
+      border: 0;
+      border-bottom: 1px solid var(--amber);
+      background: transparent;
+      padding: 4px 0;
+      cursor: pointer;
+    }
+    .minimal-menu-settings {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      margin: 14px;
+      border: 1px solid var(--line);
+    }
+    .minimal-menu-settings label {
+      min-height: 52px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 8px 10px;
+      color: var(--dim);
+      font-size: 12px;
+      cursor: pointer;
+    }
+    .minimal-menu-settings label + label { border-left: 1px solid var(--line); }
+    .minimal-menu-settings input { width: 18px; height: 18px; margin: 0; accent-color: var(--amber); }
+
+    @media (max-width: 560px) {
+      .topbar-actions .economy { display: flex; }
+      .economy-stat.orbs > strong { font-size: 10px; }
+      .prompt.hand-expanded .hand-rail { height: 274px; padding: 7px; }
+      .prompt.hand-expanded .cmd { grid-template-rows: 112px minmax(0, 1fr); }
+      .prompt.hand-expanded .cmd-copy { padding: 8px 6px; }
+      .prompt.hand-expanded .cmd-label { font-size: 12px; }
+      .prompt.hand-expanded .detail { font-size: 10px; -webkit-line-clamp: 2; }
+      .story-card-actions button { min-height: 40px; font-size: 10px; }
+      .account-panel.minimal-menu { border-right: 0; border-left: 0; }
+      .minimal-menu-player,
+      .minimal-menu-orbs,
+      .minimal-menu-rows { margin-inline: 10px; }
+      .minimal-menu-slots,
+      .minimal-menu-settings { margin: 10px; }
+      .minimal-menu-slot { min-height: 94px; }
+    }
+    @media (max-width: 350px) {
+      .minimal-orb-rack.compact i { width: 7px; height: 7px; }
+      .prompt .cmd { grid-template-columns: 44px minmax(0, 1fr); }
+      .prompt .cmd .thumb,
+      .prompt .cmd .thumb.location,
+      .prompt .cmd .thumb.avatar,
+      .prompt .cmd .thumb.item,
+      .prompt .cmd .thumb.action-mini-card { width: 44px; }
+      .prompt.hand-expanded .cmd {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: 98px minmax(0, 1fr);
+      }
+      .prompt.hand-expanded .cmd .thumb,
+      .prompt.hand-expanded .cmd .thumb.location,
+      .prompt.hand-expanded .cmd .thumb.avatar,
+      .prompt.hand-expanded .cmd .thumb.item,
+      .prompt.hand-expanded .cmd .thumb.action-mini-card { width: 100%; }
+      .minimal-menu-slot { min-height: 82px; }
+    }
   </style>
 </head>
 <body>
@@ -5972,16 +6484,34 @@
         <div class="turn-banner-controls" id="turn-banner-controls"></div>
       </div>
       <div class="hand-header">
-        <button class="hand-toggle" id="hand-toggle" type="button" aria-expanded="false" aria-controls="hand-rail hand-inspector">
-          <span class="hand-toggle-title">your hand</span>
-          <span class="hand-toggle-status" id="hand-toggle-status">3 cards · tap a card to open</span>
-          <span class="hand-toggle-chevron" aria-hidden="true">⌃</span>
+        <button class="hand-toggle" id="hand-toggle" type="button" aria-expanded="false" aria-controls="hand-rail">
+          <span class="hand-toggle-title">Story Hand</span>
+          <span class="hand-toggle-status" id="hand-toggle-status">3 cards</span>
+          <span class="hand-toggle-chevron" aria-hidden="true">Close</span>
         </button>
       </div>
       <div class="hand-rail" id="hand-rail" role="group" aria-label="Cards in your hand">
-        <button class="cmd primary" id="primary" data-player-concept="action" data-analytics-event="action.select"></button>
-        <button class="cmd secondary" id="secondary" data-player-concept="action" data-analytics-event="action.select"></button>
-        <button class="cmd tertiary" id="tertiary" data-player-concept="action" data-analytics-event="action.select"></button>
+        <article class="story-card-slot" data-story-card-slot="primary">
+          <button class="cmd primary" id="primary" data-player-concept="action" data-analytics-event="action.select"></button>
+          <div class="story-card-actions" aria-label="First card actions">
+            <button class="story-card-discard" type="button" data-hand-discard="primary">Discard</button>
+            <button class="story-card-play" type="button" data-hand-play="primary">Play</button>
+          </div>
+        </article>
+        <article class="story-card-slot" data-story-card-slot="secondary">
+          <button class="cmd secondary" id="secondary" data-player-concept="action" data-analytics-event="action.select"></button>
+          <div class="story-card-actions" aria-label="Second card actions">
+            <button class="story-card-discard" type="button" data-hand-discard="secondary">Discard</button>
+            <button class="story-card-play" type="button" data-hand-play="secondary">Play</button>
+          </div>
+        </article>
+        <article class="story-card-slot" data-story-card-slot="tertiary">
+          <button class="cmd tertiary" id="tertiary" data-player-concept="action" data-analytics-event="action.select"></button>
+          <div class="story-card-actions" aria-label="Third card actions">
+            <button class="story-card-discard" type="button" data-hand-discard="tertiary">Discard</button>
+            <button class="story-card-play" type="button" data-hand-play="tertiary">Play</button>
+          </div>
+        </article>
       </div>
       <section class="hand-inspector" id="hand-inspector" aria-label="Selected card details" hidden>
         <h2 class="action-title" id="hand-title"></h2>
@@ -11947,11 +12477,23 @@
       return `next ${nextName}`;
     }
 
+    function orbSlotPresentation(value) {
+      const total = Math.max(0, Math.floor(Number(value || 0)));
+      const tier = total >= 1000 ? 1000 : total >= 100 ? 100 : total >= 10 ? 10 : 1;
+      const filled = Math.min(5, tier === 1 ? total : Math.floor(total / tier));
+      const slots = Array.from({ length: 5 }, (_, index) => (
+        `<i class="${index < filled ? "filled" : ""}" aria-hidden="true"></i>`
+      )).join("");
+      return { total, tier, filled, slots };
+    }
+
     function renderEconomy() {
       const economy = state?.economy || {};
       const orbs = Number.isFinite(Number(economy.orbs)) ? Number(economy.orbs) : 0;
+      const orbPresentation = orbSlotPresentation(orbs);
+      const tierLabel = orbPresentation.tier > 1 ? `<strong>×${orbPresentation.tier}</strong>` : "";
       const parts = [
-        `<span class="economy-stat orbs">${iconSvg("orb")}<strong>${orbs}</strong> <span class="economy-unit">Orbs</span></span>`,
+        `<span class="economy-stat orbs" aria-label="${orbs} Orbs">${iconSvg("orb")}<span class="minimal-orb-rack compact tier-${orbPresentation.tier}">${orbPresentation.slots}</span>${tierLabel}</span>`,
       ];
       const compact = window.matchMedia("(max-width: 900px)").matches;
       if (economyFlash) {
@@ -12472,6 +13014,10 @@
     function setJournalOpen(open) {
       const closing = journalOpen && !open;
       const opening = !journalOpen && open;
+      if (opening) {
+        storyHandExpanded = false;
+        storyHandActiveKey = "";
+      }
       if (closing) {
         for (const activity of currentJournalActivities()) {
           dismissedJournalActivityKeys.add(activity.key);
@@ -14098,21 +14644,55 @@
       return `<div class="line event scene-card combat" data-event-row data-combat-beat aria-label="${escapeAttr(`Combat beat. ${text}`)}"><span class="event-label" aria-hidden="true">⚔</span><span class="text">${escapeHtml(text)}</span></div>`;
     }
 
+    function minimalMenuOrbHtml() {
+      const total = Math.max(0, Math.floor(Number(state?.economy?.orbs || 0)));
+      const presentation = orbSlotPresentation(total);
+      const tierLabel = presentation.tier > 1 ? `<strong>×${presentation.tier}</strong>` : "";
+      return `<div class="minimal-menu-orbs" aria-label="${total} Orbs"><span>Orbs</span><div class="minimal-orb-rack tier-${presentation.tier}">${presentation.slots}</div>${tierLabel}</div>`;
+    }
+
+    function minimalMenuSlotHtml(label, item) {
+      const card = item ? cardForItem(item.id) : null;
+      const image = cardImage(card);
+      const title = String(card?.display_name || item?.name || label).trim();
+      const content = image
+        ? `<img src="${escapeAttr(image)}" alt="" /><span>${escapeHtml(label)}</span>`
+        : `<span>${escapeHtml(label)}</span><b aria-hidden="true">—</b>`;
+      return `<button class="minimal-menu-slot${image ? " filled" : ""}" type="button"${cardDataAttr(card)} aria-label="${escapeAttr(image ? `Open ${title}` : `${label} slot empty`)}"${image ? "" : " disabled"}>${content}</button>`;
+    }
+
+    function minimalMenuPanelHtml() {
+      const deck = state?.deck || {};
+      const avatar = actorForId(actorId);
+      const avatarCard = cardForActor(actorId);
+      const avatarName = String(avatar?.name || avatarCard?.display_name || "Traveler").trim();
+      const avatarTitle = String(avatar?.title || avatarCard?.title || "").trim();
+      const avatarImage = cardImage(avatarCard);
+      const avatarMark = avatarImage
+        ? `<button class="minimal-menu-avatar" type="button"${cardDataAttr(avatarCard)} aria-label="Open ${escapeAttr(avatarName)}"><img src="${escapeAttr(avatarImage)}" alt="" /></button>`
+        : `<span class="minimal-menu-avatar fallback" aria-hidden="true">${escapeHtml(avatarName.charAt(0) || "C")}</span>`;
+      const equippedContainers = Array.isArray(deck.equipped_containers) ? deck.equipped_containers : [];
+      const equippedCharms = Array.isArray(deck.equipped_charms) ? deck.equipped_charms : [];
+      const preparedSpells = Array.isArray(deck.prepared_spell_cards) ? deck.prepared_spell_cards : [];
+      const slots = [
+        minimalMenuSlotHtml("Weapon", deck.equipped_weapon),
+        minimalMenuSlotHtml("Pack", equippedContainers[0]),
+        minimalMenuSlotHtml("Charm", equippedCharms[0]),
+        minimalMenuSlotHtml("Spell", preparedSpells[0]),
+      ].join("");
+      const worldName = String(worldView?.name || contentPacks?.world_name || "CosyWorld Core").trim();
+      const identityAction = identity?.authenticated
+        ? `<span class="minimal-menu-value">Passkey</span>`
+        : `<button class="minimal-menu-inline-action" type="button" data-passkey-continue>Sign in</button>`;
+      const largeText = localStorage.getItem("cosyworld.ui.largeText") === "true";
+      const reduceMotion = localStorage.getItem("cosyworld.ui.reduceMotion") === "true";
+      const level = Number(state?.character_identity?.level ?? avatar?.stats?.level ?? 1);
+      return `<section class="account-panel minimal-menu" aria-labelledby="account-panel-title"><header class="minimal-menu-heading"><span id="account-panel-title">Player</span><button type="button" data-menu-close>Return to chat</button></header><div class="minimal-menu-player">${avatarMark}<div><strong>${escapeHtml(avatarName)}</strong>${avatarTitle ? `<small>${escapeHtml(avatarTitle)}</small>` : ""}</div><span class="minimal-menu-level" aria-label="Level ${level}">${level}</span></div>${minimalMenuOrbHtml()}<div class="minimal-menu-slots" aria-label="Equipped cards">${slots}</div><div class="minimal-menu-rows"><div class="minimal-menu-row"><span>World</span><strong>${escapeHtml(worldName)}</strong></div><div class="minimal-menu-row"><span>Identity</span>${identityAction}</div></div><div class="minimal-menu-settings"><label><span>Larger text</span><input type="checkbox" data-ui-setting="largeText"${largeText ? " checked" : ""} /></label><label><span>Reduce motion</span><input type="checkbox" data-ui-setting="reduceMotion"${reduceMotion ? " checked" : ""} /></label></div></section>`;
+    }
+
     function accountPanelHtml() {
       if (!accountPanelPinned) return "";
-      if (menuSection === "deck") {
-        return `<section class="account-panel" aria-labelledby="account-panel-title">${menuNavHtml()}${deckPanelHtml()}</section>`;
-      }
-      if (menuSection === "journal") {
-        return `<section class="account-panel" aria-labelledby="account-panel-title">${menuNavHtml()}${journalPanelHtml()}</section>`;
-      }
-      if (menuSection === "settings") {
-        return `<section class="account-panel" aria-labelledby="account-panel-title">${menuNavHtml()}${settingsPanelHtml()}</section>`;
-      }
-      if (menuSection === "identity") {
-        return `<section class="account-panel" aria-labelledby="account-panel-title">${menuNavHtml()}<div class="account-title"><h2 id="account-panel-title">sign in & identity</h2><span class="account-wallet">portable account, optional linked avatars</span></div>${identitySectionHtml()}</section>`;
-      }
-      return `<section class="account-panel" aria-labelledby="account-panel-title">${menuNavHtml()}<div class="account-title"><h2 id="account-panel-title">character</h2><span class="account-wallet">story identity and growth</span></div>${characterSheetHtml()}</section>`;
+      return minimalMenuPanelHtml();
     }
 
     function identitySectionHtml() {
@@ -16603,8 +17183,28 @@
       return "not now";
     }
 
+    function handCardThink(action) {
+      return projectedHandEntryForAction(action)?.think || null;
+    }
+
+    function canDiscardHandCard(action) {
+      return Boolean(
+        !state?.branch
+        && actorId
+        && actorSession
+        && state?.primary_action?.kind !== "create_avatar"
+        && (!state?.combat || state?.turn?.is_current_actor)
+        && handCardThink(action)?.available
+        && handCardThink(action)?.offer_id
+      );
+    }
+
     function usesInlineStoryHand() {
-      return false;
+      return Boolean(
+        !state?.branch
+        && state?.primary_action?.kind !== "create_avatar"
+        && !actionBusy
+      );
     }
 
     function storyHandKey(action) {
@@ -16645,42 +17245,12 @@
 
     function renderStoryHandInspector(action) {
       const inspector = $("hand-inspector");
-      if (!usesInlineStoryHand() || !storyHandExpanded || !action || actionBusy) {
-        inspector.hidden = true;
-        $("hand-title").textContent = "";
-        $("hand-summary").textContent = "";
-        $("hand-meta").innerHTML = "";
-        $("hand-choices").hidden = true;
-        $("hand-choices").innerHTML = "";
-        return;
-      }
-      actionConfirmAction = action;
-      inspector.hidden = false;
-      $("hand-title").textContent = actionTitle(action);
-      $("hand-summary").textContent = journalSentence(actionSummary(action));
-      $("hand-meta").innerHTML = storyHandRowsHtml(action);
-      const choicesHtml = storyHandChoicesHtml(action);
-      $("hand-choices").hidden = !choicesHtml;
-      $("hand-choices").innerHTML = choicesHtml;
-      const discardButton = $("hand-discard");
-      const discardCertificate = projectedHandEntryForAction(action)?.think || null;
-      const canDiscard = !state?.branch
-        && actorId
-        && actorSession
-        && discardCertificate?.available
-        && discardCertificate?.offer_id
-        && (!state?.combat || state?.turn?.is_current_actor);
-      discardButton.hidden = !canDiscard;
-      discardButton.disabled = handShuffleBusy;
-      discardButton.textContent = discardCertificate?.free ? "discard · free" : "discard";
-      discardButton.setAttribute(
-        "aria-label",
-        canDiscard
-          ? `Discard this ${discardCertificate.slot || action.storyHandSlot || "Story Hand"} card; ${discardCertificate.free ? "free" : "uses this turn"}`
-          : "This Story Hand card cannot be discarded",
-      );
-      $("hand-actions").classList.toggle("has-discard", Boolean(canDiscard));
-      $("hand-confirm").textContent = actionConfirmLabel(action);
+      inspector.hidden = true;
+      $("hand-title").textContent = "";
+      $("hand-summary").textContent = "";
+      $("hand-meta").innerHTML = "";
+      $("hand-choices").hidden = true;
+      $("hand-choices").innerHTML = "";
     }
 
     function scrollStoryHandCardIntoView(action, behavior = "smooth") {
@@ -16703,28 +17273,29 @@
         storyHandActiveKey = "";
       }
       prompt.classList.toggle("hand-expanded", expanded);
-      $("hand-rail").style.setProperty("--hand-card-count", String(Math.max(1, visibleActions.length)));
       $("hand-toggle").setAttribute("aria-expanded", expanded ? "true" : "false");
-      let selectedIndex = visibleActions.findIndex((action) => storyHandKey(action) === storyHandActiveKey);
-      if (selectedIndex < 0) {
-        selectedIndex = Math.max(0, visibleActions.findIndex((action) => action.actionIndex === focusIndex));
-      }
-      const selectedVisible = visibleActions[selectedIndex] || visibleActions[0] || null;
-      if (expanded && selectedVisible) storyHandActiveKey = storyHandKey(selectedVisible);
       const count = visibleActions.length;
-      $("hand-toggle-status").textContent = expanded
-        ? `${Math.max(1, selectedIndex + 1)} of ${count} · swipe between cards`
-        : `${count} ${count === 1 ? "card" : "cards"} · tap a card to open`;
-      for (const button of $("hand-rail").querySelectorAll(".cmd")) {
-        const current = expanded && String(button.dataset.handKey || "") === storyHandActiveKey;
-        if (current) button.setAttribute("aria-current", "true");
-        else button.removeAttribute("aria-current");
-      }
-      renderStoryHandInspector(expanded && selectedVisible ? originalStoryHandAction(selectedVisible) : null);
-      if (expanded && selectedVisible && storyHandScrollPending) {
-        storyHandScrollPending = false;
-        window.requestAnimationFrame(() => scrollStoryHandCardIntoView(selectedVisible, "auto"));
-      }
+      $("hand-toggle-status").textContent = expanded ? "Close" : `${count} ${count === 1 ? "card" : "cards"}`;
+      ["primary", "secondary", "tertiary"].forEach((id, index) => {
+        const action = visibleActions[index] || null;
+        const slot = document.querySelector(`[data-story-card-slot="${id}"]`);
+        const play = document.querySelector(`[data-hand-play="${id}"]`);
+        const discard = document.querySelector(`[data-hand-discard="${id}"]`);
+        slot.hidden = !action;
+        if (!action) return;
+        const original = originalStoryHandAction(action);
+        const title = actionTitle(original);
+        play.disabled = !inline || Boolean(original.busy);
+        play.setAttribute("aria-label", `Play ${title}`);
+        discard.disabled = !inline || !canDiscardHandCard(original) || handShuffleBusy;
+        discard.setAttribute("aria-label", `Discard ${title}`);
+        discard.title = discard.disabled
+          ? "No replacement is available for this card right now."
+          : `Discard ${title} and draw its replacement`;
+      });
+      for (const button of $("hand-rail").querySelectorAll(".cmd")) button.removeAttribute("aria-current");
+      storyHandScrollPending = false;
+      renderStoryHandInspector(null);
     }
 
     function setStoryHandExpanded(expanded, action = null) {
@@ -16754,7 +17325,37 @@
 
     function activateStoryHandAction(action) {
       if (!action || actionBusy) return;
-      openActionModal(action, { handCard: true });
+      if (!usesInlineStoryHand()) {
+        openActionModal(action, { handCard: true });
+        return;
+      }
+      const index = actions.indexOf(action);
+      if (index >= 0) focusIndex = index;
+      focusedKey = action.focusKey || actionHandKey(action) || "";
+      storyHandActiveKey = storyHandKey(action);
+      setStoryHandExpanded(true, action);
+    }
+
+    async function discardStoryHandCard(id) {
+      const action = actionForButton(id);
+      if (!action || !canDiscardHandCard(action) || handShuffleBusy) return;
+      const index = Number($(id)?.dataset?.actionIndex);
+      if (Number.isInteger(index) && index >= 0) focusIndex = index;
+      focusedKey = action.focusKey || actionHandKey(action) || "";
+      await discardActionCard(action);
+    }
+
+    function playStoryHandCard(id) {
+      const action = actionForButton(id);
+      if (!action || actionBusy) return;
+      if (Array.isArray(action.choices) && action.choices.length > 1) {
+        openActionModal(action);
+        return;
+      }
+      if (Array.isArray(action.choices) && action.choices.length === 1 && !action.selectedChoice) {
+        action.selectedChoice = action.choices[0].value;
+      }
+      void runAction(action);
     }
 
     function selectStoryHandCardFromScroll() {
@@ -17645,7 +18246,7 @@
     }
 
     // Kept for transport/browser compatibility; the player-facing control is
-    // Discard inside the selected card's detail modal.
+    // Discard on each card in the expanded Story Hand.
     async function passHand(focused = visibleFocusedAction()) {
       return discardActionCard(focused);
     }
@@ -18111,6 +18712,12 @@
     }, true);
 
     $("log").addEventListener("click", (event) => {
+      if (event.target.closest("[data-menu-close]")) {
+        event.preventDefault();
+        toggleAccountPanel(false);
+        libraryPill.focus();
+        return;
+      }
       const menuTarget = event.target.closest("[data-menu-section]");
       if (menuTarget) {
         event.preventDefault();
@@ -18511,6 +19118,7 @@
       } else {
         menuSection = "deck";
         toggleAccountPanel(true);
+        Promise.all([loadIdentity(), ensureContentPacks()]).then(render).catch(() => render());
       }
     });
 
@@ -18521,7 +19129,11 @@
 
     function toggleAccountPanel(forceOpen = null) {
       accountPanelPinned = forceOpen === null ? !accountPanelPinned : Boolean(forceOpen);
-      if (accountPanelPinned) libraryPanelPinned = false;
+      if (accountPanelPinned) {
+        libraryPanelPinned = false;
+        storyHandExpanded = false;
+        storyHandActiveKey = "";
+      }
       render();
       return accountPanelPinned;
     }
@@ -18555,6 +19167,22 @@
 
     $("hand-toggle").addEventListener("click", () => {
       setStoryHandExpanded(!storyHandExpanded, actionConfirmAction || visibleFocusedAction());
+    });
+
+    $("hand-rail").addEventListener("click", (event) => {
+      const play = event.target.closest("[data-hand-play]");
+      if (play) {
+        event.preventDefault();
+        event.stopPropagation();
+        playStoryHandCard(play.getAttribute("data-hand-play") || "");
+        return;
+      }
+      const discard = event.target.closest("[data-hand-discard]");
+      if (discard) {
+        event.preventDefault();
+        event.stopPropagation();
+        void discardStoryHandCard(discard.getAttribute("data-hand-discard") || "");
+      }
     });
 
     $("hand-close").addEventListener("click", (event) => {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -43028,6 +43028,14 @@ mod tests {
         assert!(!INDEX_HTML.contains("function drawAndPassOrderedSceneTurn"));
         assert!(INDEX_HTML.contains("function discardActionCard"));
         assert!(INDEX_HTML.contains("id=\"action-modal-discard\""));
+        assert!(INDEX_HTML.contains("data-hand-play=\"primary\""));
+        assert!(INDEX_HTML.contains("data-hand-discard=\"primary\""));
+        assert!(INDEX_HTML.contains("function playStoryHandCard"));
+        assert!(INDEX_HTML.contains("function discardStoryHandCard"));
+        assert!(INDEX_HTML.contains("function minimalMenuPanelHtml"));
+        assert!(INDEX_HTML.contains("class=\"account-panel minimal-menu\""));
+        assert!(INDEX_HTML.contains("class=\"minimal-orb-rack"));
+        assert!(!INDEX_HTML.contains("function usesInlineStoryHand() {\n      return false;"));
         assert!(!INDEX_HTML.contains("data-player-concept=\"think\""));
         assert!(!INDEX_HTML.contains("id=\"shuffle\""));
         assert!(INDEX_HTML.contains("id=\"tertiary\""));

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -678,50 +678,50 @@ async function main() {
       initial.visibleKeys.length >= 1 && initial.visibleKeys.length <= 3 && !initial.hasFourthCard,
       `the opening scene should expose at most three cards without a fourth Think card: ${JSON.stringify(initial)}`,
     );
-    const focused = await focusThinkableCard("opening scene");
-    await page.evaluate((handKey) => {
-      const button = [...document.querySelectorAll("#hand-rail .cmd[data-hand-key]")]
-        .find((candidate) => candidate.dataset.handKey === handKey);
-      button?.click();
-    }, focused.key);
-    await page.waitForFunction(() => {
-      const discard = document.querySelector("#action-modal-discard");
-      return document.querySelector("#action-modal")?.hidden === false
-        && document.querySelector("#action-modal .action-dialog")?.classList.contains("hand-card-mode")
-        && discard
-        && !discard.hidden
-        && !discard.disabled;
-    });
-    const modalLayout = await page.evaluate(() => {
+    await focusThinkableCard("opening scene");
+    const expanded = await page.evaluate(() => {
+      const focusedIndex = Number(visibleFocusedAction()?.actionIndex);
+      const controlId = ["primary", "secondary", "tertiary"].find((id) => (
+        Number(document.querySelector(`#${id}`)?.dataset?.actionIndex) === focusedIndex
+      )) || "";
+      setStoryHandExpanded(true, visibleFocusedAction());
       const prompt = document.querySelector("footer.prompt");
-      const dialog = document.querySelector("#action-modal .action-dialog");
-      const art = document.querySelector("#action-modal-image");
+      const visibleSlots = [...document.querySelectorAll(".story-card-slot:not([hidden])")];
       return {
-        modalOpen: document.querySelector("#action-modal")?.hidden === false,
-        largeCard: dialog?.classList.contains("hand-card-mode")
-          && art?.getBoundingClientRect().height >= 240,
+        controlId,
         promptExpanded: prompt.classList.contains("hand-expanded"),
         handHeaderVisible: document.querySelector(".hand-header")?.getClientRects().length > 0,
         inspectorVisible: document.querySelector("#hand-inspector")?.hidden === false,
-        cancel: document.querySelector("#action-modal-cancel")?.textContent?.trim() || "",
-        confirm: document.querySelector("#action-modal-confirm")?.textContent?.trim() || "",
-        discard: document.querySelector("#action-modal-discard")?.textContent?.trim() || "",
-        cancelVisible: document.querySelector("#action-modal-cancel")?.getClientRects().length > 0,
-        metaVisible: document.querySelector("#action-modal-meta")?.getClientRects().length > 0,
+        modalHidden: document.querySelector("#action-modal")?.hidden === true,
+        cardCount: visibleSlots.length,
+        inlineActions: visibleSlots.every((slot) => (
+          slot.querySelector("[data-hand-play]")?.getClientRects().length > 0
+            && slot.querySelector("[data-hand-discard]")?.getClientRects().length > 0
+        )),
+        imageLed: visibleSlots.every((slot) => {
+          const thumb = slot.querySelector(".cmd .thumb");
+          return Boolean(thumb && (
+            getComputedStyle(thumb).backgroundImage !== "none"
+              || thumb.querySelector("img")?.getAttribute("src")
+          ));
+        }),
+        squareCorners: visibleSlots.every((slot) => (
+          Number.parseFloat(getComputedStyle(slot).borderTopLeftRadius) === 0
+            && Number.parseFloat(getComputedStyle(slot.querySelector(".cmd")).borderTopLeftRadius) === 0
+        )),
       };
     });
     assert(
-      modalLayout.modalOpen
-        && modalLayout.largeCard
-        && !modalLayout.promptExpanded
-        && !modalLayout.handHeaderVisible
-        && !modalLayout.inspectorVisible
-        && modalLayout.cancel === "close"
-        && modalLayout.confirm === "play"
-        && modalLayout.discard === "discard"
-        && modalLayout.cancelVisible
-        && !modalLayout.metaVisible,
-      `tapping a card should open a larger card with Close, Play, and Discard: ${JSON.stringify(modalLayout)}`,
+      expanded.controlId
+        && expanded.promptExpanded
+        && expanded.handHeaderVisible
+        && !expanded.inspectorVisible
+        && expanded.modalHidden
+        && expanded.cardCount === initial.visibleKeys.length
+        && expanded.inlineActions
+        && expanded.imageLed
+        && expanded.squareCorners,
+      `the expanded Story Hand should show three sharp illustrated cards with inline Play and Discard: ${JSON.stringify(expanded)}`,
     );
     const [response] = await Promise.all([
       page.waitForResponse((candidate) => (
@@ -729,7 +729,7 @@ async function main() {
         && new URL(candidate.url()).pathname === "/commands"
         && String(candidate.request().postData() || "").includes("\"command\":\"think\"")
       )),
-      page.locator("#action-modal-discard").click(),
+      page.locator(`[data-hand-discard="${expanded.controlId}"]`).click(),
     ]);
     const receipt = await response.json();
     const drawEvent = (receipt.events || []).find((event) => event.type === "hand.thought");
@@ -742,6 +742,7 @@ async function main() {
         && refreshInFlight === null
         && document.querySelector("#action-modal")?.hidden === true
     ));
+    await page.evaluate(() => setStoryHandExpanded(false));
     const current = await handSnapshot();
     const layout = await page.evaluate(() => {
       const prompt = document.querySelector("footer.prompt");
@@ -749,7 +750,7 @@ async function main() {
       const statusStyle = getComputedStyle(status);
       const labels = [...prompt.querySelectorAll(".cmd-label-text")];
       const handRail = document.querySelector("#hand-rail");
-      const cards = [...handRail.querySelectorAll("button")]
+      const cards = [...handRail.querySelectorAll(".cmd")]
         .filter((button) => getComputedStyle(button).display !== "none")
         .map((button) => button.getBoundingClientRect());
       return {
@@ -760,7 +761,7 @@ async function main() {
         railColumns: getComputedStyle(handRail).gridTemplateColumns.split(" ").filter(Boolean).length,
         cardsFit: cards.length <= 3
           && cards.every((rect) => rect.left >= 0 && rect.right <= window.innerWidth),
-        cardsCompact: cards.every((rect) => rect.height <= 54),
+        cardsCompact: cards.every((rect) => rect.height <= 60),
         detailsHidden: [...handRail.querySelectorAll(".detail, .cmd-meta, .provider-call, .story-call")]
           .every((node) => getComputedStyle(node).display === "none"),
         collapsed: !prompt.classList.contains("hand-expanded"),
@@ -778,10 +779,10 @@ async function main() {
         && current.visibleKeys.length <= 3
         && current.eventSeq > initial.eventSeq
         && layout.promptFits
-        && layout.promptDisplay === "block"
+        && layout.promptDisplay === "grid"
         && layout.compactHandHeight <= 100
         && layout.railDisplay === "grid"
-        && layout.railColumns === current.visibleKeys.length
+        && layout.railColumns === 3
         && layout.cardsFit
         && layout.cardsCompact
         && layout.detailsHidden
@@ -791,10 +792,10 @@ async function main() {
         && layout.primaryLabelsFit
         && layout.statusWraps
         && layout.journaled,
-      `Discard should replace one Story Hand card without adding a fourth card: ${JSON.stringify({ initial, current, layout })}`,
+      `inline Discard should replace one Story Hand card without adding a fourth card: ${JSON.stringify({ initial, current, layout })}`,
     );
     steps.push({
-      label: "browser Discard replaces one Story Hand card",
+      label: "inline Discard replaces one Story Hand card",
       actions: current.visibleKeys.length,
       draws: 1,
     });
@@ -4561,7 +4562,7 @@ async function main() {
           actionLabels: actions.map((action) => `${action.label} ${action.detail || ""}`.trim()),
           visibleHand,
           hasThirdCard: Boolean(document.querySelector("#tertiary")),
-          hasDiscardInModal: Boolean(document.querySelector("#action-modal-discard")),
+          hasInlineDiscard: document.querySelectorAll("[data-hand-discard]").length === 3,
           hasFourthCard: Boolean(document.querySelector("#shuffle")),
           semanticBindings,
           giveKindsBeforeRename,
@@ -4621,8 +4622,8 @@ async function main() {
     assert(!/eager|willingness|accepted/i.test(JSON.stringify(result.tradeCopy)), `trade copy should hide resident-economy state tags: ${JSON.stringify(result)}`);
     assert(result.visibleHand.length === 3, `the authoritative browser Story Hand should expose exactly three actions: ${JSON.stringify(result)}`);
     assert(
-      result.hasThirdCard && result.hasDiscardInModal && !result.hasFourthCard,
-      `the browser should provide three Story Hand slots with Discard in the card modal: ${JSON.stringify(result)}`,
+      result.hasThirdCard && result.hasInlineDiscard && !result.hasFourthCard,
+      `the browser should provide three Story Hand slots with inline Discard: ${JSON.stringify(result)}`,
     );
     assert(result.actionLabels.some((label) => label.startsWith("give ")) && result.actionLabels.some((label) => label.startsWith("trade ")), `actions outside the hand should remain in the complete legal surface: ${JSON.stringify(result)}`);
     assert(result.semanticBindings.find((entry) => entry.label === "give")?.kinds?.includes("give_item"), `Give must bind to the server kind rather than its display label: ${JSON.stringify(result)}`);
@@ -9991,33 +9992,35 @@ async function main() {
     );
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       await focusThinkableCard(label, preferredSlot);
-      await page.evaluate(() => openActionModal(visibleFocusedAction()));
       await page.waitForFunction(() => (
         actionBusy === false
           && refreshInFlight === null
-          && document.querySelector("#action-modal-discard")?.hidden === false
-          && document.querySelector("#action-modal-discard")?.disabled === false
       ));
       const before = await page.evaluate(() => {
         const entry = projectedHandEntryForAction(visibleFocusedAction());
         const think = entry?.think || {};
-        const control = document.querySelector("#action-modal-discard");
+        const focusedIndex = Number(visibleFocusedAction()?.actionIndex);
+        const controlId = ["primary", "secondary", "tertiary"].find((id) => (
+          Number(document.querySelector(`#${id}`)?.dataset?.actionIndex) === focusedIndex
+        )) || "";
+        setStoryHandExpanded(true, visibleFocusedAction());
+        const control = document.querySelector(`[data-hand-discard="${controlId}"]`);
         return {
           offerId: String(think.offer_id || ""),
           slot: String(think.slot || entry?.slot || ""),
           generation: Number(think.generation || 0),
-          controlId: control?.id || "",
+          controlId,
           visible: Boolean(control && getComputedStyle(control).display !== "none"),
           disabled: Boolean(control?.disabled),
-          ariaLabel: control?.getAttribute("aria-label") || "",
+          label: control?.textContent?.trim() || "",
         };
       });
       assert(
         before.offerId
-          && before.controlId === "action-modal-discard"
+          && ["primary", "secondary", "tertiary"].includes(before.controlId)
           && before.visible
           && !before.disabled
-          && /discard this .* card/i.test(before.ariaLabel),
+          && before.label.toLowerCase() === "discard",
         `${label} replacement must start from the focused card's certified Discard control: ${JSON.stringify(before)}`,
       );
       let response;
@@ -10028,7 +10031,7 @@ async function main() {
               && new URL(candidate.url()).pathname === "/commands"
               && String(candidate.request().postData() || "").includes("\"command\":\"think\"")
           ), { timeout: 10_000 }),
-          page.locator("#action-modal-discard").click(),
+          page.locator(`[data-hand-discard="${before.controlId}"]`).click(),
         ]);
       } catch (error) {
         lastRejection = { before, error: String(error?.message || error) };
@@ -10347,11 +10350,7 @@ async function main() {
       document.querySelector("#brand")?.getAttribute("aria-expanded") === "true"
         && Boolean(document.querySelector(".account-panel"))
     ));
-    await page.locator('[data-menu-section="character"]').click();
-    await page.waitForFunction(() => (
-      document.querySelector('[data-menu-section="character"]')?.classList.contains("active")
-        && Boolean(document.querySelector(".account-panel"))
-    ));
+    await page.waitForFunction(() => Boolean(document.querySelector(".minimal-menu")));
     await page.waitForTimeout(75);
     await assertNoVisibleOverflow();
     return primaryText();
@@ -10361,11 +10360,9 @@ async function main() {
     if (await page.locator("#brand").getAttribute("aria-expanded") !== "true") {
       await page.locator("#brand").click();
     }
-    await page.waitForFunction(() => Boolean(document.querySelector(".account-panel")));
-    await page.locator('[data-menu-section="identity"]').click();
     await page.waitForFunction(() => (
-      document.querySelector('[data-menu-section="identity"]')?.classList.contains("active")
-        && document.querySelector("#account-panel-title")?.textContent?.trim() === "sign in & identity"
+      document.querySelector(".minimal-menu")
+        && document.querySelector("#account-panel-title")?.textContent?.trim() === "Player"
     ));
     await assertNoVisibleOverflow();
   }
@@ -12468,9 +12465,10 @@ async function main() {
     assert(
       await page.locator("#command-toggle, #command-palette, #command-input").count() === 0
         && await page.locator("#shuffle").count() === 0
-        && await page.locator("#action-modal-discard").count() === 1
+        && await page.locator("[data-hand-discard]").count() === 3
+        && await page.locator("[data-hand-play]").count() === 3
         && await page.locator("#all-actions-modal, [data-all-action-index]").count() === 0,
-      "the browser room should expose only its three-card hand, with Discard in card details and no command entry or full-deck chooser",
+      "the browser room should expose only its three-card hand, with inline Play and Discard and no command entry or full-deck chooser",
     );
     assert(
       before.length >= 1 && before.length <= 3,
@@ -13046,64 +13044,46 @@ async function main() {
 
     await page.locator("#brand").click();
     await page.waitForFunction(() => document.querySelector(".terminal")?.classList.contains("panel-open"));
-    await page.locator('[data-menu-section="deck"]').click();
-    await page.waitForFunction(() => document.querySelector("#account-panel-title")?.textContent?.trim() === "your pack");
-    const menuDeck = await page.evaluate(() => ({
-      sections: [...document.querySelectorAll('[data-menu-section]')].map((button) => ({
-        id: button.getAttribute("data-menu-section"),
-        label: button.textContent.trim(),
-      })),
+    await page.waitForFunction(() => document.querySelector(".minimal-menu"));
+    const menu = await page.evaluate(() => ({
       role: document.querySelector("#log")?.getAttribute("role") || "",
       label: document.querySelector("#log")?.getAttribute("aria-label") || "",
       heading: document.querySelector("#account-panel-title")?.textContent?.trim() || "",
       copy: document.querySelector(".account-panel")?.textContent?.replace(/\s+/g, " ").trim() || "",
-      iconCount: document.querySelectorAll(".menu-nav .ui-icon").length,
-      decorativeIcons: [...document.querySelectorAll(".menu-nav .ui-icon")]
-        .every((icon) => icon.getAttribute("aria-hidden") === "true"),
+      navigationCount: document.querySelectorAll(".menu-nav, [data-menu-section]").length,
+      panelCount: document.querySelectorAll(".account-panel").length,
+      slotCount: document.querySelectorAll(".minimal-menu-slot").length,
+      filledSlots: [...document.querySelectorAll(".minimal-menu-slot.filled img")].map((image) => ({
+        complete: image.complete,
+        naturalWidth: image.naturalWidth,
+      })),
+      orbCount: document.querySelectorAll(".minimal-menu-orbs .minimal-orb-rack i").length,
+      rowLabels: [...document.querySelectorAll(".minimal-menu-row > span:first-child")]
+        .map((node) => node.textContent.trim()),
+      settingCount: document.querySelectorAll(".minimal-menu-settings input").length,
+      returnControl: document.querySelector("[data-menu-close]")?.textContent?.trim() || "",
+      squareCorners: [...document.querySelectorAll(".minimal-menu, .minimal-menu button, .minimal-menu input")]
+        .every((node) => Number.parseFloat(getComputedStyle(node).borderTopLeftRadius) === 0),
       brandClientWidth: document.querySelector("#brand")?.clientWidth || 0,
       brandScrollWidth: document.querySelector("#brand")?.scrollWidth || 0,
     }));
-    assert(JSON.stringify(menuDeck.sections) === JSON.stringify([
-      { id: "deck", label: "pack" },
-      { id: "character", label: "character" },
-      { id: "identity", label: "sign in / identity" },
-      { id: "world", label: "worlds & packs" },
-      { id: "journal", label: "journal" },
-      { id: "settings", label: "orbs & settings" },
-    ]), `${label}: Menu should separate pack, character, identity, worlds, journal, and settings: ${JSON.stringify(menuDeck)}`);
-    assert(menuDeck.iconCount === 6 && menuDeck.decorativeIcons, `${label}: every named Menu section should have one decorative icon: ${JSON.stringify(menuDeck)}`);
-    assert(menuDeck.role === "region" && menuDeck.label === "Your avatar menu" && menuDeck.heading === "your pack", `${label}: Pack should be a dedicated semantic panel: ${JSON.stringify(menuDeck)}`);
-    assert(menuDeck.brandScrollWidth <= menuDeck.brandClientWidth, `${label}: the open Menu control should not clip hidden branding into the mobile header: ${JSON.stringify(menuDeck)}`);
-    assert(/physical cards, not a fixed card count/i.test(menuDeck.copy) && /pack weight/i.test(menuDeck.copy) && /skill charms/i.test(menuDeck.copy) && /prepared spells/i.test(menuDeck.copy) && /spent/i.test(menuDeck.copy), `${label}: Pack should explain weight, Loadout, charms, Prepared spells, and Spent cards: ${JSON.stringify(menuDeck)}`);
-    await page.locator('[data-menu-section="world"]').click();
-    await page.waitForFunction(() => document.querySelector(".terminal")?.classList.contains("panel-open") && document.querySelector("#log")?.classList.contains("library-mode"));
-    const library = await page.evaluate(() => ({
-      role: document.querySelector("#log")?.getAttribute("role") || "",
-      label: document.querySelector("#log")?.getAttribute("aria-label") || "",
-      live: document.querySelector("#log")?.hasAttribute("aria-live") || false,
-      roomHidden: getComputedStyle(document.querySelector(".room")).display === "none",
-      promptHidden: document.querySelector(".prompt")?.hidden || false,
-      heading: document.querySelector(".library-heading h2")?.textContent?.trim() || "",
-      intro: document.querySelector(".library-intro")?.textContent?.trim() || "",
-      featured: document.querySelector(".library-grid.featured") !== null,
-      packIconCount: document.querySelectorAll(".library-pack-name .ui-icon").length,
-      supportingDisclosure: document.querySelector(".library-system-packs") !== null,
-      packCountSummaries: [...document.querySelectorAll(".library-pack-counts")]
-        .map((node) => node.textContent.replace(/\s+/g, " ").trim()),
-    }));
-    assert(library.role === "region" && library.label === "World Library" && !library.live && library.roomHidden && library.promptHidden, `${label}: library should be a dedicated semantic panel: ${JSON.stringify(library)}`);
-    assert(library.heading === "Worlds" && /ordinary places are public and need no wallet/i.test(library.intro), `${label}: library should lead with player-facing copy: ${JSON.stringify(library)}`);
-    assert(library.featured && library.packIconCount > 0 && library.supportingDisclosure, `${label}: library should separate playable worlds from supporting packs: ${JSON.stringify(library)}`);
     assert(
-      library.packCountSummaries.some((summary) => /\d+ items · \d+ cards/.test(summary))
-        && library.packCountSummaries.some((summary) => /1 character path/.test(summary))
-        && library.packCountSummaries.some((summary) => /1 art asset/.test(summary))
-        && library.packCountSummaries.every((summary) => !/\d+ items · \d+ items|1 character paths|1 art assets/.test(summary)),
-      `${label}: library resource summaries should distinguish carried items from cards: ${JSON.stringify(library.packCountSummaries)}`,
+      menu.role === "region"
+        && menu.label === "Your avatar menu"
+        && menu.heading === "Player"
+        && menu.panelCount === 1
+        && menu.navigationCount === 0
+        && menu.slotCount === 4
+        && menu.orbCount === 5
+        && JSON.stringify(menu.rowLabels) === JSON.stringify(["World", "Identity"])
+        && menu.settingCount === 2
+        && menu.returnControl === "Return to chat"
+        && menu.squareCorners
+        && menu.filledSlots.every((image) => image.complete && image.naturalWidth > 0),
+      `${label}: Menu should be one sharp, image-led player panel: ${JSON.stringify(menu)}`,
     );
-
-    await page.locator('[data-menu-section="settings"]').click();
-    await page.waitForFunction(() => document.querySelector("#account-panel-title")?.textContent?.trim() === "orbs & settings");
+    assert(menu.brandScrollWidth <= menu.brandClientWidth, `${label}: the open Menu control should not clip hidden branding into the mobile header: ${JSON.stringify(menu)}`);
+    assert(!/pack weight|prepared spells|ordinary places are public|story identity and growth/i.test(menu.copy), `${label}: the one-screen Menu should not revive the removed instruction pages: ${JSON.stringify(menu)}`);
     const preferenceBaseline = await page.evaluate(() => Number.parseFloat(getComputedStyle(document.body).fontSize));
     await page.locator('[data-ui-setting="largeText"]').check();
     await page.locator('[data-ui-setting="reduceMotion"]').check();
@@ -13143,23 +13123,9 @@ async function main() {
         && preferencesReset.reduceMotionStored === "false",
       `${label}: accessibility preferences should be reversible: ${JSON.stringify(preferencesReset)}`,
     );
-    await page.locator("#brand").click();
-    await page.waitForFunction(() => !document.querySelector(".terminal")?.classList.contains("panel-open"));
-
-    await page.locator("#brand").click();
-    await page.waitForFunction(() => document.querySelector(".terminal")?.classList.contains("panel-open"));
-    await page.locator('[data-menu-section="character"]').click();
-    await page.waitForFunction(() => document.querySelector(".terminal")?.classList.contains("panel-open") && document.querySelector("#log")?.classList.contains("account-mode"));
-    const account = await page.evaluate(() => ({
-      role: document.querySelector("#log")?.getAttribute("role") || "",
-      label: document.querySelector("#log")?.getAttribute("aria-label") || "",
-      promptHidden: document.querySelector(".prompt")?.hidden || false,
-      heading: document.querySelector("#account-panel-title")?.tagName || "",
-    }));
-    assert(account.role === "region" && account.label === "Your avatar menu" && account.promptHidden && account.heading === "H2", `${label}: character should be a dedicated semantic panel: ${JSON.stringify(account)}`);
-    await page.locator("#brand").click();
+    await page.locator("[data-menu-close]").click();
     await page.waitForFunction(() => !document.querySelector(".terminal")?.classList.contains("panel-open") && document.querySelector("#log")?.getAttribute("role") === "log");
-    steps.push({ label, mobileNavigation: "visible", dialogs: "contained", panels: "semantic" });
+    steps.push({ label, mobileNavigation: "single-panel", dialogs: "contained", panels: "semantic" });
   }
 
   async function assertStatusBarDoesNotOverlayTranscript(label) {
@@ -13927,33 +13893,32 @@ async function main() {
     );
     steps.push({ label: "open guest account inventory", primary: await focusAccountInventory() });
     await assertActionBarCapped("guest account inventory", 0);
-    await page.waitForFunction(() => (
-      document.querySelector(".account-panel")?.innerText
-        ?.includes("I listen for odd jobs nobody else wants.")
-    ), undefined, { timeout: 5_000 });
-    const guestSheetText = await page.locator(".account-panel").innerText();
-    assert(guestSheetText.includes("I listen for odd jobs nobody else wants."), `a classless new avatar should keep the safe default purpose until class selection: ${guestSheetText}`);
-    assert(/\blevel\s+1\b/i.test(guestSheetText) && !/\bclassless\b/i.test(guestSheetText), `the account sheet should show level 1 without a class label before class selection: ${guestSheetText}`);
-    assert(
-      guestSheetText.includes("journal") && guestSheetText.includes("relationships"),
-      `avatar sheet should expose the journal and authored relationship state: ${guestSheetText}`,
-    );
-    assert(
-      guestSheetText.includes("your first little moment is waiting")
-        && guestSheetText.includes("worn skill charms")
-        && guestSheetText.includes("find a skill charm, then wear it from Pack")
-        && guestSheetText.includes("someone new is waiting to meet you"),
-      `an empty avatar sheet should point warmly toward what comes next: ${guestSheetText}`,
-    );
-    assert(!/quiet for now|nothing yet|no one yet|\bnone\b|\b\d+ of \d+\b|dev-wallet/i.test(guestSheetText), `avatar sheet should avoid cold empty-state and account shorthand: ${guestSheetText}`);
-    assert(!/wooden box|avatar bundle|keepsake|collection/i.test(guestSheetText), `the avatar sheet should omit retired collection copy: ${guestSheetText}`);
-    assert(guestSheetText.includes("story identity and growth"), `the avatar sheet should describe continuity naturally: ${guestSheetText}`);
-    assert(guestSheetText.includes("purpose") && !guestSheetText.includes("calling"), `avatar sheet should use purpose rather than Calling terminology: ${guestSheetText}`);
-    assert(await page.locator(".account-portrait[data-card-key]").count() === 1, "avatar sheet should make the generated portrait card visible");
+    const guestMenu = await page.evaluate(() => ({
+      playerName: document.querySelector(".minimal-menu-player strong")?.textContent?.trim() || "",
+      level: document.querySelector(".minimal-menu-level")?.textContent?.trim() || "",
+      portraitCount: document.querySelectorAll(".minimal-menu-avatar[data-card-key]").length,
+      slotCount: document.querySelectorAll(".minimal-menu-slot").length,
+      orbCount: document.querySelectorAll(".minimal-menu-orbs .minimal-orb-rack i").length,
+      copy: document.querySelector(".minimal-menu")?.textContent?.replace(/\s+/g, " ").trim() || "",
+      purpose: String(state?.calling?.statement || ""),
+      avatar: (() => {
+        const actor = (state?.actors || []).find((candidate) => Number(candidate.id) === Number(actorId)) || null;
+        const card = cardForActor(actorId);
+        return {
+          name: actor?.name || card?.display_name || "",
+          blurb: card?.blurb || actor?.description || "",
+        };
+      })(),
+    }));
+    assert(guestMenu.purpose === "I listen for odd jobs nobody else wants.", `a classless new avatar should keep the safe default purpose: ${JSON.stringify(guestMenu)}`);
+    assert(guestMenu.playerName && guestMenu.level === "1", `the minimal Menu should show the current player and level: ${JSON.stringify(guestMenu)}`);
+    assert(guestMenu.portraitCount === 1, "the minimal Menu should show the generated portrait card");
+    assert(guestMenu.slotCount === 4 && guestMenu.orbCount === 5, `the minimal Menu should use equipment and Orb slots instead of explanatory copy: ${JSON.stringify(guestMenu)}`);
+    assert(!/journal|relationships|pack weight|prepared spells|story identity and growth|calling/i.test(guestMenu.copy), `the minimal Menu should leave narrative text to chat and the Journal: ${guestMenu.copy}`);
     const guestSheetHeight = await page.locator("#log").evaluate((node) => node.getBoundingClientRect().height);
-    assert(guestSheetHeight > 250, `mobile avatar sheet should use the available play area instead of a cramped transcript strip: ${guestSheetHeight}`);
-    const guestAvatarName = await page.locator(".account-identity-name").innerText();
-    const guestAvatarBlurb = await page.locator(".account-identity-blurb").innerText();
+    assert(guestSheetHeight > 250, `mobile Menu should use the available play area instead of a cramped transcript strip: ${guestSheetHeight}`);
+    const guestAvatarName = String(guestMenu.avatar?.name || guestMenu.playerName);
+    const guestAvatarBlurb = String(guestMenu.avatar?.blurb || "");
     assert(
       /\bI (?:like|prefer|want|dislike|avoid|hope|enjoy|am|notice|wonder|feel)\b/i.test(guestAvatarBlurb)
         && !guestAvatarBlurb.includes(guestAvatarName)
@@ -13967,7 +13932,7 @@ async function main() {
     await focusIdentityPanel();
     await page.waitForSelector(".account-panel [data-passkey-continue]");
     const identityText = await page.locator(".account-panel").innerText();
-    assert(identityText.includes("continue with passkey"), `the separate identity page should offer a durable sign-in path: ${identityText}`);
+    assert(/identity\s+sign in/i.test(identityText.replace(/\s+/g, " ")), `the minimal Menu should offer a durable sign-in path inline: ${identityText}`);
     await closeAccountInventory();
     assert((await page.locator("#brand").innerText()).toLowerCase() === "menu", "closed Menu toggle should visibly say menu");
     assert((await page.locator("#brand").getAttribute("aria-label")) === "Open Menu", "closed Menu toggle should announce that it opens");
@@ -13992,7 +13957,7 @@ async function main() {
     await page.waitForFunction(() => !document.querySelector("#primary")?.disabled);
     await focusIdentityPanel();
     const linkedIdentityText = await page.locator(".account-panel").innerText();
-    assert(linkedIdentityText.includes("linked avatars"), `signed identity should explain the optional avatar adapter: ${linkedIdentityText}`);
+    assert(/identity\s+passkey/i.test(linkedIdentityText.replace(/\s+/g, " ")), `signed identity should remain visible without opening another Menu page: ${linkedIdentityText}`);
     assert(!/Homeroom|Library|Wooden Box|bundle|keepsake|collection/i.test(linkedIdentityText), `signing a wallet must not expose retired ownership surfaces: ${linkedIdentityText}`);
     await page.evaluate(() => {
       localStorage.removeItem("cosyworld.wallet");


### PR DESCRIPTION
## What changed

- make the room transcript the persistent core surface on desktop and mobile
- expand a tapped Story Hand card into all three illustrated cards with inline Play and Discard controls
- remove the post-onboarding per-card detail step while retaining a focused choice dialog where a card genuinely has multiple targets
- replace the six-page menu with one square-edged player panel for portrait, Orb slots, equipped card art, world, identity, and accessibility settings
- preserve the visual Journal as its own one-tap destination
- bump the app to 1.0.49 and update browser/unit contracts for the reduced surface

## Why

Chat carries the text-heavy experience. The surrounding interface should read like a physical card table: image-led, compact, and sharp-edged rather than rounded dashboard chrome.

## Validation

- `npm test` — 183 tests passed
- world-pack, composition, proof-world, and kernel gates passed during pre-push
- `npm run v2:syntax`
- `cargo fmt --manifest-path v2/orchestrator-rust/Cargo.toml --check`
- `cargo test --manifest-path v2/orchestrator-rust/Cargo.toml browser_index_contract_stays_chat_mud_shell`

The local all-Rust wrapper hit its fixed 120-second compile timeout on a loaded macOS host; the same focused Rust contract completed successfully in 3m02s. The draft remains ready for the full GitHub CI run.