### PR TITLE
Prompt avatars to describe their own appearance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.126",
+  "version": "1.0.127",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.126",
+      "version": "1.0.127",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.126",
+  "version": "1.0.127",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.126"
+version = "1.0.127"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.126"
+version = "1.0.127"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/avatar_reflections.rs
+++ b/v2/orchestrator-rust/src/avatar_reflections.rs
@@ -11,8 +11,6 @@ const LOCATION_SELF_DESCRIPTION_PROMPT_VERSION: &str = "location-self-descriptio
 // publish; 48 words leaves room for ordinary word lengths and punctuation.
 const SELF_DESCRIPTION_MAX_WORDS: usize = 48;
 const SELF_DESCRIPTION_MAX_TOKENS: u32 = 128;
-pub(super) const AVATAR_APPEARANCE_MIN_CHARS: usize = 16;
-pub(super) const AVATAR_APPEARANCE_MAX_CHARS: usize = 360;
 pub(super) const AVATAR_REFLECTION_DC: u16 = 18;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -28,11 +26,13 @@ pub(super) struct AvatarSelfDescriptionProjection {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct DescribeAvatarAppearanceRequest {
     pub(super) actor_id: u64,
     pub(super) actor_session: Option<String>,
+    #[serde(rename = "wallet_session")]
+    pub(super) _wallet_session: Option<String>,
     pub(super) subject_actor_id: u64,
-    pub(super) appearance: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -316,68 +316,9 @@ impl RuntimeWorld {
             Some(projection.observed_through_seq),
         ))
     }
-
-    pub(super) fn manual_avatar_level_identity(
-        &self,
-        actor_id: u64,
-        appearance: &str,
-    ) -> Option<AvatarLevelIdentity> {
-        let actor = self.actor_by_id(actor_id)?;
-        let meta = self.actors.get(&actor_id)?;
-        let prior = self
-            .latest_avatar_level_identity(actor_id)
-            .unwrap_or_default();
-        let policy = self.avatar_identity_policy(actor_id).unwrap_or_default();
-        let persona = [
-            prior.persona.as_str(),
-            policy.persona.as_str(),
-            meta.description.as_str(),
-        ]
-        .into_iter()
-        .find(|value| !value.trim().is_empty())
-        .map(compact_whitespace)
-        .unwrap_or_else(|| "I am still finding my place in this world.".to_string());
-        let calling = self
-            .calling_view(actor_id)
-            .map(|calling| calling.statement)
-            .unwrap_or_default();
-        let continuity = [
-            prior.continuity.as_str(),
-            calling.as_str(),
-            policy.canonical_description.as_str(),
-        ]
-        .into_iter()
-        .find(|value| !value.trim().is_empty())
-        .map(compact_whitespace)
-        .unwrap_or_else(|| {
-            format!(
-                "I remain {} at level {}.",
-                grounded_avatar_name_for_prompt(actor_id, &meta.name),
-                actor.stats.level.max(1)
-            )
-        });
-        Some(AvatarLevelIdentity {
-            persona,
-            appearance: appearance.to_string(),
-            continuity,
-        })
-    }
 }
 
-pub(super) fn normalize_avatar_appearance(value: &str) -> Option<String> {
-    if has_disallowed_control_character(value) {
-        return None;
-    }
-    let normalized = compact_whitespace(value);
-    let count = normalized.chars().count();
-    ((AVATAR_APPEARANCE_MIN_CHARS..=AVATAR_APPEARANCE_MAX_CHARS).contains(&count)
-        && human_message_is_cozy_safe(&normalized)
-        && normalized
-            .chars()
-            .any(|character| character.is_alphanumeric()))
-    .then_some(normalized)
-}
-
+#[cfg(test)]
 pub(super) fn avatar_level_identity_content(identity: &AvatarLevelIdentity) -> String {
     format!(
         "PERSONA: {}\nAPPEARANCE: {}\nCONTINUITY: {}",
@@ -400,7 +341,7 @@ pub(super) async fn describe_avatar_appearance(
         return action_rate_limited_response();
     }
 
-    let (appearance_action, level, location_id, identity, self_description_job) = {
+    let self_description_job = {
         let runtime = state.inner.lock().await;
         if !client_actor_authorized_for_state(
             &runtime,
@@ -444,7 +385,7 @@ pub(super) async fn describe_avatar_appearance(
                 events: Vec::new(),
             });
         }
-        let Some(appearance_action) = runtime.avatar_appearance_action(
+        let Some("self_authored") = runtime.avatar_appearance_action(
             payload.subject_actor_id,
             level,
             Some(payload.actor_id),
@@ -455,146 +396,34 @@ pub(super) async fn describe_avatar_appearance(
                 events: Vec::new(),
             });
         };
-        let identity = if appearance_action == "write" {
-            let Some(appearance) = payload
-                .appearance
-                .as_deref()
-                .and_then(normalize_avatar_appearance)
-            else {
-                return Json(ActionResponse {
-                    ok: false,
-                    status: 400,
-                    events: Vec::new(),
-                });
-            };
-            runtime.manual_avatar_level_identity(payload.subject_actor_id, &appearance)
-        } else {
-            if payload
-                .appearance
-                .as_deref()
-                .is_some_and(|value| !value.trim().is_empty())
-            {
-                return Json(ActionResponse {
-                    ok: false,
-                    status: 400,
-                    events: Vec::new(),
-                });
-            }
-            None
-        };
-        let self_description_job = (appearance_action == "self_authored")
-            .then(|| {
-                runtime
-                    .avatar_reflection_job(payload.subject_actor_id, AvatarReflectionKind::Thought)
-            })
-            .flatten();
-        (
-            appearance_action,
-            level,
-            subject.location_id,
-            identity,
-            self_description_job,
-        )
+        runtime.avatar_reflection_job(payload.subject_actor_id, AvatarReflectionKind::Thought)
     };
 
-    if appearance_action == "self_authored" {
-        let Some(job) = self_description_job else {
-            return Json(ActionResponse {
-                ok: false,
-                status: 409,
-                events: Vec::new(),
-            });
-        };
-        if let Some(path) = state.event_store_path.as_deref() {
-            let queued = open_event_store(path)
-                .and_then(|conn| insert_avatar_self_description_job(&conn, &job));
-            if queued.is_err() {
-                return Json(ActionResponse {
-                    ok: false,
-                    status: 500,
-                    events: Vec::new(),
-                });
-            }
-            state.actor_job_notify.notify_waiters();
-        } else {
-            schedule_avatar_self_description(&state, job);
-        }
-        return Json(ActionResponse {
-            ok: true,
-            status: CW_OK,
-            events: Vec::new(),
-        });
-    }
-
-    let Some(identity) = identity else {
+    let Some(job) = self_description_job else {
         return Json(ActionResponse {
             ok: false,
-            status: 400,
+            status: 409,
             events: Vec::new(),
         });
     };
-    let events = {
-        let mut runtime = state.inner.lock().await;
-        if !runtime.avatar_self_description_due(payload.subject_actor_id, level)
-            || runtime.avatar_community_art_generation_active(payload.subject_actor_id, level)
-        {
+    if let Some(path) = state.event_store_path.as_deref() {
+        let queued =
+            open_event_store(path).and_then(|conn| insert_avatar_self_description_job(&conn, &job));
+        if queued.is_err() {
             return Json(ActionResponse {
                 ok: false,
-                status: 409,
+                status: 500,
                 events: Vec::new(),
             });
         }
-        let content_id = runtime.next_content_id_value();
-        let mut record = JournalRecord::new(
-            CwAction {
-                kind: CW_ACTION_NONE,
-                actor_id: payload.subject_actor_id,
-                location_id,
-                content_id,
-                ..CwAction::default()
-            },
-            runtime.next_seed_value(),
-        );
-        record
-            .content_upserts
-            .insert(content_id, avatar_level_identity_content(&identity));
-        record
-            .projection_mutations
-            .push(ProjectionMutation::RecordAvatarSelfDescription(
-                AvatarSelfDescriptionProjection {
-                    content_id,
-                    location_id,
-                    level,
-                    caused_by_event_seq: None,
-                    source_world_tick: runtime.world.tick,
-                    observed_through_seq: runtime.world.next_event_seq.saturating_sub(1),
-                    identity,
-                },
-            ));
-        match commit_journal_record(&state, &mut runtime, record) {
-            Ok((CW_OK, events)) if !events.is_empty() => events,
-            Ok((status, events)) => {
-                return Json(ActionResponse {
-                    ok: false,
-                    status,
-                    events,
-                });
-            }
-            Err(_) => {
-                return Json(ActionResponse {
-                    ok: false,
-                    status: 500,
-                    events: Vec::new(),
-                });
-            }
-        }
-    };
-    broadcast_events(&state, &events);
-    resume_avatar_art_after_self_description(&state, payload.subject_actor_id).await;
+        state.actor_job_notify.notify_waiters();
+    } else {
+        schedule_avatar_self_description(&state, job);
+    }
     Json(ActionResponse {
         ok: true,
         status: CW_OK,
-        events,
+        events: Vec::new(),
     })
 }
 
@@ -1305,16 +1134,18 @@ mod tests {
     }
 
     #[test]
-    fn manual_avatar_appearance_is_bounded_and_cozy_safe() {
-        assert_eq!(
-            normalize_avatar_appearance(
-                "  Copper curls, grey eyes, warm brown skin, and a moss-green wool coat.  "
-            )
-            .as_deref(),
-            Some("Copper curls, grey eyes, warm brown skin, and a moss-green wool coat.")
-        );
-        assert!(normalize_avatar_appearance("green coat").is_none());
-        assert!(normalize_avatar_appearance("A porn costume with a bright red coat.").is_none());
+    fn avatar_appearance_request_rejects_human_written_description_fields() {
+        let request = serde_json::json!({
+            "actor_id": 5000,
+            "actor_session": "test-session",
+            "wallet_session": "test-wallet-session",
+            "subject_actor_id": 5000
+        });
+        assert!(serde_json::from_value::<DescribeAvatarAppearanceRequest>(request.clone()).is_ok());
+        let mut human_written = request;
+        human_written["appearance"] =
+            serde_json::json!("Copper curls, grey eyes, and a moss-green wool coat.");
+        assert!(serde_json::from_value::<DescribeAvatarAppearanceRequest>(human_written).is_err());
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -721,7 +721,7 @@ impl RuntimeWorld {
             return None;
         }
         if viewer_actor_id == Some(actor_id) && !self.actor_uses_inference(actor_id) {
-            return Some("write");
+            return Some("self_authored");
         }
         self.avatar_has_exact_self_description_model(actor_id)
             .then_some("self_authored")

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -31,6 +31,14 @@ fn create_test_human(runtime: &mut RuntimeWorld, actor_id: u64, location_id: u64
         "A round-faced traveler with copper curls, brown eyes, and a moss-green coat.".to_string();
 }
 
+fn test_avatar_level_identity(appearance: &str) -> AvatarLevelIdentity {
+    AvatarLevelIdentity {
+        persona: "I am curious about the shared world around me.".to_string(),
+        appearance: appearance.to_string(),
+        continuity: "I remain recognizably myself as I grow.".to_string(),
+    }
+}
+
 #[test]
 fn direct_avatar_portrait_waits_for_a_visible_level_appearance() {
     let mut runtime = RuntimeWorld::seeded();
@@ -50,9 +58,7 @@ fn direct_avatar_portrait_waits_for_a_visible_level_appearance() {
 
     let appearance =
         "A freckled traveler with short copper curls, grey eyes, and a moss-green wool coat.";
-    let identity = runtime
-        .manual_avatar_level_identity(5000, appearance)
-        .expect("manual level identity");
+    let identity = test_avatar_level_identity(appearance);
     let content_id = 91_001;
     runtime
         .content
@@ -105,9 +111,7 @@ fn a_new_level_description_replaces_the_frozen_brief_and_reopens_funded_art() {
 
     let appearance =
         "A blue-skinned traveler with silver braids, dark eyes, and a saffron wrap coat.";
-    let identity = runtime
-        .manual_avatar_level_identity(5000, appearance)
-        .expect("replacement identity");
+    let identity = test_avatar_level_identity(appearance);
     let content_id = 91_011;
     runtime
         .content
@@ -171,57 +175,87 @@ fn an_elysium_void_can_use_its_exact_text_model_to_describe_itself() {
     ));
 }
 
-#[tokio::test]
-async fn a_direct_avatar_can_set_appearance_only_once_in_the_current_level() {
+#[test]
+fn a_direct_avatar_asks_its_persona_for_the_current_level_appearance() {
     let mut runtime = RuntimeWorld::seeded();
-    create_test_human(&mut runtime, 5000, COSY_COTTAGE_LOCATION_ID, "Level Look");
-    let state = test_app_state(runtime, None);
+    crate::test_support::create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Level Look",
+    );
+
+    assert_eq!(
+        runtime.avatar_appearance_action(5000, 1, Some(5000)),
+        Some("self_authored")
+    );
+    assert_eq!(runtime.avatar_appearance_action(5000, 1, Some(1002)), None);
+}
+
+#[tokio::test]
+async fn a_direct_avatar_queues_one_persona_description_without_free_text() {
+    let event_store_path = std::env::temp_dir().join(format!(
+        "cosyworld-avatar-persona-description-{}-{}.sqlite",
+        std::process::id(),
+        now_seed()
+    ));
+    let _ = fs::remove_file(&event_store_path);
+    let mut runtime = RuntimeWorld::seeded();
+    crate::test_support::create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Level Look",
+    );
+    let state = test_app_state(runtime, Some(event_store_path.clone()));
     let (actor_session, _) = issue_actor_session(&state, 5000);
-    let request = DescribeAvatarAppearanceRequest {
-        actor_id: 5000,
-        actor_session: Some(actor_session.clone()),
-        subject_actor_id: 5000,
-        appearance: Some(
-            "Warm brown skin, a round face, short black curls, and a plum wool jacket.".to_string(),
-        ),
-    };
 
     let first = describe_avatar_appearance(
         ConnectInfo("127.0.0.1:45101".parse().expect("client address")),
         State(state.clone()),
-        Json(request),
+        Json(DescribeAvatarAppearanceRequest {
+            actor_id: 5000,
+            actor_session: Some(actor_session.clone()),
+            _wallet_session: None,
+            subject_actor_id: 5000,
+        }),
     )
     .await
     .0;
     assert!(first.ok);
     assert_eq!(first.status, CW_OK);
-    let runtime = state.inner.lock().await;
-    assert_eq!(
-        runtime
-            .avatar_level_identity(5000, 1)
-            .expect("saved level identity")
-            .appearance,
-        "Warm brown skin, a round face, short black curls, and a plum wool jacket."
-    );
-    assert!(!runtime.avatar_self_description_due(5000, 1));
-    drop(runtime);
 
     let duplicate = describe_avatar_appearance(
         ConnectInfo("127.0.0.1:45101".parse().expect("client address")),
-        State(state),
+        State(state.clone()),
         Json(DescribeAvatarAppearanceRequest {
             actor_id: 5000,
             actor_session: Some(actor_session),
+            _wallet_session: None,
             subject_actor_id: 5000,
-            appearance: Some(
-                "A second look that must not replace the saved level appearance.".to_string(),
-            ),
         }),
     )
     .await
     .0;
-    assert!(!duplicate.ok);
-    assert_eq!(duplicate.status, 409);
+    assert!(duplicate.ok);
+    assert_eq!(duplicate.status, CW_OK);
+
+    let conn = open_event_store(&event_store_path).expect("open persona description store");
+    let queued: i64 = conn
+        .query_row("SELECT COUNT(*) FROM actor_jobs", [], |row| row.get(0))
+        .expect("count persona description jobs");
+    assert_eq!(queued, 1);
+    let claimed =
+        claim_next_actor_job_of_kind(&event_store_path, ACTOR_JOB_KIND_AVATAR_SELF_DESCRIPTION)
+            .expect("claim persona description job")
+            .expect("one persona description was queued");
+    let ActorJobPayload::AvatarSelfDescription(job) = claimed.payload else {
+        panic!("appearance request queued the wrong job kind");
+    };
+    assert_eq!(job.actor_id, 5000);
+    drop(conn);
+    drop(state);
+    let _ = fs::remove_file(event_store_path);
 }
 
 fn test_art_config() -> ReplicateAvatarArtConfig {

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -3233,27 +3233,6 @@
     .card-art-workshop .account-button {
       width: 100%;
     }
-    .avatar-appearance-form {
-      display: grid;
-      gap: 6px;
-    }
-    .avatar-appearance-form label {
-      color: var(--dim);
-      font-size: 11px;
-      font-weight: 800;
-    }
-    .avatar-appearance-form textarea {
-      width: 100%;
-      min-height: 76px;
-      resize: vertical;
-      border: 1px solid rgba(239, 201, 107, 0.28);
-      border-radius: 4px;
-      background: rgba(0, 0, 0, 0.2);
-      color: var(--text);
-      padding: 8px;
-      font: inherit;
-      line-height: 1.35;
-    }
     .card-copy {
       min-width: 0;
     }
@@ -10777,9 +10756,6 @@
       if (status === 503 && path === "/actions/model-interaction") {
         return "That model route is resting right now. Choose another action; nothing was spent.";
       }
-      if (status === 400 && path === "/actions/describe-avatar") {
-        return "Use 16–360 characters and describe only visible, all-ages features.";
-      }
       if (status === 409 && path === "/actions/describe-avatar") {
         return "This level’s appearance is already set, or its portrait is being made right now.";
       }
@@ -16618,9 +16594,7 @@
         : "";
       let appearanceControl = "";
       if (clientState?.status === "describing") {
-        appearanceControl = `<div class="card-art-status"><span>level ${level} appearance</span><strong>${appearanceAction === "self_authored" ? "Listening for their description…" : "Saving your description…"}</strong></div>`;
-      } else if (appearanceDue && appearanceAction === "write") {
-        appearanceControl = `<form class="avatar-appearance-form" data-avatar-appearance-form="${subject.id}"><label for="avatar-appearance-${subject.id}">Describe visible features for this level</label><textarea id="avatar-appearance-${subject.id}" name="appearance" minlength="16" maxlength="360" required placeholder="Hair, face, build, colouring, distinctive features, and practical clothes.">${escapeHtml(appearance)}</textarea><button class="account-button" type="submit">use this appearance</button></form>`;
+        appearanceControl = `<div class="card-art-status"><span>level ${level} appearance</span><strong>Listening for their description…</strong></div>`;
       } else if (appearanceDue && appearanceAction === "self_authored") {
         appearanceControl = `<button class="account-button" type="button" data-request-avatar-appearance="${subject.id}">ask ${escapeHtml(card.display_name || "this avatar")} to describe themself</button>`;
       }
@@ -17180,7 +17154,7 @@
       syncOpenCardModal();
     }
 
-    async function describeAvatarAppearance(subjectId, appearance = null) {
+    async function describeAvatarAppearance(subjectId) {
       const subjectKey = communityArtSubjectKey({ kind: "actor", id: Number(subjectId) });
       const card = cardForActor(Number(subjectId));
       const art = card?.community_art;
@@ -17202,7 +17176,6 @@
         await action("/actions/describe-avatar", {
           actor_id: actorId,
           subject_actor_id: Number(subjectId),
-          appearance,
         });
       } finally {
         if (communityArtClientStates.get(subjectKey) === clientState) {
@@ -19822,16 +19795,6 @@
     });
 
     $("card-modal").addEventListener("submit", (event) => {
-      const appearanceForm = event.target.closest("[data-avatar-appearance-form]");
-      if (appearanceForm) {
-        event.preventDefault();
-        const subjectId = Number(appearanceForm.getAttribute("data-avatar-appearance-form") || 0);
-        const appearance = String(new FormData(appearanceForm).get("appearance") || "").trim();
-        if (!subjectId || appearance.length < 16) return;
-        appearanceForm.querySelector("button[type='submit']")?.setAttribute("disabled", "");
-        void describeAvatarAppearance(subjectId, appearance);
-        return;
-      }
       const form = event.target.closest("[data-avatar-report-form]");
       if (!form) return;
       event.preventDefault();

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -37555,8 +37555,8 @@ mod tests {
         assert!(!INDEX_HTML.contains("resolve bond"));
         assert!(!INDEX_HTML.contains("return \"make bond\""));
         assert!(!INDEX_HTML.contains("prompt("));
-        assert_eq!(INDEX_HTML.matches("<textarea").count(), 1);
-        assert!(INDEX_HTML.contains("data-avatar-appearance-form"));
+        assert!(!INDEX_HTML.contains("data-avatar-appearance-form"));
+        assert!(INDEX_HTML.contains("data-request-avatar-appearance"));
         assert!(!INDEX_HTML.contains("contenteditable=\"true\""));
         assert!(!INDEX_HTML.contains("class=\"composer\""));
         assert!(INDEX_HTML.contains("class=\"chat-table-scroll\""));


### PR DESCRIPTION
## Summary

- remove the appearance text box and only show a button that asks the avatar persona to describe itself
- reject user-supplied appearance text at the API boundary
- queue one durable persona self-description job per avatar level
- preserve the exact-model self-description path used by Void avatars

## Validation

- npm run check
- local browser check: 0 textareas, 0 appearance inputs, 1 persona prompt button, no console errors

## Compatibility

Old clients that send an appearance field are rejected. This is intentional: appearance text must come from the persona.
