### PR TITLE
Retain searchable production logs for both Fly apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,13 @@ infra/terraform/*.auto.tfvars.json
 infra/aws-lonely-forest/.terraform/
 infra/aws-lonely-forest/terraform.tfstate
 infra/aws-lonely-forest/terraform.tfstate.backup
+infra/production-logs/.terraform/
+infra/production-logs/terraform.tfstate
+infra/production-logs/terraform.tfstate.backup
+infra/production-logs/terraform.tfvars
+infra/production-logs/terraform.tfvars.json
+infra/production-logs/*.auto.tfvars
+infra/production-logs/*.auto.tfvars.json
 infra/aws-lonely-forest/*.tfstate
 infra/aws-lonely-forest/*.tfstate.*
 

--- a/deploy/lonelyforest/nginx.conf
+++ b/deploy/lonelyforest/nginx.conf
@@ -7,7 +7,11 @@ events {
 }
 
 http {
-  access_log /tmp/cosyworld-nginx/access.log combined;
+  # Do not retain query strings, cookies, user agents, or credential-bearing
+  # path segments at the proxy boundary. The orchestrator emits the matched
+  # route template and propagates a log-safe request ID for correlation.
+  log_format cosyworld_safe 'process=nginx event=http_access tenant_host="$host" method="$request_method" status=$status bytes=$body_bytes_sent latency_secs=$request_time request_id="$upstream_http_x_request_id" upstream="$upstream_addr" upstream_status="$upstream_status"';
+  access_log /tmp/cosyworld-nginx/access.log cosyworld_safe;
   client_max_body_size 25m;
   client_body_temp_path /tmp/cosyworld-nginx/client-body;
   proxy_temp_path /tmp/cosyworld-nginx/proxy;

--- a/deploy/lonelyforest/run-multitenant.sh
+++ b/deploy/lonelyforest/run-multitenant.sh
@@ -66,6 +66,7 @@ run_world() {
   supervisor_pid="${11}"
   shutdown_grace_secs="${12}"
   shutdown_marker_dir="${13}"
+  worldpack="$(basename "$(dirname "$registry")")"
   active_child=""
 
   # Invoked indirectly by the signal trap below.
@@ -106,6 +107,8 @@ run_world() {
       env -u COSYWORLD_ENTRY_LOCATION_ID \
         COSYWORLD_V2_ADDR="127.0.0.1:$port" \
         COSYWORLD_PROCESS_ID="lonelyforest-$slug" \
+        COSYWORLD_LOG_TENANT="$slug" \
+        COSYWORLD_LOG_WORLDPACK="$worldpack" \
         COSYWORLD_V2_SHARD_ID="lonelyforest-$slug" \
         COSYWORLD_CONTENT_REGISTRY_PATH="$registry" \
         COSYWORLD_V2_SNAPSHOT_PATH="$snapshot_path" \
@@ -120,6 +123,8 @@ run_world() {
       env -u COSYWORLD_REQUIRED_HEALTH_URLS \
         COSYWORLD_V2_ADDR="127.0.0.1:$port" \
         COSYWORLD_PROCESS_ID="lonelyforest-$slug" \
+        COSYWORLD_LOG_TENANT="$slug" \
+        COSYWORLD_LOG_WORLDPACK="$worldpack" \
         COSYWORLD_V2_SHARD_ID="lonelyforest-$slug" \
         COSYWORLD_CONTENT_REGISTRY_PATH="$registry" \
         COSYWORLD_ENTRY_LOCATION_ID="$entry_location_id" \

--- a/deploy/observability/Dockerfile
+++ b/deploy/observability/Dockerfile
@@ -1,0 +1,8 @@
+# Vector 0.55.0, pinned to the multi-architecture image index published for
+# https://github.com/vectordotdev/vector/releases/tag/v0.55.0.
+FROM timberio/vector:0.55.0-debian@sha256:a4be1111b40303524aae2ffb02cd59cef2a4e9753bd13d265bf0233e921828d9
+
+COPY deploy/observability/vector.yaml /etc/vector/vector.yaml
+
+ENTRYPOINT ["/usr/bin/vector"]
+CMD ["--config", "/etc/vector/vector.yaml"]

--- a/deploy/observability/vector.yaml
+++ b/deploy/observability/vector.yaml
@@ -1,0 +1,338 @@
+data_dir: /var/lib/vector
+
+api:
+  enabled: true
+  address: "[::]:8686"
+
+sources:
+  fly_nats:
+    type: nats
+    url: "nats://[fdaa::3]:4223"
+    subject: "logs.>"
+    queue: cosyworld-production-cloudwatch
+    connection_name: CosyWorld production logs
+    auth:
+      strategy: user_password
+      user_password:
+        user: "${FLY_ORG:?FLY_ORG is required}"
+        password: "${ACCESS_TOKEN:?ACCESS_TOKEN is required}"
+
+transforms:
+  decode_envelope:
+    type: remap
+    inputs: [fly_nats]
+    drop_on_error: true
+    source: |
+      . = parse_json!(.message)
+
+  allowlisted_apps:
+    type: filter
+    inputs: [decode_envelope]
+    condition: >-
+      .fly.app.name == "cosyworld" ||
+      .fly.app.name == "cosyworld-lonelyforest"
+
+  normalize_and_redact:
+    type: remap
+    inputs: [allowlisted_apps]
+    source: |
+      envelope = .
+      raw_message = to_string(envelope.message) ?? ""
+      runtime, parse_error = parse_json(raw_message)
+      if parse_error != null || !is_object(runtime) {
+        runtime, parse_error = parse_key_value(raw_message)
+        if parse_error != null || !is_object(runtime) {
+          runtime = {}
+        }
+      }
+
+      event_timestamp = parse_timestamp(to_string(envelope.timestamp) ?? "", format: "%+") ?? now()
+      app = to_string(envelope.fly.app.name) ?? "unknown"
+      machine_id = if exists(envelope.host) { to_string!(envelope.host) } else if exists(envelope.fly.instance) { to_string!(envelope.fly.instance) } else { "unknown" }
+      region = if exists(envelope.fly.region) { to_string!(envelope.fly.region) } else if exists(envelope.region) { to_string!(envelope.region) } else { "unknown" }
+      severity_value = if exists(runtime.level) { to_string!(runtime.level) } else if exists(envelope.level) { to_string!(envelope.level) } else { "INFO" }
+      severity = upcase(severity_value)
+      event = if exists(runtime.event) { to_string!(runtime.event) } else { "platform_log" }
+      message = if exists(runtime.message) { to_string!(runtime.message) } else { raw_message }
+      request_id = if exists(runtime.request_id) { to_string!(runtime.request_id) } else if exists(runtime.span.request_id) { to_string!(runtime.span.request_id) } else { "" }
+      process = if exists(runtime.span.process) { to_string!(runtime.span.process) } else if exists(runtime.process) { to_string!(runtime.process) } else if exists(envelope.fly.process_group) { to_string!(envelope.fly.process_group) } else { "unknown" }
+      tenant = if exists(runtime.span.tenant) { to_string!(runtime.span.tenant) } else if exists(runtime.tenant) { to_string!(runtime.tenant) } else { "unknown" }
+      worldpack = if exists(runtime.span.worldpack) { to_string!(runtime.span.worldpack) } else if exists(runtime.worldpack) { to_string!(runtime.worldpack) } else { "unknown" }
+      provider = if exists(runtime.provider) { to_string!(runtime.provider) } else if exists(runtime.span.provider) { to_string!(runtime.span.provider) } else { "" }
+
+      # Retain only reviewed operational fields. Unknown structured fields are
+      # discarded, so a newly added prompt or credential field cannot become
+      # durable merely because an application event starts emitting it.
+      details = compact({
+        "status": runtime.status,
+        "method": runtime.method,
+        "bytes": runtime.bytes,
+        "latency_ms": runtime.latency_ms,
+        "latency_secs": runtime.latency_secs,
+        "upstream": runtime.upstream,
+        "upstream_status": runtime.upstream_status,
+        "tenant_host": runtime.tenant_host,
+        "reason": runtime.reason,
+        "exit_code": runtime.exit_code,
+        "forced_process_count": runtime.forced_process_count,
+        "worker_count": runtime.worker_count,
+        "grace_secs": runtime.grace_secs,
+        "failures": runtime.failures,
+        "error_code": runtime.error_code,
+        "http_status": runtime.http_status,
+        "gateway_attempts": runtime.gateway_attempts,
+        "retry_after_secs": runtime.retry_after_secs,
+        "retry_at_unix": runtime.retry_at_unix,
+        "retry_floor_ms": runtime.retry_floor_ms,
+        "disposition": runtime.disposition,
+        "requested_model_id": runtime.requested_model_id,
+        "profile": runtime.profile,
+        "old_state": runtime.old_state,
+        "old_route_state": runtime.old_route_state,
+        "new_state": runtime.new_state,
+        "actor_job_id": runtime.actor_job_id,
+        "actor_job_kind": runtime.actor_job_kind,
+        "actor_attempts": runtime.actor_attempts,
+        "actor_id": runtime.actor_id,
+        "target_actor_id": runtime.target_actor_id,
+        "interaction_id": runtime.interaction_id,
+        "queue_event_id": runtime.queue_event_id
+      }, nullish: true, string: true, object: true, array: true)
+
+      # Remove credential-bearing fields at any nesting level before applying
+      # value-pattern redaction. This is deliberately a last line of defense;
+      # application and proxy logs also avoid emitting secrets at the source.
+      details_json = encode_json(details)
+      details_json = replace(
+        details_json,
+        r'(?i)"(?:authorization|cookie|set-cookie|api[_-]?key|access[_-]?token|refresh[_-]?token|bearer|password|passkey|secret|session[_-]?token|actor[_-]?session|wallet[_-]?session|poll[_-]?token|signature)"\s*:\s*"(?:\\.|[^"\\])*"',
+        s'"redacted":"[REDACTED]"'
+      )
+      details = redact(object!(parse_json!(details_json)), filters: [
+        r'(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+',
+        r'(?i)\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|password|secret|session[_-]?token|actor[_-]?session|wallet[_-]?session|poll[_-]?token|signature|[a-z0-9_-]*prompt[a-z0-9_-]*)\b\s*[:=]\s*[^\s,;"&]+',
+        r'(?i)https?://[^\s"?#]+\?[^\s"#]+',
+        r'(?i)[?&](?:token|key|api_key|access_token|poll_token|actor_session|wallet_session|code|secret|password|signature)=[^&#\s"]+',
+        r'\b(?:sk|pk|rk)-[A-Za-z0-9_-]{10,}\b'
+      ])
+      message = redact(message, filters: [
+        r'(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+',
+        r'(?i)\b(?:authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|password|secret|session[_-]?token|actor[_-]?session|wallet[_-]?session|poll[_-]?token|signature|[a-z0-9_-]*prompt[a-z0-9_-]*)\b\s*[:=]\s*[^\s,;"&]+',
+        r'(?i)https?://[^\s"?#]+\?[^\s"#]+',
+        r'(?i)[?&](?:token|key|api_key|access_token|poll_token|actor_session|wallet_session|code|secret|password|signature)=[^&#\s"]+',
+        r'\b(?:sk|pk|rk)-[A-Za-z0-9_-]{10,}\b'
+      ])
+
+      searchable = downcase(event + " " + message)
+      alert_kind = null
+      if match(searchable, r'\b(?:shutdown_drain_forced|tenant_shutdown_forced|shutdown_forced|pu05)\b') {
+        alert_kind = "forced_exit"
+      } else if match(searchable, r'(?:required tenant .*failed private /health|required tenant health monitor exited|failed health check)') {
+        alert_kind = "health_failure"
+      } else if match(searchable, r'\b(?:oom|out of memory)\b|signal: killed') {
+        alert_kind = "oom"
+      } else if match(searchable, r'panicked at|thread .* panicked|\bpanic\b') {
+        alert_kind = "panic"
+      } else if event == "model_interaction_provider_failure" || (event == "ai_readiness_transition" && contains(searchable, "circuit opened")) {
+        alert_kind = "provider_unavailable"
+      } else if event == "actor_job_dead" {
+        alert_kind = "actor_job_failure"
+      }
+
+      . = compact({
+        "schema_version": 1,
+        "timestamp": event_timestamp,
+        "event_timestamp": event_timestamp,
+        "app": app,
+        "machine_id": machine_id,
+        "region": region,
+        "process": process,
+        "tenant": tenant,
+        "worldpack": worldpack,
+        "provider": provider,
+        "severity": severity,
+        "request_id": request_id,
+        "event": event,
+        "message": message,
+        "alert_kind": alert_kind,
+        "details": details
+      }, nullish: true, string: true, object: true, array: true)
+
+sinks:
+  cloudwatch:
+    type: aws_cloudwatch_logs
+    inputs: [normalize_and_redact]
+    region: "${AWS_REGION:?AWS_REGION is required}"
+    group_name: "${CLOUDWATCH_LOG_GROUP_NAME:?CLOUDWATCH_LOG_GROUP_NAME is required}"
+    stream_name: "{{ app }}/{{ machine_id }}"
+    create_missing_group: false
+    create_missing_stream: true
+    compression: gzip
+    encoding:
+      codec: json
+    buffer:
+      type: disk
+      max_size: 268435488
+      when_full: block
+    batch:
+      timeout_secs: 2
+
+tests:
+  - name: structured runtime event preserves incident dimensions
+    inputs:
+      - insert_at: allowlisted_apps
+        type: vrl
+        source: |
+          . = {
+            "timestamp": "2026-08-21T12:00:00Z",
+            "host": "0803404a047798",
+            "level": "warn",
+            "fly": {"app": {"name": "cosyworld-lonelyforest"}, "region": "sjc"},
+            "message": encode_json({
+              "timestamp": "2026-08-21T12:00:00Z",
+              "level": "WARN",
+              "event": "model_interaction_provider_failure",
+              "message": "transient exact model interaction provider failure",
+              "app": "cosyworld-lonelyforest",
+              "machine_id": "0803404a047798",
+              "region": "sjc",
+              "process": "lonelyforest-7",
+              "tenant": "7",
+              "worldpack": "bethlehem",
+              "provider": "openrouter",
+              "span": {"request_id": "incident-smoke-7"},
+              "http_status": 503
+            })
+          }
+    outputs:
+      - extract_from: normalize_and_redact
+        conditions:
+          - type: vrl
+            source: |
+              assert_eq!(.app, "cosyworld-lonelyforest")
+              assert_eq!(.machine_id, "0803404a047798")
+              assert_eq!(.region, "sjc")
+              assert_eq!(.process, "lonelyforest-7")
+              assert_eq!(.tenant, "7")
+              assert_eq!(.worldpack, "bethlehem")
+              assert_eq!(.provider, "openrouter")
+              assert_eq!(.request_id, "incident-smoke-7")
+              assert_eq!(.alert_kind, "provider_unavailable")
+              assert_eq!(.details.http_status, 503)
+
+  - name: credentials and query strings are recursively redacted
+    inputs:
+      - insert_at: allowlisted_apps
+        type: vrl
+        source: |
+          . = {
+            "timestamp": "2026-08-21T12:00:00Z",
+            "host": "machine-primary",
+            "level": "error",
+            "fly": {"app": {"name": "cosyworld"}, "region": "sjc"},
+            "message": encode_json({
+              "level": "ERROR",
+              "event": "fixture",
+              "message": "failed https://example.test/callback?access_token=do-not-retain",
+              "authorization": "Bearer top-level-secret",
+              "nested": {"api_key": "sk-do-not-retain-123456789"},
+              "prompt": "do-not-retain-prompt",
+              "error": "Authorization: Bearer another-secret",
+              "http_status": 502
+            })
+          }
+    outputs:
+      - extract_from: normalize_and_redact
+        conditions:
+          - type: vrl
+            source: |
+              encoded = encode_json(.)
+              assert!(!contains(encoded, "do-not-retain"))
+              assert!(!contains(encoded, "top-level-secret"))
+              assert!(!contains(encoded, "another-secret"))
+              assert!(!contains(encoded, "do-not-retain-prompt"))
+              assert_eq!(.details.http_status, 502)
+              assert!(contains(encoded, "[REDACTED]"))
+
+  - name: supervisor forced shutdown becomes an alert
+    inputs:
+      - insert_at: allowlisted_apps
+        type: vrl
+        source: |
+          . = {
+            "timestamp": "2026-08-21T12:00:00Z",
+            "host": "0803404a047798",
+            "level": "warn",
+            "fly": {"app": {"name": "cosyworld-lonelyforest"}, "region": "sjc"},
+            "message": "[lonelyforest-multitenant] event=tenant_shutdown_forced tenant=7 child_pid=42 forced_process_count=1"
+          }
+    outputs:
+      - extract_from: normalize_and_redact
+        conditions:
+          - type: vrl
+            source: |
+              assert_eq!(.event, "tenant_shutdown_forced")
+              assert_eq!(.tenant, "7")
+              assert_eq!(.alert_kind, "forced_exit")
+              assert_eq!(.machine_id, "0803404a047798")
+
+  - name: only a durable dead actor job becomes an actor job alert
+    inputs:
+      - insert_at: allowlisted_apps
+        type: vrl
+        source: |
+          . = {
+            "timestamp": "2026-08-21T12:00:00Z",
+            "host": "machine-primary",
+            "level": "error",
+            "fly": {"app": {"name": "cosyworld"}, "region": "sjc"},
+            "message": encode_json({
+              "level": "ERROR",
+              "event": "actor_job_dead",
+              "message": "actor job entered the durable dead state",
+              "actor_job_id": 42,
+              "actor_job_kind": "model_interaction",
+              "actor_attempts": 3,
+              "disposition": "attempt_budget_exhausted"
+            })
+          }
+    outputs:
+      - extract_from: normalize_and_redact
+        conditions:
+          - type: vrl
+            source: |
+              assert_eq!(.alert_kind, "actor_job_failure")
+              assert_eq!(.details.actor_job_id, 42)
+              assert_eq!(.details.actor_attempts, 3)
+
+  - name: safe nginx access lines preserve proxy request correlation
+    inputs:
+      - insert_at: allowlisted_apps
+        type: vrl
+        source: |
+          . = {
+            "timestamp": "2026-08-21T12:00:00Z",
+            "host": "0803404a047798",
+            "level": "info",
+            "fly": {"app": {"name": "cosyworld-lonelyforest"}, "region": "sjc"},
+            "message": "process=nginx event=http_access tenant_host=7.lonelyforest.com method=GET status=200 bytes=123 latency_secs=0.010 request_id=incident-nginx-7 upstream=127.0.0.1:3107 upstream_status=200"
+          }
+    outputs:
+      - extract_from: normalize_and_redact
+        conditions:
+          - type: vrl
+            source: |
+              assert_eq!(.timestamp, t'2026-08-21T12:00:00Z')
+              assert_eq!(.event, "http_access")
+              assert_eq!(.process, "nginx")
+              assert_eq!(.request_id, "incident-nginx-7")
+              assert_eq!(.details.method, "GET")
+              assert_eq!(.details.status, "200")
+
+  - name: unrelated Fly apps are rejected before normalization
+    no_outputs_from: [allowlisted_apps]
+    inputs:
+      - insert_at: allowlisted_apps
+        type: vrl
+        source: |
+          . = {"fly": {"app": {"name": "unrelated-app"}}, "message": "must be dropped"}

--- a/docs/deployment/07-deployment.md
+++ b/docs/deployment/07-deployment.md
@@ -52,6 +52,10 @@ The Fly config runs with `COSYWORLD_DEPLOY_PROFILE=production`, persistent
 `/data` storage, and the SQLite event journal. The protected linked-avatar feed
 is optional; ordinary play boots without it.
 
+Production log retention, incident queries, alerts, credential rotation, and
+the cross-app ingestion smoke are documented in
+[`production-logs.md`](production-logs.md).
+
 Passkey authentication also requires an exact WebAuthn relying-party configuration. The RP ID is the deployment hostname without a scheme; the origin is the public HTTPS origin:
 
 ```bash

--- a/docs/deployment/production-logs.md
+++ b/docs/deployment/production-logs.md
@@ -1,0 +1,164 @@
+# Production log retention and incident search
+
+Issue #821 moves logs for `cosyworld` and `cosyworld-lonelyforest` out of Fly's
+short native search window and into one CloudWatch Logs group. The committed
+configuration is inert until an operator explicitly applies the Terraform,
+creates the service credentials, and deploys `fly.logs.toml`.
+
+## Data path and boundaries
+
+1. Each Rust process emits newline-delimited JSON in production. Every event
+   receives `app`, `machine_id`, `region`, `process`, `tenant`, and `worldpack`.
+   HTTP activity adds a validated or generated `X-Request-Id` and logs the Axum
+   route template, never the raw URL or query string.
+2. Lonely Forest Nginx logs method, status, latency, upstream, tenant hostname,
+   and the upstream request ID. It omits path segments, query strings, cookies,
+   user agents, and authorization data.
+3. A dedicated Fly Machine subscribes to the organization's `logs.>` NATS
+   subject. NATS cannot express the union of the two app names, so Vector drops
+   every event whose exact `fly.app.name` is not `cosyworld` or
+   `cosyworld-lonelyforest` before normalization or export.
+4. Vector keeps only a reviewed allowlist of operational detail fields, so
+   unknown fields—including prompts, passkey material, and wallet or actor
+   credentials—are discarded. It also redacts bearer tokens, credential
+   assignments, query strings, and common API-key shapes from retained text.
+   Its production transform and redaction fixtures live in
+   `deploy/observability/vector.yaml`.
+5. CloudWatch stores JSON events in `/cosyworld/production`, in streams named
+   `<app>/<machine_id>`, for 30 days by default. The shipper can only append to
+   that group. Attach the Terraform output `incident_reader_policy_arn` only to
+   approved operator roles; it grants query access to this group and no writes.
+
+The Vector disk buffer is capped at 256 MiB and blocks when full rather than
+discarding the oldest event. Once CloudWatch accepts an event, retention is
+age-based rather than volume-based, so a busy tenant cannot evict another
+tenant's incident window. Provider quotas and an extended network outage can
+still prevent new events from reaching CloudWatch; the shipper's own Fly logs
+and Vector health check are the first places to inspect in that case.
+
+## Validate before provisioning
+
+Run these locally from the repository root:
+
+```sh
+FLY_ORG=test ACCESS_TOKEN=test AWS_REGION=us-east-1 \
+  CLOUDWATCH_LOG_GROUP_NAME=/cosyworld/test \
+  vector test deploy/observability/vector.yaml
+FLY_ORG=test ACCESS_TOKEN=test AWS_REGION=us-east-1 \
+  CLOUDWATCH_LOG_GROUP_NAME=/cosyworld/test \
+  vector validate --no-environment --deny-warnings deploy/observability/vector.yaml
+terraform -chdir=infra/production-logs init -backend=false
+terraform -chdir=infra/production-logs validate
+terraform -chdir=infra/production-logs plan
+```
+
+`terraform plan` is read-only but requires an AWS session. Review the planned
+region, log-group name, retention, IAM policy, SNS topic, metric filters, and
+alarms before applying.
+
+## Provision and deploy (operator authorization required)
+
+These steps create billable AWS and Fly resources. Do not run them as part of
+a feature-branch test.
+
+1. Apply `infra/production-logs`. To add email delivery, pass
+   `-var='alarm_email_endpoints=["operator@example.com"]'` and confirm the AWS
+   subscription message. With no endpoint, CloudWatch still records alarm
+   state and history but SNS has no recipient.
+   Attach `incident_reader_policy_arn` to the existing incident-response role;
+   the module deliberately does not choose an organization-specific principal.
+2. Create exactly one IAM access key for the Terraform output
+   `shipper_iam_user_name`. Do not manage that access key in Terraform, print
+   it, commit it, or leave it in a shell-history argument.
+3. Create a read-only Fly organization token for `personal`. Set that token as
+   `ACCESS_TOKEN` and the AWS key pair as `AWS_ACCESS_KEY_ID` and
+   `AWS_SECRET_ACCESS_KEY` on the `cosyworld-log-shipper` app. These are the
+   only secrets the shipper needs.
+4. Create the app without public IPs, then deploy exactly one Machine:
+
+   ```sh
+   fly apps create cosyworld-log-shipper --org personal
+   fly deploy --config fly.logs.toml --ha=false --no-public-ips
+   ```
+
+5. Confirm the Vector health check, then run:
+
+   ```sh
+   ./scripts/check-production-log-ingestion.sh
+   ```
+
+The smoke sends one safe `/meta` request to each production app with different
+request IDs, waits up to two minutes for CloudWatch, and fails unless both app,
+request-ID, and Machine-ID tuples are searchable.
+
+## Incident queries
+
+Use CloudWatch Logs Insights against `/cosyworld/production`. Always bound the
+time picker as tightly as the incident allows.
+
+Cross-app timeline around a known Machine or timestamp:
+
+```text
+fields @timestamp, severity, app, machine_id, region, process, tenant, worldpack, event, message
+| filter app in ["cosyworld", "cosyworld-lonelyforest"]
+| filter machine_id = "0803404a047798"
+| sort @timestamp asc
+| limit 1000
+```
+
+Follow one request across the proxy, application, and provider events:
+
+```text
+fields @timestamp, app, machine_id, process, tenant, worldpack, provider, event, message
+| filter request_id = "incident-request-id"
+| sort @timestamp asc
+```
+
+Review alert evidence:
+
+```text
+fields @timestamp, app, machine_id, process, tenant, worldpack, alert_kind, event, message, details
+| filter ispresent(alert_kind)
+| sort @timestamp desc
+| limit 500
+```
+
+Provider availability:
+
+```text
+fields @timestamp, app, process, tenant, worldpack, provider, event, message, details.http_status
+| filter alert_kind = "provider_unavailable" or event = "ai_readiness_transition"
+| sort @timestamp desc
+```
+
+## Retention, cost, and deletion
+
+- The default 30-day age policy exceeds the 14-day incident requirement.
+  Terraform rejects lower or unsupported CloudWatch retention values.
+  CloudWatch ingestion, retained GB-months, Logs Insights bytes scanned, six
+  metric filters and alarms, SNS delivery, and one 512 MiB shared-cpu Fly
+  Machine can incur charges. Estimate monthly cost as measured ingested GB plus
+  average retained GB plus expected query scans at the current regional rates.
+  Retention and the 256 MiB shipper buffer are hard-bounded; ingestion spend is
+  not. Set an account budget before apply if a hard operator notification is
+  required, because silently rate-limiting the shipper would lose evidence.
+- Search cost scales with bytes scanned. Prefer narrow time ranges and filters
+  on `app`, `machine_id`, `request_id`, `tenant`, or `alert_kind`.
+- Reducing `retention_days` makes older events eligible for provider deletion;
+  increasing it increases stored volume. Neither action changes the 256 MiB
+  shipper buffer.
+- `terraform destroy` deletes the CloudWatch log group and retained incident
+  history. Export required evidence first. Stop the Fly shipper and delete its
+  IAM access key before destroying the IAM user.
+- Credential rotation is: create a replacement IAM key, update the two Fly
+  secrets, verify ingestion, then delete the old key. Never keep two active
+  keys longer than the verification window.
+
+## Alert semantics
+
+Vector classifies forced exits, repeated required-health failures, OOM exits,
+panics, persistent provider unavailability, and actor-job failures. Immediate
+conditions alarm on the first event. Provider unavailability alarms at five
+events in ten minutes. Actor-job alarms fire only after the durable queue update
+has succeeded and the job has entered `dead`, either because its attempt budget
+was exhausted or its provider route was terminal.

--- a/fly.logs.toml
+++ b/fly.logs.toml
@@ -1,0 +1,32 @@
+app = "cosyworld-log-shipper"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "deploy/observability/Dockerfile"
+
+[env]
+  AWS_REGION = "us-east-1"
+  CLOUDWATCH_LOG_GROUP_NAME = "/cosyworld/production"
+  FLY_ORG = "personal"
+  VECTOR_LOG = "info"
+
+# ACCESS_TOKEN, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY are Fly secrets.
+# The NATS subscription is organization-wide because its subject grammar cannot
+# express a union of the two app names; vector.yaml immediately filters to the
+# exact production allowlist before normalizing or exporting an event.
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "512mb"
+
+[[restart]]
+  policy = "always"
+
+[checks.vector]
+  type = "http"
+  port = 8686
+  path = "/health"
+  interval = "30s"
+  timeout = "5s"
+  grace_period = "10s"

--- a/fly.lonelyforest.toml
+++ b/fly.lonelyforest.toml
@@ -7,6 +7,7 @@ primary_region = "sjc"
 
 [env]
   COSYWORLD_DEPLOY_PROFILE = "production"
+  COSYWORLD_LOG_FORMAT = "json"
   COSYWORLD_MULTITENANT_DATA_ROOT = "/data/worldpacks"
   # Children close streams within three seconds; the supervisor independently
   # force-stops a wedged child or Nginx before Fly escalates at five seconds.

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,10 @@ primary_region = "sjc"
 
 [env]
   COSYWORLD_DEPLOY_PROFILE = "production"
+  COSYWORLD_LOG_FORMAT = "json"
+  COSYWORLD_LOG_TENANT = "primary"
+  COSYWORLD_LOG_WORLDPACK = "cosyworld.official"
+  COSYWORLD_PROCESS_ID = "public-1"
   COSYWORLD_V2_ADDR = "0.0.0.0:3000"
   COSYWORLD_V2_SNAPSHOT_PATH = "/data/cosyworld-v2-snapshot.json"
   COSYWORLD_V2_EVENT_DB_PATH = "/data/cosyworld-v2-events.sqlite"

--- a/infra/production-logs/.terraform.lock.hcl
+++ b/infra/production-logs/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 5.0.0, < 6.0.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/production-logs/main.tf
+++ b/infra/production-logs/main.tf
@@ -1,0 +1,167 @@
+locals {
+  metric_namespace = "CosyWorld/ProductionLogs"
+  alerts = {
+    forced_exit = {
+      description = "A Fly process exceeded its graceful shutdown budget or was forcibly terminated."
+      threshold   = 1
+      period      = 60
+    }
+    health_failure = {
+      description = "Required production health checks repeatedly failed."
+      threshold   = 1
+      period      = 300
+    }
+    oom = {
+      description = "A production process or Machine reported an out-of-memory exit."
+      threshold   = 1
+      period      = 60
+    }
+    panic = {
+      description = "A production process panicked."
+      threshold   = 1
+      period      = 60
+    }
+    provider_unavailable = {
+      description = "AI provider unavailability persisted across the retry window."
+      threshold   = 5
+      period      = 600
+    }
+    actor_job_failure = {
+      description = "An actor job entered the durable dead state after exhausting retries or encountering a terminal provider route."
+      threshold   = 1
+      period      = 60
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "production" {
+  name              = var.log_group_name
+  retention_in_days = var.retention_days
+
+  tags = {
+    Application = "cosyworld"
+    Environment = "production"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_iam_user" "fly_log_shipper" {
+  name = var.shipper_iam_user_name
+  path = "/service-accounts/"
+
+  tags = {
+    Application = "cosyworld"
+    Purpose     = "fly-log-shipping"
+    ManagedBy   = "terraform"
+  }
+}
+
+data "aws_iam_policy_document" "fly_log_shipper" {
+  statement {
+    sid = "WriteOnlyCosyWorldProductionLogs"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.production.arn}:*"]
+  }
+}
+
+resource "aws_iam_user_policy" "fly_log_shipper" {
+  name   = "write-cosyworld-production-logs"
+  user   = aws_iam_user.fly_log_shipper.name
+  policy = data.aws_iam_policy_document.fly_log_shipper.json
+}
+
+data "aws_iam_policy_document" "incident_reader" {
+  statement {
+    sid = "QueryOnlyCosyWorldProductionLogs"
+    actions = [
+      "logs:DescribeLogStreams",
+      "logs:FilterLogEvents",
+      "logs:GetLogEvents",
+      "logs:GetLogGroupFields",
+      "logs:GetLogRecord",
+      "logs:GetQueryResults",
+      "logs:StartQuery",
+      "logs:StopQuery",
+    ]
+    resources = [
+      aws_cloudwatch_log_group.production.arn,
+      "${aws_cloudwatch_log_group.production.arn}:*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "incident_reader" {
+  name        = "cosyworld-production-log-reader"
+  description = "Query-only access to the CosyWorld production incident log group."
+  policy      = data.aws_iam_policy_document.incident_reader.json
+
+  tags = {
+    Application = "cosyworld"
+    Environment = "production"
+    ManagedBy   = "terraform"
+  }
+}
+
+# Deliberately do not create aws_iam_access_key here: putting the secret in
+# Terraform state would create a second credential store. The runbook creates
+# one key immediately before setting the three required Fly secrets.
+
+resource "aws_sns_topic" "incident_alerts" {
+  name = "cosyworld-production-log-alerts"
+
+  tags = {
+    Application = "cosyworld"
+    Environment = "production"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_sns_topic_subscription" "incident_email" {
+  for_each  = var.alarm_email_endpoints
+  topic_arn = aws_sns_topic.incident_alerts.arn
+  protocol  = "email"
+  endpoint  = each.value
+}
+
+resource "aws_cloudwatch_log_metric_filter" "incident" {
+  for_each = local.alerts
+
+  name           = "cosyworld-production-${replace(each.key, "_", "-")}"
+  pattern        = "{ $.alert_kind = \"${each.key}\" }"
+  log_group_name = aws_cloudwatch_log_group.production.name
+
+  metric_transformation {
+    name      = each.key
+    namespace = local.metric_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "incident" {
+  for_each = local.alerts
+
+  alarm_name          = "cosyworld-production-${replace(each.key, "_", "-")}"
+  alarm_description   = each.value.description
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = each.value.threshold
+  period              = each.value.period
+  statistic           = "Sum"
+  namespace           = local.metric_namespace
+  metric_name         = each.key
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.incident_alerts.arn]
+  ok_actions          = [aws_sns_topic.incident_alerts.arn]
+
+  tags = {
+    Application = "cosyworld"
+    Environment = "production"
+    ManagedBy   = "terraform"
+  }
+
+  depends_on = [aws_cloudwatch_log_metric_filter.incident]
+}

--- a/infra/production-logs/outputs.tf
+++ b/infra/production-logs/outputs.tf
@@ -1,0 +1,24 @@
+output "log_group_name" {
+  value       = aws_cloudwatch_log_group.production.name
+  description = "Set this as CLOUDWATCH_LOG_GROUP_NAME on the Fly log shipper."
+}
+
+output "shipper_iam_user_name" {
+  value       = aws_iam_user.fly_log_shipper.name
+  description = "Create one access key for this user outside Terraform, then store it only in Fly secrets."
+}
+
+output "incident_reader_policy_arn" {
+  value       = aws_iam_policy.incident_reader.arn
+  description = "Attach this query-only policy to approved incident-response roles."
+}
+
+output "incident_topic_arn" {
+  value       = aws_sns_topic.incident_alerts.arn
+  description = "SNS topic used by all production-log alarms."
+}
+
+output "alarm_names" {
+  value       = sort([for alarm in aws_cloudwatch_metric_alarm.incident : alarm.alarm_name])
+  description = "CloudWatch alarms created from normalized incident classifications."
+}

--- a/infra/production-logs/variables.tf
+++ b/infra/production-logs/variables.tf
@@ -1,0 +1,37 @@
+variable "aws_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "AWS region receiving production logs from the Fly log shipper."
+}
+
+variable "log_group_name" {
+  type        = string
+  default     = "/cosyworld/production"
+  description = "CloudWatch Logs group shared by the two production Fly apps."
+}
+
+variable "retention_days" {
+  type        = number
+  default     = 30
+  description = "Age-based CloudWatch retention. Must remain at least 14 days."
+
+  validation {
+    condition = var.retention_days >= 14 && contains([
+      14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827,
+      2192, 2557, 2922, 3288, 3653,
+    ], var.retention_days)
+    error_message = "Production log retention must be a CloudWatch-supported duration of at least 14 days."
+  }
+}
+
+variable "shipper_iam_user_name" {
+  type        = string
+  default     = "cosyworld-fly-log-shipper"
+  description = "IAM service user whose access key is stored only as Fly secrets."
+}
+
+variable "alarm_email_endpoints" {
+  type        = set(string)
+  default     = []
+  description = "Optional email addresses subscribed to the incident SNS topic. AWS requires each address to confirm."
+}

--- a/infra/production-logs/versions.tf
+++ b/infra/production-logs/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.91",
+      "version": "1.0.92",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/scripts/check-production-log-ingestion.sh
+++ b/scripts/check-production-log-ingestion.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+log_group="${COSYWORLD_LOG_GROUP_NAME:-/cosyworld/production}"
+aws_region="${AWS_REGION:-us-east-1}"
+primary_url="${COSYWORLD_PRIMARY_META_URL:-https://cosyworld.fly.dev/meta}"
+lonelyforest_url="${COSYWORLD_LONELYFOREST_META_URL:-https://lonelyforest.com/meta}"
+poll_attempts="${COSYWORLD_LOG_QUERY_POLL_ATTEMPTS:-24}"
+
+case "$poll_attempts" in
+  ""|*[!0-9]*|0) printf '%s\n' "COSYWORLD_LOG_QUERY_POLL_ATTEMPTS must be a positive integer" >&2; exit 2 ;;
+esac
+
+primary_request_id="log-smoke-primary-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+lonelyforest_request_id="log-smoke-lonelyforest-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+curl --fail --silent --show-error --output /dev/null \
+  --header "X-Request-Id: $primary_request_id" "$primary_url"
+curl --fail --silent --show-error --output /dev/null \
+  --header "X-Request-Id: $lonelyforest_request_id" "$lonelyforest_url"
+
+query_string="fields @timestamp, app, machine_id, region, process, tenant, worldpack, request_id | filter request_id in [\"$primary_request_id\", \"$lonelyforest_request_id\"] | sort @timestamp asc"
+end_time="$(date +%s)"
+start_time="$((end_time - 600))"
+query_id="$(aws logs start-query \
+  --region "$aws_region" \
+  --log-group-name "$log_group" \
+  --start-time "$start_time" \
+  --end-time "$end_time" \
+  --query-string "$query_string" \
+  --query queryId \
+  --output text)"
+
+attempt=1
+while [ "$attempt" -le "$poll_attempts" ]; do
+  result="$(aws logs get-query-results --region "$aws_region" --query-id "$query_id")"
+  status="$(printf '%s' "$result" | jq -r '.status')"
+  case "$status" in
+    Complete)
+      printf '%s' "$result" | jq -e \
+        --arg primary_id "$primary_request_id" \
+        --arg lonelyforest_id "$lonelyforest_request_id" '
+          [.results[] | map({key: .field, value: .value}) | from_entries] as $rows
+          | any($rows[]; .app == "cosyworld" and .request_id == $primary_id and (.machine_id | length) > 0)
+          and any($rows[]; .app == "cosyworld-lonelyforest" and .request_id == $lonelyforest_id and (.machine_id | length) > 0)
+        ' >/dev/null || {
+          printf '%s\n' "CloudWatch query completed without both app/request-ID pairs" >&2
+          exit 1
+        }
+      printf '%s\n' "Production log ingestion verified for both Fly apps in $log_group."
+      exit 0
+      ;;
+    Failed|Cancelled|Timeout|Unknown)
+      printf '%s\n' "CloudWatch Logs Insights query ended with status $status" >&2
+      exit 1
+      ;;
+  esac
+  sleep 5
+  attempt=$((attempt + 1))
+done
+
+printf '%s\n' "Timed out waiting for CloudWatch ingestion query $query_id" >&2
+exit 1

--- a/test/infrastructure/production-logs.test.mjs
+++ b/test/infrastructure/production-logs.test.mjs
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const vector = readFileSync("deploy/observability/vector.yaml", "utf8");
+const terraform = readFileSync("infra/production-logs/main.tf", "utf8");
+const variables = readFileSync("infra/production-logs/variables.tf", "utf8");
+const nginx = readFileSync("deploy/lonelyforest/nginx.conf", "utf8");
+const primaryFly = readFileSync("fly.toml", "utf8");
+const lonelyforestFly = readFileSync("fly.lonelyforest.toml", "utf8");
+const shipperFly = readFileSync("fly.logs.toml", "utf8");
+const smoke = readFileSync("scripts/check-production-log-ingestion.sh", "utf8");
+
+describe("durable production logs", () => {
+  it("uses structured runtime logs and omits raw Nginx request targets", () => {
+    expect(primaryFly).toContain('COSYWORLD_LOG_FORMAT = "json"');
+    expect(lonelyforestFly).toContain('COSYWORLD_LOG_FORMAT = "json"');
+    expect(nginx).toContain("log_format cosyworld_safe");
+    expect(nginx).not.toMatch(/access_log[^;]+combined/);
+    const safeFormat =
+      nginx.match(/log_format cosyworld_safe[^;]+;/)?.[0] ?? "";
+    expect(safeFormat).not.toMatch(/\$request(?:[\s"']|$)/);
+    expect(safeFormat).not.toContain("$request_uri");
+    expect(safeFormat).not.toContain("$args");
+  });
+
+  it("allowlists exactly the two production apps before export", () => {
+    expect(vector).toContain('.fly.app.name == "cosyworld"');
+    expect(vector).toContain('.fly.app.name == "cosyworld-lonelyforest"');
+    expect(vector).toMatch(
+      /inputs: \[allowlisted_apps\][\s\S]+normalize_and_redact/,
+    );
+    expect(vector).toMatch(
+      /cloudwatch:[\s\S]+type: aws_cloudwatch_logs[\s\S]+inputs: \[normalize_and_redact\]/,
+    );
+  });
+
+  it("retains at least fourteen days and never stores the IAM key in state", () => {
+    expect(variables).toContain("var.retention_days >= 14");
+    expect(variables).toContain("contains([");
+    expect(variables).toContain("default     = 30");
+    expect(terraform).toContain("retention_in_days = var.retention_days");
+    expect(terraform).not.toContain('resource "aws_iam_access_key"');
+    expect(terraform).not.toContain("logs:CreateLogGroup");
+    expect(terraform).toContain('resource "aws_iam_policy" "incident_reader"');
+    expect(terraform).toContain('"logs:StartQuery"');
+    expect(terraform).not.toContain('"logs:*"');
+  });
+
+  it("defines every required incident alarm classification", () => {
+    for (const alert of [
+      "forced_exit",
+      "health_failure",
+      "oom",
+      "panic",
+      "provider_unavailable",
+      "actor_job_failure",
+    ]) {
+      expect(vector).toContain(`alert_kind = "${alert}"`);
+      expect(terraform).toMatch(new RegExp(`\\n    ${alert} = \\{`));
+    }
+    expect(vector).toContain('event == "actor_job_dead"');
+    expect(vector).not.toMatch(/match\(searchable, r'actor job/);
+    expect(terraform).toMatch(
+      /actor_job_failure = \{[\s\S]*?threshold\s+= 1[\s\S]*?period\s+= 60/,
+    );
+  });
+
+  it("keeps the shipper private and smoke-checks both app/request pairs", () => {
+    expect(shipperFly).not.toContain("[http_service]");
+    expect(shipperFly).toContain("[checks.vector]");
+    expect(smoke).toContain("https://cosyworld.fly.dev/meta");
+    expect(smoke).toContain("https://lonelyforest.com/meta");
+    expect(smoke).toContain('.app == "cosyworld"');
+    expect(smoke).toContain('.app == "cosyworld-lonelyforest"');
+  });
+});

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.91"
+version = "1.0.92"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -1974,7 +1974,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
 ]
 
@@ -2035,6 +2034,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,12 +2053,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.91"
+version = "1.0.92"
 edition = "2021"
 publish = false
 
@@ -24,9 +24,9 @@ rusqlite = { version = "0.37", features = ["backup", "bundled"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tower-http = { version = "0.6", features = ["compression-full", "cors", "trace"] }
+tower-http = { version = "0.6", features = ["compression-full", "cors"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 webauthn-rs = { version = "0.5.5", features = ["conditional-ui"] }
 zstd = "0.13"
 

--- a/v2/orchestrator-rust/src/actor_jobs.rs
+++ b/v2/orchestrator-rust/src/actor_jobs.rs
@@ -239,7 +239,53 @@ pub(super) fn fail_actor_job_for_runtime_state(
         params![job.id, now_millis() as i64, trim_to_chars(error, 500),],
     )
     .map_err(sqlite_error)?;
+    log_dead_actor_job(job, "provider_terminal");
     Ok(())
+}
+
+pub(super) fn fail_or_retry_actor_job(
+    path: &Path,
+    job: &ActorJob,
+    error: &str,
+    retry_floor_ms: u64,
+) -> io::Result<()> {
+    let conn = open_event_store(path)?;
+    let terminal = job.attempts >= ACTOR_JOB_MAX_ATTEMPTS;
+    let backoff_ms = 250_u64
+        .saturating_mul(1_u64 << job.attempts.saturating_sub(1).min(5))
+        .max(retry_floor_ms);
+    let now = now_millis();
+    let updated = conn
+        .execute(
+            "UPDATE actor_jobs
+         SET status = ?2, lease_until_ms = NULL, available_at_ms = ?3,
+             last_error = ?4, updated_at_ms = ?5
+         WHERE id = ?1",
+            params![
+                job.id,
+                if terminal { "dead" } else { "pending" },
+                now.saturating_add(backoff_ms) as i64,
+                trim_to_chars(error, 500),
+                now as i64,
+            ],
+        )
+        .map_err(sqlite_error)?;
+    if terminal && updated > 0 {
+        log_dead_actor_job(job, "attempt_budget_exhausted");
+    }
+    Ok(())
+}
+
+pub(super) fn log_dead_actor_job(job: &ActorJob, disposition: &'static str) {
+    error!(
+        event = "actor_job_dead",
+        actor_job_id = job.id,
+        actor_job_kind = job.kind,
+        actor_id = job.actor_id,
+        actor_attempts = job.attempts,
+        disposition,
+        "actor job entered the durable dead state"
+    );
 }
 
 fn requeue_actor_job(

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -30043,35 +30043,6 @@ fn actor_job_retry_floor_ms(state: &AppState, job: &ActorJob, error: &str) -> u6
         .saturating_add(250)
 }
 
-fn fail_or_retry_actor_job(
-    path: &Path,
-    job: &ActorJob,
-    error: &str,
-    retry_floor_ms: u64,
-) -> io::Result<()> {
-    let conn = open_event_store(path)?;
-    let terminal = job.attempts >= ACTOR_JOB_MAX_ATTEMPTS;
-    let backoff_ms = 250_u64
-        .saturating_mul(1_u64 << job.attempts.saturating_sub(1).min(5))
-        .max(retry_floor_ms);
-    let now = now_millis();
-    conn.execute(
-        "UPDATE actor_jobs
-         SET status = ?2, lease_until_ms = NULL, available_at_ms = ?3,
-             last_error = ?4, updated_at_ms = ?5
-         WHERE id = ?1",
-        params![
-            job.id,
-            if terminal { "dead" } else { "pending" },
-            now.saturating_add(backoff_ms) as i64,
-            trim_to_chars(error, 500),
-            now as i64,
-        ],
-    )
-    .map_err(sqlite_error)?;
-    Ok(())
-}
-
 #[cfg(test)]
 fn read_action_journal(path: &Path) -> io::Result<Vec<JournalRecord>> {
     Ok(read_action_journal_after_seq(path, 0)?

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::Request,
+    extract::{MatchedPath, Request},
     http::HeaderValue,
     middleware,
     middleware::Next,
@@ -7,7 +7,8 @@ use axum::{
     Router,
 };
 use tokio::sync::Semaphore;
-use tower_http::{compression::CompressionLayer, cors::CorsLayer, trace::TraceLayer};
+use tower_http::{compression::CompressionLayer, cors::CorsLayer};
+use tracing::Instrument;
 
 use super::*;
 
@@ -15,6 +16,31 @@ use super::*;
 // contend for a single slot. Saturated callers fail fast and can safely retry
 // the same intent while health endpoints continue to bypass this admission gate.
 const COMMAND_CONCURRENCY_LIMIT: usize = 16;
+const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
+const MAX_REQUEST_ID_LENGTH: usize = 128;
+
+#[derive(Clone, Debug)]
+struct RequestLogContext {
+    app: String,
+    machine_id: String,
+    region: String,
+    process: String,
+    tenant: String,
+    worldpack: String,
+}
+
+impl RequestLogContext {
+    fn from_state(state: &AppState) -> Self {
+        Self {
+            app: startup::log_context_env("FLY_APP_NAME", "local"),
+            machine_id: startup::log_context_env("FLY_MACHINE_ID", "local"),
+            region: startup::log_context_env("FLY_REGION", "local"),
+            process: state.deployment.process_id.clone(),
+            tenant: startup::log_context_env("COSYWORLD_LOG_TENANT", "primary"),
+            worldpack: active_content().manifest.id.clone(),
+        }
+    }
+}
 
 pub(super) fn action_path_accepts_kind(path: &str, kind: &str) -> bool {
     match path {
@@ -88,6 +114,7 @@ fn app_router_with_dependencies(
     command_capacity: Arc<Semaphore>,
     shutdown: ShutdownSubscription,
 ) -> Router {
+    let request_log_context = RequestLogContext::from_state(&state);
     Router::new()
         .route("/", get(index))
         .route("/moderation", get(moderation_console))
@@ -396,9 +423,76 @@ fn app_router_with_dependencies(
         // draining process from a dead one.
         .layer(middleware::from_fn_with_state(shutdown, shutdown_admission))
         .layer(CompressionLayer::new())
-        .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::permissive())
+        .layer(middleware::from_fn_with_state(
+            request_log_context,
+            request_observability,
+        ))
         .with_state(state)
+}
+
+async fn request_observability(
+    State(context): State<RequestLogContext>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let request_id = request_id(&request);
+    let request_id_header = HeaderValue::from_str(&request_id)
+        .expect("validated or generated request IDs must be valid header values");
+    request
+        .headers_mut()
+        .insert(REQUEST_ID_HEADER, request_id_header.clone());
+    let method = request.method().to_string();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|path| path.as_str().to_string())
+        .unwrap_or_else(|| "<unmatched>".to_string());
+    let started = Instant::now();
+    let span = tracing::info_span!(
+        "http_request",
+        request_id = %request_id,
+        method = %method,
+        route = %route,
+        app = %context.app,
+        machine_id = %context.machine_id,
+        region = %context.region,
+        process = %context.process,
+        tenant = %context.tenant,
+        worldpack = %context.worldpack,
+    );
+    let mut response = next.run(request).instrument(span.clone()).await;
+    let status = response.status().as_u16();
+    span.in_scope(|| {
+        info!(
+            event = "http_request_complete",
+            status,
+            latency_ms = started.elapsed().as_millis() as u64,
+        );
+    });
+    response
+        .headers_mut()
+        .insert(REQUEST_ID_HEADER, request_id_header);
+    response
+}
+
+fn request_id(request: &Request) -> String {
+    request
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| valid_request_id(value))
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("cw-{}", random_hex(16)))
+}
+
+fn valid_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_REQUEST_ID_LENGTH
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
 }
 
 async fn shutdown_admission(
@@ -553,6 +647,53 @@ mod tests {
     use super::*;
     use axum::body::Bytes;
     use tower::ServiceExt;
+
+    #[test]
+    fn request_ids_are_bounded_log_safe_tokens() {
+        assert!(valid_request_id("incident-2026.08.21:smoke_1"));
+        assert!(!valid_request_id(""));
+        assert!(!valid_request_id("contains space"));
+        assert!(!valid_request_id("contains?query=secret"));
+        assert!(!valid_request_id(&"a".repeat(MAX_REQUEST_ID_LENGTH + 1)));
+    }
+
+    #[tokio::test]
+    async fn requests_propagate_valid_ids_and_replace_unsafe_ids() {
+        let app = app_router(test_app_state(RuntimeWorld::seeded(), None));
+        let accepted = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/health/live?token=must-not-be-logged")
+                    .header(REQUEST_ID_HEADER, "incident-smoke-1")
+                    .body(Body::empty())
+                    .expect("health request"),
+            )
+            .await
+            .expect("health response");
+        assert_eq!(
+            accepted.headers().get(REQUEST_ID_HEADER).unwrap(),
+            "incident-smoke-1"
+        );
+
+        let replaced = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health/live")
+                    .header(REQUEST_ID_HEADER, "unsafe request id")
+                    .body(Body::empty())
+                    .expect("health request"),
+            )
+            .await
+            .expect("health response");
+        let generated = replaced
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .expect("generated response request ID");
+        assert!(generated.starts_with("cw-"));
+        assert!(valid_request_id(generated));
+    }
 
     fn request(method: &str, body: Body, content_type: Option<&str>) -> Request {
         let mut builder = Request::builder().method(method).uri("/commands");

--- a/v2/orchestrator-rust/src/startup.rs
+++ b/v2/orchestrator-rust/src/startup.rs
@@ -34,12 +34,126 @@ pub(super) async fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn initialize_tracing() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "cosyworld_orchestrator=info,tower_http=info".into()),
-        )
-        .init();
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "cosyworld_orchestrator=info,tower_http=info".into());
+    if configured_log_format() == LogFormat::Json {
+        tracing_subscriber::fmt()
+            .event_format(ContextualJsonFormat::from_env())
+            .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
+            .with_env_filter(filter)
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LogFormat {
+    Json,
+    Text,
+}
+
+fn configured_log_format() -> LogFormat {
+    match std::env::var("COSYWORLD_LOG_FORMAT") {
+        Ok(value) if value.trim().eq_ignore_ascii_case("json") => LogFormat::Json,
+        _ => LogFormat::Text,
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ProductionLogContext {
+    app: String,
+    machine_id: String,
+    region: String,
+    process: String,
+    tenant: String,
+    worldpack: String,
+}
+
+impl ProductionLogContext {
+    fn from_env() -> Self {
+        Self {
+            app: log_context_env("FLY_APP_NAME", "local"),
+            machine_id: log_context_env("FLY_MACHINE_ID", "local"),
+            region: log_context_env("FLY_REGION", "local"),
+            process: log_context_env(
+                "COSYWORLD_PROCESS_ID",
+                &log_context_env("FLY_PROCESS_GROUP", "orchestrator"),
+            ),
+            tenant: log_context_env("COSYWORLD_LOG_TENANT", "primary"),
+            worldpack: log_context_env("COSYWORLD_LOG_WORLDPACK", "official"),
+        }
+    }
+}
+
+pub(super) fn log_context_env(name: &str, fallback: &str) -> String {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+#[derive(Clone)]
+struct ContextualJsonFormat {
+    inner: tracing_subscriber::fmt::format::Format<tracing_subscriber::fmt::format::Json>,
+    context: ProductionLogContext,
+}
+
+impl ContextualJsonFormat {
+    fn from_env() -> Self {
+        Self {
+            inner: tracing_subscriber::fmt::format()
+                .json()
+                .flatten_event(true)
+                .with_current_span(true),
+            context: ProductionLogContext::from_env(),
+        }
+    }
+}
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for ContextualJsonFormat
+where
+    S: tracing::Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
+    N: for<'writer> tracing_subscriber::fmt::FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        let mut rendered = String::new();
+        self.inner.format_event(
+            ctx,
+            tracing_subscriber::fmt::format::Writer::new(&mut rendered),
+            event,
+        )?;
+        let mut payload: serde_json::Value =
+            serde_json::from_str(rendered.trim_end()).map_err(|_| std::fmt::Error)?;
+        inject_production_log_context(&mut payload, &self.context);
+        let encoded = serde_json::to_string(&payload).map_err(|_| std::fmt::Error)?;
+        writeln!(writer, "{encoded}")
+    }
+}
+
+fn inject_production_log_context(payload: &mut serde_json::Value, context: &ProductionLogContext) {
+    let Some(fields) = payload.as_object_mut() else {
+        return;
+    };
+    fields.insert("schema_version".to_string(), serde_json::json!(1));
+    fields.insert("app".to_string(), serde_json::json!(context.app));
+    fields.insert(
+        "machine_id".to_string(),
+        serde_json::json!(context.machine_id),
+    );
+    fields.insert("region".to_string(), serde_json::json!(context.region));
+    fields.insert("process".to_string(), serde_json::json!(context.process));
+    fields.insert("tenant".to_string(), serde_json::json!(context.tenant));
+    fields.insert(
+        "worldpack".to_string(),
+        serde_json::json!(context.worldpack),
+    );
 }
 
 struct BackgroundServices {
@@ -204,7 +318,106 @@ async fn persist_final_snapshot(state: &AppState) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[derive(Clone, Default)]
+    struct CapturedOutput(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    struct CapturedWriter(CapturedOutput);
+
+    impl Write for CapturedWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.0
+                 .0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'writer> tracing_subscriber::fmt::MakeWriter<'writer> for CapturedOutput {
+        type Writer = CapturedWriter;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            CapturedWriter(self.clone())
+        }
+    }
+
+    #[test]
+    fn contextual_json_formats_span_fields_as_json() {
+        let output = CapturedOutput::default();
+        let formatter = ContextualJsonFormat {
+            inner: tracing_subscriber::fmt::format()
+                .json()
+                .flatten_event(true)
+                .with_current_span(true),
+            context: ProductionLogContext {
+                app: "cosyworld".to_string(),
+                machine_id: "machine-primary".to_string(),
+                region: "sjc".to_string(),
+                process: "public-1".to_string(),
+                tenant: "primary".to_string(),
+                worldpack: "cosyworld.official".to_string(),
+            },
+        };
+        let subscriber = tracing_subscriber::fmt()
+            .event_format(formatter)
+            .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
+            .with_writer(output.clone())
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span =
+                tracing::info_span!("http_request", request_id = "incident-821", route = "/meta");
+            let _entered = span.enter();
+            info!(event = "http_request_complete", status = 200);
+        });
+
+        let captured = output
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        let payload: serde_json::Value =
+            serde_json::from_slice(&captured).expect("one valid JSON event");
+        assert_eq!(payload["event"], "http_request_complete");
+        assert_eq!(payload["span"]["request_id"], "incident-821");
+        assert_eq!(payload["span"]["route"], "/meta");
+        assert_eq!(payload["app"], "cosyworld");
+        assert_eq!(payload["machine_id"], "machine-primary");
+    }
+
+    #[test]
+    fn production_log_context_overrides_untrusted_event_dimensions() {
+        let context = ProductionLogContext {
+            app: "cosyworld-lonelyforest".to_string(),
+            machine_id: "machine-7".to_string(),
+            region: "sjc".to_string(),
+            process: "lonelyforest-7".to_string(),
+            tenant: "7".to_string(),
+            worldpack: "bethlehem".to_string(),
+        };
+        let mut payload = serde_json::json!({
+            "event": "provider_unavailable",
+            "app": "attacker-controlled",
+            "machine_id": "wrong-machine"
+        });
+
+        inject_production_log_context(&mut payload, &context);
+
+        assert_eq!(payload["schema_version"], 1);
+        assert_eq!(payload["app"], "cosyworld-lonelyforest");
+        assert_eq!(payload["machine_id"], "machine-7");
+        assert_eq!(payload["process"], "lonelyforest-7");
+        assert_eq!(payload["tenant"], "7");
+        assert_eq!(payload["worldpack"], "bethlehem");
+    }
 
     async fn connected_request(addr: SocketAddr, path: &str) -> tokio::net::TcpStream {
         let mut connection = tokio::net::TcpStream::connect(addr)

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -414,4 +414,6 @@
 # schema initialization. The mode is now chosen ahead of WAL by
 # open_canonical_store_for_initialization in canonical_journal.rs; main.rs keeps
 # only the /meta boundary fields.
-61582
+# 61582 -> 61553: move actor-job failure persistence into actor_jobs.rs so the
+# durable dead-state transition and its incident event share one queue seam.
+61553


### PR DESCRIPTION
Closes #821

## Summary
- Emit production JSON with authoritative app, Machine, region, process, tenant, worldpack, request ID, route-template, severity, and event timestamp fields.
- Forward only cosyworld and cosyworld-lonelyforest through a pinned private Vector shipper into a 30-day CloudWatch group, with reviewed detail allowlisting and credential/query redaction.
- Add least-privilege writer and incident-reader IAM policy, six incident alarms, bounded retention, cost/deletion guidance, and an operator-authorized deployment runbook.
- Add a cross-app ingestion smoke that proves both app/request/Machine tuples are searchable.

## Validation
- npm run check
- Vector 0.55.0: 6 pipeline fixtures passed; validate --deny-warnings passed
- Terraform 1.15.7: fmt -check and validate passed
- flyctl config validate --config fly.logs.toml
- localhost request-correlation integration: safe route template, propagated X-Request-Id, valid JSON, clean drain
- git diff --check and credential-pattern audit

No AWS or Fly resources were provisioned, no credentials were created, and no production deploy was performed.