### PR TITLE
Make community art an Orb slot the player fills, not a job console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.98",
+  "version": "1.0.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.98",
+      "version": "1.0.99",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.97",
+  "version": "1.0.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.97",
+      "version": "1.0.98",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.97",
+  "version": "1.0.98",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.98",
+  "version": "1.0.99",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.97"
+version = "1.0.98"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.98"
+version = "1.0.99"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.97"
+version = "1.0.98"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.98"
+version = "1.0.99"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -10662,7 +10662,9 @@
         actorSessionHandoffChecked = false;
       }
       if (!result.ok) {
-        setError(actionFailureMessage(path, result));
+        // Orb slots absorb their own failures: the slot state is the whole
+        // report, and the player has nothing to act on.
+        if (path !== "/actions/fund-image") setError(actionFailureMessage(path, result));
       } else {
         await refresh();
       }
@@ -10700,19 +10702,6 @@
       if (path === "/actions/timeout" && timeoutRefusal?.content) {
         return String(timeoutRefusal.content);
       }
-      if (status === 402 && path.includes("fund-image")) {
-        return "You need one Orb to add to this community image.";
-      }
-      if (path.includes("fund-image") && result.error_code === "community_art_evolution_reference_unavailable") {
-        return "The earlier portrait is not available for a safe evolution, so no Orb was taken.";
-      }
-      if (path.includes("fund-image") && result.error_code === "community_art_storage_failed") {
-        return "The saved image job needs repair before it can start. No Orb was taken.";
-      }
-      if (status === 502 && path.includes("fund-image")) {
-        return "The image workshop could not be reached. Check the current status and try again.";
-      }
-      if (status === 503 && path.includes("fund-image")) return "The image workshop is unavailable, so no Orb was taken.";
       if (status === 503 && path === "/actions/model-interaction") {
         return "That model route is resting right now. Choose another action; nothing was spent.";
       }
@@ -16459,6 +16448,11 @@
       communityArtClientStates.delete(key);
     }
 
+    // An Orb slot, not a job console. The player fills a slot; generation,
+    // review, retries and their failures are the server's problem and never
+    // reach this panel. Exposing that machinery meant a failed provider call
+    // showed the player an error they could do nothing about, and swapped the
+    // slot for a retry button.
     function communityArtPanelHtml(card) {
       const art = card?.community_art;
       const subject = communityArtSubject(card);
@@ -16475,49 +16469,26 @@
       const funded = Math.max(0, Number(art.funded_orbs || 0));
       const remaining = Math.max(0, Number(art.remaining_orbs ?? (required - funded)));
       const status = String(art.status || "available");
-      const providerAttempts = Math.max(0, Number(art.provider_attempts || 0));
-      const maxProviderAttempts = Math.max(1, Number(art.max_provider_attempts || 3));
-      const retryableWithoutOrbs = Boolean(art.retryable_without_orbs);
       const viewerContributed = Boolean(art.viewer_contributed);
-      if (clientState?.status === "starting") {
-        return `<div class="card-art-status"><span>level ${level} portrait</span> <strong>Image workshop starting…</strong></div>`;
-      }
+      const slot = `<div class="card-art-status"><span>level ${level} portrait</span> <strong>Orb slot ${funded}/${required}`;
+
       if (status === "ready") {
         return `<div class="card-art-status"><span>community portrait</span> <strong>Level ${level} complete · next portrait unlocks at the next level.</strong></div>`;
       }
+      if (clientState?.status === "filling") {
+        return `${slot} · filling.</strong></div>`;
+      }
+      if (remaining <= 0) {
+        return `${slot} · filled. The portrait appears here when it is ready.</strong></div>`;
+      }
       const balance = Math.max(0, Number(state?.economy?.orbs || 0));
-      const needsOrb = remaining > 0;
-      const working = status === "generating" || status === "reviewing";
-      const buttonLabel = needsOrb
-        ? `add one Orb · ${funded}/${required}`
-        : (working
-          ? (status === "reviewing" ? "check the saved image review" : "check the image workshop")
-          : (status === "review_failed" || status === "review_unavailable"
-            ? (retryableWithoutOrbs ? "retry the saved image review" : "image review unavailable")
-            : (status === "rejected" || status === "policy_rejected"
-              ? (retryableWithoutOrbs ? "try a different image" : "image withheld")
-              : (status === "failed"
-                ? (retryableWithoutOrbs ? "try the image again" : "image workshop unavailable")
-                : "start the image workshop"))));
-      const canAct = needsOrb
-        ? balance >= 1
-        : retryableWithoutOrbs;
-      const detail = needsOrb
-        ? `${viewerContributed ? "your Orb is already helping; " : ""}${remaining} ${remaining === 1 ? "Orb is" : "Orbs are"} still needed from the community`
-        : (working
-          ? "fully funded; the saved job is still in progress"
-          : (status === "review_failed" || status === "review_unavailable"
-            ? "candidate saved; no new image will be bought while review is unavailable"
-            : (!retryableWithoutOrbs && providerAttempts >= maxProviderAttempts
-              ? `stopped after ${providerAttempts} image ${providerAttempts === 1 ? "attempt" : "attempts"}; no more provider credits will be used`
-              : "fully funded; no more Orbs will be taken")));
-      const action = canAct
-        ? `<button class="account-button" type="button" data-fund-community-image="${escapeAttr(subject.kind)}:${subject.id}">${escapeHtml(buttonLabel)}</button>`
+      const detail = viewerContributed
+        ? `${remaining} more ${remaining === 1 ? "Orb fills" : "Orbs fill"} this slot.`
+        : `${remaining} ${remaining === 1 ? "Orb fills" : "Orbs fill"} this slot.`;
+      const action = balance >= 1
+        ? `<button class="account-button" type="button" data-fund-community-image="${escapeAttr(subject.kind)}:${subject.id}">add one Orb</button>`
         : "";
-      const clientError = clientState?.status === "error"
-        ? `<div class="card-art-status error"><span>portrait update</span> <strong>${escapeHtml(clientState.message)}</strong></div>`
-        : "";
-      return `<div class="card-art-status"><span>level ${level} portrait</span> <strong>${escapeHtml(finishSentence(detail))}</strong></div>${clientError}${action}`;
+      return `${slot} · ${escapeHtml(detail)}</strong></div>${action}`;
     }
 
     function communityArtPlaceholderLabel(card) {
@@ -17002,56 +16973,50 @@
       $("card-modal-economy").innerHTML = "";
     }
 
-    async function retryCommunityArt(subjectKind, subjectId) {
+    // Filling a slot has exactly two outcomes for the player: the slot shows
+    // filled, or it stays fillable. Provider errors, review pauses and retries
+    // are handled server side and are never surfaced here.
+    async function fillCommunityArtOrbSlot(subjectKind, subjectId) {
       const subject = { kind: subjectKind, id: Number(subjectId) };
       const subjectKey = communityArtSubjectKey(subject);
       const card = subjectKind === "actor"
         ? cardForActor(subject.id)
         : (subjectKind === "item" ? cardForItem(subject.id) : cardForLocation(subject.id));
       const art = card?.community_art;
-      if (!subjectKey || !art || communityArtClientStates.get(subjectKey)?.status === "starting") return;
+      if (!subjectKey || !art || communityArtClientStates.get(subjectKey)?.status === "filling") return;
 
       const clientState = {
-        status: "starting",
+        status: "filling",
         authoritativeSignature: communityArtStateSignature(art),
         timeout: null,
       };
       communityArtClientStates.set(subjectKey, clientState);
+      // The latch is a spinner, not a deadline. If the server is slow the slot
+      // simply returns to fillable; nothing is announced.
       clientState.timeout = window.setTimeout(() => {
         if (communityArtClientStates.get(subjectKey) !== clientState) return;
-        clientState.status = "error";
-        clientState.message = "The image workshop is taking longer than expected. Check the current status and try again.";
-        setError(clientState.message);
+        clearCommunityArtClientState(subjectKey);
         syncOpenCardModal();
         void queueRefresh();
       }, 45_000);
       syncOpenCardModal();
 
       try {
-        const result = await action("/actions/fund-image", {
+        await action("/actions/fund-image", {
           actor_id: actorId,
           subject_kind: subjectKind,
           subject_id: subject.id,
           intent_id: `web-image:${globalThis.crypto?.randomUUID?.() || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`}`,
         });
-        if (!result?.ok) {
-          const failure = new Error(actionFailureMessage("/actions/fund-image", result));
-          failure.communityArtSafe = true;
-          throw failure;
-        }
-        await queueRefresh();
-        syncOpenCardModal();
-      } catch (error) {
-        if (clientState.timeout) window.clearTimeout(clientState.timeout);
-        if (communityArtClientStates.get(subjectKey) !== clientState) return;
-        clientState.status = "error";
-        clientState.message = error?.communityArtSafe
-          ? String(error.message || "")
-          : "The image workshop could not be reached. Check the current status and try again.";
-        setError(clientState.message);
-        await queueRefresh();
-        syncOpenCardModal();
+      } catch {
+        // A dropped request leaves the Orb unspent, so the slot is still
+        // fillable and that is the whole story the player needs.
       }
+      if (communityArtClientStates.get(subjectKey) === clientState) {
+        clearCommunityArtClientState(subjectKey);
+      }
+      await queueRefresh();
+      syncOpenCardModal();
     }
 
     function shapeForCard(card, fallback = "item") {
@@ -19469,7 +19434,7 @@
         const [subjectKind, subjectId] = String(fundImage.getAttribute("data-fund-community-image") || "").split(":");
         if (!subjectKind || !Number(subjectId)) return;
         fundImage.disabled = true;
-        void retryCommunityArt(subjectKind, Number(subjectId));
+        void fillCommunityArtOrbSlot(subjectKind, Number(subjectId));
         return;
       }
       if (event.target.closest("[data-card-close]") || event.target.id === "card-modal") {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -37554,11 +37554,27 @@ mod tests {
         assert!(INDEX_HTML.contains("error.payload = payload && typeof payload === \"object\""));
         assert!(INDEX_HTML.contains("return error.payload"));
         assert!(!INDEX_HTML.contains("!viewerContributed && balance >= 1"));
-        assert!(INDEX_HTML.contains("The saved image job needs repair before it can start."));
-        assert!(INDEX_HTML.contains("retry the saved image review"));
-        assert!(INDEX_HTML.contains("no new image will be bought while review is unavailable"));
-        assert!(INDEX_HTML.contains("no more provider credits will be used"));
-        assert!(INDEX_HTML.contains("art.retryable_without_orbs"));
+        // The community-art panel is an Orb slot, not a job console. Generation,
+        // review, retries and their failures are handled server side and must
+        // never reach the player, who cannot act on any of them.
+        assert!(INDEX_HTML.contains("function fillCommunityArtOrbSlot"));
+        assert!(INDEX_HTML.contains("Orb slot ${funded}/${required}"));
+        assert!(INDEX_HTML.contains("The portrait appears here when it is ready."));
+        assert!(INDEX_HTML.contains("if (path !== \"/actions/fund-image\") setError("));
+        for retired in [
+            "The saved image job needs repair before it can start.",
+            "retry the saved image review",
+            "no new image will be bought while review is unavailable",
+            "no more provider credits will be used",
+            "image workshop starting",
+            "try a different image",
+            "image withheld",
+        ] {
+            assert!(
+                !INDEX_HTML.contains(retired),
+                "the Orb slot must not surface job machinery: {retired}",
+            );
+        }
         assert!(INDEX_HTML.contains("Inspect ${firstSearch.target} for one hidden thing."));
         assert!(INDEX_HTML.contains("into your keeping"));
         assert!(INDEX_HTML.contains("function smallNumberWord"));

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -420,4 +420,8 @@
 # helpers into their existing focused modules.
 # 61539 -> 61165: move avatar-opening validation, publication, and bounded
 # retry handling into chat_action.rs beside the command's durable chat seam.
-61165
+# 61165 -> 61181: sixteen test-only lines pin the Orb slot contract in both
+# directions -- the three slot readings plus the retired job vocabulary that
+# must never return to the panel. The behaviour lives in index.html; main.rs
+# owns the cross-surface INDEX_HTML contract beside it.
+61181

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -7123,10 +7123,11 @@ async function main() {
     });
     assert(
       pathwayContract.subject === "location:990001"
-        && pathwayContract.label === "add one Orb · 0/1"
+        && pathwayContract.label === "add one Orb"
         && pathwayContract.disabled === false
         && pathwayContract.live === "polite"
-        && pathwayContract.copy.includes("1 Orb is still needed from the community"),
+        && pathwayContract.copy.includes("Orb slot 0/1")
+        && pathwayContract.copy.includes("1 Orb fills this slot"),
       `a revealed generated pathway item should expose its Orb image contract: ${JSON.stringify(pathwayContract)}`,
     );
 
@@ -7227,20 +7228,31 @@ async function main() {
     });
     assert(
       communityArtStates.noEarnedOrbs.button === ""
-        && communityArtStates.noEarnedOrbs.copy.includes("2 Orbs are still needed from the community"),
-      `players without an earned Orb should see image funding state without a contribution CTA: ${JSON.stringify(communityArtStates)}`,
+        && communityArtStates.noEarnedOrbs.copy.includes("Orb slot 0/2")
+        && communityArtStates.noEarnedOrbs.copy.includes("2 Orbs fill this slot"),
+      `players without an earned Orb should see the slot without a contribution CTA: ${JSON.stringify(communityArtStates)}`,
     );
     assert(
-      communityArtStates.contributedPending.button === "add one Orb · 1/2"
-        && communityArtStates.contributedPending.copy.toLowerCase().includes("your orb is already helping")
-        && communityArtStates.contributedPending.copy.includes("1 Orb is still needed from the community"),
-      `a player who already contributed should be able to finish funding the community image: ${JSON.stringify(communityArtStates)}`,
+      communityArtStates.contributedPending.button === "add one Orb"
+        && communityArtStates.contributedPending.copy.includes("Orb slot 1/2")
+        && communityArtStates.contributedPending.copy.includes("1 more Orb fills this slot"),
+      `a player who already contributed should be able to finish filling the slot: ${JSON.stringify(communityArtStates)}`,
+    );
+    // The player fills a slot; generation, review, retries and their failures
+    // are the server's problem. A funded slot reads the same whether the job
+    // is mid-flight or has failed behind the scenes, and offers no button,
+    // because there is nothing for the player to do either way.
+    assert(
+      communityArtStates.generating.button === ""
+        && communityArtStates.generating.copy.includes("Orb slot 2/2 · filled"),
+      `a funded slot should read as filled while the server works: ${JSON.stringify(communityArtStates)}`,
     );
     assert(
       communityArtStates.failed.button === ""
-        && communityArtStates.failed.copy.includes("no more provider credits will be used")
-        && !/buy|purchase/i.test(JSON.stringify(communityArtStates)),
-      `a terminal generation failure should be explicit and purchase-free: ${JSON.stringify(communityArtStates)}`,
+        && communityArtStates.failed.copy.includes("Orb slot 2/2 · filled")
+        && !/provider|credit|workshop|review|attempt|retry|error|unavailable|withheld/i
+          .test(JSON.stringify(communityArtStates)),
+      `a failure behind a filled slot must not surface job machinery to the player: ${JSON.stringify(communityArtStates)}`,
     );
     assert(
       Object.values(communityArtStates).every((entry) => entry.formatted),
@@ -7263,18 +7275,15 @@ async function main() {
         role: "location",
         aspect: "wide",
       };
-      const failedArt = {
+      const emptySlot = {
         level: 1,
         required_orbs: 1,
-        funded_orbs: 1,
-        remaining_orbs: 0,
-        viewer_contributed: true,
-        status: "failed",
-        provider_attempts: 1,
-        max_provider_attempts: 3,
-        retryable_without_orbs: true,
+        funded_orbs: 0,
+        remaining_orbs: 1,
+        viewer_contributed: false,
+        status: "available",
       };
-      const mount = (communityArt = failedArt) => {
+      const mount = (communityArt = emptySlot) => {
         const card = { ...baseCard, community_art: { ...communityArt } };
         state = {
           ...previousState,
@@ -7332,10 +7341,11 @@ async function main() {
           const generating = {
             ...baseCard,
             community_art: {
-              ...failedArt,
+              ...emptySlot,
+              funded_orbs: 1,
+              remaining_orbs: 0,
+              viewer_contributed: true,
               status: "generating",
-              provider_attempts: 2,
-              retryable_without_orbs: false,
             },
           };
           state = {
@@ -7413,16 +7423,19 @@ async function main() {
         && communityArtRetryLifecycle.starting.hidden === false
         && communityArtRetryLifecycle.starting.buttons === 0
         && communityArtRetryLifecycle.starting.formatted
-        && communityArtRetryLifecycle.starting.copy.toLowerCase().includes("image workshop starting"),
-      `a rapid repeated retry should coalesce and expose immediate starting state: ${JSON.stringify(communityArtRetryLifecycle)}`,
+        && communityArtRetryLifecycle.starting.copy.toLowerCase().includes("filling"),
+      `a rapid repeated click should coalesce into one fill: ${JSON.stringify(communityArtRetryLifecycle)}`,
     );
     assert(
       communityArtRetryLifecycle.generating.hidden === false
         && communityArtRetryLifecycle.generating.buttons === 0
         && communityArtRetryLifecycle.generating.formatted
-        && communityArtRetryLifecycle.generating.copy.includes("saved job is still in progress"),
-      `authoritative generation state should replace the starting latch without closing the modal: ${JSON.stringify(communityArtRetryLifecycle)}`,
+        && communityArtRetryLifecycle.generating.copy.includes("filled"),
+      `authoritative state should replace the filling latch without closing the modal: ${JSON.stringify(communityArtRetryLifecycle)}`,
     );
+    // A dropped request leaves the Orb unspent, so the only truthful report is
+    // that the slot is still fillable. Anything else asks the player to act on
+    // a workshop they do not operate.
     for (const [failureKind, failure] of [
       ["rejected fetch", communityArtRetryLifecycle.rejectedFetch],
       ["non-JSON response", communityArtRetryLifecycle.nonJsonFailure],
@@ -7430,8 +7443,9 @@ async function main() {
       assert(
         failure.hidden === false
           && failure.buttons === 1
-          && failure.copy.includes("could not be reached"),
-        `${failureKind} should leave visible recovery copy and an enabled retry: ${JSON.stringify(communityArtRetryLifecycle)}`,
+          && failure.copy.includes("Orb slot 0/1")
+          && !/could not be reached|error|unavailable|try again/i.test(failure.copy),
+        `${failureKind} should leave a quiet fillable slot: ${JSON.stringify(communityArtRetryLifecycle)}`,
       );
     }
     assert(
@@ -7491,7 +7505,8 @@ async function main() {
         && brokenArtFallback.missing === "true"
         && brokenArtFallback.placeholder === "community image pending"
         && brokenArtFallback.overlay.includes("community image pending")
-        && brokenArtFallback.panel.toLowerCase().includes("your orb is already helping"),
+        && brokenArtFallback.panel.includes("Orb slot 1/2")
+        && brokenArtFallback.panel.includes("1 more Orb fills this slot"),
       `an unresolvable generated-art URL should render the authored, state-aware placeholder: ${JSON.stringify(brokenArtFallback)}`,
     );
     await page.evaluate(() => {


### PR DESCRIPTION
Funding an image exposed the workshop's internals to the player. Clicking it could produce a red banner, a 45-second timeout that reported itself as an error, and a panel that replaced the contribute button with copy like *"retry the saved image review"*, *"image withheld"*, or *"stopped after 3 image attempts; no more provider credits will be used"*.

None of that is actionable. The player pays an Orb. Generation, review, retries, spend caps and their failures belong to the server — as #890 just demonstrated, where a paused reviewer had one job retrying 975 times with nothing a player could have done about it.

## The panel now has three readings

| State | Reads |
|---|---|
| Partly funded | `Orb slot 1/2 · 1 more Orb fills this slot.` + **add one Orb** |
| Funded | `Orb slot 2/2 · filled. The portrait appears here when it is ready.` |
| Complete | `Level 2 complete · next portrait unlocks at the next level.` |

A funded slot reads the same whether the job is mid-flight or has failed behind the scenes, and carries no button, because there is nothing for the player to do either way.

## Filling is quiet

Two outcomes: the slot shows filled, or it stays fillable. A dropped request leaves the Orb unspent, so a fillable slot is the whole truth and nothing is announced.

- `action()` no longer raises a banner for `/actions/fund-image`.
- The latch is a spinner, not a deadline — a slow server returns the slot to fillable instead of reporting a timeout.
- The retired failure copy is deleted rather than left unreachable.

## The gate pins it both ways

The browser check now asserts the slot readings *and* that no job vocabulary — provider, credit, workshop, review, attempt, retry, error, unavailable, withheld — reaches the panel. The `INDEX_HTML` contract does the same for the retired strings, so this cannot quietly regress.

## Verification

`npm run v2:browser:check` passes locally against this build, including the rewritten lifecycle scenario: a double click still coalesces into one fill, and a rejected fetch and a non-JSON 502 each leave a quiet fillable slot with no error copy. 1,265 orchestrator tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
