### PR TITLE
Capture Lonely Forest root worldpack identity

### DIFF
--- a/docs/deployment/recovery/lonelyforest-root-2026-08-23.json
+++ b/docs/deployment/recovery/lonelyforest-root-2026-08-23.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "tenant": "root",
+  "source": "operator-capture",
+  "captured_at": "2026-08-23T04:27:50Z",
+  "meta": {
+    "worldpack": {
+      "bundle_hash": "sha256:0118f492a0d2253e68023f8471ce54269649959d8b985961a3d990f78fb6b447"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.107",
+  "version": "1.0.108",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.107",
+      "version": "1.0.108",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.107",
+  "version": "1.0.108",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.107"
+version = "1.0.108"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.107"
+version = "1.0.108"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- record the observed Lonely Forest root worldpack identity in the documented audited recovery format
- identify the source as an operator capture with its UTC observation time
- bump the release to version 1.0.108

## Incident evidence

- `lonelyforest.com` publishes only an IPv6 address, which the GitHub runner cannot reach
- every tenant subdomain publishes IPv4 and IPv6 and remains available
- the live root tenant reports `sha256:0118f492a0d2253e68023f8471ce54269649959d8b985961a3d990f78fb6b447`, exactly matching the candidate bundle
- failed release 32616662300 stopped before backup or deployment

## Validation

- live root metadata matched the capture after creation
- `npm run v2:lonelyforest:contract` (16 passed)
- `npm run check:version`
- `git diff --check`
- full pre-push `npm run check`

## Deployment notes

After merge, explicitly deploy Lonely Forest from `main` with `root=docs/deployment/recovery/lonelyforest-root-2026-08-23.json`. The guard still reads and checks every other tenant live.
