### PR TITLE
Redesign item lifecycle and policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.140",
+  "version": "1.0.141",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.140",
+      "version": "1.0.141",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.139",
+  "version": "1.0.140",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.139",
+      "version": "1.0.140",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.139",
+  "version": "1.0.140",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.140",
+  "version": "1.0.141",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/test/v2/worldpack-bundle-gate.test.mjs
+++ b/test/v2/worldpack-bundle-gate.test.mjs
@@ -34,7 +34,7 @@ function digest(value) {
 const LIVE_HASH = digest("live-journal-bundle");
 const CANDIDATE_HASH = digest("candidate-bundle");
 const OLDER_HASH = digest("older-declared-bundle");
-const LANTERN_CANDIDATE_HASH = "sha256:028b50e201cba948d386d0433e51c595e43280b253fb82aafd03bfad10abbe30";
+const LANTERN_CANDIDATE_HASH = "sha256:81fda49525831c905dce5a404bcfd2f452177736245d4e9eabe00b49047c027d";
 const LANTERN_ACTIVE_HASH = "sha256:1075c33b5cbfa4ad4cbaa60477f6ebb04773b867f001e8af149bb9a408ab0d88";
 const LANTERN_PREVIOUS_ACTIVE_HASH = "sha256:4d9a92d92781710f980fb68595576b5a65176e1b02267e45d438d8c0c395a183";
 const LANTERN_PERSISTED_HASH = "sha256:f16b48db1690307acb9861bc2d5005f143ec776060d98315dd95fa21befb7911";

--- a/v2/content/bethlehem/assets.json
+++ b/v2/content/bethlehem/assets.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -15,7 +15,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/bethlehem/items.json
+++ b/v2/content/bethlehem/items.json
@@ -6,7 +6,7 @@
     "kind": "potion",
     "charges": 1,
     "location_id": 1,
-    "role": "tool",
+    "role": "consumable",
     "capabilities": [
       "camp_shelter"
     ],

--- a/v2/content/bethlehem/recipes.json
+++ b/v2/content/bethlehem/recipes.json
@@ -1,13 +1,37 @@
 [
   {
+    "schema_version": 2,
     "id": 3001,
     "key": "hearth-story-lantern",
     "name": "Hearth Story Lantern",
     "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
     "output": {
       "item_id": 2011,
       "name": "Hearth Story Lantern",
@@ -17,7 +41,7 @@
       "target_kind": "location_floor",
       "target_id": 2
     },
-    "balance": {
+    "outcome": {
       "kind": "location",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -26,15 +50,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3002,
     "key": "bank-the-cottage-hearth",
     "name": "Bank the Cottage Hearth",
     "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 1,
@@ -43,15 +91,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3003,
     "key": "tend-the-rain-soft-garden",
     "name": "Tend the Rain-Soft Garden",
     "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-    "input_item_ids": [
-      2002,
-      2007
+    "inputs": [
+      {
+        "item_id": 2002,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2007,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        2
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -60,15 +132,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3004,
     "key": "reset-the-practice-circle",
     "name": "Reset the Practice Circle",
     "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-    "input_item_ids": [
-      2003,
-      2006
+    "inputs": [
+      {
+        "item_id": 2003,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2006,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        3
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 3,

--- a/v2/content/bethlehem/registry.json
+++ b/v2/content/bethlehem/registry.json
@@ -727,7 +727,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:070906fd0fd90124fe93641d11c2c6285cf0c78b2e9126d805206a0d9136eb7f",
+    "bundle_hash": "sha256:d6bb85c9b172307abb4c06faabb6d270e583b539947abb90d2e683832dff806d",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1999,7 +1999,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+        "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
       },
       {
         "id": "cosyworld.the-holy-land",
@@ -4310,7 +4310,7 @@
         "kind": "potion",
         "charges": 1,
         "location_id": 1,
-        "role": "tool",
+        "role": "consumable",
         "capabilities": [
           "camp_shelter"
         ],
@@ -11421,14 +11421,38 @@
     ],
     "recipes": [
       {
+        "schema_version": 2,
         "id": 3001,
         "key": "hearth-story-lantern",
         "name": "Hearth Story Lantern",
         "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
         "output": {
           "item_id": 2011,
           "name": "Hearth Story Lantern",
@@ -11438,7 +11462,7 @@
           "target_kind": "location_floor",
           "target_id": 2
         },
-        "balance": {
+        "outcome": {
           "kind": "location",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -11447,15 +11471,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3002,
         "key": "bank-the-cottage-hearth",
         "name": "Bank the Cottage Hearth",
         "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 1,
@@ -11464,15 +11512,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3003,
         "key": "tend-the-rain-soft-garden",
         "name": "Tend the Rain-Soft Garden",
         "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-        "input_item_ids": [
-          2002,
-          2007
+        "inputs": [
+          {
+            "item_id": 2002,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2007,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            2
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -11481,15 +11553,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3004,
         "key": "reset-the-practice-circle",
         "name": "Reset the Practice Circle",
         "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-        "input_item_ids": [
-          2003,
-          2006
+        "inputs": [
+          {
+            "item_id": 2003,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2006,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            3
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 3,
@@ -11893,7 +11989,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -11906,7 +12002,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",

--- a/v2/content/bethlehem/worldpack.json
+++ b/v2/content/bethlehem/worldpack.json
@@ -725,7 +725,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:070906fd0fd90124fe93641d11c2c6285cf0c78b2e9126d805206a0d9136eb7f",
+  "bundle_hash": "sha256:d6bb85c9b172307abb4c06faabb6d270e583b539947abb90d2e683832dff806d",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1997,7 +1997,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
     },
     {
       "id": "cosyworld.the-holy-land",

--- a/v2/content/core-only/assets.json
+++ b/v2/content/core-only/assets.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -15,7 +15,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/core-only/items.json
+++ b/v2/content/core-only/items.json
@@ -6,7 +6,7 @@
     "kind": "potion",
     "charges": 1,
     "location_id": 1,
-    "role": "tool",
+    "role": "consumable",
     "capabilities": [
       "camp_shelter"
     ],

--- a/v2/content/core-only/recipes.json
+++ b/v2/content/core-only/recipes.json
@@ -1,13 +1,37 @@
 [
   {
+    "schema_version": 2,
     "id": 3001,
     "key": "hearth-story-lantern",
     "name": "Hearth Story Lantern",
     "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
     "output": {
       "item_id": 2011,
       "name": "Hearth Story Lantern",
@@ -17,7 +41,7 @@
       "target_kind": "location_floor",
       "target_id": 2
     },
-    "balance": {
+    "outcome": {
       "kind": "location",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -26,15 +50,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3002,
     "key": "bank-the-cottage-hearth",
     "name": "Bank the Cottage Hearth",
     "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 1,
@@ -43,15 +91,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3003,
     "key": "tend-the-rain-soft-garden",
     "name": "Tend the Rain-Soft Garden",
     "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-    "input_item_ids": [
-      2002,
-      2007
+    "inputs": [
+      {
+        "item_id": 2002,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2007,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        2
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -60,15 +132,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3004,
     "key": "reset-the-practice-circle",
     "name": "Reset the Practice Circle",
     "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-    "input_item_ids": [
-      2003,
-      2006
+    "inputs": [
+      {
+        "item_id": 2003,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2006,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        3
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 3,

--- a/v2/content/core-only/registry.json
+++ b/v2/content/core-only/registry.json
@@ -617,7 +617,7 @@
         "public_trace": "marked the first uncovered stone so the next visitor can trust the washed path"
       }
     },
-    "bundle_hash": "sha256:c25a8ef4b6aab4cea9e6d70e3153c1d0785348facdbaa97976b0bbf3f6e9978e",
+    "bundle_hash": "sha256:79f0df04f8d3a7538797da9cb26ce8c1c96ef8bec1c05f916832c8325842a3bb",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -1889,7 +1889,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+        "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
       }
     ],
     "files": {
@@ -3256,7 +3256,7 @@
         "kind": "potion",
         "charges": 1,
         "location_id": 1,
-        "role": "tool",
+        "role": "consumable",
         "capabilities": [
           "camp_shelter"
         ],
@@ -8190,14 +8190,38 @@
     ],
     "recipes": [
       {
+        "schema_version": 2,
         "id": 3001,
         "key": "hearth-story-lantern",
         "name": "Hearth Story Lantern",
         "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
         "output": {
           "item_id": 2011,
           "name": "Hearth Story Lantern",
@@ -8207,7 +8231,7 @@
           "target_kind": "location_floor",
           "target_id": 2
         },
-        "balance": {
+        "outcome": {
           "kind": "location",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -8216,15 +8240,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3002,
         "key": "bank-the-cottage-hearth",
         "name": "Bank the Cottage Hearth",
         "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 1,
@@ -8233,15 +8281,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3003,
         "key": "tend-the-rain-soft-garden",
         "name": "Tend the Rain-Soft Garden",
         "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-        "input_item_ids": [
-          2002,
-          2007
+        "inputs": [
+          {
+            "item_id": 2002,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2007,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            2
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -8250,15 +8322,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3004,
         "key": "reset-the-practice-circle",
         "name": "Reset the Practice Circle",
         "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-        "input_item_ids": [
-          2003,
-          2006
+        "inputs": [
+          {
+            "item_id": 2003,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2006,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            3
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 3,
@@ -8662,7 +8758,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -8675,7 +8771,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",

--- a/v2/content/core-only/worldpack.json
+++ b/v2/content/core-only/worldpack.json
@@ -615,7 +615,7 @@
       "public_trace": "marked the first uncovered stone so the next visitor can trust the washed path"
     }
   },
-  "bundle_hash": "sha256:c25a8ef4b6aab4cea9e6d70e3153c1d0785348facdbaa97976b0bbf3f6e9978e",
+  "bundle_hash": "sha256:79f0df04f8d3a7538797da9cb26ce8c1c96ef8bec1c05f916832c8325842a3bb",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -1887,7 +1887,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
     }
   ],
   "files": {

--- a/v2/content/core-ruby/assets.json
+++ b/v2/content/core-ruby/assets.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -15,7 +15,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/core-ruby/items.json
+++ b/v2/content/core-ruby/items.json
@@ -6,7 +6,7 @@
     "kind": "potion",
     "charges": 1,
     "location_id": 1,
-    "role": "tool",
+    "role": "consumable",
     "capabilities": [
       "camp_shelter"
     ],

--- a/v2/content/core-ruby/recipes.json
+++ b/v2/content/core-ruby/recipes.json
@@ -1,13 +1,37 @@
 [
   {
+    "schema_version": 2,
     "id": 3001,
     "key": "hearth-story-lantern",
     "name": "Hearth Story Lantern",
     "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
     "output": {
       "item_id": 2011,
       "name": "Hearth Story Lantern",
@@ -17,7 +41,7 @@
       "target_kind": "location_floor",
       "target_id": 2
     },
-    "balance": {
+    "outcome": {
       "kind": "location",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -26,15 +50,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3002,
     "key": "bank-the-cottage-hearth",
     "name": "Bank the Cottage Hearth",
     "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 1,
@@ -43,15 +91,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3003,
     "key": "tend-the-rain-soft-garden",
     "name": "Tend the Rain-Soft Garden",
     "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-    "input_item_ids": [
-      2002,
-      2007
+    "inputs": [
+      {
+        "item_id": 2002,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2007,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        2
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -60,15 +132,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3004,
     "key": "reset-the-practice-circle",
     "name": "Reset the Practice Circle",
     "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-    "input_item_ids": [
-      2003,
-      2006
+    "inputs": [
+      {
+        "item_id": 2003,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2006,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        3
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 3,

--- a/v2/content/core-ruby/registry.json
+++ b/v2/content/core-ruby/registry.json
@@ -743,7 +743,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:4c40819234949a5756abffd7de53a8767e53890e53ca2d95a3ad0118a4db749d",
+    "bundle_hash": "sha256:16cb00253fac044e2273004d53e32cce06f42610d05f8ad74a87639ce256d7cf",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -2015,7 +2015,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+        "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
       },
       {
         "id": "ruby-high.first-bell",
@@ -4094,7 +4094,7 @@
         "kind": "potion",
         "charges": 1,
         "location_id": 1,
-        "role": "tool",
+        "role": "consumable",
         "capabilities": [
           "camp_shelter"
         ],
@@ -9864,14 +9864,38 @@
     ],
     "recipes": [
       {
+        "schema_version": 2,
         "id": 3001,
         "key": "hearth-story-lantern",
         "name": "Hearth Story Lantern",
         "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
         "output": {
           "item_id": 2011,
           "name": "Hearth Story Lantern",
@@ -9881,7 +9905,7 @@
           "target_kind": "location_floor",
           "target_id": 2
         },
-        "balance": {
+        "outcome": {
           "kind": "location",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -9890,15 +9914,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3002,
         "key": "bank-the-cottage-hearth",
         "name": "Bank the Cottage Hearth",
         "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 1,
@@ -9907,15 +9955,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3003,
         "key": "tend-the-rain-soft-garden",
         "name": "Tend the Rain-Soft Garden",
         "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-        "input_item_ids": [
-          2002,
-          2007
+        "inputs": [
+          {
+            "item_id": 2002,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2007,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            2
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -9924,15 +9996,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3004,
         "key": "reset-the-practice-circle",
         "name": "Reset the Practice Circle",
         "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-        "input_item_ids": [
-          2003,
-          2006
+        "inputs": [
+          {
+            "item_id": 2003,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2006,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            3
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 3,
@@ -10757,7 +10853,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -10770,7 +10866,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",

--- a/v2/content/core-ruby/worldpack.json
+++ b/v2/content/core-ruby/worldpack.json
@@ -741,7 +741,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:4c40819234949a5756abffd7de53a8767e53890e53ca2d95a3ad0118a4db749d",
+  "bundle_hash": "sha256:16cb00253fac044e2273004d53e32cce06f42610d05f8ad74a87639ce256d7cf",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -2013,7 +2013,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
     },
     {
       "id": "ruby-high.first-bell",

--- a/v2/content/core/items.json
+++ b/v2/content/core/items.json
@@ -6,7 +6,7 @@
     "kind": "potion",
     "charges": 1,
     "location_id": 1,
-    "role": "tool",
+    "role": "consumable",
     "capabilities": ["camp_shelter"],
     "weight_tenths": 5,
     "size": "small",

--- a/v2/content/core/recipes.json
+++ b/v2/content/core/recipes.json
@@ -1,10 +1,15 @@
 [
   {
+    "schema_version": 2,
     "id": 3001,
     "key": "hearth-story-lantern",
     "name": "Hearth Story Lantern",
     "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-    "input_item_ids": [2001, 2005],
+    "inputs": [
+      {"item_id": 2001, "quantity": 1, "zones": ["carried", "world"], "min_charges": 1, "disposition": "persistent"},
+      {"item_id": 2005, "quantity": 1, "zones": ["carried", "world"], "min_charges": 1, "disposition": "persistent"}
+    ],
+    "requires": {"location_ids": [1]},
     "output": {
       "item_id": 2011,
       "name": "Hearth Story Lantern",
@@ -14,7 +19,7 @@
       "target_kind": "location_floor",
       "target_id": 2
     },
-    "balance": {
+    "outcome": {
       "kind": "location",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -22,12 +27,17 @@
     }
   },
   {
+    "schema_version": 2,
     "id": 3002,
     "key": "bank-the-cottage-hearth",
     "name": "Bank the Cottage Hearth",
     "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-    "input_item_ids": [2001, 2005],
-    "balance": {
+    "inputs": [
+      {"item_id": 2001, "quantity": 1, "zones": ["carried", "world"], "min_charges": 1, "disposition": "persistent"},
+      {"item_id": 2005, "quantity": 1, "zones": ["carried", "world"], "min_charges": 1, "disposition": "persistent"}
+    ],
+    "requires": {"location_ids": [1]},
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 1,
@@ -35,12 +45,17 @@
     }
   },
   {
+    "schema_version": 2,
     "id": 3003,
     "key": "tend-the-rain-soft-garden",
     "name": "Tend the Rain-Soft Garden",
     "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-    "input_item_ids": [2002, 2007],
-    "balance": {
+    "inputs": [
+      {"item_id": 2002, "quantity": 1, "zones": ["carried", "world"], "min_charges": 1, "disposition": "persistent"},
+      {"item_id": 2007, "quantity": 1, "zones": ["carried", "world"], "min_charges": 1, "disposition": "persistent"}
+    ],
+    "requires": {"location_ids": [2]},
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -48,12 +63,17 @@
     }
   },
   {
+    "schema_version": 2,
     "id": 3004,
     "key": "reset-the-practice-circle",
     "name": "Reset the Practice Circle",
     "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-    "input_item_ids": [2003, 2006],
-    "balance": {
+    "inputs": [
+      {"item_id": 2003, "quantity": 1, "zones": ["carried", "world"], "min_charges": 1, "disposition": "persistent"},
+      {"item_id": 2006, "quantity": 1, "zones": ["carried", "world"], "min_charges": 1, "disposition": "persistent"}
+    ],
+    "requires": {"location_ids": [3]},
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 3,

--- a/v2/content/lantern-keeper/assets.json
+++ b/v2/content/lantern-keeper/assets.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -15,7 +15,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/lantern-keeper/items.json
+++ b/v2/content/lantern-keeper/items.json
@@ -6,7 +6,7 @@
     "kind": "potion",
     "charges": 1,
     "location_id": 1,
-    "role": "tool",
+    "role": "consumable",
     "capabilities": [
       "camp_shelter"
     ],

--- a/v2/content/lantern-keeper/recipes.json
+++ b/v2/content/lantern-keeper/recipes.json
@@ -1,13 +1,37 @@
 [
   {
+    "schema_version": 2,
     "id": 3001,
     "key": "hearth-story-lantern",
     "name": "Hearth Story Lantern",
     "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
     "output": {
       "item_id": 2011,
       "name": "Hearth Story Lantern",
@@ -17,7 +41,7 @@
       "target_kind": "location_floor",
       "target_id": 2
     },
-    "balance": {
+    "outcome": {
       "kind": "location",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -26,15 +50,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3002,
     "key": "bank-the-cottage-hearth",
     "name": "Bank the Cottage Hearth",
     "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 1,
@@ -43,15 +91,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3003,
     "key": "tend-the-rain-soft-garden",
     "name": "Tend the Rain-Soft Garden",
     "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-    "input_item_ids": [
-      2002,
-      2007
+    "inputs": [
+      {
+        "item_id": 2002,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2007,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        2
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -60,15 +132,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3004,
     "key": "reset-the-practice-circle",
     "name": "Reset the Practice Circle",
     "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-    "input_item_ids": [
-      2003,
-      2006
+    "inputs": [
+      {
+        "item_id": 2003,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2006,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        3
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 3,

--- a/v2/content/lantern-keeper/registry.json
+++ b/v2/content/lantern-keeper/registry.json
@@ -760,7 +760,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:028b50e201cba948d386d0433e51c595e43280b253fb82aafd03bfad10abbe30",
+    "bundle_hash": "sha256:81fda49525831c905dce5a404bcfd2f452177736245d4e9eabe00b49047c027d",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -2035,7 +2035,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+        "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
       },
       {
         "id": "cosyworld.rules-srd-5.1",
@@ -4076,7 +4076,7 @@
         "kind": "potion",
         "charges": 1,
         "location_id": 1,
-        "role": "tool",
+        "role": "consumable",
         "capabilities": [
           "camp_shelter"
         ],
@@ -10110,14 +10110,38 @@
     ],
     "recipes": [
       {
+        "schema_version": 2,
         "id": 3001,
         "key": "hearth-story-lantern",
         "name": "Hearth Story Lantern",
         "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
         "output": {
           "item_id": 2011,
           "name": "Hearth Story Lantern",
@@ -10127,7 +10151,7 @@
           "target_kind": "location_floor",
           "target_id": 2
         },
-        "balance": {
+        "outcome": {
           "kind": "location",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -10136,15 +10160,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3002,
         "key": "bank-the-cottage-hearth",
         "name": "Bank the Cottage Hearth",
         "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 1,
@@ -10153,15 +10201,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3003,
         "key": "tend-the-rain-soft-garden",
         "name": "Tend the Rain-Soft Garden",
         "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-        "input_item_ids": [
-          2002,
-          2007
+        "inputs": [
+          {
+            "item_id": 2002,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2007,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            2
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -10170,15 +10242,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3004,
         "key": "reset-the-practice-circle",
         "name": "Reset the Practice Circle",
         "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-        "input_item_ids": [
-          2003,
-          2006
+        "inputs": [
+          {
+            "item_id": 2003,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2006,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            3
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 3,
@@ -10583,7 +10679,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -10596,7 +10692,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",

--- a/v2/content/lantern-keeper/worldpack.json
+++ b/v2/content/lantern-keeper/worldpack.json
@@ -758,7 +758,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:028b50e201cba948d386d0433e51c595e43280b253fb82aafd03bfad10abbe30",
+  "bundle_hash": "sha256:81fda49525831c905dce5a404bcfd2f452177736245d4e9eabe00b49047c027d",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -2033,7 +2033,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
     },
     {
       "id": "cosyworld.rules-srd-5.1",

--- a/v2/content/official/assets.json
+++ b/v2/content/official/assets.json
@@ -2,7 +2,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "generated/cards",
     "root": "core",
@@ -15,7 +15,7 @@
   {
     "pack_id": "cosyworld.core",
     "pack_version": "1.3.13",
-    "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+    "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
     "provider": "cosyworld.core/assets",
     "mount": "locations",
     "root": "core",

--- a/v2/content/official/items.json
+++ b/v2/content/official/items.json
@@ -6,7 +6,7 @@
     "kind": "potion",
     "charges": 1,
     "location_id": 1,
-    "role": "tool",
+    "role": "consumable",
     "capabilities": [
       "camp_shelter"
     ],

--- a/v2/content/official/recipes.json
+++ b/v2/content/official/recipes.json
@@ -1,13 +1,37 @@
 [
   {
+    "schema_version": 2,
     "id": 3001,
     "key": "hearth-story-lantern",
     "name": "Hearth Story Lantern",
     "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
     "output": {
       "item_id": 2011,
       "name": "Hearth Story Lantern",
@@ -17,7 +41,7 @@
       "target_kind": "location_floor",
       "target_id": 2
     },
-    "balance": {
+    "outcome": {
       "kind": "location",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -26,15 +50,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3002,
     "key": "bank-the-cottage-hearth",
     "name": "Bank the Cottage Hearth",
     "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-    "input_item_ids": [
-      2001,
-      2005
+    "inputs": [
+      {
+        "item_id": 2001,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2005,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        1
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 1,
@@ -43,15 +91,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3003,
     "key": "tend-the-rain-soft-garden",
     "name": "Tend the Rain-Soft Garden",
     "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-    "input_item_ids": [
-      2002,
-      2007
+    "inputs": [
+      {
+        "item_id": 2002,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2007,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        2
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 2,
@@ -60,15 +132,39 @@
     "pack_id": "cosyworld.core"
   },
   {
+    "schema_version": 2,
     "id": 3004,
     "key": "reset-the-practice-circle",
     "name": "Reset the Practice Circle",
     "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-    "input_item_ids": [
-      2003,
-      2006
+    "inputs": [
+      {
+        "item_id": 2003,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      },
+      {
+        "item_id": 2006,
+        "quantity": 1,
+        "zones": [
+          "carried",
+          "world"
+        ],
+        "min_charges": 1,
+        "disposition": "persistent"
+      }
     ],
-    "balance": {
+    "requires": {
+      "location_ids": [
+        3
+      ]
+    },
+    "outcome": {
       "kind": "covenant",
       "target_kind": "location_floor",
       "target_id": 3,

--- a/v2/content/official/registry.json
+++ b/v2/content/official/registry.json
@@ -818,7 +818,7 @@
         }
       ]
     },
-    "bundle_hash": "sha256:d2f4d610d4c55b5a0565631940db57f94d97685640ae4b74632a529022530b61",
+    "bundle_hash": "sha256:559ee546f9fc49840dc8cc11ef0d4091914364496c6d88f4ab3070cdf7f86828",
     "packs": [
       {
         "id": "cosyworld.rules-srd-5.2.1",
@@ -2093,7 +2093,7 @@
           "type": "workspace",
           "path": "../../content/core"
         },
-        "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+        "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
       },
       {
         "id": "cosyworld.rules-srd-5.1",
@@ -5704,7 +5704,7 @@
         "kind": "potion",
         "charges": 1,
         "location_id": 1,
-        "role": "tool",
+        "role": "consumable",
         "capabilities": [
           "camp_shelter"
         ],
@@ -14751,14 +14751,38 @@
     ],
     "recipes": [
       {
+        "schema_version": 2,
         "id": 3001,
         "key": "hearth-story-lantern",
         "name": "Hearth Story Lantern",
         "description": "Bind a warm tonic and a tale-button into a lantern that opens a farther cottage doorway.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
         "output": {
           "item_id": 2011,
           "name": "Hearth Story Lantern",
@@ -14768,7 +14792,7 @@
           "target_kind": "location_floor",
           "target_id": 2
         },
-        "balance": {
+        "outcome": {
           "kind": "location",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -14777,15 +14801,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3002,
         "key": "bank-the-cottage-hearth",
         "name": "Bank the Cottage Hearth",
         "description": "Set the hearth tonic beside the story button and bank the cottage fire for whoever arrives next.",
-        "input_item_ids": [
-          2001,
-          2005
+        "inputs": [
+          {
+            "item_id": 2001,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2005,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            1
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 1,
@@ -14794,15 +14842,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3003,
         "key": "tend-the-rain-soft-garden",
         "name": "Tend the Rain-Soft Garden",
         "description": "Set the dewbright button beside the watch bell and clear the puddle path for the next visitor.",
-        "input_item_ids": [
-          2002,
-          2007
+        "inputs": [
+          {
+            "item_id": 2002,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2007,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            2
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 2,
@@ -14811,15 +14883,39 @@
         "pack_id": "cosyworld.core"
       },
       {
+        "schema_version": 2,
         "id": 3004,
         "key": "reset-the-practice-circle",
         "name": "Reset the Practice Circle",
         "description": "Set the wolfprint charm beside the hearthstone tag and smooth the practice circle after a hard crossing.",
-        "input_item_ids": [
-          2003,
-          2006
+        "inputs": [
+          {
+            "item_id": 2003,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          },
+          {
+            "item_id": 2006,
+            "quantity": 1,
+            "zones": [
+              "carried",
+              "world"
+            ],
+            "min_charges": 1,
+            "disposition": "persistent"
+          }
         ],
-        "balance": {
+        "requires": {
+          "location_ids": [
+            3
+          ]
+        },
+        "outcome": {
           "kind": "covenant",
           "target_kind": "location_floor",
           "target_id": 3,
@@ -15645,7 +15741,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "generated/cards",
       "root": "core",
@@ -15658,7 +15754,7 @@
     {
       "pack_id": "cosyworld.core",
       "pack_version": "1.3.13",
-      "pack_integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "pack_integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "provider": "cosyworld.core/assets",
       "mount": "locations",
       "root": "core",

--- a/v2/content/official/worldpack.json
+++ b/v2/content/official/worldpack.json
@@ -816,7 +816,7 @@
       }
     ]
   },
-  "bundle_hash": "sha256:d2f4d610d4c55b5a0565631940db57f94d97685640ae4b74632a529022530b61",
+  "bundle_hash": "sha256:559ee546f9fc49840dc8cc11ef0d4091914364496c6d88f4ab3070cdf7f86828",
   "packs": [
     {
       "id": "cosyworld.rules-srd-5.2.1",
@@ -2091,7 +2091,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d"
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f"
     },
     {
       "id": "cosyworld.rules-srd-5.1",

--- a/v2/core-c/include/cosy_kernel.h
+++ b/v2/core-c/include/cosy_kernel.h
@@ -10,7 +10,10 @@ extern "C" {
 
 /* Version 9 is reserved by #411 for project-push ABI state. */
 /* Version 15 widens the actor array; sizeof(cw_world) changed. */
-#define CW_KERNEL_VERSION 15u
+/* Version 16 expands the item array, gives undiscovered items an explicit
+ * Hidden zone, makes transfer policy authoritative, and removes the unused
+ * recharge timestamp from cw_item. */
+#define CW_KERNEL_VERSION 16u
 
 /* Capacities are compiled into cw_world as fixed arrays, so raising one is an
  * ABI change that must be mirrored in the Rust bindings. Actors, locations,
@@ -18,7 +21,7 @@ extern "C" {
  * once: the current union is 589 actors, 580 locations, and 1269 exits, and
  * generated residents and pathway descendants grow them at runtime. */
 #define CW_MAX_ACTORS 2048u
-#define CW_MAX_ITEMS 1024u
+#define CW_MAX_ITEMS 2048u
 #define CW_MAX_LOCATIONS 2048u
 #define CW_MAX_EXITS 4096u
 #define CW_MAX_EVOLUTION_TRACKS 128u
@@ -143,7 +146,8 @@ typedef enum {
   CW_CARD_ZONE_EXHAUSTED = 5,
   CW_CARD_ZONE_CONTAINED = 6,
   CW_CARD_ZONE_ESCROW = 7,
-  CW_CARD_ZONE_INSTALLED = 8
+  CW_CARD_ZONE_INSTALLED = 8,
+  CW_CARD_ZONE_HIDDEN = 9
 } cw_card_zone;
 
 typedef enum {
@@ -155,6 +159,13 @@ typedef enum {
   CW_ITEM_FLAG_NONE = 0,
   CW_ITEM_FLAG_INERT = 1u << 0
 } cw_item_flags;
+
+typedef enum {
+  CW_ITEM_POLICY_NONE = 0,
+  CW_ITEM_POLICY_TRANSFERABLE = 1u << 0,
+  CW_ITEM_POLICY_THEFT_WHEN_CARRIED = 1u << 1,
+  CW_ITEM_POLICY_CONFIGURED = 1u << 7
+} cw_item_policy_flags;
 
 typedef enum {
   CW_GATE_TARGET_NONE = 0,
@@ -416,6 +427,8 @@ typedef struct {
 
 typedef struct {
   cw_id id;
+  /* Legacy content family retained for journal and ABI compatibility. New
+   * mechanics must dispatch on role and the authored item profile. */
   uint8_t kind;
   uint8_t status;
   uint16_t reserved;
@@ -449,20 +462,19 @@ typedef struct {
   uint8_t max_charges;
   uint8_t recovery;
   uint8_t recovery_zone;
-  uint8_t reserved2;
+  uint8_t policy_flags;
   cw_id location_id;
   cw_id holder_actor_id;
   cw_id container_item_id;
   uint64_t held_since_tick;
-  uint64_t recharge_at_tick;
 } cw_item;
 
 #ifdef __cplusplus
-static_assert(sizeof(cw_item) == 64, "cw_item ABI size must remain stable");
+static_assert(sizeof(cw_item) == 56, "cw_item ABI size must remain stable");
 static_assert(offsetof(cw_item, max_charges) == 18, "cw_item recovery ABI offset drifted");
 static_assert(offsetof(cw_item, location_id) == 24, "cw_item id ABI offset drifted");
 #else
-_Static_assert(sizeof(cw_item) == 64, "cw_item ABI size must remain stable");
+_Static_assert(sizeof(cw_item) == 56, "cw_item ABI size must remain stable");
 _Static_assert(offsetof(cw_item, max_charges) == 18, "cw_item recovery ABI offset drifted");
 _Static_assert(offsetof(cw_item, location_id) == 24, "cw_item id ABI offset drifted");
 #endif
@@ -705,6 +717,7 @@ void cw_world_init(cw_world *world);
 cw_status cw_seed_cosy_cottage(cw_world *world, cw_event_buffer *out_events);
 cw_status cw_world_set_item_profile(cw_world *world, cw_id item_id, uint16_t weight_tenths, uint8_t size_class, uint8_t role, uint16_t container_capacity_tenths);
 cw_status cw_world_set_item_recovery_profile(cw_world *world, cw_id item_id, uint8_t max_charges, uint8_t recovery, uint8_t ready_zone);
+cw_status cw_world_set_item_policy(cw_world *world, cw_id item_id, uint8_t policy_flags);
 cw_status cw_world_set_item_zone(cw_world *world, cw_id item_id, uint8_t zone, cw_id container_item_id);
 cw_status cw_world_set_evolution_track(cw_world *world, cw_id actor_id, const cw_evolution_requirement *requirements, size_t requirement_count);
 cw_status cw_world_set_gate(cw_world *world, const cw_gate *gate, const cw_gate_method_definition *methods, size_t method_count);

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -431,6 +431,50 @@ static cw_status add_actor(cw_world *world, cw_id actor_id, uint8_t kind, cw_id 
   return CW_OK;
 }
 
+static int valid_item_placement(
+    uint8_t zone,
+    cw_id holder_actor_id,
+    cw_id location_id,
+    cw_id container_item_id) {
+  switch (zone) {
+    case CW_CARD_ZONE_HIDDEN:
+      return !holder_actor_id && !location_id && !container_item_id;
+    case CW_CARD_ZONE_WORLD:
+    case CW_CARD_ZONE_INSTALLED:
+      return !holder_actor_id && location_id && !container_item_id;
+    case CW_CARD_ZONE_CARRIED:
+    case CW_CARD_ZONE_EQUIPPED:
+    case CW_CARD_ZONE_SPELL_DECK:
+    case CW_CARD_ZONE_ESCROW:
+      return holder_actor_id && !location_id && !container_item_id;
+    case CW_CARD_ZONE_CONTAINED:
+      return holder_actor_id && !location_id && container_item_id;
+    case CW_CARD_ZONE_EXHAUSTED:
+      return (!!holder_actor_id != !!location_id) && !container_item_id;
+    default:
+      return 0;
+  }
+}
+
+/* Placement is one transition so callers cannot leave holder, room, zone, and
+ * container references out of sync between assignments. */
+static cw_status place_item(
+    cw_item *item,
+    uint8_t zone,
+    cw_id holder_actor_id,
+    cw_id location_id,
+    cw_id container_item_id,
+    uint64_t held_since_tick) {
+  if (!item || !valid_item_placement(
+      zone, holder_actor_id, location_id, container_item_id)) return CW_ERR_RULE;
+  item->zone = zone;
+  item->holder_actor_id = holder_actor_id;
+  item->location_id = location_id;
+  item->container_item_id = container_item_id;
+  item->held_since_tick = held_since_tick;
+  return CW_OK;
+}
+
 static cw_status add_item(cw_world *world, cw_id item_id, uint8_t kind, cw_id location_id, uint8_t charges) {
   if (find_item(world, item_id)) return CW_OK;
   if (world->item_count >= CW_MAX_ITEMS) return CW_ERR_FULL;
@@ -443,14 +487,18 @@ static cw_status add_item(cw_world *world, cw_id item_id, uint8_t kind, cw_id lo
   item->weight_tenths = CW_ITEM_DEFAULT_WEIGHT_TENTHS;
   item->size_class = CW_ITEM_SIZE_SMALL;
   item->role = kind == CW_ITEM_POTION ? CW_ITEM_ROLE_CONSUMABLE : CW_ITEM_ROLE_GENERIC;
-  item->zone = CW_CARD_ZONE_WORLD;
-  item->location_id = location_id;
-  item->holder_actor_id = 0;
-  return CW_OK;
+  item->policy_flags = CW_ITEM_POLICY_CONFIGURED | CW_ITEM_POLICY_TRANSFERABLE;
+  return place_item(
+      item,
+      location_id ? CW_CARD_ZONE_WORLD : CW_CARD_ZONE_HIDDEN,
+      0,
+      location_id,
+      0,
+      0);
 }
 
 static cw_status create_item(cw_world *world, cw_id item_id, uint8_t kind, uint8_t charges, uint8_t target_kind, cw_id target_id) {
-  if (!item_id || !kind || !charges || find_item(world, item_id)) return CW_ERR_INVALID;
+  if (!item_id || !kind || !charges || !target_id || find_item(world, item_id)) return CW_ERR_INVALID;
   if (world->item_count >= CW_MAX_ITEMS) return CW_ERR_FULL;
   cw_item *item = &world->items[world->item_count++];
   memset(item, 0, sizeof(*item));
@@ -461,24 +509,16 @@ static cw_status create_item(cw_world *world, cw_id item_id, uint8_t kind, uint8
   item->weight_tenths = CW_ITEM_DEFAULT_WEIGHT_TENTHS;
   item->size_class = CW_ITEM_SIZE_SMALL;
   item->role = kind == CW_ITEM_POTION ? CW_ITEM_ROLE_CONSUMABLE : CW_ITEM_ROLE_GENERIC;
+  item->policy_flags = CW_ITEM_POLICY_CONFIGURED | CW_ITEM_POLICY_TRANSFERABLE;
   switch (target_kind) {
     case CW_PLACEMENT_ACTOR_HAND:
-      item->holder_actor_id = target_id;
-      item->location_id = 0;
-      item->held_since_tick = world->tick;
-      item->zone = CW_CARD_ZONE_CARRIED;
+      (void)place_item(item, CW_CARD_ZONE_CARRIED, target_id, 0, 0, world->tick);
       break;
     case CW_PLACEMENT_LOCATION_FLOOR:
-      item->holder_actor_id = 0;
-      item->location_id = target_id;
-      item->held_since_tick = 0;
-      item->zone = CW_CARD_ZONE_WORLD;
+      (void)place_item(item, CW_CARD_ZONE_WORLD, 0, target_id, 0, 0);
       break;
     case CW_PLACEMENT_LOCATION_FIXTURE:
-      item->holder_actor_id = 0;
-      item->location_id = target_id;
-      item->held_since_tick = 0;
-      item->zone = CW_CARD_ZONE_INSTALLED;
+      (void)place_item(item, CW_CARD_ZONE_INSTALLED, 0, target_id, 0, 0);
       break;
     default:
       world->item_count--;
@@ -491,8 +531,57 @@ static int actor_is_active(const cw_actor *actor) {
   return actor && actor->status == CW_ACTOR_ACTIVE;
 }
 
+static int item_policy_is_configured(const cw_item *item) {
+  return item && (item->policy_flags & CW_ITEM_POLICY_CONFIGURED);
+}
+
+static int item_is_transferable(const cw_item *item) {
+  return item && (!item_policy_is_configured(item)
+      || (item->policy_flags & CW_ITEM_POLICY_TRANSFERABLE));
+}
+
+static int item_is_directly_held(const cw_item *item) {
+  return item && item->holder_actor_id && !item->location_id
+      && !item->container_item_id && item->zone != CW_CARD_ZONE_CONTAINED
+      && item->zone != CW_CARD_ZONE_ESCROW && item->zone != CW_CARD_ZONE_INSTALLED;
+}
+
+static int item_is_theft_eligible(const cw_item *item) {
+  if (!item || !item_is_directly_held(item)
+      || (item->zone != CW_CARD_ZONE_CARRIED
+          && item->zone != CW_CARD_ZONE_EQUIPPED
+          && item->zone != CW_CARD_ZONE_WORLD
+          && item->zone != CW_CARD_ZONE_HIDDEN)) return 0;
+  return !item_policy_is_configured(item)
+      || (item->policy_flags & CW_ITEM_POLICY_THEFT_WHEN_CARRIED);
+}
+
 static uint32_t item_weight_tenths(const cw_item *item) {
   return item && item->weight_tenths ? item->weight_tenths : CW_ITEM_DEFAULT_WEIGHT_TENTHS;
+}
+
+static int item_has_contents(const cw_world *world, cw_id item_id) {
+  if (!world || !item_id) return 0;
+  for (size_t i = 0; i < world->item_count; ++i) {
+    if (world->items[i].container_item_id == item_id) return 1;
+  }
+  return 0;
+}
+
+static uint32_t container_contents_weight_tenths(
+    const cw_world *world,
+    cw_id container_item_id,
+    cw_id excluded_item_id) {
+  uint32_t weight = 0;
+  if (!world || !container_item_id) return 0;
+  for (size_t i = 0; i < world->item_count; ++i) {
+    const cw_item *item = &world->items[i];
+    if (item->id != excluded_item_id
+        && item->container_item_id == container_item_id) {
+      weight += item_weight_tenths(item);
+    }
+  }
+  return weight;
 }
 
 static uint32_t item_container_capacity_tenths(const cw_item *item) {
@@ -804,21 +893,31 @@ cw_status cw_world_set_item_recovery_profile(
   return CW_OK;
 }
 
+cw_status cw_world_set_item_policy(
+    cw_world *world,
+    cw_id item_id,
+    uint8_t policy_flags) {
+  const uint8_t allowed = CW_ITEM_POLICY_TRANSFERABLE
+      | CW_ITEM_POLICY_THEFT_WHEN_CARRIED;
+  if (!world || !item_id || (policy_flags & ~allowed)) return CW_ERR_INVALID;
+  cw_item *item = find_item(world, item_id);
+  if (!item) return CW_ERR_NOT_FOUND;
+  item->policy_flags = CW_ITEM_POLICY_CONFIGURED | policy_flags;
+  return CW_OK;
+}
+
 cw_status cw_world_set_item_zone(
     cw_world *world,
     cw_id item_id,
     uint8_t zone,
     cw_id container_item_id) {
-  if (!world || !item_id || zone < CW_CARD_ZONE_WORLD || zone > CW_CARD_ZONE_INSTALLED) {
+  if (!world || !item_id || zone < CW_CARD_ZONE_WORLD || zone > CW_CARD_ZONE_HIDDEN) {
     return CW_ERR_INVALID;
   }
   cw_item *item = find_item(world, item_id);
   if (!item) return CW_ERR_NOT_FOUND;
-  if (zone == CW_CARD_ZONE_WORLD || zone == CW_CARD_ZONE_INSTALLED) {
-    if (item->holder_actor_id || !item->location_id || container_item_id) return CW_ERR_RULE;
-  } else {
-    if (!item->holder_actor_id || item->location_id) return CW_ERR_RULE;
-  }
+  if (!valid_item_placement(
+      zone, item->holder_actor_id, item->location_id, container_item_id)) return CW_ERR_RULE;
   if (zone == CW_CARD_ZONE_CONTAINED) {
     cw_item *container = find_item(world, container_item_id);
     int item_contains_cards = 0;
@@ -834,7 +933,9 @@ cw_status cw_world_set_item_zone(
         || container->role != CW_ITEM_ROLE_CONTAINER
         || container->holder_actor_id != item->holder_actor_id
         || container->zone == CW_CARD_ZONE_CONTAINED
-        || item->size_class > container->size_class) {
+        || item->size_class > container->size_class
+        || container_contents_weight_tenths(world, container->id, item->id)
+            + item_weight_tenths(item) > container->container_capacity_tenths) {
       return CW_ERR_RULE;
     }
   } else if (container_item_id) {
@@ -844,20 +945,27 @@ cw_status cw_world_set_item_zone(
       && item->role != CW_ITEM_ROLE_WEAPON
       && item->role != CW_ITEM_ROLE_SKILL_CHARM
       && item->role != CW_ITEM_ROLE_CONTAINER
-      && item->role != CW_ITEM_ROLE_TOOL) {
+      && item->role != CW_ITEM_ROLE_TOOL
+      && item->role != CW_ITEM_ROLE_CONSUMABLE) {
     return CW_ERR_RULE;
   }
   if (zone == CW_CARD_ZONE_SPELL_DECK && item->role != CW_ITEM_ROLE_SPELL) {
     return CW_ERR_RULE;
   }
-  item->zone = zone;
-  item->container_item_id = container_item_id;
-  return CW_OK;
+  return place_item(
+      item,
+      zone,
+      item->holder_actor_id,
+      item->location_id,
+      container_item_id,
+      item->held_since_tick);
 }
 
 static void exhaust_item(cw_item *item) {
   if (!item) return;
-  if (item->zone != CW_CARD_ZONE_NONE && item->zone != CW_CARD_ZONE_EXHAUSTED) {
+  if (item->zone != CW_CARD_ZONE_NONE
+      && item->zone != CW_CARD_ZONE_EXHAUSTED
+      && item->zone != CW_CARD_ZONE_HIDDEN) {
     item->recovery_zone = item->zone;
   }
   item->zone = CW_CARD_ZONE_EXHAUSTED;
@@ -1032,7 +1140,7 @@ static cw_status apply_complete_avatar_rescue(
     return reject(world, out_events, action, CW_REASON_NOT_SAME_LOCATION);
   }
   if (!draught) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (draught->kind != CW_ITEM_POTION
+  if (draught->role != CW_ITEM_ROLE_CONSUMABLE
       || draught->holder_actor_id != rescuer->id
       || draught->charges == 0) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
@@ -1104,7 +1212,7 @@ static cw_status apply_replace_avatar_rescuer(
   if (!retired_draught) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
   }
-  if (retired_draught->kind != CW_ITEM_POTION) {
+  if (retired_draught->role != CW_ITEM_ROLE_CONSUMABLE) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
   if (oldest->status != CW_ACTOR_KNOCKED_OUT
@@ -1424,7 +1532,8 @@ static cw_status apply_pick_up_item(cw_world *world, const cw_action *action, cw
   if (!item) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
   if (item->holder_actor_id
       || item->location_id != actor->location_id
-      || item->zone != CW_CARD_ZONE_WORLD) {
+      || item->zone != CW_CARD_ZONE_WORLD
+      || !item_is_transferable(item)) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
 
@@ -1434,17 +1543,16 @@ static cw_status apply_pick_up_item(cw_world *world, const cw_action *action, cw
       exchanged = find_item(world, action->target_item_id);
     }
     if (!exchanged || exchanged->holder_actor_id != actor->id
+        || !item_is_directly_held(exchanged)
+        || !item_is_transferable(exchanged)
+        || item_has_contents(world, exchanged->id)
         || !actor_can_exchange(world, actor, exchanged, item)) {
       return reject(world, out_events, action, CW_REASON_CAPACITY_EXCEEDED);
     }
   }
 
   if (exchanged) {
-    exchanged->holder_actor_id = 0;
-    exchanged->location_id = actor->location_id;
-    exchanged->held_since_tick = 0;
-    exchanged->zone = CW_CARD_ZONE_WORLD;
-    exchanged->container_item_id = 0;
+    (void)place_item(exchanged, CW_CARD_ZONE_WORLD, 0, actor->location_id, 0, 0);
     append_event(world, out_events, CW_EVENT_ITEM_DROPPED);
     if (out_events && out_events->count > 0) {
       cw_event *event = &out_events->events[out_events->count - 1];
@@ -1455,11 +1563,7 @@ static cw_status apply_pick_up_item(cw_world *world, const cw_action *action, cw
     }
   }
 
-  item->holder_actor_id = actor->id;
-  item->location_id = 0;
-  item->held_since_tick = world->tick;
-  item->zone = CW_CARD_ZONE_CARRIED;
-  item->container_item_id = 0;
+  (void)place_item(item, CW_CARD_ZONE_CARRIED, actor->id, 0, 0, world->tick);
 
   append_event(world, out_events, CW_EVENT_ITEM_PICKED_UP);
   if (out_events && out_events->count > 0) {
@@ -1480,17 +1584,16 @@ static cw_status apply_drop_item(cw_world *world, const cw_action *action, cw_ev
 
   cw_item *item = find_item(world, action->item_id);
   if (!item) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (item->holder_actor_id != actor->id) {
+  if (item->holder_actor_id != actor->id
+      || !item_is_directly_held(item)
+      || !item_is_transferable(item)
+      || item_has_contents(world, item->id)) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
   if (!actor_can_exchange(world, actor, item, 0)) {
     return reject(world, out_events, action, CW_REASON_CAPACITY_EXCEEDED);
   }
-  item->holder_actor_id = 0;
-  item->location_id = actor->location_id;
-  item->held_since_tick = 0;
-  item->zone = CW_CARD_ZONE_WORLD;
-  item->container_item_id = 0;
+  (void)place_item(item, CW_CARD_ZONE_WORLD, 0, actor->location_id, 0, 0);
 
   append_event(world, out_events, CW_EVENT_ITEM_DROPPED);
   if (out_events && out_events->count > 0) {
@@ -1511,7 +1614,10 @@ static cw_status apply_use_item(cw_world *world, const cw_action *action, cw_eve
 
   cw_item *item = find_item(world, action->item_id);
   if (!item) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (item->holder_actor_id != actor->id || item->charges == 0) {
+  if (item->holder_actor_id != actor->id
+      || !item_is_directly_held(item)
+      || item->zone == CW_CARD_ZONE_EXHAUSTED
+      || item->charges == 0) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
 
@@ -1520,7 +1626,7 @@ static cw_status apply_use_item(cw_world *world, const cw_action *action, cw_eve
   if (target->location_id != actor->location_id) return reject(world, out_events, action, CW_REASON_NOT_SAME_LOCATION);
 
   int16_t healed = 0;
-  if (item->kind == CW_ITEM_POTION) {
+  if (item->role == CW_ITEM_ROLE_CONSUMABLE) {
     if (target->status == CW_ACTOR_ACTIVE && target->damage <= 0) {
       return reject(world, out_events, action, CW_REASON_TARGET_UNAVAILABLE);
     }
@@ -1716,7 +1822,9 @@ static cw_status apply_theft(cw_world *world, const cw_action *action, uint64_t 
     return reject(world, out_events, action, CW_REASON_NOT_SAME_LOCATION);
   }
   if (!item) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (item->holder_actor_id != target->id || item->zone == CW_CARD_ZONE_ESCROW) {
+  if (item->holder_actor_id != target->id
+      || !item_is_theft_eligible(item)
+      || item_has_contents(world, item->id)) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
   if (!actor_can_exchange(world, actor, 0, item)) {
@@ -1741,11 +1849,7 @@ static cw_status apply_theft(cw_world *world, const cw_action *action, uint64_t 
     event->dc = dc;
   }
   if (!succeeded) return CW_OK;
-  item->holder_actor_id = actor->id;
-  item->location_id = 0;
-  item->zone = CW_CARD_ZONE_CARRIED;
-  item->container_item_id = 0;
-  item->held_since_tick = world->tick;
+  (void)place_item(item, CW_CARD_ZONE_CARRIED, actor->id, 0, 0, world->tick);
   append_event(world, out_events, CW_EVENT_ITEM_STOLEN);
   if (out_events && out_events->count > 0) {
     cw_event *event = &out_events->events[out_events->count - 1];
@@ -1814,12 +1918,20 @@ static cw_status apply_give_item(cw_world *world, const cw_action *action, cw_ev
 
   cw_item *item = find_item(world, action->item_id);
   if (!item) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (item->holder_actor_id != actor->id) return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
+  if (item->holder_actor_id != actor->id
+      || !item_is_directly_held(item)
+      || !item_is_transferable(item)
+      || item_has_contents(world, item->id)) {
+    return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
+  }
 
   cw_item *returned_item = 0;
   if (action->target_item_id) {
     returned_item = find_item(world, action->target_item_id);
-    if (!returned_item || returned_item->holder_actor_id != target->id) {
+    if (!returned_item || returned_item->holder_actor_id != target->id
+        || !item_is_directly_held(returned_item)
+        || !item_is_transferable(returned_item)
+        || item_has_contents(world, returned_item->id)) {
       return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
     }
   }
@@ -1828,17 +1940,10 @@ static cw_status apply_give_item(cw_world *world, const cw_action *action, cw_ev
     return reject(world, out_events, action, CW_REASON_CAPACITY_EXCEEDED);
   }
 
-  item->holder_actor_id = target->id;
-  item->location_id = 0;
-  item->held_since_tick = world->tick;
-  item->zone = CW_CARD_ZONE_CARRIED;
-  item->container_item_id = 0;
+  (void)place_item(item, CW_CARD_ZONE_CARRIED, target->id, 0, 0, world->tick);
   if (returned_item) {
-    returned_item->holder_actor_id = actor->id;
-    returned_item->location_id = 0;
-    returned_item->held_since_tick = world->tick;
-    returned_item->zone = CW_CARD_ZONE_CARRIED;
-    returned_item->container_item_id = 0;
+    (void)place_item(
+        returned_item, CW_CARD_ZONE_CARRIED, actor->id, 0, 0, world->tick);
   }
 
   append_event(world, out_events, CW_EVENT_ITEM_GIVEN);
@@ -1873,7 +1978,14 @@ static cw_status apply_trade_item(cw_world *world, const cw_action *action, cw_e
   cw_item *offered = find_item(world, action->item_id);
   cw_item *requested = find_item(world, action->target_item_id);
   if (!offered || !requested) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (offered->holder_actor_id != actor->id || requested->holder_actor_id != target->id) {
+  if (offered->holder_actor_id != actor->id
+      || requested->holder_actor_id != target->id
+      || !item_is_directly_held(offered)
+      || !item_is_directly_held(requested)
+      || !item_is_transferable(offered)
+      || !item_is_transferable(requested)
+      || item_has_contents(world, offered->id)
+      || item_has_contents(world, requested->id)) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
   if (!actor_can_exchange(world, actor, offered, requested)
@@ -1881,16 +1993,8 @@ static cw_status apply_trade_item(cw_world *world, const cw_action *action, cw_e
     return reject(world, out_events, action, CW_REASON_CAPACITY_EXCEEDED);
   }
 
-  offered->holder_actor_id = target->id;
-  offered->location_id = 0;
-  offered->held_since_tick = world->tick;
-  offered->zone = CW_CARD_ZONE_CARRIED;
-  offered->container_item_id = 0;
-  requested->holder_actor_id = actor->id;
-  requested->location_id = 0;
-  requested->held_since_tick = world->tick;
-  requested->zone = CW_CARD_ZONE_CARRIED;
-  requested->container_item_id = 0;
+  (void)place_item(offered, CW_CARD_ZONE_CARRIED, target->id, 0, 0, world->tick);
+  (void)place_item(requested, CW_CARD_ZONE_CARRIED, actor->id, 0, 0, world->tick);
 
   append_event(world, out_events, CW_EVENT_ITEM_TRADED);
   if (out_events && out_events->count > 0) {
@@ -1917,15 +2021,14 @@ static cw_status apply_search(cw_world *world, const cw_action *action, cw_event
   if (!find_location(world, location_id)) return reject(world, out_events, action, CW_REASON_LOCATION_NOT_FOUND);
   cw_item *item = find_item(world, action->item_id);
   if (!item) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (item->holder_actor_id != 0 || item->location_id != 0 || item->charges == 0) {
+  if (item->holder_actor_id != 0
+      || item->location_id != 0
+      || item->zone != CW_CARD_ZONE_HIDDEN
+      || item->charges == 0) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
 
-  item->holder_actor_id = 0;
-  item->location_id = location_id;
-  item->held_since_tick = 0;
-  item->zone = CW_CARD_ZONE_WORLD;
-  item->container_item_id = 0;
+  (void)place_item(item, CW_CARD_ZONE_WORLD, 0, location_id, 0, 0);
 
   append_event(world, out_events, CW_EVENT_ITEM_FOUND);
   if (out_events && out_events->count > 0) {
@@ -2188,19 +2291,11 @@ static cw_status apply_gate_transition(
   uint8_t item_event_type = CW_EVENT_NONE;
   switch (input->transition) {
     case CW_GATE_TRANSITION_INSTALL:
-      item->holder_actor_id = 0;
-      item->location_id = actor->location_id;
-      item->held_since_tick = 0;
-      item->zone = CW_CARD_ZONE_INSTALLED;
-      item->container_item_id = 0;
+      (void)place_item(item, CW_CARD_ZONE_INSTALLED, 0, actor->location_id, 0, 0);
       item_event_type = CW_EVENT_ITEM_INSTALLED;
       break;
     case CW_GATE_TRANSITION_REMOVE:
-      item->holder_actor_id = actor->id;
-      item->location_id = 0;
-      item->held_since_tick = world->tick;
-      item->zone = CW_CARD_ZONE_CARRIED;
-      item->container_item_id = 0;
+      (void)place_item(item, CW_CARD_ZONE_CARRIED, actor->id, 0, 0, world->tick);
       item_event_type = CW_EVENT_ITEM_REMOVED;
       break;
     case CW_GATE_TRANSITION_EXHAUST:
@@ -2250,13 +2345,13 @@ static cw_status apply_reveal_item(cw_world *world, const cw_action *action, cw_
   }
   cw_item *item = find_item(world, action->item_id);
   if (!item) return reject(world, out_events, action, CW_REASON_ITEM_NOT_FOUND);
-  if (item->holder_actor_id != 0 || item->location_id != 0 || item->charges == 0) {
+  if (item->holder_actor_id != 0
+      || item->location_id != 0
+      || item->zone != CW_CARD_ZONE_HIDDEN
+      || item->charges == 0) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
-  item->location_id = action->location_id;
-  item->held_since_tick = 0;
-  item->zone = CW_CARD_ZONE_WORLD;
-  item->container_item_id = 0;
+  (void)place_item(item, CW_CARD_ZONE_WORLD, 0, action->location_id, 0, 0);
   append_event(world, out_events, CW_EVENT_ITEM_REVEALED);
   if (out_events && out_events->count > 0) {
     cw_event *event = &out_events->events[out_events->count - 1];
@@ -2364,13 +2459,19 @@ static cw_status validate_output_slot(cw_world *world, const cw_action *action, 
 }
 
 static int valid_craft_input_disposition(uint8_t disposition) {
-  return disposition <= CW_CRAFT_INPUT_TRANSFORMED;
+  return disposition == CW_CRAFT_INPUT_PERSISTS
+      || disposition == CW_CRAFT_INPUT_EXHAUSTED
+      || disposition == CW_CRAFT_INPUT_TRANSFORMED;
 }
 
 static int craft_input_is_local(const cw_item *item, const cw_actor *actor) {
   return item && actor
-      && ((item->holder_actor_id == actor->id && item->location_id == 0)
-          || (item->holder_actor_id == 0 && item->location_id == actor->location_id));
+      && ((item->holder_actor_id == actor->id
+              && item->location_id == 0
+              && item->zone == CW_CARD_ZONE_CARRIED)
+          || (item->holder_actor_id == 0
+              && item->location_id == actor->location_id
+              && item->zone == CW_CARD_ZONE_WORLD));
 }
 
 static void append_craft_input_transition(
@@ -3531,8 +3632,8 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
     }
   }
 
-  int actor_has_held_item = 0;
-  int room_actor_has_held_item = 0;
+  int actor_has_transferable_item = 0;
+  int room_actor_has_transferable_item = 0;
   int room_has_active_actor = 0;
   int room_has_loose_item = 0;
   int hidden_search_item_available = 0;
@@ -3547,43 +3648,56 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
     const cw_item *item = &world->items[i];
     if (!item->holder_actor_id
         && item->location_id == actor->location_id
-        && item->zone == CW_CARD_ZONE_WORLD) {
+        && item->zone == CW_CARD_ZONE_WORLD
+        && item_is_transferable(item)) {
       room_has_loose_item = 1;
       if (actor_can_pick_up(world, actor, item)) {
         out_offers->option_flags |= CW_OFFER_PICK_UP;
       }
     }
-    if (!item->holder_actor_id && item->location_id == 0 && item->charges > 0) {
+    if (!item->holder_actor_id
+        && item->location_id == 0
+        && item->zone == CW_CARD_ZONE_HIDDEN
+        && item->charges > 0) {
       hidden_search_item_available = 1;
     }
     if (item->holder_actor_id == actor->id
-        && (item->kind == CW_ITEM_POTION || item->role == CW_ITEM_ROLE_SPELL)
+        && item_is_directly_held(item)
+        && item->zone != CW_CARD_ZONE_EXHAUSTED
+        && (item->role == CW_ITEM_ROLE_CONSUMABLE || item->role == CW_ITEM_ROLE_SPELL)
         && item->charges > 0) {
       out_offers->option_flags |= CW_OFFER_USE_ITEM;
     }
-    if (item->holder_actor_id == actor->id) {
-      actor_has_held_item = 1;
+    if (item->holder_actor_id == actor->id
+        && item_is_directly_held(item)
+        && item_is_transferable(item)
+        && !item_has_contents(world, item->id)) {
+      actor_has_transferable_item = 1;
     }
     if (item->holder_actor_id && item->holder_actor_id != actor->id) {
       const cw_actor *holder = find_actor_const(world, item->holder_actor_id);
-      if (holder && actor_is_active(holder) && holder->location_id == actor->location_id) {
-        room_actor_has_held_item = 1;
+      if (holder && actor_is_active(holder)
+          && holder->location_id == actor->location_id
+          && item_is_directly_held(item)
+          && item_is_transferable(item)
+          && !item_has_contents(world, item->id)) {
+        room_actor_has_transferable_item = 1;
       }
     }
   }
-  if (actor_has_held_item && room_has_active_actor) {
+  if (actor_has_transferable_item && room_has_active_actor) {
     out_offers->option_flags |= CW_OFFER_GIVE_ITEM;
   }
-  if (actor_has_held_item) {
+  if (actor_has_transferable_item) {
     out_offers->option_flags |= CW_OFFER_DROP_ITEM;
   }
   if (hidden_search_item_available) {
     out_offers->option_flags |= CW_OFFER_SEARCH;
   }
-  if (actor_has_held_item && room_has_loose_item) {
+  if (actor_has_transferable_item && room_has_loose_item) {
     out_offers->option_flags |= CW_OFFER_CRAFT;
   }
-  if (actor_has_held_item && room_actor_has_held_item) {
+  if (actor_has_transferable_item && room_actor_has_transferable_item) {
     out_offers->option_flags |= CW_OFFER_TRADE_ITEM;
   }
 

--- a/v2/core-c/src/cosy_kernel.c
+++ b/v2/core-c/src/cosy_kernel.c
@@ -2253,15 +2253,6 @@ static cw_status apply_reveal_item(cw_world *world, const cw_action *action, cw_
   if (item->holder_actor_id != 0 || item->location_id != 0 || item->charges == 0) {
     return reject(world, out_events, action, CW_REASON_ITEM_NOT_AVAILABLE);
   }
-  for (size_t i = 0; i < world->item_count; ++i) {
-    const cw_item *floor_item = &world->items[i];
-    if (floor_item->holder_actor_id == 0
-        && floor_item->location_id == action->location_id
-        && floor_item->zone == CW_CARD_ZONE_WORLD) {
-      return reject(world, out_events, action, CW_REASON_CAPACITY_EXCEEDED);
-    }
-  }
-
   item->location_id = action->location_id;
   item->held_since_tick = 0;
   item->zone = CW_CARD_ZONE_WORLD;
@@ -3583,10 +3574,10 @@ cw_status cw_get_action_offers(const cw_world *world, cw_id actor_id, cw_action_
   if (actor_has_held_item && room_has_active_actor) {
     out_offers->option_flags |= CW_OFFER_GIVE_ITEM;
   }
-  if (actor_has_held_item && !room_has_loose_item) {
+  if (actor_has_held_item) {
     out_offers->option_flags |= CW_OFFER_DROP_ITEM;
   }
-  if (!room_has_loose_item && hidden_search_item_available) {
+  if (hidden_search_item_available) {
     out_offers->option_flags |= CW_OFFER_SEARCH;
   }
   if (actor_has_held_item && room_has_loose_item) {

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -1758,17 +1758,26 @@ static void test_authoritative_world_effect_actions(void) {
   reveal.actor_id = 1001;
   reveal.location_id = 1;
   reveal.item_id = 2005;
-  assert(cw_world_apply(&world, &reveal, 82, &events) == CW_ERR_RULE);
-  assert(events.count == 1);
-  assert(events.events[0].reason == 21);
-  assert(test_find_item(&world, 2005)->location_id == 0);
-
-  test_find_item(&world, 2001)->location_id = 0;
-  assert(cw_world_apply(&world, &reveal, 83, &events) == CW_OK);
+  assert(cw_world_apply(&world, &reveal, 82, &events) == CW_OK);
   assert(events.count == 1);
   assert(events.events[0].type == CW_EVENT_ITEM_REVEALED);
   assert(events.events[0].item_id == 2005);
+  assert(test_find_item(&world, 2001)->location_id == 1);
   assert(test_find_item(&world, 2005)->location_id == 1);
+
+  cw_action pickup = {0};
+  pickup.kind = CW_ACTION_PICK_UP_ITEM;
+  pickup.actor_id = 1001;
+  pickup.item_id = 2005;
+  assert(cw_world_apply(&world, &pickup, 83, &events) == CW_OK);
+  assert(events.count == 1);
+  assert(events.events[0].type == CW_EVENT_ITEM_PICKED_UP);
+
+  cw_action_offers offers = {0};
+  assert(cw_get_action_offers(&world, 1001, &offers) == CW_OK);
+  assert((offers.option_flags & CW_OFFER_DROP_ITEM) != 0);
+  assert((offers.option_flags & CW_OFFER_SEARCH) != 0);
+
   assert(cw_world_apply(&world, &reveal, 84, &events) == CW_ERR_RULE);
 }
 

--- a/v2/core-c/tests/test_kernel.c
+++ b/v2/core-c/tests/test_kernel.c
@@ -41,7 +41,7 @@ static void test_kernel_capacities_are_runtime_sized(void) {
    * 1269 exits. Keep at least another seed's worth of room for generated
    * residents and pathway descendants while the world is live. */
   assert(CW_MAX_ACTORS >= 1178u);
-  assert(CW_MAX_ITEMS >= 1024u);
+  assert(CW_MAX_ITEMS >= 2048u);
   assert(CW_MAX_LOCATIONS >= 1160u);
   assert(CW_MAX_EXITS >= 2538u);
   assert(CW_MAX_EXITS >= CW_MAX_LOCATIONS);
@@ -51,7 +51,7 @@ static void test_kernel_capacities_are_runtime_sized(void) {
   assert(CW_MAX_GATE_CLAIMS >= 128u);
   /* The world is one flat struct handed across the ABI. Keep it small enough
    * to stay comfortable on a 2 MB worker stack even when built unoptimized. */
-  assert(sizeof(cw_world) <= 340000u);
+  assert(sizeof(cw_world) <= 410000u);
 }
 
 static void test_seed_and_chat(void) {
@@ -120,6 +120,7 @@ static void test_linked_avatar_rescue_and_double_knockout_cascade(void) {
   memset(draught, 0, sizeof(*draught));
   draught->id = 9001;
   draught->kind = CW_ITEM_POTION;
+  draught->role = CW_ITEM_ROLE_CONSUMABLE;
   draught->charges = 1;
   draught->max_charges = 1;
   draught->zone = CW_CARD_ZONE_CARRIED;
@@ -151,6 +152,7 @@ static void test_linked_avatar_rescue_and_double_knockout_cascade(void) {
   memset(next_draught, 0, sizeof(*next_draught));
   next_draught->id = 9002;
   next_draught->kind = CW_ITEM_POTION;
+  next_draught->role = CW_ITEM_ROLE_CONSUMABLE;
   next_draught->charges = 1;
   next_draught->max_charges = 1;
   next_draught->zone = CW_CARD_ZONE_CARRIED;
@@ -329,6 +331,7 @@ static void test_d20_roll_modes_bloodied_and_nonlethal_knockout(void) {
 
   world.items[0].holder_actor_id = attacker->id;
   world.items[0].location_id = 0;
+  world.items[0].zone = CW_CARD_ZONE_CARRIED;
   world.items[0].charges = 1;
   cw_action use = {0};
   use.kind = CW_ACTION_USE_ITEM;
@@ -883,8 +886,19 @@ static void test_card_zones_spell_exhaustion_and_theft_atomicity(void) {
   content->location_id = 0;
   content->zone = CW_CARD_ZONE_CARRIED;
   assert(cw_world_set_item_zone(&world, 2005, CW_CARD_ZONE_EQUIPPED, 0) == CW_OK);
+  container->container_capacity_tenths = 4;
+  assert(cw_world_set_item_zone(&world, 2006, CW_CARD_ZONE_CONTAINED, 2005) == CW_ERR_RULE);
+  container->container_capacity_tenths = 100;
   assert(cw_world_set_item_zone(&world, 2006, CW_CARD_ZONE_CONTAINED, 2005) == CW_OK);
   assert(content->container_item_id == 2005);
+  assert(cw_world_set_item_zone(&world, 2005, CW_CARD_ZONE_CARRIED, 0) == CW_OK);
+  cw_action nonempty_drop = {0};
+  nonempty_drop.kind = CW_ACTION_DROP_ITEM;
+  nonempty_drop.actor_id = 5001;
+  nonempty_drop.item_id = 2005;
+  assert(cw_world_apply(&world, &nonempty_drop, 420, &events) == CW_ERR_RULE);
+  assert(container->holder_actor_id == 5001 && content->container_item_id == 2005);
+  assert(cw_world_set_item_zone(&world, 2005, CW_CARD_ZONE_EQUIPPED, 0) == CW_OK);
   assert(cw_world_set_item_zone(&world, 2005, CW_CARD_ZONE_CONTAINED, 2006) == CW_ERR_RULE);
   assert(cw_world_set_item_zone(&world, 2006, CW_CARD_ZONE_EQUIPPED, 0) == CW_OK);
   assert(content->zone == CW_CARD_ZONE_EQUIPPED);
@@ -947,6 +961,11 @@ static void test_card_zones_spell_exhaustion_and_theft_atomicity(void) {
   theft.target_actor_id = 1001;
   theft.item_id = 2004;
   theft.dc = 100;
+  assert(cw_world_apply(&world, &theft, 422, &events) == CW_ERR_RULE);
+  assert(cw_world_set_item_policy(
+      &world,
+      2004,
+      CW_ITEM_POLICY_TRANSFERABLE | CW_ITEM_POLICY_THEFT_WHEN_CARRIED) == CW_OK);
   assert(cw_world_apply(&world, &theft, 422, &events) == CW_OK);
   assert(events.count == 1 && events.events[0].type == CW_EVENT_ITEM_THEFT_ATTEMPT);
   assert(events.events[0].success == 0);
@@ -1174,8 +1193,10 @@ static void test_maximum_evolution_burst_fits_event_buffer(void) {
   assert(gift);
   shared_requirement->holder_actor_id = 0;
   shared_requirement->location_id = 1;
+  shared_requirement->zone = CW_CARD_ZONE_WORLD;
   gift->holder_actor_id = 5001;
   gift->location_id = 0;
+  gift->zone = CW_CARD_ZONE_CARRIED;
 
   const cw_evolution_requirement requirement = {
     2005, CW_PLACEMENT_LOCATION_FLOOR, {0}, 1
@@ -1227,15 +1248,19 @@ static void test_npc_trade_items(void) {
   assert(story);
   dewbright->holder_actor_id = 1001;
   dewbright->location_id = 0;
+  dewbright->zone = CW_CARD_ZONE_CARRIED;
   dewbright->held_since_tick = 10;
   moonlit->holder_actor_id = 1002;
   moonlit->location_id = 0;
+  moonlit->zone = CW_CARD_ZONE_CARRIED;
   moonlit->held_since_tick = 9;
   story->holder_actor_id = 1002;
   story->location_id = 0;
+  story->zone = CW_CARD_ZONE_CARRIED;
   story->held_since_tick = 11;
   moonlit->holder_actor_id = 0;
   moonlit->location_id = 3;
+  moonlit->zone = CW_CARD_ZONE_WORLD;
   moonlit->held_since_tick = 0;
 
   cw_action_offers offers = {0};
@@ -1279,9 +1304,11 @@ static void test_npc_give_items(void) {
   assert(moonlit);
   dewbright->holder_actor_id = 1001;
   dewbright->location_id = 0;
+  dewbright->zone = CW_CARD_ZONE_CARRIED;
   dewbright->held_since_tick = 10;
   moonlit->holder_actor_id = 0;
   moonlit->location_id = 3;
+  moonlit->zone = CW_CARD_ZONE_WORLD;
   moonlit->held_since_tick = 0;
 
   cw_action give = {0};
@@ -1324,8 +1351,14 @@ static void test_actor_affordances_do_not_depend_on_controller_provenance(void) 
   assert(button);
   tonic->holder_actor_id = 5001;
   tonic->location_id = 0;
+  tonic->zone = CW_CARD_ZONE_CARRIED;
   button->holder_actor_id = 5002;
   button->location_id = 0;
+  button->zone = CW_CARD_ZONE_CARRIED;
+  assert(cw_world_set_item_policy(
+      &world,
+      button->id,
+      CW_ITEM_POLICY_TRANSFERABLE | CW_ITEM_POLICY_THEFT_WHEN_CARRIED) == CW_OK);
 
   cw_action_offers offers = {0};
   assert(cw_get_action_offers(&world, 5001, &offers) == CW_OK);
@@ -1411,8 +1444,10 @@ static void test_give_can_exchange_an_item_to_make_weight_capacity(void) {
   assert(returned);
   offered->holder_actor_id = 5001;
   offered->location_id = 0;
+  offered->zone = CW_CARD_ZONE_CARRIED;
   returned->holder_actor_id = 1001;
   returned->location_id = 0;
+  returned->zone = CW_CARD_ZONE_CARRIED;
   world.actors[0].stats.strength = 1;
   assert(cw_world_set_item_profile(&world, 2002, 100, CW_ITEM_SIZE_SMALL, CW_ITEM_ROLE_GENERIC, 0) == CW_OK);
   assert(cw_world_set_item_profile(&world, 2005, 100, CW_ITEM_SIZE_SMALL, CW_ITEM_ROLE_GENERIC, 0) == CW_OK);
@@ -1447,9 +1482,11 @@ static void test_npc_pickup_can_evolve_self(void) {
   world.actors[1].location_id = 2;
   dewbright->holder_actor_id = 0;
   dewbright->location_id = 2;
+  dewbright->zone = CW_CARD_ZONE_WORLD;
   dewbright->held_since_tick = 0;
   moonlit->holder_actor_id = 0;
   moonlit->location_id = 3;
+  moonlit->zone = CW_CARD_ZONE_WORLD;
   moonlit->held_since_tick = 0;
 
   cw_action pickup = {0};
@@ -1497,12 +1534,15 @@ static void test_inventory_uses_weight_and_container_capacity(void) {
 
   held_a->holder_actor_id = 5001;
   held_a->location_id = 0;
+  held_a->zone = CW_CARD_ZONE_CARRIED;
   held_a->held_since_tick = 10;
   new_item->holder_actor_id = 0;
   new_item->location_id = 1;
+  new_item->zone = CW_CARD_ZONE_WORLD;
   new_item->held_since_tick = 0;
   bag->holder_actor_id = 0;
   bag->location_id = 1;
+  bag->zone = CW_CARD_ZONE_WORLD;
   bag->held_since_tick = 0;
 
   world.tick = 100;
@@ -1530,6 +1570,7 @@ static void test_inventory_uses_weight_and_container_capacity(void) {
   cw_item *too_heavy = test_find_item(&world, 2002);
   too_heavy->holder_actor_id = 0;
   too_heavy->location_id = 1;
+  too_heavy->zone = CW_CARD_ZONE_WORLD;
   cw_action_offers offers = {0};
   assert(cw_get_action_offers(&world, 5001, &offers) == CW_OK);
   assert((offers.option_flags & CW_OFFER_PICK_UP) == 0);
@@ -1555,6 +1596,10 @@ static void test_inventory_uses_weight_and_container_capacity(void) {
   drop.kind = CW_ACTION_DROP_ITEM;
   drop.actor_id = 5001;
   drop.item_id = 2005;
+  assert(cw_world_set_item_policy(&world, 2005, CW_ITEM_POLICY_NONE) == CW_OK);
+  assert(cw_world_apply(&world, &drop, 65, &events) == CW_ERR_RULE);
+  assert(new_item->holder_actor_id == 5001);
+  assert(cw_world_set_item_policy(&world, 2005, CW_ITEM_POLICY_TRANSFERABLE) == CW_OK);
   assert(cw_world_apply(&world, &drop, 65, &events) == CW_OK);
   assert(events.count == 1);
   assert(events.events[0].type == CW_EVENT_ITEM_DROPPED);
@@ -1580,6 +1625,7 @@ static void test_search_and_craft_create_without_consuming_inputs(void) {
   search.location_id = 1;
   search.content_id = 9001;
   search.item_id = 2005;
+  assert(test_find_item(&world, 2005)->zone == CW_CARD_ZONE_HIDDEN);
   assert(cw_world_apply(&world, &search, 71, &events) == CW_OK);
   assert(events.count == 1);
   assert(events.events[0].type == CW_EVENT_ITEM_FOUND);
@@ -2271,7 +2317,7 @@ static void test_discovery_procedures_reveal_regardless_of_pressure_check(void) 
  */
 _Static_assert(sizeof(cw_event) == 144, "cw_event changed; update assert_event_equal");
 _Static_assert(sizeof(cw_actor) == 40, "cw_actor changed; update assert_actor_equal");
-_Static_assert(sizeof(cw_item) == 64, "cw_item changed; update assert_item_equal");
+_Static_assert(sizeof(cw_item) == 56, "cw_item changed; update assert_item_equal");
 _Static_assert(sizeof(cw_location) == 16, "cw_location changed; update assert_location_equal");
 
 /* Fill the stack with a known pattern so two replays cannot accidentally
@@ -2345,12 +2391,11 @@ static void assert_item_equal(const cw_item *left, const cw_item *right) {
   assert(left->max_charges == right->max_charges);
   assert(left->recovery == right->recovery);
   assert(left->recovery_zone == right->recovery_zone);
-  assert(left->reserved2 == right->reserved2);
+  assert(left->policy_flags == right->policy_flags);
   assert(left->location_id == right->location_id);
   assert(left->holder_actor_id == right->holder_actor_id);
   assert(left->container_item_id == right->container_item_id);
   assert(left->held_since_tick == right->held_since_tick);
-  assert(left->recharge_at_tick == right->recharge_at_tick);
 }
 
 static void assert_location_equal(const cw_location *left, const cw_location *right) {

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.140"
+version = "1.0.141"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.139"
+version = "1.0.140"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.139"
+version = "1.0.140"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.140"
+version = "1.0.141"
 edition = "2021"
 publish = false
 

--- a/v2/orchestrator-rust/src/autonomy.rs
+++ b/v2/orchestrator-rust/src/autonomy.rs
@@ -1356,7 +1356,7 @@ impl RuntimeWorld {
                 {
                     return None;
                 }
-                let (action, mutation) = if recipe.schema_version == 2 {
+                let (action, mutation) = if recipe_uses_receipt(recipe) {
                     let plan = self.versioned_craft_plan(actor.id, recipe_id, None)?;
                     (
                         plan.action,

--- a/v2/orchestrator-rust/src/cards.rs
+++ b/v2/orchestrator-rust/src/cards.rs
@@ -174,8 +174,15 @@ impl RuntimeWorld {
                 } else if item.location_id != 0 {
                     CW_CARD_ZONE_WORLD
                 } else {
-                    0
+                    CW_CARD_ZONE_HIDDEN
                 };
+            } else if item.zone == CW_CARD_ZONE_WORLD
+                && item.holder_actor_id == 0
+                && item.location_id == 0
+            {
+                // Version 15 and older used an impossible World placement as
+                // the hidden-item sentinel. Normalize it once on load.
+                item.zone = CW_CARD_ZONE_HIDDEN;
             }
             if item.zone != CW_CARD_ZONE_CONTAINED {
                 item.container_item_id = 0;
@@ -1342,6 +1349,7 @@ impl RuntimeWorld {
         items
     }
 
+    #[cfg(test)]
     pub(super) fn room_floor_empty(&self, location_id: u64) -> bool {
         self.loose_items_at_location(location_id).is_empty()
     }
@@ -1357,6 +1365,7 @@ pub(super) fn card_zone(zone: u8, holder_actor_id: u64, location_id: u64) -> &'s
         CW_CARD_ZONE_CONTAINED => "contained",
         CW_CARD_ZONE_ESCROW => "escrow",
         CW_CARD_ZONE_INSTALLED => "installed",
+        CW_CARD_ZONE_HIDDEN => "hidden",
         _ if holder_actor_id != 0 => "carried",
         _ if location_id != 0 => "world",
         _ => "collection",

--- a/v2/orchestrator-rust/src/composition.rs
+++ b/v2/orchestrator-rust/src/composition.rs
@@ -1225,7 +1225,7 @@ impl RuntimeWorld {
             "use_item" => self
                 .actor_held_items(actor_id)
                 .into_iter()
-                .filter(|item| item.kind == CW_ITEM_POTION && item.charges > 0)
+                .filter(|item| item.role == CW_ITEM_ROLE_CONSUMABLE && item.charges > 0)
                 .min_by_key(|item| item.id)
                 .map(|item| {
                     let name = self
@@ -1661,17 +1661,23 @@ impl RuntimeWorld {
         let held_items = self.actor_held_items(actor_id);
         self.loose_items_at_location(actor.location_id)
             .into_iter()
+            .filter(|incoming| Self::item_is_transferable(*incoming))
             .filter(|incoming| {
                 self.actor_can_receive_item(actor, incoming.id)
                     || held_items.iter().any(|outgoing| {
-                        self.actor_can_exchange_items(actor_id, Some(*outgoing), *incoming)
+                        self.item_can_leave_actor(actor_id, *outgoing)
+                            && self.actor_can_exchange_items(actor_id, Some(*outgoing), *incoming)
                     })
             })
             .collect()
     }
 
     pub(super) fn drop_offer_items(&self, actor_id: u64) -> Vec<CwItem> {
-        let mut items = self.actor_held_items(actor_id);
+        let mut items = self
+            .actor_held_items(actor_id)
+            .into_iter()
+            .filter(|item| self.item_can_leave_actor(actor_id, *item))
+            .collect::<Vec<_>>();
         items.sort_by_key(|item| item.id);
         items
     }
@@ -2213,7 +2219,7 @@ impl RuntimeWorld {
                 }
             }),
             "craft" => self.default_craft_recipe(actor_id).map(|recipe| {
-                if recipe.schema_version == 2 {
+                if recipe_uses_receipt(recipe) {
                     recipe.description.clone()
                 } else {
                     let output = recipe

--- a/v2/orchestrator-rust/src/content_load.rs
+++ b/v2/orchestrator-rust/src/content_load.rs
@@ -937,10 +937,8 @@ pub(super) struct SeedItemContent {
     #[serde(default)]
     pub(super) allowed_contents: Vec<String>,
     #[serde(default)]
-    #[allow(dead_code)]
     pub(super) access_cost: Option<String>,
     #[serde(default)]
-    #[allow(dead_code)]
     pub(super) nested_containers: Option<String>,
 }
 
@@ -1266,17 +1264,12 @@ pub(super) struct SeedAvatarLevelEffectContent {
     pub(super) amount: i16,
 }
 
-fn default_recipe_schema_version() -> u8 {
-    1
-}
-
 fn default_recipe_input_quantity() -> u8 {
     1
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub(super) struct SeedRecipeContent {
-    #[serde(default = "default_recipe_schema_version")]
     pub(super) schema_version: u8,
     pub(super) id: u64,
     pub(super) key: String,
@@ -1285,18 +1278,19 @@ pub(super) struct SeedRecipeContent {
     #[serde(default)]
     pub(super) pack_id: String,
     #[serde(default)]
-    pub(super) input_item_ids: Vec<u64>,
-    #[serde(default)]
     pub(super) inputs: Vec<SeedRecipeInputContent>,
     #[serde(default)]
     pub(super) requires: SeedRecipeRequirementsContent,
     pub(super) output: Option<SeedRecipeOutputContent>,
     #[serde(default)]
-    pub(super) balance: Option<SeedRecipeBalanceContent>,
+    pub(super) outcome: Option<SeedRecipeOutcomeContent>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub(super) struct SeedRecipeInputContent {
+    #[serde(default)]
+    pub(super) item_id: u64,
+    #[serde(default)]
     pub(super) template_id: String,
     #[serde(default = "default_recipe_input_quantity")]
     pub(super) quantity: u8,
@@ -1316,6 +1310,8 @@ pub(super) struct SeedRecipeRequirementsContent {
     pub(super) natural_features: Vec<String>,
     #[serde(default)]
     pub(super) location_features: Vec<String>,
+    #[serde(default)]
+    pub(super) location_ids: Vec<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1347,7 +1343,7 @@ pub(super) struct SeedRecipeOutputContent {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub(super) struct SeedRecipeBalanceContent {
+pub(super) struct SeedRecipeOutcomeContent {
     pub(super) kind: String,
     pub(super) target_kind: String,
     pub(super) target_id: u64,
@@ -2589,12 +2585,22 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
                 .capabilities
                 .iter()
                 .any(|capability| capability != CAMP_SHELTER_ITEM_CAPABILITY)
-            || (!item.capabilities.is_empty() && item.role != "tool")
+            || (!item.capabilities.is_empty()
+                && !matches!(item.role.as_str(), "tool" | "consumable"))
         {
             return Err(format!(
                 "seed item {} has invalid or role-incompatible capabilities",
                 item.id
             ));
+        }
+        if item.mechanics.as_ref().is_some_and(|mechanics| {
+            !matches!(mechanics.transfer_policy.as_str(), "transferable" | "bound")
+                || !matches!(
+                    mechanics.theft_policy.as_str(),
+                    "eligible_when_carried" | "ineligible"
+                )
+        }) {
+            return Err(format!("seed item {} has invalid transfer policy", item.id));
         }
     }
 
@@ -3824,7 +3830,7 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
         {
             return Err(format!("invalid seed recipe {}", recipe.id));
         }
-        if recipe.schema_version == 2 {
+        if recipe_uses_receipt(recipe) {
             let mut input_templates = BTreeSet::new();
             let physical_input_count = recipe
                 .inputs
@@ -3835,7 +3841,7 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
                 .output
                 .as_ref()
                 .is_some_and(|output| output.effect == "provisioned_supply");
-            if !recipe.input_item_ids.is_empty()
+            if recipe.schema_version != 2
                 || recipe.inputs.len() > 2
                 || (recipe.inputs.is_empty() && !provisioned_supply)
                 || (physical_input_count == 0 && !provisioned_supply)
@@ -3851,14 +3857,15 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
                             .any(|zone| !matches!(zone.as_str(), "carried" | "world"))
                         || !matches!(
                             input.disposition.as_str(),
-                            "persistent" | "consume" | "exhaust" | "transform"
+                            "persistent" | "exhaust" | "transform"
                         )
                         || !input_templates.insert(input.template_id.as_str())
                 })
                 || (recipe.requires.building_capabilities.is_empty()
                     && recipe.requires.recipe_tags.is_empty()
                     && recipe.requires.natural_features.is_empty()
-                    && recipe.requires.location_features.is_empty())
+                    && recipe.requires.location_features.is_empty()
+                    && recipe.requires.location_ids.is_empty())
                 || (recipe.requires.building_capabilities.is_empty()
                     != recipe.requires.recipe_tags.is_empty())
                 || (!recipe.requires.building_capabilities.is_empty()
@@ -3919,50 +3926,67 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
             }
             continue;
         }
-        let Some(balance) = recipe.balance.as_ref() else {
-            return Err(format!("legacy recipe {} is missing balance", recipe.id));
+        let Some(outcome) = recipe.outcome.as_ref() else {
+            return Err(format!("recipe {} is missing its outcome", recipe.id));
         };
-        if recipe.schema_version != 1
-            || recipe.input_item_ids.len() != 2
-            || recipe.input_item_ids[0] == recipe.input_item_ids[1]
-            || recipe
-                .input_item_ids
+        let input_item_ids = recipe
+            .inputs
+            .iter()
+            .map(|input| input.item_id)
+            .collect::<Vec<_>>();
+        if recipe.schema_version != 2
+            || input_item_ids.len() != 2
+            || input_item_ids[0] == input_item_ids[1]
+            || recipe.inputs.iter().any(|input| {
+                input.item_id == 0
+                    || !input.template_id.is_empty()
+                    || input.quantity != 1
+                    || input.zones.is_empty()
+                    || input
+                        .zones
+                        .iter()
+                        .any(|zone| !matches!(zone.as_str(), "carried" | "world"))
+                    || input.disposition != "persistent"
+            })
+            || input_item_ids
                 .iter()
                 .any(|item_id| !item_ids.contains(item_id))
-            || balance.kind.trim().is_empty()
-            || balance.reason.trim().is_empty()
+            || recipe.requires.location_ids.len() != 1
+            || !location_ids.contains(&recipe.requires.location_ids[0])
+            || outcome.kind.trim().is_empty()
+            || outcome.reason.trim().is_empty()
         {
             return Err(format!("invalid seed recipe {}", recipe.id));
         }
         if !matches!(
-            balance.kind.as_str(),
+            outcome.kind.as_str(),
             "location" | "avatar" | "resident" | "covenant" | "evolution"
         ) {
             return Err(format!(
-                "recipe {} has invalid balance kind {}",
-                recipe.id, balance.kind
+                "recipe {} has invalid outcome kind {}",
+                recipe.id, outcome.kind
             ));
         }
-        let Some(balance_target_kind) = placement_target_kind_from_str(&balance.target_kind) else {
+        let Some(outcome_target_kind) = placement_target_kind_from_str(&outcome.target_kind) else {
             return Err(format!(
-                "recipe {} has invalid balance target kind {}",
-                recipe.id, balance.target_kind
+                "recipe {} has invalid outcome target kind {}",
+                recipe.id, outcome.target_kind
             ));
         };
-        match balance_target_kind {
+        match outcome_target_kind {
             CW_PLACEMENT_ACTOR_HAND => {
-                if !actor_ids.contains(&balance.target_id) {
+                if !actor_ids.contains(&outcome.target_id) {
                     return Err(format!(
-                        "recipe {} balance references missing actor {}",
-                        recipe.id, balance.target_id
+                        "recipe {} outcome references missing actor {}",
+                        recipe.id, outcome.target_id
                     ));
                 }
             }
             CW_PLACEMENT_LOCATION_FLOOR => {
-                if !location_ids.contains(&balance.target_id) {
+                if !location_ids.contains(&outcome.target_id) {
                     return Err(format!(
-                        "recipe {} balance references missing location {}",
-                        recipe.id, balance.target_id
+                        "recipe {} outcome references missing location {}",
+                        recipe.id, outcome.target_id
                     ));
                 }
             }
@@ -4005,9 +4029,9 @@ pub(super) fn validate_seed_content(content: &SeedContent) -> Result<(), String>
                 }
                 _ => {}
             }
-            if output.target_kind != balance.target_kind || output.target_id != balance.target_id {
+            if output.target_kind != outcome.target_kind || output.target_id != outcome.target_id {
                 return Err(format!(
-                    "recipe {} output slot must match its balance declaration",
+                    "recipe {} output slot must match its outcome declaration",
                     recipe.id
                 ));
             }

--- a/v2/orchestrator-rust/src/crafting.rs
+++ b/v2/orchestrator-rust/src/crafting.rs
@@ -5,6 +5,13 @@ pub(super) const HEARTH_TONIC_RECIPE_ID: u64 = 3105;
 const CRAFT_ITEM_ID_BASE: u64 = 11_000_000_000;
 const CRAFT_ITEM_ID_RANGE: u64 = 1_000_000_000;
 
+pub(super) fn recipe_uses_receipt(recipe: &SeedRecipeContent) -> bool {
+    recipe
+        .output
+        .as_ref()
+        .is_some_and(|output| !output.template_id.is_empty())
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(super) struct CraftInputState {
     pub(super) item_id: u64,
@@ -54,10 +61,9 @@ pub(super) struct VersionedCraftPlan {
     pub(super) receipt: CraftReceiptState,
 }
 
-fn craft_disposition(value: &str) -> Option<u8> {
+pub(super) fn craft_disposition(value: &str) -> Option<u8> {
     match value {
         "persistent" => Some(CW_CRAFT_INPUT_PERSISTS),
-        "consume" => Some(CW_CRAFT_INPUT_CONSUMED),
         "exhaust" => Some(CW_CRAFT_INPUT_EXHAUSTED),
         "transform" => Some(CW_CRAFT_INPUT_TRANSFORMED),
         _ => None,
@@ -109,6 +115,91 @@ fn natural_resource_id(kind: NaturalResourceKind) -> &'static str {
 }
 
 impl RuntimeWorld {
+    pub(super) fn recipe_by_id(&self, recipe_id: u64) -> Option<&'static SeedRecipeContent> {
+        active_content()
+            .recipes
+            .iter()
+            .find(|recipe| recipe.id == recipe_id)
+    }
+
+    pub(super) fn craft_action_for_recipe(
+        &self,
+        actor_id: u64,
+        recipe_id: u64,
+    ) -> Option<CwAction> {
+        if recipe_uses_receipt(self.recipe_by_id(recipe_id)?) {
+            return self
+                .versioned_craft_plan(actor_id, recipe_id, None)
+                .map(|plan| plan.action);
+        }
+        let actor = self.actor_by_id(actor_id)?;
+        if actor.status != CW_ACTOR_ACTIVE {
+            return None;
+        }
+        let recipe = self.recipe_by_id(recipe_id)?;
+        let held_items = self.actor_held_items(actor_id);
+        let floor_items = self.loose_items_at_location(actor.location_id);
+        if !recipe.requires.location_ids.contains(&actor.location_id) {
+            return None;
+        }
+        let exact_inputs = recipe
+            .inputs
+            .iter()
+            .filter(|input| input.item_id != 0)
+            .collect::<Vec<_>>();
+        if exact_inputs.len() != 2 {
+            return None;
+        }
+        let held = held_items
+            .iter()
+            .copied()
+            .find(|item| exact_inputs.iter().any(|input| input.item_id == item.id))?;
+        let floor = floor_items.iter().copied().find(|item| {
+            item.id != held.id && exact_inputs.iter().any(|input| input.item_id == item.id)
+        })?;
+        if exact_inputs
+            .iter()
+            .any(|input| input.item_id != held.id && input.item_id != floor.id)
+        {
+            return None;
+        }
+        let held_input = exact_inputs.iter().find(|input| input.item_id == held.id)?;
+        let floor_input = exact_inputs
+            .iter()
+            .find(|input| input.item_id == floor.id)?;
+        let mut action = CwAction {
+            kind: CW_ACTION_CRAFT,
+            actor_id,
+            content_id: recipe.id,
+            item_id: held.id,
+            target_item_id: floor.id,
+            item_disposition: craft_disposition(&held_input.disposition)?,
+            target_item_disposition: craft_disposition(&floor_input.disposition)?,
+            ..CwAction::default()
+        };
+        if let Some(output) = recipe.output.as_ref() {
+            if self.item_by_id(output.item_id).is_some() {
+                return None;
+            }
+            action.output_item_id = output.item_id;
+            action.output_target_id = output.target_id;
+            action.output_target_kind = placement_target_kind_from_str(&output.target_kind)?;
+            action.output_item_kind = seed_item_kind_from_str(&output.kind)?;
+            action.output_item_charges = output.charges;
+            match action.output_target_kind {
+                CW_PLACEMENT_ACTOR_HAND => {
+                    let target = self.actor_by_id(output.target_id)?;
+                    if target.status != CW_ACTOR_ACTIVE {
+                        return None;
+                    }
+                }
+                CW_PLACEMENT_LOCATION_FLOOR => {}
+                _ => return None,
+            }
+        }
+        Some(action)
+    }
+
     pub(super) fn physical_item_template_id(&self, item_id: u64) -> Option<String> {
         self.physical_item_delivery_facts(item_id).template_id
     }
@@ -210,6 +301,11 @@ impl RuntimeWorld {
         }) {
             return None;
         }
+        if !recipe.requires.location_ids.is_empty()
+            && !recipe.requires.location_ids.contains(&location_id)
+        {
+            return None;
+        }
         if let Some(feature) = recipe.requires.natural_features.first() {
             return Some(format!("natural_feature:{feature}"));
         }
@@ -237,8 +333,12 @@ impl RuntimeWorld {
             for _ in 0..input.quantity {
                 let item = candidates.iter().copied().find(|item| {
                     if used.contains(&item.id)
-                        || self.physical_item_template_id(item.id).as_deref()
-                            != Some(input.template_id.as_str())
+                        || if input.item_id != 0 {
+                            item.id != input.item_id
+                        } else {
+                            self.physical_item_template_id(item.id).as_deref()
+                                != Some(input.template_id.as_str())
+                        }
                         || item.charges < input.min_charges
                     {
                         return false;
@@ -304,7 +404,7 @@ impl RuntimeWorld {
             return None;
         }
         let recipe = self.recipe_by_id(recipe_id)?;
-        if recipe.schema_version != 2 {
+        if !recipe_uses_receipt(recipe) {
             return None;
         }
         let capability_source =
@@ -352,6 +452,7 @@ impl RuntimeWorld {
             container_capacity_tenths: template.container_capacity_tenths,
             size_class: item_size_from_str(&template.size)?,
             role: output_role,
+            policy_flags: declared_item_policy_flags(template.mechanics.as_ref()),
             zone: CW_CARD_ZONE_CARRIED,
             holder_actor_id: actor_id,
             ..CwItem::default()
@@ -501,12 +602,14 @@ impl RuntimeWorld {
         let Some(size_class) = item_size_from_str(&template.size) else {
             return;
         };
+        let policy_flags = declared_item_policy_flags(template.mechanics.as_ref());
         item.kind = kind;
         item.charges = template.charges;
         item.weight_tenths = template.weight_tenths;
         item.container_capacity_tenths = template.container_capacity_tenths;
         item.size_class = size_class;
         item.role = role;
+        item.policy_flags = policy_flags;
         self.items.insert(
             receipt.output_item_id,
             ItemMeta {
@@ -855,12 +958,12 @@ mod tests {
         assert_ne!(first_tonic_id, second_tonic_id);
         assert!(runtime.item_by_id(first_tonic_id).is_some_and(|item| {
             item.holder_actor_id == FIRST_PLAYER_ID
-                && item.kind == CW_ITEM_POTION
+                && item.role == CW_ITEM_ROLE_CONSUMABLE
                 && item.charges == 1
         }));
         assert!(runtime.item_by_id(second_tonic_id).is_some_and(|item| {
             item.holder_actor_id == SECOND_PLAYER_ID
-                && item.kind == CW_ITEM_POTION
+                && item.role == CW_ITEM_ROLE_CONSUMABLE
                 && item.charges == 1
         }));
         assert!(runtime
@@ -900,7 +1003,7 @@ mod tests {
             .damage = 6;
         for item in runtime.world.items[..runtime.world.item_count]
             .iter_mut()
-            .filter(|item| item.kind == CW_ITEM_POTION)
+            .filter(|item| item.role == CW_ITEM_ROLE_CONSUMABLE)
         {
             item.charges = 0;
         }

--- a/v2/orchestrator-rust/src/discovery_pipeline.rs
+++ b/v2/orchestrator-rust/src/discovery_pipeline.rs
@@ -1341,9 +1341,7 @@ mod tests {
             COSY_COTTAGE_LOCATION_ID,
             "Discovery Tester",
         );
-        // The kernel allows one loose item per floor, and the seed cottage
-        // already has one. Clear it so the reveal is testing materialization
-        // rather than the capacity rule the effect seam already pins.
+        // Clear the seed floor so this test can name the exact revealed item.
         runtime.hide_loose_items_at_location(COSY_COTTAGE_LOCATION_ID);
         let hidden = runtime.world.items[..runtime.world.item_count]
             .iter_mut()
@@ -1351,7 +1349,7 @@ mod tests {
             .expect("seed item 2005");
         hidden.holder_actor_id = 0;
         hidden.location_id = 0;
-        hidden.zone = CW_CARD_ZONE_WORLD;
+        hidden.zone = CW_CARD_ZONE_HIDDEN;
         runtime.install_discovery_catalog_for_test(
             materializing_catalog(),
             "cosyworld.core",

--- a/v2/orchestrator-rust/src/first_tale.rs
+++ b/v2/orchestrator-rust/src/first_tale.rs
@@ -810,7 +810,7 @@ mod tests {
     }
 
     #[test]
-    fn latecomer_generic_listen_check_advances_after_search_is_spent() {
+    fn latecomer_search_continues_after_seed_exits_are_discovered() {
         let actor_id = 5000;
         let mut runtime = RuntimeWorld::seeded();
         create_test_human(
@@ -830,8 +830,7 @@ mod tests {
             clock.filled = clock.segments;
         }
 
-        // Spend the single-shot Search reveal by discovering every seed exit,
-        // mirroring a latecomer who already searched Rain-Soft Garden.
+        // Discover every seed exit. Hidden items still keep Search useful.
         for exit in active_content()
             .exits
             .iter()
@@ -857,26 +856,23 @@ mod tests {
                 },
             );
         }
-        assert!(
-            runtime.default_search_target(actor_id).is_none(),
-            "discovering every seed exit must consume the room Search so only the Listen Check remains"
-        );
-        assert!(runtime.first_tale_latecomer_needs_listen_fallback(actor_id));
+        assert!(runtime.default_search_target(actor_id).is_some());
+        assert!(!runtime.first_tale_latecomer_needs_listen_fallback(actor_id));
 
         let (_, offers) =
             runtime.legal_action_candidates(Some(actor_id), &AccessContext::default());
-        let check_offer = offers
+        let search_offer = offers
             .iter()
-            .find(|offer| offer.kind == "check" && offer.project.is_none())
-            .expect("the generic Listen Check is retained once Search is spent");
+            .find(|offer| offer.kind == "search")
+            .expect("hidden items keep Search available after exits are known");
         assert!(
-            runtime.first_tale_offer_advances(actor_id, FirstTaleStage::Contribute, check_offer),
-            "a still-available Listen Check must advance a latecomer whose shared question is complete"
+            runtime.first_tale_offer_advances(actor_id, FirstTaleStage::Contribute, search_offer),
+            "a useful Search must advance a latecomer whose shared question is complete"
         );
         let advancing_ids = runtime
-            .first_tale_advancing_offer_selection(actor_id, std::slice::from_ref(check_offer))
+            .first_tale_advancing_offer_selection(actor_id, std::slice::from_ref(search_offer))
             .0
-            .expect("the Listen Check is selectable as the advancing card");
-        assert_eq!(advancing_ids, check_offer.offer_id);
+            .expect("Search is selectable as the advancing card");
+        assert_eq!(advancing_ids, search_offer.offer_id);
     }
 }

--- a/v2/orchestrator-rust/src/kernel.rs
+++ b/v2/orchestrator-rust/src/kernel.rs
@@ -12,7 +12,7 @@ pub(crate) use rejections::*;
 // These mirror the compiled capacities in core-c/include/cosy_kernel.h. They
 // are part of the cw_world layout, so the two files must move together.
 pub const CW_MAX_ACTORS: usize = 2048;
-pub const CW_MAX_ITEMS: usize = 1024;
+pub const CW_MAX_ITEMS: usize = 2048;
 pub const CW_MAX_LOCATIONS: usize = 2048;
 pub const CW_MAX_EXITS: usize = 4096;
 pub const CW_MAX_EVENTS: usize = 256;
@@ -32,7 +32,8 @@ pub const CW_ITEM_DEFAULT_WEIGHT_TENTHS: u16 = 10;
 
 // Kernel version 9 is reserved by #411 for project-push ABI state.
 // Version 15 widens the actor array; sizeof(cw_world) changed.
-pub const CW_KERNEL_VERSION: u32 = 15;
+// Version 16 adds explicit hidden-item placement and item transfer policy.
+pub const CW_KERNEL_VERSION: u32 = 16;
 
 pub const CW_OK: u32 = 0;
 pub const CW_ERR_INVALID: u32 = 1;
@@ -129,6 +130,11 @@ pub const CW_CARD_ZONE_EXHAUSTED: u8 = 5;
 pub const CW_CARD_ZONE_CONTAINED: u8 = 6;
 pub const CW_CARD_ZONE_ESCROW: u8 = 7;
 pub const CW_CARD_ZONE_INSTALLED: u8 = 8;
+pub const CW_CARD_ZONE_HIDDEN: u8 = 9;
+
+pub const CW_ITEM_POLICY_TRANSFERABLE: u8 = 1 << 0;
+pub const CW_ITEM_POLICY_THEFT_WHEN_CARRIED: u8 = 1 << 1;
+pub const CW_ITEM_POLICY_CONFIGURED: u8 = 1 << 7;
 
 pub const CW_ITEM_RECOVERY_NONE: u8 = 0;
 pub const CW_ITEM_RECOVERY_REST: u8 = 1;
@@ -365,15 +371,14 @@ pub struct CwItem {
     pub recovery: u8,
     #[serde(default, skip_serializing_if = "is_zero_u8")]
     pub recovery_zone: u8,
-    #[serde(default, skip_serializing_if = "is_zero_u8")]
-    pub reserved2: u8,
+    #[serde(default, alias = "reserved2", skip_serializing_if = "is_zero_u8")]
+    pub policy_flags: u8,
     pub location_id: u64,
     pub holder_actor_id: u64,
     #[serde(default)]
     pub container_item_id: u64,
     #[serde(default)]
     pub held_since_tick: u64,
-    pub recharge_at_tick: u64,
 }
 
 fn default_item_weight_tenths() -> u16 {
@@ -804,6 +809,7 @@ extern "C" {
         recovery: u8,
         ready_zone: u8,
     ) -> u32;
+    pub fn cw_world_set_item_policy(world: *mut CwWorld, item_id: u64, policy_flags: u8) -> u32;
     pub fn cw_world_set_item_zone(
         world: *mut CwWorld,
         item_id: u64,
@@ -920,7 +926,7 @@ mod tests {
 
     #[test]
     fn rest_adapter_never_accepts_client_entitlement_as_authority() {
-        assert_eq!(std::mem::size_of::<CwItem>(), 64);
+        assert_eq!(std::mem::size_of::<CwItem>(), 56);
         assert_eq!(std::mem::offset_of!(CwItem, max_charges), 18);
         assert_eq!(std::mem::offset_of!(CwItem, location_id), 24);
         let tampered = serde_json::json!({

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -3912,6 +3912,17 @@ fn seed_item_recovery_profile(item: &SeedItemContent) -> (u8, u8, u8) {
     declared_item_recovery_profile(item.charges, item.mechanics.as_ref())
 }
 
+fn declared_item_policy_flags(mechanics: Option<&SeedPlayableItemMechanics>) -> u8 {
+    let mut flags = CW_ITEM_POLICY_CONFIGURED;
+    if mechanics.is_none_or(|mechanics| mechanics.transfer_policy == "transferable") {
+        flags |= CW_ITEM_POLICY_TRANSFERABLE;
+    }
+    if mechanics.is_some_and(|mechanics| mechanics.theft_policy == "eligible_when_carried") {
+        flags |= CW_ITEM_POLICY_THEFT_WHEN_CARRIED;
+    }
+    flags
+}
+
 fn placement_target_kind_from_str(kind: &str) -> Option<u8> {
     match kind {
         "actor_hand" => Some(CW_PLACEMENT_ACTOR_HAND),
@@ -7081,6 +7092,15 @@ impl RuntimeWorld {
                 )
             };
             debug_assert_eq!(recovery_status, CW_OK);
+            let policy_status = unsafe {
+                cw_world_set_item_policy(
+                    &mut *self.world,
+                    item.id,
+                    declared_item_policy_flags(item.mechanics.as_ref())
+                        & !CW_ITEM_POLICY_CONFIGURED,
+                )
+            };
+            debug_assert_eq!(policy_status, CW_OK);
             if role == CW_ITEM_ROLE_WEAPON {
                 if let Some(world_item) = self.world.items[..self.world.item_count]
                     .iter_mut()
@@ -7187,7 +7207,12 @@ impl RuntimeWorld {
             charges,
             weight_tenths: CW_ITEM_DEFAULT_WEIGHT_TENTHS,
             size_class: CW_ITEM_SIZE_SMALL,
-            zone: CW_CARD_ZONE_WORLD,
+            zone: if location_id == 0 {
+                CW_CARD_ZONE_HIDDEN
+            } else {
+                CW_CARD_ZONE_WORLD
+            },
+            policy_flags: CW_ITEM_POLICY_CONFIGURED | CW_ITEM_POLICY_TRANSFERABLE,
             location_id,
             holder_actor_id: 0,
             ..CwItem::default()
@@ -9425,7 +9450,8 @@ impl RuntimeWorld {
                 .resident_feature_use_match_for_item(resident, item_id)
                 .is_some()
             || self.item_by_id(item_id).is_some_and(|item| {
-                item.kind == CW_ITEM_POTION && self.resident_healing_target(resident).is_some()
+                item.role == CW_ITEM_ROLE_CONSUMABLE
+                    && self.resident_healing_target(resident).is_some()
             })
     }
 
@@ -10493,6 +10519,16 @@ impl RuntimeWorld {
         } else if item.zone != CW_CARD_ZONE_EQUIPPED {
             return Vec::new();
         }
+        if !equipped
+            && item.role == CW_ITEM_ROLE_CONTAINER
+            && self.actor_carried_weight_tenths(actor_id)
+                > self
+                    .actor_carrying_capacity_tenths(actor_id)
+                    .unwrap_or_default()
+                    .saturating_sub(u32::from(item.container_capacity_tenths))
+        {
+            return Vec::new();
+        }
         let zone = if equipped {
             CW_CARD_ZONE_EQUIPPED
         } else {
@@ -10534,12 +10570,18 @@ impl RuntimeWorld {
             let Some(contract) = self.seed_item_contract_for_instance(container_id) else {
                 return Vec::new();
             };
+            if contract.access_cost.as_deref() == Some("free_out_of_combat")
+                && self.active_combat_encounter_for_actor(actor_id).is_some()
+            {
+                return Vec::new();
+            }
             let opening = contract
                 .container_opening_size
                 .as_deref()
                 .and_then(item_size_from_str)
                 .unwrap_or(0);
             let stores_empty_container = item.role == CW_ITEM_ROLE_CONTAINER
+                && contract.nested_containers.as_deref() == Some("empty_storage_only")
                 && contract
                     .allowed_contents
                     .iter()
@@ -10572,6 +10614,16 @@ impl RuntimeWorld {
             (CW_CARD_ZONE_CONTAINED, container_id, "item.contained")
         } else {
             if item.zone != CW_CARD_ZONE_CONTAINED {
+                return Vec::new();
+            }
+            let Some(container_contract) =
+                self.seed_item_contract_for_instance(item.container_item_id)
+            else {
+                return Vec::new();
+            };
+            if container_contract.access_cost.as_deref() == Some("free_out_of_combat")
+                && self.active_combat_encounter_for_actor(actor_id).is_some()
+            {
                 return Vec::new();
             }
             (
@@ -11057,11 +11109,13 @@ impl RuntimeWorld {
             .any(|desired_item_id| desired_item_id == item_id)
         {
             format!("{resident_name} wanted {item_name}")
-        } else if item.is_some_and(|item| item.kind == CW_ITEM_POTION)
+        } else if item.is_some_and(|item| item.role == CW_ITEM_ROLE_CONSUMABLE)
             && healing_target.is_some_and(|target| target.id == resident.id)
         {
             format!("{resident_name} needed {item_name}")
-        } else if item.is_some_and(|item| item.kind == CW_ITEM_POTION) && healing_target.is_some() {
+        } else if item.is_some_and(|item| item.role == CW_ITEM_ROLE_CONSUMABLE)
+            && healing_target.is_some()
+        {
             let target = healing_target.expect("healing target checked");
             let target_name = self
                 .actor_name(target.id)
@@ -11075,7 +11129,7 @@ impl RuntimeWorld {
                 "{resident_name} could use {item_name} with {}",
                 candidate.feature_name
             )
-        } else if item.is_some_and(|item| item.kind == CW_ITEM_POTION) {
+        } else if item.is_some_and(|item| item.role == CW_ITEM_ROLE_CONSUMABLE) {
             format!("{resident_name} could use {item_name}")
         } else {
             format!("{resident_name} valued {item_name}")
@@ -12068,7 +12122,7 @@ impl RuntimeWorld {
             .filter(|item| {
                 item.holder_actor_id == 0
                     && item.charges > 0
-                    && (item.location_id == 0
+                    && ((item.location_id == 0 && item.zone == CW_CARD_ZONE_HIDDEN)
                         || self.forgotten_search_item_at_location(*item, location_id))
                     && !self.search_item_remembered(item.id)
             })
@@ -12491,72 +12545,6 @@ impl RuntimeWorld {
         record
     }
 
-    fn recipe_by_id(&self, recipe_id: u64) -> Option<&'static SeedRecipeContent> {
-        active_content()
-            .recipes
-            .iter()
-            .find(|recipe| recipe.id == recipe_id)
-    }
-
-    fn craft_action_for_recipe(&self, actor_id: u64, recipe_id: u64) -> Option<CwAction> {
-        if self.recipe_by_id(recipe_id)?.schema_version == 2 {
-            return self
-                .versioned_craft_plan(actor_id, recipe_id, None)
-                .map(|plan| plan.action);
-        }
-        let actor = self.actor_by_id(actor_id)?;
-        if actor.status != CW_ACTOR_ACTIVE {
-            return None;
-        }
-        let recipe = self.recipe_by_id(recipe_id)?;
-        let held_items = self.actor_held_items(actor_id);
-        let floor_items = self.loose_items_at_location(actor.location_id);
-        let held = held_items
-            .iter()
-            .copied()
-            .find(|item| recipe.input_item_ids.contains(&item.id))?;
-        let floor = floor_items
-            .iter()
-            .copied()
-            .find(|item| item.id != held.id && recipe.input_item_ids.contains(&item.id))?;
-        if recipe
-            .input_item_ids
-            .iter()
-            .any(|item_id| *item_id != held.id && *item_id != floor.id)
-        {
-            return None;
-        }
-        let mut action = CwAction {
-            kind: CW_ACTION_CRAFT,
-            actor_id,
-            content_id: recipe.id,
-            item_id: held.id,
-            target_item_id: floor.id,
-            ..CwAction::default()
-        };
-        if let Some(output) = recipe.output.as_ref() {
-            if self.item_by_id(output.item_id).is_some() {
-                return None;
-            }
-            action.output_item_id = output.item_id;
-            action.output_target_id = output.target_id;
-            action.output_target_kind = placement_target_kind_from_str(&output.target_kind)?;
-            action.output_item_kind = seed_item_kind_from_str(&output.kind)?;
-            action.output_item_charges = output.charges;
-            match action.output_target_kind {
-                CW_PLACEMENT_ACTOR_HAND => {
-                    let target = self.actor_by_id(output.target_id)?;
-                    if target.status != CW_ACTOR_ACTIVE {
-                        return None;
-                    }
-                }
-                CW_PLACEMENT_LOCATION_FLOOR => {}
-                _ => return None,
-            }
-        }
-        Some(action)
-    }
-
     fn default_craft_recipe(&self, actor_id: u64) -> Option<&'static SeedRecipeContent> {
         active_content()
             .recipes
@@ -12573,6 +12561,9 @@ impl RuntimeWorld {
         for item in &mut self.world.items[..self.world.item_count] {
             if hidden_item_ids.contains(&item.id) {
                 item.location_id = 0;
+                item.holder_actor_id = 0;
+                item.container_item_id = 0;
+                item.zone = CW_CARD_ZONE_HIDDEN;
                 item.held_since_tick = 0;
             }
         }
@@ -12991,7 +12982,7 @@ The relationship statement they are preserving is: {statement}"
         if action.kind == CW_ACTION_CRAFT
             && self
                 .recipe_by_id(action.content_id)
-                .is_some_and(|recipe| recipe.schema_version == 2)
+                .is_some_and(recipe_uses_receipt)
         {
             return self
                 .versioned_craft_plan(action.actor_id, action.content_id, None)
@@ -13436,10 +13427,11 @@ The relationship statement they are preserving is: {statement}"
         if directly_desired && !resident_already_holds_item {
             return RESIDENT_DESIRED_ITEM_SCORE;
         }
-        if item.kind == CW_ITEM_POTION && self.resident_healing_target(resident).is_some() {
+        if item.role == CW_ITEM_ROLE_CONSUMABLE && self.resident_healing_target(resident).is_some()
+        {
             return RESIDENT_DESIRED_ITEM_SCORE - 10;
         }
-        if item.kind == CW_ITEM_POTION {
+        if item.role == CW_ITEM_ROLE_CONSUMABLE {
             return RESIDENT_USEFUL_ITEM_SCORE;
         }
         if self
@@ -13455,10 +13447,11 @@ The relationship statement they are preserving is: {statement}"
         if self.resident_item_is_attached(resident.id, item) {
             return RESIDENT_ATTACHED_ITEM_SCORE;
         }
-        if item.kind == CW_ITEM_POTION && self.resident_healing_target(resident).is_some() {
+        if item.role == CW_ITEM_ROLE_CONSUMABLE && self.resident_healing_target(resident).is_some()
+        {
             return RESIDENT_DESIRED_ITEM_SCORE - 5;
         }
-        if item.kind == CW_ITEM_POTION {
+        if item.role == CW_ITEM_ROLE_CONSUMABLE {
             return RESIDENT_USEFUL_ITEM_SCORE;
         }
         if self
@@ -13489,6 +13482,7 @@ The relationship statement they are preserving is: {statement}"
         let mut candidates: Vec<_> = self
             .actor_held_items(resident.id)
             .into_iter()
+            .filter(|item| self.item_can_leave_actor(resident.id, *item))
             .filter(|item| !self.resident_item_is_attached(resident.id, *item))
             .filter(|item| {
                 incoming_item.is_none_or(|incoming| {
@@ -13656,6 +13650,9 @@ The relationship statement they are preserving is: {statement}"
         let incoming = self
             .item_by_id(incoming_item_id)
             .ok_or_else(|| "That item is no longer available for Pick Up.".to_string())?;
+        if !Self::item_is_transferable(incoming) {
+            return Err("That item cannot be picked up or transferred.".to_string());
+        }
         if self.actor_can_receive_item(actor, incoming_item_id) {
             return Ok(None);
         }
@@ -13675,6 +13672,7 @@ The relationship statement they are preserving is: {statement}"
         });
         outgoing
             .into_iter()
+            .filter(|item| self.item_can_leave_actor(actor_id, *item))
             .find(|item| self.actor_can_exchange_items(actor_id, Some(*item), incoming))
             .map(|item| Some(item.id))
             .ok_or_else(|| "That pickup cannot make room in the pack.".to_string())
@@ -15532,13 +15530,8 @@ The relationship statement they are preserving is: {statement}"
                 self.actor_held_items(target.id)
                     .into_iter()
                     .find_map(|item| {
-                        let eligible = self
-                            .items
-                            .get(&item.id)
-                            .and_then(|meta| meta.mechanics.as_ref())
-                            .is_some_and(|mechanics| {
-                                mechanics.theft_policy == "eligible_when_carried"
-                            });
+                        let eligible =
+                            Self::item_is_theft_eligible(item) && !self.item_has_contents(item.id);
                         (eligible && self.actor_can_exchange_items(actor.id, None, item))
                             .then_some((target, item))
                     })
@@ -15551,7 +15544,11 @@ The relationship statement they are preserving is: {statement}"
             return None;
         }
 
-        let held_items = self.actor_held_items(actor_id);
+        let held_items = self
+            .actor_held_items(actor_id)
+            .into_iter()
+            .filter(|item| self.item_can_leave_actor(actor_id, *item))
+            .collect::<Vec<_>>();
         if held_items.is_empty() {
             return None;
         }
@@ -15620,8 +15617,11 @@ The relationship statement they are preserving is: {statement}"
             .copied()
             .find(|item| item.id == item_id)
             .ok_or_else(|| "That item is not here.".to_string())?;
-        if offered_item.holder_actor_id != actor_id {
-            return Err("You are not holding that item.".to_string());
+        if !self.item_can_leave_actor(actor_id, offered_item) {
+            return Err(
+                "That item must be carried, transferable, and empty before it can be given."
+                    .to_string(),
+            );
         }
         let requested = self
             .resident_request_for_holder(target, actor_id)
@@ -15669,8 +15669,10 @@ The relationship statement they are preserving is: {statement}"
         let requested_item = self
             .item_by_id(target_item_id)
             .ok_or_else(|| "That trade item is not here.".to_string())?;
-        if offered_item.holder_actor_id != actor.id || requested_item.holder_actor_id != target.id {
-            return Err("Those items are not held by the trading partners.".to_string());
+        if !self.item_can_leave_actor(actor.id, offered_item)
+            || !self.item_can_leave_actor(target.id, requested_item)
+        {
+            return Err("Both trade items must be carried, transferable, and empty.".to_string());
         }
         if !self.actor_can_exchange_items(actor.id, Some(offered_item), requested_item)
             || !self.actor_can_exchange_items(target.id, Some(requested_item), offered_item)
@@ -15714,7 +15716,11 @@ The relationship statement they are preserving is: {statement}"
         if !Self::actor_can_act(actor) {
             return Vec::new();
         }
-        let offered_items = self.actor_held_items(actor_id);
+        let offered_items = self
+            .actor_held_items(actor_id)
+            .into_iter()
+            .filter(|item| self.item_can_leave_actor(actor_id, *item))
+            .collect::<Vec<_>>();
         if offered_items.is_empty() {
             return Vec::new();
         }
@@ -15727,7 +15733,11 @@ The relationship statement they are preserving is: {statement}"
         targets.sort_by_key(|target| target.id);
         let mut candidates = Vec::new();
         for target in targets {
-            for target_item in self.actor_held_items(target.id) {
+            for target_item in self
+                .actor_held_items(target.id)
+                .into_iter()
+                .filter(|item| self.item_can_leave_actor(target.id, *item))
+            {
                 if !self.economy_known_by(actor_id, target.id)
                     && !self.resident_remembers_actor_holding_item_at(
                         actor_id,
@@ -24390,7 +24400,7 @@ async fn craft(
         let Some(recipe) = runtime.recipe_by_id(payload.recipe_id) else {
             return action_offer_rejected("recipe is not available");
         };
-        if recipe.schema_version == 2 {
+        if recipe_uses_receipt(recipe) {
             if let Some(receipt_id) = payload.receipt_id.as_deref() {
                 if let Some(existing) = runtime.craft_receipts.get(receipt_id) {
                     return Json(ActionResponse {
@@ -34991,7 +35001,7 @@ mod tests {
     #[test]
     fn rust_ffi_kernel_capacities_are_runtime_sized() {
         assert_eq!(CW_MAX_ACTORS, 2048);
-        assert_eq!(CW_MAX_ITEMS, 1024);
+        assert_eq!(CW_MAX_ITEMS, 2048);
         assert_eq!(CW_MAX_LOCATIONS, 2048);
         assert_eq!(CW_MAX_EXITS, 4096);
         assert_eq!(CW_MAX_EVENTS, 256);
@@ -49469,7 +49479,7 @@ mod tests {
     }
 
     #[test]
-    fn reveal_item_effect_respects_the_single_floor_slot() {
+    fn reveal_item_effect_adds_to_an_occupied_room() {
         let mut runtime = RuntimeWorld::seeded();
         let hidden_item = runtime.world.items[..runtime.world.item_count]
             .iter_mut()
@@ -49477,7 +49487,7 @@ mod tests {
             .expect("seed reveal item");
         hidden_item.holder_actor_id = 0;
         hidden_item.location_id = 0;
-        hidden_item.zone = CW_CARD_ZONE_WORLD;
+        hidden_item.zone = CW_CARD_ZONE_HIDDEN;
         assert!(!runtime.room_floor_empty(COSY_COTTAGE_LOCATION_ID));
         assert_eq!(
             runtime.world.items[..runtime.world.item_count]
@@ -49488,49 +49498,29 @@ mod tests {
         );
         insert_effect_test_clock(
             &mut runtime,
-            "test:blocked-reveal",
+            "test:occupied-room-reveal",
             vec![EffectDescriptor::RevealItem {
                 item_id: 2005,
                 location_id: COSY_COTTAGE_LOCATION_ID,
-                reason: Some("blocked_reveal_test".to_string()),
+                reason: Some("occupied_room_reveal_test".to_string()),
             }],
         );
-        let blocked = runtime.advance_clock("test:blocked-reveal", 1, 1001, "blocked_reveal_test");
-        assert!(blocked
-            .iter()
-            .any(|event| event.type_name == "clock.fill_effect_rejected"));
-        assert_eq!(
-            runtime.world.items[..runtime.world.item_count]
-                .iter()
-                .find(|item| item.id == 2005)
-                .map(|item| item.location_id),
-            Some(0)
+        let revealed = runtime.advance_clock(
+            "test:occupied-room-reveal",
+            1,
+            1001,
+            "occupied_room_reveal_test",
         );
-
-        runtime.hide_loose_items_at_location(COSY_COTTAGE_LOCATION_ID);
-        assert!(runtime.room_floor_empty(COSY_COTTAGE_LOCATION_ID));
-        insert_effect_test_clock(
-            &mut runtime,
-            "test:successful-reveal",
-            vec![EffectDescriptor::RevealItem {
-                item_id: 2005,
-                location_id: COSY_COTTAGE_LOCATION_ID,
-                reason: Some("successful_reveal_test".to_string()),
-            }],
-        );
-        let revealed =
-            runtime.advance_clock("test:successful-reveal", 1, 1001, "successful_reveal_test");
         assert!(revealed
             .iter()
             .any(|event| event.type_name == "item.revealed"));
-        assert_eq!(
-            runtime
-                .loose_items_at_location(COSY_COTTAGE_LOCATION_ID)
-                .iter()
-                .map(|item| item.id)
-                .collect::<Vec<_>>(),
-            vec![2005]
-        );
+        let floor_items = runtime
+            .loose_items_at_location(COSY_COTTAGE_LOCATION_ID)
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>();
+        assert!(floor_items.contains(&HEARTH_TONIC_ITEM_ID));
+        assert!(floor_items.contains(&STORY_BUTTON_ITEM_ID));
     }
 
     #[test]
@@ -51198,6 +51188,8 @@ mod tests {
             } else if item.id == STORY_BUTTON_ITEM_ID {
                 item.location_id = 0;
                 item.holder_actor_id = 0;
+                item.container_item_id = 0;
+                item.zone = CW_CARD_ZONE_HIDDEN;
             }
         }
         runtime.beliefs.clear();

--- a/v2/orchestrator-rust/src/main.rs
+++ b/v2/orchestrator-rust/src/main.rs
@@ -12242,22 +12242,20 @@ impl RuntimeWorld {
                 hidden_exit_id: hidden_exit.id.clone(),
             });
         }
-        if self.room_floor_empty(location_id) {
-            let hidden_item_id = self.hidden_search_item_for_location(location_id);
-            let feature_uses_hidden_item = self
-                .room_features(location_id)
-                .into_iter()
-                .find(|feature| feature.key == feature_key)
-                .is_some_and(|feature| {
-                    feature
-                        .uses
-                        .iter()
-                        .any(|use_case| Some(use_case.item_id) == hidden_item_id)
-                });
-            if feature_uses_hidden_item {
-                if let Some(item_id) = hidden_item_id {
-                    candidates.push(SearchRevealCandidate::Item { item_id });
-                }
+        let hidden_item_id = self.hidden_search_item_for_location(location_id);
+        let feature_uses_hidden_item = self
+            .room_features(location_id)
+            .into_iter()
+            .find(|feature| feature.key == feature_key)
+            .is_some_and(|feature| {
+                feature
+                    .uses
+                    .iter()
+                    .any(|use_case| Some(use_case.item_id) == hidden_item_id)
+            });
+        if feature_uses_hidden_item {
+            if let Some(item_id) = hidden_item_id {
+                candidates.push(SearchRevealCandidate::Item { item_id });
             }
         }
         candidates.sort_by_key(|candidate| self.search_candidate_sort_key(candidate));
@@ -12286,10 +12284,8 @@ impl RuntimeWorld {
                 location_id,
             });
         }
-        if self.room_floor_empty(location_id) {
-            if let Some(item_id) = self.hidden_search_item_for_location(location_id) {
-                candidates.push(SearchRevealCandidate::Item { item_id });
-            }
+        if let Some(item_id) = self.hidden_search_item_for_location(location_id) {
+            candidates.push(SearchRevealCandidate::Item { item_id });
         }
         candidates.sort_by_key(|candidate| self.search_candidate_sort_key(candidate));
         candidates
@@ -12553,15 +12549,8 @@ impl RuntimeWorld {
                     if target.status != CW_ACTOR_ACTIVE {
                         return None;
                     }
-                    if self.actor_inventory_count(output.target_id) != 0 {
-                        return None;
-                    }
                 }
-                CW_PLACEMENT_LOCATION_FLOOR => {
-                    if !self.room_floor_empty(output.target_id) {
-                        return None;
-                    }
-                }
+                CW_PLACEMENT_LOCATION_FLOOR => {}
                 _ => return None,
             }
         }
@@ -21752,22 +21741,14 @@ async fn command_inner(
             let candidates =
                 runtime.search_reveal_candidates_for_feature(location_id, &feature_key);
             if candidates.is_empty() && feature_key == "room" {
-                let status = if runtime.room_floor_empty(location_id) {
-                    404
-                } else {
-                    409
-                };
-                let output = if status == 409 {
-                    "Something is already waiting here. Pick it up, use it, or pass it on before looking for another keepsake."
-                } else {
-                    "This room has shared everything it is ready to share."
-                };
                 return Json(CommandResponse {
                     ok: false,
-                    status,
+                    status: 404,
                     command: resolved.command,
                     verb: resolved.verb,
-                    output: Some(output.to_string()),
+                    output: Some(
+                        "This room has shared everything it is ready to share.".to_string(),
+                    ),
                     error_kind: None,
                     action: resolved.action,
                     receipt: None,

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -1434,22 +1434,14 @@ impl RuntimeWorld {
                 let candidates =
                     self.search_reveal_candidates_for_feature(actor.location_id, &target.key);
                 if candidates.is_empty() && target.key == "room" {
-                    let output = if self.room_floor_empty(actor.location_id) {
-                        "This room has shared everything it is ready to share."
-                    } else {
-                        "Something is already waiting here. Pick it up, use it, or pass it on before looking for another keepsake."
-                    };
                     return Ok(ResolvedCommand {
                         command: command.clone(),
                         verb,
                         action: Some(command_action("search", "Search", &command)),
                         dispatch: CommandDispatch::Disabled {
-                            status: if self.room_floor_empty(actor.location_id) {
-                                404
-                            } else {
-                                409
-                            },
-                            output: output.to_string(),
+                            status: 404,
+                            output: "This room has shared everything it is ready to share."
+                                .to_string(),
                         },
                     });
                 }

--- a/v2/orchestrator-rust/src/mud.rs
+++ b/v2/orchestrator-rust/src/mud.rs
@@ -1292,7 +1292,7 @@ fn tag_belongs_in_room_description(tag: &TagView) -> bool {
 impl RuntimeWorld {
     pub(crate) fn item_can_be_equipped(&self, item: &CwItem) -> bool {
         matches!(item.role, CW_ITEM_ROLE_WEAPON | CW_ITEM_ROLE_CONTAINER)
-            || (item.role == CW_ITEM_ROLE_TOOL
+            || (matches!(item.role, CW_ITEM_ROLE_TOOL | CW_ITEM_ROLE_CONSUMABLE)
                 && self
                     .seed_item_contract_for_instance(item.id)
                     .is_some_and(|contract| {

--- a/v2/orchestrator-rust/src/quest_loot.rs
+++ b/v2/orchestrator-rust/src/quest_loot.rs
@@ -805,6 +805,7 @@ impl RuntimeWorld {
             container_capacity_tenths: template.container_capacity_tenths,
             size_class: item_size_from_str(&template.size)?,
             role: loot_item_role(&template.role)?,
+            policy_flags: declared_item_policy_flags(template.mechanics.as_ref()),
             zone: if holder_actor_id == 0 {
                 CW_CARD_ZONE_WORLD
             } else {

--- a/v2/orchestrator-rust/src/residents/memory.rs
+++ b/v2/orchestrator-rust/src/residents/memory.rs
@@ -382,6 +382,8 @@ impl RuntimeWorld {
             if forgotten_item_ids.contains(&item.id) {
                 item.location_id = 0;
                 item.holder_actor_id = 0;
+                item.container_item_id = 0;
+                item.zone = CW_CARD_ZONE_HIDDEN;
                 item.held_since_tick = 0;
             }
         }

--- a/v2/orchestrator-rust/src/residents/needs.rs
+++ b/v2/orchestrator-rust/src/residents/needs.rs
@@ -133,7 +133,7 @@ impl RuntimeWorld {
         let item = self
             .actor_held_items(resident.id)
             .into_iter()
-            .filter(|item| item.kind == CW_ITEM_POTION && item.charges > 0)
+            .filter(|item| item.role == CW_ITEM_ROLE_CONSUMABLE && item.charges > 0)
             .min_by_key(|item| (item.held_since_tick, item.id))?;
         Some((item, target))
     }
@@ -200,7 +200,7 @@ impl RuntimeWorld {
         if self.resident_needs_medicine(resident) {
             return self
                 .item_by_id(item_id)
-                .is_some_and(|item| item.kind == CW_ITEM_POTION && item.charges > 0);
+                .is_some_and(|item| item.role == CW_ITEM_ROLE_CONSUMABLE && item.charges > 0);
         }
         if !self
             .actor_held_items(resident.id)
@@ -235,7 +235,7 @@ impl RuntimeWorld {
                 })
                 .filter_map(|memory| {
                     self.item_by_id(memory.subject_id)
-                        .filter(|item| item.kind == CW_ITEM_POTION)
+                        .filter(|item| item.role == CW_ITEM_ROLE_CONSUMABLE)
                         .map(|item| {
                             (
                                 item.id,
@@ -390,7 +390,7 @@ impl RuntimeWorld {
         if self.resident_needs_medicine(resident)
             && self
                 .item_by_id(item_id)
-                .is_some_and(|item| item.kind == CW_ITEM_POTION)
+                .is_some_and(|item| item.role == CW_ITEM_ROLE_CONSUMABLE)
         {
             return "medicine";
         }
@@ -442,11 +442,13 @@ impl RuntimeWorld {
             .any(|desired_item_id| desired_item_id == item_id)
         {
             format!("{resident_name} wants {item_name}.")
-        } else if item.is_some_and(|item| item.kind == CW_ITEM_POTION)
+        } else if item.is_some_and(|item| item.role == CW_ITEM_ROLE_CONSUMABLE)
             && healing_target.is_some_and(|target| target.id == resident.id)
         {
             format!("{resident_name} needs {item_name}.")
-        } else if item.is_some_and(|item| item.kind == CW_ITEM_POTION) && healing_target.is_some() {
+        } else if item.is_some_and(|item| item.role == CW_ITEM_ROLE_CONSUMABLE)
+            && healing_target.is_some()
+        {
             let target = healing_target.expect("healing target checked");
             let target_name = self
                 .actor_name(target.id)
@@ -460,7 +462,7 @@ impl RuntimeWorld {
                 "{resident_name} could use {item_name} with {}.",
                 candidate.feature_name
             )
-        } else if item.is_some_and(|item| item.kind == CW_ITEM_POTION) {
+        } else if item.is_some_and(|item| item.role == CW_ITEM_ROLE_CONSUMABLE) {
             format!("{resident_name} could use {item_name}.")
         } else {
             format!("{resident_name} values {item_name}.")
@@ -944,7 +946,8 @@ mod tests {
                 item.location_id = 0;
                 item.holder_actor_id = 5000;
                 item.charges = 1;
-            } else if item.holder_actor_id == RATI_ACTOR_ID && item.kind == CW_ITEM_POTION {
+            } else if item.holder_actor_id == RATI_ACTOR_ID && item.role == CW_ITEM_ROLE_CONSUMABLE
+            {
                 item.holder_actor_id = 0;
                 item.location_id = RAIN_SOFT_GARDEN_LOCATION_ID;
             }

--- a/v2/orchestrator-rust/src/rest.rs
+++ b/v2/orchestrator-rust/src/rest.rs
@@ -51,7 +51,7 @@ impl RuntimeWorld {
 
     fn actor_has_equipped_item_capability(&self, actor_id: u64, capability: &str) -> bool {
         self.actor_held_items(actor_id).into_iter().any(|item| {
-            item.role == CW_ITEM_ROLE_TOOL
+            matches!(item.role, CW_ITEM_ROLE_TOOL | CW_ITEM_ROLE_CONSUMABLE)
                 && item.zone == CW_CARD_ZONE_EQUIPPED
                 && item.container_item_id == 0
                 && self
@@ -532,7 +532,7 @@ mod tests {
         let contract = runtime
             .seed_item_contract_for_instance(HEARTH_TONIC_ITEM_ID)
             .expect("Hearth Tonic has an authored item contract");
-        assert_eq!(contract.role, "tool");
+        assert_eq!(contract.role, "consumable");
         assert_eq!(
             contract.capabilities,
             vec![CAMP_SHELTER_ITEM_CAPABILITY.to_string()]
@@ -1136,7 +1136,7 @@ mod tests {
         let legacy_item = legacy_json["projection_mutations"][0]["item"]
             .as_object_mut()
             .expect("materialized legacy item");
-        for field in ["max_charges", "recovery", "recovery_zone", "reserved2"] {
+        for field in ["max_charges", "recovery", "recovery_zone", "policy_flags"] {
             legacy_item.remove(field);
             assert!(!legacy_item.contains_key(field));
         }

--- a/v2/orchestrator-rust/src/rpg/effects.rs
+++ b/v2/orchestrator-rust/src/rpg/effects.rs
@@ -402,7 +402,11 @@ impl RuntimeWorld {
                     if self.location_name(*location_id).is_none() {
                         return Err(format!("missing room {location_id}"));
                     }
-                    if item.holder_actor_id != 0 || item.location_id != 0 || item.charges == 0 {
+                    if item.holder_actor_id != 0
+                        || item.location_id != 0
+                        || item.zone != CW_CARD_ZONE_HIDDEN
+                        || item.charges == 0
+                    {
                         return Err(format!("item {item_id} is not hidden"));
                     }
                 }

--- a/v2/orchestrator-rust/src/rpg/effects.rs
+++ b/v2/orchestrator-rust/src/rpg/effects.rs
@@ -405,9 +405,6 @@ impl RuntimeWorld {
                     if item.holder_actor_id != 0 || item.location_id != 0 || item.charges == 0 {
                         return Err(format!("item {item_id} is not hidden"));
                     }
-                    if !self.room_floor_empty(*location_id) {
-                        return Err(format!("room {location_id} floor is full"));
-                    }
                 }
                 EffectDescriptor::Unknown => {
                     return Err("unknown effect op".to_string());

--- a/v2/orchestrator-rust/src/transfers.rs
+++ b/v2/orchestrator-rust/src/transfers.rs
@@ -1,5 +1,52 @@
 use super::*;
 
+impl RuntimeWorld {
+    pub(super) fn item_policy_is_configured(item: CwItem) -> bool {
+        item.policy_flags & CW_ITEM_POLICY_CONFIGURED != 0
+    }
+
+    pub(super) fn item_is_transferable(item: CwItem) -> bool {
+        !Self::item_policy_is_configured(item)
+            || item.policy_flags & CW_ITEM_POLICY_TRANSFERABLE != 0
+    }
+
+    pub(super) fn item_is_theft_eligible(item: CwItem) -> bool {
+        Self::item_is_directly_held(item)
+            && matches!(
+                item.zone,
+                CW_CARD_ZONE_CARRIED
+                    | CW_CARD_ZONE_EQUIPPED
+                    | CW_CARD_ZONE_WORLD
+                    | CW_CARD_ZONE_HIDDEN
+            )
+            && (!Self::item_policy_is_configured(item)
+                || item.policy_flags & CW_ITEM_POLICY_THEFT_WHEN_CARRIED != 0)
+    }
+
+    pub(super) fn item_is_directly_held(item: CwItem) -> bool {
+        item.holder_actor_id != 0
+            && item.location_id == 0
+            && item.container_item_id == 0
+            && !matches!(
+                item.zone,
+                CW_CARD_ZONE_CONTAINED | CW_CARD_ZONE_ESCROW | CW_CARD_ZONE_INSTALLED
+            )
+    }
+
+    pub(super) fn item_has_contents(&self, item_id: u64) -> bool {
+        self.world.items[..self.world.item_count]
+            .iter()
+            .any(|item| item.container_item_id == item_id)
+    }
+
+    pub(super) fn item_can_leave_actor(&self, actor_id: u64, item: CwItem) -> bool {
+        item.holder_actor_id == actor_id
+            && Self::item_is_directly_held(item)
+            && Self::item_is_transferable(item)
+            && !self.item_has_contents(item.id)
+    }
+}
+
 pub(super) fn private_actor_event(
     type_name: &str,
     actor_id: u64,
@@ -214,7 +261,7 @@ impl RuntimeWorld {
                     && self.actor_control_mode(recipient.id).is_direct_input()
                     && self.actor_control_mode(holder.id).is_direct_input()
                     && recipient.location_id == holder.location_id
-                    && item.holder_actor_id == holder.id
+                    && self.item_can_leave_actor(holder.id, item)
                     && !self.actors_blocked(recipient.id, holder.id)
                     && self.economy_known_by(recipient.id, holder.id)
                     && self.actor_can_receive_item(recipient, item.id)

--- a/v2/orchestrator-rust/src/uses.rs
+++ b/v2/orchestrator-rust/src/uses.rs
@@ -274,7 +274,7 @@ impl RuntimeWorld {
         let mut items = self
             .actor_held_items(actor_id)
             .into_iter()
-            .filter(|item| item.kind == CW_ITEM_POTION && item.charges > 0)
+            .filter(|item| item.role == CW_ITEM_ROLE_CONSUMABLE && item.charges > 0)
             .collect::<Vec<_>>();
         items.sort_by_key(|item| (item.held_since_tick, item.id));
         let mut targets = self.world.actors[..self.world.actor_count]

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -2118,6 +2118,12 @@ pub(super) struct ItemView {
     pub(super) weight_tenths: u16,
     pub(super) size: String,
     pub(super) container_capacity_tenths: u16,
+    pub(super) container_contents_weight_tenths: u32,
+    pub(super) container_remaining_capacity_tenths: u32,
+    pub(super) transferable: bool,
+    pub(super) theft_eligible: bool,
+    pub(super) available_actions: Vec<&'static str>,
+    pub(super) blocked_reason: Option<&'static str>,
     pub(super) skill_id: Option<String>,
     pub(super) skill_bonus: i8,
     pub(super) mechanics: Option<SeedPlayableItemMechanics>,
@@ -2134,7 +2140,7 @@ impl Serialize for ItemView {
     where
         S: serde::Serializer,
     {
-        let mut out = serializer.serialize_struct("ItemView", 15)?;
+        let mut out = serializer.serialize_struct("ItemView", 21)?;
         out.serialize_field("id", &self.id)?;
         out.serialize_field("name", &self.name)?;
         out.serialize_field("description", &self.description)?;
@@ -2143,6 +2149,18 @@ impl Serialize for ItemView {
         out.serialize_field("weight_tenths", &self.weight_tenths)?;
         out.serialize_field("size", &self.size)?;
         out.serialize_field("container_capacity_tenths", &self.container_capacity_tenths)?;
+        out.serialize_field(
+            "container_contents_weight_tenths",
+            &self.container_contents_weight_tenths,
+        )?;
+        out.serialize_field(
+            "container_remaining_capacity_tenths",
+            &self.container_remaining_capacity_tenths,
+        )?;
+        out.serialize_field("transferable", &self.transferable)?;
+        out.serialize_field("theft_eligible", &self.theft_eligible)?;
+        out.serialize_field("available_actions", &self.available_actions)?;
+        out.serialize_field("blocked_reason", &self.blocked_reason)?;
         out.serialize_field("skill_id", &self.skill_id)?;
         out.serialize_field("skill_bonus", &self.skill_bonus)?;
         out.serialize_field("zone", &self.zone)?;
@@ -3347,6 +3365,56 @@ impl RuntimeWorld {
 
     pub(super) fn item_view(&self, item: CwItem) -> ItemView {
         let meta = self.items.get(&item.id);
+        let contents_weight = self.world.items[..self.world.item_count]
+            .iter()
+            .copied()
+            .filter(|candidate| candidate.container_item_id == item.id)
+            .map(effective_item_weight_tenths)
+            .map(u32::from)
+            .sum::<u32>();
+        let container_capacity = if item.role == CW_ITEM_ROLE_CONTAINER {
+            item.container_capacity_tenths
+        } else {
+            0
+        };
+        let transferable = Self::item_is_transferable(item);
+        let has_contents = contents_weight > 0;
+        let mut available_actions = Vec::new();
+        match item.zone {
+            CW_CARD_ZONE_WORLD if transferable => available_actions.push("pick_up"),
+            CW_CARD_ZONE_CONTAINED => available_actions.push("take_out"),
+            CW_CARD_ZONE_CARRIED | CW_CARD_ZONE_EQUIPPED if transferable && !has_contents => {
+                available_actions.extend(["drop", "give", "trade"]);
+            }
+            CW_CARD_ZONE_SPELL_DECK => available_actions.push("unprepare"),
+            _ => {}
+        }
+        if item.zone == CW_CARD_ZONE_EQUIPPED {
+            available_actions.push("unequip");
+        }
+        if item.holder_actor_id != 0
+            && matches!(item.zone, CW_CARD_ZONE_CARRIED | CW_CARD_ZONE_EQUIPPED)
+            && item.charges > 0
+            && meta.and_then(|meta| meta.mechanics.as_ref()).is_some()
+        {
+            available_actions.push("use");
+        }
+        if item.role == CW_ITEM_ROLE_CONTAINER
+            && matches!(item.zone, CW_CARD_ZONE_CARRIED | CW_CARD_ZONE_EQUIPPED)
+        {
+            available_actions.push("stow");
+        }
+        let blocked_reason = if !transferable {
+            Some("This item cannot be transferred.")
+        } else if has_contents {
+            Some("Empty this container before transferring it.")
+        } else {
+            match item.zone {
+                CW_CARD_ZONE_CONTAINED => Some("Take it out before using or transferring it."),
+                CW_CARD_ZONE_EXHAUSTED => Some("It must recover before use."),
+                _ => None,
+            }
+        };
         ItemView {
             id: item.id,
             canonical_ref: self
@@ -3366,11 +3434,14 @@ impl RuntimeWorld {
             role: item_role(item.role).to_string(),
             weight_tenths: effective_item_weight_tenths(item),
             size: item_size(item.size_class).to_string(),
-            container_capacity_tenths: if item.role == CW_ITEM_ROLE_CONTAINER {
-                item.container_capacity_tenths
-            } else {
-                0
-            },
+            container_capacity_tenths: container_capacity,
+            container_contents_weight_tenths: contents_weight,
+            container_remaining_capacity_tenths: u32::from(container_capacity)
+                .saturating_sub(contents_weight),
+            transferable,
+            theft_eligible: Self::item_is_theft_eligible(item),
+            available_actions,
+            blocked_reason,
             skill_id: meta.and_then(|meta| meta.skill_id.clone()),
             skill_bonus: meta.map(|meta| meta.skill_bonus).unwrap_or_default(),
             mechanics: meta.and_then(|meta| meta.mechanics.clone()),
@@ -3425,7 +3496,9 @@ impl RuntimeWorld {
                 "attached",
                 format!("{resident_name} has carried {item_name} long enough to become attached."),
             )
-        } else if item.kind == CW_ITEM_POTION && self.resident_healing_target(resident).is_some() {
+        } else if item.role == CW_ITEM_ROLE_CONSUMABLE
+            && self.resident_healing_target(resident).is_some()
+        {
             (
                 "medicine",
                 format!("{resident_name} keeps {item_name} as medicine for someone nearby."),

--- a/v2/orchestrator-rust/src/views.rs
+++ b/v2/orchestrator-rust/src/views.rs
@@ -4273,10 +4273,8 @@ impl RuntimeWorld {
                     || actor_id
                         .map(|id| self.feature_search_claimed(id, location_id, &feature.key))
                         .unwrap_or(false);
-                let searched = explicitly_searched
-                    || (!hidden_exit_pending
-                        && !search_reveal_pending
-                        && !self.room_floor_empty(location_id));
+                let searched =
+                    explicitly_searched || (!hidden_exit_pending && !search_reveal_pending);
                 let uses = feature
                     .uses
                     .iter()

--- a/v2/scripts/check-proof-world.mjs
+++ b/v2/scripts/check-proof-world.mjs
@@ -92,6 +92,12 @@ function recipeOutputLocationId(recipe) {
     : null;
 }
 
+function recipeExactInputIds(recipe) {
+  return (recipe.inputs ?? [])
+    .map((input) => input.item_id)
+    .filter(Number.isInteger);
+}
+
 function active(row) {
   return row.status === undefined || row.status === "active";
 }
@@ -159,7 +165,7 @@ export function analyzeProofWorld(spec, content) {
   for (const recipe of content.recipes) {
     const involvedLocationIds = new Set(
       [
-        ...(recipe.input_item_ids ?? []).map(
+        ...recipeExactInputIds(recipe).map(
           (itemId) => itemById.get(itemId)?.location_id,
         ),
         recipeOutputLocationId(recipe),
@@ -283,14 +289,14 @@ export function analyzeProofWorld(spec, content) {
 
   const criticalInputIds = new Set();
   for (const recipe of content.recipes) {
-    const inputLocations = (recipe.input_item_ids ?? []).map(
+    const inputLocations = recipeExactInputIds(recipe).map(
       (itemId) => itemById.get(itemId)?.location_id,
     );
     if (
       sliceIds.has(recipeOutputLocationId(recipe)) ||
       inputLocations.some((locationId) => sliceIds.has(locationId))
     ) {
-      for (const itemId of recipe.input_item_ids ?? [])
+      for (const itemId of recipeExactInputIds(recipe))
         criticalInputIds.add(itemId);
     }
   }
@@ -325,7 +331,7 @@ export function analyzeProofWorld(spec, content) {
 
   const productionLoops = content.recipes
     .filter((recipe) => {
-      const inputIds = recipe.input_item_ids ?? [];
+      const inputIds = recipeExactInputIds(recipe);
       return (
         inputIds.length > 0 &&
         recipe.output == null &&
@@ -334,9 +340,9 @@ export function analyzeProofWorld(spec, content) {
             (input) => input.item_id === itemId && input.available,
           ),
         ) &&
-        recipe.balance?.target_kind === "location_floor" &&
-        sliceIds.has(recipe.balance.target_id) &&
-        reachable.has(recipe.balance.target_id)
+        recipe.outcome?.target_kind === "location_floor" &&
+        sliceIds.has(recipe.outcome.target_id) &&
+        reachable.has(recipe.outcome.target_id)
       );
     })
     .map((recipe) => recipe.id);

--- a/v2/scripts/check-worldpack.mjs
+++ b/v2/scripts/check-worldpack.mjs
@@ -1707,8 +1707,8 @@ for (const item of items) {
     || itemCapabilities.some((capability) => !allowedItemCapabilities.has(capability))) {
     fail(`item ${item.id} has invalid capabilities`);
   }
-  if (itemCapabilities.length && item.role !== "tool") {
-    fail(`item ${item.id} capabilities require the tool role`);
+  if (itemCapabilities.length && !["tool", "consumable"].includes(item.role)) {
+    fail(`item ${item.id} capabilities require the tool or consumable role`);
   }
   if (!allowedItemSizes.has(item.size)) {
     fail(`item ${item.id} has invalid size ${item.size}`);
@@ -1742,8 +1742,8 @@ for (const item of items) {
       || !Number.isInteger(mechanics.uses)
       || !isNonEmptyString(mechanics.exhaustion)
       || !isNonEmptyString(mechanics.recovery)
-      || mechanics.transfer_policy !== "transferable"
-      || !isNonEmptyString(mechanics.theft_policy)) {
+      || !["transferable", "bound"].includes(mechanics.transfer_policy)
+      || !["eligible_when_carried", "ineligible"].includes(mechanics.theft_policy)) {
       fail(`mechanical item ${item.id} lacks a validated playable-item descriptor`);
     }
     if (item.role === "spell" && !magicEffectIds.has(mechanics?.magic_effect)) {
@@ -2829,16 +2829,35 @@ for (const recipe of recipes) {
   }
   recipeIds.add(recipe.id);
   validateRequiredStrings("recipe", recipe, ["key", "name", "description"]);
-  if (recipe.schema_version === 2) {
+  if (recipe.schema_version !== 2) {
+    fail(`recipe ${recipe.id} schema_version must be 2`);
+    continue;
+  }
+  {
     for (const error of versionedRecipeValidationErrors(
       recipe,
       {
         templateIds: mountedLootTemplateIds,
         buildingArchetypes: mountedBuildingArchetypes,
+        itemIds,
+        actorIds,
+        locationIds,
       },
       `recipe ${recipe.id}`,
     )) {
       fail(error);
+    }
+    const exactRecipe = (recipe.inputs ?? []).some((input) => Number.isInteger(input?.item_id));
+    if (exactRecipe) {
+      if (isObject(recipe.output)) {
+        if (allItemIds.has(recipe.output.item_id)) {
+          fail(`recipe ${recipe.id} has duplicate fixed output item ${recipe.output.item_id}`);
+        } else {
+          allItemIds.add(recipe.output.item_id);
+          recipeOutputById.set(recipe.output.item_id, recipe.output);
+        }
+      }
+      continue;
     }
     const provisionedSupply = recipe.output?.effect === "provisioned_supply";
     if (!Array.isArray(recipe.inputs)
@@ -2874,7 +2893,7 @@ for (const recipe of recipes) {
           || input.zones.some((zone) => !["carried", "world"].includes(zone))) {
         fail(`recipe ${recipe.id} input ${input?.template_id} has ambiguous zones`);
       }
-      if (!["persistent", "consume", "exhaust", "transform"].includes(input?.disposition)) {
+      if (!["persistent", "exhaust", "transform"].includes(input?.disposition)) {
         fail(`recipe ${recipe.id} input ${input?.template_id} has undeclared consumption`);
       }
     }
@@ -2967,72 +2986,6 @@ for (const recipe of recipes) {
       fail(`recipe ${recipe.id} provisioned supply must be inputless and bound to one authored room feature`);
     }
     continue;
-  }
-  if (recipe.schema_version !== undefined && recipe.schema_version !== 1) {
-    fail(`recipe ${recipe.id} has unsupported schema_version ${recipe.schema_version}`);
-  }
-  if (!Array.isArray(recipe.input_item_ids) || recipe.input_item_ids.length !== 2 || recipe.input_item_ids[0] === recipe.input_item_ids[1]) {
-    fail(`recipe ${recipe.id} must declare exactly two distinct input_item_ids`);
-  }
-  for (const itemId of recipe.input_item_ids ?? []) {
-    if (!has(itemIds, itemId)) {
-      fail(`recipe ${recipe.id} references missing input item ${itemId}`);
-    }
-  }
-  if (!isObject(recipe.balance)) {
-    fail(`recipe ${recipe.id} is missing balance declaration`);
-  } else {
-    if (!["location", "avatar", "resident", "covenant", "evolution"].includes(recipe.balance.kind)) {
-      fail(`recipe ${recipe.id} has invalid balance kind ${recipe.balance.kind}`);
-    }
-    if (!isNonEmptyString(recipe.balance.reason)) {
-      fail(`recipe ${recipe.id} balance is missing reason`);
-    }
-    const targetKind = placementTargetKind(recipe.balance.target_kind);
-    if (!targetKind) {
-      fail(`recipe ${recipe.id} balance has invalid target kind ${recipe.balance.target_kind}`);
-    } else if (targetKind === "actor_hand" && !has(actorIds, recipe.balance.target_id)) {
-      fail(`recipe ${recipe.id} balance references missing actor ${recipe.balance.target_id}`);
-    } else if (targetKind === "location_floor" && !has(locationIds, recipe.balance.target_id)) {
-      fail(`recipe ${recipe.id} balance references missing location ${recipe.balance.target_id}`);
-    }
-  }
-  if (recipe.output !== undefined && recipe.output !== null) {
-    if (!isObject(recipe.output)) {
-      fail(`recipe ${recipe.id} output must be an object`);
-      continue;
-    }
-    validateRequiredStrings(`recipe ${recipe.id} output`, recipe.output, ["name", "description", "kind", "target_kind"]);
-    if (!Number.isInteger(recipe.output.item_id) || recipe.output.item_id <= 0 || has(itemIds, recipe.output.item_id) || allItemIds.has(recipe.output.item_id)) {
-      fail(`recipe ${recipe.id} has invalid or duplicate output item ${recipe.output.item_id}`);
-    } else {
-      allItemIds.add(recipe.output.item_id);
-      recipeOutputById.set(recipe.output.item_id, recipe.output);
-    }
-    if (!["potion", "evolution", "keepsake"].includes(recipe.output.kind)) {
-      fail(`recipe ${recipe.id} output has invalid item kind ${recipe.output.kind}`);
-    }
-    if (!Number.isInteger(recipe.output.charges) || recipe.output.charges <= 0) {
-      fail(`recipe ${recipe.id} output has invalid charges`);
-    }
-    const outputTargetKind = placementTargetKind(recipe.output.target_kind);
-    if (!outputTargetKind) {
-      fail(`recipe ${recipe.id} output has invalid target kind ${recipe.output.target_kind}`);
-    } else if (outputTargetKind === "actor_hand" && !has(actorIds, recipe.output.target_id)) {
-      fail(`recipe ${recipe.id} output references missing actor ${recipe.output.target_id}`);
-    } else if (outputTargetKind === "location_floor" && !has(locationIds, recipe.output.target_id)) {
-      fail(`recipe ${recipe.id} output references missing location ${recipe.output.target_id}`);
-    }
-    if (outputTargetKind === "location_floor" && has(locationIds, recipe.output.target_id)) {
-      validateProgressionLocationAccess(
-        `recipe ${recipe.id} output`,
-        recipe.output.target_id,
-        recipe.output.required_grant_id,
-      );
-    }
-    if (isObject(recipe.balance) && (recipe.output.target_kind !== recipe.balance.target_kind || recipe.output.target_id !== recipe.balance.target_id)) {
-      fail(`recipe ${recipe.id} output slot must match its balance declaration`);
-    }
   }
 }
 
@@ -3190,7 +3143,7 @@ function buildWorldpackReport() {
       .filter((track) => (track.requirements ?? []).some((requirement) => requirement.item_id === item.id))
       .map((track) => ({ actor_id: track.actor_id, actor_name: actors.find((actor) => actor.id === track.actor_id)?.name ?? null }));
     const recipeInputs = recipes
-      .filter((recipe) => (recipe.input_item_ids ?? []).includes(item.id))
+      .filter((recipe) => (recipe.inputs ?? []).some((input) => input.item_id === item.id))
       .map((recipe) => ({ recipe_id: recipe.id, recipe_name: recipe.name }));
     const demand = desires.length + attachments.length + evolutionRequirements.length + recipeInputs.length;
     return {
@@ -3353,11 +3306,20 @@ function buildWorldpackReport() {
       effects: effectSummaries(hook.effects),
     })),
     recipes: recipes.map((recipe) => ({
+      ...(() => {
+        const exactInputIds = (recipe.inputs ?? [])
+          .map((input) => input.item_id)
+          .filter(Number.isInteger);
+        return {
+          input_item_ids: exactInputIds,
+          input_item_names: exactInputIds.map(
+            (itemId) => itemById.get(itemId)?.name ?? null,
+          ),
+        };
+      })(),
       id: recipe.id,
       key: recipe.key,
-      schema_version: recipe.schema_version ?? 1,
-      input_item_ids: recipe.input_item_ids,
-      input_item_names: (recipe.input_item_ids ?? []).map((itemId) => itemById.get(itemId)?.name ?? null),
+      schema_version: recipe.schema_version,
       input_templates: (recipe.inputs ?? []).map((input) => ({
         template_id: input.template_id,
         zones: input.zones,
@@ -3368,7 +3330,7 @@ function buildWorldpackReport() {
       output_template_id: recipe.output?.template_id ?? null,
       output_destination: recipe.output?.destination ?? recipe.output?.target_kind ?? null,
       requirements: recipe.requires ?? null,
-      balance: recipe.balance ? `${recipe.balance.kind}:${recipe.balance.target_kind}:${recipe.balance.target_id}` : null,
+      outcome: recipe.outcome ? `${recipe.outcome.kind}:${recipe.outcome.target_kind}:${recipe.outcome.target_id}` : null,
     })),
     evolution_tracks: evolutionTracks.map((track) => ({
       actor_id: track.actor_id,
@@ -3450,7 +3412,7 @@ function printWorldpackReport(report) {
   if (report.recipes.length) {
     console.log("recipes:");
     for (const recipe of report.recipes) {
-      console.log(`- ${recipe.id} ${recipe.key}: ${recipe.input_item_names.join(" + ")} -> ${recipe.output_item_name ?? "event"} (${recipe.balance})`);
+      console.log(`- ${recipe.id} ${recipe.key}: ${recipe.input_item_names.join(" + ")} -> ${recipe.output_item_name ?? "event"} (${recipe.outcome})`);
     }
   }
 }

--- a/v2/scripts/generate-elysium-cast.mjs
+++ b/v2/scripts/generate-elysium-cast.mjs
@@ -531,7 +531,7 @@ async function main() {
   );
   assert(resources.locations.length <= 2048, "Elysium exceeds the location capacity");
   assert(resources.exits.length <= EXIT_CAPACITY, "Elysium exceeds the exit capacity");
-  assert(resources.items.length <= 1024, "Elysium exceeds the item capacity");
+  assert(resources.items.length <= 2048, "Elysium exceeds the item capacity");
   assert(
     new Set(resources.actors.map((actor) => actor.location_id)).size === bindings.length,
     "Elysium avatars do not have unique void locations",

--- a/v2/scripts/main-rs-line-ceiling.txt
+++ b/v2/scripts/main-rs-line-ceiling.txt
@@ -440,4 +440,4 @@
 # answer is still #325/#61 extraction, not a higher ceiling.
 # 60043 -> 59955: move community-art card decoration and subject-level lookup
 # into community_art.rs while adding per-level avatar appearance at that seam.
-59955
+59928

--- a/v2/scripts/recipe-schema.mjs
+++ b/v2/scripts/recipe-schema.mjs
@@ -1,5 +1,5 @@
 const inputZones = new Set(["carried", "world"]);
-const inputDispositions = new Set(["persistent", "consume", "exhaust", "transform"]);
+const inputDispositions = new Set(["persistent", "exhaust", "transform"]);
 const naturalFeatures = new Set([
   "fish_rich_water",
   "ore_seam",
@@ -47,12 +47,72 @@ export function versionedRecipeValidationErrors(
   {
     templateIds = new Set(),
     buildingArchetypes = [],
+    itemIds = new Set(),
+    actorIds = new Set(),
+    locationIds = new Set(),
   } = {},
   label = `recipe ${String(recipe?.id ?? "unknown")}`,
 ) {
   const errors = [];
   if (!object(recipe) || recipe.schema_version !== 2) {
     return [`${label} schema_version must be 2`];
+  }
+  const exactInputs = Array.isArray(recipe.inputs)
+    && recipe.inputs.some((input) => Number.isInteger(input?.item_id));
+  if (exactInputs) {
+    if (recipe.inputs.length !== 2) {
+      errors.push(`${label} exact recipe must declare two physical inputs`);
+    }
+    const seenItems = new Set();
+    for (const input of recipe.inputs ?? []) {
+      const inputLabel = `${label} input ${String(input?.item_id ?? "unknown")}`;
+      if (!object(input)
+          || !Number.isInteger(input.item_id)
+          || !itemIds.has(input.item_id)
+          || seenItems.has(input.item_id)
+          || input.template_id !== undefined) {
+        errors.push(`${inputLabel} has an orphan, duplicate, or mixed item binding`);
+      }
+      seenItems.add(input?.item_id);
+      if (input?.quantity !== 1
+          || !uniqueStrings(input?.zones, inputZones)
+          || !inputDispositions.has(input?.disposition)) {
+        errors.push(`${inputLabel} has invalid physical input rules`);
+      }
+    }
+    const exactLocations = recipe.requires?.location_ids;
+    if (!object(recipe.requires)
+        || !Array.isArray(exactLocations)
+        || exactLocations.length !== 1
+        || !locationIds.has(exactLocations[0])) {
+      errors.push(`${label} must name one valid crafting location`);
+    }
+    const outcome = recipe.outcome;
+    if (!object(outcome)
+        || !["location", "avatar", "resident", "covenant", "evolution"].includes(outcome?.kind)
+        || !nonEmpty(outcome?.reason)
+        || !["actor_hand", "location_floor"].includes(outcome?.target_kind)
+        || (outcome?.target_kind === "actor_hand" && !actorIds.has(outcome?.target_id))
+        || (outcome?.target_kind === "location_floor" && !locationIds.has(outcome?.target_id))) {
+      errors.push(`${label} has an invalid exact outcome`);
+    }
+    if (recipe.output != null) {
+      const output = recipe.output;
+      if (!object(output)
+          || !Number.isInteger(output.item_id)
+          || output.item_id <= 0
+          || itemIds.has(output.item_id)
+          || !nonEmpty(output.name)
+          || !nonEmpty(output.description)
+          || !["potion", "evolution", "keepsake"].includes(output.kind)
+          || !Number.isInteger(output.charges)
+          || output.charges <= 0
+          || output.target_kind !== outcome?.target_kind
+          || output.target_id !== outcome?.target_id) {
+        errors.push(`${label} has an invalid fixed output`);
+      }
+    }
+    return errors;
   }
   const provisionedSupply = recipe.output?.effect === "provisioned_supply";
   if (!Array.isArray(recipe.inputs)

--- a/v2/scripts/recipe-schema.test.mjs
+++ b/v2/scripts/recipe-schema.test.mjs
@@ -8,12 +8,31 @@ import {
 
 const context = {
   templateIds: new Set(["iron_nodule", "iron_bloom", "hearth_tonic"]),
+  itemIds: new Set([2001, 2002]),
+  actorIds: new Set([5000]),
+  locationIds: new Set([1]),
   buildingArchetypes: [
     {
       capabilities: ["transformation_recipes", "metalworking"],
       recipe_tags: ["smithy", "refinement"],
     },
   ],
+};
+
+const exact = {
+  schema_version: 2,
+  id: 3001,
+  inputs: [
+    {item_id: 2001, quantity: 1, zones: ["carried"], disposition: "persistent"},
+    {item_id: 2002, quantity: 1, zones: ["world"], disposition: "persistent"},
+  ],
+  requires: {location_ids: [1]},
+  outcome: {
+    kind: "location",
+    target_kind: "location_floor",
+    target_id: 1,
+    reason: "A fixed story outcome.",
+  },
 };
 
 const valid = {
@@ -46,6 +65,20 @@ test("accepts physical capability-bound transformations", () => {
   const pair = structuredClone(valid);
   pair.inputs[0].quantity = 2;
   assert.equal(assertVersionedRecipe(pair, context), pair);
+});
+
+test("accepts exact item recipes only in the unified schema", () => {
+  assert.equal(assertVersionedRecipe(exact, context), exact);
+  const legacy = {
+    ...exact,
+    schema_version: 1,
+    input_item_ids: [2001, 2002],
+    balance: exact.outcome,
+  };
+  assert.match(
+    versionedRecipeValidationErrors(legacy, context).join("\n"),
+    /schema_version must be 2/,
+  );
 });
 
 test("rejects orphan outputs, ambiguous zones, and undeclared consumption", () => {

--- a/v2/spine-rust/Cargo.lock
+++ b/v2/spine-rust/Cargo.lock
@@ -40,6 +40,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "cosyworld-spine"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "rusqlite",
  "serde",
  "serde_json",

--- a/v2/spine-rust/Cargo.toml
+++ b/v2/spine-rust/Cargo.toml
@@ -9,3 +9,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
+
+[build-dependencies]
+cc = "1"

--- a/v2/spine-rust/src/kernel_ffi.rs
+++ b/v2/spine-rust/src/kernel_ffi.rs
@@ -23,10 +23,10 @@ use serde::{Deserialize, Serialize};
 use crate::kernel::{KernelOutcome, KernelPort};
 use crate::types::{Action, ActionKind, KernelEvent, KernelStatus};
 
-pub const CW_KERNEL_VERSION: u32 = 15;
+pub const CW_KERNEL_VERSION: u32 = 16;
 
 pub const CW_MAX_ACTORS: usize = 2048;
-pub const CW_MAX_ITEMS: usize = 1024;
+pub const CW_MAX_ITEMS: usize = 2048;
 pub const CW_MAX_LOCATIONS: usize = 2048;
 pub const CW_MAX_EXITS: usize = 4096;
 pub const CW_MAX_EVENTS: usize = 256;
@@ -113,12 +113,12 @@ pub struct CwItem {
     pub max_charges: u8,
     pub recovery: u8,
     pub recovery_zone: u8,
-    pub reserved2: u8,
+    #[serde(default, alias = "reserved2")]
+    pub policy_flags: u8,
     pub location_id: u64,
     pub holder_actor_id: u64,
     pub container_item_id: u64,
     pub held_since_tick: u64,
-    pub recharge_at_tick: u64,
 }
 
 #[repr(C)]

--- a/v2/worlds/bethlehem/pack.lock.json
+++ b/v2/worlds/bethlehem/pack.lock.json
@@ -86,7 +86,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",

--- a/v2/worlds/core-only/pack.lock.json
+++ b/v2/worlds/core-only/pack.lock.json
@@ -83,7 +83,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",

--- a/v2/worlds/core-ruby/pack.lock.json
+++ b/v2/worlds/core-ruby/pack.lock.json
@@ -85,7 +85,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",

--- a/v2/worlds/lantern-keeper/pack.lock.json
+++ b/v2/worlds/lantern-keeper/pack.lock.json
@@ -87,7 +87,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",

--- a/v2/worlds/official/pack.lock.json
+++ b/v2/worlds/official/pack.lock.json
@@ -91,7 +91,7 @@
         "type": "workspace",
         "path": "../../content/core"
       },
-      "integrity": "sha256:8e41acb7fe7c06de909c3b49bc736202ea7a1cbcc51ee688549d11789b333e6d",
+      "integrity": "sha256:1dce6a4d9ee46d392f3713f5d646bedaf6581b37597a399df7a071f086ef683f",
       "dependencies": [
         {
           "id": "cosyworld.rules-profile-srd5",


### PR DESCRIPTION
## Summary
- allow multiple loose items in a room and keep search, reveal, pickup, drop, and craft offers independent
- add explicit hidden placement, transfer and theft policies, container limits, and richer item-card actions
- unify recipe schema version 2, remove dead item lifecycle state, and expand item capacity

## Verification
- npm run check
- npm run v2:spine:test

The first full check inside the file sandbox blocked loopback test servers. The same Rust gate passed outside that restriction, and the pre-push hook then passed the complete check suite.