### PR TITLE
Let a busy required tenant miss a health probe without killing the Machine

### DIFF
--- a/deploy/lonelyforest/check-required-health.sh
+++ b/deploy/lonelyforest/check-required-health.sh
@@ -5,14 +5,30 @@ tenant_config="${1:?tenant configuration path is required}"
 supervisor_pid="${2:?supervisor pid is required}"
 startup_grace_secs="${3:?startup grace seconds are required}"
 interval_secs="${4:?health interval seconds are required}"
+# A required tenant that is merely busy must not cost every hostname on this
+# Machine. Root can hold the authoritative runtime lock for several seconds
+# under load, which starves its readiness endpoint while the world is alive and
+# serving, so a single missed probe is not evidence of a hung process.
+failure_threshold="${5:-3}"
+probe_timeout_secs="${6:-10}"
 
 log() {
   printf '[lonelyforest-required-health] %s\n' "$*"
 }
 
-case "$startup_grace_secs:$interval_secs" in
+case "$startup_grace_secs:$interval_secs:$failure_threshold:$probe_timeout_secs" in
   *[!0-9:]*|:*|*:) log "health timing must be integer seconds"; exit 2 ;;
 esac
+if [ "$failure_threshold" -lt 1 ]; then
+  log "health failure threshold must be at least 1"
+  exit 2
+fi
+
+# Slugs are tenant ids like "7" or "hoppycat", so they cannot be shell variable
+# names on their own.
+counter_var() {
+  printf 'consecutive_failures_%s' "$(printf '%s' "$1" | tr -c '[:alnum:]' '_')"
+}
 
 # All processes are given time to validate their registry and replay their
 # persisted journal before a composite readiness failure is actionable. Once
@@ -25,11 +41,20 @@ while :; do
       ""|\#*) continue ;;
     esac
     [ "$requirement" = "required" ] || continue
-    if ! curl --noproxy '*' --fail --silent --show-error --max-time 3 "http://127.0.0.1:$port/health" >/dev/null; then
-      log "required tenant $slug failed private /health on 127.0.0.1:$port; failing supervisor $supervisor_pid"
+    variable="$(counter_var "$slug")"
+    if curl --noproxy '*' --fail --silent --show-error --max-time "$probe_timeout_secs" "http://127.0.0.1:$port/health" >/dev/null; then
+      eval "$variable=0"
+      continue
+    fi
+    eval "failures=\${$variable:-0}"
+    failures=$((failures + 1))
+    eval "$variable=$failures"
+    if [ "$failures" -ge "$failure_threshold" ]; then
+      log "required tenant $slug failed private /health on 127.0.0.1:$port ${failures} consecutive times; failing supervisor $supervisor_pid"
       kill -USR1 "$supervisor_pid" 2>/dev/null || true
       exit 1
     fi
+    log "required tenant $slug missed private /health on 127.0.0.1:$port (${failures}/${failure_threshold}); still within tolerance"
   done < "$tenant_config"
   sleep "$interval_secs"
 done

--- a/deploy/lonelyforest/run-multitenant.sh
+++ b/deploy/lonelyforest/run-multitenant.sh
@@ -8,6 +8,8 @@ tenant_config="${COSYWORLD_MULTITENANT_TENANTS_CONFIG:-/app/deploy/lonelyforest/
 health_monitor="${COSYWORLD_MULTITENANT_HEALTH_MONITOR:-/app/deploy/lonelyforest/check-required-health.sh}"
 health_startup_grace_secs="${COSYWORLD_MULTITENANT_HEALTH_STARTUP_GRACE_SECS:-45}"
 health_interval_secs="${COSYWORLD_MULTITENANT_HEALTH_INTERVAL_SECS:-5}"
+health_failure_threshold="${COSYWORLD_MULTITENANT_HEALTH_FAILURE_THRESHOLD:-3}"
+health_probe_timeout_secs="${COSYWORLD_MULTITENANT_HEALTH_PROBE_TIMEOUT_SECS:-10}"
 restart_delay="${COSYWORLD_MULTITENANT_RESTART_DELAY_SECS:-2}"
 supervisor_pid="$$"
 workers=""
@@ -112,7 +114,7 @@ tenant_data_path() {
 }
 
 monitor_required_tenants() {
-  if "$health_monitor" "$tenant_config" "$supervisor_pid" "$health_startup_grace_secs" "$health_interval_secs"; then
+  if "$health_monitor" "$tenant_config" "$supervisor_pid" "$health_startup_grace_secs" "$health_interval_secs" "$health_failure_threshold" "$health_probe_timeout_secs"; then
     status=0
   else
     status="$?"
@@ -237,7 +239,7 @@ nginx_pid="$!"
 log "hostname router listening on 0.0.0.0:3000"
 monitor_required_tenants &
 health_monitor_pid="$!"
-log "required tenant health monitor started after ${health_startup_grace_secs}s grace"
+log "required tenant health monitor started after ${health_startup_grace_secs}s grace; ${health_failure_threshold} consecutive misses at ${health_probe_timeout_secs}s fail the Machine"
 
 if wait "$nginx_pid"; then
   status=0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.65",
+  "version": "1.0.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.65",
+      "version": "1.0.67",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.65",
+  "version": "1.0.67",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.65"
+version = "1.0.67"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.65"
+version = "1.0.67"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/lonelyforest-multitenant-contract.test.mjs
+++ b/v2/scripts/lonelyforest-multitenant-contract.test.mjs
@@ -57,8 +57,30 @@ test("Lonely Forest tenant manifest strictly covers supervisor, nginx, Fly healt
   assert.match(supervisor, /required tenant health monitor exited with status \$status; failing supervisor \$supervisor_pid/);
   assert.match(healthMonitor, /sleep "\$startup_grace_secs"/);
   assert.match(healthMonitor, /\[ "\$requirement" = "required" \] \|\| continue/);
-  assert.match(healthMonitor, /curl --noproxy '\*' --fail --silent --show-error --max-time 3 "http:\/\/127\.0\.0\.1:\$port\/health"/);
+  assert.match(
+    healthMonitor,
+    /curl --noproxy '\*' --fail --silent --show-error --max-time "\$probe_timeout_secs" "http:\/\/127\.0\.0\.1:\$port\/health"/,
+  );
   assert.match(healthMonitor, /required tenant \$slug failed private \/health[\s\S]*?kill -USR1 "\$supervisor_pid"/);
+  // A required tenant that is briefly busy must not cost every hostname on the
+  // Machine: root can hold the authoritative runtime lock for seconds under
+  // load, so the supervisor only fails after repeated misses.
+  assert.match(healthMonitor, /failure_threshold="\$\{5:-3\}"/);
+  assert.match(healthMonitor, /probe_timeout_secs="\$\{6:-10\}"/);
+  assert.match(healthMonitor, /\[ "\$failures" -ge "\$failure_threshold" \]/);
+  assert.match(healthMonitor, /still within tolerance/);
+  assert.match(
+    supervisor,
+    /health_failure_threshold="\$\{COSYWORLD_MULTITENANT_HEALTH_FAILURE_THRESHOLD:-3\}"/,
+  );
+  assert.match(
+    supervisor,
+    /health_probe_timeout_secs="\$\{COSYWORLD_MULTITENANT_HEALTH_PROBE_TIMEOUT_SECS:-10\}"/,
+  );
+  assert.match(
+    supervisor,
+    /"\$health_monitor" "\$tenant_config" "\$supervisor_pid" "\$health_startup_grace_secs" "\$health_interval_secs" "\$health_failure_threshold" "\$health_probe_timeout_secs"/,
+  );
 
   for (const tenant of tenants) {
     assert.match(
@@ -319,6 +341,59 @@ test("required-tenant health monitor fails the Machine after startup grace when 
       assert.match(requests, new RegExp(`127\\.0\\.0\\.1:${port}/health`));
     }
     assert.doesNotMatch(requests, /127\.0\.0\.1:3101\/health/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("a required tenant that misses one probe and recovers keeps every hostname up", async () => {
+  // Root can hold the authoritative runtime lock for several seconds under
+  // load, which starves its readiness endpoint while the world is alive and
+  // serving. Tearing down every hostname on the first missed probe turned that
+  // into a site-wide flap, so a miss inside the threshold must be survivable.
+  const tempRoot = await mkdtemp(resolve(tmpdir(), "cosyworld-required-health-transient-"));
+  try {
+    const binDir = resolve(tempRoot, "bin");
+    const curlLog = resolve(tempRoot, "curl.log");
+    const stateFile = resolve(tempRoot, "root-probe-count");
+    const fakeCurl = resolve(binDir, "curl");
+    const tenantConfig = resolve(deploymentRoot, "tenants.tsv");
+    await mkdir(binDir);
+    // Root fails its very first probe, then answers normally for good.
+    await writeFile(
+      fakeCurl,
+      "#!/bin/sh\n"
+        + "printf '%s\\n' \"$*\" >> \"$FAKE_CURL_LOG\"\n"
+        + "case \"$*\" in\n"
+        + "  *:3100*)\n"
+        + "    if [ -f \"$FAKE_CURL_STATE\" ]; then exit 0; fi\n"
+        + "    : > \"$FAKE_CURL_STATE\"\n"
+        + "    exit 1\n"
+        + "    ;;\n"
+        + "  *) exit 0 ;;\n"
+        + "esac\n",
+    );
+    await chmod(fakeCurl, 0o755);
+    const child = spawn(
+      "sh",
+      [resolve(deploymentRoot, "check-required-health.sh"), tenantConfig, "999999", "0", "1"],
+      {
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, FAKE_CURL_LOG: curlLog, FAKE_CURL_STATE: stateFile },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let output = "";
+    child.stdout.on("data", (chunk) => { output += chunk; });
+    child.stderr.on("data", (chunk) => { output += chunk; });
+    const exited = new Promise((resolveResult) => child.once("close", (code) => resolveResult(code)));
+    const settled = await Promise.race([
+      exited,
+      new Promise((resolveRace) => setTimeout(() => resolveRace("still-running"), 4_000)),
+    ]);
+    child.kill("SIGKILL");
+    assert.equal(settled, "still-running", `monitor must survive one missed probe: ${output}`);
+    assert.match(output, /required tenant root missed private \/health[\s\S]*?\(1\/3\)/);
+    assert.doesNotMatch(output, /failing supervisor/);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

lonelyforest flaps every one to two minutes. Users see intermittent failures across all
seven hostnames, and the machine restarts straight back into the same condition.

The worlds are healthy. `check-required-health.sh` probed with `curl --max-time 3` and
killed the supervisor on the **first** failure — no retry, no threshold:

```sh
if ! curl --noproxy '*' --fail --silent --show-error --max-time 3 ".../health"; then
    kill -USR1 "$supervisor_pid"
fi
```

Root regularly holds the authoritative runtime lock for several seconds under load. From
production:

```
WARN projection_cache: observational projection refresh waited for the authoritative
runtime lock  runtime_lock_wait_ms=8161  endpoints="/world,/meta"
```

So a world that is alive and serving misses one 3s probe, and every hostname on the
Machine goes down with it. The monitor cannot tell "hung" from "briefly busy" on a single
sample.

## Change

Take several samples instead of one:

- fail only after `COSYWORLD_MULTITENANT_HEALTH_FAILURE_THRESHOLD` consecutive misses
  (default 3)
- give each probe `COSYWORLD_MULTITENANT_HEALTH_PROBE_TIMEOUT_SECS` (default 10), so an
  ordinary lock wait is not a miss at all

Counters are per tenant and reset on success. A genuinely hung or exited process still
fails the Machine, within three intervals rather than one, and every tolerated miss is
logged so the contention stays visible rather than silent.

## Tests

New: `a required tenant that misses one probe and recovers keeps every hostname up`.

It is not a vacuous guard — run against the previous script it fails in ~100ms, killed by
the immediate teardown this replaces. The existing test that a genuinely unready tenant
*does* fail the Machine still passes, so the failure path is intact.

`node --test v2/scripts/lonelyforest-multitenant-contract.test.mjs` — 9 passed.

## Note

This cannot deploy until #838 fixes the release build, which has been OOM-killing rustc
since 2026-08-17T02:01Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)