### PR TITLE
Keep funded avatar generation alive through AI startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.128",
+  "version": "1.0.129",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.128",
+      "version": "1.0.129",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.128",
+  "version": "1.0.129",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.128"
+version = "1.0.129"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.128"
+version = "1.0.129"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/actor_jobs.rs
+++ b/v2/orchestrator-rust/src/actor_jobs.rs
@@ -715,6 +715,28 @@ pub(super) fn fail_actor_job_for_runtime_state(
     error: &str,
     retry_floor_ms: u64,
 ) -> io::Result<()> {
+    if matches!(
+        error,
+        AI_READINESS_PROBING | AI_RATE_LIMITED | AI_PROVIDER_UNAVAILABLE
+    ) {
+        let readiness_delay_ms = state
+            .ai_config
+            .as_ref()
+            .as_ref()
+            .map(|config| {
+                config
+                    .recommended_readiness_probe_delay()
+                    .as_millis()
+                    .min(u64::MAX as u128) as u64
+            })
+            .unwrap_or(1_000);
+        return defer_actor_job_without_attempt(
+            path,
+            job,
+            error,
+            retry_floor_ms.max(readiness_delay_ms),
+        );
+    }
     if matches!(&job.payload, ActorJobPayload::OrbChat(_))
         && pending_chat_context_rejection(error).is_some()
     {
@@ -838,6 +860,83 @@ fn requeue_actor_job(
     )
     .map_err(sqlite_error)?;
     Ok(())
+}
+
+fn defer_actor_job_without_attempt(
+    path: &Path,
+    job: &ActorJob,
+    error: &str,
+    retry_floor_ms: u64,
+) -> io::Result<()> {
+    let conn = open_event_store(path)?;
+    let now = now_millis();
+    conn.execute(
+        "UPDATE actor_jobs
+         SET status = 'pending', attempts = MAX(attempts - 1, 0),
+             lease_until_ms = NULL, available_at_ms = ?2,
+             last_error = ?3, updated_at_ms = ?4
+         WHERE id = ?1 AND status = 'running'",
+        params![
+            job.id,
+            now.saturating_add(retry_floor_ms.max(250)) as i64,
+            trim_to_chars(error, 500),
+            now as i64,
+        ],
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod readiness_retry_tests {
+    use super::*;
+
+    #[test]
+    fn readiness_deferral_does_not_consume_an_actor_attempt() {
+        let path = std::env::temp_dir().join(format!(
+            "cosyworld-readiness-deferral-{}-{}.sqlite",
+            std::process::id(),
+            now_seed()
+        ));
+        let _ = fs::remove_file(&path);
+        init_event_store(&path).expect("initialize readiness deferral store");
+        let conn = open_event_store(&path).expect("open readiness deferral store");
+        let payload = ActorJobPayload::RoomRope(RoomRopeJob {
+            location_id: 11,
+            actor_id: 22,
+            activation: 33,
+        });
+        assert!(insert_actor_job_payload(
+            &conn,
+            ACTOR_JOB_KIND_ROOM_ROPE,
+            22,
+            None,
+            1,
+            1,
+            Some(11),
+            "readiness-deferral",
+            &payload,
+            0,
+        )
+        .expect("queue readiness deferral job"));
+        drop(conn);
+        let claimed = claim_next_actor_job_of_kind(&path, ACTOR_JOB_KIND_ROOM_ROPE)
+            .expect("claim readiness deferral job")
+            .expect("readiness deferral job exists");
+        assert_eq!(claimed.attempts, 1);
+        defer_actor_job_without_attempt(&path, &claimed, AI_READINESS_PROBING, 250)
+            .expect("defer readiness job");
+        let conn = open_event_store(&path).expect("inspect deferred readiness job");
+        let deferred: (String, u32, Option<i64>) = conn
+            .query_row(
+                "SELECT status, attempts, lease_until_ms FROM actor_jobs WHERE id = ?1",
+                params![claimed.id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read deferred readiness job");
+        assert_eq!(deferred, ("pending".to_string(), 0, None));
+        let _ = fs::remove_file(path);
+    }
 }
 
 #[cfg(test)]

--- a/v2/orchestrator-rust/src/ai_gateway.rs
+++ b/v2/orchestrator-rust/src/ai_gateway.rs
@@ -622,6 +622,30 @@ impl AiConfig {
         self.readiness.gate(endpoint, requested_model_id)
     }
 
+    pub(crate) fn voice_route_gate(
+        &self,
+        binding: Option<&crate::content_load::SeedActorModelBinding>,
+    ) -> Result<AiReadinessGate, RegistryError> {
+        let selections = match binding {
+            Some(binding) => vec![self.pin_actor_model(binding)?],
+            None => self.pin_models(ModelCapability::Voice)?,
+        };
+        let mut blocked = None;
+        for selection in selections {
+            let gate =
+                self.exact_route_gate(CHAT_COMPLETIONS_ENDPOINT, selection.requested_model_id());
+            if gate.is_ready() {
+                return Ok(gate);
+            }
+            if blocked.is_none_or(|current: AiReadinessGate| {
+                current.is_terminal_block() && gate.is_retryable_block()
+            }) {
+                blocked = Some(gate);
+            }
+        }
+        Ok(blocked.unwrap_or_else(AiReadinessGate::ready))
+    }
+
     #[allow(dead_code)]
     pub(crate) fn actor_image_route_is_ready(
         &self,
@@ -6277,6 +6301,18 @@ mod tests {
         }
 
         let probing = AiReadiness::probing_with_low_credit_threshold(5.0);
+        let voice_config = AiConfig {
+            model: "provider/model".to_string(),
+            readiness: probing.clone(),
+            ..AiConfig::default()
+        };
+        assert_eq!(
+            voice_config
+                .voice_route_gate(None)
+                .expect("legacy voice route")
+                .reason_code(),
+            Some(crate::ai_readiness::AI_READINESS_PROBING)
+        );
         let probing_error = AiGatewayError::readiness(
             "test",
             probing.gate(CHAT_COMPLETIONS_ENDPOINT, "provider/model"),

--- a/v2/orchestrator-rust/src/ai_readiness.rs
+++ b/v2/orchestrator-rust/src/ai_readiness.rs
@@ -129,7 +129,7 @@ pub(crate) struct AiReadinessGate {
 }
 
 impl AiReadinessGate {
-    const fn ready() -> Self {
+    pub(crate) const fn ready() -> Self {
         Self {
             reason_code: None,
             retry_at_unix: None,

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -1166,6 +1166,30 @@ fn claim_voice_job(
             Ok(JobClaim::Accepted(Box::new(speech)))
         }
         "unavailable" => {
+            if voice_terminal_code_is_retryable(row.6.as_deref()) {
+                tx.execute(
+                    "UPDATE ai_voice_jobs
+                     SET status = 'pending', lease_owner = ?2, lease_expires_ms = ?3,
+                         lease_retries = 0, policy_json = ?4, decisions_json = NULL,
+                         terminal_code = NULL, updated_at_ms = ?5
+                     WHERE generation_id = ?1 AND status = 'unavailable'",
+                    params![
+                        generation_id,
+                        owner,
+                        lease_expires as i64,
+                        policy_json,
+                        now as i64,
+                    ],
+                )
+                .map_err(crate::sqlite_error)?;
+                tx.execute(
+                    "DELETE FROM ai_voice_attempt_decisions WHERE generation_id = ?1",
+                    params![generation_id],
+                )
+                .map_err(crate::sqlite_error)?;
+                tx.commit().map_err(crate::sqlite_error)?;
+                return Ok(JobClaim::Acquired);
+            }
             tx.commit().map_err(crate::sqlite_error)?;
             Ok(JobClaim::Unavailable(row.6.unwrap_or_else(|| {
                 "voice_candidates_exhausted".to_string()
@@ -1208,6 +1232,15 @@ fn claim_voice_job(
             })
         }
     }
+}
+
+fn voice_terminal_code_is_retryable(code: Option<&str>) -> bool {
+    matches!(
+        code,
+        Some(
+            "voice_latency_exhausted" | "voice_provider_unavailable" | "voice_job_retry_exhausted"
+        )
+    )
 }
 
 fn restored_speech(
@@ -1917,6 +1950,55 @@ mod tests {
             .expect("read the migrated schema version");
         assert_eq!(version, crate::EVENT_STORE_SCHEMA_VERSION);
         drop(conn);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn transiently_unavailable_voice_job_can_be_claimed_again() {
+        let path = test_path("transient-retry");
+        let _ = fs::remove_file(&path);
+        let policy = VoiceRoutingConfig::default();
+        assert!(matches!(
+            claim_voice_job(
+                &path,
+                "retry-generation",
+                "retry-key",
+                "avatar_self_description",
+                "prose",
+                "first-owner",
+                &policy,
+            )
+            .expect("claim first voice attempt"),
+            JobClaim::Acquired
+        ));
+        finish_voice_job_unavailable(
+            Some(&path),
+            "retry-generation",
+            "first-owner",
+            "voice_latency_exhausted",
+        );
+        assert!(matches!(
+            claim_voice_job(
+                &path,
+                "retry-generation",
+                "retry-key",
+                "avatar_self_description",
+                "prose",
+                "second-owner",
+                &policy,
+            )
+            .expect("reclaim transiently unavailable voice attempt"),
+            JobClaim::Acquired
+        ));
+        let state: (String, Option<String>, u32) = crate::open_event_store(&path)
+            .expect("open retried voice store")
+            .query_row(
+                "SELECT status, terminal_code, lease_retries FROM ai_voice_jobs",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read retried voice state");
+        assert_eq!(state, ("pending".to_string(), None, 0));
         let _ = fs::remove_file(path);
     }
 

--- a/v2/orchestrator-rust/src/avatar_reflections.rs
+++ b/v2/orchestrator-rust/src/avatar_reflections.rs
@@ -374,6 +374,22 @@ fn parse_avatar_level_identity(content: &str) -> Result<AvatarLevelIdentity, Str
     Ok(identity)
 }
 
+fn avatar_self_description_route_error(gate: AiReadinessGate) -> Option<&'static str> {
+    let reason = gate.reason_code()?;
+    Some(
+        if gate.is_retryable_block()
+            && !matches!(
+                reason,
+                AI_READINESS_PROBING | AI_RATE_LIMITED | AI_PROVIDER_UNAVAILABLE
+            )
+        {
+            AI_PROVIDER_UNAVAILABLE
+        } else {
+            reason
+        },
+    )
+}
+
 fn reflection_context_spine(job: &AvatarReflectionJob) -> AvatarContextSpine {
     if job.context_spine.is_current() {
         return job.context_spine.clone();
@@ -627,6 +643,12 @@ pub(super) async fn complete_avatar_self_description(
         .as_ref()
         .as_ref()
         .ok_or_else(|| "avatar self-description inference is not configured".to_string())?;
+    let route_gate = config
+        .voice_route_gate(model_binding.as_ref())
+        .map_err(|error| format!("avatar self-description model is unavailable: {error}"))?;
+    if let Some(error) = avatar_self_description_route_error(route_gate) {
+        return Err(error.to_string());
+    }
     let speech = route_certified_voice(
         config,
         state
@@ -956,7 +978,8 @@ pub(super) fn insert_avatar_self_description_job(
     job: &AvatarReflectionJob,
 ) -> io::Result<bool> {
     let payload = ActorJobPayload::AvatarSelfDescription(Box::new(job.clone()));
-    insert_actor_job_payload(
+    let generation_key = avatar_self_description_generation_key(job);
+    if insert_actor_job_payload(
         conn,
         ACTOR_JOB_KIND_AVATAR_SELF_DESCRIPTION,
         job.actor_id,
@@ -964,10 +987,42 @@ pub(super) fn insert_avatar_self_description_job(
         job.source_world_tick,
         job.observed_through_seq,
         Some(job.source_location_id),
-        &avatar_self_description_generation_key(job),
+        &generation_key,
         &payload,
         0,
-    )
+    )? {
+        return Ok(true);
+    }
+    let context_json = serde_json::to_string(&payload)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let now = now_millis() as i64;
+    let revived = conn
+        .execute(
+            "UPDATE actor_jobs
+             SET actor_id = ?2, cause_event_seq = ?3, source_tick = ?4,
+                 observed_through_seq = ?5, location_id = ?6, status = 'pending',
+                 attempts = 0, lease_until_ms = NULL, available_at_ms = ?7,
+                 context_json = ?8, last_error = NULL, updated_at_ms = ?7
+             WHERE dedupe_key = ?1 AND kind = ?9 AND status = 'dead'
+               AND last_error IN (
+                   'ai_readiness_probing', 'ai_rate_limited',
+                   'ai_provider_unavailable', 'voice_latency_exhausted',
+                   'voice_provider_unavailable', 'voice_job_retry_exhausted'
+               )",
+            params![
+                generation_key,
+                job.actor_id as i64,
+                job.caused_by_event_seq.map(|seq| seq as i64),
+                job.source_world_tick as i64,
+                job.observed_through_seq as i64,
+                job.source_location_id as i64,
+                now,
+                context_json,
+                ACTOR_JOB_KIND_AVATAR_SELF_DESCRIPTION,
+            ],
+        )
+        .map_err(sqlite_error)?;
+    Ok(revived > 0)
 }
 
 pub(super) fn insert_avatar_reflection_job(
@@ -1236,6 +1291,32 @@ mod tests {
         assert!(insert_avatar_self_description_job(&conn, &job).expect("first level job is queued"));
         assert!(!insert_avatar_self_description_job(&conn, &job)
             .expect("duplicate level job is ignored"));
+        conn.execute(
+            "UPDATE actor_jobs SET status = 'dead', attempts = 3,
+                    lease_until_ms = NULL, last_error = 'voice_no_eligible_candidates'",
+            [],
+        )
+        .expect("dead-letter the first self-description attempt");
+        assert!(!insert_avatar_self_description_job(&conn, &job)
+            .expect("a permanently failed level job stays dead"));
+        conn.execute(
+            "UPDATE actor_jobs SET last_error = 'ai_readiness_probing'",
+            [],
+        )
+        .expect("mark the dead job as a transient startup failure");
+        assert!(
+            insert_avatar_self_description_job(&conn, &job).expect("a dead level job is revived")
+        );
+        let revived: (String, u32, Option<String>) = conn
+            .query_row(
+                "SELECT status, attempts, last_error FROM actor_jobs",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read revived self-description job");
+        assert_eq!(revived, ("pending".to_string(), 0, None));
+        assert!(!insert_avatar_self_description_job(&conn, &job)
+            .expect("the revived pending level job is still deduplicated"));
         drop(conn);
         let claimed = claim_next_actor_job_of_kind(&path, ACTOR_JOB_KIND_AVATAR_SELF_DESCRIPTION)
             .expect("claim self-description job")
@@ -1245,5 +1326,31 @@ mod tests {
         };
         assert_eq!(committed.actor_id, 1002);
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn self_description_route_errors_preserve_retryable_and_terminal_meaning() {
+        let probing = AiReadiness::probing_with_low_credit_threshold(5.0);
+        assert_eq!(
+            avatar_self_description_route_error(probing.gate("chat/completions", "provider/model")),
+            Some(AI_READINESS_PROBING)
+        );
+
+        let exact_route = AiReadiness::default();
+        exact_route.record_http_failure("chat/completions", "provider/model", 404, None);
+        assert_eq!(
+            avatar_self_description_route_error(
+                exact_route.gate("chat/completions", "provider/model")
+            ),
+            Some(AI_PROVIDER_UNAVAILABLE),
+            "a temporary incompatible route stays retryable without spending an attempt"
+        );
+
+        probing.record_probe_http_failure(401);
+        assert_eq!(
+            avatar_self_description_route_error(probing.gate("chat/completions", "provider/model")),
+            Some(AI_ACCOUNT_UNAUTHORIZED),
+            "a permanent account failure must not enter the endless retry lane"
+        );
     }
 }


### PR DESCRIPTION
## What changed
- check voice-route readiness before starting a funded avatar self-description
- defer temporary AI readiness blocks without consuming actor-job attempts
- revive only self-description jobs that died from transient provider failures
- allow transiently unavailable voice generations to be claimed again
- bump the release to 1.0.129

## Why
Briony's fully funded portrait queued correctly, but the worker ran while AI readiness was still probing. Three fast failures dead-lettered the durable self-description job, and its inner voice job remained unavailable. The image stage never started.

## Verification
- complete pre-push release gate
- 1,297 orchestrator tests
- 211 web tests
- worldpack, kernel, architecture, lint, formatting, syntax, and version checks