### PR TITLE
Keep the Story Hand visible through turns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.110",
+      "version": "1.0.111",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.110"
+version = "1.0.111"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.110"
+version = "1.0.111"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5747,7 +5747,8 @@
     }
     @media (prefers-reduced-motion: reduce) {
       .hand-toggle-chevron,
-      .prompt.hand-expanded .cmd {
+      .prompt.hand-expanded .cmd,
+      .story-card-actions .story-card-play.turn-progress::before {
         transition: none;
       }
     }
@@ -6045,7 +6046,18 @@
     }
     .turn-banner {
       grid-column: 1;
+      justify-content: flex-end;
       margin: 6px 8px 0;
+    }
+    /* Turn status remains available to assistive technology, but initiative
+       should not become a fourth card above the Story Hand. */
+    .turn-status {
+      position: absolute !important;
+      width: 1px !important;
+      height: 1px !important;
+      overflow: hidden !important;
+      clip-path: inset(50%) !important;
+      white-space: nowrap !important;
     }
     .hand-header {
       width: 100%;
@@ -6177,15 +6189,39 @@
     }
     .story-card-actions button + button { border-left: 1px solid rgba(var(--slot-accent-rgb), 0.28); }
     .story-card-actions .story-card-play {
+      position: relative;
+      isolation: isolate;
+      overflow: hidden;
       background: rgba(var(--slot-accent-rgb), 0.12);
       color: var(--slot-accent);
+    }
+    .story-card-actions .story-card-play.turn-progress {
+      --turn-progress: 8%;
+      background: rgba(var(--slot-accent-rgb), 0.06);
+      color: var(--text);
+      opacity: 1;
+    }
+    .story-card-actions .story-card-play.turn-progress::before {
+      content: "";
+      position: absolute;
+      inset: 0 auto 0 0;
+      z-index: -1;
+      width: var(--turn-progress);
+      background: rgba(var(--slot-accent-rgb), 0.28);
+      border-right: 1px solid rgba(var(--slot-accent-rgb), 0.62);
+      transition: width 240ms ease;
+    }
+    .story-card-play .turn-progress-copy {
+      position: relative;
+      z-index: 1;
     }
     .story-card-actions button:hover,
     .story-card-actions button:focus-visible {
       background: rgba(var(--slot-accent-rgb), 0.2);
       color: var(--text);
     }
-    .story-card-actions button:disabled { opacity: 0.5; cursor: default; }
+    .story-card-actions button:disabled:not(.turn-progress) { opacity: 0.5; }
+    .story-card-actions button:disabled { cursor: default; }
     .prompt .cmd {
       width: 100%;
       min-width: 0;
@@ -6797,8 +6833,8 @@
     </main>
     <div class="status" id="error" role="status" aria-live="polite" aria-atomic="true"></div>
     <footer class="prompt" aria-label="Story Hand">
+      <div class="turn-ping-pill turn-status" id="turn-ping-pill" role="status" aria-live="polite" aria-atomic="true"></div>
       <div class="turn-banner" id="turn-banner" hidden>
-        <div class="turn-ping-pill" id="turn-ping-pill" role="status" aria-live="polite" aria-atomic="true"></div>
         <div class="turn-banner-controls" id="turn-banner-controls"></div>
       </div>
       <div class="hand-header">
@@ -6979,6 +7015,7 @@
     let handPassSubmission = null;
     let storyHandExpanded = false;
     let storyHandActiveKey = "";
+    let heldStoryHand = null;
     let storyHandScrollPending = false;
     let storyHandScrollFrame = null;
     let recoveryPromptPending = false;
@@ -10173,7 +10210,7 @@
 
     function renderTurnBannerControls() {
       const host = $("turn-banner-controls");
-      if (!host) return;
+      if (!host) return 0;
       const specs = turnBannerControlSpecs();
       turnBannerControlRuns = new Map(specs.map((spec) => [spec.key, spec.run]));
       const html = specs
@@ -10182,6 +10219,7 @@
         ))
         .join("");
       if (host.innerHTML !== html) host.innerHTML = html;
+      return specs.length;
     }
 
     function renderTurnPingPill() {
@@ -10189,8 +10227,8 @@
       if (!pill) return;
       const html = turnPingPillHtml();
       const banner = $("turn-banner");
-      if (banner) banner.hidden = !html;
-      renderTurnBannerControls();
+      const controlCount = renderTurnBannerControls();
+      if (banner) banner.hidden = controlCount === 0;
       pill.classList.toggle("urgent", Boolean(state?.turn?.enabled && state?.turn?.is_current_actor));
       const handoffKey = html ? String(state?.turn?.handoff_key || "") : "";
       if (!html) {
@@ -17590,7 +17628,6 @@
       return Boolean(
         !state?.branch
         && state?.primary_action?.kind !== "create_avatar"
-        && !actionBusy
       );
     }
 
@@ -17599,10 +17636,67 @@
     }
 
     function originalStoryHandAction(action) {
+      if (action?.heldStoryHandAction) return action;
       const index = Number(action?.actionIndex);
       return Number.isInteger(index) && index >= 0 && index < actions.length
         ? actions[index]
         : action;
+    }
+
+    function turnActivation(turn = state?.turn) {
+      const match = String(turn?.handoff_key || "").match(/(?:^|:)activation:(\d+)(?:$|:)/);
+      return match ? Number(match[1]) : 0;
+    }
+
+    function holdStoryHandForAction(action) {
+      if (!usesInlineStoryHand() || (state?.turn?.enabled && !state.turn.is_current_actor)) return;
+      const actionIndex = actions.indexOf(action);
+      const visibleActions = actionBarActions().slice(0, handCapacity());
+      const played = visibleActions.find((candidate) => candidate.actionIndex === actionIndex);
+      if (!played) return;
+      const participants = new Set([
+        Number(actorId || 0),
+        ...((state?.turn?.waiting_actor_ids || []).map((id) => Number(id || 0))),
+      ].filter(Boolean));
+      heldStoryHand = {
+        actions: visibleActions.map((candidate) => ({
+          ...candidate,
+          heldStoryHandAction: true,
+        })),
+        playedKey: storyHandKey(played),
+        startActivation: turnActivation(),
+        participantCount: Math.max(1, participants.size),
+      };
+      storyHandExpanded = true;
+      storyHandActiveKey = storyHandKey(played);
+    }
+
+    function activeHeldStoryHandActions() {
+      if (!heldStoryHand) return null;
+      if (actionBusy || (state?.turn?.enabled && !state.turn.is_current_actor)) {
+        return heldStoryHand.actions;
+      }
+      heldStoryHand = null;
+      return null;
+    }
+
+    function heldStoryHandProgress() {
+      if (!heldStoryHand) return null;
+      const total = Math.max(1, Number(heldStoryHand.participantCount || 1));
+      const activation = turnActivation();
+      const advanced = Math.max(
+        actionBusy ? 0 : 1,
+        activation && heldStoryHand.startActivation
+          ? activation - heldStoryHand.startActivation
+          : 0,
+      );
+      const percent = Math.max(8, Math.min(92, Math.round((advanced / total) * 100)));
+      return {
+        percent,
+        value: Math.min(total, Math.max(0, advanced)),
+        max: total,
+        label: total > 1 ? "other turns…" : (actionSlow ? "still playing…" : "playing…"),
+      };
     }
 
     function storyHandRowsHtml(action) {
@@ -17654,8 +17748,8 @@
     function renderStoryHandChrome(visibleActions) {
       const prompt = document.querySelector(".prompt");
       const inline = usesInlineStoryHand();
-      const expanded = inline && storyHandExpanded && !actionBusy && visibleActions.length > 0;
-      if (!expanded && storyHandExpanded && (!inline || !visibleActions.length || actionBusy)) {
+      const expanded = inline && storyHandExpanded && visibleActions.length > 0;
+      if (!expanded && storyHandExpanded && (!inline || !visibleActions.length)) {
         storyHandExpanded = false;
         storyHandActiveKey = "";
       }
@@ -17672,9 +17766,22 @@
         if (!action) return;
         const original = originalStoryHandAction(action);
         const title = actionTitle(original);
-        play.disabled = !inline || Boolean(original.busy);
-        play.setAttribute("aria-label", `Play ${title}`);
-        discard.disabled = !inline || !canDiscardHandCard(original) || handShuffleBusy;
+        const held = Boolean(action.heldStoryHandAction);
+        const progress = held && storyHandKey(action) === heldStoryHand?.playedKey
+          ? heldStoryHandProgress()
+          : null;
+        play.disabled = !inline || Boolean(original.busy) || held || actionBusy;
+        play.classList.toggle("turn-progress", Boolean(progress));
+        if (progress) {
+          play.style.setProperty("--turn-progress", `${progress.percent}%`);
+          play.innerHTML = `<span class="turn-progress-copy" role="progressbar" aria-valuemin="0" aria-valuemax="${progress.max}" aria-valuenow="${progress.value}" aria-valuetext="${escapeAttr(progress.label)}">${escapeHtml(progress.label)}</span>`;
+          play.setAttribute("aria-label", `${progress.label} after playing ${title}`);
+        } else {
+          play.style.removeProperty("--turn-progress");
+          play.textContent = "Play";
+          play.setAttribute("aria-label", `Play ${title}`);
+        }
+        discard.disabled = !inline || held || actionBusy || !canDiscardHandCard(original) || handShuffleBusy;
         discard.setAttribute("aria-label", `Discard ${title}`);
         discard.title = discard.disabled
           ? "No replacement is available for this card right now."
@@ -17689,7 +17796,7 @@
       if (!usesInlineStoryHand()) return false;
       storyHandExpanded = Boolean(expanded);
       if (storyHandExpanded) {
-        const visibleActions = actionBarActions();
+        const visibleActions = activeHeldStoryHandActions() || actionBarActions();
         const actionIndex = actions.indexOf(action);
         const selected = visibleActions.find((candidate) => candidate.actionIndex === actionIndex)
           || visibleActions.find((candidate) => storyHandKey(candidate) === storyHandActiveKey)
@@ -18409,7 +18516,7 @@
           busyDetail: presentation.pending[pending.stage] || presentation.pending.queued,
         };
       }
-      button.disabled = Boolean(action.busy);
+      button.disabled = Boolean(action.busy || action.heldStoryHandAction);
       if (action.busy) button.setAttribute("aria-busy", "true");
       else button.removeAttribute("aria-busy");
       if (action.command) button.dataset.command = action.command;
@@ -18501,6 +18608,7 @@
           storyGuideLabel,
           count ? `suggestion ${count}` : "",
           action.busy ? "in progress" : "",
+          action.heldStoryHandAction ? "waiting for other turns" : "",
         ].filter(Boolean).join(", ")
       );
       // A journey travel card keeps the endpoint's Location art — the card is
@@ -18658,7 +18766,26 @@
       const buttonIds = ["primary", "secondary", "tertiary"];
       renderTurnPingPill();
       prompt.classList.toggle("onboarding-mode", state?.primary_action?.kind === "create_avatar");
-      prompt.classList.toggle("single-action", actionBusy);
+      const heldActions = activeHeldStoryHandActions();
+      prompt.classList.toggle("single-action", actionBusy && !heldActions);
+      if (heldActions) {
+        prompt.classList.remove("choice-mode");
+        prompt.classList.toggle("combat-mode", Boolean(state?.combat));
+        for (let index = 0; index < buttonIds.length; index += 1) {
+          const id = buttonIds[index];
+          const visibleAction = heldActions[index]
+            ? {
+                ...heldActions[index],
+                suggestionIndex: index,
+                suggestionCount: heldActions.length,
+              }
+            : null;
+          renderButton(id, visibleAction);
+          $(id).style.display = visibleAction ? "flex" : "none";
+        }
+        renderStoryHandChrome(heldActions);
+        return;
+      }
       if (actionBusy) {
         prompt.classList.remove("choice-mode");
         const busyDetail = typeof pendingAction?.busyDetail === "function"
@@ -18721,6 +18848,7 @@
         render();
         return;
       }
+      holdStoryHandForAction(action);
       actionBusy = true;
       actionSlow = false;
       pendingAction = action;

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -855,6 +855,146 @@ async function main() {
     });
   }
 
+  async function assertPlayedHandStaysVisibleDuringOtherTurns() {
+    const result = await page.evaluate(() => {
+      const previous = {
+        state,
+        actions,
+        actorId,
+        actorSession,
+        handKeys: [...handKeys],
+        discardedHandKeys: [...discardedHandKeys],
+        authoritativeHandIdentity,
+        focusIndex,
+        focusedKey,
+        actionBusy,
+        actionSlow,
+        pendingAction,
+        storyHandExpanded,
+        storyHandActiveKey,
+        heldStoryHand,
+        announcedTurnHandoffKey,
+        turnBannerControlRuns,
+      };
+      try {
+        const visible = actionBarActions().slice(0, handCapacity());
+        const played = originalStoryHandAction(visible[0]);
+        if (!played || !visible.length) return { skipped: true };
+        actorId = Number(actorId || 5000);
+        actorSession = actorSession || "story-hand-progress-fixture";
+        state = {
+          ...state,
+          turn: {
+            enabled: true,
+            policy: "scene-turn",
+            scene_kind: "room",
+            current_actor_id: actorId,
+            current_actor_name: "Progress Player",
+            is_current_actor: true,
+            can_need_time: false,
+            waiting_actor_ids: [9001, 9002],
+            handoff_key: "room:1:round:2:activation:10:actor:5000",
+          },
+        };
+        storyHandExpanded = true;
+        holdStoryHandForAction(played);
+        actionBusy = true;
+        pendingAction = played;
+        renderCommands();
+        const playedKey = heldStoryHand?.playedKey || "";
+        const progressButton = [...document.querySelectorAll("[data-hand-play]")]
+          .find((button) => {
+            const id = button.getAttribute("data-hand-play");
+            return storyHandKey(originalStoryHandAction(actionForButton(id))) === playedKey;
+          }) || document.querySelector("[data-hand-play]");
+        const busy = {
+          cards: document.querySelectorAll(".story-card-slot:not([hidden])").length,
+          expanded: document.querySelector(".prompt")?.classList.contains("hand-expanded") === true,
+          progressText: progressButton?.textContent.trim() || "",
+          progressClass: progressButton?.classList.contains("turn-progress") === true,
+          progressValue: progressButton?.querySelector('[role="progressbar"]')?.getAttribute("aria-valuenow") || "",
+          handStatus: document.querySelector("#hand-toggle-status")?.textContent.trim() || "",
+          bannerHidden: document.querySelector("#turn-banner")?.hidden === true,
+          statusOutsideBanner: !document.querySelector("#turn-ping-pill")?.closest("#turn-banner"),
+          statusPosition: getComputedStyle(document.querySelector("#turn-ping-pill")).position,
+        };
+
+        actionBusy = false;
+        pendingAction = null;
+        state = {
+          ...state,
+          turn: {
+            ...state.turn,
+            current_actor_id: 9001,
+            current_actor_name: "Other Player",
+            is_current_actor: false,
+            handoff_key: "room:1:round:2:activation:11:actor:9001",
+          },
+        };
+        actions = [];
+        renderCommands();
+        const waitingProgress = document.querySelector(".story-card-play.turn-progress");
+        const waiting = {
+          cards: document.querySelectorAll(".story-card-slot:not([hidden])").length,
+          expanded: document.querySelector(".prompt")?.classList.contains("hand-expanded") === true,
+          progressText: waitingProgress?.textContent.trim() || "",
+          progressValue: waitingProgress?.querySelector('[role="progressbar"]')?.getAttribute("aria-valuenow") || "",
+          progressWidth: waitingProgress?.style.getPropertyValue("--turn-progress") || "",
+          handStatus: document.querySelector("#hand-toggle-status")?.textContent.trim() || "",
+          allCardsDisabled: [...document.querySelectorAll(".story-card-slot:not([hidden]) .cmd")]
+            .every((button) => button.disabled),
+          bannerHidden: document.querySelector("#turn-banner")?.hidden === true,
+        };
+        return { skipped: false, visibleCount: visible.length, busy, waiting };
+      } finally {
+        state = previous.state;
+        actions = previous.actions;
+        actorId = previous.actorId;
+        actorSession = previous.actorSession;
+        handKeys = previous.handKeys;
+        discardedHandKeys = previous.discardedHandKeys;
+        authoritativeHandIdentity = previous.authoritativeHandIdentity;
+        focusIndex = previous.focusIndex;
+        focusedKey = previous.focusedKey;
+        actionBusy = previous.actionBusy;
+        actionSlow = previous.actionSlow;
+        pendingAction = previous.pendingAction;
+        storyHandExpanded = previous.storyHandExpanded;
+        storyHandActiveKey = previous.storyHandActiveKey;
+        heldStoryHand = previous.heldStoryHand;
+        announcedTurnHandoffKey = previous.announcedTurnHandoffKey;
+        turnBannerControlRuns = previous.turnBannerControlRuns;
+        render();
+      }
+    });
+    assert(
+      !result.skipped
+        && result.busy.cards === result.visibleCount
+        && result.busy.expanded
+        && result.busy.progressText === "other turns…"
+        && result.busy.progressClass
+        && result.busy.progressValue === "0"
+        && result.busy.handStatus === `${result.visibleCount} cards`
+        && result.busy.bannerHidden
+        && result.busy.statusOutsideBanner
+        && result.busy.statusPosition === "absolute"
+        && result.waiting.cards === result.visibleCount
+        && result.waiting.expanded
+        && result.waiting.progressText === "other turns…"
+        && result.waiting.progressValue === "1"
+        && result.waiting.progressWidth === "33%"
+        && result.waiting.handStatus === `${result.visibleCount} cards`
+        && result.waiting.allCardsDisabled
+        && result.waiting.bannerHidden,
+      `playing a card should keep the hand visible and move initiative progress onto its Play button: ${JSON.stringify(result)}`,
+    );
+    steps.push({
+      label: "played hand stays visible through other turns",
+      cards: result.visibleCount,
+      progress: result.waiting.progressWidth,
+    });
+  }
+
   async function assertFirstThreadGuide() {
     const guide = await page.evaluate(() => {
       const node = document.querySelector("#updates");
@@ -5382,6 +5522,8 @@ async function main() {
           footerBannerHidden: document.querySelector("#turn-banner").hidden,
           needTimeInFooter: Boolean(document.querySelector('#turn-banner [data-turn-control="need-time"]')),
           footerCopy: document.querySelector("#turn-ping-pill")?.textContent.replace(/\s+/g, " ").trim() || "",
+          footerStatusSeparate: !document.querySelector("#turn-ping-pill")?.closest("#turn-banner"),
+          footerStatusPosition: getComputedStyle(document.querySelector("#turn-ping-pill")).position,
         };
 
         const overflow = rescueRow.querySelector(".combat-rescue-overflow");
@@ -5464,7 +5606,9 @@ async function main() {
       && !result.combat.hasSecondStage, `the existing room rail should be the only combat roster and must not synthesize range zones: ${JSON.stringify(result)}`);
     assert(!result.combat.footerBannerHidden
       && result.combat.needTimeInFooter
-      && result.combat.footerCopy.includes("ordered combat — your turn"), `ordered-combat timing and controls should remain in the banner above the hand: ${JSON.stringify(result)}`);
+      && result.combat.footerCopy.includes("ordered combat — your turn")
+      && result.combat.footerStatusSeparate
+      && result.combat.footerStatusPosition === "absolute", `ordered-combat status should be screen-reader-only while the small need-time control stays available: ${JSON.stringify(result)}`);
     assert(result.ordinary.ariaLabel === "Avatars in this location"
       && result.ordinary.portraitCount === 9
       && result.ordinary.hasOnlooker
@@ -14799,6 +14943,7 @@ async function main() {
   await assertFirstThreadGuide();
   await assertStalePassRefreshesAndRotatesReceipt();
   await assertBrowserDrawReachesEveryLegalAction();
+  await assertPlayedHandStaysVisibleDuringOtherTurns();
   await assertNoComposerOrDebugChrome();
   const itemAvailable = await page.evaluate(() => actions.some((action) => (
     [compactActionLabel(action), action?.detail, action?.command]


### PR DESCRIPTION
## Summary
- keep the current Story Hand visible after Play while the room advances
- replace the full room initiative strip with subtle progress on the played Play button
- keep turn announcements accessible and preserve the small combat Need time control
- add browser coverage for the waiting state

## Validation
- npm test
- npm run check:version
- npm run v2:syntax
- npm run v2:browser:check
- npm run v2:check
- full pre-push gate
- direct browser visual check
- git diff --check

## Compatibility
- Presentation only; server turn authority and replay behavior are unchanged.
- Version 1.0.111.

## Review checklist
- [x] Story Hand stays visible during other turns
- [x] Turn progress appears only on the played Play button
- [x] Full room initiative bar is removed
- [x] Accessible live turn status is retained
- [x] Generated version files were updated through the version task