### PR TITLE
Mount Lonely Forest character art in the Lantern Keeper world

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.63",
+      "version": "1.0.64",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/worldpack-bundle-gate.test.mjs
+++ b/test/v2/worldpack-bundle-gate.test.mjs
@@ -34,8 +34,8 @@ function digest(value) {
 const LIVE_HASH = digest("live-journal-bundle");
 const CANDIDATE_HASH = digest("candidate-bundle");
 const OLDER_HASH = digest("older-declared-bundle");
-const LANTERN_ACTIVE_HASH = "sha256:603bf802566d36b81c2da472f36f8d94d951e54716a0fa1deb2e798b09a4ad71";
-const LANTERN_PREVIOUS_ACTIVE_HASH = "sha256:ff28d95b0c55d4add61634860c53892a87130b1829bb619c744cc8f4e6114a1a";
+const LANTERN_ACTIVE_HASH = "sha256:75a8ad1bb47c1bb3a94803bb2077a2f1928250cf6e1851ca18e8aca508dc9ba8";
+const LANTERN_PREVIOUS_ACTIVE_HASH = "sha256:603bf802566d36b81c2da472f36f8d94d951e54716a0fa1deb2e798b09a4ad71";
 const LANTERN_PERSISTED_HASH = "sha256:f16b48db1690307acb9861bc2d5005f143ec776060d98315dd95fa21befb7911";
 const ELYSIUM_ACTIVE_HASH = "sha256:e23cc846746aadf9aba63f0c3ea821ac5f1a1b4df111fd0510fe3a6101e8bf1c";
 const ELYSIUM_FAILED_CANDIDATE_HASH = "sha256:494ba3ac7bf357b45a0d88b4e17ceb07fe0413cfc9eec561bdc875dbf0103099";
@@ -291,6 +291,13 @@ describe("worldpack deploy gate CLI", () => {
       candidateHash: candidate.bundleHash,
       candidateReplayCompatible: candidate.replayCompatible,
       liveHash: LANTERN_PERSISTED_HASH,
+    })).toMatchObject({ ok: true, status: "declared_migration" });
+    // The deployed world is persisted at the outgoing active hash, so mounting
+    // the character art pack must not strand it.
+    expect(evaluateWorldpackGate({
+      candidateHash: candidate.bundleHash,
+      candidateReplayCompatible: candidate.replayCompatible,
+      liveHash: LANTERN_PREVIOUS_ACTIVE_HASH,
     })).toMatchObject({ ok: true, status: "declared_migration" });
   });
 

--- a/v2/content/lantern-keeper/assets.json
+++ b/v2/content/lantern-keeper/assets.json
@@ -24,5 +24,18 @@
     "content_hash": "sha256:656d332e4a10235b882f187db185869072987cece36fe78218c8ac4039d2d144",
     "optional": false,
     "fallback": null
+  },
+  {
+    "pack_id": "cosyworld.lonely-forest.characters",
+    "pack_version": "1.1.1",
+    "pack_integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+    "provider": "cosyworld.lonely-forest.characters/assets",
+    "mount": "characters",
+    "root": "lonely-forest",
+    "directory": "assets/characters/slices",
+    "public_prefix": "/assets/lonely-forest/characters",
+    "content_hash": "sha256:d45eb30a962de236ddba913834e8bdaa7b9c530bc6b66383e272118218797d93",
+    "optional": false,
+    "fallback": null
   }
 ]

--- a/v2/content/lantern-keeper/licenses.json
+++ b/v2/content/lantern-keeper/licenses.json
@@ -116,5 +116,18 @@
       "source_url": "https://github.com/cenetex/cosyworld"
     },
     "notices": []
+  },
+  {
+    "pack_id": "cosyworld.lonely-forest.characters",
+    "name": "Lonely Forest Character Art",
+    "version": "1.1.1",
+    "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+    "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+    "provenance": {
+      "author": "Cenetex",
+      "source_name": "Cenetex Lonely Forest character art",
+      "source_url": "https://github.com/cenetex/cosyworld"
+    },
+    "notices": []
   }
 ]

--- a/v2/content/lantern-keeper/registry.json
+++ b/v2/content/lantern-keeper/registry.json
@@ -12,6 +12,7 @@
     "persistence_compatibility": {
       "schema_version": 1,
       "replay_compatible_bundle_hashes": [
+        "sha256:603bf802566d36b81c2da472f36f8d94d951e54716a0fa1deb2e798b09a4ad71",
         "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586",
         "sha256:29db5ba3069c84dea79e90a5f707d0c1fc730c446f3948224f70539c91fe2bfb",
         "sha256:f16b48db1690307acb9861bc2d5005f143ec776060d98315dd95fa21befb7911",
@@ -756,7 +757,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:603bf802566d36b81c2da472f36f8d94d951e54716a0fa1deb2e798b09a4ad71",
+    "bundle_hash": "sha256:75a8ad1bb47c1bb3a94803bb2077a2f1928250cf6e1851ca18e8aca508dc9ba8",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -2447,6 +2448,97 @@
           "path": "../../content/core-lantern-keeper-bridge"
         },
         "integrity": "sha256:81a880cc3d9afaa6767c9ae64eba5016749de8807df69cef68eb1ca2ea34e35e"
+      },
+      {
+        "id": "cosyworld.lonely-forest.characters",
+        "name": "Lonely Forest Character Art",
+        "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
+        "version": "1.1.1",
+        "kind": "assets",
+        "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+        "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+        "engine": ">=0.0.20 <0.1.0",
+        "capabilities": [
+          {
+            "id": "cosyworld.lonely-forest.characters/assets",
+            "kind": "assets",
+            "version": "1.0.0"
+          }
+        ],
+        "dependencies": [
+          "cosyworld.core",
+          "cosyworld.rules-profile-srd5"
+        ],
+        "dependency_requirements": [
+          {
+            "id": "cosyworld.core",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.core/world"
+            ]
+          },
+          {
+            "id": "cosyworld.rules-profile-srd5",
+            "version": ">=1.0.0 <2.0.0",
+            "capabilities": [
+              "cosyworld.rules-profile-srd5/rules"
+            ]
+          }
+        ],
+        "dependency_closure": [
+          "cosyworld.rules-srd-5.2.1",
+          "cosyworld.rules-profile-srd5",
+          "cosyworld.core"
+        ],
+        "default_ruleset": null,
+        "entry_points": [
+          {
+            "kind": "asset_mount",
+            "id": "characters"
+          }
+        ],
+        "provenance": {
+          "author": "Cenetex",
+          "source_name": "Cenetex Lonely Forest character art",
+          "source_url": "https://github.com/cenetex/cosyworld"
+        },
+        "resource_counts": {
+          "actors": 0,
+          "actor_facets": 0,
+          "access_gates": 0,
+          "factions": 0,
+          "items": 0,
+          "locations": 0,
+          "exits": 0,
+          "hidden_exits": 0,
+          "room_features": 0,
+          "room_sheets": 0,
+          "clocks": 0,
+          "jobs": 0,
+          "action_vocabulary": 0,
+          "fronts": 0,
+          "cards": 0,
+          "card_bindings": 0,
+          "lifecycle_hooks": 0,
+          "evolution_tracks": 0,
+          "recipes": 0,
+          "sentences": 0,
+          "spatial_scenes": 0,
+          "external_cards": 0,
+          "assets": 1,
+          "rules": 0,
+          "character_creation": 0,
+          "reskins": 0,
+          "offers": 0,
+          "variants": 0,
+          "extensions": 0
+        },
+        "rules_profile": "cosyworld.srd5/1",
+        "source": {
+          "type": "workspace",
+          "path": "../../content/lonely-forest"
+        },
+        "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff"
       }
     ],
     "files": {
@@ -10400,6 +10492,19 @@
       "content_hash": "sha256:656d332e4a10235b882f187db185869072987cece36fe78218c8ac4039d2d144",
       "optional": false,
       "fallback": null
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "pack_version": "1.1.1",
+      "pack_integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+      "provider": "cosyworld.lonely-forest.characters/assets",
+      "mount": "characters",
+      "root": "lonely-forest",
+      "directory": "assets/characters/slices",
+      "public_prefix": "/assets/lonely-forest/characters",
+      "content_hash": "sha256:d45eb30a962de236ddba913834e8bdaa7b9c530bc6b66383e272118218797d93",
+      "optional": false,
+      "fallback": null
     }
   ],
   "rules": [
@@ -12276,6 +12381,19 @@
       "provenance": {
         "author": "Cenetex",
         "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "version": "1.1.1",
+      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
         "source_url": "https://github.com/cenetex/cosyworld"
       },
       "notices": []

--- a/v2/content/lantern-keeper/worldpack.json
+++ b/v2/content/lantern-keeper/worldpack.json
@@ -10,6 +10,7 @@
   "persistence_compatibility": {
     "schema_version": 1,
     "replay_compatible_bundle_hashes": [
+      "sha256:603bf802566d36b81c2da472f36f8d94d951e54716a0fa1deb2e798b09a4ad71",
       "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586",
       "sha256:29db5ba3069c84dea79e90a5f707d0c1fc730c446f3948224f70539c91fe2bfb",
       "sha256:f16b48db1690307acb9861bc2d5005f143ec776060d98315dd95fa21befb7911",
@@ -754,7 +755,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:603bf802566d36b81c2da472f36f8d94d951e54716a0fa1deb2e798b09a4ad71",
+  "bundle_hash": "sha256:75a8ad1bb47c1bb3a94803bb2077a2f1928250cf6e1851ca18e8aca508dc9ba8",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -2445,6 +2446,97 @@
         "path": "../../content/core-lantern-keeper-bridge"
       },
       "integrity": "sha256:81a880cc3d9afaa6767c9ae64eba5016749de8807df69cef68eb1ca2ea34e35e"
+    },
+    {
+      "id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "description": "Character source art and reviewed slices used by the Lonely Forest residents.",
+      "version": "1.1.1",
+      "kind": "assets",
+      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "engine": ">=0.0.20 <0.1.0",
+      "capabilities": [
+        {
+          "id": "cosyworld.lonely-forest.characters/assets",
+          "kind": "assets",
+          "version": "1.0.0"
+        }
+      ],
+      "dependencies": [
+        "cosyworld.core",
+        "cosyworld.rules-profile-srd5"
+      ],
+      "dependency_requirements": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core"
+      ],
+      "default_ruleset": null,
+      "entry_points": [
+        {
+          "kind": "asset_mount",
+          "id": "characters"
+        }
+      ],
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "resource_counts": {
+        "actors": 0,
+        "actor_facets": 0,
+        "access_gates": 0,
+        "factions": 0,
+        "items": 0,
+        "locations": 0,
+        "exits": 0,
+        "hidden_exits": 0,
+        "room_features": 0,
+        "room_sheets": 0,
+        "clocks": 0,
+        "jobs": 0,
+        "action_vocabulary": 0,
+        "fronts": 0,
+        "cards": 0,
+        "card_bindings": 0,
+        "lifecycle_hooks": 0,
+        "evolution_tracks": 0,
+        "recipes": 0,
+        "sentences": 0,
+        "spatial_scenes": 0,
+        "external_cards": 0,
+        "assets": 1,
+        "rules": 0,
+        "character_creation": 0,
+        "reskins": 0,
+        "offers": 0,
+        "variants": 0,
+        "extensions": 0
+      },
+      "rules_profile": "cosyworld.srd5/1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/lonely-forest"
+      },
+      "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff"
     }
   ],
   "files": {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.63"
+version = "1.0.64"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.63"
+version = "1.0.64"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-standalone-compositions.mjs
+++ b/v2/scripts/smoke-standalone-compositions.mjs
@@ -69,7 +69,11 @@ const worldCases = [
       "cosyworld.rules-srd-5.1",
       "cosyworld.campaign.the-lantern-keeper",
       "cosyworld.composition.core-lantern-keeper",
+      "cosyworld.lonely-forest.characters",
     ],
+    // Core card rows point at this pack's art, so the composition must mount it
+    // or every character card degrades to the provider placeholder.
+    cardImagePath: "/assets/lonely-forest/characters/29-grey-winged-boy.png",
     location: "The Cosy Cottage",
     locationPack: "cosyworld.core",
     selectedBy: "cosyworld.core",

--- a/v2/worlds/lantern-keeper/pack.lock.json
+++ b/v2/worlds/lantern-keeper/pack.lock.json
@@ -9,7 +9,8 @@
     "cosyworld.core",
     "cosyworld.rules-srd-5.1",
     "cosyworld.campaign.the-lantern-keeper",
-    "cosyworld.composition.core-lantern-keeper"
+    "cosyworld.composition.core-lantern-keeper",
+    "cosyworld.lonely-forest.characters"
   ],
   "packs": [
     {
@@ -261,6 +262,50 @@
         "source_name": "CosyWorld official composition",
         "source_url": "https://github.com/cenetex/cosyworld"
       }
+    },
+    {
+      "id": "cosyworld.lonely-forest.characters",
+      "version": "1.1.1",
+      "source": {
+        "type": "workspace",
+        "path": "../../content/lonely-forest"
+      },
+      "integrity": "sha256:b0fe32d424fd1fd9d4d99049c711607a90cb3787bb4fce8e99a559473022b2ff",
+      "dependencies": [
+        {
+          "id": "cosyworld.core",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.core/world"
+          ]
+        },
+        {
+          "id": "cosyworld.rules-profile-srd5",
+          "version": ">=1.0.0 <2.0.0",
+          "capabilities": [
+            "cosyworld.rules-profile-srd5/rules"
+          ]
+        }
+      ],
+      "dependency_closure": [
+        "cosyworld.rules-srd-5.2.1",
+        "cosyworld.rules-profile-srd5",
+        "cosyworld.core"
+      ],
+      "capabilities": [
+        {
+          "id": "cosyworld.lonely-forest.characters/assets",
+          "kind": "assets",
+          "version": "1.0.0"
+        }
+      ],
+      "license": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      }
     }
   ],
   "license_records": [
@@ -283,7 +328,7 @@
           "file": "ATTRIBUTION.md",
           "source_name": "System Reference Document 5.2.1",
           "source_url": "https://www.dndbeyond.com/srd",
-          "text": "This work includes material from the System Reference Document 5.2.1 (“SRD\n5.2.1”) by Wizards of the Coast LLC, available at https://www.dndbeyond.com/srd.\nThe SRD 5.2.1 is licensed under the Creative Commons Attribution 4.0\nInternational License, available at\nhttps://creativecommons.org/licenses/by/4.0/legalcode."
+          "text": "This work includes material from the System Reference Document 5.2.1 (\u201cSRD\n5.2.1\u201d) by Wizards of the Coast LLC, available at https://www.dndbeyond.com/srd.\nThe SRD 5.2.1 is licensed under the Creative Commons Attribution 4.0\nInternational License, available at\nhttps://creativecommons.org/licenses/by/4.0/legalcode."
         }
       ]
     },
@@ -342,7 +387,7 @@
           "file": "ATTRIBUTION.md",
           "source_name": "System Reference Document 5.1",
           "source_url": "https://www.dndbeyond.com/srd",
-          "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode.\n\nConversion of the source document to the JSON reference files used by the\nimporter was performed by the team at Tabyltop (https://www.tabyltop.com)."
+          "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(\u201cSRD 5.1\u201d) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode.\n\nConversion of the source document to the JSON reference files used by the\nimporter was performed by the team at Tabyltop (https://www.tabyltop.com)."
         }
       ]
     },
@@ -365,7 +410,7 @@
           "file": "ATTRIBUTION.md",
           "source_name": "System Reference Document 5.1",
           "source_url": "https://www.dndbeyond.com/srd",
-          "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(“SRD 5.1”) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
+          "text": "# SRD 5.1 attribution\n\nThis work includes material taken from the System Reference Document 5.1\n(\u201cSRD 5.1\u201d) by Wizards of the Coast LLC and available at\nhttps://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is\nlicensed under the Creative Commons Attribution 4.0 International License\navailable at https://creativecommons.org/licenses/by/4.0/legalcode."
         }
       ]
     },
@@ -378,6 +423,19 @@
       "provenance": {
         "author": "Cenetex",
         "source_name": "CosyWorld official composition",
+        "source_url": "https://github.com/cenetex/cosyworld"
+      },
+      "notices": []
+    },
+    {
+      "pack_id": "cosyworld.lonely-forest.characters",
+      "name": "Lonely Forest Character Art",
+      "version": "1.1.1",
+      "license_identifier": "LicenseRef-Cenetex-Lonely-Forest-Art",
+      "license_url": "https://github.com/cenetex/cosyworld/tree/main/v2/content/lonely-forest",
+      "provenance": {
+        "author": "Cenetex",
+        "source_name": "Cenetex Lonely Forest character art",
         "source_url": "https://github.com/cenetex/cosyworld"
       },
       "notices": []

--- a/v2/worlds/lantern-keeper/world.json
+++ b/v2/worlds/lantern-keeper/world.json
@@ -23,6 +23,7 @@
   "persistence_compatibility": {
     "schema_version": 1,
     "replay_compatible_bundle_hashes": [
+      "sha256:603bf802566d36b81c2da472f36f8d94d951e54716a0fa1deb2e798b09a4ad71",
       "sha256:31d24881001c9b38518b4e08c02ca4ff16fc2c2c67f6f9ce560b05ef6c517586",
       "sha256:29db5ba3069c84dea79e90a5f707d0c1fc730c446f3948224f70539c91fe2bfb",
       "sha256:f16b48db1690307acb9861bc2d5005f143ec776060d98315dd95fa21befb7911",
@@ -40,6 +41,7 @@
     "cosyworld.rules-srd-5.2.1",
     "cosyworld.rules-profile-srd5",
     "cosyworld.campaign.the-lantern-keeper",
+    "cosyworld.lonely-forest.characters",
     "cosyworld.composition.core-lantern-keeper"
   ]
 }


### PR DESCRIPTION
## Problem

Every character card on `lantern.lonelyforest.com` renders the placeholder
**"WORLD PACK PROVIDER NOT MOUNTED"** instead of its portrait.

`cosyworld.core` card rows reference `/assets/lonely-forest/characters/*`, but that
prefix is provided by `cosyworld.lonely-forest.characters` — a pack the Lantern Keeper
selection never mounted. With no provider for the prefix, the asset route falls through
to `unavailable_asset_provider_placeholder`, which answers `200 image/svg+xml`, so the
client has nothing to retry and just paints the placeholder card.

Reproduced against production:

| host | result |
| --- | --- |
| `lonelyforest.com` | `200 image/png` (mounts the pack) |
| `7.lonelyforest.com` | `200 image/png` (mounts the pack) |
| `lantern.lonelyforest.com` | `200 image/svg+xml` — placeholder |

`x-cosyworld-asset-diagnostic: no active asset provider for /assets/lonely-forest/characters/29-grey-winged-boy.png`

**25 distinct character images** were affected, not just the one spotted.

## Change

Select `cosyworld.lonely-forest.characters` for the Lantern Keeper world and lock it,
mirroring the already-reviewed `bethlehem` lock entry (same version, integrity,
capability, and license record), then recompile the bundle.

The deployed lantern world is persisted at the outgoing bundle hash
`sha256:603bf802…` — verified by reading `/data/worldpacks/lantern/snapshot.json` on the
running machine — so that hash is declared replay-compatible in the same diff rather
than stranding the live journal. `test/v2/worldpack-bundle-gate.test.mjs` moves its
pinned constants forward and gains an explicit assertion that the live hash still
resolves to `declared_migration`.

## Verification

- `npm test` — 183 passed
- `npm run v2:worldpack` — bundle current, proof world ready
- `npm run v2:rust:test` — 1184 passed
- `npm run check:version`, `git diff --check` — clean
- Audited every compiled bundle for asset references with no mounting provider:
  `lantern-keeper` goes from 25 unmounted to **0**.

## Follow-ups (not in this PR)

- `core-only` and `core-ruby` carry the same 25 unmounted references. Neither is a live
  tenant, so I left their selections alone rather than guess at their intent — "core-only"
  may be deliberately minimal, in which case the fix is `requires_packs` on those card
  rows instead of adding the pack.
- `check-worldpack.mjs` validates asset *mounts* thoroughly but never checks that an
  `image_url` under `/assets/…` has a mounting provider. That gap is why this shipped;
  adding the check would have caught it at compile time (and would currently fail the two
  compositions above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)