### PR TITLE
Publish funded avatar descriptions as structured data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.129",
+  "version": "1.0.130",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.129",
+      "version": "1.0.130",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.129",
+  "version": "1.0.130",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.129"
+version = "1.0.130"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.129"
+version = "1.0.130"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/ai_publication.rs
+++ b/v2/orchestrator-rust/src/ai_publication.rs
@@ -58,6 +58,7 @@ pub(crate) enum SpeechMode {
     EmojiOnly,
     EmoteOnly,
     Raw,
+    Structured,
 }
 
 impl SpeechMode {
@@ -76,6 +77,7 @@ impl SpeechMode {
             Self::EmojiOnly => "emoji_only",
             Self::EmoteOnly => "emote_only",
             Self::Raw => "raw",
+            Self::Structured => "structured",
         }
     }
 }
@@ -720,8 +722,9 @@ fn evaluate_checks(
 ) -> Vec<PublicationCheck> {
     let word_count = text.split_whitespace().count();
     let lowered = text.to_ascii_lowercase();
-    let raw = context.mode == SpeechMode::Raw;
-    let safe_tone = if raw {
+    let machine_readable = matches!(context.mode, SpeechMode::Raw | SpeechMode::Structured);
+    let structured = context.mode == SpeechMode::Structured;
+    let safe_tone = if machine_readable {
         human_message_is_public_safe(text)
     } else {
         human_message_is_cozy_safe(text)
@@ -735,12 +738,12 @@ fn evaluate_checks(
         (
             PublicationCheckCode::VoiceBudgetExceeded,
             word_count <= context.max_words
-                && text.chars().count() <= if raw { 1_200 } else { 360 },
+                && text.chars().count() <= if machine_readable { 1_200 } else { 360 },
         ),
         (
             PublicationCheckCode::VoiceFinishIncomplete,
             matches!(finish_reason, "stop" | "end_turn")
-                && (raw || has_clean_terminal_structure(text)),
+                && (machine_readable || has_clean_terminal_structure(text)),
         ),
         (
             PublicationCheckCode::VoiceRepeatedNgram,
@@ -748,15 +751,15 @@ fn evaluate_checks(
         ),
         (
             PublicationCheckCode::VoiceMultipleSpeakers,
-            !has_multiple_speakers(candidate_text, context),
+            structured || !has_multiple_speakers(candidate_text, context),
         ),
         (
             PublicationCheckCode::VoiceInstructionLeakage,
-            raw || !contains_instruction_leakage(&lowered),
+            context.mode == SpeechMode::Raw || !contains_instruction_leakage(&lowered),
         ),
         (
             PublicationCheckCode::VoiceModeMismatch,
-            mode_matches(text, context.mode),
+            mode_matches(text, context.mode, context.feature),
         ),
         (
             PublicationCheckCode::VoiceAnchorMissing,
@@ -781,7 +784,7 @@ fn evaluate_checks(
         ),
         (
             PublicationCheckCode::VoiceFallbackIdentity,
-            raw || !contains_numeric_traveler_identity(text),
+            machine_readable || !contains_numeric_traveler_identity(text),
         ),
         (
             PublicationCheckCode::VoiceSignpostOpening,
@@ -1125,7 +1128,7 @@ fn has_clean_terminal_structure(value: &str) -> bool {
 
 fn bounded_normalize(value: &str, context: &SpeechGateContext) -> String {
     let normalized = strip_outer_quote_pair(value.trim());
-    if context.mode == SpeechMode::Raw {
+    if matches!(context.mode, SpeechMode::Raw | SpeechMode::Structured) {
         return normalized;
     }
     normalized
@@ -1555,10 +1558,13 @@ fn contains_instruction_leakage(value: &str) -> bool {
     .any(|needle| value.contains(needle))
 }
 
-fn mode_matches(value: &str, mode: SpeechMode) -> bool {
+fn mode_matches(value: &str, mode: SpeechMode, feature: &str) -> bool {
     match mode {
         SpeechMode::Prose => value.chars().any(char::is_alphanumeric),
         SpeechMode::Raw => !value.trim().is_empty(),
+        SpeechMode::Structured => {
+            feature == "avatar_self_description" && avatar_self_description_shape_matches(value)
+        }
         SpeechMode::EmojiOnly => {
             let visible = value.chars().filter(|character| !character.is_whitespace());
             let count = visible
@@ -1579,6 +1585,25 @@ fn mode_matches(value: &str, mode: SpeechMode) -> bool {
                 && value.matches('*').count() == 2
         }
     }
+}
+
+fn avatar_self_description_shape_matches(value: &str) -> bool {
+    let lines = value
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    if lines.len() != 3 {
+        return false;
+    }
+    ["PERSONA", "APPEARANCE", "CONTINUITY"]
+        .into_iter()
+        .zip(lines)
+        .all(|(expected, line)| {
+            line.split_once(':').is_some_and(|(label, content)| {
+                label.trim().eq_ignore_ascii_case(expected) && !content.trim().is_empty()
+            })
+        })
 }
 
 fn is_emoji(character: char) -> bool {
@@ -2957,6 +2982,59 @@ mod tests {
                 },
             ),
             PublicationCheckCode::VoiceAnchorMissing
+        );
+    }
+
+    #[test]
+    fn structured_avatar_self_description_keeps_labels_and_certifies() {
+        let text = "PERSONA: I am careful beside the cottage hearth.\nAPPEARANCE: I have warm brown skin, dark curls, green eyes, and a moss coat.\nCONTINUITY: The hearth keeps my patience rooted.";
+        let speech = certify_speech(
+            None,
+            completion(text),
+            text,
+            SpeechGateContext {
+                feature: "avatar_self_description",
+                mode: SpeechMode::Structured,
+                max_words: 72,
+                anchors: vec!["cottage hearth".to_string()],
+                ..context(&[], &[])
+            },
+        )
+        .expect("structured self-description certifies");
+
+        assert_eq!(speech.text(), text, "structured output keeps line labels");
+        for code in [
+            PublicationCheckCode::VoiceBudgetExceeded,
+            PublicationCheckCode::VoiceMultipleSpeakers,
+            PublicationCheckCode::VoiceModeMismatch,
+            PublicationCheckCode::VoiceAnchorMissing,
+        ] {
+            assert_eq!(
+                speech
+                    .receipt()
+                    .checks
+                    .iter()
+                    .find(|check| check.code == code)
+                    .map(|check| check.passed),
+                Some(true)
+            );
+        }
+    }
+
+    #[test]
+    fn structured_avatar_self_description_rejects_a_malformed_shape() {
+        let text = "PERSONA: I stay near the cottage hearth.\nAPPEARANCE: I wear a moss coat.";
+        assert_check_failed(
+            text,
+            completion(text),
+            SpeechGateContext {
+                feature: "avatar_self_description",
+                mode: SpeechMode::Structured,
+                max_words: 72,
+                anchors: vec!["cottage hearth".to_string()],
+                ..context(&[], &[])
+            },
+            PublicationCheckCode::VoiceModeMismatch,
         );
     }
 

--- a/v2/orchestrator-rust/src/ai_voice_routing.rs
+++ b/v2/orchestrator-rust/src/ai_voice_routing.rs
@@ -630,7 +630,7 @@ fn request_with_retry_feedback(
 ) -> VoiceAttemptRequest {
     let mut request = request.clone();
     if let Some(instruction) = retry_instruction(rejections, gate, request.max_tokens) {
-        request.prompt = if gate.mode == SpeechMode::Raw {
+        request.prompt = if matches!(gate.mode, SpeechMode::Raw | SpeechMode::Structured) {
             request
                 .prompt
                 .user(instruction, PromptSegmentKind::Envelope, u8::MAX, true)
@@ -681,6 +681,10 @@ fn retry_instruction(
                 let conservative_words = gate.max_words.min((max_tokens as usize / 2).clamp(8, 64));
                 format!("one complete response · at most {conservative_words} words")
             }
+            SpeechMode::Structured => format!(
+                "exactly three non-empty lines beginning PERSONA:, APPEARANCE:, and CONTINUITY: · at most {} words",
+                gate.max_words
+            ),
         });
     }
     // Repetition is enforced only by the deterministic publication gate.
@@ -698,6 +702,7 @@ fn retry_instruction(
                 SpeechMode::EmojiOnly => "emoji only",
                 SpeechMode::EmoteOnly => "one emote only",
                 SpeechMode::Raw => "plain response only",
+                SpeechMode::Structured => "exactly PERSONA:, APPEARANCE:, and CONTINUITY: lines",
             }
             .to_string(),
         );

--- a/v2/orchestrator-rust/src/avatar_context_spine.rs
+++ b/v2/orchestrator-rust/src/avatar_context_spine.rs
@@ -273,6 +273,10 @@ impl AvatarContextSpine {
                         "one native-voice response by {name}, at most {} words",
                         options.max_words
                     ),
+                    SpeechMode::Structured => format!(
+                        "one structured response by {name}, at most {} words",
+                        options.max_words
+                    ),
                     SpeechMode::Prose => format!(
                         "only {name}'s next spoken line, at most {} words",
                         options.max_words
@@ -283,7 +287,10 @@ impl AvatarContextSpine {
                 } else {
                     ""
                 };
-                let native_model = if options.speech_mode == SpeechMode::Raw {
+                let native_model = if matches!(
+                    options.speech_mode,
+                    SpeechMode::Raw | SpeechMode::Structured
+                ) {
                     " Keep the model avatar's native identity and voice; it need not pretend to be human. It is nevertheless an in-world participant, not a general assistant handling a private API request."
                 } else {
                     ""

--- a/v2/orchestrator-rust/src/avatar_reflections.rs
+++ b/v2/orchestrator-rust/src/avatar_reflections.rs
@@ -3,13 +3,13 @@ use crate::ai_voice_routing::{route_certified_voice, VoiceAttemptRequest};
 
 const AVATAR_THOUGHT_PROMPT_VERSION: &str = "avatar-thought-context-spine-v2";
 const AVATAR_DREAM_PROMPT_VERSION: &str = "avatar-dream-context-spine-v2";
-const AVATAR_SELF_DESCRIPTION_PROMPT_VERSION: &str = "avatar-self-description-context-spine-v3";
+const AVATAR_SELF_DESCRIPTION_PROMPT_VERSION: &str = "avatar-self-description-context-spine-v4";
 const ITEM_SELF_DESCRIPTION_PROMPT_VERSION: &str = "item-self-description-context-spine-v2";
 const LOCATION_SELF_DESCRIPTION_PROMPT_VERSION: &str = "location-self-description-context-spine-v2";
-// The prose publication gate also enforces a 360-character ceiling. Ninety
-// words invited valid prompt-following output that the gate could never
-// publish; 48 words leaves room for ordinary word lengths and punctuation.
-const SELF_DESCRIPTION_MAX_WORDS: usize = 48;
+// Three useful identity fields need more room than a spoken line. Structured
+// publication keeps a separate 1,200-character ceiling and validates the
+// exact three-line shape before the response can be cached as accepted.
+const SELF_DESCRIPTION_MAX_WORDS: usize = 72;
 const SELF_DESCRIPTION_MAX_TOKENS: u32 = 128;
 pub(super) const AVATAR_REFLECTION_DC: u16 = 18;
 
@@ -623,11 +623,7 @@ pub(super) async fn complete_avatar_self_description(
         (spine, model_binding)
     };
     let level = spine.speaker.level;
-    let speech_mode = if model_binding.is_some() {
-        SpeechMode::Raw
-    } else {
-        SpeechMode::Prose
-    };
+    let speech_mode = SpeechMode::Structured;
     let prompt = spine.prompt(AvatarContextPromptOptions {
         mode: AvatarContextMode::SelfDescription,
         speech_mode,
@@ -944,9 +940,10 @@ static AVATAR_SELF_DESCRIPTION_JOBS: OnceLock<StdMutex<BTreeSet<String>>> = Once
 
 fn avatar_self_description_generation_key(job: &AvatarReflectionJob) -> String {
     format!(
-        "avatar-self-description:{}:level:{}",
+        "avatar-self-description:{}:level:{}:{}",
         job.actor_id,
-        job.context_spine.speaker.level.max(1)
+        job.context_spine.speaker.level.max(1),
+        AVATAR_SELF_DESCRIPTION_PROMPT_VERSION,
     )
 }
 
@@ -1289,6 +1286,10 @@ mod tests {
         let conn = open_event_store(&path).expect("open self-description outbox");
 
         assert!(insert_avatar_self_description_job(&conn, &job).expect("first level job is queued"));
+        let durable_key: String = conn
+            .query_row("SELECT dedupe_key FROM actor_jobs", [], |row| row.get(0))
+            .expect("read the versioned self-description key");
+        assert!(durable_key.ends_with(AVATAR_SELF_DESCRIPTION_PROMPT_VERSION));
         assert!(!insert_avatar_self_description_job(&conn, &job)
             .expect("duplicate level job is ignored"));
         conn.execute(


### PR DESCRIPTION
## Summary
- send fully funded avatar self-descriptions through a structured publication contract instead of the spoken-dialogue contract
- preserve and validate the required PERSONA, APPEARANCE, and CONTINUITY lines before caching
- version the durable job key so portraits rejected by the old contract resume automatically
- raise the structured description budget while keeping safety, grounding, and provider checks

## Production cause
Version 1.0.129 proved the readiness retry worked, then Briony's valid response was rejected as speech: the field labels looked like multiple speakers and the prose character budget was too small.

## Checks
- npm run check (211 web tests; 1,299 Rust tests; worldpacks; kernel; architecture; lint; syntax)
- cargo test self_description
- npm run check:version