### PR TITLE
Let a knocked-out avatar actually reach the abandon endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.93",
+  "version": "1.0.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.93",
+      "version": "1.0.94",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.93",
+  "version": "1.0.94",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.93"
+version = "1.0.94"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.93"
+version = "1.0.94"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_presence.rs
+++ b/v2/orchestrator-rust/src/actor_presence.rs
@@ -1672,6 +1672,92 @@ mod tests {
         }));
     }
 
+    /// The planner, the projection, and the route were all correct while the
+    /// endpoint refused every real attempt: its authorization gate required an
+    /// ACTIVE actor, and only a knocked-out one may abandon. Driving the
+    /// handler is the only way to catch that -- planning-level coverage passes
+    /// either way.
+    #[tokio::test]
+    async fn the_abandon_endpoint_accepts_a_knocked_out_avatar_holding_its_session() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(
+            &mut runtime,
+            5000,
+            COSY_COTTAGE_LOCATION_ID,
+            "Fallen Traveler",
+        );
+        {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == 5000)
+                .expect("the avatar exists");
+            actor.status = CW_ACTOR_KNOCKED_OUT;
+        }
+        let state = test_app_state(runtime, None);
+        let (actor_session, _) = issue_actor_session(&state, 5000);
+
+        let response = crate::avatar_rescue::abandon_avatar(
+            ConnectInfo("127.0.0.1:45001".parse().expect("client address")),
+            State(state.clone()),
+            Json(ActorRequest {
+                actor_id: 5000,
+                actor_session: Some(actor_session),
+            }),
+        )
+        .await
+        .0;
+        assert!(
+            response.ok,
+            "a knocked-out avatar must be able to release itself: status {} {:?}",
+            response.status, response.events,
+        );
+        assert_eq!(response.status, CW_OK);
+
+        let runtime = state.inner.lock().await;
+        assert!(
+            !runtime.actor_control_mode(5000).is_direct_input(),
+            "the released avatar must leave direct control",
+        );
+    }
+
+    #[tokio::test]
+    async fn the_abandon_endpoint_refuses_a_session_that_does_not_own_the_avatar() {
+        let mut runtime = RuntimeWorld::seeded();
+        create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Fallen");
+        create_test_human(&mut runtime, 5001, COSY_COTTAGE_LOCATION_ID, "Bystander");
+        {
+            let actor = runtime
+                .world
+                .actors
+                .iter_mut()
+                .take(runtime.world.actor_count)
+                .find(|actor| actor.id == 5000)
+                .expect("the avatar exists");
+            actor.status = CW_ACTOR_KNOCKED_OUT;
+        }
+        let state = test_app_state(runtime, None);
+        let (other_session, _) = issue_actor_session(&state, 5001);
+
+        let response = crate::avatar_rescue::abandon_avatar(
+            ConnectInfo("127.0.0.1:45002".parse().expect("client address")),
+            State(state.clone()),
+            Json(ActorRequest {
+                actor_id: 5000,
+                actor_session: Some(other_session),
+            }),
+        )
+        .await
+        .0;
+        assert!(!response.ok);
+        assert_eq!(
+            response.status, 403,
+            "another player's session must never release someone else's avatar",
+        );
+    }
+
     #[tokio::test]
     async fn knocked_out_avatar_can_be_abandoned_to_roaming_ai() {
         let mut runtime = RuntimeWorld::seeded();

--- a/v2/orchestrator-rust/src/avatar_rescue.rs
+++ b/v2/orchestrator-rust/src/avatar_rescue.rs
@@ -628,6 +628,29 @@ fn abandon_avatar_claim_key(actor_id: u64) -> String {
     format!("avatar_abandon:{actor_id}")
 }
 
+/// Releasing a fallen avatar is the one mutation a knocked-out player may
+/// submit, so it cannot use the ordinary submit gate.
+/// `client_actor_authorized_for_state` requires `client_actor_can_submit`,
+/// which requires an ACTIVE actor -- a state an abandoning player is never in.
+/// Gating the endpoint that way refused every real attempt with 403 while the
+/// route, the projection, and the planner were all correct.
+///
+/// The session must still own this exact actor, the avatar must still be
+/// present and under direct control, and the account must not be suspended.
+/// `plan_abandon_avatar` enforces the rest: knocked out, out of combat, and
+/// not already released.
+fn abandon_avatar_authorized(
+    runtime: &RuntimeWorld,
+    state: &AppState,
+    actor_id: u64,
+    actor_session: Option<&str>,
+) -> bool {
+    !actor_is_suspended(state, actor_id)
+        && runtime.client_actor_can_observe(actor_id)
+        && actor_session.and_then(|token| actor_for_session(&state.actor_sessions, token))
+            == Some(actor_id)
+}
+
 pub(super) async fn abandon_avatar(
     ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
@@ -643,7 +666,7 @@ pub(super) async fn abandon_avatar(
         return action_rate_limited_response();
     }
     let mut runtime = state.inner.lock().await;
-    if !client_actor_authorized_for_state(
+    if !abandon_avatar_authorized(
         &runtime,
         &state,
         payload.actor_id,


### PR DESCRIPTION
The Abandon Avatar card now renders in production and still does nothing: playing it returns 403.

## Cause

`abandon_avatar` gated on `client_actor_authorized_for_state`, which requires `client_actor_can_submit`, which requires `CW_ACTOR_ACTIVE`. Abandon is legal only while an avatar is `CW_ACTOR_KNOCKED_OUT`. The two conditions are mutually exclusive by construction, so the endpoint refused every real attempt while the route, the projection, and the planner were all correct.

This is the third defect in one feature, each in a different layer:

| Layer | Defect | Fixed by |
|---|---|---|
| Projection | offer filtering replaced the lifecycle action with a disabled `wait` | #872 |
| Routing | `/actions/abandon-avatar` was never registered, so it 404'd | #872 |
| Authorization | the handler requires an ACTIVE actor, which an abandoning player never is | this PR |

## Fix

`abandon_avatar_authorized` keeps every check that protects the avatar — the session must own this exact actor, the avatar must be present and under direct control, the account must not be suspended — and drops the one that made success impossible. `plan_abandon_avatar` still enforces knocked out, out of combat, and not already released.

## Why it survived two releases

The existing test called `plan_abandon_avatar` and journalled the record by hand, under a comment claiming it did so "exactly the way the endpoint journals it". It never called the endpoint. Planning-level coverage passes whether the gate is right or wrong.

Both new tests drive the handler itself: a knocked-out avatar holding its own session succeeds, and another player's session is still refused with 403.

My own route-reachability test from #872 asserted the path is *served*, not that the action can *succeed* — which is why I observed the 403 after deploying and read it as a healthy auth rejection. #883 tracks making this a class of guard rather than a case-by-case fix.

## Verification

1,253 orchestrator tests pass, including all seven abandon tests. `main.rs` is at its lowered 61,553 ceiling; version check passes at 1.0.94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
