### PR TITLE
Fix Story Hand narrow-viewport card layout: full-bleed art, swipe, shorter cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.71",
+      "version": "1.0.72",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.71"
+version = "1.0.72"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.71"
+version = "1.0.72"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -6549,6 +6549,128 @@
       .prompt.hand-expanded .cmd .thumb.action-mini-card { width: 100%; }
       .minimal-menu-slot { min-height: 82px; }
     }
+
+    /*
+     * Consolidated narrow-viewport Story Hand card layout. Placed last so it
+     * is authoritative over the earlier, partially-conflicting 561-900px
+     * rules above: several older `@media (max-width: 900px)` blocks size
+     * `.cmd` as a horizontal list row (small fixed thumb beside text), while
+     * the `.cmd.has-copy .thumb` selector's extra `.has-copy` class outranks
+     * the unconditional full-bleed rule's specificity, so a viewport between
+     * 561px and 900px got a small boxed thumbnail floating in an otherwise
+     * empty stacked card — full-bleed only actually worked at <=560px. This
+     * block unifies the whole <=900px range on one full-bleed, swipeable,
+     * shorter card design instead of maintaining two half-finished ones.
+     */
+    @media (max-width: 900px) {
+      .prompt.hand-expanded .hand-rail {
+        display: flex;
+        gap: 8px;
+        overflow-x: auto;
+        padding: 9px 14px 8px;
+        scroll-padding-inline: 14px;
+        scroll-snap-type: x mandatory;
+        overscroll-behavior-inline: contain;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        cursor: grab;
+      }
+      .prompt.hand-expanded .hand-rail::-webkit-scrollbar { display: none; }
+      /* Added by pointer-drag swipe (script below) while a mouse/pen drag is
+         in progress, so scroll-snap does not fight the live drag. */
+      .prompt.hand-expanded .hand-rail.dragging {
+        cursor: grabbing;
+        scroll-snap-type: none;
+      }
+      .prompt.hand-expanded .story-card-slot {
+        flex: 0 0 calc(100% - 28px);
+        width: calc(100% - 28px);
+        min-width: 0;
+        height: clamp(268px, 48dvh, 346px);
+        scroll-snap-align: center;
+      }
+      .prompt.hand-expanded .cmd {
+        width: 100%;
+        min-width: 0;
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: clamp(108px, 20dvh, 148px) minmax(0, 1fr);
+        gap: 0;
+        padding: 0;
+        text-align: left;
+        opacity: 0.66;
+        transition: border-color 140ms ease, opacity 140ms ease;
+      }
+      .prompt.hand-expanded .cmd[aria-current="true"] {
+        border-color: rgba(var(--cmd-accent-rgb), 0.78);
+        box-shadow:
+          inset 3px 0 0 rgba(var(--cmd-accent-rgb), 0.72),
+          0 0 0 1px rgba(var(--cmd-accent-rgb), 0.16);
+        opacity: 1;
+      }
+      .prompt.hand-expanded .cmd-copy {
+        align-content: start;
+        gap: 4px;
+        padding: 10px 12px 8px;
+      }
+      .prompt.hand-expanded .cmd-kicker { font-size: 10px; }
+      .prompt.hand-expanded .cmd-label {
+        display: flex;
+        align-items: flex-start;
+        gap: 6px;
+        overflow: visible;
+        color: var(--text);
+        font-size: 17px;
+        font-weight: 820;
+        line-height: 1.16;
+        white-space: normal;
+      }
+      .prompt.hand-expanded .cmd-label-text {
+        display: -webkit-box;
+        min-width: 0;
+        overflow: hidden;
+        white-space: normal;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+      .prompt.hand-expanded .detail {
+        display: -webkit-box;
+        margin-top: 2px;
+        overflow: hidden;
+        font-size: 13px;
+        line-height: 1.3;
+        white-space: normal;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+      .prompt.hand-expanded :is(.cmd-meta, .provider-call, .story-call) {
+        overflow: hidden;
+        font-size: 10px;
+        line-height: 1.25;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      /* The full-bleed fix: `.has-copy` on the same selector as the older
+         rules gives this the specificity to win regardless of source-order
+         tie-breaks against the blocks above. */
+      .prompt.hand-expanded .cmd.has-copy .thumb,
+      .prompt.hand-expanded .cmd.has-copy .thumb.item,
+      .prompt.hand-expanded .cmd.has-copy .thumb.location,
+      .prompt.hand-expanded .cmd.has-copy .thumb.avatar,
+      .prompt.hand-expanded .cmd.has-copy .thumb.action-mini-card {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        flex: none;
+        border-right: 0;
+        border-bottom: 1px solid rgba(var(--cmd-accent-rgb), 0.46);
+        background-position: center 42%;
+      }
+      .prompt.hand-expanded .cmd.has-copy .thumb.avatar { background-position: center 22%; }
+      .prompt.hand-expanded .story-card-actions button {
+        min-height: 44px;
+        font-size: 10px;
+      }
+    }
   </style>
 </head>
 <body>
@@ -19420,6 +19542,52 @@
         selectStoryHandCardFromScroll();
       });
     }, { passive: true });
+
+    // Touch already swipes the hand rail natively via CSS scroll-snap. A
+    // narrow desktop window (a resized browser, no touch input) has no other
+    // way to reach it: the scrollbar is deliberately hidden for the mobile
+    // card look, and there is no click-drag affordance without this. Mouse
+    // and pen pointers get one here; touch is left to the native gesture so
+    // it is never double-handled.
+    (function enableHandRailPointerSwipe() {
+      const rail = $("hand-rail");
+      let pointerId = null;
+      let dragging = false;
+      let startX = 0;
+      let startScrollLeft = 0;
+      const DRAG_ENGAGE_PX = 6;
+
+      rail.addEventListener("pointerdown", (event) => {
+        if (event.pointerType === "touch" || !usesInlineStoryHand()) return;
+        pointerId = event.pointerId;
+        dragging = false;
+        startX = event.clientX;
+        startScrollLeft = rail.scrollLeft;
+      });
+
+      rail.addEventListener("pointermove", (event) => {
+        if (pointerId !== event.pointerId) return;
+        const delta = event.clientX - startX;
+        if (!dragging) {
+          if (Math.abs(delta) < DRAG_ENGAGE_PX) return;
+          dragging = true;
+          rail.classList.add("dragging");
+          rail.setPointerCapture(pointerId);
+        }
+        event.preventDefault();
+        rail.scrollLeft = startScrollLeft - delta;
+      });
+
+      const releaseDrag = (event) => {
+        if (pointerId !== event.pointerId) return;
+        if (dragging) rail.classList.remove("dragging");
+        if (rail.hasPointerCapture?.(pointerId)) rail.releasePointerCapture(pointerId);
+        pointerId = null;
+        dragging = false;
+      };
+      rail.addEventListener("pointerup", releaseDrag);
+      rail.addEventListener("pointercancel", releaseDrag);
+    })();
 
     window.matchMedia("(max-width: 900px)").addEventListener("change", () => {
       storyHandExpanded = false;


### PR DESCRIPTION
## Problem

The Story Hand's expanded card layout (`.prompt.hand-expanded`) had three
problems on a "narrow browser window" — specifically 561–900px viewport
width, which covers a resized desktop window but not a phone:

1. Card art rendered as a small boxed thumbnail (~46-58% of card width)
   instead of full-bleed, leaving a large empty black area on the card.
2. No way to reach the other two cards without touch input — the rail is
   horizontally scrollable but its scrollbar is deliberately hidden.
3. Cards could be tall enough that Discard/Play required scrolling to reach.

## Root cause (full-bleed)

The file has several separate, historically-added `@media (max-width: 900px)`
blocks. One sizes `.cmd` as a horizontal list row with a small fixed
thumbnail:

```css
.prompt.hand-expanded .cmd.has-copy .thumb,
.prompt.hand-expanded .cmd.has-copy .thumb.item,
.prompt.hand-expanded .cmd.has-copy .thumb.location {
  width: 82px;
  height: 72px;
  flex: 0 0 82px;
}
```

The intended full-bleed rule for hand-expanded mode omits `.has-copy`:

```css
.prompt.hand-expanded .cmd .thumb.action-mini-card { width: 100%; height: 100%; }
```

`.has-copy` gives the first rule higher selector specificity (6 classes vs.
5), so it wins **regardless of source order** wherever both are in scope —
which is everywhere `<=900px`. Full-bleed only actually worked at `<=560px`,
where a *different*, separately-added override correctly includes
`.has-copy` and wins on both specificity and (tied) source order. The
561-900px range never got that fix.

## Change

Added one new, consolidated `@media (max-width: 900px)` block, placed last
in the stylesheet so it's unambiguously authoritative for the properties it
touches, regardless of the older blocks' specificity/order quirks:

- **Full-bleed**: the thumb selector now includes `.has-copy`, matching (and
  beating, by position) every earlier competing rule.
- **Swipe**: a small pointer-drag handler on `#hand-rail`, scoped to
  non-touch pointers (`event.pointerType !== "touch"`), so a mouse or pen
  drag pans the rail with scroll-snap settling on release. Touch already
  works natively via `scroll-snap-type: x mandatory` and is untouched.
- **Shorter cards**: reduced the card and art-row height clamps for this
  range (card: `clamp(268px, 48dvh, 346px)`, was up to 410-460px across the
  two blocks it supersedes; art row: `clamp(108px, 20dvh, 148px)`, was up to
  232px), so Discard/Play stay in view without an internal scroll.

Desktop (`>900px`) is untouched — the 3-column grid and its rules are
unaffected, verified below.

The change is purely additive to `v2/orchestrator-rust/src/index.html` (no
lines removed) — the older, now-superseded rules are left in place rather
than deleted, so there's no risk to anything else those blocks govern
(`.hand-inspector`, `.minimal-menu`, etc.) that I didn't audit line-by-line.

## Verification

Built and ran the actual server, drove it with Playwright through account
creation into a live scene with a real Story Hand, and measured the rendered
DOM directly (not just visual inspection):

| viewport | thumb fills card width | Discard/Play visible without scroll |
|---|---|---|
| 560px | ✅ | ✅ |
| 700px | ✅ | ✅ |
| 900px | ✅ | ✅ |
| 950px (desktop) | `.hand-rail` is `display: grid` (3-column), unaffected | ✅ |

A synthetic pointer-drag on `#hand-rail` (`pointerdown` → `pointermove` ×2 →
`pointerup`, `pointerType: "mouse"`) moved `scrollLeft` from 0 to 638 against
a real `scrollWidth` of 1976px (three ~660px cards) — the swipe works.

`cargo test --bin cosyworld-orchestrator`: 1212 passed, 0 failed.
`node v2/scripts/check-browser-shell-syntax.mjs`: clean.

## Note on scope

This branch was built in an isolated worktree because the shared checkout
had unrelated, uncommitted, in-progress work (`create_rescuer` /
`await_rescue` rescue-flow changes) actively being edited by another session
at the time — kept completely separate from this change, per the repo's own
guidance for exactly that situation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
