### PR TITLE
Serialise the release build so the remote builder stops OOM-killing rustc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,13 @@ COPY v2/media /app/v2/media
 COPY v2/ai-model-rust /app/v2/ai-model-rust
 COPY v2/orchestrator-rust /app/v2/orchestrator-rust
 
-RUN cargo build --release
+# The remote builder's OOM killer SIGKILLs rustc partway through the release
+# build of the orchestrator bin crate, which has kept main undeployable.
+# Cargo hands rustc one jobserver token per job, and rustc sizes its parallel
+# LLVM codegen against those tokens, so serialising jobs keeps a single
+# optimising codegen unit resident instead of many. This trades build time for
+# peak memory and does not change the emitted binary.
+RUN CARGO_BUILD_JOBS=1 cargo build --release
 
 FROM debian:bookworm-slim AS runtime
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/infrastructure/deploy-workflow.test.mjs
+++ b/test/infrastructure/deploy-workflow.test.mjs
@@ -540,7 +540,9 @@ describe('deploy workflow', () => {
     const engineVersionCopy =
       'COPY v2/content-engine-version.txt /app/v2/content-engine-version.txt';
     const mediaCopy = 'COPY v2/media /app/v2/media';
-    const releaseBuild = 'RUN cargo build --release';
+    // Matched without the RUN prefix so the ordering contract survives
+    // env prefixes on the build command, such as CARGO_BUILD_JOBS.
+    const releaseBuild = 'cargo build --release';
 
     expect(dockerignore).toContain('!v2/content-engine-version.txt');
     expect(dockerignore).toContain('!v2/media/');

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.64"
+version = "1.0.65"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.64"
+version = "1.0.65"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Problem

`main` has been **undeployable since 2026-08-17T02:01Z**. Three consecutive deploys failed
identically at `RUN cargo build --release`:

```
rustc ... (signal: 9, SIGKILL: kill)
error: could not compile `cosyworld-orchestrator` (bin "cosyworld-orchestrator")
```

SIGKILL is the builder's OOM killer, not a compile error. Runs `31986715826`, `31989284707`,
and `32042637995` all died this way, which is why the Lantern Keeper art fix in #836 merged
but never reached production.

## Change

Pin `CARGO_BUILD_JOBS=1` for the release build.

Cargo hands out one jobserver token per job, and rustc sizes its parallel LLVM codegen
against the tokens it receives. Unbounded, several optimising codegen units of the large
orchestrator bin crate stay resident at once — on top of `cosyworld-ai-model` compiling
concurrently, which the logs show starting 3ms later. Serialising keeps one resident.

This constrains **scheduling only**. It does not touch `opt-level`, `codegen-units`, `lto`,
or any other codegen input, so the emitted binary is unchanged. It trades build time for
peak memory.

## Confidence

I could not reproduce the builder's memory ceiling locally, so this is reasoned from the
failure signature rather than proven by a local repro. The next deploy is a safe test: all
three failures died at the build step without touching any machine, so a further failure
costs nothing but time.

If it is still killed, the next lever is raising `codegen-units` for the release profile —
but that *does* change the emitted binary, so it should be a deliberate decision rather
than a quiet follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)