### PR TITLE
Keep pathway discovery narration from claiming departure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.115",
+  "version": "1.0.116",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.115",
+      "version": "1.0.116",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.115",
+  "version": "1.0.116",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.115"
+version = "1.0.116"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.115"
+version = "1.0.116"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -664,6 +664,10 @@ struct JourneyNarrationPlan {
     current_step: usize,
     total_steps: usize,
     discovery: bool,
+    /// True only when the planned action actually moves the actor this turn.
+    /// Pathway discovery plans a route without moving, so its narration must
+    /// never claim the actor has already left.
+    moved: bool,
 }
 
 const JOB_CONTRIBUTION_SCHEMA_VERSION: u8 = 1;
@@ -11328,6 +11332,7 @@ impl RuntimeWorld {
                         1
                     },
                     discovery: false,
+                    moved: true,
                 };
                 return Ok(Some((
                     CwAction {
@@ -11382,6 +11387,7 @@ impl RuntimeWorld {
                 current_step: next_step,
                 total_steps: current.path.len().saturating_sub(1),
                 discovery: false,
+                moved: true,
             };
             return Ok(Some((
                 CwAction {
@@ -11467,6 +11473,7 @@ impl RuntimeWorld {
                         current_step: 1,
                         total_steps: path.len().saturating_sub(1),
                         discovery: false,
+                        moved: true,
                     },
                 )));
             }
@@ -11530,6 +11537,7 @@ impl RuntimeWorld {
             current_step: 1,
             total_steps: path.len().saturating_sub(1),
             discovery: discovering_pathway,
+            moved: false,
         };
         Ok((
             CwAction {
@@ -11595,6 +11603,7 @@ impl RuntimeWorld {
             current_step: next_step,
             total_steps: current.path.len().saturating_sub(1),
             discovery: true,
+            moved: false,
         };
         Ok((
             CwAction {
@@ -22930,34 +22939,6 @@ fn trim_to_chars(value: &str, max_chars: usize) -> String {
         .collect::<String>();
     out.push('…');
     out
-}
-
-fn travel_narration_fallback(plan: &JourneyNarrationPlan) -> String {
-    if plan.current_step >= plan.total_steps {
-        return format!(
-            "The last turn of the path gives way, and {} arrives in {}.",
-            plan.actor_name, plan.destination_name
-        );
-    }
-    if plan.discovery {
-        return format!(
-            "{} reads the ground beyond {}. A way into {} takes shape, one usable landmark at a time.",
-            plan.actor_name, plan.from_name, plan.to_name
-        );
-    }
-    format!(
-        "{} leaves {} behind. The path gathers itself around {}, with {} turn{} still between here and {}.",
-        plan.actor_name,
-        plan.from_name,
-        plan.to_name,
-        plan.total_steps.saturating_sub(plan.current_step),
-        if plan.total_steps.saturating_sub(plan.current_step) == 1 {
-            ""
-        } else {
-            "s"
-        },
-        plan.destination_name
-    )
 }
 
 async fn generate_hidden_pathway_content(

--- a/v2/orchestrator-rust/src/topology.rs
+++ b/v2/orchestrator-rust/src/topology.rs
@@ -211,6 +211,51 @@ impl RouteRecordState {
     }
 }
 
+/// Deterministic narration for a planned journey transition. The `moved`
+/// flag distinguishes a route that was only charted or revealed (no actor
+/// movement) from an actual travel step: discovery narration must never
+/// claim the actor has already left, because room memory feeds this copy to
+/// later AI prompts as world state.
+pub(crate) fn travel_narration_fallback(plan: &JourneyNarrationPlan) -> String {
+    let remaining_turns = plan.total_steps.saturating_sub(plan.current_step);
+    let turn_word = if remaining_turns == 1 { "" } else { "s" };
+    if plan.current_step >= plan.total_steps {
+        return format!(
+            "The last turn of the path gives way, and {} arrives in {}.",
+            plan.actor_name, plan.destination_name
+        );
+    }
+    if plan.discovery {
+        return format!(
+        "{} reads the ground beyond {}. A way into {} takes shape, one usable landmark at a time.",
+        plan.actor_name, plan.from_name, plan.to_name
+    );
+    }
+    if !plan.moved {
+        // The action only plans or reveals the route; the actor has not moved
+        // yet. Narrate the charted way without claiming a completed departure,
+        // so room memory never reports the actor as already gone.
+        return format!(
+            "{} charts a way from {} toward {}, with {} turn{} still between here and {}.",
+            plan.actor_name,
+            plan.from_name,
+            plan.to_name,
+            remaining_turns,
+            turn_word,
+            plan.destination_name
+        );
+    }
+    format!(
+    "{} leaves {} behind. The path gathers itself around {}, with {} turn{} still between here and {}.",
+    plan.actor_name,
+    plan.from_name,
+    plan.to_name,
+    remaining_turns,
+    turn_word,
+    plan.destination_name
+)
+}
+
 impl RuntimeWorld {
     pub(super) fn restore_canonical_topology_for_snapshot(
         &mut self,
@@ -1861,6 +1906,7 @@ impl RuntimeWorld {
                 current_step: 1,
                 total_steps: 1,
                 discovery: true,
+                moved: false,
             },
         ))
     }
@@ -2628,6 +2674,46 @@ impl RuntimeWorld {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{travel_narration_fallback, JourneyNarrationPlan};
+
+    /// Regression guard for the Void 004 wrong-world-state incident: a
+    /// `pathway.discovered` event whose narration said the actor had already
+    /// "left" kept entering room memory and every later chat prompt, so model
+    /// avatars were told they were "three turns gone" while still standing in
+    /// the room. Discovery plans a route; it never moves anyone.
+    #[test]
+    fn pathway_discovery_narration_never_claims_departure() {
+        let plan = |discovery: bool, moved: bool, current_step: usize| JourneyNarrationPlan {
+            actor_name: "Claude".to_string(),
+            from_name: "Void 004".to_string(),
+            to_name: "Warm Rowan Verge".to_string(),
+            destination_name: "Void 002".to_string(),
+            current_step,
+            total_steps: 4,
+            discovery,
+            moved,
+        };
+
+        // A re-used pathway on journey start: no movement happened.
+        let charted = travel_narration_fallback(&plan(false, false, 1));
+        assert!(charted.contains("charts a way from Void 004 toward Warm Rowan Verge"));
+        assert!(!charted.contains("leaves Void 004 behind"));
+        assert!(charted.contains("3 turns still between here and Void 002"));
+
+        // A fresh hidden-pathway discovery also does not move the actor.
+        let discovered = travel_narration_fallback(&plan(true, false, 1));
+        assert!(discovered.contains("reads the ground beyond Void 004"));
+        assert!(!discovered.contains("leaves"));
+
+        // An actual mid-journey step may keep the departure phrasing.
+        let progressed = travel_narration_fallback(&plan(false, true, 2));
+        assert!(progressed.contains("leaves Void 004 behind"));
+        assert!(progressed.contains("2 turns still between here and Void 002"));
+
+        // Arrival copy is unchanged.
+        let arrived = travel_narration_fallback(&plan(false, true, 4));
+        assert!(arrived.contains("arrives in Void 002"));
+    }
 
     fn lock_first_authored_route_edge(runtime: &mut RuntimeWorld) -> (String, u64, u64, u64) {
         let (route_id, from_location_id, to_location_id) = runtime


### PR DESCRIPTION
## Summary

Model avatars in Void 004 kept insisting the room told them they were
already "three turns gone" toward Warm Rowan Verge while still standing
in the room. The journal shows why: a `pathway.discovered` event whose
journey plan re-used an existing pathway (`discovery: false`) fell
through to the mid-journey narration fallback and emitted
"`<actor>` leaves `<room>` behind" — a departure claim on an action
(`CW_ACTION_NONE`) where nobody moved.

That event type is whitelisted into AI chat prompts by
`recent_room_consequences`, so in a quiet private cell the false line
stayed inside the prompt's recent-evidence window for hours and every
chat turn re-asserted it.

`JourneyNarrationPlan` now carries an explicit `moved` flag, set only
on planner branches whose action actually moves the actor (journey
progression, adjacent pathway start, backtrack/pause step). When no
movement happened, discovery narration now says the actor *charts* a way
toward the destination with N turns still between here and there — plan
language, not accomplished fact. Real journey steps keep the existing
departure phrasing; arrival copy is unchanged.

The fallback narration helper and its regression test move beside the
route seam they narrate in `topology.rs`; `main.rs` stays under its
line ceiling without raising it.

No journal semantics change: action codes, event types, and replay
behavior are untouched. Only projected narration copy differs for
non-moving discovery actions.

## Validation

- `npm run v2:rust:test`: all suites pass (1275 orchestrator tests, 0
  failed); `cargo fmt --check` clean.
- New regression test
  `pathway_discovery_narration_never_claims_departure` covers all four
  fallback branches (charted-but-not-moved, hidden discovery,
  mid-journey progression, arrival).
- `main.rs` at 59923 lines against the 59942 ceiling; the narration
  helper moved to `topology.rs` rather than raising the ceiling.
- `npm run check:version` passes after `npm run version:bump`
  (1.0.115 → 1.0.116).
- `git diff --check` clean.

## Review checklist

- [x] Narrow change: narration planning only, no unrelated churn
- [x] No new system in main.rs; helper moved to its owning route seam
- [x] No generated artifacts touched (`v2/content/official/**`, lockfiles)
- [x] No secrets or runtime data in the diff
- [x] Version bumped across package.json, package-lock.json, Cargo.toml, Cargo.lock