### PR TITLE
Make Story Hand cards collectible and keep Travel endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,19 @@ jobs:
           pandoc --version
           epubcheck --version
 
+      - name: Restore Playwright browsers
+        id: publication-playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Chromium system dependencies
+        run: npx playwright install-deps chromium
+
       - name: Install Chromium
-        run: npx playwright install --with-deps chromium
+        if: steps.publication-playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
 
       - name: Build and validate the guide
         run: npm run docs:dm-guide:check

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.52"
+version = "1.0.53"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.52"
+version = "1.0.53"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5994,44 +5994,48 @@
     }
     .hand-header {
       width: 100%;
-      min-height: 36px;
+      min-height: 42px;
       display: none;
       border: 0;
       border-bottom: 1px solid var(--line);
-      background: transparent;
+      background:
+        linear-gradient(90deg, rgba(222, 194, 141, 0.06), transparent 30%, transparent 70%, rgba(222, 194, 141, 0.04)),
+        #0d0e0a;
     }
     .prompt.hand-expanded .hand-header { display: block; }
     .hand-toggle {
       width: 100%;
-      min-height: 36px;
+      min-height: 42px;
       display: grid;
       grid-template-columns: auto minmax(0, 1fr) auto;
       align-items: center;
-      gap: 8px;
+      gap: 12px;
       border: 0;
       background: transparent;
       color: var(--dim);
-      padding: 7px 12px;
+      padding: 8px 16px;
       text-align: left;
       cursor: pointer;
     }
     .hand-toggle:hover,
     .hand-toggle:focus-visible { color: var(--text); }
     .hand-toggle-title {
-      color: inherit;
-      font: 800 10px/1.2 ui-sans-serif, system-ui, sans-serif;
-      letter-spacing: 0.12em;
+      color: var(--text);
+      font: 850 11px/1.2 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.16em;
       text-transform: uppercase;
     }
     .hand-toggle-status {
-      color: var(--amber);
-      font: 800 10px/1.2 ui-sans-serif, system-ui, sans-serif;
-      letter-spacing: 0.06em;
+      min-width: 0;
+      color: var(--dim);
+      font: 700 10px/1.2 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
     .hand-toggle-chevron {
       color: var(--amber);
-      font: 800 10px/1.2 ui-sans-serif, system-ui, sans-serif;
-      letter-spacing: 0.08em;
+      font: 850 10px/1.2 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
       transform: none !important;
     }
@@ -6039,43 +6043,94 @@
       min-width: 0;
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 1px;
+      gap: 7px;
       overflow: visible;
-      padding: 7px;
-      background: var(--line);
+      padding: 8px;
+      background:
+        radial-gradient(circle at 50% -30%, rgba(222, 194, 141, 0.09), transparent 52%),
+        #090a07;
     }
     .story-card-slot {
+      --slot-accent: var(--card-control);
+      --slot-accent-rgb: var(--card-control-rgb);
       min-width: 0;
       overflow: hidden;
       display: grid;
       grid-template-rows: minmax(0, 1fr);
-      border: 1px solid rgba(var(--cmd-accent-rgb, var(--card-control-rgb)), 0.38);
-      background: #11110d;
+      position: relative;
+      isolation: isolate;
+      border: 1px solid rgba(var(--slot-accent-rgb), 0.58);
+      outline: 1px solid rgba(244, 239, 227, 0.07);
+      outline-offset: -4px;
+      background:
+        linear-gradient(145deg, rgba(var(--slot-accent-rgb), 0.1), transparent 42%),
+        #12120e;
+      box-shadow: 0 9px 24px rgba(0, 0, 0, 0.3);
     }
+    .story-card-slot:has(> .cmd.suit-head) {
+      --slot-accent: var(--suit-head);
+      --slot-accent-rgb: var(--suit-head-rgb);
+    }
+    .story-card-slot:has(> .cmd.suit-heart) {
+      --slot-accent: var(--suit-heart);
+      --slot-accent-rgb: var(--suit-heart-rgb);
+    }
+    .story-card-slot:has(> .cmd.suit-honor) {
+      --slot-accent: var(--suit-honor);
+      --slot-accent-rgb: var(--suit-honor-rgb);
+    }
+    .story-card-slot:has(> .cmd.suit-hustle) {
+      --slot-accent: var(--suit-hustle);
+      --slot-accent-rgb: var(--suit-hustle-rgb);
+    }
+    .prompt.hand-expanded .story-card-slot::after {
+      position: absolute;
+      top: 9px;
+      right: 9px;
+      z-index: 4;
+      display: grid;
+      width: 24px;
+      height: 24px;
+      place-items: center;
+      border: 1px solid rgba(var(--slot-accent-rgb), 0.76);
+      background: rgba(8, 9, 6, 0.82);
+      color: var(--slot-accent);
+      font: 800 9px/1 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.04em;
+    }
+    .prompt.hand-expanded .story-card-slot[data-story-card-slot="primary"]::after { content: "I"; }
+    .prompt.hand-expanded .story-card-slot[data-story-card-slot="secondary"]::after { content: "II"; }
+    .prompt.hand-expanded .story-card-slot[data-story-card-slot="tertiary"]::after { content: "III"; }
     .story-card-slot[hidden] { display: none !important; }
     .story-card-actions {
       display: none;
       grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-      border-top: 1px solid var(--line);
+      border-top: 1px solid rgba(var(--slot-accent-rgb), 0.42);
+      background: rgba(7, 8, 5, 0.58);
     }
     .story-card-actions button {
       min-width: 0;
-      min-height: 42px;
+      min-height: 46px;
       border: 0;
       background: transparent;
       color: var(--dim);
       padding: 7px 4px;
-      font: 750 11px/1 ui-sans-serif, system-ui, sans-serif;
+      font: 820 10px/1 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
       cursor: pointer;
     }
-    .story-card-actions button + button { border-left: 1px solid var(--line); }
-    .story-card-actions .story-card-play { color: var(--amber); }
+    .story-card-actions button + button { border-left: 1px solid rgba(var(--slot-accent-rgb), 0.28); }
+    .story-card-actions .story-card-play {
+      background: rgba(var(--slot-accent-rgb), 0.12);
+      color: var(--slot-accent);
+    }
     .story-card-actions button:hover,
     .story-card-actions button:focus-visible {
-      background: rgba(var(--cmd-accent-rgb, var(--card-control-rgb)), 0.1);
+      background: rgba(var(--slot-accent-rgb), 0.2);
       color: var(--text);
     }
-    .story-card-actions button:disabled { opacity: 0.32; cursor: default; }
+    .story-card-actions button:disabled { opacity: 0.5; cursor: default; }
     .prompt .cmd {
       width: 100%;
       min-width: 0;
@@ -6148,22 +6203,25 @@
     }
     .prompt .detail { display: none; }
     .prompt.hand-expanded .hand-rail {
-      height: clamp(238px, 34dvh, 330px);
+      height: auto;
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 1px;
+      gap: clamp(8px, 1.2vw, 14px);
       overflow: visible;
-      padding: 8px;
+      padding: clamp(10px, 1.5vw, 16px);
     }
     .prompt.hand-expanded .story-card-slot {
-      grid-template-rows: minmax(0, 1fr) 42px;
+      height: clamp(326px, 49dvh, 438px);
+      grid-template-rows: minmax(0, 1fr) 46px;
     }
     .prompt.hand-expanded .story-card-actions { display: grid; }
     .prompt.hand-expanded .cmd {
       width: 100%;
       min-width: 0;
       grid-template-columns: minmax(0, 1fr);
-      grid-template-rows: minmax(104px, 1.2fr) minmax(86px, 0.8fr);
+      grid-template-rows: clamp(174px, 27dvh, 232px) minmax(0, 1fr);
+      gap: 0;
+      padding: 0;
       opacity: 1;
       transition: none;
     }
@@ -6175,25 +6233,63 @@
       width: 100%;
       height: 100%;
       border-right: 0;
-      border-bottom: 1px solid var(--line);
+      border-bottom: 1px solid rgba(var(--cmd-accent-rgb), 0.46);
+      background-position: center 42%;
+    }
+    .prompt.hand-expanded .cmd .thumb.avatar { background-position: center 22%; }
+    .prompt.hand-expanded .cmd .thumb::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      background:
+        linear-gradient(180deg, rgba(4, 5, 3, 0.02) 55%, rgba(4, 5, 3, 0.48)),
+        linear-gradient(90deg, rgba(4, 5, 3, 0.26), transparent 7%, transparent 93%, rgba(4, 5, 3, 0.26));
+      pointer-events: none;
+    }
+    .prompt.hand-expanded .cmd .thumb::after {
+      content: "";
+      position: absolute;
+      inset: 6px;
+      z-index: 2;
+      border: 1px solid rgba(244, 239, 227, 0.34);
+      outline: 1px solid rgba(var(--cmd-accent-rgb), 0.28);
+      outline-offset: 2px;
+      pointer-events: none;
     }
     .prompt.hand-expanded .cmd-copy {
       align-content: start;
-      gap: 5px;
-      padding: 9px 8px;
+      gap: 7px;
+      padding: 13px 13px 10px;
     }
-    .prompt.hand-expanded .cmd-kicker { font-size: 9px; }
-    .prompt.hand-expanded .cmd-label { font-size: clamp(12px, 1.4vw, 16px); }
+    .prompt.hand-expanded .cmd-kicker {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--cmd-accent);
+      font-size: 9px;
+      letter-spacing: 0.14em;
+    }
+    .prompt.hand-expanded .cmd-kicker::after {
+      content: "";
+      height: 1px;
+      flex: 1 1 auto;
+      background: linear-gradient(90deg, rgba(var(--cmd-accent-rgb), 0.52), transparent);
+    }
+    .prompt.hand-expanded .cmd-label {
+      font-size: clamp(17px, 1.75vw, 22px);
+      line-height: 1.08;
+    }
     .prompt.hand-expanded .detail {
       display: -webkit-box;
       overflow: hidden;
       color: var(--dim);
-      font-size: 11px;
-      font-weight: 500;
-      line-height: 1.28;
+      font-size: clamp(11px, 1.05vw, 13px);
+      font-weight: 560;
+      line-height: 1.38;
       white-space: normal;
       -webkit-box-orient: vertical;
-      -webkit-line-clamp: 2;
+      -webkit-line-clamp: 3;
     }
     .hand-inspector { display: none !important; }
     .prompt.onboarding-mode .hand-header,
@@ -6394,12 +6490,38 @@
     @media (max-width: 560px) {
       .topbar-actions .economy { display: flex; }
       .economy-stat.orbs > strong { font-size: 10px; }
-      .prompt.hand-expanded .hand-rail { height: 274px; padding: 7px; }
-      .prompt.hand-expanded .cmd { grid-template-rows: 112px minmax(0, 1fr); }
-      .prompt.hand-expanded .cmd-copy { padding: 8px 6px; }
-      .prompt.hand-expanded .cmd-label { font-size: 12px; }
-      .prompt.hand-expanded .detail { font-size: 10px; -webkit-line-clamp: 2; }
-      .story-card-actions button { min-height: 40px; font-size: 10px; }
+      .prompt.hand-expanded .hand-rail {
+        height: auto;
+        display: flex;
+        gap: 10px;
+        overflow-x: auto;
+        padding: 10px 18px 14px;
+        scroll-padding-inline: 18px;
+        scroll-snap-type: x mandatory;
+        overscroll-behavior-inline: contain;
+        scrollbar-width: none;
+      }
+      .prompt.hand-expanded .hand-rail::-webkit-scrollbar { display: none; }
+      .prompt.hand-expanded .story-card-slot {
+        height: clamp(316px, 60dvh, 410px);
+        flex: 0 0 calc(100% - 36px);
+        scroll-snap-align: center;
+      }
+      .prompt.hand-expanded .cmd { grid-template-rows: clamp(146px, 28dvh, 190px) minmax(0, 1fr); }
+      .prompt.hand-expanded .cmd.has-copy .thumb,
+      .prompt.hand-expanded .cmd.has-copy .thumb.avatar,
+      .prompt.hand-expanded .cmd.has-copy .thumb.item,
+      .prompt.hand-expanded .cmd.has-copy .thumb.location,
+      .prompt.hand-expanded .cmd.has-copy .thumb.action-mini-card {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        flex: none;
+      }
+      .prompt.hand-expanded .cmd-copy { padding: 12px 11px 9px; }
+      .prompt.hand-expanded .cmd-label { font-size: 18px; }
+      .prompt.hand-expanded .detail { font-size: 11px; -webkit-line-clamp: 3; }
+      .story-card-actions button { min-height: 46px; font-size: 10px; }
       .account-panel.minimal-menu { border-right: 0; border-left: 0; }
       .minimal-menu-player,
       .minimal-menu-orbs,
@@ -6418,7 +6540,7 @@
       .prompt .cmd .thumb.action-mini-card { width: 44px; }
       .prompt.hand-expanded .cmd {
         grid-template-columns: minmax(0, 1fr);
-        grid-template-rows: 98px minmax(0, 1fr);
+        grid-template-rows: clamp(138px, 27dvh, 172px) minmax(0, 1fr);
       }
       .prompt.hand-expanded .cmd .thumb,
       .prompt.hand-expanded .cmd .thumb.location,
@@ -9119,7 +9241,10 @@
           const groupedExits = routeGroup.exits;
           const firstExit = groupedExits[0];
           const onePath = groupedExits.length === 1;
-          const firstPathwayDirection = pathwayDirectionForExit(firstExit, pathwayJourney);
+          // A journey exists at its origin before the pathway progress stage is
+          // active. Travel cards still represent the journey endpoint there,
+          // rather than the first generated waypoint.
+          const firstPathwayDirection = pathwayDirectionForExit(firstExit, journey);
           const searchingPathway = false;
           const fleeing = routeGroup.mode === "flee";
           const routeOffer = routeOffers.find((offer) => (
@@ -9222,7 +9347,7 @@
               : (searchingPathway ? "the first adjacent stretch of the chosen pathway is revealed" : "you arrive at the place you choose"),
             ...(onePath ? {} : {
               choices: groupedExits.map((exit) => {
-                const direction = pathwayDirectionForExit(exit, pathwayJourney);
+                const direction = pathwayDirectionForExit(exit, journey);
                 return {
                   label: direction ? `toward ${direction.endpointName}` : (exit.route_label || exit.destination_location_name),
                   detail: direction
@@ -9246,7 +9371,7 @@
             : (searchingPathway ? "searching" : "travelling");
           routeAction.busyDetail = () => {
             const selectedExit = selectedRouteExit();
-            const selectedDirection = pathwayDirectionForExit(selectedExit, pathwayJourney);
+            const selectedDirection = pathwayDirectionForExit(selectedExit, journey);
             if (selectedDirection) return `following the path toward ${selectedDirection.endpointName}…`;
             if (fleeing) return `hurrying toward ${selectedExit.destination_location_name}…`;
             if (searchingPathway) return `finding the path toward ${selectedExit.destination_location_name}…`;
@@ -17342,7 +17467,7 @@
       prompt.classList.toggle("hand-expanded", expanded);
       $("hand-toggle").setAttribute("aria-expanded", expanded ? "true" : "false");
       const count = visibleActions.length;
-      $("hand-toggle-status").textContent = expanded ? "Close" : `${count} ${count === 1 ? "card" : "cards"}`;
+      $("hand-toggle-status").textContent = `${count} ${count === 1 ? "card" : "cards"}`;
       ["primary", "secondary", "tertiary"].forEach((id, index) => {
         const action = visibleActions[index] || null;
         const slot = document.querySelector(`[data-story-card-slot="${id}"]`);

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -694,6 +694,8 @@ async function main() {
       setStoryHandExpanded(true, visibleFocusedAction());
       const prompt = document.querySelector("footer.prompt");
       const visibleSlots = [...document.querySelectorAll(".story-card-slot:not([hidden])")];
+      const artRects = visibleSlots.map((slot) => slot.querySelector(".cmd .thumb")?.getBoundingClientRect());
+      const commandRects = visibleSlots.map((slot) => slot.querySelector(".cmd")?.getBoundingClientRect());
       return {
         controlId,
         promptExpanded: prompt.classList.contains("hand-expanded"),
@@ -712,6 +714,18 @@ async function main() {
               || thumb.querySelector("img")?.getAttribute("src")
           ));
         }),
+        fullWidthArtwork: artRects.every((rect, index) => (
+          rect && commandRects[index] && Math.abs(rect.width - commandRects[index].width) < 2
+        )),
+        consistentArtwork: artRects.every((rect) => (
+          rect
+            && Math.abs(rect.width - artRects[0].width) < 2
+            && Math.abs(rect.height - artRects[0].height) < 2
+        )),
+        framed: visibleSlots.every((slot) => (
+          getComputedStyle(slot).borderTopStyle === "solid"
+            && getComputedStyle(slot).outlineStyle === "solid"
+        )),
         squareCorners: visibleSlots.every((slot) => (
           Number.parseFloat(getComputedStyle(slot).borderTopLeftRadius) === 0
             && Number.parseFloat(getComputedStyle(slot.querySelector(".cmd")).borderTopLeftRadius) === 0
@@ -727,6 +741,9 @@ async function main() {
         && expanded.cardCount === initial.visibleKeys.length
         && expanded.inlineActions
         && expanded.imageLed
+        && expanded.fullWidthArtwork
+        && expanded.consistentArtwork
+        && expanded.framed
         && expanded.squareCorners,
       `the expanded Story Hand should show three sharp illustrated cards with inline Play and Discard: ${JSON.stringify(expanded)}`,
     );
@@ -9462,6 +9479,35 @@ async function main() {
         },
       });
       const travelling = travellingActions.find((action) => action.focusKey === "exit:100001");
+      const originTravelActions = buildActions({
+        ...base,
+        action_offers: [...nonScoutOffers, moveOffer(100000, "Dappled Heather Run")],
+        exits: [{
+          destination_location_id: 100000,
+          destination_location_name: "Dappled Heather Run",
+          route_label: "Unmarked way from Rain-Soft Garden to Moonlit Trail",
+          direction: "east",
+          distance: 1,
+          accessible: true,
+          locked: false,
+        }],
+        journey: {
+          origin_location_id: 2,
+          origin_name: "Rain-Soft Garden",
+          destination_location_id: 3,
+          destination_name: "Moonlit Trail",
+          current_step: 0,
+          total_steps: 3,
+          steps_remaining: 3,
+          on_pathway: false,
+          explorer: true,
+          previous_location_id: null,
+          previous_location_name: null,
+          next_location_id: 100000,
+          next_location_name: "Dappled Heather Run",
+        },
+      });
+      const originTravel = originTravelActions.find((action) => action.focusKey === "exit:100000");
       const backtrackingActions = buildActions({
         ...base,
         action_offers: [...nonScoutOffers, moveOffer(2, "Rain-Soft Garden")],
@@ -9696,6 +9742,12 @@ async function main() {
           modalSummary: travelling?.modalSummary,
           direction: travelling?.pathwayDirection,
         },
+        originTravel: {
+          detail: originTravel?.detail,
+          accessibleLabel: originTravel?.accessibleLabel,
+          destinationOnlyCardLabel: originTravel?.destinationOnlyCardLabel,
+          direction: originTravel?.pathwayDirection,
+        },
         backtracking: {
           label: backtracking?.label,
           detail: backtracking?.detail,
@@ -9754,6 +9806,14 @@ async function main() {
         && result.travelling.direction?.endpointName === "Moonlit Trail"
         && result.travellingActionCount > 1,
       `a revealed adjacent interior segment should present endpoint direction instead of its waypoint name: ${JSON.stringify(result)}`,
+    );
+    assert(
+      result.originTravel.detail === "toward Moonlit Trail"
+        && result.originTravel.accessibleLabel === "Travel toward Moonlit Trail"
+        && result.originTravel.destinationOnlyCardLabel === "Moonlit Trail"
+        && result.originTravel.direction?.side === "forward"
+        && result.originTravel.direction?.endpointId === 3,
+      `the first Travel card should present the final journey destination instead of its next path segment: ${JSON.stringify(result)}`,
     );
     assert(
       result.backtracking.label === "travel"
@@ -14489,6 +14549,7 @@ async function main() {
   await assertRoomSummaryStaysFlatAndMechanical();
   await assertGapRecoveryStatusClears();
   await assertStatusBarDoesNotOverlayTranscript("mobile status row");
+  await assertJourneyCardContract();
   await assertJournalModeContract("mobile Journal");
   await assertJournalTickerLayout();
   await assertUiAccessibilityContract("mobile accessibility and navigation");
@@ -14502,7 +14563,6 @@ async function main() {
   await assertCardBeatsStayInSceneAndBookkeepingStaysOut();
   await assertLanternKeeperSemanticStoryReceipt();
   await assertLanternQuestionAndTwoSuggestionAccessibility();
-  await assertJourneyCardContract();
   await assertHumanActionRequiresActorSession();
   await assertSeedArtAvailable();
   await assertFirstBellCatalogAssetsAvailable();

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -12901,6 +12901,17 @@ async function main() {
       const viewportWidth = window.innerWidth;
       const viewportHeight = window.innerHeight;
       const selector = ".shell,.topbar,.terminal,.room,.room-log-toggle,.journal-view,.journal-heading,.journal-stream,.journal-row,.journal-row-summary,.room-memory,.room-avatar-pfp,.chat-pfp,.updates,.log,.line,.speaker,.text,.status,.prompt,.cmd,.thumb,.location-pill";
+      const hasScrollableAncestor = (node, axis) => {
+        for (let ancestor = node.parentElement; ancestor; ancestor = ancestor.parentElement) {
+          const style = getComputedStyle(ancestor);
+          const overflowStyle = axis === "x" ? style.overflowX : style.overflowY;
+          if (!["auto", "scroll"].includes(overflowStyle)) continue;
+          const scrollSize = axis === "x" ? ancestor.scrollWidth : ancestor.scrollHeight;
+          const clientSize = axis === "x" ? ancestor.clientWidth : ancestor.clientHeight;
+          if (scrollSize > clientSize + 1) return true;
+        }
+        return false;
+      };
       return [...document.querySelectorAll(selector)]
         .filter((node) => {
           const style = getComputedStyle(node);
@@ -12911,7 +12922,8 @@ async function main() {
           const rect = node.getBoundingClientRect();
           return {
             selector: node.id ? `#${node.id}` : node.className || node.tagName,
-            inScrollableLog: Boolean(node.closest("#log, .journal-stream")),
+            inHorizontalScroller: hasScrollableAncestor(node, "x"),
+            inVerticalScroller: hasScrollableAncestor(node, "y"),
             left: rect.left,
             right: rect.right,
             top: rect.top,
@@ -12921,9 +12933,8 @@ async function main() {
           };
         })
         .find((rect) => (
-          rect.left < -1
-          || rect.right > viewportWidth + 1
-          || (!rect.inScrollableLog && (rect.top < -1 || rect.bottom > viewportHeight + 1))
+          (!rect.inHorizontalScroller && (rect.left < -1 || rect.right > viewportWidth + 1))
+          || (!rect.inVerticalScroller && (rect.top < -1 || rect.bottom > viewportHeight + 1))
         ));
     });
     assert(!overflow, `visible UI overflowed the viewport: ${JSON.stringify(overflow)}`);


### PR DESCRIPTION
## Summary

- redesign the expanded Story Hand as a consistent collectible-card set with full-width framed artwork, suit accents, numbered marks, and mobile swipe sizing
- keep expanded-hand copy and actions visually consistent across all three slots
- make Travel cards show and illustrate the journey's final destination from the first path segment, including reconnect/at-origin state
- add browser regressions for card framing and the Dappled Heather Run → Moonlit Trail endpoint case
- bump the release version to 1.0.53 as required by the repository gate

## Verification

- `cargo build`
- complete Playwright browser smoke on mobile and desktop
- repository pre-push `npm run check` (unit, worldpack, composition, kernel, 1,183 Rust tests, architecture, lint, and syntax checks)