### PR TITLE
Pin the redacting proxy log format in the deployment contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.92",
+      "version": "1.0.93",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.92"
+version = "1.0.93"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.92"
+version = "1.0.93"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/lonelyforest-multitenant-contract.test.mjs
+++ b/v2/scripts/lonelyforest-multitenant-contract.test.mjs
@@ -204,7 +204,20 @@ test("Lonely Forest tenant manifest strictly covers supervisor, nginx, Fly healt
   assert.doesNotMatch(nginx, /\/dev\/(?:stdout|stderr)/, "non-root nginx must not open container-owned standard streams");
   assert.doesNotMatch(nginx, /\/var\/lib\/nginx/, "non-root nginx must not retain default temp paths");
   assert.match(nginx, /^error_log \/tmp\/cosyworld-nginx\/error\.log notice;$/m);
-  assert.match(nginx, /^\s*access_log \/tmp\/cosyworld-nginx\/access\.log combined;$/m);
+  // The proxy boundary logs through the redacting cosyworld_safe format, not
+  // nginx's combined format, which retains query strings, cookies, and user
+  // agents. This assertion only runs in the deployment gate, so pinning the
+  // named format here is what keeps a later revert from reaching production
+  // through a green PR.
+  assert.match(
+    nginx,
+    /^\s*access_log \/tmp\/cosyworld-nginx\/access\.log cosyworld_safe;$/m,
+  );
+  assert.doesNotMatch(
+    nginx,
+    /access_log[^;]*\bcombined;/,
+    "the combined format retains credential-bearing request detail",
+  );
   assert.match(supervisor, /mkdir -p[\s\S]*?\/tmp\/cosyworld-nginx \\/);
   assert.match(supervisor, /tail -n 0 -F \/tmp\/cosyworld-nginx\/error\.log \/tmp\/cosyworld-nginx\/access\.log/);
   assert.match(supervisor, /kill -TERM "\$nginx_log_pid"/);


### PR DESCRIPTION
Every deploy since "Retain searchable production logs" has failed its gate before reaching Fly, and PR CI never saw it.

`deploy/lonelyforest/nginx.conf` moved to the redacting `cosyworld_safe` log format — it drops query strings, cookies, user agents, and credential-bearing path segments at the proxy boundary. `test/infrastructure/production-logs.test.mjs` was added to assert that. But `v2/scripts/lonelyforest-multitenant-contract.test.mjs` still asserted nginx's `combined` format, and that contract runs **only in the V2 production deployment gate**, not in PR CI. So the change reviewed green, merged, and then blocked every release:

```
AssertionError: The input did not match /^\s*access_log \/tmp\/cosyworld-nginx\/access\.log combined;$/m
Input: '  access_log /tmp/cosyworld-nginx/access.log cosyworld_safe;'
```

The assertion now names the safe format, and a second assertion refuses `combined` outright, so a revert has to fail here instead of quietly restoring credential-bearing request logs.

`npm run v2:lonelyforest:contract` passes 15/15.

## Worth a follow-up

This is the same shape as the Abandon Avatar 404 from earlier today: a guard existed, but nothing in the pull-request path exercised it. Two deployment-only contracts now sit outside PR CI. Either running them on PRs that touch `deploy/**` or failing the deploy loudly enough to notice would have caught this in minutes rather than at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
