### PR TITLE
Add Abandon Avatar: free a knocked-out player to begin again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.71",
+  "version": "1.0.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.71",
+      "version": "1.0.73",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.71",
+  "version": "1.0.73",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.71"
+version = "1.0.73"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.71"
+version = "1.0.73"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -1694,7 +1694,12 @@ mod tests {
     #[tokio::test]
     async fn knocked_out_avatar_can_be_abandoned_to_roaming_ai() {
         let mut runtime = RuntimeWorld::seeded();
-        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Fallen Traveler");
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Fallen Traveler",
+        );
         {
             let actor = runtime
                 .world

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -406,16 +406,11 @@ impl RuntimeWorld {
             return Some(create_avatar_primary_action());
         };
 
-        // Knockout keeps the body in the world but opens a linked-account
-        // rescue run. The replacement is a rescuer, not a reconnect prompt.
+        // Knockout keeps the body in the world. A linked account summons a
+        // rescuer; anyone else abandons the fallen avatar to live on as a
+        // resident and begins again.
         if Self::actor_is_present(actor) && !Self::actor_can_act(actor) {
-            return Some(PrimaryAction {
-                kind: "create_rescuer".to_string(),
-                label: "Create Rescuer".to_string(),
-                command: "create rescuer".to_string(),
-                disabled: false,
-                options: Vec::new(),
-            });
+            return Some(abandon_avatar_primary_action());
         }
         (!Self::actor_can_act(actor)).then(create_avatar_primary_action)
     }
@@ -488,6 +483,16 @@ pub(super) fn summon_avatar_primary_action() -> PrimaryAction {
         kind: "summon_avatar".to_string(),
         label: "Summon a New Avatar".to_string(),
         command: "summon avatar".to_string(),
+        disabled: false,
+        options: Vec::new(),
+    }
+}
+
+pub(super) fn abandon_avatar_primary_action() -> PrimaryAction {
+    PrimaryAction {
+        kind: "abandon_avatar".to_string(),
+        label: "Abandon Avatar".to_string(),
+        command: "abandon avatar".to_string(),
         disabled: false,
         options: Vec::new(),
     }
@@ -922,8 +927,8 @@ mod tests {
             false,
         );
         assert_eq!(
-            downed.primary_action.kind, "create_rescuer",
-            "a knocked-out avatar must expose the linked rescue run",
+            downed.primary_action.kind, "abandon_avatar",
+            "a knocked-out avatar must expose the abandon path",
         );
         assert!(!downed.primary_action.disabled);
         assert!(
@@ -1013,8 +1018,8 @@ mod tests {
             .iter()
             .any(|item| item.id == STORY_BUTTON_ITEM_ID && item.holder_actor_id == Some(5001)));
         // Present and observable does not mean playable. The one available
-        // lifecycle action starts a linked rescue run without removing it.
-        assert_eq!(observer_view.primary_action.kind, "create_rescuer");
+        // lifecycle action abandons the body without removing it.
+        assert_eq!(observer_view.primary_action.kind, "abandon_avatar");
         assert!(!observer_view.primary_action.disabled);
         assert!(observer_view.action_offers.is_empty());
 
@@ -1684,5 +1689,35 @@ mod tests {
                     .as_deref()
                     .is_some_and(|content| content.contains("witness:noticed"))
         }));
+    }
+
+    #[tokio::test]
+    async fn knocked_out_avatar_can_be_abandoned_to_roaming_ai() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Fallen Traveler");
+        {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == 5000)
+                .expect("the avatar exists");
+            actor.status = CW_ACTOR_KNOCKED_OUT;
+        }
+        assert!(runtime.actor_control_mode(5000).is_direct_input());
+
+        let (action, mutation) = runtime.plan_abandon_avatar(5000).expect("plan abandon");
+        assert_eq!(action.kind, CW_ACTION_ABANDON_AVATAR);
+        match mutation {
+            ProjectionMutation::AbandonAvatar { actor_id } => assert_eq!(actor_id, 5000),
+            _ => panic!("expected AbandonAvatar mutation"),
+        }
+
+        let events = runtime.apply_abandon_avatar(5000);
+        assert!(runtime.actor_control_mode(5000).uses_inference());
+        assert!(!events.is_empty());
+        // Replaying the same abandonment is a no-op.
+        assert!(runtime.apply_abandon_avatar(5000).is_empty());
     }
 }

--- a/v2/orchestrator-rust/src/avatar_rescue.rs
+++ b/v2/orchestrator-rust/src/avatar_rescue.rs
@@ -520,4 +520,135 @@ impl RuntimeWorld {
             ),
         )]
     }
+
+    pub(super) fn plan_abandon_avatar(
+        &self,
+        actor_id: u64,
+    ) -> Result<(CwAction, ProjectionMutation), String> {
+        let actor = self
+            .actor_by_id(actor_id)
+            .ok_or_else(|| "No avatar to abandon.".to_string())?;
+        if !Self::actor_is_present(actor) {
+            return Err("This avatar is no longer in the world.".to_string());
+        }
+        if actor.status != CW_ACTOR_KNOCKED_OUT {
+            return Err("Only a knocked-out avatar can be abandoned.".to_string());
+        }
+        if !self.actor_control_mode(actor_id).is_direct_input() {
+            return Err("This avatar is already beyond your direct control.".to_string());
+        }
+        Ok((
+            CwAction {
+                kind: CW_ACTION_ABANDON_AVATAR,
+                actor_id,
+                ..CwAction::default()
+            },
+            ProjectionMutation::AbandonAvatar { actor_id },
+        ))
+    }
+
+    pub(super) fn abandon_avatar_record_preconditions_hold(
+        &self,
+        record: &JournalRecord,
+    ) -> bool {
+        for mutation in &record.projection_mutations {
+            if let ProjectionMutation::AbandonAvatar { actor_id } = mutation {
+                if record.action.kind != CW_ACTION_ABANDON_AVATAR
+                    || record.action.actor_id != *actor_id
+                    || self.actor_by_id(*actor_id).is_none_or(|actor| {
+                        !Self::actor_is_present(actor) || actor.status != CW_ACTOR_KNOCKED_OUT
+                    })
+                {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    pub(super) fn apply_abandon_avatar(&mut self, actor_id: u64) -> Vec<EventView> {
+        let claim_key = abandon_avatar_claim_key(actor_id);
+        if self.rpg_claims.contains(&claim_key) || self.actor_by_id(actor_id).is_none() {
+            return Vec::new();
+        }
+        self.ensure_actor_autonomy();
+        if let Some(autonomy) = self.actor_autonomy.get_mut(&actor_id) {
+            autonomy.control_mode = ActorControlMode::RoamingAi;
+            autonomy.attention_credits = autonomy.attention_credits.max(1);
+            autonomy.pending_intent = None;
+        }
+        self.rpg_claims.insert(claim_key);
+        vec![self.append_async_job_event(
+            "avatar.abandoned",
+            actor_id,
+            None,
+            Some(
+                "Their avatar now lives on as an independent resident of the world.".to_string(),
+            ),
+        )]
+    }
+}
+
+fn abandon_avatar_claim_key(actor_id: u64) -> String {
+    format!("avatar_abandon:{actor_id}")
+}
+
+pub(super) async fn abandon_avatar(
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    Json(payload): Json<ActorRequest>,
+) -> Json<ActionResponse> {
+    if !allow_actor_mutation(
+        &state,
+        client_addr,
+        payload.actor_id,
+        "action-actor",
+        GENERAL_ACTION_LIMIT,
+    ) {
+        return action_rate_limited_response();
+    }
+    let mut runtime = state.inner.lock().await;
+    if !client_actor_authorized_for_state(
+        &runtime,
+        &state,
+        payload.actor_id,
+        payload.actor_session.as_deref(),
+    ) {
+        return client_actor_rejected_response();
+    }
+    let (action, mutation) = match runtime.plan_abandon_avatar(payload.actor_id) {
+        Ok(planned) => planned,
+        Err(reason) => return action_offer_rejected(reason),
+    };
+    let turn_location_id = runtime
+        .actor_by_id(payload.actor_id)
+        .map(|actor| actor.location_id);
+    let mut record = JournalRecord::new(action, runtime.next_seed_value());
+    record.bind_offer_kind("abandon_avatar");
+    record.projection_mutations.push(mutation);
+    let Ok((status, mut events)) = commit_journal_record(&state, &mut runtime, record) else {
+        return Json(ActionResponse {
+            ok: false,
+            status: 500,
+            events: Vec::new(),
+        });
+    };
+    let reply_plan = advance_turn_and_capture_player_tick_observation(
+        &state,
+        &mut runtime,
+        turn_location_id,
+        payload.actor_id,
+        status,
+        &mut events,
+    );
+    drop(runtime);
+    broadcast_events(&state, &events);
+    if let Some(plan) = reply_plan {
+        schedule_player_tick_observation(&state, plan);
+    }
+    Json(ActionResponse {
+        ok: status == CW_OK,
+        status,
+        events,
+    })
 }

--- a/v2/orchestrator-rust/src/avatar_rescue.rs
+++ b/v2/orchestrator-rust/src/avatar_rescue.rs
@@ -547,10 +547,7 @@ impl RuntimeWorld {
         ))
     }
 
-    pub(super) fn abandon_avatar_record_preconditions_hold(
-        &self,
-        record: &JournalRecord,
-    ) -> bool {
+    pub(super) fn abandon_avatar_record_preconditions_hold(&self, record: &JournalRecord) -> bool {
         for mutation in &record.projection_mutations {
             if let ProjectionMutation::AbandonAvatar { actor_id } = mutation {
                 if record.action.kind != CW_ACTION_ABANDON_AVATAR
@@ -582,9 +579,7 @@ impl RuntimeWorld {
             "avatar.abandoned",
             actor_id,
             None,
-            Some(
-                "Their avatar now lives on as an independent resident of the world.".to_string(),
-            ),
+            Some("Their avatar now lives on as an independent resident of the world.".to_string()),
         )]
     }
 }

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -547,7 +547,10 @@ impl RuntimeWorld {
                 primary_action.disabled = offer.disabled;
             }
             primary_action.command = offer.command.clone();
-        } else if !primary_action.disabled && primary_action.kind != "create_rescuer" {
+        } else if !primary_action.disabled
+            && primary_action.kind != "create_rescuer"
+            && primary_action.kind != "abandon_avatar"
+        {
             primary_action = PrimaryAction {
                 kind: "wait".to_string(),
                 label: "Wait".to_string(),

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -8122,6 +8122,22 @@
         return [action, campaignAction];
       }
 
+      if (view.primary_action?.kind === "abandon_avatar") {
+        return [{
+          kind: "abandon-avatar",
+          label: "abandon avatar",
+          detail: "release this fallen avatar to live on as a resident",
+          command: "abandon avatar",
+          focusKey: "abandon-avatar",
+          card: cardForActor(actorId) || cardForLocation(view.location?.id),
+          shape: "avatar",
+          effect: "frees your account to begin a new avatar while this one stays in the world",
+          busyLabel: "abandoning",
+          busyDetail: "handing your avatar to the world…",
+          run: () => action("/actions/abandon-avatar", { actor_id: actorId }),
+        }];
+      }
+
       if (view.primary_action?.kind === "await_rescue") return [];
 
       const characterIdentity = view.character_identity || null;

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -194,6 +194,9 @@ pub const CW_ACTION_STUDY_V2: u8 = 37;
 pub const CW_ACTION_SCOUT_V2: u8 = 38;
 pub const CW_ACTION_COMPLETE_AVATAR_RESCUE: u8 = 39;
 pub const CW_ACTION_REPLACE_AVATAR_RESCUER: u8 = 40;
+// Player frees their knocked-out avatar to live on as an independent
+// roaming NPC, releasing the account to begin a new avatar.
+pub const CW_ACTION_ABANDON_AVATAR: u8 = 41;
 
 pub const CW_EVENT_ACTOR_CREATED: u8 = 2;
 pub const CW_EVENT_ABILITY_CHECK_ROLLED: u8 = 6;

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1080,6 +1080,9 @@ enum ProjectionMutation {
         previous_rescue_id: String,
         rescue: AvatarRescueState,
     },
+    AbandonAvatar {
+        actor_id: u64,
+    },
     PlaceResident {
         actor_id: u64,
         location_id: u64,
@@ -9212,6 +9215,7 @@ impl RuntimeWorld {
             || !card_policy_preference_record_preconditions_hold(record)
             || (!avatar_rescue_already_applied
                 && !self.avatar_rescue_record_preconditions_hold(record))
+            || !self.abandon_avatar_record_preconditions_hold(record)
         {
             return (CW_ERR_RULE, Vec::new());
         }
@@ -9960,6 +9964,9 @@ impl RuntimeWorld {
                     rescue,
                 } => {
                     events.extend(self.apply_cascade_avatar_rescue(previous_rescue_id, rescue));
+                }
+                ProjectionMutation::AbandonAvatar { actor_id } => {
+                    events.extend(self.apply_abandon_avatar(*actor_id));
                 }
                 ProjectionMutation::PlaceResident {
                     actor_id,
@@ -20719,6 +20726,14 @@ async fn submit_action_offer(
         }
         "/actions/unlock-charm-slot" => {
             unlock_charm_slot(
+                ConnectInfo(client_addr),
+                State(state),
+                Json(parsed!(ActorRequest)),
+            )
+            .await
+        }
+        "/actions/abandon-avatar" => {
+            abandon_avatar(
                 ConnectInfo(client_addr),
                 State(state),
                 Json(parsed!(ActorRequest)),
@@ -39761,6 +39776,7 @@ mod tests {
         assert!(INDEX_HTML.contains("Stay with them while help arrives."));
         assert!(INDEX_HTML.contains("Summon one new traveler to attempt the rescue."));
         assert!(INDEX_HTML.contains("[\"await_rescue\", \"summon_avatar\"].includes(rescueAction)"));
+        assert!(INDEX_HTML.contains("abandon avatar"));
         assert!(INDEX_HTML.contains("summon_from_actor_id: summonFromActorId"));
         assert!(INDEX_HTML.contains("/avatar/session"));
         assert!(INDEX_HTML.contains("restore this same avatar"));

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -353,4 +353,10 @@
 # the predicate itself lives in ai_publication.rs. This unbricks worlds whose
 # replay hit a colliding deterministic-fallback publication key, which left
 # three of them unbootable on 2026-08-16/17.
-63586
+# 63586 -> 63602: sixteen lines wiring Abandon Avatar at the existing
+# boundaries main.rs already owns -- the ProjectionMutation variant, its
+# precondition call and apply arm, the /actions/abandon-avatar route entry,
+# and one INDEX_HTML contract assertion. The action's planning, precondition,
+# and apply logic all live in avatar_rescue.rs beside the rescue lifecycle it
+# extends. Existing routing/projection seams, no new system in main.rs.
+63602


### PR DESCRIPTION
## Summary

Fixes #844 — when a player avatar is knocked out, the only action was "look", leaving the player stuck spectating. This adds an **Abandon Avatar** action so a KO'd player can release the body and continue.

## What changed

**Server (Rust orchestrator)**
- New `CW_ACTION_ABANDON_AVATAR` + `ProjectionMutation::AbandonAvatar { actor_id }`.
- `apply_abandon_avatar()` flips the fallen avatar's `ActorControlMode` to `RoamingAi` (an independent resident) and inserts an idempotent `avatar_abandon:{id}` claim key for replay.
- `plan_abandon_avatar()` + precondition check: only present, knocked-out, directly-controlled avatars can be abandoned.
- New `POST /actions/abandon-avatar` route + handler (follows the `rest` action commit pattern).
- The knocked-out lifecycle primary action now reads **"abandon avatar"** (wallet-linked accounts still override to the summon-rescuer flow).

**Client (`index.html`)**
- New "abandon avatar" action card in the KO state → `POST /actions/abandon-avatar`.

**Tests**
- Updated the two `knocked_out_avatar_*` assertions to `"abandon_avatar"`.
- Added `knocked_out_avatar_can_be_abandoned_to_roaming_ai`.

## Validation
- `cargo check` ✅
- `cargo test knocked_out_avatar` (6 tests) ✅
- `cargo test browser_index_contract_stays_chat_mud_shell` ✅

Version bump: `1.0.71 → 1.0.73`.
