### PR TITLE
Keep a Listen fallback for stranded first-tale latecomers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.71",
+      "version": "1.0.72",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.72",
+      "version": "1.0.73",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.72"
+version = "1.0.73"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.71"
+version = "1.0.72"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.72"
+version = "1.0.73"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.71"
+version = "1.0.72"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -805,7 +805,11 @@ impl RuntimeWorld {
         offers = self.expand_route_action_offers(actor_id, access, offers);
         offers.extend(self.threshold_method_action_offers(actor_id, access));
         offers.extend(self.discovery_action_offers(actor_id));
-        offers.retain(|offer| offer.kind != "check" || offer.project.is_some());
+        let keep_projectless_listen_check =
+            self.first_tale_latecomer_needs_listen_fallback(actor_id);
+        offers.retain(|offer| {
+            offer.kind != "check" || offer.project.is_some() || keep_projectless_listen_check
+        });
         offers.extend(self.notice_actor_action_offers(actor_id));
         if let Some(reason) = self.rest_offer_unavailable_reason(actor_id) {
             let mut unavailable = self.ranked_offer_from_parts(

--- a/v2/orchestrator-rust/src/first_tale.rs
+++ b/v2/orchestrator-rust/src/first_tale.rs
@@ -223,6 +223,30 @@ impl RuntimeWorld {
         })
     }
 
+    /// In the `contribute` phase, a latecomer whose shared question is already
+    /// answered still owes one truthful Listen. When the single-shot Search
+    /// reveal is spent, the only remaining hand card that resolves to that
+    /// Listen check is the generic Check, which the offer pipeline normally
+    /// discards. Keeping it only here (when Search is already exhausted)
+    /// preserves the existing latecomer flow while guaranteeing an advancing
+    /// card.
+    pub(super) fn first_tale_latecomer_needs_listen_fallback(&self, actor_id: u64) -> bool {
+        if self.first_tale_stage(actor_id) != Some(FirstTaleStage::Contribute) {
+            return false;
+        }
+        let Some(first_tale) = active_first_tale() else {
+            return false;
+        };
+        if !self
+            .clocks
+            .get(&first_tale.progress_clock_id)
+            .is_some_and(|clock| clock.filled >= clock.segments)
+        {
+            return false;
+        }
+        self.default_search_target(actor_id).is_none()
+    }
+
     fn first_tale_offer_advances(
         &self,
         actor_id: u64,
@@ -276,9 +300,16 @@ impl RuntimeWorld {
                             && project.progress_clock_id == first_tale.progress_clock_id
                     }))
                     || (shared_question_complete
-                        && offer.intention == "inspect"
                         && offer.target.as_ref().and_then(|target| target.id)
-                            == Some(first_tale.destination_location_id))
+                            == Some(first_tale.destination_location_id)
+                        && (offer.intention == "inspect"
+                            // A latecomer still owes one truthful Listen. After
+                            // the single-shot Search reveal is spent, the generic
+                            // Check (kind `check`, no project) resolves to a
+                            // Listen check in this room and can complete the
+                            // tale, so it must stay selectable as the advancing
+                            // card instead of leaving the hand without a pin.
+                            || (offer.kind == "check" && offer.project.is_none())))
             }
             FirstTaleStage::ContinuationTravel => first_tale
                 .continuation
@@ -776,5 +807,76 @@ mod tests {
                 .is_empty(),
             "the latecomer trace remains exactly once"
         );
+    }
+
+    #[test]
+    fn latecomer_generic_listen_check_advances_after_search_is_spent() {
+        let actor_id = 5000;
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            actor_id,
+            RAIN_SOFT_GARDEN_LOCATION_ID,
+            "Stranded Path Listener",
+        );
+        runtime
+            .listen_attempt_claims
+            .insert(listen_attempt_claim_key(actor_id, COSY_COTTAGE_LOCATION_ID));
+        {
+            let clock = runtime
+                .clocks
+                .get_mut(FIRST_TALE_PROGRESS_CLOCK_ID)
+                .expect("official first-tale clock");
+            clock.filled = clock.segments;
+        }
+
+        // Spend the single-shot Search reveal by discovering every seed exit,
+        // mirroring a latecomer who already searched Rain-Soft Garden.
+        for exit in active_content()
+            .exits
+            .iter()
+            .filter(|exit| exit.from_location_id == RAIN_SOFT_GARDEN_LOCATION_ID)
+        {
+            let id = seed_exit_discovered_tag_id(exit.from_location_id, exit.to_location_id);
+            runtime.tags.insert(
+                id.clone(),
+                RpgTagState {
+                    id,
+                    scope: "room".to_string(),
+                    scope_id: exit.from_location_id,
+                    label: format!(
+                        "path to {}",
+                        runtime
+                            .location_name(exit.to_location_id)
+                            .unwrap_or_else(|| format!("Location {}", exit.to_location_id))
+                    ),
+                    kind: "discovery".to_string(),
+                    active: true,
+                    source_event_seq: None,
+                    expires: None,
+                },
+            );
+        }
+        assert!(
+            runtime.default_search_target(actor_id).is_none(),
+            "discovering every seed exit must consume the room Search so only the Listen Check remains"
+        );
+        assert!(runtime.first_tale_latecomer_needs_listen_fallback(actor_id));
+
+        let (_, offers) =
+            runtime.legal_action_candidates(Some(actor_id), &AccessContext::default());
+        let check_offer = offers
+            .iter()
+            .find(|offer| offer.kind == "check" && offer.project.is_none())
+            .expect("the generic Listen Check is retained once Search is spent");
+        assert!(
+            runtime.first_tale_offer_advances(actor_id, FirstTaleStage::Contribute, check_offer),
+            "a still-available Listen Check must advance a latecomer whose shared question is complete"
+        );
+        let advancing_ids = runtime
+            .first_tale_advancing_offer_selection(actor_id, std::slice::from_ref(check_offer))
+            .0
+            .expect("the Listen Check is selectable as the advancing card");
+        assert_eq!(advancing_ids, check_offer.offer_id);
     }
 }


### PR DESCRIPTION
## Summary

A first-tale **latecomer** (someone who arrives at Rain-Soft Garden after the shared
`rain-soft-garden:trustworthy-path` question is already complete) could be left with
**no advancing card** and a tale stuck in the `contribute` phase.

Root cause: the latecomer completion path is a truthful Listen check at the
destination. The single-shot Search reveal (`intention: "inspect"`) is the natural
completion card, but once it has been spent the offer pipeline was discarding the
project-less generic **Check** (Listen) offer, and
`first_tale_advancing_offer_selection` returned `None` — so the hand had no pin and
the tale could never reach its continuation (Mara Wick).

The fix keeps the generic Check for that latecomer state only (Search already spent,
shared clock full, still in `contribute`) and lets it be selected as the advancing
completion card.

## Details

- `composition.rs`: stop discarding the project-less `check` offer when
  `first_tale_latecomer_needs_listen_fallback` holds.
- `first_tale.rs`:
  - new `first_tale_latecomer_needs_listen_fallback` gate (latecomer + full clock +
    Search reveal spent);
  - `first_tale_offer_advances` also accepts `kind == "check"` (no project) at the
    destination when the shared question is complete.

## Validation

Ran in an isolated worktree from `main` (note: the shared working tree also held
unrelated in-flight work, so this PR was built on a clean checkout):

```sh
git diff --check
npm run check:version                      # passes (1.0.71 -> 1.0.72)
RUSTUP_TOOLCHAIN=stable npm run v2:rust:test   # fmt + 1213 unit tests + 6 integration tests, all pass
cargo +stable fmt --check                   # clean
```

New regression test: `first_tale::tests::latecomer_generic_listen_check_advances_after_search_is_spent`
covers the stranded latecomer state and asserts the retained Listen Check advances.

## Notes

- Local `cargo clippy --all-targets` reports 227 warnings on an **unmodified** `main`
  checkout under the installed stable (1.97.0) vs. the committed ceiling of 225 — a
  pre-existing toolchain drift, not introduced here. This branch adds zero new clippy
  warnings (verified by diffing against a detached `main` baseline).
- The browser recovery path for the player (Bibi Pollenwhisk, actor 8316) is that
  after this lands, their next `/state` will pin the Listen Check so the tale can
  complete.