### PR TITLE
Show turn activity on the played card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.112",
+  "version": "1.0.113",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.112",
+      "version": "1.0.113",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.112",
+  "version": "1.0.113",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.112"
+version = "1.0.113"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.112"
+version = "1.0.113"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -1596,24 +1596,6 @@
       color: var(--dim);
       font-style: italic;
     }
-    .line.story-card-activity {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.38em;
-      padding: 2px 0;
-      color: rgba(185, 184, 167, 0.58);
-      font: 650 10px/1.3 ui-sans-serif, system-ui, sans-serif;
-      letter-spacing: 0.045em;
-    }
-    .story-card-activity::before,
-    .story-card-activity::after {
-      content: "";
-      width: min(7vw, 38px);
-      height: 1px;
-      background: rgba(222, 194, 141, 0.12);
-    }
-    .story-card-activity-card { color: rgba(222, 194, 141, 0.68); }
     .chat-thinking-dots {
       display: inline-flex;
       gap: 4px;
@@ -5769,6 +5751,9 @@
       .story-card-actions .story-card-play.turn-progress::before {
         transition: none;
       }
+      .story-card-play .turn-progress-copy.turn-activity-live {
+        animation: none;
+      }
     }
     /* Combat is a live game state, not a kind of chat. Keep the immediate
        result beside the encounter and disclose the deeper ledger on demand. */
@@ -6234,8 +6219,23 @@
       transition: width 240ms ease;
     }
     .story-card-play .turn-progress-copy {
+      display: block;
+      max-width: 100%;
+      overflow: hidden;
       position: relative;
       z-index: 1;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .story-card-play .turn-progress-copy.turn-activity-live {
+      color: var(--slot-accent);
+      letter-spacing: 0.035em;
+      text-transform: none;
+      animation: turn-activity-live 2600ms ease-out both;
+    }
+    @keyframes turn-activity-live {
+      0%, 72% { opacity: 1; }
+      100% { opacity: 0; }
     }
     .story-card-actions button:hover,
     .story-card-actions button:focus-visible {
@@ -7053,6 +7053,8 @@
     let storyHandExpanded = false;
     let storyHandActiveKey = "";
     let heldStoryHand = null;
+    let storyHandTurnActivity = "";
+    let storyHandTurnActivityTimer = null;
     let storyHandScrollPending = false;
     let storyHandScrollFrame = null;
     let recoveryPromptPending = false;
@@ -11424,6 +11426,7 @@
       const pendingInteractionCountBefore = pendingModelInteractions.length;
       let chatProgressChanged = false;
       let modelInteractionProgressChanged = false;
+      let storyHandActivityChanged = false;
       for (const event of events) {
         if (captureDefeatTransition(event)) changed = true;
         if (applyActionReceipt(event)) {
@@ -11438,6 +11441,7 @@
         const authoritativeSeq = Number(event?.seq || 0);
         if (!event || eventIsMuted(event) || (authoritativeSeq > 0 && seenSeq.has(authoritativeSeq))) continue;
         if (authoritativeSeq > 0) seenSeq.add(authoritativeSeq);
+        if (presentStoryHandTurnActivity(event)) storyHandActivityChanged = true;
         if (resolvePendingChat(event)) {
           changed = true;
           chatProgressChanged = true;
@@ -11492,7 +11496,8 @@
       logEvents = logEvents.slice(-90);
       if (pendingChats.length !== pendingChatCountBefore
           || pendingModelInteractions.length !== pendingInteractionCountBefore
-          || chatProgressChanged || modelInteractionProgressChanged) renderCommands();
+          || chatProgressChanged || modelInteractionProgressChanged
+          || storyHandActivityChanged) renderCommands();
       renderJournalActivity();
       return changed;
     }
@@ -11976,7 +11981,6 @@
       "model_interaction.output",
       "avatar.thought",
       "avatar.dream",
-      "story.card.played",
     ]);
     const combatTranscriptEventTypes = new Set([
       "combat.encounter.started",
@@ -15070,7 +15074,7 @@
     }
 
     function eventIsChatTranscriptEvent(event) {
-      return ["message.created", "image.created", "model_interaction.output", "avatar.thought", "avatar.dream", "story.card.played"].includes(event?.type);
+      return ["message.created", "image.created", "model_interaction.output", "avatar.thought", "avatar.dream"].includes(event?.type);
     }
 
     function transcriptEventHtml(event) {
@@ -15078,16 +15082,8 @@
       if (event?.type === "image.created") return residentImageHtml(event);
       if (event?.type === "model_interaction.output") return modelInteractionOutputHtml(event);
       if (["avatar.thought", "avatar.dream"].includes(event?.type)) return avatarReflectionHtml(event);
-      if (event?.type === "story.card.played") return storyCardPlayedHtml(event);
       if (event?.type === "combat.attack.attempt") return combatAttackTranscriptBeatHtml(event);
       return sceneCardEventHtml(event);
-    }
-
-    function storyCardPlayedHtml(event) {
-      const actor = cleanStatusText(event?.actor_name || "Someone") || "Someone";
-      const card = cleanStatusText(event?.content || "a card").toLowerCase() || "a card";
-      const text = `${actor} played ${card}`;
-      return `<div class="line story-card-activity" aria-label="${escapeAttr(text)}"><span>${escapeHtml(actor)} played</span><span class="story-card-activity-card">${escapeHtml(card)}</span></div>`;
     }
 
     function combatAttackTranscriptBeatHtml(event) {
@@ -17687,6 +17683,7 @@
         Number(actorId || 0),
         ...((state?.turn?.waiting_actor_ids || []).map((id) => Number(id || 0))),
       ].filter(Boolean));
+      clearStoryHandTurnActivity();
       heldStoryHand = {
         actions: visibleActions.map((candidate) => ({
           ...candidate,
@@ -17700,12 +17697,33 @@
       storyHandActiveKey = "";
     }
 
+    function clearStoryHandTurnActivity() {
+      if (storyHandTurnActivityTimer) window.clearTimeout(storyHandTurnActivityTimer);
+      storyHandTurnActivityTimer = null;
+      storyHandTurnActivity = "";
+    }
+
+    function presentStoryHandTurnActivity(event) {
+      if (!heldStoryHand || event?.type !== "story.card.played") return false;
+      const actor = cleanStatusText(event.actor_name || "Someone") || "Someone";
+      const card = cleanStatusText(event.content || "a card").toLowerCase() || "a card";
+      storyHandTurnActivity = `${actor} played ${card}`;
+      if (storyHandTurnActivityTimer) window.clearTimeout(storyHandTurnActivityTimer);
+      storyHandTurnActivityTimer = window.setTimeout(() => {
+        storyHandTurnActivityTimer = null;
+        storyHandTurnActivity = "";
+        if (state) renderCommands();
+      }, 2600);
+      return true;
+    }
+
     function activeHeldStoryHandActions() {
       if (!heldStoryHand) return null;
       if (actionBusy || (state?.turn?.enabled && !state.turn.is_current_actor)) {
         return heldStoryHand.actions;
       }
       heldStoryHand = null;
+      clearStoryHandTurnActivity();
       return null;
     }
 
@@ -17724,7 +17742,8 @@
         percent,
         value: Math.min(total, Math.max(0, advanced)),
         max: total,
-        label: total > 1 ? "other turns…" : (actionSlow ? "still playing…" : "playing…"),
+        label: storyHandTurnActivity || (total > 1 ? "" : (actionSlow ? "still playing…" : "playing…")),
+        activity: Boolean(storyHandTurnActivity),
       };
     }
 
@@ -17824,9 +17843,10 @@
         play.disabled = !inline || waitingForTurn || Boolean(original.busy) || held || actionBusy;
         play.classList.toggle("turn-progress", Boolean(progress));
         if (progress) {
+          const progressAria = progress.label || "Waiting for the next turn";
           play.style.setProperty("--turn-progress", `${progress.percent}%`);
-          play.innerHTML = `<span class="turn-progress-copy" role="progressbar" aria-valuemin="0" aria-valuemax="${progress.max}" aria-valuenow="${progress.value}" aria-valuetext="${escapeAttr(progress.label)}">${escapeHtml(progress.label)}</span>`;
-          play.setAttribute("aria-label", `${progress.label} after playing ${title}`);
+          play.innerHTML = `<span class="turn-progress-copy${progress.activity ? " turn-activity-live" : ""}" role="progressbar" aria-valuemin="0" aria-valuemax="${progress.max}" aria-valuenow="${progress.value}" aria-valuetext="${escapeAttr(progressAria)}">${escapeHtml(progress.label)}</span>`;
+          play.setAttribute("aria-label", `${progressAria} after playing ${title}`);
         } else {
           play.style.removeProperty("--turn-progress");
           play.textContent = "Play";
@@ -18670,7 +18690,7 @@
           storyGuideLabel,
           count ? `suggestion ${count}` : "",
           action.busy ? "in progress" : "",
-          action.heldStoryHandAction ? "waiting for other turns" : "",
+          action.heldStoryHandAction ? "turn in progress" : "",
         ].filter(Boolean).join(", ")
       );
       // A journey travel card keeps the endpoint's Location art — the card is

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -37155,7 +37155,7 @@ mod tests {
             "log.innerHTML = `${visibleEvents.map(transcriptEventHtml).join(\"\")}${defeatScene}${observerScene}${pendingConversation}${pendingChatReplies}${pendingModelOutputs}`;"
         ));
         assert!(INDEX_HTML.contains(
-            "return [\"message.created\", \"image.created\", \"model_interaction.output\", \"avatar.thought\", \"avatar.dream\", \"story.card.played\"].includes(event?.type);"
+            "return [\"message.created\", \"image.created\", \"model_interaction.output\", \"avatar.thought\", \"avatar.dream\"].includes(event?.type);"
         ));
         assert!(INDEX_HTML.contains("function avatarReflectionHtml"));
         assert!(INDEX_HTML.contains("function transcriptEventHtml"));

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -873,6 +873,7 @@ async function main() {
         storyHandExpanded,
         storyHandActiveKey,
         heldStoryHand,
+        storyHandTurnActivity,
         announcedTurnHandoffKey,
         turnBannerControlRuns,
       };
@@ -975,12 +976,15 @@ async function main() {
         ];
         const activityTranscript = sharedRoomTranscriptEvents(activityEvents);
         const activityHtml = activityTranscript.map(transcriptEventHtml).join("");
-        const activityRow = transcriptEventHtml(activityEvents[1]);
+        const activityPresented = presentStoryHandTurnActivity(activityEvents[1]);
+        renderCommands();
+        const activityProgress = document.querySelector(".story-card-play.turn-progress");
         const activity = {
           order: activityTranscript.map((event) => event.type).join(","),
-          exactText: /Marnie played<\/span><span class="story-card-activity-card">scout<\/span>/.test(activityHtml),
-          subtleRow: activityHtml.includes('class="line story-card-activity"'),
-          noAvatar: !activityRow.includes("chat-pfp"),
+          presented: activityPresented,
+          onCardText: activityProgress?.textContent.trim() || "",
+          live: activityProgress?.querySelector(".turn-activity-live") !== null,
+          notInChat: !activityHtml.includes("played scout"),
           notRoomMemory: roomMemoryEntryForEvent(activityEvents[1]) === null,
         };
         return { skipped: false, visibleCount: visible.length, busy, waiting, activity };
@@ -1000,6 +1004,8 @@ async function main() {
         storyHandExpanded = previous.storyHandExpanded;
         storyHandActiveKey = previous.storyHandActiveKey;
         heldStoryHand = previous.heldStoryHand;
+        clearStoryHandTurnActivity();
+        storyHandTurnActivity = previous.storyHandTurnActivity;
         announcedTurnHandoffKey = previous.announcedTurnHandoffKey;
         turnBannerControlRuns = previous.turnBannerControlRuns;
         render();
@@ -1009,7 +1015,7 @@ async function main() {
       !result.skipped
         && result.busy.cards === result.visibleCount
         && !result.busy.expanded
-        && result.busy.progressText === "other turns…"
+        && result.busy.progressText === ""
         && result.busy.progressClass
         && result.busy.progressVisible
         && result.busy.progressValue === "0"
@@ -1021,7 +1027,7 @@ async function main() {
         && result.busy.statusPosition === "absolute"
         && result.waiting.cards === result.visibleCount
         && result.waiting.expanded
-        && result.waiting.progressText === "other turns…"
+        && result.waiting.progressText === ""
         && result.waiting.progressValue === "1"
         && result.waiting.progressWidth === "33%"
         && result.waiting.handStatus === `${result.visibleCount} cards`
@@ -1033,12 +1039,13 @@ async function main() {
         && result.waiting.selectedCardInView
         && result.waiting.selectedSlot === "tertiary"
         && result.waiting.bannerHidden
-        && result.activity.order === "message.created,story.card.played,message.created"
-        && result.activity.exactText
-        && result.activity.subtleRow
-        && result.activity.noAvatar
+        && result.activity.order === "message.created,message.created"
+        && result.activity.presented
+        && result.activity.onCardText === "Marnie played scout"
+        && result.activity.live
+        && result.activity.notInChat
         && result.activity.notRoomMemory,
-      `playing a card should collapse the hand, hide turn locks, keep inspection available, and add subtle card activity to chat: ${JSON.stringify(result)}`,
+      `playing a card should collapse the hand, hide turn locks, keep inspection available, and show card activity on its progress strip: ${JSON.stringify(result)}`,
     );
     steps.push({
       label: "played hand collapses with subtle turn progress",
@@ -12186,17 +12193,15 @@ async function main() {
         nonChatRows: rows.filter((node) => (
           node.classList.contains("line")
             && !node.classList.contains("chat")
-            && !node.classList.contains("story-card-activity")
         )).length,
-        cardActivity: [...document.querySelectorAll("#log .story-card-activity")]
-          .map((node) => node.textContent.trim().replace(/\s+/g, " ")),
+        cardPlayed: newEvents.some((event) => event.type === "story.card.played"),
       };
     }, noticeBefore);
     assert(
       scene.eventRows === 0
         && scene.nonChatRows === 0
-        && scene.cardActivity.some((line) => /played\s*notice$/i.test(line)),
-      `Notice outcomes should stay out of group chat except for the subtle played-card line: ${JSON.stringify(scene)}`,
+        && scene.cardPlayed,
+      `Notice outcomes and card-play receipts should stay out of group chat: ${JSON.stringify(scene)}`,
     );
     assert(
       scene.observed === true
@@ -13938,11 +13943,10 @@ async function main() {
         transcriptVisible: visible(document.querySelector("#log")),
         promptVisible: visible(document.querySelector("footer.prompt")),
         chatRows: document.querySelectorAll("#log .line.chat").length,
-        activityRows: document.querySelectorAll("#log .story-card-activity").length,
         roomRows: document.querySelectorAll("#log .line.event.room").length,
         sceneRows: document.querySelectorAll("#log .line.event.scene-card, #log .roll-line").length,
         quietScene: document.querySelectorAll("#log .chat-empty").length,
-        unexpectedRows: document.querySelectorAll("#log .line:not(.chat):not(.event.room):not(.scene-card):not(.story-card-activity)").length,
+        unexpectedRows: document.querySelectorAll("#log .line:not(.chat):not(.event.room):not(.scene-card)").length,
         stateSignature: JSON.stringify({
           sharedQuestions: state?.shared_questions,
           roomMemory: state?.room_memory,
@@ -13964,8 +13968,8 @@ async function main() {
     assert(room.heroVisible && room.transcriptVisible && room.promptVisible, `${label}: room mode should show location, chat, and actions: ${JSON.stringify(room)}`);
     assert(room.unexpectedRows === 0 && room.roomRows === 0 && room.sceneRows === 0, `${label}: normal chat should keep system chrome out of the transcript: ${JSON.stringify(room)}`);
     assert(
-      room.chatRows > 0 || room.activityRows > 0 || room.quietScene === 1,
-      `${label}: the room should show speech, subtle card activity, or a single quiet chat invitation: ${JSON.stringify(room)}`,
+      room.chatRows > 0 || room.quietScene === 1,
+      `${label}: the room should show speech or a single quiet chat invitation: ${JSON.stringify(room)}`,
     );
 
     const emptyTicker = await page.evaluate(() => {
@@ -14253,7 +14257,6 @@ async function main() {
         logRole: document.querySelector("#log")?.getAttribute("role") || "",
         lineCount: document.querySelectorAll("#log .line").length,
         chatLineCount: document.querySelectorAll("#log .line.chat").length,
-        activityLineCount: document.querySelectorAll("#log .story-card-activity").length,
         roomLineCount: document.querySelectorAll("#log .line.event.room").length,
         sceneLineCount: document.querySelectorAll("#log .line.event.scene-card").length,
         chatFailureSceneCount: [...document.querySelectorAll("#log .line.event.scene-card")]
@@ -14262,7 +14265,7 @@ async function main() {
         roomFallbackStacked: !roomRow || Boolean(roomLabelRect && roomTextRect && roomLabelRect.bottom <= roomTextRect.top + 1),
         roomFallbackClipped: Boolean(roomText && roomText.scrollHeight > roomText.clientHeight + 1),
         speakerClippedCount,
-        unexpectedLineCount: document.querySelectorAll("#log .line:not(.chat):not(.event.room):not(.scene-card):not(.story-card-activity)").length,
+        unexpectedLineCount: document.querySelectorAll("#log .line:not(.chat):not(.event.room):not(.scene-card)").length,
         legacyListChromeCount: document.querySelectorAll("#route-map,#presence,#features,.route-node,.chip,.feature-pill").length,
         avatarRailCount: document.querySelectorAll(".room-avatar-pfp").length,
         handThumbCount: document.querySelectorAll("footer.prompt .thumb").length,
@@ -14294,8 +14297,8 @@ async function main() {
         && shell.rollLineCount === 0
         && shell.sceneLineCount === 0
         && shell.chatFailureSceneCount === 0
-        && shell.lineCount === shell.chatLineCount + shell.activityLineCount,
-      `${label}: group chat should contain speech and subtle card activity, with no system rows: ${JSON.stringify(shell)}`,
+        && shell.lineCount === shell.chatLineCount,
+      `${label}: group chat should contain speech with no system rows: ${JSON.stringify(shell)}`,
     );
     assert(shell.unexpectedLineCount === 0, `${label}: normal feed should not show bookkeeping rows: ${JSON.stringify(shell)}`);
     assert(shell.legacyListChromeCount === 0, `${label}: inline item/location/avatar lists should be absent: ${JSON.stringify(shell)}`);


### PR DESCRIPTION
## What changed
- remove played-card notices from the shared chat transcript
- briefly show each live card play in the played card's progress strip
- keep the progress strip quiet between turns and preserve screen-reader status
- bump the app to 1.0.113

## Checks
- npm run check
- npm run v2:browser:check
- live visual check at desktop size