### PR TITLE
Journal Abandon Avatar as a projection-only record instead of an unknown kernel action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.76",
+  "version": "1.0.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.76",
+      "version": "1.0.77",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.76",
+  "version": "1.0.77",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.76"
+version = "1.0.77"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.76"
+version = "1.0.77"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -1713,16 +1713,308 @@ mod tests {
         assert!(runtime.actor_control_mode(5000).is_direct_input());
 
         let (action, mutation) = runtime.plan_abandon_avatar(5000).expect("plan abandon");
-        assert_eq!(action.kind, CW_ACTION_ABANDON_AVATAR);
+        assert_eq!(action.kind, CW_ACTION_NONE);
         match mutation {
             ProjectionMutation::AbandonAvatar { actor_id } => assert_eq!(actor_id, 5000),
             _ => panic!("expected AbandonAvatar mutation"),
         }
 
-        let events = runtime.apply_abandon_avatar(5000);
+        // Commit the record exactly the way the endpoint journals it. The
+        // abandon effect is projection-only; a record that reached the C
+        // kernel would be rejected and poison replay.
+        let mut record = JournalRecord::new(action, runtime.next_seed_value()).into_player_card();
+        record.bind_offer_kind("abandon_avatar");
+        record.projection_mutations.push(mutation);
+        let tick_before = runtime.world.tick;
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK, "the abandon record must commit cleanly");
         assert!(runtime.actor_control_mode(5000).uses_inference());
-        assert!(!events.is_empty());
-        // Replaying the same abandonment is a no-op.
-        assert!(runtime.apply_abandon_avatar(5000).is_empty());
+        assert!(events
+            .iter()
+            .any(|event| event.type_name == "avatar.abandoned"));
+        assert_eq!(runtime.world.tick, tick_before + 1);
+
+        // Re-applying the same committed record is a settled no-op.
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert!(
+            events.is_empty(),
+            "a settled abandon record replays as a no-op"
+        );
+        assert_eq!(runtime.world.tick, tick_before + 1);
+    }
+
+    #[tokio::test]
+    async fn legacy_rejected_abandon_records_replay_as_no_ops() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Fallen Traveler",
+        );
+        {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == 5000)
+                .expect("the avatar exists");
+            actor.status = CW_ACTOR_KNOCKED_OUT;
+        }
+
+        // The first release of Abandon Avatar journalled kind 41, which the C
+        // kernel never knew: every such row was rejected at commit time, so
+        // its live effect was "nothing happened". Replay must preserve that
+        // history instead of failing the boot or applying a late effect.
+        let mut record = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_ABANDON_AVATAR,
+                actor_id: 5000,
+                ..CwAction::default()
+            },
+            72_001,
+        );
+        record
+            .projection_mutations
+            .push(ProjectionMutation::AbandonAvatar { actor_id: 5000 });
+        let tick_before = runtime.world.tick;
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK, "a legacy rejected abandon row must replay");
+        assert!(events.is_empty());
+        assert!(runtime.actor_control_mode(5000).is_direct_input());
+        assert_eq!(runtime.world.tick, tick_before);
+
+        // Even once the world has moved on (the body recovered), the settled
+        // row still replays instead of bricking the journal.
+        {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == 5000)
+                .expect("the avatar exists");
+            actor.status = CW_ACTOR_ACTIVE;
+        }
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn abandon_avatar_is_refused_while_combat_still_holds_the_body() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Held Witness",
+        );
+        create_test_human(
+            &mut runtime,
+            5001,
+            MOONLIT_TRAIL_LOCATION_ID,
+            "Standing Rival",
+        );
+        for actor_id in [5000, 5001] {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == actor_id)
+                .expect("encounter participant");
+            actor.stats.dexterity = 100;
+            actor.stats.hp_base = 100;
+        }
+        let start = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_COMBAT_START,
+                actor_id: 5001,
+                target_actor_id: 5000,
+                content_id: combat_encounter_id(MOONLIT_JOB_ID),
+                ..CwAction::default()
+            },
+            72_310,
+        )
+        .into_system();
+        assert_eq!(runtime.apply_journal_record(&start).0, CW_OK);
+        assert!(
+            runtime.active_combat_encounter_for_actor(5000).is_some(),
+            "the fixture must hold the avatar in an active encounter"
+        );
+
+        {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == 5000)
+                .expect("the avatar exists");
+            actor.status = CW_ACTOR_KNOCKED_OUT;
+        }
+        let refusal = runtime
+            .plan_abandon_avatar(5000)
+            .expect_err("an encounter still owns the fallen body");
+        assert_eq!(refusal, "The fight around their body has not ended.");
+    }
+
+    #[tokio::test]
+    async fn abandon_avatar_is_refused_once_already_released() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Fallen Traveler",
+        );
+        {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == 5000)
+                .expect("the avatar exists");
+            actor.status = CW_ACTOR_KNOCKED_OUT;
+        }
+        let (action, mutation) = runtime.plan_abandon_avatar(5000).expect("plan abandon");
+        let mut record = JournalRecord::new(action, runtime.next_seed_value()).into_player_card();
+        record.projection_mutations.push(mutation);
+        assert_eq!(runtime.apply_journal_record(&record).0, CW_OK);
+
+        // A later cycle returns the released body to direct control (the
+        // rescue-inhabit path can do this). Planning must refuse instead of
+        // journalling a record whose claim is already spent.
+        runtime.actor_autonomy.entry(5000).or_default().control_mode =
+            ActorControlMode::DirectInput;
+        let refusal = runtime
+            .plan_abandon_avatar(5000)
+            .expect_err("the abandon claim is already spent");
+        assert_eq!(
+            refusal,
+            "This avatar was already released to the world once."
+        );
+    }
+
+    #[test]
+    fn abandoned_avatar_survives_a_full_journal_reboot() {
+        std::thread::Builder::new()
+            .name("abandon-durable-reboot".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(run_abandoned_avatar_durable_reboot)
+            .expect("spawn abandon durable reboot thread")
+            .join()
+            .expect("abandon durable reboot thread");
+    }
+
+    fn run_abandoned_avatar_durable_reboot() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-abandon-reboot-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let snapshot_path = std::env::temp_dir().join(format!(
+            "cosyworld-abandon-reboot-{}-{}.json",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&snapshot_path);
+        let mut state = test_app_state(RuntimeWorld::seeded(), Some(path.clone()));
+        let mut create = JournalRecord::new(
+            CwAction {
+                kind: CW_ACTION_CREATE_ACTOR,
+                actor_id: 5000,
+                location_id: COSY_COTTAGE_LOCATION_ID,
+                ..CwAction::default()
+            },
+            70_500,
+        );
+        create.actor_meta_upserts.insert(
+            5000,
+            ActorMeta {
+                name: "Fallen Traveler".to_string(),
+                speech_mode: "prose".to_string(),
+                title: "Relay Test Avatar".to_string(),
+                description: "A test avatar controlled through the narrative move relay."
+                    .to_string(),
+            },
+        );
+        {
+            let mut runtime = state.inner.blocking_lock();
+            assert_eq!(
+                commit_journal_record(&state, &mut runtime, create)
+                    .expect("journal the avatar creation")
+                    .0,
+                CW_OK
+            );
+            // The knockout is world state the snapshot carries; the journal
+            // tail below must replay on top of it.
+            {
+                let world = &mut runtime.world;
+                let actor = world
+                    .actors
+                    .iter_mut()
+                    .take(world.actor_count)
+                    .find(|actor| actor.id == 5000)
+                    .expect("the avatar exists");
+                actor.status = CW_ACTOR_KNOCKED_OUT;
+                actor.conditions |= CW_CONDITION_UNCONSCIOUS;
+                actor.damage = actor.stats.hp_base.saturating_sub(1);
+            }
+            runtime
+                .save_snapshot(&snapshot_path)
+                .expect("checkpoint the knocked-out world");
+        }
+        {
+            let mut runtime = state.inner.blocking_lock();
+            let (action, mutation) = runtime.plan_abandon_avatar(5000).expect("plan abandon");
+            let mut record =
+                JournalRecord::new(action, runtime.next_seed_value()).into_player_card();
+            record.bind_offer_kind("abandon_avatar");
+            record.projection_mutations.push(mutation);
+            let (status, events) =
+                commit_journal_record(&state, &mut runtime, record).expect("commit abandon");
+            assert_eq!(status, CW_OK);
+            assert!(events
+                .iter()
+                .any(|event| event.type_name == "avatar.abandoned"));
+
+            // A legacy kind-41 row from the broken first release must also
+            // journal and replay as a settled no-op instead of bricking boot.
+            let mut legacy = JournalRecord::new(
+                CwAction {
+                    kind: CW_ACTION_ABANDON_AVATAR,
+                    actor_id: 5000,
+                    ..CwAction::default()
+                },
+                runtime.next_seed_value(),
+            )
+            .into_player_card();
+            legacy.bind_offer_kind("abandon_avatar");
+            legacy
+                .projection_mutations
+                .push(ProjectionMutation::AbandonAvatar { actor_id: 5000 });
+            let (status, events) =
+                commit_journal_record(&state, &mut runtime, legacy).expect("commit legacy row");
+            assert_eq!(status, CW_OK);
+            assert!(events.is_empty());
+        }
+        state.snapshot_path = Some(Arc::new(snapshot_path.clone()));
+        {
+            let mut runtime = state.inner.blocking_lock();
+            restore_runtime_from_durable_state(&state, &mut runtime, &path)
+                .expect("reboot replays the abandon journal without poison");
+            assert!(
+                runtime.actor_control_mode(5000).uses_inference(),
+                "the replayed world keeps the abandoned avatar as a resident"
+            );
+        }
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&snapshot_path);
     }
 }

--- a/v2/orchestrator-rust/src/avatar_rescue.rs
+++ b/v2/orchestrator-rust/src/avatar_rescue.rs
@@ -537,9 +537,22 @@ impl RuntimeWorld {
         if !self.actor_control_mode(actor_id).is_direct_input() {
             return Err("This avatar is already beyond your direct control.".to_string());
         }
+        if self.active_combat_encounter_for_actor(actor_id).is_some() {
+            return Err("The fight around their body has not ended.".to_string());
+        }
+        if self
+            .rpg_claims
+            .contains(&abandon_avatar_claim_key(actor_id))
+        {
+            return Err("This avatar was already released to the world once.".to_string());
+        }
+        // The abandon effect is pure orchestrator state (autonomy control
+        // mode, claim, event), so the record is projection-only. Kind 41 was
+        // never a kernel action; sending it there got every attempt rejected
+        // and journalled as an unreplayable poison row.
         Ok((
             CwAction {
-                kind: CW_ACTION_ABANDON_AVATAR,
+                kind: CW_ACTION_NONE,
                 actor_id,
                 ..CwAction::default()
             },
@@ -550,7 +563,7 @@ impl RuntimeWorld {
     pub(super) fn abandon_avatar_record_preconditions_hold(&self, record: &JournalRecord) -> bool {
         for mutation in &record.projection_mutations {
             if let ProjectionMutation::AbandonAvatar { actor_id } = mutation {
-                if record.action.kind != CW_ACTION_ABANDON_AVATAR
+                if record.action.kind != CW_ACTION_NONE
                     || record.action.actor_id != *actor_id
                     || self.actor_by_id(*actor_id).is_none_or(|actor| {
                         !Self::actor_is_present(actor) || actor.status != CW_ACTOR_KNOCKED_OUT
@@ -561,6 +574,33 @@ impl RuntimeWorld {
             }
         }
         true
+    }
+
+    /// A settled abandon record replays as a no-op. This covers records whose
+    /// abandon claim already ran (idempotent re-application) and the legacy
+    /// kind-41 records written before the projection-only fix: those were
+    /// rejected by the kernel at commit time, so their live effect was
+    /// "nothing happened", and replay must preserve exactly that history
+    /// instead of failing the boot or applying a late effect.
+    pub(super) fn abandon_avatar_record_already_applied(&self, record: &JournalRecord) -> bool {
+        for mutation in &record.projection_mutations {
+            if let ProjectionMutation::AbandonAvatar { actor_id } = mutation {
+                if record.action.kind == CW_ACTION_ABANDON_AVATAR
+                    && record.action.actor_id == *actor_id
+                {
+                    return true;
+                }
+                if record.action.kind == CW_ACTION_NONE
+                    && record.action.actor_id == *actor_id
+                    && self
+                        .rpg_claims
+                        .contains(&abandon_avatar_claim_key(*actor_id))
+                {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     pub(super) fn apply_abandon_avatar(&mut self, actor_id: u64) -> Vec<EventView> {
@@ -618,7 +658,7 @@ pub(super) async fn abandon_avatar(
     let turn_location_id = runtime
         .actor_by_id(payload.actor_id)
         .map(|actor| actor.location_id);
-    let mut record = JournalRecord::new(action, runtime.next_seed_value());
+    let mut record = JournalRecord::new(action, runtime.next_seed_value()).into_player_card();
     record.bind_offer_kind("abandon_avatar");
     record.projection_mutations.push(mutation);
     let Ok((status, mut events)) = commit_journal_record(&state, &mut runtime, record) else {

--- a/v2/orchestrator-rust/src/combat.rs
+++ b/v2/orchestrator-rust/src/combat.rs
@@ -359,7 +359,7 @@ impl RuntimeWorld {
             .find(|encounter| encounter.id == encounter_id)
     }
 
-    pub(super) fn active_combat_encounter_for_actor(
+    pub(crate) fn active_combat_encounter_for_actor(
         &self,
         actor_id: u64,
     ) -> Option<&CwCombatEncounter> {

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -194,8 +194,12 @@ pub const CW_ACTION_STUDY_V2: u8 = 37;
 pub const CW_ACTION_SCOUT_V2: u8 = 38;
 pub const CW_ACTION_COMPLETE_AVATAR_RESCUE: u8 = 39;
 pub const CW_ACTION_REPLACE_AVATAR_RESCUER: u8 = 40;
-// Player frees their knocked-out avatar to live on as an independent
-// roaming NPC, releasing the account to begin a new avatar.
+// Legacy journal-only code from the broken first release of Abandon Avatar:
+// the C kernel never learned kind 41, so every record written with it was
+// rejected by `cw_world_apply_with_tick` and replay treats those rows as
+// settled no-ops. Never send this to the kernel and never reuse 41 for a
+// real kernel action; abandon records are projection-only (kind
+// CW_ACTION_NONE) and the effect lives in ProjectionMutation::AbandonAvatar.
 pub const CW_ACTION_ABANDON_AVATAR: u8 = 41;
 
 pub const CW_EVENT_ACTOR_CREATED: u8 = 2;

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -9203,6 +9203,7 @@ impl RuntimeWorld {
 
     fn apply_journal_record(&mut self, record: &JournalRecord) -> (u32, Vec<EventView>) {
         let avatar_rescue_already_applied = self.avatar_rescue_record_already_applied(record);
+        let abandon_avatar_already_applied = self.abandon_avatar_record_already_applied(record);
         if !focused_encounter_journal_context_is_supported(self, record)
             || !self.route_record_preconditions_hold(record)
             || !threshold_record_preconditions_hold(record)
@@ -9215,7 +9216,8 @@ impl RuntimeWorld {
             || !card_policy_preference_record_preconditions_hold(record)
             || (!avatar_rescue_already_applied
                 && !self.avatar_rescue_record_preconditions_hold(record))
-            || !self.abandon_avatar_record_preconditions_hold(record)
+            || (!abandon_avatar_already_applied
+                && !self.abandon_avatar_record_preconditions_hold(record))
         {
             return (CW_ERR_RULE, Vec::new());
         }
@@ -9223,6 +9225,7 @@ impl RuntimeWorld {
             || discovery_record_claim_already_applied(self, record)
             || avatar_rescue_already_applied
             || self.ai_publication_record_already_applied(record)
+            || abandon_avatar_already_applied
         {
             return (CW_OK, Vec::new());
         }

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -359,4 +359,10 @@
 # and one INDEX_HTML contract assertion. The action's planning, precondition,
 # and apply logic all live in avatar_rescue.rs beside the rescue lifecycle it
 # extends. Existing routing/projection seams, no new system in main.rs.
-63602
+# 63602 -> 63605: three lines in apply_journal_record treat settled abandon
+# records like the existing already-applied rescue/publication groups: legacy
+# kind-41 rows (rejected by the kernel at commit, so their live effect was
+# "nothing happened") and claim-settled rows replay as no-ops instead of
+# failing boot or double-advancing the tick. The predicates live in
+# avatar_rescue.rs beside the abandon lifecycle; no new system in main.rs.
+63605

--- a/v2/scripts/rust-lint-warning-ceiling.txt
+++ b/v2/scripts/rust-lint-warning-ceiling.txt
@@ -29,4 +29,11 @@
 #
 # 237 -> 225: removed the remaining unused merged-inline continuity helpers
 # and other dead Rust surfaces while preserving test-only snapshot helpers.
-225
+#
+# 225 -> 226: no code moved this. Under the current local stable toolchain an
+# unmodified origin/main checkout (94d46d15) already reports 226 under this
+# script's counting; the abandon-avatar journal fix was verified to add zero
+# warnings by diffing clippy's per-warning short-format output between clean
+# main and the branch -- the sets are identical apart from line-number shifts
+# from the fix's three added main.rs lines.
+226


### PR DESCRIPTION
## Summary

Abandon Avatar (#848) planned its journal record with action kind 41 — a code the C kernel never learned. Every attempt reached `cw_world_apply_with_tick`, hit the `default:` reject arm, and returned `CW_ERR_RULE`, so the feature never actually worked. Worse: `commit_journal_record` journals records unconditionally *before* the kernel verdict, and replay treats a rejected record as fatal — so every player click on the abandon card appended an unreplayable poison row to `action_journal`. A later reboot that crossed those rows (missing snapshot, snapshot behind the record, or post-commit recovery) would fail with `action journal record N was rejected during replay with status 4` and production boots fail-closed — the same failure class as the 2026-08-16/19 unbootable-world incidents.

Fix:

- Plan the abandon record as **projection-only** (`kind: CW_ACTION_NONE`, `PlayerCard` origin), matching the existing prepare/chat lifecycle pattern. The abandon effect was always pure orchestrator state (autonomy control mode, idempotence claim, event); it never needed a kernel action.
- Refuse to plan while an **active combat encounter** still holds the body — this also keeps the record out of the combat-blocked projection path that falls back to the kernel (`projection_only_blocked_by_combat`). A stranded KO'd participant in a stuck encounter was otherwise a guaranteed poison write.
- Refuse to plan once the **abandon claim is spent**, so a re-inhabited/re-released body cannot journal a record that silently does nothing.
- Replay **legacy kind-41 rows as settled no-ops**: those rows were rejected by the kernel at commit time, so their live effect was "nothing happened", and replay must preserve exactly that history instead of failing the boot or applying a late effect. Journals written by the broken release boot again.
- Keep kind 41 reserved and documented in `kernel.rs` so no future kernel action silently collides with the legacy journal code.

Closes the "abandon card is dead and poisons the journal" defect from #848 (feature issue #844 remains satisfied end-to-end now).

## Validation

- `cargo test --manifest-path v2/orchestrator-rust/Cargo.toml abandon` — 5/5 pass, including:
  - commit through `commit_journal_record`, idempotent re-apply, world-tick advance;
  - legacy kind-41 rows replay as no-ops (even after the body recovers);
  - combat-held-body and already-released planning refusals;
  - **full reboot**: snapshot + journal tail replay through `restore_runtime_from_durable_state` with both a fresh abandon row and a legacy kind-41 row; the abandoned avatar stays a roaming resident.
- `npm run v2:rust:test` — 1244 passed, 0 failed (incl. upstream #852's tests).
- `npm run v2:kernel` — pass. `npm test` — 183 passed. `npm run check:version`, `git diff --check`, `cargo fmt --check` — clean.
- `node v2/scripts/smoke-browser.mjs` against a deterministic local server — exit 0. `node v2/scripts/smoke-production-profile.mjs` — exit 0.
- `npm run v2:architecture` — pass. Note: `rust-lint-warning-ceiling.txt` is re-pinned 225 → 226 with a drift entry: an unmodified origin/main checkout already reports 226 under the current stable toolchain; this branch was verified to add zero warnings by diffing clippy's short-format per-warning output against clean main (sets identical apart from line-number shifts).

## Compatibility notes

- No kernel/ABI change; kind 41 stays a reserved legacy journal code.
- Journals containing rejected kind-41 rows from the broken release now replay; no migration needed.
- `abandon_avatar_record_preconditions_hold` now validates `kind == CW_ACTION_NONE`; the already-applied predicate carries the legacy-kind tolerance.

## Review checklist

- [x] One coherent behavior fix; no unrelated churn
- [x] New tests cover live commit, idempotent replay, legacy-row replay, reboot, and both refusal paths
- [x] Version bumped in package.json, package-lock.json, Cargo.toml, Cargo.lock (1.0.77)
- [x] main.rs ceiling entry and clippy ceiling entry documented in-file
- [x] No secrets, logs, or runtime databases in the diff