### PR TITLE
Retry transient Lonely Forest deploy checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.106",
+  "version": "1.0.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.106",
+      "version": "1.0.107",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.106",
+  "version": "1.0.107",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.106"
+version = "1.0.107"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.106"
+version = "1.0.107"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/check-lonelyforest-worldpacks.mjs
+++ b/v2/scripts/check-lonelyforest-worldpacks.mjs
@@ -36,6 +36,8 @@ import {
 
 const scriptPath = fileURLToPath(import.meta.url);
 const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_LIVE_FETCH_ATTEMPTS = 3;
+const DEFAULT_LIVE_FETCH_RETRY_DELAY_MS = 1_000;
 const CAPTURE_SOURCES = new Set(["tenant-volume", "operator-capture"]);
 
 export class LonelyForestGateError extends Error {}
@@ -112,6 +114,31 @@ function registryForTenant(tenant, root) {
   }
 }
 
+async function fetchLiveWorldpackHashWithRetries({
+  baseUrl,
+  timeoutMs,
+  fetchImpl,
+  attempts,
+  retryDelayMs,
+  tenant,
+  log,
+}) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fetchLiveWorldpackHash({ baseUrl, timeoutMs, fetchImpl });
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) break;
+      log(`::warning::tenant=${tenant.slug} live /meta read attempt ${attempt}/${attempts} failed (${error.message}); retrying in ${retryDelayMs}ms`);
+      if (retryDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+  }
+  throw lastError;
+}
+
 export async function verifyLonelyForestTenants({
   tenants = readLonelyForestTenants(),
   root = repoRoot,
@@ -120,6 +147,8 @@ export async function verifyLonelyForestTenants({
   freshEmptyTenants = new Set(),
   fetchImpl = fetch,
   log = console.log,
+  liveFetchAttempts = DEFAULT_LIVE_FETCH_ATTEMPTS,
+  liveFetchRetryDelayMs = DEFAULT_LIVE_FETCH_RETRY_DELAY_MS,
 }) {
   const results = [];
   const usedRecoveryCaptures = new Set();
@@ -139,7 +168,15 @@ export async function verifyLonelyForestTenants({
     let liveHash;
     let identitySource = "live /meta";
     try {
-      liveHash = await fetchLiveWorldpackHash({ baseUrl, timeoutMs, fetchImpl });
+      liveHash = await fetchLiveWorldpackHashWithRetries({
+        baseUrl,
+        timeoutMs,
+        fetchImpl,
+        attempts: liveFetchAttempts,
+        retryDelayMs: liveFetchRetryDelayMs,
+        tenant,
+        log,
+      });
     } catch (error) {
       if (freshEmptyTenants.has(tenant.slug)) {
         usedFreshEmptyTenants.add(tenant.slug);

--- a/v2/scripts/lonelyforest-multitenant-contract.test.mjs
+++ b/v2/scripts/lonelyforest-multitenant-contract.test.mjs
@@ -310,6 +310,28 @@ test("Lonely Forest deploy gate proves every configured tenant before image repl
   assert.ok(results.every((result) => result.ok));
 });
 
+test("Lonely Forest deploy gate retries a transient live meta read and still checks the hash", async () => {
+  const hashes = await candidateHashes();
+  const rootTenant = tenants.find((tenant) => tenant.slug === "root");
+  let attempts = 0;
+  const logs = [];
+  const results = await verifyLonelyForestTenants({
+    tenants: [rootTenant],
+    fetchImpl: async (url) => {
+      attempts += 1;
+      if (attempts < 3) throw new Error("temporary network failure");
+      const host = new URL(url).host;
+      return new Response(JSON.stringify({ worldpack: { bundle_hash: hashes.get(host) } }), { status: 200 });
+    },
+    liveFetchRetryDelayMs: 0,
+    log: (message) => logs.push(message),
+  });
+
+  assert.equal(attempts, 3);
+  assert.equal(results[0].status, "exact");
+  assert.equal(logs.filter((message) => message.includes("retrying in 0ms")).length, 2);
+});
+
 test("a new tenant can bootstrap only while its live identity is absent", async () => {
   const hashes = await candidateHashes();
   const unavailableHoppycat = async (url) => {
@@ -320,6 +342,7 @@ test("a new tenant can bootstrap only while its live identity is absent", async 
   const results = await verifyLonelyForestTenants({
     fetchImpl: unavailableHoppycat,
     freshEmptyTenants: new Set(["hoppycat"]),
+    liveFetchRetryDelayMs: 0,
     log: () => {},
   });
   assert.equal(results.find((result) => result.tenant.slug === "hoppycat")?.status, "fresh_install");
@@ -364,7 +387,11 @@ test("an unavailable tenant needs an explicit audited captured identity, never a
     return new Response(JSON.stringify({ worldpack: { bundle_hash: hashes.get(host) } }), { status: 200 });
   };
   await assert.rejects(
-    verifyLonelyForestTenants({ fetchImpl: unavailableLantern, log: () => {} }),
+    verifyLonelyForestTenants({
+      fetchImpl: unavailableLantern,
+      liveFetchRetryDelayMs: 0,
+      log: () => {},
+    }),
     /tenant=lantern.*Refusing to replace the image/,
   );
 
@@ -382,6 +409,7 @@ test("an unavailable tenant needs an explicit audited captured identity, never a
     const results = await verifyLonelyForestTenants({
       fetchImpl: unavailableLantern,
       recoveryCaptures: captures,
+      liveFetchRetryDelayMs: 0,
       log: () => {},
     });
     assert.equal(results.find((result) => result.tenant.slug === "lantern")?.identitySource.includes("recovery capture"), true);


### PR DESCRIPTION
## Summary

- retry each live Lonely Forest `/meta` read up to three times before using the existing fail-closed recovery path
- preserve exact world-data compatibility checks and the explicit recovery and fresh-install rules
- add regression coverage for two transient failures followed by a valid exact hash

## Validation

- `npm run v2:lonelyforest:contract` (16 passed)
- `npm run check:version`
- `node --check v2/scripts/check-lonelyforest-worldpacks.mjs`
- `git diff --check`
- full pre-push `npm run check`

## Deployment notes

Version 1.0.107. No schema or state migration. After merge, explicitly deploy Lonely Forest from `main`; ordinary pushes still deploy only the primary app.
