### PR TITLE
Start avatar descriptions from fully funded portraits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.127",
+  "version": "1.0.128",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.127",
+      "version": "1.0.128",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.127",
+  "version": "1.0.128",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.127"
+version = "1.0.128"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.127"
+version = "1.0.128"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/avatar_context_spine.rs
+++ b/v2/orchestrator-rust/src/avatar_context_spine.rs
@@ -975,12 +975,18 @@ impl RuntimeWorld {
             })
     }
 
-    pub(crate) fn avatar_can_redescribe_appearance(&self, actor_id: u64, level: u8) -> bool {
+    pub(crate) fn avatar_requires_self_description(&self, actor_id: u64, level: u8) -> bool {
         let identity_mode = self
             .avatar_identity_policy(actor_id)
             .map(|identity| identity.mode)
             .unwrap_or_else(|| "direct".to_string());
         identity_mode != "authored" && self.avatar_self_description_due(actor_id, level)
+    }
+
+    pub(crate) fn avatar_can_redescribe_appearance(&self, actor_id: u64, level: u8) -> bool {
+        self.avatar_requires_self_description(actor_id, level)
+            && (!self.actor_uses_inference(actor_id)
+                || self.avatar_has_exact_self_description_model(actor_id))
     }
 
     fn avatar_observation_anomalies(&self, actor_id: u64) -> Vec<String> {

--- a/v2/orchestrator-rust/src/avatar_reflections.rs
+++ b/v2/orchestrator-rust/src/avatar_reflections.rs
@@ -25,16 +25,6 @@ pub(super) struct AvatarSelfDescriptionProjection {
     pub(super) identity: AvatarLevelIdentity,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(super) struct DescribeAvatarAppearanceRequest {
-    pub(super) actor_id: u64,
-    pub(super) actor_session: Option<String>,
-    #[serde(rename = "wallet_session")]
-    pub(super) _wallet_session: Option<String>,
-    pub(super) subject_actor_id: u64,
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum AvatarReflectionKind {
@@ -290,7 +280,6 @@ impl RuntimeWorld {
         let current_level = self.actor_by_id(actor_id)?.stats.level.max(1);
         if projection.level != current_level
             || !self.avatar_self_description_due(actor_id, projection.level)
-            || self.avatar_community_art_generation_active(actor_id, projection.level)
         {
             return None;
         }
@@ -326,105 +315,33 @@ pub(super) fn avatar_level_identity_content(identity: &AvatarLevelIdentity) -> S
     )
 }
 
-pub(super) async fn describe_avatar_appearance(
-    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
-    State(state): State<AppState>,
-    Json(payload): Json<DescribeAvatarAppearanceRequest>,
-) -> Json<ActionResponse> {
-    if !allow_actor_mutation(
-        &state,
-        client_addr,
-        payload.actor_id,
-        "avatar-appearance-actor",
-        CHAT_ACTION_LIMIT,
-    ) {
-        return action_rate_limited_response();
-    }
-
-    let self_description_job = {
+pub(super) async fn queue_avatar_self_description(
+    state: &AppState,
+    actor_id: u64,
+) -> Result<bool, String> {
+    let job = {
         let runtime = state.inner.lock().await;
-        if !client_actor_authorized_for_state(
-            &runtime,
-            &state,
-            payload.actor_id,
-            payload.actor_session.as_deref(),
-        ) {
-            return client_actor_rejected_response();
+        let actor = runtime
+            .actor_by_id(actor_id)
+            .ok_or_else(|| "the self-describing avatar no longer exists".to_string())?;
+        let level = actor.stats.level.max(1);
+        if !runtime.avatar_can_redescribe_appearance(actor_id, level) {
+            return Ok(false);
         }
-        let Some(requester) = runtime
-            .actor_by_id(payload.actor_id)
-            .filter(|actor| RuntimeWorld::actor_can_act(*actor))
-        else {
-            return Json(ActionResponse {
-                ok: false,
-                status: 404,
-                events: Vec::new(),
-            });
-        };
-        let Some(subject) = runtime.actor_by_id(payload.subject_actor_id) else {
-            return Json(ActionResponse {
-                ok: false,
-                status: 404,
-                events: Vec::new(),
-            });
-        };
-        if subject.location_id != requester.location_id
-            || !runtime.actor_visible_in_projection(subject, Some(payload.actor_id), None)
-        {
-            return Json(ActionResponse {
-                ok: false,
-                status: 404,
-                events: Vec::new(),
-            });
-        }
-        let level = subject.stats.level.max(1);
-        if runtime.avatar_community_art_generation_active(payload.subject_actor_id, level) {
-            return Json(ActionResponse {
-                ok: false,
-                status: 409,
-                events: Vec::new(),
-            });
-        }
-        let Some("self_authored") = runtime.avatar_appearance_action(
-            payload.subject_actor_id,
-            level,
-            Some(payload.actor_id),
-        ) else {
-            return Json(ActionResponse {
-                ok: false,
-                status: 409,
-                events: Vec::new(),
-            });
-        };
-        runtime.avatar_reflection_job(payload.subject_actor_id, AvatarReflectionKind::Thought)
-    };
-
-    let Some(job) = self_description_job else {
-        return Json(ActionResponse {
-            ok: false,
-            status: 409,
-            events: Vec::new(),
-        });
+        runtime
+            .avatar_reflection_job(actor_id, AvatarReflectionKind::Thought)
+            .ok_or_else(|| "self-description context could not be constructed".to_string())?
     };
     if let Some(path) = state.event_store_path.as_deref() {
-        let queued =
-            open_event_store(path).and_then(|conn| insert_avatar_self_description_job(&conn, &job));
-        if queued.is_err() {
-            return Json(ActionResponse {
-                ok: false,
-                status: 500,
-                events: Vec::new(),
-            });
-        }
+        let queued = open_event_store(path)
+            .and_then(|conn| insert_avatar_self_description_job(&conn, &job))
+            .map_err(|error| error.to_string())?;
         state.actor_job_notify.notify_waiters();
+        Ok(queued)
     } else {
-        schedule_avatar_self_description(&state, job);
+        schedule_avatar_self_description(state, job);
+        Ok(true)
     }
-    Json(ActionResponse {
-        ok: true,
-        status: CW_OK,
-        events: Vec::new(),
-    })
 }
 
 fn parse_avatar_level_identity(content: &str) -> Result<AvatarLevelIdentity, String> {
@@ -1131,21 +1048,6 @@ mod tests {
     #[test]
     fn avatar_identity_output_requires_persona_appearance_and_continuity() {
         assert!(parse_avatar_level_identity("PERSONA: I am still forming.").is_err());
-    }
-
-    #[test]
-    fn avatar_appearance_request_rejects_human_written_description_fields() {
-        let request = serde_json::json!({
-            "actor_id": 5000,
-            "actor_session": "test-session",
-            "wallet_session": "test-wallet-session",
-            "subject_actor_id": 5000
-        });
-        assert!(serde_json::from_value::<DescribeAvatarAppearanceRequest>(request.clone()).is_ok());
-        let mut human_written = request;
-        human_written["appearance"] =
-            serde_json::json!("Copper curls, grey eyes, and a moss-green wool coat.");
-        assert!(serde_json::from_value::<DescribeAvatarAppearanceRequest>(human_written).is_err());
     }
 
     #[test]

--- a/v2/orchestrator-rust/src/cards.rs
+++ b/v2/orchestrator-rust/src/cards.rs
@@ -101,7 +101,6 @@ pub(super) struct CommunityArtView {
     pub(super) appearance: Option<String>,
     pub(super) appearance_due: bool,
     pub(super) appearance_required: bool,
-    pub(super) appearance_action: Option<String>,
 }
 
 impl Serialize for CommunityArtView {
@@ -109,7 +108,7 @@ impl Serialize for CommunityArtView {
     where
         S: serde::Serializer,
     {
-        let mut out = serializer.serialize_struct("CommunityArtView", 13)?;
+        let mut out = serializer.serialize_struct("CommunityArtView", 12)?;
         out.serialize_field("level", &self.level)?;
         out.serialize_field("required_orbs", &self.required_orbs)?;
         out.serialize_field("funded_orbs", &self.funded_orbs)?;
@@ -124,9 +123,6 @@ impl Serialize for CommunityArtView {
         }
         out.serialize_field("appearance_due", &self.appearance_due)?;
         out.serialize_field("appearance_required", &self.appearance_required)?;
-        if let Some(value) = &self.appearance_action {
-            out.serialize_field("appearance_action", value)?;
-        }
         out.end()
     }
 }

--- a/v2/orchestrator-rust/src/community_art.rs
+++ b/v2/orchestrator-rust/src/community_art.rs
@@ -31,13 +31,13 @@ use crate::{
     commit_journal_record, community_art_eligible_card, execute_prepared_replicate_art,
     freeze_approved_community_media_reference, immutable_media_asset_bytes,
     is_safe_image_content_type, now_millis, prepare_replicate_art, prepare_replicate_evolution_art,
-    reconcile_community_media_asset_status, record_ai_usage_for_provider,
-    register_derived_community_media_asset, register_generated_media_asset,
-    request_image_policy_decision, resolve_generation_media_config, ActorMeta, AiConfig, AppState,
-    CardView, CommunityArtView, CwAction, EventView, EvolutionRolloutRoute,
-    FrozenCommunityArtEvolutionJob, FrozenMediaAssetReference, GeneratedPolicyBinding,
-    ImagePolicyRequest, ItemMeta, JournalRecord, MediaAssetBackfill, MediaAssetProvenance,
-    PreparedReplicateExecution, ProjectionMutation, PublicArtHistoryEvent,
+    queue_avatar_self_description, reconcile_community_media_asset_status,
+    record_ai_usage_for_provider, register_derived_community_media_asset,
+    register_generated_media_asset, request_image_policy_decision, resolve_generation_media_config,
+    ActorMeta, AiConfig, AppState, CardView, CommunityArtView, CwAction, EventView,
+    EvolutionRolloutRoute, FrozenCommunityArtEvolutionJob, FrozenMediaAssetReference,
+    GeneratedPolicyBinding, ImagePolicyRequest, ItemMeta, JournalRecord, MediaAssetBackfill,
+    MediaAssetProvenance, PreparedReplicateExecution, ProjectionMutation, PublicArtHistoryEvent,
     ReplicateAvatarArtConfig, RuntimeWorld, WorldEntityRef, CW_ACTION_NONE, CW_OK,
     EVOLUTION_EXECUTION_MODEL_REVISION, EVOLUTION_EXECUTION_RECIPE,
 };
@@ -628,15 +628,13 @@ impl RuntimeWorld {
         let retryable_without_orbs = generation.is_some_and(|state| {
             community_art_generation_retryable_for_profile(state, false, generation_profile_version)
         });
-        let appearance = (subject_kind == "actor")
-            .then(|| self.avatar_portrait_appearance(subject_id, level))
-            .flatten();
+        let self_description_required =
+            subject_kind == "actor" && self.avatar_requires_self_description(subject_id, level);
         let appearance_due =
             subject_kind == "actor" && self.avatar_can_redescribe_appearance(subject_id, level);
-        let appearance_action = (subject_kind == "actor")
-            .then(|| self.avatar_appearance_action(subject_id, level, viewer_actor_id))
-            .flatten()
-            .map(ToString::to_string);
+        let appearance = (subject_kind == "actor" && !self_description_required)
+            .then(|| self.avatar_portrait_appearance(subject_id, level))
+            .flatten();
         if let Some(published) = published_generation {
             card.image_url = Some(community_art_image_url(
                 subject_kind,
@@ -668,10 +666,10 @@ impl RuntimeWorld {
             provider_attempts,
             max_provider_attempts: MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS,
             retryable_without_orbs,
-            appearance_required: subject_kind == "actor" && appearance.is_none(),
+            appearance_required: subject_kind == "actor"
+                && (self_description_required || appearance.is_none()),
             appearance,
             appearance_due,
-            appearance_action,
         });
         card
     }
@@ -708,30 +706,6 @@ impl RuntimeWorld {
                     actor_id,
                     &active_content().actor_model_bindings,
                 )
-            })
-    }
-
-    pub(super) fn avatar_appearance_action(
-        &self,
-        actor_id: u64,
-        level: u8,
-        viewer_actor_id: Option<u64>,
-    ) -> Option<&'static str> {
-        if !self.avatar_can_redescribe_appearance(actor_id, level) {
-            return None;
-        }
-        if viewer_actor_id == Some(actor_id) && !self.actor_uses_inference(actor_id) {
-            return Some("self_authored");
-        }
-        self.avatar_has_exact_self_description_model(actor_id)
-            .then_some("self_authored")
-    }
-
-    pub(super) fn avatar_community_art_generation_active(&self, actor_id: u64, level: u8) -> bool {
-        self.community_art_generations
-            .get(&community_art_generation_key("actor", actor_id, level))
-            .is_some_and(|generation| {
-                matches!(generation.status.as_str(), "generating" | "reviewing")
             })
     }
 
@@ -927,8 +901,16 @@ impl RuntimeWorld {
         let level = self
             .community_art_subject_level(subject_kind, subject_id)
             .ok_or_else(|| "That card does not have community-generated art.".to_string())?;
-        if subject_kind == "actor" && self.avatar_portrait_appearance(subject_id, level).is_none() {
-            return Err(AVATAR_APPEARANCE_REQUIRED_CODE.to_string());
+        if subject_kind == "actor" {
+            let self_description_required =
+                self.avatar_requires_self_description(subject_id, level);
+            if (self_description_required
+                && !self.avatar_can_redescribe_appearance(subject_id, level))
+                || (!self_description_required
+                    && self.avatar_portrait_appearance(subject_id, level).is_none())
+            {
+                return Err(AVATAR_APPEARANCE_REQUIRED_CODE.to_string());
+            }
         }
         let generation_profile_version = community_art_generation_profile_version(subject_kind);
         if let Some(frozen_plan) = self
@@ -1303,6 +1285,38 @@ impl RuntimeWorld {
             Some(format!("{subject_kind}:{subject_id}:level:{level}")),
         ))
     }
+}
+
+pub(super) async fn continue_community_art_generation(
+    state: &AppState,
+    actor_id: u64,
+    plan: CommunityArtPlan,
+) {
+    let queue_self_description = if plan.subject_kind == "actor" {
+        let runtime = state.inner.lock().await;
+        runtime
+            .community_art_generations
+            .get(&community_art_generation_key(
+                "actor",
+                plan.subject_id,
+                plan.level,
+            ))
+            .is_some_and(|generation| generation.funded_orbs >= generation.required_orbs)
+            && runtime.avatar_requires_self_description(plan.subject_id, plan.level)
+    } else {
+        false
+    };
+    if queue_self_description {
+        if let Err(error) = queue_avatar_self_description(state, plan.subject_id).await {
+            warn!(
+                actor_id = plan.subject_id,
+                level = plan.level,
+                "fully funded portrait could not queue its persona self-description: {error}"
+            );
+        }
+        return;
+    }
+    schedule_community_art_generation(state, actor_id, plan);
 }
 
 pub(super) async fn resume_avatar_art_after_self_description(state: &AppState, actor_id: u64) {
@@ -2384,13 +2398,17 @@ pub(super) fn pending_community_art_resumption_plans(
         .community_art_generations
         .values()
         .filter(|generation| {
+            let self_description_required = generation.subject_kind == "actor"
+                && runtime
+                    .avatar_requires_self_description(generation.subject_id, generation.level);
             let interrupted = matches!(
                 generation.status.as_str(),
                 "funded" | "generating" | "reviewing"
             );
             let stale_brief =
                 generation.last_error_code.as_deref() == Some("community_art_storage_failed");
-            generation.funded_orbs >= generation.required_orbs && (interrupted || stale_brief)
+            generation.funded_orbs >= generation.required_orbs
+                && (self_description_required || interrupted || stale_brief)
         })
         .filter_map(|generation| {
             generation
@@ -2408,8 +2426,14 @@ pub(super) fn pending_community_art_resumption_plans(
                     let candidate_exists =
                         community_art_candidate_availability(generated_asset_dir, &plan)
                             != CommunityArtCandidateAvailability::Absent;
-                    plan.generation_retryable(generation, candidate_exists)
-                        .then_some((actor_id, plan))
+                    let self_description_required = generation.subject_kind == "actor"
+                        && runtime.avatar_requires_self_description(
+                            generation.subject_id,
+                            generation.level,
+                        );
+                    (self_description_required
+                        || plan.generation_retryable(generation, candidate_exists))
+                    .then_some((actor_id, plan))
                 })
         })
         .collect()
@@ -2429,7 +2453,7 @@ pub(super) fn resume_pending_community_art_generations(state: &AppState) {
             pending_community_art_resumption_plans(&runtime, &state.generated_asset_dir)
         };
         for (actor_id, plan) in resumptions {
-            schedule_community_art_generation(&state, actor_id, plan);
+            continue_community_art_generation(&state, actor_id, plan).await;
         }
     });
 }

--- a/v2/orchestrator-rust/src/community_art_tests.rs
+++ b/v2/orchestrator-rust/src/community_art_tests.rs
@@ -20,15 +20,19 @@ fn create_test_human(runtime: &mut RuntimeWorld, actor_id: u64, location_id: u64
         .actor_by_id(actor_id)
         .map(|actor| actor.stats.level.max(1))
         .unwrap_or(1);
-    runtime
+    let memory = runtime
         .entity_memories
         .entry(WorldEntityRef::avatar(actor_id).key())
-        .or_default()
+        .or_default();
+    memory
         .identity_by_level
         .entry(level)
         .or_default()
         .appearance =
         "A round-faced traveler with copper curls, brown eyes, and a moss-green coat.".to_string();
+    memory
+        .descriptions_by_level
+        .insert(level, "A complete test persona description.".to_string());
 }
 
 fn test_avatar_level_identity(appearance: &str) -> AvatarLevelIdentity {
@@ -40,7 +44,7 @@ fn test_avatar_level_identity(appearance: &str) -> AvatarLevelIdentity {
 }
 
 #[test]
-fn direct_avatar_portrait_waits_for_a_visible_level_appearance() {
+fn direct_avatar_portrait_can_be_funded_before_its_async_level_description() {
     let mut runtime = RuntimeWorld::seeded();
     crate::test_support::create_test_human(
         &mut runtime,
@@ -49,12 +53,12 @@ fn direct_avatar_portrait_waits_for_a_visible_level_appearance() {
         "Portrait Author",
     );
 
-    assert_eq!(
-        runtime
-            .community_art_plan(5000, "actor", 5000)
-            .expect_err("a generic fallback must not be funded"),
-        AVATAR_APPEARANCE_REQUIRED_CODE
-    );
+    let pending = runtime
+        .community_art_plan(5000, "actor", 5000)
+        .expect("the Orb timeline can be funded before the persona responds");
+    assert!(runtime.avatar_requires_self_description(5000, 1));
+    assert!(runtime.avatar_can_redescribe_appearance(5000, 1));
+    assert_eq!(pending.required_orbs, 1);
 
     let appearance =
         "A freckled traveler with short copper curls, grey eyes, and a moss-green wool coat.";
@@ -88,7 +92,7 @@ fn direct_avatar_portrait_waits_for_a_visible_level_appearance() {
 #[test]
 fn a_new_level_description_replaces_the_frozen_brief_and_reopens_funded_art() {
     let mut runtime = RuntimeWorld::seeded();
-    create_test_human(
+    crate::test_support::create_test_human(
         &mut runtime,
         5000,
         COSY_COTTAGE_LOCATION_ID,
@@ -176,7 +180,7 @@ fn an_elysium_void_can_use_its_exact_text_model_to_describe_itself() {
 }
 
 #[test]
-fn a_direct_avatar_asks_its_persona_for_the_current_level_appearance() {
+fn a_direct_avatar_can_be_queued_for_its_current_level_appearance() {
     let mut runtime = RuntimeWorld::seeded();
     crate::test_support::create_test_human(
         &mut runtime,
@@ -185,15 +189,12 @@ fn a_direct_avatar_asks_its_persona_for_the_current_level_appearance() {
         "Level Look",
     );
 
-    assert_eq!(
-        runtime.avatar_appearance_action(5000, 1, Some(5000)),
-        Some("self_authored")
-    );
-    assert_eq!(runtime.avatar_appearance_action(5000, 1, Some(1002)), None);
+    assert!(runtime.avatar_requires_self_description(5000, 1));
+    assert!(runtime.avatar_can_redescribe_appearance(5000, 1));
 }
 
 #[tokio::test]
-async fn a_direct_avatar_queues_one_persona_description_without_free_text() {
+async fn a_fully_funded_portrait_queues_one_persona_description_before_generation() {
     let event_store_path = std::env::temp_dir().join(format!(
         "cosyworld-avatar-persona-description-{}-{}.sqlite",
         std::process::id(),
@@ -207,38 +208,19 @@ async fn a_direct_avatar_queues_one_persona_description_without_free_text() {
         COSY_COTTAGE_LOCATION_ID,
         "Level Look",
     );
+    let plan = runtime
+        .community_art_plan(5000, "actor", 5000)
+        .expect("the undescribed portrait can accept Orb funding");
+    fund_test_community_art(
+        &mut runtime,
+        5000,
+        &plan,
+        "fully-funded-persona-timeline",
+        91_012,
+    );
     let state = test_app_state(runtime, Some(event_store_path.clone()));
-    let (actor_session, _) = issue_actor_session(&state, 5000);
-
-    let first = describe_avatar_appearance(
-        ConnectInfo("127.0.0.1:45101".parse().expect("client address")),
-        State(state.clone()),
-        Json(DescribeAvatarAppearanceRequest {
-            actor_id: 5000,
-            actor_session: Some(actor_session.clone()),
-            _wallet_session: None,
-            subject_actor_id: 5000,
-        }),
-    )
-    .await
-    .0;
-    assert!(first.ok);
-    assert_eq!(first.status, CW_OK);
-
-    let duplicate = describe_avatar_appearance(
-        ConnectInfo("127.0.0.1:45101".parse().expect("client address")),
-        State(state.clone()),
-        Json(DescribeAvatarAppearanceRequest {
-            actor_id: 5000,
-            actor_session: Some(actor_session),
-            _wallet_session: None,
-            subject_actor_id: 5000,
-        }),
-    )
-    .await
-    .0;
-    assert!(duplicate.ok);
-    assert_eq!(duplicate.status, CW_OK);
+    continue_community_art_generation(&state, 5000, plan.clone()).await;
+    continue_community_art_generation(&state, 5000, plan).await;
 
     let conn = open_event_store(&event_store_path).expect("open persona description store");
     let queued: i64 = conn
@@ -253,6 +235,12 @@ async fn a_direct_avatar_queues_one_persona_description_without_free_text() {
         panic!("appearance request queued the wrong job kind");
     };
     assert_eq!(job.actor_id, 5000);
+    let runtime = state.inner.lock().await;
+    let generation =
+        &runtime.community_art_generations[&community_art_generation_key("actor", 5000, 1)];
+    assert_eq!(generation.status, "funded");
+    assert_eq!(generation.provider_attempts, 0);
+    drop(runtime);
     drop(conn);
     drop(state);
     let _ = fs::remove_file(event_store_path);
@@ -722,6 +710,41 @@ fn funded_avatar_generation_is_selected_for_boot_resumption() {
         1,
         "a legacy frozen-brief failure is repaired automatically on boot"
     );
+    let _ = std::fs::remove_dir_all(asset_root);
+}
+
+#[test]
+fn a_fully_funded_rejected_avatar_without_a_level_description_resumes_at_the_persona_stage() {
+    let mut runtime = RuntimeWorld::seeded();
+    crate::test_support::create_test_human(
+        &mut runtime,
+        5000,
+        COSY_COTTAGE_LOCATION_ID,
+        "Recovered Persona",
+    );
+    let plan = runtime
+        .community_art_plan(5000, "actor", 5000)
+        .expect("the undescribed avatar can fill its Orb slot");
+    fund_test_community_art(&mut runtime, 5000, &plan, "rejected-persona-recovery", 9002);
+    let generation = runtime
+        .community_art_generations
+        .get_mut(&community_art_generation_key("actor", 5000, 1))
+        .expect("funded avatar generation");
+    generation.status = "policy_rejected".to_string();
+    generation.provider_attempts = MAX_COMMUNITY_ART_PROVIDER_ATTEMPTS;
+    generation.last_error_code = Some("community_art_policy_rejected".to_string());
+
+    let asset_root = std::env::temp_dir().join(format!(
+        "cosyworld-community-art-persona-resume-{}-{}",
+        std::process::id(),
+        now_seed()
+    ));
+    std::fs::create_dir_all(&asset_root).expect("create generated-asset root");
+    let resumptions = pending_community_art_resumption_plans(&runtime, &asset_root);
+    assert_eq!(resumptions.len(), 1);
+    assert_eq!(resumptions[0].1.subject_kind, "actor");
+    assert_eq!(resumptions[0].1.subject_id, 5000);
+    assert!(runtime.avatar_requires_self_description(5000, 1));
     let _ = std::fs::remove_dir_all(asset_root);
 }
 

--- a/v2/orchestrator-rust/src/index.html
+++ b/v2/orchestrator-rust/src/index.html
@@ -10756,9 +10756,6 @@
       if (status === 503 && path === "/actions/model-interaction") {
         return "That model route is resting right now. Choose another action; nothing was spent.";
       }
-      if (status === 409 && path === "/actions/describe-avatar") {
-        return "This level’s appearance is already set, or its portrait is being made right now.";
-      }
       if (status === 403) return avatarIsKnockedOut()
         ? "This avatar is knocked out and cannot act. Wait for a rescue, or abandon this avatar to begin again."
         : "Reconnect your account to restore this same avatar. The world will not replace it.";
@@ -16588,26 +16585,22 @@
       const appearance = String(art.appearance || "").trim();
       const appearanceDue = Boolean(art.appearance_due);
       const appearanceRequired = Boolean(art.appearance_required);
-      const appearanceAction = String(art.appearance_action || "");
       const appearanceStatus = appearance
         ? `<div class="card-art-status"><span>level ${level} appearance</span><strong>${escapeHtml(appearance)}</strong></div>`
         : "";
-      let appearanceControl = "";
-      if (clientState?.status === "describing") {
-        appearanceControl = `<div class="card-art-status"><span>level ${level} appearance</span><strong>Listening for their description…</strong></div>`;
-      } else if (appearanceDue && appearanceAction === "self_authored") {
-        appearanceControl = `<button class="account-button" type="button" data-request-avatar-appearance="${subject.id}">ask ${escapeHtml(card.display_name || "this avatar")} to describe themself</button>`;
-      }
-      const appearancePanel = `${appearanceStatus}${appearanceControl}`;
+      const appearanceTimeline = appearanceDue
+        ? `<div class="card-art-status"><span>level ${level} appearance</span><strong>${remaining > 0
+          ? "Their persona will describe themself when this Orb slot fills."
+          : "Their persona is describing themself before portrait generation."
+        }</strong></div>`
+        : "";
+      const appearancePanel = `${appearanceStatus}${appearanceTimeline}`;
 
-      if (appearanceRequired) {
-        const waiting = appearanceAction
-          ? "A visible description is needed before this portrait can be funded."
-          : "This avatar cannot create a visible description with its current voice.";
-        return `${appearancePanel}<div class="card-art-status"><span>community portrait</span><strong>${escapeHtml(waiting)}</strong></div>`;
+      if (appearanceRequired && !appearanceDue) {
+        return `${appearancePanel}<div class="card-art-status"><span>community portrait</span><strong>This avatar cannot create a visible description with its current voice.</strong></div>`;
       }
 
-      if (status === "ready") {
+      if (status === "ready" && !appearanceDue) {
         return `${appearancePanel}<div class="card-art-status"><span>community portrait</span> <strong>Level ${level} complete · next portrait unlocks at the next level.</strong></div>`;
       }
       if (clientState?.status === "filling") {
@@ -17152,38 +17145,6 @@
       }
       await queueRefresh();
       syncOpenCardModal();
-    }
-
-    async function describeAvatarAppearance(subjectId) {
-      const subjectKey = communityArtSubjectKey({ kind: "actor", id: Number(subjectId) });
-      const card = cardForActor(Number(subjectId));
-      const art = card?.community_art;
-      if (!subjectKey || !art || communityArtClientStates.get(subjectKey)?.status) return;
-      const clientState = {
-        status: "describing",
-        authoritativeSignature: communityArtStateSignature(art),
-        timeout: null,
-      };
-      communityArtClientStates.set(subjectKey, clientState);
-      clientState.timeout = window.setTimeout(() => {
-        if (communityArtClientStates.get(subjectKey) !== clientState) return;
-        clearCommunityArtClientState(subjectKey);
-        syncOpenCardModal();
-        void queueRefresh();
-      }, 45_000);
-      syncOpenCardModal();
-      try {
-        await action("/actions/describe-avatar", {
-          actor_id: actorId,
-          subject_actor_id: Number(subjectId),
-        });
-      } finally {
-        if (communityArtClientStates.get(subjectKey) === clientState) {
-          clearCommunityArtClientState(subjectKey);
-        }
-        await queueRefresh();
-        syncOpenCardModal();
-      }
     }
 
     function shapeForCard(card, fallback = "item") {
@@ -19776,16 +19737,6 @@
         if (!subjectKind || !Number(subjectId)) return;
         fundImage.disabled = true;
         void fillCommunityArtOrbSlot(subjectKind, Number(subjectId));
-        return;
-      }
-      const requestAppearance = event.target.closest("[data-request-avatar-appearance]");
-      if (requestAppearance) {
-        event.preventDefault();
-        event.stopPropagation();
-        const subjectId = Number(requestAppearance.getAttribute("data-request-avatar-appearance") || 0);
-        if (!subjectId) return;
-        requestAppearance.disabled = true;
-        void describeAvatarAppearance(subjectId);
         return;
       }
       if (event.target.closest("[data-card-close]") || event.target.id === "card-modal") {

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -19088,7 +19088,7 @@ async fn fund_community_image(
         if current_fingerprint != initial_generation_fingerprint && existing.is_some() {
             drop(runtime);
             if working && retry_generation {
-                schedule_community_art_generation(&state, payload.actor_id, plan);
+                continue_community_art_generation(&state, payload.actor_id, plan).await;
             }
             return FundCommunityImageResponse::action(true, CW_OK, Vec::new());
         }
@@ -19101,7 +19101,7 @@ async fn fund_community_image(
         if working {
             drop(runtime);
             if retry_generation {
-                schedule_community_art_generation(&state, payload.actor_id, plan);
+                continue_community_art_generation(&state, payload.actor_id, plan).await;
             }
             return FundCommunityImageResponse::action(true, CW_OK, Vec::new());
         }
@@ -19197,7 +19197,7 @@ async fn fund_community_image(
             .is_some_and(|generation| plan.generation_retryable(generation, candidate_retry_path));
         drop(runtime);
         if retry_generation {
-            schedule_community_art_generation(&state, payload.actor_id, plan);
+            continue_community_art_generation(&state, payload.actor_id, plan).await;
         }
         return FundCommunityImageResponse::action(true, CW_OK, Vec::new());
     }
@@ -19266,7 +19266,7 @@ async fn fund_community_image(
         broadcast_events(&state, &events);
     }
     if fully_funded {
-        schedule_community_art_generation(&state, payload.actor_id, plan);
+        continue_community_art_generation(&state, payload.actor_id, plan).await;
     }
     FundCommunityImageResponse::action(true, CW_OK, events)
 }
@@ -37555,8 +37555,8 @@ mod tests {
         assert!(!INDEX_HTML.contains("resolve bond"));
         assert!(!INDEX_HTML.contains("return \"make bond\""));
         assert!(!INDEX_HTML.contains("prompt("));
-        assert!(!INDEX_HTML.contains("data-avatar-appearance-form"));
-        assert!(INDEX_HTML.contains("data-request-avatar-appearance"));
+        assert!(!INDEX_HTML.contains("data-request-avatar-appearance"));
+        assert!(!INDEX_HTML.contains("/actions/describe-avatar"));
         assert!(!INDEX_HTML.contains("contenteditable=\"true\""));
         assert!(!INDEX_HTML.contains("class=\"composer\""));
         assert!(INDEX_HTML.contains("class=\"chat-table-scroll\""));

--- a/v2/orchestrator-rust/src/routes.rs
+++ b/v2/orchestrator-rust/src/routes.rs
@@ -294,7 +294,6 @@ fn app_router_with_dependencies(
             post(legacy_action_requires_certificate),
         )
         .route("/actions/fund-image", post(fund_community_image))
-        .route("/actions/describe-avatar", post(describe_avatar_appearance))
         .route("/media/room-scenes", post(create_room_scene))
         .route("/media/room-scenes/{job_id}", get(room_scene_status))
         .route(


### PR DESCRIPTION
## Summary

- remove the manual avatar-description button and endpoint
- queue one durable persona self-description job when the portrait reaches full Orb funding
- start image generation only after that description commits
- recover older fully funded/rejected portraits at the persona stage on startup
- preserve exact-model self-description for Void avatars

## Validation

- `npm run check`
- browser: 0 description buttons, 0 appearance forms, 0 textareas, 1 Orb button, automatic timeline shown, no console errors

## Compatibility

The removed describe-avatar action is intentional. Persona self-description is now server-owned and starts from the fully funded portrait timeline.
