### PR TITLE
Co-locate autonomy decision system into autonomy.rs, delete dead ripple zone branch (-241)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.62",
+      "version": "1.0.63",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.62"
+version = "1.0.63"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.62"
+version = "1.0.63"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/autonomy.rs
+++ b/v2/orchestrator-rust/src/autonomy.rs
@@ -1874,6 +1874,247 @@ impl RuntimeWorld {
             .next()
             .map(|candidate| candidate.record.action)
     }
+
+    pub(crate) fn resident_waits_for_player_gift(&self, resident: CwActor) -> bool {
+        self.world.actors[..self.world.actor_count]
+            .iter()
+            .copied()
+            .filter(|actor| {
+                Self::actor_can_act(*actor)
+                    && actor.id != resident.id
+                    && actor.location_id == resident.location_id
+            })
+            .any(|actor| {
+                self.resident_request_for_holder(resident, actor.id)
+                    .is_some()
+            })
+    }
+
+    pub(crate) fn resident_mutual_trade_candidate(
+        &self,
+        actor: CwActor,
+    ) -> Option<ResidentMutualTradeCandidate> {
+        if !Self::actor_can_act(actor) {
+            return None;
+        }
+        let actor_items = self.actor_held_items(actor.id);
+        if actor_items.is_empty() {
+            return None;
+        }
+
+        let mut targets: Vec<_> = self.world.actors[..self.world.actor_count]
+            .iter()
+            .copied()
+            .filter(|target| {
+                target.id != actor.id
+                    && Self::actor_can_act(*target)
+                    && target.location_id == actor.location_id
+                    && self.resident_remembers_actor_at(actor.id, target.id, actor.location_id)
+            })
+            .collect();
+        targets.sort_by_key(|target| target.id);
+
+        let mut candidates = Vec::new();
+        for target in targets {
+            for actor_item in &actor_items {
+                for target_item in self.actor_held_items(target.id) {
+                    if !self.resident_remembers_actor_holding_item_at(
+                        actor.id,
+                        target.id,
+                        target_item.id,
+                        actor.location_id,
+                    ) {
+                        continue;
+                    }
+                    let Some(target_desire_memory) =
+                        self.resident_actor_wants_item_memory(actor.id, target.id, actor_item.id)
+                    else {
+                        continue;
+                    };
+                    let target_preference =
+                        self.resident_trade_preference(target.id, *actor_item, target_item);
+                    let actor_preference =
+                        self.resident_trade_preference(actor.id, target_item, *actor_item);
+                    if target_preference.accepted && actor_preference.accepted {
+                        candidates.push(ResidentMutualTradeCandidate {
+                            actor_item: *actor_item,
+                            target,
+                            target_item,
+                            actor_preference,
+                            target_preference,
+                            target_desire_confidence: target_desire_memory.confidence,
+                            target_desire_salience: target_desire_memory.salience,
+                            target_desire_observed_tick: target_desire_memory.observed_tick,
+                        });
+                    }
+                }
+            }
+        }
+        candidates.sort_by(|left, right| {
+            let left_score = left
+                .actor_preference
+                .score
+                .saturating_add(left.target_preference.score);
+            let right_score = right
+                .actor_preference
+                .score
+                .saturating_add(right.target_preference.score);
+            right_score
+                .cmp(&left_score)
+                .then_with(|| {
+                    right
+                        .target_desire_salience
+                        .cmp(&left.target_desire_salience)
+                })
+                .then_with(|| {
+                    right
+                        .target_desire_confidence
+                        .cmp(&left.target_desire_confidence)
+                })
+                .then_with(|| {
+                    right
+                        .target_desire_observed_tick
+                        .cmp(&left.target_desire_observed_tick)
+                })
+                .then_with(|| left.target.id.cmp(&right.target.id))
+                .then_with(|| left.target_item.id.cmp(&right.target_item.id))
+                .then_with(|| left.actor_item.id.cmp(&right.actor_item.id))
+        });
+        candidates.into_iter().next()
+    }
+
+    pub(crate) fn resident_gift_candidate(&self, actor: CwActor) -> Option<ResidentGiftCandidate> {
+        if !Self::actor_can_act(actor) {
+            return None;
+        }
+        let actor_items = self.actor_held_items(actor.id);
+        if actor_items.is_empty() {
+            return None;
+        }
+
+        let mut targets: Vec<_> = self.world.actors[..self.world.actor_count]
+            .iter()
+            .copied()
+            .filter(|target| {
+                target.id != actor.id
+                    && Self::actor_can_act(*target)
+                    && target.location_id == actor.location_id
+                    && self.resident_remembers_actor_at(actor.id, target.id, actor.location_id)
+            })
+            .collect();
+        targets.sort_by_key(|target| target.id);
+
+        let mut candidates = Vec::new();
+        for actor_item in actor_items {
+            if self.resident_item_is_attached(actor.id, actor_item) {
+                continue;
+            }
+            for target in &targets {
+                if !self.actor_can_receive_item(*target, actor_item.id) {
+                    continue;
+                }
+                if let Some(desire_memory) =
+                    self.resident_actor_wants_item_memory(actor.id, target.id, actor_item.id)
+                {
+                    candidates.push(ResidentGiftCandidate {
+                        actor_item,
+                        target: *target,
+                        desire_confidence: desire_memory.confidence,
+                        desire_salience: desire_memory.salience,
+                        desire_observed_tick: desire_memory.observed_tick,
+                    });
+                }
+            }
+        }
+        candidates.sort_by_key(|candidate| {
+            (
+                std::cmp::Reverse(candidate.desire_salience),
+                std::cmp::Reverse(candidate.desire_confidence),
+                std::cmp::Reverse(candidate.desire_observed_tick),
+                self.resident_item_keep_score(actor, candidate.actor_item),
+                candidate.target.id,
+                candidate.actor_item.id,
+            )
+        });
+        candidates.into_iter().next()
+    }
+
+    pub(crate) fn resident_delivery_candidate(
+        &self,
+        actor: CwActor,
+    ) -> Option<ResidentDeliveryCandidate> {
+        if !Self::actor_can_act(actor) {
+            return None;
+        }
+        let actor_items = self.actor_held_items(actor.id);
+        if actor_items.is_empty() {
+            return None;
+        }
+
+        let mut candidates = Vec::new();
+        for actor_item in actor_items {
+            if self.resident_item_is_attached(actor.id, actor_item) {
+                continue;
+            }
+            let target_memories: Vec<_> = self
+                .beliefs
+                .values()
+                .filter(|memory| {
+                    memory.holder_actor_id == actor.id
+                        && memory.kind == BELIEF_KIND_ACTOR_LOCATION
+                        && memory.subject_id != actor.id
+                        && memory.confidence >= BELIEF_TUNING.minimum_action_confidence
+                })
+                .cloned()
+                .collect();
+            for memory in target_memories {
+                let Some(target) = self.actor_by_id(memory.subject_id) else {
+                    continue;
+                };
+                if !Self::actor_can_act(target) {
+                    continue;
+                }
+                let Some(desire_memory) =
+                    self.resident_actor_wants_item_memory(actor.id, target.id, actor_item.id)
+                else {
+                    continue;
+                };
+                if memory.location_id == actor.location_id
+                    || self
+                        .next_unlocked_step_toward(actor.location_id, memory.location_id)
+                        .is_none()
+                {
+                    continue;
+                }
+                candidates.push(ResidentDeliveryCandidate {
+                    actor_item,
+                    target,
+                    target_location_id: memory.location_id,
+                    confidence: memory.confidence,
+                    salience: memory.salience,
+                    observed_tick: memory.observed_tick,
+                    desire_confidence: desire_memory.confidence,
+                    desire_salience: desire_memory.salience,
+                    desire_observed_tick: desire_memory.observed_tick,
+                });
+            }
+        }
+        candidates.sort_by_key(|candidate| {
+            (
+                std::cmp::Reverse(candidate.desire_salience),
+                std::cmp::Reverse(candidate.desire_confidence),
+                std::cmp::Reverse(candidate.desire_observed_tick),
+                self.resident_item_keep_score(actor, candidate.actor_item),
+                std::cmp::Reverse(candidate.salience),
+                std::cmp::Reverse(candidate.confidence),
+                std::cmp::Reverse(candidate.observed_tick),
+                candidate.target_location_id,
+                candidate.target.id,
+                candidate.actor_item.id,
+            )
+        });
+        candidates.into_iter().next()
+    }
 }
 
 #[cfg(test)]

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -65,6 +65,7 @@ mod local_leads;
 mod materialization_retirement;
 // The legacy canary evaluator remains readable for frozen-job compatibility
 // and audit tests, while live evolution now always preserves its parent image.
+mod autonomy;
 #[allow(dead_code)]
 mod media_evolution;
 mod media_recipes;
@@ -92,7 +93,6 @@ mod quest_loot;
 mod rate_limit;
 mod relationships;
 mod resident_image;
-mod resident_offer_scoring;
 mod residents;
 mod rest;
 mod room_memory;
@@ -2200,17 +2200,14 @@ impl RippleBudget {
                 allow_movement: false,
             };
         }
-        match zone {
-            ZONE_FRONTIER => Self {
-                resident_actions: 1,
-                allow_wander: true,
-                allow_movement: true,
-            },
-            _ => Self {
-                resident_actions: 1,
-                allow_wander: true,
-                allow_movement: true,
-            },
+        // Zone does not differentiate the ripple budget: both frontier and
+        // sanctuary residents receive the same allowance. The zone is still
+        // tracked in the RippleContext for downstream filtering and projection.
+        let _ = zone;
+        Self {
+            resident_actions: 1,
+            allow_wander: true,
+            allow_movement: true,
         }
     }
 }
@@ -14303,21 +14300,6 @@ impl RuntimeWorld {
             .find(|item| item.id == item_id)
     }
 
-    fn resident_waits_for_player_gift(&self, resident: CwActor) -> bool {
-        self.world.actors[..self.world.actor_count]
-            .iter()
-            .copied()
-            .filter(|actor| {
-                Self::actor_can_act(*actor)
-                    && actor.id != resident.id
-                    && actor.location_id == resident.location_id
-            })
-            .any(|actor| {
-                self.resident_request_for_holder(resident, actor.id)
-                    .is_some()
-            })
-    }
-
     fn resident_economy_prompt_note(
         &self,
         resident: CwActor,
@@ -17613,229 +17595,6 @@ The relationship statement they are preserving is: {statement}"
                 .then_with(|| left.offered_item.id.cmp(&right.offered_item.id))
         });
         candidates
-    }
-
-    fn resident_mutual_trade_candidate(
-        &self,
-        actor: CwActor,
-    ) -> Option<ResidentMutualTradeCandidate> {
-        if !Self::actor_can_act(actor) {
-            return None;
-        }
-        let actor_items = self.actor_held_items(actor.id);
-        if actor_items.is_empty() {
-            return None;
-        }
-
-        let mut targets: Vec<_> = self.world.actors[..self.world.actor_count]
-            .iter()
-            .copied()
-            .filter(|target| {
-                target.id != actor.id
-                    && Self::actor_can_act(*target)
-                    && target.location_id == actor.location_id
-                    && self.resident_remembers_actor_at(actor.id, target.id, actor.location_id)
-            })
-            .collect();
-        targets.sort_by_key(|target| target.id);
-
-        let mut candidates = Vec::new();
-        for target in targets {
-            for actor_item in &actor_items {
-                for target_item in self.actor_held_items(target.id) {
-                    if !self.resident_remembers_actor_holding_item_at(
-                        actor.id,
-                        target.id,
-                        target_item.id,
-                        actor.location_id,
-                    ) {
-                        continue;
-                    }
-                    let Some(target_desire_memory) =
-                        self.resident_actor_wants_item_memory(actor.id, target.id, actor_item.id)
-                    else {
-                        continue;
-                    };
-                    let target_preference =
-                        self.resident_trade_preference(target.id, *actor_item, target_item);
-                    let actor_preference =
-                        self.resident_trade_preference(actor.id, target_item, *actor_item);
-                    if target_preference.accepted && actor_preference.accepted {
-                        candidates.push(ResidentMutualTradeCandidate {
-                            actor_item: *actor_item,
-                            target,
-                            target_item,
-                            actor_preference,
-                            target_preference,
-                            target_desire_confidence: target_desire_memory.confidence,
-                            target_desire_salience: target_desire_memory.salience,
-                            target_desire_observed_tick: target_desire_memory.observed_tick,
-                        });
-                    }
-                }
-            }
-        }
-        candidates.sort_by(|left, right| {
-            let left_score = left
-                .actor_preference
-                .score
-                .saturating_add(left.target_preference.score);
-            let right_score = right
-                .actor_preference
-                .score
-                .saturating_add(right.target_preference.score);
-            right_score
-                .cmp(&left_score)
-                .then_with(|| {
-                    right
-                        .target_desire_salience
-                        .cmp(&left.target_desire_salience)
-                })
-                .then_with(|| {
-                    right
-                        .target_desire_confidence
-                        .cmp(&left.target_desire_confidence)
-                })
-                .then_with(|| {
-                    right
-                        .target_desire_observed_tick
-                        .cmp(&left.target_desire_observed_tick)
-                })
-                .then_with(|| left.target.id.cmp(&right.target.id))
-                .then_with(|| left.target_item.id.cmp(&right.target_item.id))
-                .then_with(|| left.actor_item.id.cmp(&right.actor_item.id))
-        });
-        candidates.into_iter().next()
-    }
-
-    fn resident_gift_candidate(&self, actor: CwActor) -> Option<ResidentGiftCandidate> {
-        if !Self::actor_can_act(actor) {
-            return None;
-        }
-        let actor_items = self.actor_held_items(actor.id);
-        if actor_items.is_empty() {
-            return None;
-        }
-
-        let mut targets: Vec<_> = self.world.actors[..self.world.actor_count]
-            .iter()
-            .copied()
-            .filter(|target| {
-                target.id != actor.id
-                    && Self::actor_can_act(*target)
-                    && target.location_id == actor.location_id
-                    && self.resident_remembers_actor_at(actor.id, target.id, actor.location_id)
-            })
-            .collect();
-        targets.sort_by_key(|target| target.id);
-
-        let mut candidates = Vec::new();
-        for actor_item in actor_items {
-            if self.resident_item_is_attached(actor.id, actor_item) {
-                continue;
-            }
-            for target in &targets {
-                if !self.actor_can_receive_item(*target, actor_item.id) {
-                    continue;
-                }
-                if let Some(desire_memory) =
-                    self.resident_actor_wants_item_memory(actor.id, target.id, actor_item.id)
-                {
-                    candidates.push(ResidentGiftCandidate {
-                        actor_item,
-                        target: *target,
-                        desire_confidence: desire_memory.confidence,
-                        desire_salience: desire_memory.salience,
-                        desire_observed_tick: desire_memory.observed_tick,
-                    });
-                }
-            }
-        }
-        candidates.sort_by_key(|candidate| {
-            (
-                std::cmp::Reverse(candidate.desire_salience),
-                std::cmp::Reverse(candidate.desire_confidence),
-                std::cmp::Reverse(candidate.desire_observed_tick),
-                self.resident_item_keep_score(actor, candidate.actor_item),
-                candidate.target.id,
-                candidate.actor_item.id,
-            )
-        });
-        candidates.into_iter().next()
-    }
-
-    fn resident_delivery_candidate(&self, actor: CwActor) -> Option<ResidentDeliveryCandidate> {
-        if !Self::actor_can_act(actor) {
-            return None;
-        }
-        let actor_items = self.actor_held_items(actor.id);
-        if actor_items.is_empty() {
-            return None;
-        }
-
-        let mut candidates = Vec::new();
-        for actor_item in actor_items {
-            if self.resident_item_is_attached(actor.id, actor_item) {
-                continue;
-            }
-            let target_memories: Vec<_> = self
-                .beliefs
-                .values()
-                .filter(|memory| {
-                    memory.holder_actor_id == actor.id
-                        && memory.kind == BELIEF_KIND_ACTOR_LOCATION
-                        && memory.subject_id != actor.id
-                        && memory.confidence >= BELIEF_TUNING.minimum_action_confidence
-                })
-                .cloned()
-                .collect();
-            for memory in target_memories {
-                let Some(target) = self.actor_by_id(memory.subject_id) else {
-                    continue;
-                };
-                if !Self::actor_can_act(target) {
-                    continue;
-                }
-                let Some(desire_memory) =
-                    self.resident_actor_wants_item_memory(actor.id, target.id, actor_item.id)
-                else {
-                    continue;
-                };
-                if memory.location_id == actor.location_id
-                    || self
-                        .next_unlocked_step_toward(actor.location_id, memory.location_id)
-                        .is_none()
-                {
-                    continue;
-                }
-                candidates.push(ResidentDeliveryCandidate {
-                    actor_item,
-                    target,
-                    target_location_id: memory.location_id,
-                    confidence: memory.confidence,
-                    salience: memory.salience,
-                    observed_tick: memory.observed_tick,
-                    desire_confidence: desire_memory.confidence,
-                    desire_salience: desire_memory.salience,
-                    desire_observed_tick: desire_memory.observed_tick,
-                });
-            }
-        }
-        candidates.sort_by_key(|candidate| {
-            (
-                std::cmp::Reverse(candidate.desire_salience),
-                std::cmp::Reverse(candidate.desire_confidence),
-                std::cmp::Reverse(candidate.desire_observed_tick),
-                self.resident_item_keep_score(actor, candidate.actor_item),
-                std::cmp::Reverse(candidate.salience),
-                std::cmp::Reverse(candidate.confidence),
-                std::cmp::Reverse(candidate.observed_tick),
-                candidate.target_location_id,
-                candidate.target.id,
-                candidate.actor_item.id,
-            )
-        });
-        candidates.into_iter().next()
     }
 
     fn resident_trade_is_willing(

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -342,4 +342,9 @@
 # from main.rs into resident_offer_scoring.rs as pub(crate). The 3 AI-speech
 # collision methods (resident_reply_repeats_recent_event, collision_safe_*)
 # stay in main.rs. Pure, behavior-preserving.
-63826
+# Co-locate autonomy cascade candidate generators (resident_waits_for_player_gift,
+# resident_mutual_trade/gift/delivery_candidate) from main.rs into autonomy.rs
+# (was resident_offer_scoring.rs). Rename module to reflect its role as the
+# autonomy decision system home. Delete dead RippleBudget zone branch where
+# frontier and sanctuary returned identical budgets. Behavior-preserving.
+63585


### PR DESCRIPTION
## What this does

Step 0 of making the resident autonomy system extensible: **co-locate the entire autonomy decision system into one module** and clean up a dead branch.

### Changes

1. **Move 4 candidate generators from `main.rs` into the autonomy module** (`pub(crate)`):
   - `resident_waits_for_player_gift`
   - `resident_mutual_trade_candidate`
   - `resident_gift_candidate`
   - `resident_delivery_candidate`

   These are the "verb candidate generators" that the intra-actor cascade (`resident_economy_autonomy_action`) tries in order. The cascade already lived in this module; the generators it calls were still in `main.rs`. They're now co-located.

2. **Rename `resident_offer_scoring.rs` → `autonomy.rs`** and update the `mod` declaration. The old name described a subset of the file's content. The file is now the single home for the entire resident autonomy decision system: the greedy cascade, the inter-actor priority scheduler, the 20 named rank tiers, record generation, ripple candidate selection, intent projection, and the candidate generators themselves.

3. **Delete the dead `RippleBudget::for_zone_and_action` zone branch.** The `ZONE_FRONTIER` arm and the `_` catch-all arm returned byte-identical budgets (`resident_actions: 1, allow_wander: true, allow_movement: true`). The zone is still tracked in `RippleContext` for downstream filtering; only the budget computation was dead. Replaced with a single return + explanatory comment.

### What this does NOT do (deferred to follow-up PRs)

- **Close the stringly-typed verb vocabulary.** `resident_record_offer_kind` returns a `String` matched against ~27 string literals. Converting to a closed `enum ResidentOfferKind` is the natural next step but has a wider blast radius (touch offer matching, priority, intent projection). Safer as its own PR once all call sites are visible in `autonomy.rs`.
- **Move the shared trade/gift policy helpers** (`resident_trade_is_willing`, `resident_item_offer_score`, `resident_trade_preference`, etc.) — these are called from both the autonomy cascade and the player-action path, so they belong in a separate `trade.rs`/`gifts.rs` module, not the autonomy module.
- **Move autonomy inline tests** from `main.rs`'s `mod tests` into `autonomy.rs`'s `mod tests`. Cosmetic; the tests work fine via `pub(crate)` visibility.

### Why this matters

Before this PR, extending autonomy required touching 4 places across 3 files (a cascade branch in `autonomy.rs`, a candidate generator in `main.rs`, a rank constant, and a priority match arm). This PR doesn't yet make verbs data-driven, but it makes the whole decision system **legible in one file** — the prerequisite for the next step (declared verb priorities in pack data).

### Verification

- `cargo test`: 1184 passed, 0 failed
- `cargo clippy`: 225 warnings (at ceiling)
- `cargo fmt`: clean
- `check-main-size.sh`: 63585 lines (ceiling 63585, was 63826)
- Pre-push hook: full `npm run check` (Vitest + worldpack + C kernel + Rust + architecture + syntax) — all green
- Behavior-preserving: no logic changes, only code movement + dead-branch deletion

main.rs: 63826 → 63585 (−241 lines)
