### PR TITLE
Align Lonely Forest logging deployment contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.92",
+      "version": "1.0.93",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.92"
+version = "1.0.93"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.92"
+version = "1.0.93"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/lonelyforest-multitenant-contract.test.mjs
+++ b/v2/scripts/lonelyforest-multitenant-contract.test.mjs
@@ -204,7 +204,12 @@ test("Lonely Forest tenant manifest strictly covers supervisor, nginx, Fly healt
   assert.doesNotMatch(nginx, /\/dev\/(?:stdout|stderr)/, "non-root nginx must not open container-owned standard streams");
   assert.doesNotMatch(nginx, /\/var\/lib\/nginx/, "non-root nginx must not retain default temp paths");
   assert.match(nginx, /^error_log \/tmp\/cosyworld-nginx\/error\.log notice;$/m);
-  assert.match(nginx, /^\s*access_log \/tmp\/cosyworld-nginx\/access\.log combined;$/m);
+  assert.equal(
+    nginx.match(/^\s*log_format cosyworld_safe (.+)$/m)?.[1],
+    `'process=nginx event=http_access tenant_host="$host" method="$request_method" status=$status bytes=$body_bytes_sent latency_secs=$request_time request_id="$upstream_http_x_request_id" upstream="$upstream_addr" upstream_status="$upstream_status"';`,
+    "the proxy access log must remain an exact metadata allowlist without requests, paths, query strings, cookies, or user agents",
+  );
+  assert.match(nginx, /^\s*access_log \/tmp\/cosyworld-nginx\/access\.log cosyworld_safe;$/m);
   assert.match(supervisor, /mkdir -p[\s\S]*?\/tmp\/cosyworld-nginx \\/);
   assert.match(supervisor, /tail -n 0 -F \/tmp\/cosyworld-nginx\/error\.log \/tmp\/cosyworld-nginx\/access\.log/);
   assert.match(supervisor, /kill -TERM "\$nginx_log_pid"/);


### PR DESCRIPTION
## Summary
- update the Lonely Forest deployment contract for the privacy-safe structured nginx access log introduced in #878
- pin the exact metadata allowlist so paths, query strings, cookies, and user agents cannot silently re-enter production logs
- bump the release version to 1.0.93 across Node and Rust manifests

## Verification
- exact production deployment gate passed locally
- 15/15 Lonely Forest supervisor/router contract tests
- 27/27 deploy-workflow tests and 5/5 production-log tests
- worldpacks, kernel, syntax, architecture, Clippy 225/225
- Rust: 12 library + 4 lab + 3 mock provider + 1,251 orchestrator + 6 integration tests