### PR TITLE
Specify the Story Hand as three entity piles: Item, Location, Avatar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.74",
+  "version": "1.0.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.74",
+      "version": "1.0.75",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.74",
+  "version": "1.0.75",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/story-hand.md
+++ b/v2/docs/story-hand.md
@@ -21,20 +21,48 @@ different actions even though each is Hustle. Danger is risk metadata, not a
 fifth suit. A Spell is still an Item/source card; the spell action's suit is
 derived from its effect.
 
-## Three stable slots
+## Three stable piles
 
-The server composes exactly three independent queues:
+The server composes exactly three independent queues, one per kind of world
+entity the action is *about*:
 
-- **Story** — the scene's strongest invitation: location, quest, route, or
-  danger.
-- **Self** — an action grounded in the avatar: Calling, Friendship, Journal,
-  equipped gear, or prepared spell.
-- **Anchor** — a safe, legible foundation that keeps the hand usable.
+- **Item** — a tangible object: Take, Drop, Use, Give, Trade, Accept, Craft.
+- **Location** — a place or the room itself: Travel, Flee, Search, Study,
+  Scout, Explore, Open, Use feature, and the place-bound job verbs
+  (Prepare, Work, Help) plus the room Check.
+- **Avatar** — a person, yourself or another: Chat, Notice, Befriend,
+  Remember, Attack, Defend, Rescue, Steal, Rest, Train, Evolve, Cast.
 
-Sparse scenes borrow a deterministic card into an empty slot before any card
-is selected. The queues remain disjoint, so advancing one slot cannot move
-another. First-tale and journey guarantees are inserted into the Story queue,
-not layered over the completed hand.
+Each pile always surfaces its own strongest current offer, so the hand cannot
+show two Travel cards and no Notice. Because a pile holds every verb for its
+entity kind, the verb variants of one thing (Take / Drop / Give for the same
+item) sit in the same queue — so Discard reveals *another way to act on this
+thing*, not an unrelated replacement. See Discard below.
+
+Grouping is by exact verb (`offer.kind`), not by suit, provider, or narrative
+role. A few kinds are deliberately filed against their literal target:
+`give_item` and `trade_item` target the other avatar but belong to **Item**,
+because the item is what is being decided about; `theft` targets the item but
+belongs to **Avatar**, because stealing is a confrontation with the person.
+An unrecognised kind falls to **Avatar**, the catch-all.
+
+Sparse scenes borrow a deterministic card into an empty pile before any card
+is selected. The queues remain disjoint, so advancing one pile cannot move
+another. First-tale and journey guarantees are inserted into the pile that
+owns their entity, not layered over the completed hand.
+
+### Status: specified, not yet implemented
+
+The runtime still composes the older Story / Self / Anchor slots. Moving to
+piles is not a rename: slot identity is load-bearing for the progression pin
+(guaranteed at the head of one slot), Think/Discard availability (a slot needs
+a second card to be rotatable), ordered-combat pass, first-tale and journey
+guarantees, and cross-process hand convergence. A prototype that only
+reclassified offers and re-targeted the pin left 16 authoritative tests
+failing across `first_tale`, `movement`, `action_hand_tests`, combat ordering,
+and replay convergence — those are the invariants any real implementation has
+to carry, not incidental test churn. Land it as its own change with those
+paths reworked deliberately.
 
 ## Discard
 
@@ -48,7 +76,10 @@ Discard.
 - The first Discard after entering a safe scene is free.
 - Later Discards in that scene consume the turn.
 - Discard always consumes the turn in risky, dangerous, and ordered scenes.
-- A slot with no other current possibility does not show Discard.
+- A pile with no other current possibility does not show Discard, and the
+  card says so rather than showing a dead control.
+- Because a pile is one entity's verbs, Discard reads as "show me another way
+  to act on this" — the same rotation mechanism, a legible meaning.
 - Moving to another scene resets the slot counters and safe-scene allowance.
 
 The hidden deterministic structure is an **Offer queue**, not a player deck.

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.74"
+version = "1.0.75"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.74"
+version = "1.0.75"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

Replaces the Story Hand's **Story / Self / Anchor** slot model in the spec
with three piles keyed to the kind of world entity each action is *about*:
**Item**, **Location**, **Avatar**.

This is a **doc-only** change and is explicitly marked as not yet
implemented — see the honest scoping note below.

## Why

Two real problems with role-based slots, both observed in play:

1. **A hand could deal two Travel cards and no Notice.** Nothing constrained
   the three slots to differ in *kind* — "the scene's strongest invitation"
   and "a safe legible foundation" can both resolve to a route. One pile per
   entity kind makes that impossible by construction.
2. **Discard read as an opaque reroll.** It swapped the card for something
   unrelated, and a slot with no alternative rendered a *disabled button with
   no explanation* (the reason lived only in a `title=` tooltip, effectively
   invisible on mobile). When a pile holds every verb for one entity, Discard
   becomes "show me another way to act on this thing" — the same rotation
   mechanism, a legible meaning — and "no alternative" becomes a statement
   about that entity rather than a mystery.

Grouping is by exact verb (`offer.kind`), not suit or provider. Two
placements are deliberately against the literal target and are called out in
the doc: `give_item`/`trade_item` target the other avatar but file under
**Item** (the item is what's being decided about); `theft` targets the item
but files under **Avatar** (it's a confrontation with a person).

## Why doc-only

I prototyped the runtime change and it does not work as a rename. Slot
identity is load-bearing in more places than the vocabulary suggests:

- the **progression pin** is guaranteed at the head of a fixed slot;
- **Think/Discard availability** is `replacement_count > 0` — a slot needs a
  second card to be rotatable at all;
- **ordered-combat pass**, **first-tale** and **journey** guarantees, and
  **cross-process hand convergence** all read slot position.

A prototype that reclassified offers *and* re-pointed the progression pin at
the pinned offer's own pile (rather than hardcoded slot 0) still left **16
authoritative tests failing** across `first_tale`, `movement`,
`action_hand_tests`, ordered-combat pass, and replay convergence. Those are
real invariants, not incidental test churn — chasing them green one at a time
would have meant reshaping authoritative behaviour without a deliberate
design pass. The runtime change belongs in its own PR.

The prototype findings are recorded in the doc's "Status" section so whoever
picks it up starts from the known blockers instead of rediscovering them.

## Validation

- `npm run check:version` ✅ (1.0.74 → 1.0.75)
- No Rust or client code changed; the runtime still composes the old slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
