### PR TITLE
Let a colliding publication receipt replay instead of bricking the world

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.65",
+      "version": "1.0.66",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.65"
+version = "1.0.66"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.65"
+version = "1.0.66"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -595,15 +595,43 @@ impl crate::RuntimeWorld {
         } else {
             None
         };
-        !self.ai_publications.contains_key(&receipt.generation_id)
-            && receipt.generation_id
-                == publication_generation_id_for(
-                    &receipt.feature,
-                    &receipt.prompt_version,
-                    &receipt.generation_key,
-                    record.action.actor_id,
-                )
+        // A generation key is not always unique per utterance: the
+        // deterministic-fallback key is a pure function of actor and scope, so
+        // two different lines by one resident derive the same generation id.
+        // The live path accepts both, so replay must too — rejecting the second
+        // leaves the world permanently unbootable. Only a receipt that
+        // reproduces a registered publication byte for byte is a true repeat,
+        // and that is handled as already-applied rather than as a violation.
+        if self.ai_publication_record_already_applied(record) {
+            // Not a violation: apply_journal_record's already-applied group
+            // turns this into an idempotent skip.
+            return true;
+        }
+        receipt.generation_id
+            == publication_generation_id_for(
+                &receipt.feature,
+                &receipt.prompt_version,
+                &receipt.generation_key,
+                record.action.actor_id,
+            )
             && published_text.is_some_and(|text| receipt_matches_text(receipt, text))
+    }
+
+    /// True when this record's publication is already reflected in world state.
+    ///
+    /// Registration is keyed by generation id, but a colliding id whose output
+    /// differs belongs to a distinct utterance that still has to be applied, so
+    /// only an identical output counts as already applied.
+    pub(crate) fn ai_publication_record_already_applied(
+        &self,
+        record: &crate::JournalRecord,
+    ) -> bool {
+        let Some(receipt) = record.ai_publication.as_ref() else {
+            return false;
+        };
+        self.ai_publications
+            .get(&receipt.generation_id)
+            .is_some_and(|stored| stored.output_hash == receipt.output_hash)
     }
 }
 
@@ -2693,9 +2721,23 @@ mod tests {
             );
         let mut statuses = vec![first.await.unwrap(), second.await.unwrap()];
         statuses.sort_unstable();
-        assert_eq!(statuses, vec![CW_OK, CW_ERR_RULE]);
+        // Re-applying the identical receipt is idempotent rather than a rule
+        // violation: the loser is already-applied and skips. A hard rejection
+        // here would make an ordinary replay unbootable.
+        assert_eq!(statuses, vec![CW_OK, CW_OK]);
         let runtime = runtime.lock().await;
         assert_eq!(runtime.ai_publications.len(), 1);
+        // The point of the test: one commit, not two.
+        assert_eq!(
+            runtime
+                .event_log
+                .iter()
+                .filter(|event| event.type_name == "message.created"
+                    && event.content.as_deref()
+                        == Some("The teapot sits beside the basket, lid askew."))
+                .count(),
+            1
+        );
         assert_eq!(
             runtime
                 .ai_publications
@@ -2703,6 +2745,75 @@ mod tests {
                 .map(|stored| stored.publication_id.as_str()),
             Some(receipt.publication_id.as_str())
         );
+    }
+
+    #[tokio::test]
+    async fn colliding_generation_key_still_replays_the_second_distinct_line() {
+        // Regression for the outages of 2026-08-16/17, which bricked three
+        // worlds. publication_beat_id() falls back to
+        // "deterministic-fallback:actor:{id}:scope:{scope}" when a caller has no
+        // explicit beat id, and the generation id derives from that key, so a
+        // resident's second fallback line derives the id its first line already
+        // registered. The live path commits both. Replay used to refuse the
+        // second, and with the journal compacted past it no bootable path
+        // remained.
+        let first = certified_record(
+            1001,
+            98_101,
+            "The teapot sits beside the basket, lid askew.",
+            "context-before",
+        );
+        let mut second = certified_record(
+            1001,
+            98_102,
+            "The teapot sits beside the basket, steam curling.",
+            "context-after",
+        );
+        let first_receipt = first.ai_publication.as_ref().unwrap().clone();
+
+        // Reproduce the weak key: the fixture derives a unique key per content
+        // id, so force the two receipts to share one, exactly as the
+        // deterministic fallback does in production.
+        {
+            let receipt = second.ai_publication.as_mut().unwrap();
+            receipt.generation_key = first_receipt.generation_key.clone();
+            receipt.generation_id = publication_generation_id_for(
+                &receipt.feature,
+                &receipt.prompt_version,
+                &receipt.generation_key,
+                1001,
+            );
+            receipt.publication_id = sha256_hex(
+                format!("{}\0{}", receipt.generation_id, receipt.output_hash).as_bytes(),
+            );
+        }
+        let second_receipt = second.ai_publication.as_ref().unwrap().clone();
+
+        assert_eq!(
+            first_receipt.generation_id, second_receipt.generation_id,
+            "the two distinct utterances must collide on one generation id"
+        );
+        assert_ne!(first_receipt.output_hash, second_receipt.output_hash);
+
+        let mut runtime = RuntimeWorld::seeded();
+        assert_eq!(runtime.apply_journal_record(&first).0, CW_OK);
+        let (status, events) = runtime.apply_journal_record(&second);
+
+        assert_eq!(status, CW_OK, "the second distinct line must still replay");
+        assert!(!events.is_empty(), "it publishes its own speech");
+        assert_eq!(
+            runtime
+                .ai_publications
+                .get(&second_receipt.generation_id)
+                .map(|stored| stored.output_hash.as_str()),
+            Some(second_receipt.output_hash.as_str()),
+            "the newer publication is what stays registered"
+        );
+        assert!(runtime.event_log.iter().any(|event| {
+            event.type_name == "message.created"
+                && event.content.as_deref()
+                    == Some("The teapot sits beside the basket, steam curling.")
+        }));
     }
 
     #[test]
@@ -2751,8 +2862,22 @@ mod tests {
         assert!(replayed
             .ai_publications
             .contains_key(&receipt.generation_id));
-        assert_eq!(replayed.apply_journal_record(&record).0, CW_ERR_RULE);
+        // Re-applying the identical record is an idempotent no-op, not a rule
+        // violation: it emits nothing and leaves the registration alone.
+        let (status, events) = replayed.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert!(events.is_empty());
         assert_eq!(replayed.ai_publications.len(), 1);
+        assert_eq!(
+            replayed
+                .event_log
+                .iter()
+                .filter(|event| event.type_name == "message.created"
+                    && event.content.as_deref()
+                        == Some("The teapot is still warm beside the basket."))
+                .count(),
+            1
+        );
         let snapshot = RuntimeSnapshot::from_runtime(&replayed)
             .into_runtime()
             .expect("snapshot round trip");

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -9218,6 +9218,7 @@ impl RuntimeWorld {
         if threshold_record_claim_already_applied(self, record)
             || discovery_record_claim_already_applied(self, record)
             || avatar_rescue_already_applied
+            || self.ai_publication_record_already_applied(record)
         {
             return (CW_OK, Vec::new());
         }

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -347,4 +347,10 @@
 # (was resident_offer_scoring.rs). Rename module to reflect its role as the
 # autonomy decision system home. Delete dead RippleBudget zone branch where
 # frontier and sanctuary returned identical budgets. Behavior-preserving.
-63585
+# 63585 -> 63586: one line adding ai_publication_record_already_applied to the
+# existing already-applied group in apply_journal_record, alongside the
+# threshold, discovery, and rescue claim checks it sits with. No new system --
+# the predicate itself lives in ai_publication.rs. This unbricks worlds whose
+# replay hit a colliding deterministic-fallback publication key, which left
+# three of them unbootable on 2026-08-16/17.
+63586


### PR DESCRIPTION
## Problem

Three worlds were left permanently unbootable on 2026-08-16/17:

| world | snapshot | rejected record |
| --- | --- | --- |
| lonelyforest `root` | 6942 | 6943 |
| Elysium (`0`) | 10765 | 10766 |
| bethlehem (`7`) | 1703 | 1704 |

Each showed the same shape — a snapshot one record behind, a journal compacted up to that
record, and no bootable path in either direction:

```
journal checkpoint <snapshot> is unavailable; attempting full replay:
action journal record N was rejected during replay with status 4
→ action journal was compacted through checkpoint N-1; a matching snapshot is required
```

`publication_beat_id()` falls back to `deterministic-fallback:actor:{id}:scope:{scope}` when
a caller has no explicit beat id, and `generation_id` is sha256 over feature, prompt version,
generation key, and actor. That fallback carries **no per-utterance entropy**, so a resident's
second fallback line derives the id its first line already registered.
`ai_publication_preconditions_hold` required the id to be unregistered, so the live path
committed both lines and replay refused the second one forever.

Each was verified as a genuinely distinct utterance, not a duplicate — different
`candidate_id`, different `output_hash`, and a `generation_id` that derives correctly from
its own receipt.

## Change

Registration is a dedup record, so:

- a receipt reproducing a registered publication **byte for byte** is *already applied* — an
  idempotent skip through the same group that already handles threshold, discovery, and
  rescue claims
- a colliding id whose **output differs** proceeds as the distinct utterance it is

Every other precondition still holds: the id must derive from its own receipt, and the
receipt must match the published text.

## Why this does not reinterpret history

The rejecting path made the world unbootable, so no world ever replayed through it. There is
no prior behaviour to preserve — only worlds that never got to boot.

## Tests

Three existing tests encoded the old rejection and were updated to assert the idempotent
skip **plus** an event-count assertion, so they now prove "commits exactly once" directly
rather than through a status code:

- `concurrent_publication_of_one_generation_commits_exactly_once`
- `publication_receipt_survives_timeout_reconnect_replay_and_snapshot_round_trip`

New: `colliding_generation_key_still_replays_the_second_distinct_line` reproduces the
production failure. The shared fixture derives a unique key per `content_id`, so the test
forces the shared key exactly as the deterministic fallback does in production.

`cargo test --bin cosyworld-orchestrator` — **1185 passed, 0 failed**. `cargo fmt --check`
clean.

## Follow-up

The fallback key itself is still weak. Giving it per-utterance entropy means folding
`context_hash` into the derivation, which changes it for **every receipt ever written** —
and `receipt_matches_text` pins `schema_version == AI_PUBLICATION_RECEIPT_VERSION`, so doing
it without receipt versioning would fail every world at once. That lands separately.

Note this PR cannot deploy until #838 fixes the release build, which has been OOM-killing
rustc since 2026-08-17T02:01Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)