### PR TITLE
Keep campaign class card visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.123",
+  "version": "1.0.124",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.123",
+      "version": "1.0.124",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.123",
+  "version": "1.0.124",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/two-action-hand.test.mjs
+++ b/test/v2/two-action-hand.test.mjs
@@ -67,6 +67,22 @@ describe("three-slot Story Hand", () => {
     expect(browser).toContain('scoutAction.selectedPayload = () => ({');
   });
 
+  it("keeps the pending campaign Class card visible outside ranked action offers", () => {
+    const classSelectionBlock = browser.slice(
+      browser.indexOf("if (characterIdentity?.class_selection_ready"),
+      browser.indexOf("const turn = view.turn || {}"),
+    );
+    const handOrderBlock = browser.slice(
+      browser.indexOf("function orderedActionIndexesForHand"),
+      browser.indexOf("function handCapacity"),
+    );
+
+    expect(classSelectionBlock).toContain('kind: "choose-class"');
+    expect(classSelectionBlock).toContain("standaloneHandProjection: true");
+    expect(handOrderBlock).toContain("actions[index]?.standaloneHandProjection === true");
+    expect(handOrderBlock).toContain("if (standaloneIndexes.length) return standaloneIndexes;");
+  });
+
   it("shows Travel and the destination without route-type copy in the hand", () => {
     const routeBlock = browser.slice(
       browser.indexOf("const projectedRouteOfferIds"),

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.123"
+version = "1.0.124"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.123"
+version = "1.0.124"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -8416,6 +8416,10 @@
             detail: "optional rules for this campaign",
             command: "choose campaign class",
             focusKey: "choose-class",
+            // Class selection is validated by its own server endpoint rather
+            // than represented by a ranked action offer. Keep this one
+            // progression card visible while the choice is pending.
+            standaloneHandProjection: true,
             card: cardForActor(actorId),
             shape: "avatar",
             modalTitle: creationProfile.class_prompt || "which campaign path will you use?",
@@ -18365,6 +18369,10 @@
     function orderedActionIndexesForHand() {
       const indexes = actions.map((_, index) => index);
       if (state?.branch) return indexes;
+      const standaloneIndexes = indexes.filter((index) => (
+        actions[index]?.standaloneHandProjection === true
+      ));
+      if (standaloneIndexes.length) return standaloneIndexes;
       const ordered = [];
       const chosen = new Set();
       const authoritativeEntries = state?.action_hand?.entries || [];


### PR DESCRIPTION
Fix the empty hand shown when an avatar must choose a campaign class. Standalone class-selection cards now stay visible even though they do not have a server offer ID. Includes a regression test and bumps the app version to 1.0.124.\n\nChecks: full npm check passed, including 205 JavaScript tests and 1,287 Rust tests.