### PR TITLE
Keep journey Travel cards as destination cards with a direction badge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.77",
+      "version": "1.0.78",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.77"
+version = "1.0.78"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.77"
+version = "1.0.78"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -2535,23 +2535,6 @@
       flex-basis: 58px;
       height: 34px;
     }
-    .cmd.pathway-direction {
-      background:
-        linear-gradient(90deg, rgba(var(--cmd-accent-rgb), 0.18), rgba(16, 25, 18, 0.92) 44%),
-        var(--terminal-2);
-    }
-    .cmd.pathway-direction .pathway-direction-thumb {
-      width: 50px;
-      flex-basis: 50px;
-      height: 36px;
-      border: 0;
-      background: transparent;
-      box-shadow: none;
-      color: var(--cmd-accent);
-      font-size: 28px;
-      font-weight: 500;
-      cursor: inherit;
-    }
     .cmd .thumb.action-mini-card,
     .cmd .thumb.action-mini-card.avatar,
     .cmd .thumb.action-mini-card.item,
@@ -2585,6 +2568,23 @@
       background: rgba(5, 8, 6, 0.78);
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.34);
       font-size: 15px;
+      z-index: 1;
+    }
+    .thumb .pathway-side-badge {
+      position: absolute;
+      top: 3px;
+      right: 3px;
+      width: 16px;
+      height: 16px;
+      display: grid;
+      place-items: center;
+      border: 1px solid rgba(255, 255, 255, 0.34);
+      border-radius: 999px;
+      background: rgba(5, 8, 6, 0.78);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.34);
+      color: var(--type-travel);
+      font-size: 11px;
+      font-weight: 700;
       z-index: 1;
     }
     .cmd-label .card-emoji,
@@ -17075,7 +17075,7 @@
       return String(action?.handProvider?.reason || "").trim();
     }
 
-    function thumbnailHtml(action, interactive = true, extraClass = "") {
+    function thumbnailHtml(action, interactive = true, extraClass = "", badgeHtml = "") {
       const card = action.card || null;
       const shape = action.shape || shapeForCard(card);
       const fallback = card || {
@@ -17087,7 +17087,7 @@
       const imageEmoji = cardImage(card) ? "" : emojiHtml(cardEmoji(fallback, shape));
       const dataAttr = interactive && card ? cardDataAttr(card) : "";
       const className = ["thumb", extraClass, shape].filter(Boolean).join(" ");
-      return `<span class="${escapeAttr(className)}"${dataAttr} aria-hidden="true" style="background-image:url('${escapeAttr(image)}')">${imageEmoji}</span>`;
+      return `<span class="${escapeAttr(className)}"${dataAttr} aria-hidden="true" style="background-image:url('${escapeAttr(image)}')">${imageEmoji}${badgeHtml}</span>`;
     }
 
     function actionImage(action) {
@@ -18437,12 +18437,18 @@
           action.busy ? "in progress" : "",
         ].filter(Boolean).join(", ")
       );
-      const directionArrow = action.pathwayDirection?.side === "back"
-        ? "←"
-        : (action.pathwayDirection?.side === "forward" ? "→" : "↔");
-      const thumb = action.pathwayDirection
-        ? `<span class="thumb pathway-direction-thumb" aria-hidden="true">${directionArrow}</span>`
-        : thumbnailHtml(action, false, "action-mini-card");
+      // A journey travel card keeps the endpoint's Location art — the card is
+      // about the destination, and the arrow that used to replace the art said
+      // "direction exists" while hiding where the road leads. Direction rides
+      // a small corner badge on the art and the endpoint labels instead.
+      const pathwaySide = action.pathwayDirection?.side === "back"
+        || action.pathwayDirection?.side === "forward"
+        ? action.pathwayDirection.side
+        : "";
+      const pathwayBadgeHtml = pathwaySide
+        ? `<span class="pathway-side-badge" aria-hidden="true">${pathwaySide === "back" ? "←" : "→"}</span>`
+        : "";
+      const thumb = thumbnailHtml(action, false, "action-mini-card", pathwayBadgeHtml);
       button.classList.add("has-copy");
       const labelText = cardTitle;
       const detailHtml = effectText && !destinationOnlyCardLabel

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -39740,8 +39740,10 @@ mod tests {
         assert!(INDEX_HTML.contains("Reveal the first adjacent stretch without moving."));
         assert!(!INDEX_HTML.contains("journey-step:"));
         assert!(!INDEX_HTML.contains("travel turn"));
-        assert!(INDEX_HTML.contains("const thumb = action.pathwayDirection"));
-        assert!(INDEX_HTML.contains(": thumbnailHtml(action, false, \"action-mini-card\");"));
+        assert!(INDEX_HTML.contains("const pathwaySide = action.pathwayDirection?.side"));
+        assert!(INDEX_HTML
+            .contains("thumbnailHtml(action, false, \"action-mini-card\", pathwayBadgeHtml)"));
+        assert!(INDEX_HTML.contains("pathway-side-badge"));
         assert!(INDEX_HTML.contains("button.classList.add(\"has-copy\");"));
         assert!(INDEX_HTML.contains("<span class=\"cmd-copy\"><span class=\"cmd-kicker\">"));
         assert!(INDEX_HTML.contains("cardImage(card) || fallbackCardImage(fallback)"));

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -365,4 +365,8 @@
 # "nothing happened") and claim-settled rows replay as no-ops instead of
 # failing boot or double-advancing the tick. The predicates live in
 # avatar_rescue.rs beside the abandon lifecycle; no new system in main.rs.
-63605
+# 63605 -> 63607: two test-only lines in the browser shell contract -- the
+# pathway thumb pins now also assert the pathway-side badge, so journey
+# travel cards keep destination art with a direction badge instead of an
+# arrow replacing the art. The behaviour lives in index.html.
+63607

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -9701,6 +9701,23 @@ async function main() {
         chatLabel: document.querySelector("#log")?.getAttribute("aria-label") || "",
         chatHeading: document.querySelector(".party-channel-heading")?.textContent || "",
       };
+      const handThumbEvidence = () => [...document.querySelectorAll("footer.prompt .cmd")]
+        .filter((button) => ["primary", "secondary", "tertiary"].includes(button.id))
+        .map((button) => {
+          const thumb = button.querySelector(".thumb");
+          const badge = button.querySelector(".thumb .pathway-side-badge");
+          return {
+            id: button.id,
+            command: button.dataset.command || "",
+            hasMiniCard: Boolean(thumb?.classList.contains("action-mini-card")),
+            hasImage: Boolean(thumb && getComputedStyle(thumb).backgroundImage !== "none"),
+            badge: badge?.textContent?.trim() || "",
+          };
+        });
+      const travellingThumbs = handThumbEvidence();
+      actions = backtrackingActions;
+      render();
+      const backtrackingThumbs = handThumbEvidence();
       state = previousState;
       actions = previousActions;
       render();
@@ -9773,6 +9790,8 @@ async function main() {
           targets: inspectTargets,
         },
         pathwayStage: pathwayStage.textContent.replace(/\s+/g, " ").trim(),
+        travellingThumbs,
+        backtrackingThumbs,
         journeyPresentation,
       };
     });
@@ -9822,6 +9841,20 @@ async function main() {
         && result.backtracking.direction?.side === "back"
         && result.backtracking.direction?.endpointName === "Rain-Soft Garden",
       `reverse travel should point toward the pathway's origin instead of naming an interior waypoint: ${JSON.stringify(result)}`,
+    );
+    assert(
+      result.travellingThumbs.length >= 1
+        && result.travellingThumbs.every((card) => !card.command || (card.hasMiniCard && card.hasImage))
+        && result.travellingThumbs.some((card) => card.command === "go Cedar Hollow" && card.hasMiniCard && card.hasImage && card.badge === "→")
+        && !result.travellingThumbs.some((card) => card.badge === "←"),
+      `a pathway Travel card must keep destination card art with a forward badge instead of replacing the art with an arrow: ${JSON.stringify(result.travellingThumbs)}`,
+    );
+    assert(
+      result.backtrackingThumbs.length >= 1
+        && result.backtrackingThumbs.every((card) => !card.command || (card.hasMiniCard && card.hasImage))
+        && result.backtrackingThumbs.some((card) => card.command === "go Rain-Soft Garden" && card.hasMiniCard && card.hasImage && card.badge === "←")
+        && !result.backtrackingThumbs.some((card) => card.badge === "→"),
+      `a backtracking Travel card must keep destination card art with a back badge: ${JSON.stringify(result.backtrackingThumbs)}`,
     );
     assert(
       result.pathwayStage.includes("Bethlehem — Jerusalem")


### PR DESCRIPTION
## Summary

#757 fixed a real labeling problem — interior pathway waypoints presented as destinations — but did it by replacing each journey travel card's **art with a bare direction arrow**. That traded a labeling bug for a category error:

- The Story Hand is *cards about entities* (`v2/docs/story-hand.md`); a travel card IS the Location it leads to. On a journey, every travel card collapsed into the same anonymous arrow, recognizable only by its text.
- Direction was already carried four other ways: the pathway stage track, its `← to X / to Y →` endpoint labels, the card kicker ("TRAVEL Bethlehem"), and the detail line ("toward …"). The arrow duplicated all four while suppressing the one signal nothing else carried — where the road leads.
- A persistent left/right chevron in the footer reads as browser back/forward chrome — the opposite of a committed move-one-stretch action.
- Off-journey travel cards kept destination art, so the same verb had two visual grammars depending on journey state.

**The change:** journey travel cards render like every other hand card — the endpoint's Location art through the normal `action-mini-card` path (the render code already had the right card and was discarding it) — and direction rides a small corner badge on that art, mirroring the existing `.card-emoji` badge pattern. All #757 endpoint labeling is kept. Dead arrow-thumb CSS deleted; the impossible `↔` fallback is gone.

**This also un-flakes the fresh-seed browser gate.** The visual contract (`smoke-browser.mjs:13780`) demands every hand card carry mini card art — which is the product's own spec, not a stale assertion. It failed on main (the #848 merge commit, and #853's first run) whenever ambient world state put a pathway card in the hand at assert time. Now pathway cards honor the contract by construction, and the journey harness pins it deterministically: forward and backtracking travel cards must keep art and show the correct badge.

## Validation

- `node v2/scripts/smoke-browser.mjs` against a deterministic local server (release binary, fresh runtime) — exit 0, including the two new deterministic journey-card assertions (forward badge `→` on `go Cedar Hollow`, back badge `←` on `go Rain-Soft Garden`, art retained).
- `COSYWORLD_SMOKE_LIVING_WORLD_STRESS=1` living-world stress smoke — exit 0.
- `node v2/scripts/smoke-production-profile.mjs` — exit 0.
- `npm run v2:rust:test` — 1244 passed, 0 failed (browser shell contract updated to pin the new markup).
- `npm test` — 183 passed. `npm run v2:worldpack` — pass. `npm run v2:kernel` — pass. `npm run v2:syntax` — pass.
- `npm run v2:architecture` — pass (main.rs +2 test-only lines with a ceiling entry; clippy unchanged at 226/226, zero new warnings).
- `git diff --check`, `npm run check:version` — clean.

## Review checklist

- [x] One coherent behavior fix; no unrelated churn
- [x] Deterministic regression coverage for the flake's exact contract
- [x] Version bumped in package.json, package-lock.json, Cargo.toml, Cargo.lock (1.0.78)
- [x] Visual baselines unaffected (the prompt footer is masked in visual snapshots)
- [x] No secrets, logs, or runtime databases in the diff