### PR TITLE
Keep the Story Hand visible and turn progress quiet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.111",
+  "version": "1.0.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.111",
+      "version": "1.0.112",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.111",
+  "version": "1.0.112",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.111"
+version = "1.0.112"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.111"
+version = "1.0.112"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1596,6 +1596,24 @@
       color: var(--dim);
       font-style: italic;
     }
+    .line.story-card-activity {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.38em;
+      padding: 2px 0;
+      color: rgba(185, 184, 167, 0.58);
+      font: 650 10px/1.3 ui-sans-serif, system-ui, sans-serif;
+      letter-spacing: 0.045em;
+    }
+    .story-card-activity::before,
+    .story-card-activity::after {
+      content: "";
+      width: min(7vw, 38px);
+      height: 1px;
+      background: rgba(222, 194, 141, 0.12);
+    }
+    .story-card-activity-card { color: rgba(222, 194, 141, 0.68); }
     .chat-thinking-dots {
       display: inline-flex;
       gap: 4px;
@@ -6175,6 +6193,10 @@
       border-top: 1px solid rgba(var(--slot-accent-rgb), 0.42);
       background: rgba(7, 8, 5, 0.58);
     }
+    .story-card-actions[hidden],
+    .story-card-actions button[hidden] { display: none !important; }
+    .story-card-actions.progress-only { grid-template-columns: minmax(0, 1fr); }
+    .story-card-actions.progress-only .story-card-play { border-left: 0; }
     .story-card-actions button {
       min-width: 0;
       min-height: 46px;
@@ -6222,6 +6244,18 @@
     }
     .story-card-actions button:disabled:not(.turn-progress) { opacity: 0.5; }
     .story-card-actions button:disabled { cursor: default; }
+    .prompt:not(.hand-expanded) .story-card-slot:has(.story-card-play.turn-progress:not([hidden])) {
+      grid-template-rows: 58px 20px;
+    }
+    .prompt:not(.hand-expanded) .story-card-actions.progress-only {
+      display: grid;
+      min-height: 20px;
+    }
+    .prompt:not(.hand-expanded) .story-card-actions.progress-only button {
+      min-height: 20px;
+      padding: 2px 4px;
+      font-size: 8px;
+    }
     .prompt .cmd {
       width: 100%;
       min-width: 0;
@@ -6304,6 +6338,9 @@
     .prompt.hand-expanded .story-card-slot {
       height: clamp(326px, 49dvh, 438px);
       grid-template-rows: minmax(0, 1fr) 46px;
+    }
+    .prompt.hand-expanded .story-card-slot:has(> .story-card-actions[hidden]) {
+      grid-template-rows: minmax(0, 1fr);
     }
     .prompt.hand-expanded .story-card-actions { display: grid; }
     .prompt.hand-expanded .cmd {
@@ -11939,6 +11976,7 @@
       "model_interaction.output",
       "avatar.thought",
       "avatar.dream",
+      "story.card.played",
     ]);
     const combatTranscriptEventTypes = new Set([
       "combat.encounter.started",
@@ -14283,7 +14321,7 @@
 
     function roomMemoryEntryForEvent(event) {
       if (!event) return null;
-      if (["message.created", "image.created", "avatar.thought", "avatar.dream"].includes(event.type)) {
+      if (["message.created", "image.created", "avatar.thought", "avatar.dream", "story.card.played"].includes(event.type)) {
         return null;
       }
       if (
@@ -15032,7 +15070,7 @@
     }
 
     function eventIsChatTranscriptEvent(event) {
-      return ["message.created", "image.created", "model_interaction.output", "avatar.thought", "avatar.dream"].includes(event?.type);
+      return ["message.created", "image.created", "model_interaction.output", "avatar.thought", "avatar.dream", "story.card.played"].includes(event?.type);
     }
 
     function transcriptEventHtml(event) {
@@ -15040,8 +15078,16 @@
       if (event?.type === "image.created") return residentImageHtml(event);
       if (event?.type === "model_interaction.output") return modelInteractionOutputHtml(event);
       if (["avatar.thought", "avatar.dream"].includes(event?.type)) return avatarReflectionHtml(event);
+      if (event?.type === "story.card.played") return storyCardPlayedHtml(event);
       if (event?.type === "combat.attack.attempt") return combatAttackTranscriptBeatHtml(event);
       return sceneCardEventHtml(event);
+    }
+
+    function storyCardPlayedHtml(event) {
+      const actor = cleanStatusText(event?.actor_name || "Someone") || "Someone";
+      const card = cleanStatusText(event?.content || "a card").toLowerCase() || "a card";
+      const text = `${actor} played ${card}`;
+      return `<div class="line story-card-activity" aria-label="${escapeAttr(text)}"><span>${escapeHtml(actor)} played</span><span class="story-card-activity-card">${escapeHtml(card)}</span></div>`;
     }
 
     function combatAttackTranscriptBeatHtml(event) {
@@ -17650,8 +17696,8 @@
         startActivation: turnActivation(),
         participantCount: Math.max(1, participants.size),
       };
-      storyHandExpanded = true;
-      storyHandActiveKey = storyHandKey(played);
+      storyHandExpanded = false;
+      storyHandActiveKey = "";
     }
 
     function activeHeldStoryHandActions() {
@@ -17750,6 +17796,7 @@
         const action = visibleActions[index] || null;
         const slot = document.querySelector(`[data-story-card-slot="${id}"]`);
         const card = slot.querySelector(".cmd");
+        const cardActions = slot.querySelector(".story-card-actions");
         const play = document.querySelector(`[data-hand-play="${id}"]`);
         const discard = document.querySelector(`[data-hand-discard="${id}"]`);
         slot.hidden = !action;
@@ -17769,6 +17816,11 @@
         const progress = held && storyHandKey(action) === heldStoryHand?.playedKey
           ? heldStoryHandProgress()
           : null;
+        const hideTurnActions = waitingForTurn && !progress;
+        play.hidden = hideTurnActions;
+        discard.hidden = waitingForTurn || Boolean(progress);
+        cardActions.hidden = hideTurnActions;
+        cardActions.classList.toggle("progress-only", Boolean(progress));
         play.disabled = !inline || waitingForTurn || Boolean(original.busy) || held || actionBusy;
         play.classList.toggle("turn-progress", Boolean(progress));
         if (progress) {

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -8681,38 +8681,11 @@
         chatAction.run = () => action("/actions/create-bond", chatAction.selectedPayload());
         return chatAction;
       };
-      if (turn.enabled && !turn.is_current_actor) {
-        const currentName = turn.current_actor_name || "another avatar";
-        const waitingActions = [];
-        if (turn.can_request_timeout) {
-          waitingActions.push({
-            handProvider: {
-              kind: "rules",
-              id: "rules:ordered-scene-timeout",
-              label: "Ordered scene",
-              reason: "Ask the current participant to play or pass",
-              priority: 0,
-            },
-            label: "nudge",
-            detail: `ask ${currentName} to play or pass`,
-            command: "nudge",
-            focusKey: "scene-timeout",
-            card: cardForActor(turn.current_actor_id) || cardForLocation(view.location?.id),
-            shape: "avatar",
-            priority: 0,
-            modalTitle: `gently nudge ${currentName}`,
-            modalSummary: `Ask ${currentName} to play or pass.`,
-            effect: "passes the ordered floor to the next eligible participant",
-            run: () => action("/actions/timeout", { actor_id: actorId }),
-          });
-        }
-        // Ordered-scene status belongs in the turn banner, not the card hand.
-        // A waiting player receives no dealt card here, so nothing can bypass
-      // or crowd the initiative floor. See issue #461.
-      return waitingActions.map(decorateActionHand);
-    }
+      // Initiative controls whether a card can be played or discarded. It
+      // must not replace the player's hand: cards remain available to inspect
+      // while another participant has the floor.
 
-      // Pass and Need time are timing controls, not ranked combat actions.
+      // Pass, Need time, and Nudge are timing controls, not ranked actions.
       // They render in the turn banner so the card row stays reserved for
       // legal current-activation choices. See issue #461 and turnBannerControlSpecs.
       const built = [];
@@ -10197,7 +10170,17 @@
     }
 
     function turnBannerControlSpecs(turn = state?.turn) {
-      if (!turn?.enabled || turn?.policy !== "scene-turn" || !turn?.is_current_actor) return [];
+      if (!turn?.enabled || turn?.policy !== "scene-turn") return [];
+      if (!turn.is_current_actor) {
+        if (!turn.can_request_timeout) return [];
+        const currentName = turn.current_actor_name || "the current player";
+        return [{
+          key: "nudge",
+          label: "nudge",
+          title: `Ask ${currentName} to play or pass.`,
+          run: () => action("/actions/timeout", { actor_id: actorId }),
+        }];
+      }
       if (!turn.can_need_time) return [];
       const seconds = Math.round(Number(turn.need_time_extension_ms || 60000) / 1000);
       return [{
@@ -17741,7 +17724,9 @@
       const card = [...rail.querySelectorAll(".cmd[data-hand-key]")]
         .find((button) => String(button.dataset.handKey || "") === key);
       if (!card) return;
-      const left = card.offsetLeft - Math.max(0, (rail.clientWidth - card.offsetWidth) / 2);
+      const slot = card.closest(".story-card-slot");
+      if (!slot) return;
+      const left = slot.offsetLeft - Math.max(0, (rail.clientWidth - slot.offsetWidth) / 2);
       rail.scrollTo({ left, behavior });
     }
 
@@ -17757,20 +17742,34 @@
       $("hand-toggle").setAttribute("aria-expanded", expanded ? "true" : "false");
       const count = visibleActions.length;
       $("hand-toggle-status").textContent = `${count} ${count === 1 ? "card" : "cards"}`;
+      const selected = visibleActions.find((action) => storyHandKey(action) === storyHandActiveKey)
+        || visibleActions[0]
+        || null;
+      if (expanded && selected && !storyHandActiveKey) storyHandActiveKey = storyHandKey(selected);
       ["primary", "secondary", "tertiary"].forEach((id, index) => {
         const action = visibleActions[index] || null;
         const slot = document.querySelector(`[data-story-card-slot="${id}"]`);
+        const card = slot.querySelector(".cmd");
         const play = document.querySelector(`[data-hand-play="${id}"]`);
         const discard = document.querySelector(`[data-hand-discard="${id}"]`);
         slot.hidden = !action;
-        if (!action) return;
+        if (!action) {
+          card.removeAttribute("aria-current");
+          return;
+        }
+        if (expanded && storyHandKey(action) === storyHandKey(selected)) {
+          card.setAttribute("aria-current", "true");
+        } else {
+          card.removeAttribute("aria-current");
+        }
         const original = originalStoryHandAction(action);
         const title = actionTitle(original);
         const held = Boolean(action.heldStoryHandAction);
+        const waitingForTurn = Boolean(state?.turn?.enabled && !state.turn.is_current_actor);
         const progress = held && storyHandKey(action) === heldStoryHand?.playedKey
           ? heldStoryHandProgress()
           : null;
-        play.disabled = !inline || Boolean(original.busy) || held || actionBusy;
+        play.disabled = !inline || waitingForTurn || Boolean(original.busy) || held || actionBusy;
         play.classList.toggle("turn-progress", Boolean(progress));
         if (progress) {
           play.style.setProperty("--turn-progress", `${progress.percent}%`);
@@ -17787,8 +17786,11 @@
           ? "No replacement is available for this card right now."
           : `Discard ${title} and draw its replacement`;
       });
-      for (const button of $("hand-rail").querySelectorAll(".cmd")) button.removeAttribute("aria-current");
+      const shouldScroll = storyHandScrollPending;
       storyHandScrollPending = false;
+      if (expanded && selected && shouldScroll) {
+        window.requestAnimationFrame(() => scrollStoryHandCardIntoView(selected, "auto"));
+      }
       renderStoryHandInspector(null);
     }
 
@@ -17818,8 +17820,9 @@
     }
 
     function activateStoryHandAction(action) {
-      if (!action || actionBusy) return;
+      if (!action) return;
       if (!usesInlineStoryHand()) {
+        if (actionBusy) return;
         openActionModal(action, { handCard: true });
         return;
       }
@@ -17841,7 +17844,7 @@
 
     function playStoryHandCard(id) {
       const action = actionForButton(id);
-      if (!action || actionBusy) return;
+      if (!action || actionBusy || (state?.turn?.enabled && !state.turn.is_current_actor)) return;
       if (Array.isArray(action.choices) && action.choices.length > 1) {
         openActionModal(action);
         return;
@@ -17859,9 +17862,15 @@
         .filter((button) => getComputedStyle(button).display !== "none");
       if (!cards.length) return;
       const railCenter = rail.scrollLeft + rail.clientWidth / 2;
+      const cardCenter = (button) => {
+        const slot = button.closest(".story-card-slot");
+        return slot
+          ? slot.offsetLeft + slot.offsetWidth / 2
+          : button.offsetLeft + button.offsetWidth / 2;
+      };
       const card = cards.reduce((nearest, candidate) => {
-        const candidateCenter = candidate.offsetLeft + candidate.offsetWidth / 2;
-        const nearestCenter = nearest.offsetLeft + nearest.offsetWidth / 2;
+        const candidateCenter = cardCenter(candidate);
+        const nearestCenter = cardCenter(nearest);
         return Math.abs(candidateCenter - railCenter) < Math.abs(nearestCenter - railCenter)
           ? candidate
           : nearest;
@@ -18516,7 +18525,8 @@
           busyDetail: presentation.pending[pending.stage] || presentation.pending.queued,
         };
       }
-      button.disabled = Boolean(action.busy || action.heldStoryHandAction);
+      button.disabled = Boolean(action.busy || action.heldStoryHandAction)
+        && !action.inspectableStoryHandAction;
       if (action.busy) button.setAttribute("aria-busy", "true");
       else button.removeAttribute("aria-busy");
       if (action.command) button.dataset.command = action.command;
@@ -18776,6 +18786,7 @@
           const visibleAction = heldActions[index]
             ? {
                 ...heldActions[index],
+                inspectableStoryHandAction: true,
                 suggestionIndex: index,
                 suggestionCount: heldActions.length,
               }
@@ -18817,6 +18828,7 @@
         const visibleAction = visibleActions[index]
           ? {
               ...visibleActions[index],
+              inspectableStoryHandAction: true,
               suggestionIndex: index,
               suggestionCount: visibleActions.length,
             }
@@ -18829,6 +18841,9 @@
 
     function actionForButton(id) {
       const button = $(id);
+      const handKey = String(button?.dataset?.handKey || "");
+      const held = heldStoryHand?.actions?.find((action) => storyHandKey(action) === handKey);
+      if (held) return held;
       const actionIndex = Number(button?.dataset?.actionIndex);
       if (!Number.isInteger(actionIndex) || actionIndex < 0 || actionIndex >= actions.length) {
         return null;

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -1980,7 +1980,7 @@ struct JournalRecord {
     orb_deltas: Vec<OrbDelta>,
 }
 
-const JOURNAL_RECORD_VERSION: u32 = 18;
+const JOURNAL_RECORD_VERSION: u32 = 19;
 
 impl JournalRecord {
     fn new(action: CwAction, seed: u64) -> Self {
@@ -7691,7 +7691,7 @@ impl RuntimeWorld {
             events.extend(self.apply_avatar_level_progression(record.seed, &events.clone()));
             self.record_autonomous_action(record);
             self.refresh_craft_event_presentation(&mut events);
-            self.append_lantern_story_receipt(record, &mut events);
+            self.append_story_presentation_receipts(record, &mut events);
             if record.source_world_tick.is_some() {
                 for event in &mut events {
                     event.apply_async_causality(record);
@@ -37155,7 +37155,7 @@ mod tests {
             "log.innerHTML = `${visibleEvents.map(transcriptEventHtml).join(\"\")}${defeatScene}${observerScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;"
         ));
         assert!(INDEX_HTML.contains(
-            "return [\"message.created\", \"image.created\", \"model_interaction.output\", \"avatar.thought\", \"avatar.dream\"].includes(event?.type);"
+            "return [\"message.created\", \"image.created\", \"model_interaction.output\", \"avatar.thought\", \"avatar.dream\", \"story.card.played\"].includes(event?.type);"
         ));
         assert!(INDEX_HTML.contains("function avatarReflectionHtml"));
         assert!(INDEX_HTML.contains("function transcriptEventHtml"));

--- a/v2/orchestrator-rust/src/room_memory.rs
+++ b/v2/orchestrator-rust/src/room_memory.rs
@@ -318,6 +318,7 @@ pub(super) fn room_memory_entry_for_event_at_location(
                 | "actor.presence"
                 | "message.created"
                 | "image.created"
+                | "story.card.played"
                 | "combat.participant.joined"
                 | "combat.initiative.rolled"
                 | "combat.turn.started"
@@ -1546,6 +1547,7 @@ mod tests {
             "pathway.refined",
             "community_art.funded",
             "community_art.ready",
+            "story.card.played",
         ] {
             let event = EventView {
                 type_name: type_name.to_string(),

--- a/v2/orchestrator-rust/src/semantic_receipts.rs
+++ b/v2/orchestrator-rust/src/semantic_receipts.rs
@@ -445,7 +445,24 @@ fn build_lantern_story_receipt(
 }
 
 impl RuntimeWorld {
-    pub(crate) fn append_lantern_story_receipt(
+    pub(crate) fn append_story_presentation_receipts(
+        &mut self,
+        record: &JournalRecord,
+        events: &mut Vec<EventView>,
+    ) {
+        self.append_lantern_story_receipt(record, events);
+        let Some(card_label) = story_card_activity_label(record) else {
+            return;
+        };
+        events.push(self.append_async_job_event(
+            "story.card.played",
+            record.action.actor_id,
+            None,
+            Some(card_label),
+        ));
+    }
+
+    fn append_lantern_story_receipt(
         &mut self,
         record: &JournalRecord,
         events: &mut Vec<EventView>,
@@ -479,6 +496,49 @@ impl RuntimeWorld {
     }
 }
 
+fn story_card_activity_label(record: &JournalRecord) -> Option<String> {
+    if record.version < 19
+        || !matches!(
+            record.origin,
+            JournalOrigin::PlayerCard | JournalOrigin::ActorConsequence
+        )
+    {
+        return None;
+    }
+    let kind = record.offer_kind.as_deref()?.trim();
+    if kind.is_empty()
+        || matches!(
+            kind,
+            "pass"
+                | "draw"
+                | "wait"
+                | "think"
+                | "prepare"
+                | "need_time"
+                | "nudge"
+                | "timeout"
+                | "abandon_avatar"
+        )
+    {
+        return None;
+    }
+    let label = match kind {
+        "explore_path" => "scout",
+        "move" => "travel",
+        "notice_actor" => "notice",
+        "model_interaction" => "ask",
+        "create_bond" => "befriend",
+        "resolve_bond" => "bond",
+        "pick_up" | "pick_up_item" => "take",
+        "drop_item" => "drop",
+        "use_item" | "use_feature" => "use",
+        "give_item" => "give",
+        "trade_item" => "trade",
+        other => other,
+    };
+    Some(label.replace('_', " "))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -510,6 +570,21 @@ mod tests {
 
     fn receipt(kind: &str, events: &[EventView]) -> SemanticStoryReceipt {
         build_lantern_story_receipt(&record(kind), events).expect("Lantern action receipt")
+    }
+
+    #[test]
+    fn played_cards_get_quiet_activity_labels() {
+        let mut played = record("explore_path").into_player_card();
+        played.version = JOURNAL_RECORD_VERSION;
+        assert_eq!(story_card_activity_label(&played).as_deref(), Some("scout"));
+
+        let mut historical = played.clone();
+        historical.version = 18;
+        assert_eq!(story_card_activity_label(&historical), None);
+        assert_eq!(
+            story_card_activity_label(&record("wait").into_player_card()),
+            None
+        );
     }
 
     #[test]

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -912,7 +912,11 @@ async function main() {
           expanded: document.querySelector(".prompt")?.classList.contains("hand-expanded") === true,
           progressText: progressButton?.textContent.trim() || "",
           progressClass: progressButton?.classList.contains("turn-progress") === true,
+          progressVisible: Boolean(progressButton?.getClientRects().length),
           progressValue: progressButton?.querySelector('[role="progressbar"]')?.getAttribute("aria-valuenow") || "",
+          compactHeight: document.querySelector("#hand-rail")?.getBoundingClientRect().height || 0,
+          turnLocksHidden: [...document.querySelectorAll(".story-card-slot:not([hidden]) [data-hand-play]:not(.turn-progress), .story-card-slot:not([hidden]) [data-hand-discard]")]
+            .every((button) => button.getClientRects().length === 0),
           handStatus: document.querySelector("#hand-toggle-status")?.textContent.trim() || "",
           bannerHidden: document.querySelector("#turn-banner")?.hidden === true,
           statusOutsideBanner: !document.querySelector("#turn-ping-pill")?.closest("#turn-banner"),
@@ -951,6 +955,8 @@ async function main() {
           allCardsInspectable: inspectableCards.every((button) => !button.disabled),
           playAndDiscardDisabled: [...document.querySelectorAll(".story-card-slot:not([hidden]) [data-hand-play], .story-card-slot:not([hidden]) [data-hand-discard]")]
             .every((button) => button.disabled),
+          turnLocksHidden: [...document.querySelectorAll(".story-card-slot:not([hidden]) [data-hand-play]:not(.turn-progress), .story-card-slot:not([hidden]) [data-hand-discard]")]
+            .every((button) => button.getClientRects().length === 0),
           selectedCardCurrent: selectedCard?.getAttribute("aria-current") === "true",
           selectedCardActive: String(selectedCard?.dataset.handKey || "") === storyHandActiveKey,
           selectedCardInView: Boolean(selectedRect && railRect
@@ -962,7 +968,22 @@ async function main() {
           selectedSlot: selectedSlot?.dataset.storyCardSlot || "",
           bannerHidden: document.querySelector("#turn-banner")?.hidden === true,
         };
-        return { skipped: false, visibleCount: visible.length, busy, waiting };
+        const activityEvents = [
+          { type: "message.created", seq: 101, actor_id: 9001, actor_name: "Marnie", location_id: state.location?.id, content: "Let me check the path." },
+          { type: "story.card.played", seq: 102, actor_id: 9001, actor_name: "Marnie", location_id: state.location?.id, content: "scout" },
+          { type: "message.created", seq: 103, actor_id: 9001, actor_name: "Marnie", location_id: state.location?.id, content: "There is a trail here." },
+        ];
+        const activityTranscript = sharedRoomTranscriptEvents(activityEvents);
+        const activityHtml = activityTranscript.map(transcriptEventHtml).join("");
+        const activityRow = transcriptEventHtml(activityEvents[1]);
+        const activity = {
+          order: activityTranscript.map((event) => event.type).join(","),
+          exactText: /Marnie played<\/span><span class="story-card-activity-card">scout<\/span>/.test(activityHtml),
+          subtleRow: activityHtml.includes('class="line story-card-activity"'),
+          noAvatar: !activityRow.includes("chat-pfp"),
+          notRoomMemory: roomMemoryEntryForEvent(activityEvents[1]) === null,
+        };
+        return { skipped: false, visibleCount: visible.length, busy, waiting, activity };
       } finally {
         state = previous.state;
         actions = previous.actions;
@@ -987,10 +1008,13 @@ async function main() {
     assert(
       !result.skipped
         && result.busy.cards === result.visibleCount
-        && result.busy.expanded
+        && !result.busy.expanded
         && result.busy.progressText === "other turns…"
         && result.busy.progressClass
+        && result.busy.progressVisible
         && result.busy.progressValue === "0"
+        && result.busy.compactHeight <= 100
+        && result.busy.turnLocksHidden
         && result.busy.handStatus === `${result.visibleCount} cards`
         && result.busy.bannerHidden
         && result.busy.statusOutsideBanner
@@ -1003,15 +1027,21 @@ async function main() {
         && result.waiting.handStatus === `${result.visibleCount} cards`
         && result.waiting.allCardsInspectable
         && result.waiting.playAndDiscardDisabled
+        && result.waiting.turnLocksHidden
         && result.waiting.selectedCardCurrent
         && result.waiting.selectedCardActive
         && result.waiting.selectedCardInView
         && result.waiting.selectedSlot === "tertiary"
-        && result.waiting.bannerHidden,
-      `playing a card should keep the hand inspectable, center the clicked card, and move initiative progress onto its Play button: ${JSON.stringify(result)}`,
+        && result.waiting.bannerHidden
+        && result.activity.order === "message.created,story.card.played,message.created"
+        && result.activity.exactText
+        && result.activity.subtleRow
+        && result.activity.noAvatar
+        && result.activity.notRoomMemory,
+      `playing a card should collapse the hand, hide turn locks, keep inspection available, and add subtle card activity to chat: ${JSON.stringify(result)}`,
     );
     steps.push({
-      label: "played hand stays visible through other turns",
+      label: "played hand collapses with subtle turn progress",
       cards: result.visibleCount,
       progress: result.waiting.progressWidth,
     });
@@ -12153,10 +12183,21 @@ async function main() {
           event.type === "ledger.marked" || event.type === "ledger.banked"),
         ledger: state?.ledger || {},
         eventRows: document.querySelectorAll("#log .line.event, #log .roll-line").length,
-        nonChatRows: rows.filter((node) => node.classList.contains("line") && !node.classList.contains("chat")).length,
+        nonChatRows: rows.filter((node) => (
+          node.classList.contains("line")
+            && !node.classList.contains("chat")
+            && !node.classList.contains("story-card-activity")
+        )).length,
+        cardActivity: [...document.querySelectorAll("#log .story-card-activity")]
+          .map((node) => node.textContent.trim().replace(/\s+/g, " ")),
       };
     }, noticeBefore);
-    assert(scene.eventRows === 0 && scene.nonChatRows === 0, `Notice outcomes should stay out of group chat: ${JSON.stringify(scene)}`);
+    assert(
+      scene.eventRows === 0
+        && scene.nonChatRows === 0
+        && scene.cardActivity.some((line) => /played\s*notice$/i.test(line)),
+      `Notice outcomes should stay out of group chat except for the subtle played-card line: ${JSON.stringify(scene)}`,
+    );
     assert(
       scene.observed === true
         && scene.rolled === false
@@ -13897,10 +13938,11 @@ async function main() {
         transcriptVisible: visible(document.querySelector("#log")),
         promptVisible: visible(document.querySelector("footer.prompt")),
         chatRows: document.querySelectorAll("#log .line.chat").length,
+        activityRows: document.querySelectorAll("#log .story-card-activity").length,
         roomRows: document.querySelectorAll("#log .line.event.room").length,
         sceneRows: document.querySelectorAll("#log .line.event.scene-card, #log .roll-line").length,
         quietScene: document.querySelectorAll("#log .chat-empty").length,
-        unexpectedRows: document.querySelectorAll("#log .line:not(.chat):not(.event.room):not(.scene-card)").length,
+        unexpectedRows: document.querySelectorAll("#log .line:not(.chat):not(.event.room):not(.scene-card):not(.story-card-activity)").length,
         stateSignature: JSON.stringify({
           sharedQuestions: state?.shared_questions,
           roomMemory: state?.room_memory,
@@ -13922,8 +13964,8 @@ async function main() {
     assert(room.heroVisible && room.transcriptVisible && room.promptVisible, `${label}: room mode should show location, chat, and actions: ${JSON.stringify(room)}`);
     assert(room.unexpectedRows === 0 && room.roomRows === 0 && room.sceneRows === 0, `${label}: normal chat should keep system chrome out of the transcript: ${JSON.stringify(room)}`);
     assert(
-      room.chatRows > 0 || room.quietScene === 1,
-      `${label}: the room should show speech or a single quiet chat invitation: ${JSON.stringify(room)}`,
+      room.chatRows > 0 || room.activityRows > 0 || room.quietScene === 1,
+      `${label}: the room should show speech, subtle card activity, or a single quiet chat invitation: ${JSON.stringify(room)}`,
     );
 
     const emptyTicker = await page.evaluate(() => {
@@ -14211,6 +14253,7 @@ async function main() {
         logRole: document.querySelector("#log")?.getAttribute("role") || "",
         lineCount: document.querySelectorAll("#log .line").length,
         chatLineCount: document.querySelectorAll("#log .line.chat").length,
+        activityLineCount: document.querySelectorAll("#log .story-card-activity").length,
         roomLineCount: document.querySelectorAll("#log .line.event.room").length,
         sceneLineCount: document.querySelectorAll("#log .line.event.scene-card").length,
         chatFailureSceneCount: [...document.querySelectorAll("#log .line.event.scene-card")]
@@ -14219,7 +14262,7 @@ async function main() {
         roomFallbackStacked: !roomRow || Boolean(roomLabelRect && roomTextRect && roomLabelRect.bottom <= roomTextRect.top + 1),
         roomFallbackClipped: Boolean(roomText && roomText.scrollHeight > roomText.clientHeight + 1),
         speakerClippedCount,
-        unexpectedLineCount: document.querySelectorAll("#log .line:not(.chat):not(.event.room):not(.scene-card)").length,
+        unexpectedLineCount: document.querySelectorAll("#log .line:not(.chat):not(.event.room):not(.scene-card):not(.story-card-activity)").length,
         legacyListChromeCount: document.querySelectorAll("#route-map,#presence,#features,.route-node,.chip,.feature-pill").length,
         avatarRailCount: document.querySelectorAll(".room-avatar-pfp").length,
         handThumbCount: document.querySelectorAll("footer.prompt .thumb").length,
@@ -14251,8 +14294,8 @@ async function main() {
         && shell.rollLineCount === 0
         && shell.sceneLineCount === 0
         && shell.chatFailureSceneCount === 0
-        && shell.lineCount === shell.chatLineCount,
-      `${label}: group chat should contain speech and no system rows: ${JSON.stringify(shell)}`,
+        && shell.lineCount === shell.chatLineCount + shell.activityLineCount,
+      `${label}: group chat should contain speech and subtle card activity, with no system rows: ${JSON.stringify(shell)}`,
     );
     assert(shell.unexpectedLineCount === 0, `${label}: normal feed should not show bookkeeping rows: ${JSON.stringify(shell)}`);
     assert(shell.legacyListChromeCount === 0, `${label}: inline item/location/avatar lists should be absent: ${JSON.stringify(shell)}`);

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -934,6 +934,13 @@ async function main() {
         actions = [];
         renderCommands();
         const waitingProgress = document.querySelector(".story-card-play.turn-progress");
+        const inspectableCards = [...document.querySelectorAll(".story-card-slot:not([hidden]) .cmd")];
+        const selectedCard = inspectableCards.at(-1) || null;
+        selectedCard?.click();
+        scrollStoryHandCardIntoView(actionForButton(selectedCard?.id || ""), "auto");
+        const selectedSlot = selectedCard?.closest(".story-card-slot");
+        const selectedRect = selectedSlot?.getBoundingClientRect();
+        const railRect = document.querySelector("#hand-rail")?.getBoundingClientRect();
         const waiting = {
           cards: document.querySelectorAll(".story-card-slot:not([hidden])").length,
           expanded: document.querySelector(".prompt")?.classList.contains("hand-expanded") === true,
@@ -941,8 +948,18 @@ async function main() {
           progressValue: waitingProgress?.querySelector('[role="progressbar"]')?.getAttribute("aria-valuenow") || "",
           progressWidth: waitingProgress?.style.getPropertyValue("--turn-progress") || "",
           handStatus: document.querySelector("#hand-toggle-status")?.textContent.trim() || "",
-          allCardsDisabled: [...document.querySelectorAll(".story-card-slot:not([hidden]) .cmd")]
+          allCardsInspectable: inspectableCards.every((button) => !button.disabled),
+          playAndDiscardDisabled: [...document.querySelectorAll(".story-card-slot:not([hidden]) [data-hand-play], .story-card-slot:not([hidden]) [data-hand-discard]")]
             .every((button) => button.disabled),
+          selectedCardCurrent: selectedCard?.getAttribute("aria-current") === "true",
+          selectedCardActive: String(selectedCard?.dataset.handKey || "") === storyHandActiveKey,
+          selectedCardInView: Boolean(selectedRect && railRect
+            && selectedRect.left >= railRect.left - 1
+            && selectedRect.right <= railRect.right + 1),
+          selectedRect: selectedRect ? { left: selectedRect.left, right: selectedRect.right, width: selectedRect.width } : null,
+          railRect: railRect ? { left: railRect.left, right: railRect.right, width: railRect.width } : null,
+          railScrollLeft: document.querySelector("#hand-rail")?.scrollLeft || 0,
+          selectedSlot: selectedSlot?.dataset.storyCardSlot || "",
           bannerHidden: document.querySelector("#turn-banner")?.hidden === true,
         };
         return { skipped: false, visibleCount: visible.length, busy, waiting };
@@ -984,9 +1001,14 @@ async function main() {
         && result.waiting.progressValue === "1"
         && result.waiting.progressWidth === "33%"
         && result.waiting.handStatus === `${result.visibleCount} cards`
-        && result.waiting.allCardsDisabled
+        && result.waiting.allCardsInspectable
+        && result.waiting.playAndDiscardDisabled
+        && result.waiting.selectedCardCurrent
+        && result.waiting.selectedCardActive
+        && result.waiting.selectedCardInView
+        && result.waiting.selectedSlot === "tertiary"
         && result.waiting.bannerHidden,
-      `playing a card should keep the hand visible and move initiative progress onto its Play button: ${JSON.stringify(result)}`,
+      `playing a card should keep the hand inspectable, center the clicked card, and move initiative progress onto its Play button: ${JSON.stringify(result)}`,
     );
     steps.push({
       label: "played hand stays visible through other turns",
@@ -1127,6 +1149,7 @@ async function main() {
             enabled: true,
             policy: "scene-turn",
             is_current_actor: false,
+            can_request_timeout: true,
             current_actor_id: 5001,
             current_actor_name: "Mabel Crumblethorn",
           };
@@ -1187,6 +1210,16 @@ async function main() {
         waitingWelcomeWithoutOption: buildActions({
           location: { id: 1, name: "The Cosy Cottage" },
           primary_action: { options: [] },
+          action_offers: [{
+            offer_id: "core:1:notice-rati",
+            kind: "notice_actor",
+            command: "notice Rati",
+            target: { kind: "actor", id: 1001, label: "Rati" },
+            provider: { kind: "actor", id: "actor:1001", priority: 40 },
+          }],
+          action_hand: {
+            entries: [{ offer_id: "core:1:notice-rati", kind: "notice_actor" }],
+          },
           economy: { listen_attempted_here: false },
           ledger: { unbanked_count: 1, unbanked_marks: [{ category: "witness" }] },
           turn: {
@@ -1493,25 +1526,22 @@ async function main() {
         && guide.roomThreadHand.buttonCue === "",
       `a client-only room guide must not override the authoritative projected hand: ${JSON.stringify(guide.roomThreadHand)}`,
     );
-    // Issue #461: ordered-scene timing is banner status, never a dealt card.
-    // The floor is preserved by dealing a waiting player no bypass action at
-    // all, which is stricter than the previous single observational card.
-    assert(guide.arrivalActions.length === 0, `an explicitly ordered scene should remain authoritative while the newcomer's first-tale Notice waits, dealing no bypass card: ${JSON.stringify(guide)}`);
+    // Initiative limits action, not inspection. The current hand stays dealt
+    // while Play and Discard enforce the ordered floor.
+    assert(guide.arrivalActions.length === 1 && guide.arrivalActions[0]?.label === "look", `an explicitly ordered scene should keep an inspectable fallback hand: ${JSON.stringify(guide)}`);
     assert(guide.welcomingListenWithoutOption.some((action) => action.label === "notice" && action.focusKey === "actor:1001"), `the welcoming Notice should remain playable when ordinary room options rotate: ${JSON.stringify(guide)}`);
-    assert(guide.waitingWelcomeWithoutOption.length === 0, `another player's explicit combat turn should not be bypassed by first-tale guidance: ${JSON.stringify(guide)}`);
-    assert(guide.waitingActions.length === 0, `ordinary ordered-scene waiting should preserve the combat floor without a timer card: ${JSON.stringify(guide)}`);
+    assert(guide.waitingWelcomeWithoutOption.some((action) => action.label === "notice" && action.focusKey === "actor:1001"), `another player's turn should leave the projected hand available to inspect: ${JSON.stringify(guide)}`);
+    assert(guide.waitingActions.length === 1 && guide.waitingActions[0]?.label === "look", `ordinary ordered-scene waiting should keep an inspectable hand: ${JSON.stringify(guide)}`);
     assert(
       guide.nudgeActions.length === 1
-        && guide.nudgeActions[0]?.label === "nudge"
-        && guide.nudgeActions[0]?.focusKey === "scene-timeout"
-        && /play or pass/i.test(guide.nudgeActions[0]?.detail || ""),
-      `an eligible waiting participant should receive the nudge and nothing else: ${JSON.stringify(guide.nudgeActions)}`,
+        && guide.nudgeActions[0]?.label === "look",
+      `a timeout affordance should not replace the inspectable Story Hand: ${JSON.stringify(guide.nudgeActions)}`,
     );
-    assert(guide.gatheringActions.length === 0, `a pending ordered-scene handoff should preserve the combat floor: ${JSON.stringify(guide)}`);
+    assert(guide.gatheringActions.length === 1 && guide.gatheringActions[0]?.label === "look", `a pending ordered-scene handoff should keep the Story Hand inspectable: ${JSON.stringify(guide)}`);
     assert(
       guide.orderedTurnBanner?.copy === "ordered combat — Mabel Crumblethorn acts now"
-        && guide.orderedTurnBanner?.controls?.length === 0,
-      `a waiting combat participant should read the ordered status from the banner: ${JSON.stringify(guide.orderedTurnBanner)}`,
+        && guide.orderedTurnBanner?.controls?.join(",") === "nudge",
+      `a waiting combat participant should reach the timeout affordance without replacing the hand: ${JSON.stringify(guide.orderedTurnBanner)}`,
     );
     assert(
       guide.currentTurnBanner?.copy === "ordered combat — your turn"
@@ -13197,20 +13227,31 @@ async function main() {
         && actionBusy === false
         && document.querySelector("#action-modal")?.hidden === true
       ));
-      const afterFirstListen = await other.evaluate(() => ({
-        currentActorId: Number(state?.turn?.current_actor_id || 0),
-        isCurrentActor: state?.turn?.is_current_actor === true,
-        visibleLabels: actionBarActions().map((action) => action.label),
-        primary: document.querySelector("#primary")?.getAttribute("aria-label") || "",
-        economy: document.querySelector("#economy")?.textContent?.trim().replace(/\s+/g, " ") || "",
-        guide: document.querySelector("#updates")?.textContent?.trim().replace(/\s+/g, " ") || "",
-        firstTale: state?.first_tale || null,
-        ledger: state?.ledger || {},
-      }));
+      const afterFirstListen = await other.evaluate(() => {
+        setStoryHandExpanded(true, visibleFocusedAction());
+        return {
+          currentActorId: Number(state?.turn?.current_actor_id || 0),
+          isCurrentActor: state?.turn?.is_current_actor === true,
+          visibleLabels: actionBarActions().map((action) => action.label),
+          primary: document.querySelector("#primary")?.getAttribute("aria-label") || "",
+          handExpanded: document.querySelector(".prompt")?.classList.contains("hand-expanded") === true,
+          cardsInspectable: [...document.querySelectorAll(".story-card-slot:not([hidden]) .cmd")]
+            .every((button) => !button.disabled),
+          turnActionsDisabled: [...document.querySelectorAll(".story-card-slot:not([hidden]) [data-hand-play], .story-card-slot:not([hidden]) [data-hand-discard]")]
+            .every((button) => button.disabled),
+          economy: document.querySelector("#economy")?.textContent?.trim().replace(/\s+/g, " ") || "",
+          guide: document.querySelector("#updates")?.textContent?.trim().replace(/\s+/g, " ") || "",
+          firstTale: state?.first_tale || null,
+          ledger: state?.ledger || {},
+        };
+      });
       assert(!afterFirstListen.isCurrentActor, `the second player should not acquire an ordered combat turn from their first Notice: ${JSON.stringify(afterFirstListen)}`);
       assert(
-        afterFirstListen.visibleLabels.length === 0,
-        `the newcomer should receive no bypass actions while another room participant acts: ${JSON.stringify(afterFirstListen)}`,
+        afterFirstListen.visibleLabels.length > 0
+          && afterFirstListen.handExpanded
+          && afterFirstListen.cardsInspectable
+          && afterFirstListen.turnActionsDisabled,
+        `the newcomer should be able to inspect their hand without bypassing another participant's turn: ${JSON.stringify(afterFirstListen)}`,
       );
       assert(
         !/earned one|\+1/i.test(afterFirstListen.economy)


### PR DESCRIPTION
## Summary
- keep the player’s Story Hand visible and expandable while another participant acts
- center and select the exact card that was clicked, including on narrow screens
- limit turns only to Play and Discard; inspection remains available
- collapse the hand after Play and show a thin “other turns” progress strip on the played card
- hide turn-lock controls instead of showing disabled buttons or a separate initiative bar
- add quiet shared activity lines such as “Marnie played scout” between chat messages
- keep card activity out of durable room memory
- bump the release to 1.0.112

## Void 002 chat analysis
- production AI readiness and persistence are healthy now
- the exact `~anthropic/claude-haiku-latest` route returned HTTP 200 and resolved to `anthropic/claude-haiku-4.5`
- the exact past failed request is no longer available because the durable production log group is missing and short Fly logs have rolled over
- the visible failure is consistent with the turn UI hiding or locking Chat; this PR removes that UI failure mode

## Validation
- complete pre-push `npm run check`
- browser smoke, including multiplayer held-hand inspection and subtle activity rows
- `npm test` (195 tests)
- full Rust suite (1,273 main tests plus library and integration targets)
- syntax, formatting, architecture, lint, version, kernel, and all world-pack checks
