### PR TITLE
Bound the clock on_fill cascade before authors get cascading clocks

### DIFF
--- a/ENG.md
+++ b/ENG.md
@@ -128,7 +128,13 @@ Implements PRD "Next", per RPG Bible Phases 4–6 plus the arrangement-evolution
 - Extend the live player-turn world pulses beyond classified ambient weather, opportunity-level trade/faction/conflict, and consented danger-clock escalation: let stakes spawn frontier jobs through audited descriptors, and add smoke coverage for the full consequence chain. Keep the proven assertions that automatic pulses never mutate sanctuary state or turn an unrelated action into stakes.
 - **Arrangement evolution.** Generalize the kernel evolution table from "N unique items gained by one actor" to a **placement pattern**: a list of `(item, target)` requirements where a target is an avatar's keeping or a location's floor. The kernel checks satisfaction against state it already owns (item holder/location ids) and remains the sole authority on the evolve event; satisfaction re-checks ride item transfer, placement, search-reveal, and future craft/attunement hooks. Ceremony completion is claim-keyed, pays placer and witness Journal credit through projection, increments the resident once, and leaves the arranged items in their current slots.
 - **Generated quest lists per level.** A level's pattern may be generated: AI or tables propose from a closed vocabulary (existing item tags, currently reachable ungated locations, present residents); a fail-closed compiler — the same seam as on-fill descriptors — validates reachability, availability, and safety before the pattern is committed as authoritative jobs. Rejected proposals fall back to authored patterns. No generated pattern may require gated-room access for a free player's core-loop resident.
-- On-fill cascade guard (bounded depth, visited set) before content authors get cascading clocks.
+- On-fill cascade guard: **done.** `apply_bounded_clock_fill` cuts a clock-fill
+  chain at four hops and refuses re-entry into a clock already filling, and
+  reports either cut as `clock.fill_effect_rejected` instead of dropping the
+  effects. Saturation already prevented a two-clock cycle — a filled clock
+  returns before re-entering — so the depth bound is the live protection and
+  the visited set is what holds if a repeatable or resettable clock is ever
+  added. Content authors can now be given cascading clocks.
 - Conflict objectives: objective clocks in danger rooms, durability-absorbs-harm, nonlethal outcomes (Phase 6).
 
 ### 7. Crafting and generated content

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.77",
+      "version": "1.0.78",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.77"
+version = "1.0.78"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.77"
+version = "1.0.78"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/keys.rs
+++ b/v2/orchestrator-rust/src/keys.rs
@@ -32,6 +32,11 @@ pub(super) fn listen_attempt_claim_key(actor_id: u64, location_id: u64) -> Strin
     format!("listen_attempt:{actor_id}:{location_id}")
 }
 
+/// How deep one committed action may cascade clock fills before the chain is
+/// cut. Four is enough for an authored consequence chain to read as a story
+/// beat and far short of anything that could exhaust the stack.
+pub(super) const CLOCK_FILL_CASCADE_MAX_DEPTH: usize = 4;
+
 pub(super) fn clock_fill_claim_key(clock_id: &str, event_seq: u64) -> String {
     format!("clock_fill:{clock_id}:{event_seq}")
 }

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1626,6 +1626,8 @@ struct RuntimeWorld {
     treasure_objectives: BTreeMap<String, TreasureObjectiveState>,
     card_policy_preferences: BTreeMap<u64, BTreeMap<String, i16>>,
     world_simulation: WorldSimulationState,
+    /// Clocks filling right now; transient. See `apply_bounded_clock_fill`.
+    clock_fill_cascade: Vec<String>,
     rpg_claims: BTreeSet<String>,
     orb_balances: BTreeMap<u64, i32>,
     orb_reward_claims: BTreeSet<String>,
@@ -5480,6 +5482,7 @@ impl RuntimeSnapshot {
 
         Ok(RuntimeWorld {
             world,
+            clock_fill_cascade: Vec::new(),
             canonical_identities: self.canonical_identities,
             command_receipts: CommandReceiptCache::from_persisted(self.command_receipts),
             ai_publications: self.ai_publications,
@@ -5907,6 +5910,7 @@ impl RuntimeWorld {
 
         let mut runtime = RuntimeWorld {
             world,
+            clock_fill_cascade: Vec::new(),
             canonical_identities: CanonicalIdentityState::default(),
             command_receipts: CommandReceiptCache::default(),
             ai_publications: BTreeMap::new(),
@@ -11395,12 +11399,8 @@ impl RuntimeWorld {
         if crossed_fill && !clock.on_fill.is_empty() {
             let claim_key = clock_fill_claim_key(&clock.id, update_event.seq);
             if self.rpg_claims.insert(claim_key) {
-                let mut fill_events = self.apply_effects(
-                    EffectApplicationSource::ClockFill(&clock.id),
-                    actor_id,
-                    update_event.seq,
-                    &clock.on_fill,
-                );
+                let mut fill_events =
+                    self.apply_bounded_clock_fill(&clock, actor_id, update_event.seq);
                 self.link_events_to_cause(&mut fill_events, update_event.seq);
                 events.extend(fill_events);
             }

--- a/v2/orchestrator-rust/src/rpg/effects.rs
+++ b/v2/orchestrator-rust/src/rpg/effects.rs
@@ -89,6 +89,60 @@ impl<'a> EffectApplicationSource<'a> {
 }
 
 impl RuntimeWorld {
+    /// Run one clock's `on_fill` effects with the cascade bounded.
+    ///
+    /// `on_fill` may advance another clock, which may fill and advance a third,
+    /// so the descriptor vocabulary already allows a chain as long as there are
+    /// clocks to author. The per-fill claim key does not bound it: every hop
+    /// crosses at a new event sequence and so mints a fresh key.
+    ///
+    /// Saturation is what stops a *cycle* today — a filled clock returns early
+    /// because `after == before`, so A -> B -> A cannot re-enter A. That makes
+    /// the visited-set check below currently unreachable, and it is kept
+    /// deliberately: it is the guard that holds if a repeatable or resettable
+    /// clock ever exists, and it costs one comparison. The depth bound is the
+    /// live protection, since saturation alone still permits a chain as deep as
+    /// the clock table.
+    ///
+    /// Either cut is reported in the feed rather than dropping effects
+    /// silently.
+    pub(crate) fn apply_bounded_clock_fill(
+        &mut self,
+        clock: &ClockState,
+        actor_id: u64,
+        source_event_seq: u64,
+    ) -> Vec<EventView> {
+        if self.clock_fill_cascade.iter().any(|id| id == &clock.id) {
+            return vec![self.append_clock_event(
+                "clock.fill_effect_rejected",
+                actor_id,
+                clock,
+                0,
+                "this clock is already filling in the current cascade",
+            )];
+        }
+        if self.clock_fill_cascade.len() >= CLOCK_FILL_CASCADE_MAX_DEPTH {
+            return vec![self.append_clock_event(
+                "clock.fill_effect_rejected",
+                actor_id,
+                clock,
+                0,
+                &format!(
+                    "clock fill cascade reached its depth bound of {CLOCK_FILL_CASCADE_MAX_DEPTH}"
+                ),
+            )];
+        }
+        self.clock_fill_cascade.push(clock.id.clone());
+        let events = self.apply_effects(
+            EffectApplicationSource::ClockFill(&clock.id),
+            actor_id,
+            source_event_seq,
+            &clock.on_fill,
+        );
+        self.clock_fill_cascade.pop();
+        events
+    }
+
     pub(crate) fn apply_effects(
         &mut self,
         source: EffectApplicationSource<'_>,
@@ -480,5 +534,111 @@ mod tests {
             .expect("test tag remains present")
             .active = false;
         assert!(!lifecycle_hook_requirements_met(&hook, &tags));
+    }
+
+    /// Two clocks that fill each other. Saturation is the first line of
+    /// defence — a filled clock cannot advance again, so `after == before`
+    /// returns before the cascade re-enters — and this pins that, because the
+    /// depth bound alone would not stop a cycle among many distinct clocks.
+    #[test]
+    fn mutually_filling_clocks_do_not_recurse() {
+        let mut runtime = RuntimeWorld::seeded();
+        insert_effect_test_clock(
+            &mut runtime,
+            "test:cycle-a",
+            vec![EffectDescriptor::AdvanceClock {
+                clock_id: "test:cycle-b".to_string(),
+                amount: 1,
+                reason: Some("cycle_test".to_string()),
+            }],
+        );
+        insert_effect_test_clock(
+            &mut runtime,
+            "test:cycle-b",
+            vec![EffectDescriptor::AdvanceClock {
+                clock_id: "test:cycle-a".to_string(),
+                amount: 1,
+                reason: Some("cycle_test".to_string()),
+            }],
+        );
+
+        // Returning at all is the assertion: unbounded re-entry ends in a
+        // stack overflow, not a failed comparison.
+        runtime.advance_clock("test:cycle-a", 1, 1001, "cycle_test");
+
+        assert_eq!(runtime.clocks["test:cycle-a"].filled, 1);
+        assert_eq!(runtime.clocks["test:cycle-b"].filled, 1);
+        assert!(
+            runtime.clock_fill_cascade.is_empty(),
+            "the cascade stack unwinds completely"
+        );
+    }
+
+    /// A chain longer than the bound is cut at the bound rather than running to
+    /// whatever depth an author happened to write.
+    #[test]
+    fn a_clock_fill_chain_stops_at_its_depth_bound() {
+        let mut runtime = RuntimeWorld::seeded();
+        let depth = CLOCK_FILL_CASCADE_MAX_DEPTH + 2;
+        for step in 0..depth {
+            let effects = vec![EffectDescriptor::AdvanceClock {
+                clock_id: format!("test:chain-{}", step + 1),
+                amount: 1,
+                reason: Some("chain_test".to_string()),
+            }];
+            insert_effect_test_clock(&mut runtime, &format!("test:chain-{step}"), effects);
+        }
+        insert_effect_test_clock(&mut runtime, &format!("test:chain-{depth}"), Vec::new());
+
+        let events = runtime.advance_clock("test:chain-0", 1, 1001, "chain_test");
+
+        assert!(
+            events.iter().any(|event| {
+                event.type_name == "clock.fill_effect_rejected"
+                    && event
+                        .content
+                        .as_deref()
+                        .is_some_and(|content| content.contains("depth bound"))
+            }),
+            "the cut names the depth bound"
+        );
+        assert_eq!(
+            runtime.clocks[&format!("test:chain-{CLOCK_FILL_CASCADE_MAX_DEPTH}")].filled,
+            1,
+            "the chain runs right up to the bound"
+        );
+        assert_eq!(
+            runtime.clocks[&format!("test:chain-{}", CLOCK_FILL_CASCADE_MAX_DEPTH + 1)].filled,
+            0,
+            "and no further"
+        );
+        assert!(runtime.clock_fill_cascade.is_empty());
+    }
+
+    /// The guard must not disturb an ordinary authored consequence.
+    #[test]
+    fn an_ordinary_single_fill_still_applies_its_effects() {
+        let mut runtime = RuntimeWorld::seeded();
+        insert_effect_test_clock(
+            &mut runtime,
+            "test:plain-fill",
+            vec![EffectDescriptor::SetTag {
+                tag_id: "test:plain-tag".to_string(),
+                scope: "room".to_string(),
+                scope_id: COSY_COTTAGE_LOCATION_ID,
+                label: "Plain".to_string(),
+                kind: "condition".to_string(),
+                expires: None,
+                reason: Some("plain_test".to_string()),
+            }],
+        );
+
+        let events = runtime.advance_clock("test:plain-fill", 1, 1001, "plain_test");
+
+        assert!(!events
+            .iter()
+            .any(|event| event.type_name == "clock.fill_effect_rejected"));
+        assert!(runtime.tags.contains_key("test:plain-tag"));
+        assert!(runtime.clock_fill_cascade.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

A clock's `on_fill` may advance another clock, which may fill and advance a third. Nothing bounded that chain. The per-fill claim key cannot: every hop crosses at a new event sequence and so mints a fresh key, so it never collides. Authored content is one `advance_clock` descriptor away from a chain as deep as the clock table, and `on_fill` arrays are already authored in `clocks.json` (currently `set_tag` / `set_job_status` / `unlock_exit` only).

`apply_bounded_clock_fill` cuts the chain at four hops and refuses re-entry into a clock already filling, reporting either cut as `clock.fill_effect_rejected` rather than dropping the effects silently.

**One finding worth review attention.** Saturation turns out to be the first line of defence against a true cycle: a filled clock returns early because `after == before`, so `A -> B -> A` cannot re-enter `A`. That makes the visited-set branch unreachable today. I kept it deliberately and documented it as such — it costs one comparison and it is the guard that holds the moment a repeatable or resettable clock exists. The depth bound is the live protection, because saturation alone still permits a chain as deep as the clock table. The cycle test asserts the true current behaviour (both clocks fill once, the stack unwinds, no overflow) rather than asserting a rejection that cannot currently happen.

This closes the on-fill cascade guard bullet under ENG priority 6, updated in the same diff.

The guard lives in `rpg/effects.rs` beside `apply_effects`, which owns effect application. `main.rs` keeps only the transient cascade field and lands **exactly at its existing line ceiling**, so no ceiling exception is needed.

## Validation

- `cargo test` — 1222 passed, 0 failed (3 new tests in `rpg::effects`)
- `npm test` — 183 passed across 18 files
- `npm run v2:kernel` — cosy kernel tests passed
- `npm run v2:architecture` — `main.rs` 63605 lines (ceiling 63605); clippy 226 warnings (ceiling 226)
- `npm run check:version` — passed; version bumped to 1.0.78 in `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`
- `cargo fmt --check` and `git diff --check` — clean

New tests:

- `mutually_filling_clocks_do_not_recurse` — returning at all is the assertion; unbounded re-entry ends in a stack overflow, not a failed comparison
- `a_clock_fill_chain_stops_at_its_depth_bound` — the chain runs to the bound and no further, and the cut names the bound
- `an_ordinary_single_fill_still_applies_its_effects` — the guard does not disturb an ordinary authored consequence

Not run: `npm run v2:check` (browser/visual smoke). No client surface changes; `clock.fill_effect_rejected` is an existing event type the feed already renders.

## Review checklist

- [x] Tests cover the changed behavior or the PR explains why no test applies.
- [x] Generated worldpack files and locks are refreshed when source content changes. — no source content changed.
- [x] Register review completed for changes under `v2/content/**` against `v2/docs/writing-style.md` (or not applicable). — not applicable; no content changes.
- [x] Genre review completed: which kindness does any new horror enlarge? — not applicable; no new horror. A bounded cascade keeps authored consequence legible instead of runaway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
