### PR TITLE
Prove the action-journal head is on disk before a checkpoint cites it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.75",
+      "version": "1.0.76",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.75"
+version = "1.0.76"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.75"
+version = "1.0.76"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/canonical_journal.rs
+++ b/v2/orchestrator-rust/src/canonical_journal.rs
@@ -2350,6 +2350,45 @@ pub(super) fn open_event_store(path: &Path) -> io::Result<Connection> {
     open_canonical_store(path)
 }
 
+/// An action-journal head that is guaranteed to already be on disk.
+///
+/// `synchronous = NORMAL` (see `open_canonical_store`) lets SQLite report a
+/// WAL-committed row as the head before that WAL frame has been fsynced, so a
+/// plain `MAX(journal_seq)` can name a row that a hard stop will discard. A
+/// snapshot that cites such a row becomes unbootable the moment the stop
+/// happens: the checkpoint leads the surviving journal head, and compaction
+/// has already removed the path back.
+///
+/// The head is read *before* the checkpoint on purpose. Everything at or
+/// below that value is transferred into the database file by the time this
+/// returns, so the answer stays correct even if a concurrent writer appends
+/// afterwards -- a later append can only make the real head larger, never
+/// invalidate the value returned here.
+///
+/// `FULL` (rather than `TRUNCATE`) transfers every frame without also
+/// requiring the WAL to be reset, which is far less likely to be refused by a
+/// concurrent reader. A refused or partial checkpoint is reported as an error
+/// so callers stay conservative: an unverifiable head must never be written
+/// into a checkpoint.
+pub(super) fn durable_action_journal_head(path: &Path) -> io::Result<u64> {
+    let conn = open_event_store(path)?;
+    let head = max_action_journal_seq(&conn)?;
+    conn.pragma_update(None, "synchronous", "FULL")
+        .map_err(sqlite_error)?;
+    let busy = conn
+        .query_row("PRAGMA wal_checkpoint(FULL)", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(sqlite_error)?;
+    if busy != 0 {
+        return Err(io::Error::other(format!(
+            "wal checkpoint did not complete for {}; action-journal head {head} is not proven durable",
+            path.display()
+        )));
+    }
+    Ok(head)
+}
+
 /// Retain an activated WAL reader for the process lifetime so closing each
 /// short-lived writer does not checkpoint the whole database.
 pub(super) fn open_event_store_keepalive(path: &Path) -> io::Result<Connection> {

--- a/v2/orchestrator-rust/src/snapshot_persistence.rs
+++ b/v2/orchestrator-rust/src/snapshot_persistence.rs
@@ -160,10 +160,28 @@ impl SnapshotJob {
             );
             return false;
         }
-        let journal_head = match latest_action_journal_seq(path) {
+        // This must be the *durable* head, not whatever SQLite currently
+        // reports. Under `synchronous = NORMAL` a WAL-committed row counts as
+        // the head before its frame is fsynced, so comparing against a plain
+        // `MAX(journal_seq)` was not enough: the guard agreed, the machine
+        // stopped, the un-fsynced row evaporated, and the checkpoint it had
+        // already blessed was left leading the surviving journal. That is the
+        // 2026-08-19 outage, which happened *with* the earlier version of this
+        // guard in place. `durable_action_journal_head` flushes the WAL and
+        // only reports a head it has proven is on disk.
+        let journal_head = match durable_action_journal_head(path) {
             Ok(journal_head) => journal_head,
-            // Same reasoning as above: an unreadable head contradicts nothing.
-            Err(_) => return true,
+            // Unlike the commit point above, an unverifiable journal head must
+            // refuse the write. Allowing it is exactly how a world becomes
+            // unbootable; refusing only keeps the previous good checkpoint,
+            // which replay can still reach.
+            Err(error) => {
+                error!(
+                    "refusing to checkpoint CosyWorld snapshot: could not prove the action-journal \
+                     head is durable: {error}"
+                );
+                return false;
+            }
         };
         // Unlike `next_event_seq`, `action_journal_seq` has no bootstrap
         // pathway that advances it without a durable `action_journal` insert
@@ -502,5 +520,56 @@ mod tests {
 
         let _ = fs::remove_file(snapshot_path);
         let _ = fs::remove_file(store_path);
+    }
+
+    /// The 2026-08-19 outage happened *with* the action-journal guard in
+    /// place, because the guard compared against whatever SQLite reported as
+    /// the head -- and `synchronous = NORMAL` reports a WAL-committed row
+    /// before its frame has been transferred into the database file.
+    ///
+    /// Losing the WAL is modelled by copying *only* the main `.sqlite` file
+    /// and opening that copy: whatever is still WAL-resident does not come
+    /// along, exactly as an un-fsynced machine stop would leave it. The
+    /// production keepalive reader is held open throughout so closing the
+    /// short-lived writers cannot checkpoint on our behalf and mask the bug.
+    #[test]
+    fn an_accepted_checkpoint_cites_only_journal_rows_that_survive_losing_the_wal() {
+        let store_path = std::env::temp_dir().join(format!(
+            "cosyworld-v2-durable-head-store-{}-{}.sqlite",
+            std::process::id(),
+            now_millis()
+        ));
+        let salvaged_path = store_path.with_extension("salvaged.sqlite");
+        let _ = fs::remove_file(&store_path);
+        let _ = fs::remove_file(&salvaged_path);
+
+        append_action_journal(&store_path, &fixture_action_journal_record(1))
+            .expect("seed the store so it exists");
+        // Hold the keepalive reader for the rest of the test so closing the
+        // writers below cannot quietly checkpoint the WAL for us.
+        let keepalive =
+            open_event_store_keepalive(&store_path).expect("process-lifetime WAL keepalive");
+        for seed in 2..=6 {
+            append_action_journal(&store_path, &fixture_action_journal_record(seed))
+                .expect("append action journal record");
+        }
+
+        let head = durable_action_journal_head(&store_path).expect("durable head");
+        assert_eq!(head, 6, "every committed row is reported as the head");
+
+        // Salvage only the database file, leaving any WAL-resident frames
+        // behind, while the keepalive still holds the WAL open.
+        fs::copy(&store_path, &salvaged_path).expect("salvage the database file alone");
+        drop(keepalive);
+
+        let surviving =
+            latest_action_journal_seq(&salvaged_path).expect("the salvaged database opens");
+        assert!(
+            surviving >= head,
+            "a head the guard blessed ({head}) must survive losing the WAL, but only {surviving} did"
+        );
+
+        let _ = fs::remove_file(store_path);
+        let _ = fs::remove_file(salvaged_path);
     }
 }


### PR DESCRIPTION
## Problem

PR #847 added a guard that refuses any snapshot whose `action_journal_seq`
leads the journal head. **It was not enough.** Production went unbootable
again on 2026-08-19 *with that guard active*:

```
snapshot action-journal checkpoint 20443 is ahead of journal head 20442
→ action journal was compacted through checkpoint 20442; a matching snapshot is required
```

The guard compared against `latest_action_journal_seq`, which asks SQLite.
Under `synchronous = NORMAL` SQLite counts a WAL-committed row as the head
*before* its frame reaches the database file. So at write time the guard saw
head 20443, agreed, and blessed the checkpoint. The deploy's machine stop then
discarded the un-transferred frame and the real head fell back to 20442.

**#847 closed "the runtime leads SQLite". It never closed "SQLite leads the
disk"** — which is exactly what a machine stop triggers, and why both the
08-18 (19186/19184) and 08-19 (20443/20442) recurrences happened immediately
after a stop rather than during play.

## Change

`durable_action_journal_head` reads the head and *then* runs
`PRAGMA wal_checkpoint(FULL)` under `synchronous = FULL`.

Reading first is what makes the answer sound: everything at or below the
returned value is in the database file by the time the call returns, and a
later append can only make the real head *larger*, never invalidate it.

`FULL` rather than `TRUNCATE` transfers every frame without also requiring the
WAL to be reset, which is far less likely to be refused by a concurrent
reader. A refused or partial checkpoint is an error, and the guard now treats
an unverifiable head as a **refusal** rather than a pass — allowing is how a
world becomes unbootable, while refusing only keeps the previous good
checkpoint, which replay can still reach.

This also covers the shutdown path: `persist_final_snapshot` (`startup.rs`)
goes through the same guard, so the final snapshot a graceful stop writes can
no longer name a row that same stop is about to discard.

### Deliberately *not* setting `synchronous = FULL` globally

That would fsync every commit on the hot command path to fix a fault that only
manifests at checkpoint-citation time, which this addresses directly. Global
`FULL` protects a *different* property — not losing recently committed world
state on a crash — and is worth considering on its own merits, not smuggled in
here.

## Verification

The regression test reproduces the production shape rather than a convenient
approximation:

- holds the same **process-lifetime keepalive reader** production uses, so
  short-lived writers cannot checkpoint on close and mask the bug;
- **salvages only the main `.sqlite` file**, modelling an un-fsynced stop —
  whatever is still WAL-resident does not come along.

Confirmed it **fails without the fix**:

```
a head the guard blessed (6) must survive losing the WAL, but only 1 did
```

and passes with it. Two earlier versions of this test passed either way (one
because `append_action_journal` auto-checkpoints on connection close, one
because dropping the keepalive did the same) — both were discarded rather than
kept as false assurance.

- `cargo test --bin cosyworld-orchestrator`: **1215 passed, 0 failed**
- `cargo fmt --check`: clean
- `check-main-size.sh`: unchanged at its ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
