### PR TITLE
Double the daily server AI budget

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -167,12 +167,12 @@ The server key pays for autonomous/public text inference, including the resident
 reply after Chat and other card plays. Failure is skipped or remains visible as
 appropriate, but no reservation, debit, or refund touches the Orb ledger.
 
-Server-paid OpenRouter inference has a $10 UTC daily admission limit. Before
+Server-paid OpenRouter inference has a $20 UTC daily admission limit. Before
 each request, the gateway checks the server key's authoritative `usage_daily`
 value through `/api/v1/key`, serializes in-process admissions, and fails closed
-when usage cannot be verified. Once the reported value reaches $10, inference
+when usage cannot be verified. Once the reported value reaches $20, inference
 pauses until the next UTC day. Because OpenRouter reports cost after a request,
-the last admitted request can take the final total slightly over $10.
+the last admitted request can take the final total slightly over $20.
 
 Community image generation is different: the server validates a level-scoped shared funding pool before starting Replicate. One card gets one generation at each level, the pooled Orb price equals that level, and retries after full funding are free.
 
@@ -891,7 +891,7 @@ Current status: browser-owned PKCE connection implemented.
   daily usage, and disconnect removes the local key.
 - Explicit public model interactions may carry the key transiently and record
   `player_openrouter` as payer; autonomous inference remains server-paid.
-- The server-paid OpenRouter lane stops admitting work at $10 reported daily
+- The server-paid OpenRouter lane stops admitting work at $20 reported daily
   usage and fails closed if usage cannot be checked.
 
 ### Stage 3: Community-Funded Card Images

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.103",
+  "version": "1.0.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.103",
+      "version": "1.0.104",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.103",
+  "version": "1.0.104",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.103"
+version = "1.0.104"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.103"
+version = "1.0.104"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -72,7 +72,7 @@ const OPENROUTER_CURRENT_KEY_ENDPOINT: &str = "key";
 const OPENROUTER_KEY_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const OPENROUTER_KEY_RESPONSE_MAX_BYTES: usize = 64 * 1024;
 const OPENROUTER_ROOM_SESSION_PREFIX: &str = "cosyworld-room-";
-const SERVER_PAID_DAILY_LIMIT_USD: f64 = 10.0;
+const SERVER_PAID_DAILY_LIMIT_USD: f64 = 20.0;
 static SERVER_PAID_INFERENCE_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 // The exact-bound STT gateway is intentionally dormant until a server-authored
 // transcription action owns its input provenance and publication contract.
@@ -905,7 +905,7 @@ impl AiGatewayError {
                 terminal: true,
             },
             message: format!(
-                "AI {feature} is paused because the $10 UTC daily server budget is exhausted"
+                "AI {feature} is paused because the ${SERVER_PAID_DAILY_LIMIT_USD:.0} UTC daily server budget is exhausted"
             ),
             attempts: 0,
             latency: Duration::ZERO,
@@ -4453,10 +4453,10 @@ mod tests {
     use tokio::net::TcpListener;
 
     #[test]
-    fn server_budget_closes_at_ten_dollars_and_resets_on_utc_boundary() {
-        assert!(!server_daily_spend_exhausted(9.999_999));
-        assert!(server_daily_spend_exhausted(10.0));
-        assert!(server_daily_spend_exhausted(10.01));
+    fn server_budget_closes_at_twenty_dollars_and_resets_on_utc_boundary() {
+        assert!(!server_daily_spend_exhausted(19.999_999));
+        assert!(server_daily_spend_exhausted(20.0));
+        assert!(server_daily_spend_exhausted(20.01));
         assert_eq!(next_utc_day_unix(0), 86_400);
         assert_eq!(next_utc_day_unix(86_399), 86_400);
         assert_eq!(next_utc_day_unix(86_400), 172_800);


### PR DESCRIPTION
Summary:
- raise the server-paid OpenRouter daily limit from $10 to $20 UTC
- keep the exhausted-budget message and AI policy in sync
- bump the release to 1.0.104

Checks:
- focused Rust boundary test
- Rust formatting
- version check
- diff check