### PR TITLE
Route Lonely Forest deployment smoke through Fly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -312,7 +312,7 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_LONELYFOREST_API_TOKEN }}
 
       - name: Verify Lonely Forest readiness and persistence
-        run: npm run v2:lonelyforest:smoke -- --base-url=https://lonelyforest.com --expect-elysium --allow-remote-mutations
+        run: npm run v2:lonelyforest:smoke -- --base-url=https://cosyworld-lonelyforest.fly.dev --shared-transport --expect-elysium --allow-remote-mutations
 
   github-release:
     name: Create GitHub release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.108",
+  "version": "1.0.109",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.108",
+      "version": "1.0.109",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.108",
+  "version": "1.0.109",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.108"
+version = "1.0.109"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.108"
+version = "1.0.109"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-lonelyforest-multitenant.mjs
+++ b/v2/scripts/smoke-lonelyforest-multitenant.mjs
@@ -10,6 +10,7 @@ const baseUrl = new URL(
     ?? "http://127.0.0.1:3000",
 );
 const expectElysium = args.includes("--expect-elysium");
+const useSharedTransport = args.includes("--shared-transport");
 const loopbackHosts = new Set(["127.0.0.1", "localhost", "::1"]);
 const scriptPath = fileURLToPath(import.meta.url);
 
@@ -44,11 +45,14 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-export function requestTarget(base, host, { routerProbe = false } = {}) {
-  // Local router tests deliberately exercise nginx's Host dispatch through one
-  // loopback listener. A remote smoke must instead connect to the hostname it
-  // advertises, so DNS and TLS SNI agree with Host.
-  const connectToBase = loopbackHosts.has(base.hostname) || routerProbe;
+export function requestTarget(base, host, {
+  routerProbe = false,
+  sharedTransport = false,
+} = {}) {
+  // Local tests and the explicit deployment transport exercise nginx's Host
+  // dispatch through one listener. Other remote smokes still connect to each
+  // advertised hostname so DNS, TLS SNI, and Host agree.
+  const connectToBase = loopbackHosts.has(base.hostname) || routerProbe || sharedTransport;
   const hostname = connectToBase ? base.hostname : host;
   return {
     hostname,
@@ -65,10 +69,15 @@ export function requestContext({ method, host, path, target }) {
   return `${method} host=${host} path=${path} connect=${authority}`;
 }
 
-export function request(host, path, { method = "GET", body, routerProbe = false } = {}, base = baseUrl) {
+export function request(host, path, {
+  method = "GET",
+  body,
+  routerProbe = false,
+  sharedTransport = false,
+} = {}, base = baseUrl) {
   const payload = body === undefined ? null : JSON.stringify(body);
   const transport = base.protocol === "https:" ? https : http;
-  const target = requestTarget(base, host, { routerProbe });
+  const target = requestTarget(base, host, { routerProbe, sharedTransport });
   const context = requestContext({ method, host, path, target });
   return new Promise((resolveRequest, rejectRequest) => {
     const req = transport.request(
@@ -122,7 +131,7 @@ async function ready(host, expectedStatus = 200) {
   let last;
   while (Date.now() < deadline) {
     try {
-      last = await request(host, "/meta");
+      last = await request(host, "/meta", { sharedTransport: useSharedTransport });
       if (last.status === expectedStatus) return last;
     } catch (error) {
       last = { text: error.message };

--- a/v2/scripts/smoke-lonelyforest-multitenant.test.mjs
+++ b/v2/scripts/smoke-lonelyforest-multitenant.test.mjs
@@ -19,6 +19,20 @@ test("remote Lonely Forest tenant smokes connect and negotiate TLS with the tena
   );
 });
 
+test("an explicit shared transport keeps the tenant Host while using Fly DNS and TLS", () => {
+  const target = requestTarget(
+    new URL("https://cosyworld-lonelyforest.fly.dev"),
+    "0.lonelyforest.com",
+    { sharedTransport: true },
+  );
+  assert.deepEqual(target, {
+    hostname: "cosyworld-lonelyforest.fly.dev",
+    port: undefined,
+    hostHeader: "0.lonelyforest.com",
+    servername: "cosyworld-lonelyforest.fly.dev",
+  });
+});
+
 test("loopback Lonely Forest router smokes retain one transport target and vary Host", () => {
   const target = requestTarget(new URL("http://127.0.0.1:3000"), "lantern.lonelyforest.com");
   assert.deepEqual(target, {


### PR DESCRIPTION
## Summary

- add an explicit shared transport mode for Lonely Forest multitenant smoke tests
- keep each real tenant hostname in the Host header while connecting through Fly's dual-stack app hostname
- use the shared transport only for the post-deploy readiness check and keep normal tenant DNS/TLS checks unchanged
- add regression coverage for the transport target and Host header contract

## Incident evidence

Lonely Forest 1.0.108 deployed successfully and every tenant passed an independent live health check. The workflow's final readiness step failed only because `lonelyforest.com` publishes an IPv6-only root record and GitHub's runner had no IPv6 route. The same smoke test passes against the live app when it connects through `cosyworld-lonelyforest.fly.dev` and sends the tenant hostname as the Host header.

## Validation

- 17 Lonely Forest contract tests
- exact live shared-transport multitenant smoke command
- deployment impact tests
- full pre-push check suite
- version and syntax checks

## Deployment notes

- version: 1.0.109
- no data migration
- post-deploy smoke transport only; runtime request routing is unchanged
