### PR TITLE
Keep voice variety from blocking chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.109",
+  "version": "1.0.110",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.109",
+      "version": "1.0.110",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.109",
+  "version": "1.0.110",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.109"
+version = "1.0.110"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.109"
+version = "1.0.110"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -174,13 +174,14 @@ pub(crate) struct SpeechGateContext {
 /// A deterministic rank for candidates that have already passed every hard
 /// publication check. This is intentionally not another safety gate and does
 /// not ask a second model to judge the first one: it only prefers deeper scene
-/// grounding, then narrative-shape fit, then wording that is less similar to
-/// recent dialogue, then lexical variety. The tuple ordering is the selection
-/// policy.
+/// grounding, then narrative-shape fit, then voice variety, then wording that
+/// is less similar to recent dialogue, then lexical variety. The tuple ordering
+/// is the selection policy.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct SpeechCandidateScore {
     pub(crate) anchor_matches: u16,
     pub(crate) narrative_preference_matches: u8,
+    pub(crate) voice_variety_bps: u16,
     pub(crate) novelty_bps: u16,
     pub(crate) lexical_diversity_bps: u16,
 }
@@ -222,9 +223,18 @@ pub(crate) fn score_speech_candidate(
         .into_iter()
         .filter(|check| check.code.is_narrative_preference() && check.passed)
         .count() as u8;
+    let voice_variety_bps =
+        if reuses_overused_voice_term(value, &context.recent_speaker_shingle_hashes)
+            || reuses_recent_closing(value, &context.recent_speaker_shingle_hashes)
+        {
+            0
+        } else {
+            10_000
+        };
     SpeechCandidateScore {
         anchor_matches,
         narrative_preference_matches,
+        voice_variety_bps,
         novelty_bps: 10_000u16.saturating_sub(max_recent_similarity_bps),
         lexical_diversity_bps,
     }
@@ -755,9 +765,7 @@ fn evaluate_checks(
         (
             PublicationCheckCode::VoiceRecentDuplicate,
             !repeats_recent_dialogue(text, context)
-                && !shares_recent_speaker_phrase(text, &context.recent_speaker_shingle_hashes)
-                && !reuses_overused_voice_term(text, &context.recent_speaker_shingle_hashes)
-                && !reuses_recent_closing(text, &context.recent_speaker_shingle_hashes),
+                && !shares_recent_speaker_phrase(text, &context.recent_speaker_shingle_hashes),
         ),
         (
             PublicationCheckCode::VoiceUnsafeTone,
@@ -2085,19 +2093,38 @@ mod tests {
     }
 
     #[test]
-    fn repeated_terms_and_closing_clauses_stay_out_of_retry_prompts() {
+    fn repeated_terms_and_closing_clauses_rank_lower_without_blocking_speech() {
         let mut gate = context(&["marker".to_string(), "gate".to_string()], &[]);
         gate.recent_speaker_shingle_hashes = vec![
             voice_overused_term_hash("marker"),
             voice_closing_hash("I left it beside the old gate.").expect("closing hash"),
         ];
+        let repeated_term = certify_speech(
+            None,
+            completion("The marker is cold."),
+            "The marker is cold.",
+            gate.clone(),
+        )
+        .expect("a required scene anchor cannot make every candidate impossible");
+        let repeated_closing = certify_speech(
+            None,
+            completion("Tea waits beside the old gate."),
+            "Tea waits beside the old gate.",
+            gate.clone(),
+        )
+        .expect("a familiar closing is a style preference, not a publication boundary");
+
         assert_eq!(
-            rejected_code("The marker is cold.", gate.clone()),
-            PublicationCheckCode::VoiceRecentDuplicate,
+            score_speech_candidate(repeated_term.text(), &gate).voice_variety_bps,
+            0
         );
         assert_eq!(
-            rejected_code("Tea waits beside the old gate.", gate),
-            PublicationCheckCode::VoiceRecentDuplicate,
+            score_speech_candidate(repeated_closing.text(), &gate).voice_variety_bps,
+            0
+        );
+        assert_eq!(
+            score_speech_candidate("The gate feels cold.", &gate).voice_variety_bps,
+            10_000
         );
     }
 

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -518,6 +518,7 @@ async fn route_certified_voice_with(
                                 candidate_round = candidate.decision.ordinal,
                                 anchor_matches = score.anchor_matches,
                                 narrative_preference_matches = score.narrative_preference_matches,
+                                voice_variety_bps = score.voice_variety_bps,
                                 novelty_bps = score.novelty_bps,
                                 lexical_diversity_bps = score.lexical_diversity_bps,
                                 "AI voice candidate passed the gate and entered ranking"
@@ -577,6 +578,7 @@ async fn route_certified_voice_with(
             certified_pool_size,
             anchor_matches = winner.score.anchor_matches,
             narrative_preference_matches = winner.score.narrative_preference_matches,
+            voice_variety_bps = winner.score.voice_variety_bps,
             novelty_bps = winner.score.novelty_bps,
             lexical_diversity_bps = winner.score.lexical_diversity_bps,
             "selected the highest-ranked certified AI voice candidate"


### PR DESCRIPTION
## Summary

- keep verbatim echoes and repeated multi-word signature phrases as hard publication failures
- move single overused scene terms and familiar four-word endings into deterministic candidate ranking
- allow required scene anchors to remain publishable even after a resident has used that noun several times
- expose the voice-variety score in routing telemetry and add regression coverage

## Incident evidence

Tenant 0's durable Void 012 records show the chat entered retrying state at source event 28472. OpenRouter returned dialogue candidates, but multiple rounds were rejected as `voice_recent_duplicate`; a later attempt also recorded `inference_timeout`, and the bounded route ended as `candidates_exhausted`. The provider was available and tenant health stayed ready. The publication check combined true phrase duplication with two style-only signals: one content term seen in three recent lines, or the same four-word ending. A required room/model anchor could therefore make every otherwise valid answer impossible.

## Validation

- 64 AI publication tests
- 29 voice-routing tests
- full project check suite, including 1,272 Rust tests
- worldpack, kernel, architecture, lint, syntax, and version checks
- full pre-push gate

## Deployment notes

- version: 1.0.110
- no data migration
- publication safety and authority checks are unchanged
- exact echoes and repeated signature phrases remain blocked
