### PR TITLE
Guard the action-journal checkpoint cursor, not just the world-event one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.70",
+      "version": "1.0.71",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.70"
+version = "1.0.71"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.70"
+version = "1.0.71"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/snapshot_persistence.rs
+++ b/v2/orchestrator-rust/src/snapshot_persistence.rs
@@ -120,11 +120,22 @@ impl SnapshotJob {
 
     /// Is the captured cursor backed by the durable commit point?
     ///
-    /// A checkpoint whose `next_event_seq` leads `committed_seq` is not a valid
-    /// checkpoint: every boot restores that lead, and the first commit then
-    /// proposes a sequence the journal must reject. Keeping the previous good
-    /// checkpoint is strictly better than freezing a torn cursor, and skipping
-    /// the write also skips compaction, so nothing is discarded behind it.
+    /// A checkpoint whose `next_event_seq` leads `committed_seq`, or whose
+    /// `action_journal_seq` leads the durable action-journal head, is not a
+    /// valid checkpoint: every boot restores that lead, and the first replay
+    /// then finds a gap the journal can never fill. `synchronous = NORMAL`
+    /// lets SQLite ack a commit that a hard stop can still discard, so the
+    /// in-memory runtime (and the snapshot captured from it) can race ahead
+    /// of what actually reached disk on either cursor independently. Keeping
+    /// the previous good checkpoint is strictly better than freezing a torn
+    /// one, and skipping the write also skips compaction, so nothing is
+    /// discarded behind it.
+    ///
+    /// This guards both cursors because they are durable on separate tables
+    /// (`world_events` vs `action_journal`) and a hard stop can lose either
+    /// one without the other: an unguarded action-journal cursor was exactly
+    /// what left production unbootable on 2026-08-16 and 2026-08-18 even
+    /// though the world-event cursor below was fine both times.
     fn checkpoint_cursor_is_durable(&self) -> bool {
         let (Some(path), Some(snapshot)) =
             (self.event_store_path.as_deref(), self.snapshot.as_ref())
@@ -141,15 +152,33 @@ impl SnapshotJob {
         };
         // A store with no commit point yet still carries a freshly seeded world's
         // bootstrap events in memory only, so there is nothing to contradict.
-        if committed_seq == 0 || snapshot.next_event_seq <= committed_seq.saturating_add(1) {
-            return true;
+        if committed_seq != 0 && snapshot.next_event_seq > committed_seq.saturating_add(1) {
+            error!(
+                "refusing to checkpoint CosyWorld snapshot: captured event cursor {} leads the \
+                 durable commit point {}; keeping the previous checkpoint",
+                snapshot.next_event_seq, committed_seq
+            );
+            return false;
         }
-        error!(
-            "refusing to checkpoint CosyWorld snapshot: captured event cursor {} leads the durable \
-             commit point {}; keeping the previous checkpoint",
-            snapshot.next_event_seq, committed_seq
-        );
-        false
+        let journal_head = match latest_action_journal_seq(path) {
+            Ok(journal_head) => journal_head,
+            // Same reasoning as above: an unreadable head contradicts nothing.
+            Err(_) => return true,
+        };
+        // Unlike `next_event_seq`, `action_journal_seq` has no bootstrap
+        // pathway that advances it without a durable `action_journal` insert
+        // (the only writer is the commit path, which sets it from that
+        // insert's own row id). So a lead over the durable head is always a
+        // genuine overshoot, even from a head of 0.
+        if snapshot.action_journal_seq > journal_head {
+            error!(
+                "refusing to checkpoint CosyWorld snapshot: captured action-journal cursor {} \
+                 leads the durable journal head {}; keeping the previous checkpoint",
+                snapshot.action_journal_seq, journal_head
+            );
+            return false;
+        }
+        true
     }
 
     fn write(self) -> io::Result<()> {
@@ -387,6 +416,89 @@ mod tests {
         persist_runtime_now(&state, &runtime);
         let kept = RuntimeWorld::load_snapshot(&snapshot_path).expect("previous snapshot survives");
         assert_eq!(kept.world.tick, 11);
+
+        let _ = fs::remove_file(snapshot_path);
+        let _ = fs::remove_file(store_path);
+    }
+
+    fn fixture_action_journal_record(seed: u64) -> JournalRecord {
+        let content_id = 900_000 + seed;
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_SAY,
+                actor_id: RATI_ACTOR_ID,
+                content_id,
+                ..CwAction::default()
+            },
+            seed,
+        );
+        record
+            .content_upserts
+            .insert(content_id, format!("checkpoint fixture {seed}"));
+        record
+    }
+
+    /// Regression for the 2026-08-16 and 2026-08-18 outages: an unguarded
+    /// `action_journal_seq` let a checkpoint whose action-journal cursor
+    /// outran the durable journal survive into the only file a compacted
+    /// journal can be rebuilt from, leaving production unbootable. This
+    /// mirrors `a_checkpoint_that_leads_the_commit_point_is_refused` above,
+    /// but for the action-journal cursor instead of the world-event cursor —
+    /// the two are durable on separate tables and a hard stop can lose
+    /// either one independently of the other.
+    #[test]
+    fn a_checkpoint_that_leads_the_action_journal_head_is_refused() {
+        let snapshot_path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-torn-journal-cursor-snapshot-{}-{}.json",
+            std::process::id(),
+            now_millis()
+        ));
+        let store_path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-torn-journal-cursor-store-{}-{}.sqlite",
+            std::process::id(),
+            now_millis()
+        ));
+        let _ = fs::remove_file(&snapshot_path);
+        let _ = fs::remove_file(&store_path);
+
+        let mut state = test_app_state(RuntimeWorld::seeded(), Some(store_path.clone()));
+        state.snapshot_path = Some(Arc::new(snapshot_path.clone()));
+        state.snapshot_writer = Some(Arc::new(SnapshotWriter::spawn().expect("snapshot writer")));
+        // Keep the world-event cursor durable throughout so only the
+        // action-journal guard is under test.
+        append_event_store(
+            &store_path,
+            &[EventView {
+                seq: 1,
+                type_name: "actor.presence".to_string(),
+                success: true,
+                location_id: Some(1),
+                content: Some("active".to_string()),
+                ..EventView::default()
+            }],
+        )
+        .expect("append durable event");
+        append_action_journal(&store_path, &fixture_action_journal_record(1))
+            .expect("append durable action journal record");
+
+        // A cursor level with the durable journal head checkpoints normally.
+        let mut runtime = RuntimeWorld::seeded();
+        runtime.world.next_event_seq = 2;
+        runtime.action_journal_seq = 1;
+        runtime.world.tick = 11;
+        persist_runtime_now(&state, &runtime);
+        let durable = RuntimeWorld::load_snapshot(&snapshot_path).expect("durable snapshot loads");
+        assert_eq!(durable.world.tick, 11);
+
+        // A cursor that leads the durable head — as if the runtime applied
+        // an action whose journal insert never reached disk — must not
+        // overwrite that checkpoint.
+        runtime.action_journal_seq = 5;
+        runtime.world.tick = 22;
+        persist_runtime_now(&state, &runtime);
+        let kept = RuntimeWorld::load_snapshot(&snapshot_path).expect("previous snapshot survives");
+        assert_eq!(kept.world.tick, 11);
+        assert_eq!(kept.action_journal_seq, 1);
 
         let _ = fs::remove_file(snapshot_path);
         let _ = fs::remove_file(store_path);


### PR DESCRIPTION
## Problem

`checkpoint_cursor_is_durable()` in `snapshot_persistence.rs` only compared the
snapshot's `next_event_seq` against the durable `world_events` commit point. It
never checked `action_journal_seq` against the durable **action-journal** head
— and passing this guard is what unlocks compaction, so a torn action-journal
cursor plus compaction removed every bootable path.

`synchronous = NORMAL` lets SQLite ack a commit that a hard stop can still
discard. Because the two cursors are durable on *separate tables*
(`world_events` vs `action_journal`), a hard stop can lose either one without
the other. Only the world-event cursor was guarded, so this recurred with the
identical shape:

```
snapshot action-journal checkpoint N is ahead of journal head N-2
-> action journal was compacted through checkpoint F; a matching snapshot is required
```

- 2026-08-16: lonelyforest `root` world, checkpoint 6943
- 2026-08-18: primary app, checkpoint 19186 vs journal head 19184

Both were recovered by hand: pull the live snapshot + journal, confirm via
`next_event_seq` vs the durable `world_events` max that the missing records
produced no events, patch `action_journal_seq` down to the true head in a
local copy, prove that copy boots cleanly, then install it on the volume.
That manual recovery is now unnecessary going forward — the bad checkpoint is
refused at the write, the same way the existing world-event guard already
refuses it.

## Change

Extend `checkpoint_cursor_is_durable()` with a second comparison:
`snapshot.action_journal_seq` against `latest_action_journal_seq(path)`
(the durable action-journal head). A lead refuses the checkpoint write,
exactly like the existing world-event-cursor guard, and for the same reason:
keeping the previous good checkpoint is strictly better than freezing a torn
one, and skipping the write also skips compaction, so nothing is discarded
behind it.

One asymmetry from the world-event guard is intentional: `next_event_seq` has
a legitimate `committed_seq == 0` exemption (a freshly seeded world carries
in-memory bootstrap events before any durable commit). `action_journal_seq`
has no such pathway — the only writer of `runtime.action_journal_seq` is the
commit path, which sets it from the action-journal insert's own row id — so
the new guard treats any lead over the durable head as a genuine overshoot,
including from a head of 0.

## Tests

New `a_checkpoint_that_leads_the_action_journal_head_is_refused` mirrors the
existing `a_checkpoint_that_leads_the_commit_point_is_refused`, but for the
action-journal cursor. Confirmed it fails without the fix — reproducing the
outage shape exactly, the torn cursor silently overwrites the good checkpoint
— and passes with it.

`cargo test --bin cosyworld-orchestrator`: 1212 passed, 0 failed.
`cargo fmt --check`: clean. `main.rs` unchanged at the 63586-line ceiling; the
entire fix is contained in `snapshot_persistence.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
