### PR TITLE
Materialize discovered items, and bound the clock on_fill cascade

### DIFF
--- a/ENG.md
+++ b/ENG.md
@@ -128,7 +128,13 @@ Implements PRD "Next", per RPG Bible Phases 4–6 plus the arrangement-evolution
 - Extend the live player-turn world pulses beyond classified ambient weather, opportunity-level trade/faction/conflict, and consented danger-clock escalation: let stakes spawn frontier jobs through audited descriptors, and add smoke coverage for the full consequence chain. Keep the proven assertions that automatic pulses never mutate sanctuary state or turn an unrelated action into stakes.
 - **Arrangement evolution.** Generalize the kernel evolution table from "N unique items gained by one actor" to a **placement pattern**: a list of `(item, target)` requirements where a target is an avatar's keeping or a location's floor. The kernel checks satisfaction against state it already owns (item holder/location ids) and remains the sole authority on the evolve event; satisfaction re-checks ride item transfer, placement, search-reveal, and future craft/attunement hooks. Ceremony completion is claim-keyed, pays placer and witness Journal credit through projection, increments the resident once, and leaves the arranged items in their current slots.
 - **Generated quest lists per level.** A level's pattern may be generated: AI or tables propose from a closed vocabulary (existing item tags, currently reachable ungated locations, present residents); a fail-closed compiler — the same seam as on-fill descriptors — validates reachability, availability, and safety before the pattern is committed as authoritative jobs. Rejected proposals fall back to authored patterns. No generated pattern may require gated-room access for a free player's core-loop resident.
-- On-fill cascade guard (bounded depth, visited set) before content authors get cascading clocks.
+- On-fill cascade guard: **done.** `apply_bounded_clock_fill` cuts a clock-fill
+  chain at four hops and refuses re-entry into a clock already filling, and
+  reports either cut as `clock.fill_effect_rejected` instead of dropping the
+  effects. Saturation already prevented a two-clock cycle — a filled clock
+  returns before re-entering — so the depth bound is the live protection and
+  the visited set is what holds if a repeatable or resettable clock is ever
+  added. Content authors can now be given cascading clocks.
 - Conflict objectives: objective clocks in danger rooms, durability-absorbs-harm, nonlethal outcomes (Phase 6).
 
 ### 7. Crafting and generated content

--- a/docs/backlog/thresholds-trails-and-strict-referee.md
+++ b/docs/backlog/thresholds-trails-and-strict-referee.md
@@ -170,11 +170,38 @@ THR-7L are proposed extensions with no filed issue.
 
 ## THR-D2 — Materialize Bounded Item And Location Discoveries
 
-**Priority**: P1 / later / blocked
-
 **Scope**: Worldpack stocking tables and bounded runtime materialization
 
 **Depends on**: THR-3, THR-D0, THR-D1
+
+### Status: item materialization shipped; locations and authored sources have not
+
+The discovery procedure previously committed a frozen receipt and then
+recorded `"materialization": "not_performed"` alongside `movement`, `custody`,
+and `reward`. A resolved `item` slot now places its selected item through the
+same fail-closed `EffectDescriptor::RevealItem` seam authored clock effects
+use, so the kernel remains the only authority on whether the item may appear,
+and the committed event reports what actually happened — `revealed`,
+`rejected`, `unresolved_result`, or `unsupported_target_kind` — instead of a
+constant.
+
+Because that changes what a committed row means, the procedure version is
+append-only: `discovery-procedure-v2` rows keep their receipt-only meaning on
+replay forever and `discovery-procedure-v3` rows materialize. Both versions
+must stay accepted by `discovery_record_preconditions_hold`, because replay
+fails the entire boot on one rejected record.
+
+Still open, in dependency order:
+
+- **Authored sources.** No pack ships `x-cosyworld-discovery-slots` yet, so the
+  procedure still only runs against fixtures. This is now the binding
+  constraint on everything below.
+- **Location and route materialization.** `location`, `route`, `feature`, and
+  `resource` slots keep their frozen receipts and report
+  `unsupported_target_kind`. The bounded hidden graph, incremental reveal, and
+  `authorized_topology_ids` enforcement are untouched.
+- **Movement, custody, and reward** remain `not_performed` by design; Open,
+  Take, and Travel stay separate operations after Reveal.
 
 ### What to do
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.77",
+      "version": "1.0.78",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.77"
+version = "1.0.78"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.77"
+version = "1.0.78"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/discovery_pipeline.rs
+++ b/v2/orchestrator-rust/src/discovery_pipeline.rs
@@ -2,7 +2,24 @@ use super::*;
 use serde::ser::SerializeStruct;
 
 pub(super) const DISCOVERY_PIPELINE_SCHEMA_VERSION: u8 = 1;
-pub(super) const DISCOVERY_PROCEDURE_VERSION: &str = "discovery-procedure-v2";
+/// Append-only. `discovery-procedure-v2` froze a selection and deliberately
+/// materialized nothing; every v2 row in the journal means "receipt only", and
+/// replay must keep meaning exactly that. `v3` is the same procedure with the
+/// selected item actually placed, so the two versions stay distinguishable in
+/// history instead of one silently reinterpreting the other.
+pub(super) const DISCOVERY_PROCEDURE_VERSION: &str = "discovery-procedure-v3";
+const DISCOVERY_PROCEDURE_VERSION_RECEIPT_ONLY: &str = "discovery-procedure-v2";
+
+/// Replay rejects a whole boot when one record fails its preconditions, so a
+/// superseded procedure version has to stay *readable* forever even though
+/// nothing new is minted at it. Only the current version is offered; both
+/// replay.
+fn discovery_procedure_version_is_supported(version: &str) -> bool {
+    matches!(
+        version,
+        DISCOVERY_PROCEDURE_VERSION | DISCOVERY_PROCEDURE_VERSION_RECEIPT_ONLY
+    )
+}
 pub(super) const FOCUSED_NOTICE_OFFER_KIND: &str = "focused_notice";
 pub(super) const DISCOVERY_SEARCH_OFFER_KIND: &str = "search_discovery";
 pub(super) const DISCOVERY_STUDY_OFFER_KIND: &str = "study_discovery";
@@ -719,6 +736,16 @@ impl RuntimeWorld {
                 ));
             }
         }
+        let source_event_seq = committed_events
+            .iter()
+            .filter(|event| event.actor_id == Some(intent.actor_id))
+            .map(|event| event.seq)
+            .max()
+            .unwrap_or_default();
+        let (materialization, materialized_events) =
+            self.materialize_discovery_result(intent, source_event_seq);
+        events.extend(materialized_events);
+
         let content = serde_json::json!({
             "procedure_version": intent.procedure_version,
             "procedure": intent.procedure,
@@ -730,7 +757,7 @@ impl RuntimeWorld {
             "target_kind": intent.target_kind,
             "origin_id": intent.origin_id,
             "result_ids": intent.receipt.materialized_entity_ids,
-            "materialization": "not_performed",
+            "materialization": materialization,
             "movement": "not_performed",
             "custody": "not_performed",
             "reward": "not_performed",
@@ -746,6 +773,85 @@ impl RuntimeWorld {
             serde_json::to_string(&content).ok(),
         ));
         events
+    }
+
+    /// Place the truth a discovery receipt already selected.
+    ///
+    /// The receipt froze *what* was found when it was minted; this turns that
+    /// frozen selection into world state through the same fail-closed effect
+    /// seam authored clock effects use, so the kernel stays the only authority
+    /// on whether the item may appear. Returns the disposition recorded in the
+    /// committed event, which never claims more than actually happened.
+    fn materialize_discovery_result(
+        &mut self,
+        intent: &AcceptedDiscoveryIntent,
+        source_event_seq: u64,
+    ) -> (&'static str, Vec<EventView>) {
+        if intent.procedure_version == DISCOVERY_PROCEDURE_VERSION_RECEIPT_ONLY {
+            // A historical row. It meant "receipt only" when it was committed
+            // and it still does; replay must not invent a placement.
+            return ("not_performed", Vec::new());
+        }
+        if intent.phase_after != "revealed" {
+            // A Lead names where to look. Nothing is found yet.
+            return ("not_performed", Vec::new());
+        }
+        if intent.target_kind != "item" {
+            // Location, route, feature, and resource slots keep their frozen
+            // receipts until their own materializers exist. Saying so is more
+            // useful than an empty field that reads like success.
+            return ("unsupported_target_kind", Vec::new());
+        }
+
+        let effects = intent
+            .receipt
+            .materialized_entity_ids
+            .iter()
+            .filter_map(|entity_id| {
+                let canonical = discovery_canonical_ref(entity_id)?;
+                let item_id = self.discovery_item_handle(&canonical)?;
+                Some(EffectDescriptor::RevealItem {
+                    item_id,
+                    location_id: intent.location_id,
+                    reason: Some(format!("discovery {}", intent.slot_id)),
+                })
+            })
+            .collect::<Vec<_>>();
+        if effects.len() != intent.receipt.materialized_entity_ids.len() {
+            // A selected id that no longer resolves to an authored item means
+            // content moved under a frozen receipt. Fail closed and say so.
+            return ("unresolved_result", Vec::new());
+        }
+
+        let events = self.apply_effects(
+            EffectApplicationSource::DiscoveryMaterialization,
+            intent.actor_id,
+            source_event_seq,
+            &effects,
+        );
+        let revealed = events
+            .iter()
+            .filter(|event| event.success && event.type_name == "item.revealed")
+            .count();
+        if revealed == effects.len() {
+            ("revealed", events)
+        } else if revealed == 0 {
+            ("rejected", events)
+        } else {
+            ("partially_revealed", events)
+        }
+    }
+
+    fn discovery_item_handle(&self, canonical_ref: &str) -> Option<u64> {
+        self.runtime_handle_for_canonical_ref("item", canonical_ref)
+            .or_else(|| {
+                active_content().items.iter().find_map(|item| {
+                    content_registry()
+                        .content_reference("item", item.id)
+                        .is_some_and(|entry| entry.canonical_ref == canonical_ref)
+                        .then_some(item.id)
+                })
+            })
     }
 }
 
@@ -774,7 +880,7 @@ pub(super) fn discovery_record_preconditions_hold(
     }
     let intent = intents[0];
     if intent.schema_version != DISCOVERY_PIPELINE_SCHEMA_VERSION
-        || intent.procedure_version != DISCOVERY_PROCEDURE_VERSION
+        || !discovery_procedure_version_is_supported(&intent.procedure_version)
         || discovery_offer_kind(&intent.procedure) != Some(intent.offer_kind.as_str())
         || discovery_action_kind(&intent.procedure) != Some(record.action.kind)
         || record.action.actor_id != intent.actor_id
@@ -1162,5 +1268,254 @@ mod tests {
             })
             .expect("second actor still has an offer");
         assert_ne!(second.claim_key.as_deref(), Some(first_claim.as_str()));
+    }
+
+    /// A slot whose frozen selection names a real authored core item, so the
+    /// receipt can actually be turned into world state. A catalog may only
+    /// name entities inside its own pack, so this one is authored as core.
+    fn materializing_catalog() -> DiscoveryAuthorityCatalog {
+        serde_json::from_str(
+            r#"{
+              "schema_version": 1,
+              "receipt_version": "discovery-receipt-v1",
+              "roll_algorithm": "weighted-fnv1a-v1",
+              "stocking_tables": [
+                {
+                  "id": "cosyworld.core:discovery-table/hearth-cache",
+                  "version": 1,
+                  "target_kind": "item",
+                  "eligible_inputs": [
+                    "worldpack_bundle_hash",
+                    "slot_id",
+                    "slot_version",
+                    "origin_id",
+                    "claim_scope_id"
+                  ],
+                  "rows": [
+                    {
+                      "id": "tucked_keepsake",
+                      "weight": 1,
+                      "result_ids": ["cosyworld.core:item/2005"]
+                    }
+                  ],
+                  "fallback_row_id": "tucked_keepsake"
+                }
+              ],
+              "event_tables": [],
+              "presentation_tables": [],
+              "slots": [
+                {
+                  "id": "cosyworld.core:discovery/hidden-cache",
+                  "version": 1,
+                  "target_kind": "item",
+                  "origin_id": "cosyworld.core:feature/hollow-stone",
+                  "scope": "world",
+                  "initial_phase": "signed",
+                  "tells": [
+                    {
+                      "id": "hollow_note",
+                      "sense": "sight",
+                      "text": "One hearthstone sits a finger proud of the rest."
+                    }
+                  ],
+                  "reveal_methods": ["search"],
+                  "claim_policy": "once_per_scope",
+                  "stocking": {
+                    "kind": "table",
+                    "table_id": "cosyworld.core:discovery-table/hearth-cache",
+                    "table_version": 1
+                  },
+                  "progression": { "kind": "optional" }
+                }
+              ]
+            }"#,
+        )
+        .expect("materializing discovery fixture")
+    }
+
+    fn runtime_with_materializing_slot() -> RuntimeWorld {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Discovery Tester",
+        );
+        // The kernel allows one loose item per floor, and the seed cottage
+        // already has one. Clear it so the reveal is testing materialization
+        // rather than the capacity rule the effect seam already pins.
+        runtime.hide_loose_items_at_location(COSY_COTTAGE_LOCATION_ID);
+        let hidden = runtime.world.items[..runtime.world.item_count]
+            .iter_mut()
+            .find(|item| item.id == 2005)
+            .expect("seed item 2005");
+        hidden.holder_actor_id = 0;
+        hidden.location_id = 0;
+        hidden.zone = CW_CARD_ZONE_WORLD;
+        runtime.install_discovery_catalog_for_test(
+            materializing_catalog(),
+            "cosyworld.core",
+            "1.0.0",
+            COSY_COTTAGE_LOCATION_ID,
+            None,
+        );
+        runtime
+    }
+
+    fn hidden_cache_search_record(runtime: &mut RuntimeWorld, seed: u64) -> JournalRecord {
+        let offer = runtime
+            .discovery_action_offers(5_000)
+            .into_iter()
+            .find(|offer| {
+                offer.discovery.as_ref().is_some_and(|binding| {
+                    binding.slot_id == "cosyworld.core:discovery/hidden-cache"
+                })
+            })
+            .expect("hidden cache Search offer");
+        runtime
+            .discovery_record_for_offer(5_000, &offer, seed)
+            .expect("hidden cache record")
+    }
+
+    #[test]
+    fn a_revealed_item_slot_places_its_frozen_selection_on_the_floor() {
+        let mut runtime = runtime_with_materializing_slot();
+        assert!(runtime.room_floor_empty(COSY_COTTAGE_LOCATION_ID));
+
+        let record = hidden_cache_search_record(&mut runtime, 91_101);
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(status, CW_OK);
+
+        assert!(events
+            .iter()
+            .any(|event| event.success && event.type_name == "item.revealed"));
+        assert_eq!(
+            runtime
+                .loose_items_at_location(COSY_COTTAGE_LOCATION_ID)
+                .iter()
+                .map(|item| item.id)
+                .collect::<Vec<_>>(),
+            vec![2005],
+            "the selected item is placed where it was found"
+        );
+
+        let revealed = events
+            .iter()
+            .find(|event| event.type_name == "discovery.revealed")
+            .expect("discovery.revealed");
+        let content: serde_json::Value =
+            serde_json::from_str(revealed.content.as_deref().expect("content"))
+                .expect("discovery content");
+        assert_eq!(content["materialization"], "revealed");
+        // Reveal is not Take and not Travel; those stay separate operations.
+        assert_eq!(content["custody"], "not_performed");
+        assert_eq!(content["movement"], "not_performed");
+    }
+
+    #[test]
+    fn a_historical_receipt_only_record_replays_without_materializing() {
+        let mut runtime = runtime_with_materializing_slot();
+        let mut record = hidden_cache_search_record(&mut runtime, 91_102);
+        for mutation in &mut record.projection_mutations {
+            if let ProjectionMutation::ResolveDiscovery { intent } = mutation {
+                intent.procedure_version = DISCOVERY_PROCEDURE_VERSION_RECEIPT_ONLY.to_string();
+            }
+        }
+
+        let (status, events) = runtime.apply_journal_record(&record);
+        assert_eq!(
+            status, CW_OK,
+            "a superseded procedure version must still replay, or boot dies on it"
+        );
+        assert!(
+            runtime.room_floor_empty(COSY_COTTAGE_LOCATION_ID),
+            "a v2 row meant receipt-only when it was written and still does"
+        );
+        let revealed = events
+            .iter()
+            .find(|event| event.type_name == "discovery.revealed")
+            .expect("discovery.revealed");
+        let content: serde_json::Value =
+            serde_json::from_str(revealed.content.as_deref().expect("content"))
+                .expect("discovery content");
+        assert_eq!(content["materialization"], "not_performed");
+    }
+
+    #[test]
+    fn both_procedure_versions_satisfy_replay_preconditions() {
+        let mut runtime = runtime_with_materializing_slot();
+        let current = hidden_cache_search_record(&mut runtime, 91_103);
+        assert!(discovery_record_preconditions_hold(&runtime, &current));
+
+        let mut historical = current.clone();
+        for mutation in &mut historical.projection_mutations {
+            if let ProjectionMutation::ResolveDiscovery { intent } = mutation {
+                intent.procedure_version = DISCOVERY_PROCEDURE_VERSION_RECEIPT_ONLY.to_string();
+            }
+        }
+        assert!(
+            discovery_record_preconditions_hold(&runtime, &historical),
+            "replay rejects the whole boot when a record fails preconditions"
+        );
+
+        let mut unknown = current.clone();
+        for mutation in &mut unknown.projection_mutations {
+            if let ProjectionMutation::ResolveDiscovery { intent } = mutation {
+                intent.procedure_version = "discovery-procedure-v99".to_string();
+            }
+        }
+        assert!(
+            !discovery_record_preconditions_hold(&runtime, &unknown),
+            "an unknown procedure version is still refused"
+        );
+    }
+
+    #[test]
+    fn a_selection_that_no_longer_resolves_fails_closed() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5_000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Discovery Tester",
+        );
+        runtime.hide_loose_items_at_location(COSY_COTTAGE_LOCATION_ID);
+        // The stock fixture names items that no pack authors.
+        runtime.install_discovery_catalog_for_test(
+            fixture(),
+            "fixture.discovery",
+            "1.0.0",
+            COSY_COTTAGE_LOCATION_ID,
+            Some("fixture.discovery:region/mossy-verge"),
+        );
+        let offer = runtime
+            .discovery_action_offers(5_000)
+            .into_iter()
+            .find(|offer| {
+                offer.kind == DISCOVERY_SEARCH_OFFER_KIND
+                    && offer
+                        .discovery
+                        .as_ref()
+                        .is_some_and(|binding| binding.target_kind == "item")
+            })
+            .expect("item Search");
+        let record = runtime
+            .discovery_record_for_offer(5_000, &offer, 91_104)
+            .expect("record");
+        let (status, events) = runtime.apply_journal_record(&record);
+
+        assert_eq!(status, CW_OK);
+        assert!(
+            runtime.room_floor_empty(COSY_COTTAGE_LOCATION_ID),
+            "an unresolvable selection materializes nothing"
+        );
+        let revealed = events
+            .iter()
+            .find(|event| event.type_name == "discovery.revealed")
+            .expect("discovery.revealed");
+        let content: serde_json::Value =
+            serde_json::from_str(revealed.content.as_deref().expect("content"))
+                .expect("discovery content");
+        assert_eq!(content["materialization"], "unresolved_result");
     }
 }

--- a/v2/orchestrator-rust/src/keys.rs
+++ b/v2/orchestrator-rust/src/keys.rs
@@ -32,6 +32,11 @@ pub(super) fn listen_attempt_claim_key(actor_id: u64, location_id: u64) -> Strin
     format!("listen_attempt:{actor_id}:{location_id}")
 }
 
+/// How deep one committed action may cascade clock fills before the chain is
+/// cut. Four is enough for an authored consequence chain to read as a story
+/// beat and far short of anything that could exhaust the stack.
+pub(super) const CLOCK_FILL_CASCADE_MAX_DEPTH: usize = 4;
+
 pub(super) fn clock_fill_claim_key(clock_id: &str, event_seq: u64) -> String {
     format!("clock_fill:{clock_id}:{event_seq}")
 }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1626,6 +1626,8 @@ struct RuntimeWorld {
     treasure_objectives: BTreeMap<String, TreasureObjectiveState>,
     card_policy_preferences: BTreeMap<u64, BTreeMap<String, i16>>,
     world_simulation: WorldSimulationState,
+    /// Clocks filling right now; transient. See `apply_bounded_clock_fill`.
+    clock_fill_cascade: Vec<String>,
     rpg_claims: BTreeSet<String>,
     orb_balances: BTreeMap<u64, i32>,
     orb_reward_claims: BTreeSet<String>,
@@ -5480,6 +5482,7 @@ impl RuntimeSnapshot {
 
         Ok(RuntimeWorld {
             world,
+            clock_fill_cascade: Vec::new(),
             canonical_identities: self.canonical_identities,
             command_receipts: CommandReceiptCache::from_persisted(self.command_receipts),
             ai_publications: self.ai_publications,
@@ -5907,6 +5910,7 @@ impl RuntimeWorld {
 
         let mut runtime = RuntimeWorld {
             world,
+            clock_fill_cascade: Vec::new(),
             canonical_identities: CanonicalIdentityState::default(),
             command_receipts: CommandReceiptCache::default(),
             ai_publications: BTreeMap::new(),
@@ -11395,12 +11399,8 @@ impl RuntimeWorld {
         if crossed_fill && !clock.on_fill.is_empty() {
             let claim_key = clock_fill_claim_key(&clock.id, update_event.seq);
             if self.rpg_claims.insert(claim_key) {
-                let mut fill_events = self.apply_effects(
-                    EffectApplicationSource::ClockFill(&clock.id),
-                    actor_id,
-                    update_event.seq,
-                    &clock.on_fill,
-                );
+                let mut fill_events =
+                    self.apply_bounded_clock_fill(&clock, actor_id, update_event.seq);
                 self.link_events_to_cause(&mut fill_events, update_event.seq);
                 events.extend(fill_events);
             }

--- a/v2/orchestrator-rust/src/rpg/effects.rs
+++ b/v2/orchestrator-rust/src/rpg/effects.rs
@@ -52,6 +52,10 @@ pub(crate) enum EffectApplicationSource<'a> {
     Lifecycle(&'a str),
     ClockFill(&'a str),
     JobContribution,
+    /// A frozen discovery receipt materializing the truth it already selected.
+    /// The roll happened when the receipt was minted; this source only places
+    /// the authored result, so it carries no clock and no authored reason.
+    DiscoveryMaterialization,
 }
 
 pub(crate) fn lifecycle_hook_requirements_met(
@@ -70,20 +74,21 @@ impl<'a> EffectApplicationSource<'a> {
             Self::Lifecycle(_) => "lifecycle_effect",
             Self::ClockFill(_) => "clock_fill",
             Self::JobContribution => "job_contribution",
+            Self::DiscoveryMaterialization => "discovery_materialization",
         }
     }
 
     fn authored_reason(self) -> Option<&'a str> {
         match self {
             Self::Lifecycle(hook_name) => Some(hook_name),
-            Self::ClockFill(_) | Self::JobContribution => None,
+            Self::ClockFill(_) | Self::JobContribution | Self::DiscoveryMaterialization => None,
         }
     }
 
     fn clock_id(self) -> Option<&'a str> {
         match self {
             Self::ClockFill(clock_id) => Some(clock_id),
-            Self::Lifecycle(_) | Self::JobContribution => None,
+            Self::Lifecycle(_) | Self::JobContribution | Self::DiscoveryMaterialization => None,
         }
     }
 }

--- a/v2/orchestrator-rust/src/rpg/effects.rs
+++ b/v2/orchestrator-rust/src/rpg/effects.rs
@@ -89,6 +89,60 @@ impl<'a> EffectApplicationSource<'a> {
 }
 
 impl RuntimeWorld {
+    /// Run one clock's `on_fill` effects with the cascade bounded.
+    ///
+    /// `on_fill` may advance another clock, which may fill and advance a third,
+    /// so the descriptor vocabulary already allows a chain as long as there are
+    /// clocks to author. The per-fill claim key does not bound it: every hop
+    /// crosses at a new event sequence and so mints a fresh key.
+    ///
+    /// Saturation is what stops a *cycle* today — a filled clock returns early
+    /// because `after == before`, so A -> B -> A cannot re-enter A. That makes
+    /// the visited-set check below currently unreachable, and it is kept
+    /// deliberately: it is the guard that holds if a repeatable or resettable
+    /// clock ever exists, and it costs one comparison. The depth bound is the
+    /// live protection, since saturation alone still permits a chain as deep as
+    /// the clock table.
+    ///
+    /// Either cut is reported in the feed rather than dropping effects
+    /// silently.
+    pub(crate) fn apply_bounded_clock_fill(
+        &mut self,
+        clock: &ClockState,
+        actor_id: u64,
+        source_event_seq: u64,
+    ) -> Vec<EventView> {
+        if self.clock_fill_cascade.iter().any(|id| id == &clock.id) {
+            return vec![self.append_clock_event(
+                "clock.fill_effect_rejected",
+                actor_id,
+                clock,
+                0,
+                "this clock is already filling in the current cascade",
+            )];
+        }
+        if self.clock_fill_cascade.len() >= CLOCK_FILL_CASCADE_MAX_DEPTH {
+            return vec![self.append_clock_event(
+                "clock.fill_effect_rejected",
+                actor_id,
+                clock,
+                0,
+                &format!(
+                    "clock fill cascade reached its depth bound of {CLOCK_FILL_CASCADE_MAX_DEPTH}"
+                ),
+            )];
+        }
+        self.clock_fill_cascade.push(clock.id.clone());
+        let events = self.apply_effects(
+            EffectApplicationSource::ClockFill(&clock.id),
+            actor_id,
+            source_event_seq,
+            &clock.on_fill,
+        );
+        self.clock_fill_cascade.pop();
+        events
+    }
+
     pub(crate) fn apply_effects(
         &mut self,
         source: EffectApplicationSource<'_>,
@@ -480,5 +534,111 @@ mod tests {
             .expect("test tag remains present")
             .active = false;
         assert!(!lifecycle_hook_requirements_met(&hook, &tags));
+    }
+
+    /// Two clocks that fill each other. Saturation is the first line of
+    /// defence — a filled clock cannot advance again, so `after == before`
+    /// returns before the cascade re-enters — and this pins that, because the
+    /// depth bound alone would not stop a cycle among many distinct clocks.
+    #[test]
+    fn mutually_filling_clocks_do_not_recurse() {
+        let mut runtime = RuntimeWorld::seeded();
+        insert_effect_test_clock(
+            &mut runtime,
+            "test:cycle-a",
+            vec![EffectDescriptor::AdvanceClock {
+                clock_id: "test:cycle-b".to_string(),
+                amount: 1,
+                reason: Some("cycle_test".to_string()),
+            }],
+        );
+        insert_effect_test_clock(
+            &mut runtime,
+            "test:cycle-b",
+            vec![EffectDescriptor::AdvanceClock {
+                clock_id: "test:cycle-a".to_string(),
+                amount: 1,
+                reason: Some("cycle_test".to_string()),
+            }],
+        );
+
+        // Returning at all is the assertion: unbounded re-entry ends in a
+        // stack overflow, not a failed comparison.
+        runtime.advance_clock("test:cycle-a", 1, 1001, "cycle_test");
+
+        assert_eq!(runtime.clocks["test:cycle-a"].filled, 1);
+        assert_eq!(runtime.clocks["test:cycle-b"].filled, 1);
+        assert!(
+            runtime.clock_fill_cascade.is_empty(),
+            "the cascade stack unwinds completely"
+        );
+    }
+
+    /// A chain longer than the bound is cut at the bound rather than running to
+    /// whatever depth an author happened to write.
+    #[test]
+    fn a_clock_fill_chain_stops_at_its_depth_bound() {
+        let mut runtime = RuntimeWorld::seeded();
+        let depth = CLOCK_FILL_CASCADE_MAX_DEPTH + 2;
+        for step in 0..depth {
+            let effects = vec![EffectDescriptor::AdvanceClock {
+                clock_id: format!("test:chain-{}", step + 1),
+                amount: 1,
+                reason: Some("chain_test".to_string()),
+            }];
+            insert_effect_test_clock(&mut runtime, &format!("test:chain-{step}"), effects);
+        }
+        insert_effect_test_clock(&mut runtime, &format!("test:chain-{depth}"), Vec::new());
+
+        let events = runtime.advance_clock("test:chain-0", 1, 1001, "chain_test");
+
+        assert!(
+            events.iter().any(|event| {
+                event.type_name == "clock.fill_effect_rejected"
+                    && event
+                        .content
+                        .as_deref()
+                        .is_some_and(|content| content.contains("depth bound"))
+            }),
+            "the cut names the depth bound"
+        );
+        assert_eq!(
+            runtime.clocks[&format!("test:chain-{CLOCK_FILL_CASCADE_MAX_DEPTH}")].filled,
+            1,
+            "the chain runs right up to the bound"
+        );
+        assert_eq!(
+            runtime.clocks[&format!("test:chain-{}", CLOCK_FILL_CASCADE_MAX_DEPTH + 1)].filled,
+            0,
+            "and no further"
+        );
+        assert!(runtime.clock_fill_cascade.is_empty());
+    }
+
+    /// The guard must not disturb an ordinary authored consequence.
+    #[test]
+    fn an_ordinary_single_fill_still_applies_its_effects() {
+        let mut runtime = RuntimeWorld::seeded();
+        insert_effect_test_clock(
+            &mut runtime,
+            "test:plain-fill",
+            vec![EffectDescriptor::SetTag {
+                tag_id: "test:plain-tag".to_string(),
+                scope: "room".to_string(),
+                scope_id: COSY_COTTAGE_LOCATION_ID,
+                label: "Plain".to_string(),
+                kind: "condition".to_string(),
+                expires: None,
+                reason: Some("plain_test".to_string()),
+            }],
+        );
+
+        let events = runtime.advance_clock("test:plain-fill", 1, 1001, "plain_test");
+
+        assert!(!events
+            .iter()
+            .any(|event| event.type_name == "clock.fill_effect_rejected"));
+        assert!(runtime.tags.contains_key("test:plain-tag"));
+        assert!(runtime.clock_fill_cascade.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Two independent runtime-authority fixes, combined into one release (1.0.78) because both were developed in parallel and both bumped to the same version. `feat/bound-clock-fill-cascade` (previously PR #860) is merged into this branch; #860 is closed in favour of this one. The merge was conflict-free.

### 1. A resolved item discovery now places its item (THR-D2)

The unified discovery procedure already froze a selection, committed a replayable receipt, and enforced claim keys and phase transitions. What it did not do was create anything — a resolved Search committed `"materialization": "not_performed"` alongside `movement`, `custody`, and `reward`, so the whole procedure produced receipts about nothing.

A resolved `item` slot now places its selected item through the existing fail-closed `EffectDescriptor::RevealItem` seam. The kernel's `apply_reveal_item` remains the only authority on whether the item may appear, and its one-loose-item-per-floor rule is enforced unchanged. The event reports what actually happened — `revealed`, `rejected`, `unresolved_result`, or `unsupported_target_kind` — instead of a constant that reads like success.

**Replay safety is the load-bearing part.** Materializing changes what a committed row *means*, so the procedure version is append-only: `discovery-procedure-v2` rows keep their receipt-only meaning on replay forever, and only `v3` rows place anything. Critically, both versions must remain accepted by `discovery_record_preconditions_hold` — boot replay fails the entire process on one rejected record, so narrowing that check to the current version alone would have bricked any world holding a v2 discovery row. A test pins that in both directions, including that an unknown version is still refused.

Reveal stays distinct from Open, Take, and Travel: `movement`, `custody`, and `reward` remain `not_performed` by design.

Deliberately out of scope, recorded in the THR-D2 doc section rather than left implied:

- Location, route, feature, and resource slots keep their frozen receipts and report `unsupported_target_kind`.
- No pack ships `x-cosyworld-discovery-slots` yet, so the procedure still only runs against fixtures. Materialization works, but nothing in the official world can trigger it — this is now the binding constraint on the rest of the THR chain, ahead of the location half.

### 2. The clock `on_fill` cascade is bounded (ENG priority 6)

A clock's `on_fill` may advance another clock, which may fill and advance a third. Nothing bounded that chain. The per-fill claim key cannot: every hop crosses at a new event sequence and so mints a fresh key. Authored content is one `advance_clock` descriptor away from a chain as deep as the clock table.

`apply_bounded_clock_fill` cuts the chain at four hops and refuses re-entry into a clock already filling, reporting either cut as `clock.fill_effect_rejected` rather than dropping the effects silently.

**One finding worth review attention.** Saturation turns out to be the first line of defence against a true cycle: a filled clock returns early because `after == before`, so `A -> B -> A` cannot re-enter `A`. That makes the visited-set branch unreachable today. It is kept deliberately and documented as such — it costs one comparison and is the guard that holds the moment a repeatable or resettable clock exists. The depth bound is the live protection, because saturation alone still permits a chain as deep as the clock table. The cycle test asserts the true current behaviour (both clocks fill once, the stack unwinds, no overflow) rather than asserting a rejection that cannot currently happen.

The guard lives in `rpg/effects.rs` beside `apply_effects`, which owns effect application. `main.rs` keeps only the transient cascade field and lands **exactly at its existing line ceiling**, so no ceiling exception is needed.

## Validation

Run on the merged branch:

- `cargo test` — 1226 passed, 0 failed (7 new tests: 4 in `discovery_pipeline`, 3 in `rpg::effects`)
- `npm test` — 183 passed across 18 files
- `npm run v2:kernel` — cosy kernel tests passed
- `npm run v2:worldpack` — ok; proof world ready, 8/8 rooms reachable
- `npm run v2:architecture` — `main.rs` 63605 lines (ceiling 63605); clippy 226 warnings (ceiling 226)
- `npm run check:version` — passed; 1.0.78 across `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`
- `cargo fmt --check` and `git diff --check` — clean

New tests:

- `a_revealed_item_slot_places_its_frozen_selection_on_the_floor`
- `a_historical_receipt_only_record_replays_without_materializing`
- `both_procedure_versions_satisfy_replay_preconditions`
- `a_selection_that_no_longer_resolves_fails_closed`
- `mutually_filling_clocks_do_not_recurse`
- `a_clock_fill_chain_stops_at_its_depth_bound`
- `an_ordinary_single_fill_still_applies_its_effects`

The pre-existing `safe_search_reveals_without_a_roll_or_physical_side_effect` still passes unchanged.

Not run: `npm run v2:check` (browser/visual smoke). Neither change adds a client surface — the browser already renders `item.revealed` and `clock.fill_effect_rejected`.

## Review checklist

- [x] Tests cover the changed behavior or the PR explains why no test applies.
- [x] Generated worldpack files and locks are refreshed when source content changes. — no source content changed.
- [x] Register review completed for changes under `v2/content/**` against `v2/docs/writing-style.md` (or not applicable). — not applicable; no content changes.
- [x] Genre review completed: which kindness does any new horror enlarge? — not applicable; no new horror. A hidden item becoming a found item is the cozy half of discovery, and a bounded cascade keeps authored consequence legible instead of runaway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
