### PR TITLE
Keep card activity visible until replaced

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.113",
+  "version": "1.0.114",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.113",
+      "version": "1.0.114",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.113",
+  "version": "1.0.114",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.113"
+version = "1.0.114"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.113"
+version = "1.0.114"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -5751,9 +5751,6 @@
       .story-card-actions .story-card-play.turn-progress::before {
         transition: none;
       }
-      .story-card-play .turn-progress-copy.turn-activity-live {
-        animation: none;
-      }
     }
     /* Combat is a live game state, not a kind of chat. Keep the immediate
        result beside the encounter and disclose the deeper ledger on demand. */
@@ -6231,11 +6228,6 @@
       color: var(--slot-accent);
       letter-spacing: 0.035em;
       text-transform: none;
-      animation: turn-activity-live 2600ms ease-out both;
-    }
-    @keyframes turn-activity-live {
-      0%, 72% { opacity: 1; }
-      100% { opacity: 0; }
     }
     .story-card-actions button:hover,
     .story-card-actions button:focus-visible {
@@ -7054,7 +7046,6 @@
     let storyHandActiveKey = "";
     let heldStoryHand = null;
     let storyHandTurnActivity = "";
-    let storyHandTurnActivityTimer = null;
     let storyHandScrollPending = false;
     let storyHandScrollFrame = null;
     let recoveryPromptPending = false;
@@ -17698,8 +17689,6 @@
     }
 
     function clearStoryHandTurnActivity() {
-      if (storyHandTurnActivityTimer) window.clearTimeout(storyHandTurnActivityTimer);
-      storyHandTurnActivityTimer = null;
       storyHandTurnActivity = "";
     }
 
@@ -17708,12 +17697,6 @@
       const actor = cleanStatusText(event.actor_name || "Someone") || "Someone";
       const card = cleanStatusText(event.content || "a card").toLowerCase() || "a card";
       storyHandTurnActivity = `${actor} played ${card}`;
-      if (storyHandTurnActivityTimer) window.clearTimeout(storyHandTurnActivityTimer);
-      storyHandTurnActivityTimer = window.setTimeout(() => {
-        storyHandTurnActivityTimer = null;
-        storyHandTurnActivity = "";
-        if (state) renderCommands();
-      }, 2600);
       return true;
     }
 

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -984,9 +984,26 @@ async function main() {
           presented: activityPresented,
           onCardText: activityProgress?.textContent.trim() || "",
           live: activityProgress?.querySelector(".turn-activity-live") !== null,
+          timerFree: !presentStoryHandTurnActivity.toString().includes("setTimeout"),
           notInChat: !activityHtml.includes("played scout"),
           notRoomMemory: roomMemoryEntryForEvent(activityEvents[1]) === null,
         };
+        activity.unrelatedPresented = presentStoryHandTurnActivity(activityEvents[2]);
+        renderCommands();
+        const persistentProgress = document.querySelector(".story-card-play.turn-progress");
+        activity.persistentText = persistentProgress?.textContent.trim() || "";
+        const replacementPresented = presentStoryHandTurnActivity({
+          type: "story.card.played",
+          seq: 104,
+          actor_id: 9002,
+          actor_name: "Ruby",
+          location_id: state.location?.id,
+          content: "notice",
+        });
+        renderCommands();
+        const replacementProgress = document.querySelector(".story-card-play.turn-progress");
+        activity.replacementPresented = replacementPresented;
+        activity.replacementText = replacementProgress?.textContent.trim() || "";
         return { skipped: false, visibleCount: visible.length, busy, waiting, activity };
       } finally {
         state = previous.state;
@@ -1043,9 +1060,14 @@ async function main() {
         && result.activity.presented
         && result.activity.onCardText === "Marnie played scout"
         && result.activity.live
+        && result.activity.timerFree
+        && !result.activity.unrelatedPresented
+        && result.activity.persistentText === "Marnie played scout"
+        && result.activity.replacementPresented
+        && result.activity.replacementText === "Ruby played notice"
         && result.activity.notInChat
         && result.activity.notRoomMemory,
-      `playing a card should collapse the hand, hide turn locks, keep inspection available, and show card activity on its progress strip: ${JSON.stringify(result)}`,
+      `playing a card should collapse the hand, hide turn locks, keep inspection available, and keep card activity on its progress strip until the next play: ${JSON.stringify(result)}`,
     );
     steps.push({
       label: "played hand collapses with subtle turn progress",


### PR DESCRIPTION
## Summary
- remove the card activity timeout and fade
- keep the last played-card notice visible until another card play replaces it
- add browser coverage for persistence, unrelated chat, and replacement

## Checks
- npm run v2:browser:check
- npm test
- npm run v2:architecture
- npm run check