### PR TITLE
Stop a funded image job from re-reviewing itself forever

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.96",
+  "version": "1.0.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.96",
+      "version": "1.0.97",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.96",
+  "version": "1.0.97",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.96"
+version = "1.0.97"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.96"
+version = "1.0.97"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -41,6 +41,13 @@ use crate::{
 };
 
 pub(super) const MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS: u8 = 3;
+/// Mirrors `MAX_REVIEW_FAILURES` in the media verdict store, which already
+/// counts and clamps review failures per candidate.
+pub(super) const MAX_COMMUNITY_ART_REVIEW_ATTEMPTS: u8 = 3;
+
+fn exhausted_community_art_review_attempts() -> u8 {
+    MAX_COMMUNITY_ART_REVIEW_ATTEMPTS
+}
 pub(super) const LEGACY_COMMUNITY_ART_GENERATION_PROFILE_VERSION: u8 = 1;
 pub(super) const ACTOR_ITEM_GENERATION_PROFILE_VERSION: u8 = 2;
 pub(super) const LOCATION_LANDSCAPE_GENERATION_PROFILE_VERSION: u8 = 5;
@@ -106,6 +113,21 @@ pub(super) struct CommunityArtGenerationState {
     pub(super) revision: u32,
     #[serde(default)]
     pub(super) provider_attempts: u8,
+    /// Review attempts spent on a saved candidate.
+    ///
+    /// A job whose candidate exists but whose review failed used to be
+    /// retryable forever. On Lonely Forest one such job re-ran 975 times
+    /// between 2026-08-15 and 2026-08-22, accelerating to 239 attempts a day,
+    /// because the reviewer was paused by the daily spend cap and nothing
+    /// counted the attempts. `MAX_REVIEW_FAILURES` existed in the verdict
+    /// record and saturated at 3 while the retry decision never read it.
+    ///
+    /// A state that predates this counter is treated as exhausted: it is only
+    /// reachable through a status this field now governs, and a job already
+    /// looping must stop rather than earn a fresh budget. Replay converges on
+    /// the same value because the counter saturates at the cap.
+    #[serde(default = "exhausted_community_art_review_attempts")]
+    pub(super) review_attempts: u8,
     #[serde(default)]
     pub(super) last_prediction_id: Option<String>,
     #[serde(default)]
@@ -400,7 +422,9 @@ pub(super) fn community_art_generation_retryable(
     }
     match generation.status.as_str() {
         "ready" => false,
-        "review_failed" | "review_unavailable" if candidate_exists => true,
+        "review_failed" | "review_unavailable" if candidate_exists => {
+            generation.review_attempts < MAX_COMMUNITY_ART_REVIEW_ATTEMPTS
+        }
         "funded" | "generating" | "reviewing" | "failed" | "rejected" | "policy_rejected" => {
             candidate_exists || generation.provider_attempts < MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS
         }
@@ -882,6 +906,7 @@ impl RuntimeWorld {
                 history_through_seq,
                 revision: 0,
                 provider_attempts: 0,
+                review_attempts: 0,
                 last_prediction_id: None,
                 last_error_code: None,
                 status_event_seq: None,
@@ -1016,6 +1041,14 @@ impl RuntimeWorld {
         if generation.status != status && matches!(status, "ready" | "rejected" | "policy_rejected")
         {
             generation.revision = generation.revision.saturating_add(1);
+        }
+        if matches!(status, "review_failed" | "review_unavailable") {
+            // Saturating keeps journal replay and snapshot load on the same
+            // value once the cap is reached.
+            generation.review_attempts = generation
+                .review_attempts
+                .saturating_add(1)
+                .min(MAX_COMMUNITY_ART_REVIEW_ATTEMPTS);
         }
         generation.status = status.to_string();
         generation.last_prediction_id = prediction_id.map(ToString::to_string);

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -112,6 +112,82 @@ fn higher_level_without_prior_art_uses_a_base_generation_catch_up() {
     let _ = fs::remove_dir_all(generated_dir);
 }
 
+fn review_failed_generation(review_attempts: u8) -> CommunityArtGenerationState {
+    CommunityArtGenerationState {
+        subject_kind: "actor".to_string(),
+        subject_id: 906_220_117_126,
+        level: 1,
+        generation_profile_version: community_art_generation_profile_version("actor"),
+        generation_policy: GeneratedPolicyBinding::default(),
+        required_orbs: 1,
+        funded_orbs: 1,
+        contributions: BTreeMap::from([(992_630_739_740, 1)]),
+        funding_intent_ids: BTreeSet::from(["web-image:review-cap".to_string()]),
+        status: "review_failed".to_string(),
+        history_through_seq: 6_625,
+        revision: 3,
+        provider_attempts: 1,
+        review_attempts,
+        last_prediction_id: Some("928bg416f9rmy0czx1g8wa77c4".to_string()),
+        last_error_code: Some("community_art_policy_review_failed".to_string()),
+        status_event_seq: None,
+        evolution_job: None,
+        frozen_plan: None,
+    }
+}
+
+/// A saved candidate whose review failed used to be retryable forever. One
+/// Lonely Forest job re-ran 975 times over seven days because the reviewer was
+/// paused by the daily spend cap and nothing counted the attempts.
+#[test]
+fn a_failed_review_stops_retrying_once_its_attempts_are_spent() {
+    for attempts in 0..MAX_COMMUNITY_ART_REVIEW_ATTEMPTS {
+        assert!(
+            community_art_generation_retryable(&review_failed_generation(attempts), true),
+            "attempt {attempts} is still within the review budget",
+        );
+    }
+    assert!(
+        !community_art_generation_retryable(
+            &review_failed_generation(MAX_COMMUNITY_ART_REVIEW_ATTEMPTS),
+            true,
+        ),
+        "a spent review budget must not keep re-running a funded job",
+    );
+    assert_eq!(
+        review_failed_generation(MAX_COMMUNITY_ART_REVIEW_ATTEMPTS).funded_orbs,
+        1,
+        "the paid Orb stays with the job; only the retrying stops",
+    );
+}
+
+/// A newer generation profile is the documented way back in, and it must still
+/// reopen a job whose review budget is spent.
+#[test]
+fn a_newer_generation_profile_reopens_a_spent_review_budget() {
+    let spent = review_failed_generation(MAX_COMMUNITY_ART_REVIEW_ATTEMPTS);
+    assert!(community_art_generation_retryable_for_profile(
+        &spent,
+        true,
+        spent.generation_profile_version.saturating_add(1),
+    ));
+}
+
+/// Every state written before this counter existed belongs to a job that was
+/// already looping, so it loads as exhausted rather than earning a new budget.
+#[test]
+fn a_legacy_state_without_the_counter_loads_as_exhausted() {
+    let mut value = serde_json::to_value(review_failed_generation(0)).expect("serialize");
+    value
+        .as_object_mut()
+        .expect("object")
+        .remove("review_attempts");
+    let restored: CommunityArtGenerationState =
+        serde_json::from_value(value).expect("legacy state loads");
+    assert_eq!(restored.review_attempts, MAX_COMMUNITY_ART_REVIEW_ATTEMPTS);
+    assert!(!community_art_generation_retryable(&restored, true));
+}
+
 #[test]
 fn actor_item_profile_reopens_paid_policy_exhaustion_with_stronger_typography_guards() {
     let exhausted = CommunityArtGenerationState {
@@ -128,6 +204,7 @@ fn actor_item_profile_reopens_paid_policy_exhaustion_with_stronger_typography_gu
         history_through_seq: 1_041,
         revision: 3,
         provider_attempts: MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS,
+        review_attempts: 0,
         last_prediction_id: Some("third-policy-rejected-candidate".to_string()),
         last_error_code: Some("community_art_policy_rejected".to_string()),
         status_event_seq: Some(1_041),

--- a/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
+++ b/v2/orchestrator-rust/src/media_recipes/media_verdict.rs
@@ -346,6 +346,11 @@ pub(crate) struct MediaVerdictDashboard {
     review_retries: u64,
     provider_failures: u64,
     cooldown_routes: u64,
+    /// Directories left by a storage preflight whose job never produced a
+    /// candidate. They are reported rather than fatal: 19 of the primary's 40
+    /// verdict directories were in this state, and failing the listing on the
+    /// first one made the whole moderation surface answer 500.
+    incomplete_records: u64,
     slices: Vec<MediaVerdictSlice>,
 }
 
@@ -655,9 +660,10 @@ pub(crate) fn make_visual_verdict(
 }
 
 pub(crate) fn media_verdict_dashboard(root: &Path) -> Result<MediaVerdictDashboard, String> {
-    let records = list_records(root)?;
+    let (records, incomplete_records) = list_records(root)?;
     let mut dashboard = MediaVerdictDashboard {
         records: records.len() as u64,
+        incomplete_records,
         ..MediaVerdictDashboard::default()
     };
     let mut slices = BTreeMap::<(String, String), MediaVerdictSlice>::new();
@@ -1144,22 +1150,36 @@ fn load_record(root: &Path, record_id: &str) -> Result<PersistedMediaVerdict, St
     Ok(record)
 }
 
-fn list_records(root: &Path) -> Result<Vec<PersistedMediaVerdict>, String> {
+/// Returns every readable verdict record, plus the count of directories that
+/// hold no record yet.
+///
+/// A storage preflight creates the record and candidate directories before the
+/// provider is paid, so a job that never returns an image leaves a directory
+/// with no `record.json`. Propagating that as an error made one abandoned job
+/// hide every healthy record behind a 500.
+fn list_records(root: &Path) -> Result<(Vec<PersistedMediaVerdict>, u64), String> {
     let directory = root.join(MEDIA_VERDICT_DIR);
     let Ok(entries) = fs::read_dir(directory) else {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), 0));
     };
     let mut records = Vec::new();
+    let mut incomplete = 0u64;
     for entry in entries {
         let entry = entry.map_err(|error| error.to_string())?;
         let Some(record_id) = entry.file_name().to_str().map(ToString::to_string) else {
             continue;
         };
         if valid_digest(&record_id) && entry.path().is_dir() {
-            records.push(load_record(root, &record_id)?);
+            match load_record(root, &record_id) {
+                Ok(record) => records.push(record),
+                Err(error) if error.contains("not found") => {
+                    incomplete = incomplete.saturating_add(1);
+                }
+                Err(error) => return Err(error),
+            }
         }
     }
-    Ok(records)
+    Ok((records, incomplete))
 }
 
 fn store_record(root: &Path, record: &PersistedMediaVerdict) -> Result<(), String> {


### PR DESCRIPTION
## What is happening in production

One Lonely Forest job — `actor:906220117126:level:1` — produced **975 of tenant 0's 976** `community_art.failed` events, accelerating and still running:

| Aug 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 (partial) |
|---|---|---|---|---|---|---|---|
| 2 | 76 | 72 | 129 | 172 | 220 | 239 | 49 |

Its image was already generated and paid for (`provider_attempts: 1`, prediction `928bg416f9rmy0czx1g8wa77c4`). What fails is the vision review afterwards, and its recorded reason is not a defect in the reviewer:

```
media.generated_image_verdict is paused because the $10 UTC daily server
budget is exhausted (code=inference_daily_spend_exhausted)
```

## Cause

`community_art_generation_retryable` returned `true` unconditionally for a `review_failed` job holding a saved candidate:

```rust
"review_failed" | "review_unavailable" if candidate_exists => true,
```

The line directly below it caps provider attempts. The verdict store already counts review failures and clamps them at `MAX_REVIEW_FAILURES = 3` — the retry decision simply never read that counter, and the record for this job still sits at `review_failures: 1` after 975 attempts, because a paused reviewer never reaches the code that increments it.

Each retry fails before touching a provider, so there is **no inference spend**. The cost is roughly two journal events per attempt — about 1,950 rows of pure growth on a tenant whose volume needed extending today.

## Fix

`review_attempts` is persisted beside `provider_attempts` and capped at 3.

- It saturates at the cap, so journal replay and snapshot load converge on the same value.
- It counts inside the durable projection rather than from a clock, so replay stays deterministic — a wall-clock backoff deadline would not.
- A state written before the counter existed loads as **exhausted**. That state is only reachable through a status this field governs, and a job already looping must stop rather than earn a fresh budget. This is what clears the current backlog without re-triggering anything.
- The paid Orb stays with the job (`funded_orbs` untouched), and a newer generation profile version still reopens it — the documented way back in.

## Also: the moderation dashboard stops answering 500

`list_records` propagated the first missing `record.json`. A storage preflight creates that directory *before* the provider is paid, so any job that never returns an image leaves one behind — 19 of the primary's 40 verdict directories. One abandoned job hid every healthy record behind an error, which is why nobody saw the above. Incomplete directories are now skipped and reported as `incomplete_records`.

## Verification

1,265 orchestrator tests pass. Four new tests cover the cap, that a spent budget keeps the Orb, that a newer profile still reopens the job, and that a legacy state without the counter loads as exhausted.

## Not in this PR

The Orb-slot UX — funding currently surfaces workshop errors to the player and hides the button. That is a client change with its own browser-gate expectations and follows next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
