### PR TITLE
Render the authored first-tale public trace in room memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.120",
+  "version": "1.0.121",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.120",
+      "version": "1.0.121",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.120",
+  "version": "1.0.121",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.120"
+version = "1.0.121"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.120"
+version = "1.0.121"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/room_memory.rs
+++ b/v2/orchestrator-rust/src/room_memory.rs
@@ -491,9 +491,18 @@ pub(super) fn room_memory_log_text_at_location(
         | "pathway.familiarized" => event.content.clone().unwrap_or_else(|| {
             format!("{actor_name} carries the path a little farther into the world")
         }),
-        "first_tale.public_trace" => format!(
-            "{actor_name} marked the first uncovered stone so the next visitor can trust the washed path"
-        ),
+        "first_tale.public_trace" => {
+            // The trace copy is authored per worldpack (project89 records a
+            // covenant, not a garden stone). Render the authored content so
+            // room memory never describes a tale the pack does not contain.
+            let trace = event
+                .content
+                .as_deref()
+                .map(str::trim)
+                .filter(|content| !content.is_empty())
+                .unwrap_or("left an authored public trace");
+            format!("{actor_name} {trace}")
+        }
         "natural_feature.revealed" => {
             let feature = event
                 .content
@@ -1427,6 +1436,47 @@ impl crate::RuntimeWorld {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression guard for the wrong-world-state class found beside the Void
+    /// 004 pathway narration bug: the public-trace room-memory line hardcoded
+    /// the core pack's washed-garden copy, so a worldpack that authors its own
+    /// trace (project89 records a liberation covenant) would report a tale its
+    /// world does not contain. The rendered line must be the authored copy.
+    #[test]
+    fn first_tale_public_trace_renders_the_authored_pack_copy() {
+        let trace = |content: Option<&str>| EventView {
+            seq: 9,
+            type_name: "first_tale.public_trace".to_string(),
+            success: true,
+            actor_name: Some("Rati".to_string()),
+            location_id: Some(COSY_COTTAGE_LOCATION_ID),
+            content: content.map(str::to_string),
+            ..EventView::default()
+        };
+
+        // A pack-authored trace renders that pack's words, not the core
+        // pack's garden stone.
+        let covenant = room_memory_log_text(&trace(Some(
+            "recorded an attributed liberation covenant so the next independent actor can audit the changed convergence protocol",
+        )))
+        .expect("authored trace becomes room memory");
+        assert!(covenant.contains("recorded an attributed liberation covenant"));
+        assert!(!covenant.contains("washed path"));
+        assert!(covenant.contains("Rati recorded"));
+
+        // The core pack's own trace still reads as before.
+        let garden = room_memory_log_text(&trace(Some(
+            "marked the first uncovered stone so the next visitor can trust the washed path",
+        )))
+        .expect("core trace becomes room memory");
+        assert!(garden.contains("marked the first uncovered stone"));
+
+        // Missing authored copy falls back to a truthful generic line.
+        let fallback =
+            room_memory_log_text(&trace(None)).expect("empty trace still becomes room memory");
+        assert!(fallback.contains("left an authored public trace"));
+        assert!(!fallback.contains("washed path"));
+    }
 
     #[test]
     fn failures_back_off_and_expired_retries_reopen() {


### PR DESCRIPTION
## Summary

Follow-up to the Void 004 pathway narration fix (#912), from an audit of
every event type whitelisted into AI room-memory evidence
(`recent_room_consequences`).

`room_memory_log_text_at_location` hardcoded the core pack's washed-
garden copy for `first_tale.public_trace`:

> `${actor} marked the first uncovered stone so the next visitor can trust the washed path`

But the event's content is authored per worldpack. Project 89 — live as
Lonely Forest tenant `89` (`89.lonelyforest.com`) — authors its own
trace: *"recorded an attributed liberation covenant so the next
independent actor can audit the changed convergence protocol"*. Anyone
completing Operation Liberation there would put a false garden-stone
tale into room memory and every subsequent AI chat prompt, in a world
with no washed garden. Same wrong-world-state class as #912, just
dormant because nobody has finished that tale on tenant 89 yet.

The renderer now uses the authored event content (already stored
verbatim by the projection) with the same `${actor} ${trace}` grammar,
falling back to a truthful generic line if authored copy is ever empty.
All seven other whitelisted types were audited and describe genuine
committed mutations; no copy changes needed for them.

## Validation

- `npm run v2:rust:test`: all suites pass (1284 orchestrator tests, 0
  failed); `cargo fmt --check` clean.
- New regression test
  `first_tale_public_trace_renders_the_authored_pack_copy` pins the
  project89 covenant rendering, the core pack's unchanged garden line,
  and the missing-copy fallback.
- `main.rs` untouched on this branch (59955 vs 59974 ceiling).
- `npm run check:version` passes after `npm run version:bump`
  (1.0.116 → 1.0.117).
- `git diff --check` clean.

## Review checklist

- [x] Narrow change: one render branch plus its regression test
- [x] No journal semantics change; replay untouched
- [x] No generated artifacts or lockfile churn beyond the version bump
- [x] Version bumped across package.json, package-lock.json, Cargo.toml, Cargo.lock