### PR TITLE
Keep safe chat replies publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.105",
+  "version": "1.0.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.105",
+      "version": "1.0.106",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.105",
+  "version": "1.0.106",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/docs/ai-capability-registry.md
+++ b/v2/docs/ai-capability-registry.md
@@ -175,11 +175,15 @@ The router is bounded by:
 Each generation is a durable leased job in the orchestrator SQLite store.
 Every provider request is pinned to one selected candidate with provider-local
 retries disabled. All responses completed inside the configured bounds pass
-through the hard publication gate. Certified responses are ranked
-deterministically by scene-anchor depth, novelty against recent dialogue, and
-lexical diversity; candidate ID is the stable final tie-break. The highest
-ranked response wins one atomic compare-and-set. Duplicate or restarted work
-returns the accepted text and receipt without selecting again; an expired lease
+through the publication gate. Safety, grounding, envelope, completion,
+repetition, speech mode, prose-quality, and action-authority checks remain hard
+failures. The rotating beat-form check remains recorded in the receipt but is a
+ranking preference, so sentence shape alone cannot turn a safe grounded Chat
+into a visible failure. Certified responses are ranked deterministically by
+scene-anchor depth, beat-form fit, novelty against recent dialogue, and lexical
+diversity; candidate ID is the stable final tie-break. The highest ranked
+response wins one atomic compare-and-set. Duplicate or restarted work returns
+the accepted text and receipt without selecting again; an expired lease
 receives at most one named retry. Exhausted bounds return a stable typed
 unavailable code. Rejected candidates persist hashes, evidence, and decision
 metadata, never raw output bytes. The existing publication journal precondition

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.105"
+version = "1.0.106"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.105"
+version = "1.0.106"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -135,6 +135,18 @@ impl PublicationCheckCode {
             Self::VoiceAnomalyOmitted => "voice_anomaly_omitted",
         }
     }
+
+    /// Narrative variety is useful for ranking, but it is not a safety,
+    /// grounding, or action-authority boundary. A safe grounded line must not
+    /// disappear merely because its prose shape differs from the requested
+    /// rotation.
+    pub(crate) fn blocks_publication(self) -> bool {
+        self != Self::VoiceBeatFormMismatch
+    }
+
+    fn is_narrative_preference(self) -> bool {
+        !self.blocks_publication()
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -162,11 +174,13 @@ pub(crate) struct SpeechGateContext {
 /// A deterministic rank for candidates that have already passed every hard
 /// publication check. This is intentionally not another safety gate and does
 /// not ask a second model to judge the first one: it only prefers deeper scene
-/// grounding, then wording that is less similar to recent dialogue, then
-/// lexical variety. The tuple ordering is the selection policy.
+/// grounding, then narrative-shape fit, then wording that is less similar to
+/// recent dialogue, then lexical variety. The tuple ordering is the selection
+/// policy.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct SpeechCandidateScore {
     pub(crate) anchor_matches: u16,
+    pub(crate) narrative_preference_matches: u8,
     pub(crate) novelty_bps: u16,
     pub(crate) lexical_diversity_bps: u16,
 }
@@ -204,8 +218,13 @@ pub(crate) fn score_speech_candidate(
     } else {
         ((candidate_words.len() * 10_000) / words.len()).min(10_000) as u16
     };
+    let narrative_preference_matches = evaluate_checks(value, value, "stop", context)
+        .into_iter()
+        .filter(|check| check.code.is_narrative_preference() && check.passed)
+        .count() as u8;
     SpeechCandidateScore {
         anchor_matches,
+        narrative_preference_matches,
         novelty_bps: 10_000u16.saturating_sub(max_recent_similarity_bps),
         lexical_diversity_bps,
     }
@@ -390,7 +409,7 @@ pub(crate) fn certify_speech(
     if let Some(failure_code) = receipt
         .checks
         .iter()
-        .find_map(|check| (!check.passed).then_some(check.code))
+        .find_map(|check| (!check.passed && check.code.blocks_publication()).then_some(check.code))
     {
         return Err(Box::new(PublicationRejection {
             receipt,
@@ -2001,7 +2020,7 @@ mod tests {
     }
 
     #[test]
-    fn beat_forms_rotate_and_are_enforced_by_the_gate() {
+    fn beat_forms_rotate_and_are_recorded_without_blocking_safe_speech() {
         assert_eq!(BeatForm::for_beat(0), BeatForm::PureDialogue);
         assert_eq!(BeatForm::for_beat(1), BeatForm::SingleSentence);
         assert_eq!(BeatForm::for_beat(2), BeatForm::UnresolvedQuestion);
@@ -2020,6 +2039,16 @@ mod tests {
             &gate,
             PublicationCheckCode::VoiceBeatFormMismatch,
         ));
+        let speech = certify_speech(
+            None,
+            completion("The teapot clicks. Rain follows."),
+            "The teapot clicks. Rain follows.",
+            gate.clone(),
+        )
+        .expect("a narrative-shape preference must not discard safe grounded speech");
+        assert!(speech.receipt().checks.iter().any(|check| {
+            check.code == PublicationCheckCode::VoiceBeatFormMismatch && !check.passed
+        }));
 
         gate.requirements.required_form = Some(BeatForm::UnresolvedQuestion);
         assert!(check_passed(
@@ -2033,6 +2062,26 @@ mod tests {
             &gate,
             PublicationCheckCode::VoiceBeatFormMismatch,
         ));
+    }
+
+    #[test]
+    fn narrative_shape_preferences_rank_but_never_become_hard_failures() {
+        let mut gate = context(&["teapot".to_string()], &[]);
+        gate.requirements.required_form = Some(BeatForm::SingleSentence);
+
+        let preferred = score_speech_candidate("The teapot clicks once.", &gate);
+        let safe_alternative = score_speech_candidate("The teapot clicks. Rain follows.", &gate);
+        assert!(
+            preferred.narrative_preference_matches > safe_alternative.narrative_preference_matches
+        );
+        assert!(preferred > safe_alternative);
+
+        assert!(!PublicationCheckCode::VoiceBeatFormMismatch.blocks_publication());
+        assert!(PublicationCheckCode::VoiceQuestionMonoculture.blocks_publication());
+        assert!(PublicationCheckCode::VoiceTerminalAphorism.blocks_publication());
+        assert!(PublicationCheckCode::VoiceUnsafeTone.blocks_publication());
+        assert!(PublicationCheckCode::VoiceAnchorMissing.blocks_publication());
+        assert!(PublicationCheckCode::VoiceUnbackedActionIntent.blocks_publication());
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -517,6 +517,7 @@ async fn route_certified_voice_with(
                                 generation_id = %generation_id,
                                 candidate_round = candidate.decision.ordinal,
                                 anchor_matches = score.anchor_matches,
+                                narrative_preference_matches = score.narrative_preference_matches,
                                 novelty_bps = score.novelty_bps,
                                 lexical_diversity_bps = score.lexical_diversity_bps,
                                 "AI voice candidate passed the gate and entered ranking"
@@ -575,6 +576,7 @@ async fn route_certified_voice_with(
             candidate_round = winner.candidate.decision.ordinal,
             certified_pool_size,
             anchor_matches = winner.score.anchor_matches,
+            narrative_preference_matches = winner.score.narrative_preference_matches,
             novelty_bps = winner.score.novelty_bps,
             lexical_diversity_bps = winner.score.lexical_diversity_bps,
             "selected the highest-ranked certified AI voice candidate"


### PR DESCRIPTION
## Summary
- keep beat-form mismatches recorded but treat them as a ranking preference
- preserve hard safety, grounding, completion, repetition, prose-quality, and action-authority checks
- include beat-form fit in deterministic ranking and telemetry

## Validation
- `cargo test ai_publication::tests::` (64 passed)
- `cargo test ai_voice_routing::tests::` (29 passed)
- `npm run v2:rust:test` (1,306 passed)
- full pre-push `npm run check`
- `npm run check:version`
- `git diff --check`

## Deployment notes
Version 1.0.106. Merge to main deploys the primary Fly app. No state or schema migration is required. Existing receipts remain compatible; the beat-form check stays recorded.

## Review checklist
- [x] Safe grounded beat mismatches publish
- [x] Hard safety and authority gates remain blocking
- [x] Version and lock entries were updated by the version bump script
