### PR TITLE
Fix composition route discovery after item redesign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosyworld",
-  "version": "1.0.141",
+  "version": "1.0.142",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosyworld",
-      "version": "1.0.141",
+      "version": "1.0.142",
       "license": "MIT",
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.38.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyworld",
-  "version": "1.0.141",
+  "version": "1.0.142",
   "description": "Shared AI MUD runtime with a deterministic C kernel and Rust orchestrator",
   "type": "module",
   "private": true,

--- a/v2/orchestrator-rust/Cargo.lock
+++ b/v2/orchestrator-rust/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cosyworld-orchestrator"
-version = "1.0.141"
+version = "1.0.142"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/v2/orchestrator-rust/Cargo.toml
+++ b/v2/orchestrator-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosyworld-orchestrator"
-version = "1.0.141"
+version = "1.0.142"
 edition = "2021"
 publish = false
 

--- a/v2/scripts/smoke-browser.mjs
+++ b/v2/scripts/smoke-browser.mjs
@@ -12381,7 +12381,7 @@ async function main() {
     await assertActionBarCapped("combat attack action bar");
   }
 
-  async function focusGiftForResident(name, stopWhen = null) {
+  async function focusGiftForResident(name, stopWhen = null, expectedItemName = "") {
     await page.waitForFunction(() => (
       actionBusy === false
         && refreshInFlight === null
@@ -12390,13 +12390,22 @@ async function main() {
     const deckSize = await fetchInspectableDeckSize();
     let result = null;
     for (let draw = 0; draw < deckSize; draw += 1) {
-      result = await page.evaluate((residentName) => {
+      result = await page.evaluate(({ residentName, itemName }) => {
         const needle = residentName.toLowerCase();
+        const itemNeedle = itemName.toLowerCase();
         const action = actionBarActions().find((candidate) => (
           ["give", "swap", "trade"].includes(candidate.label)
           && (
             String(candidate.detail || "").toLowerCase().includes(needle)
             || (candidate.choices || []).some((choice) => String(choice.label || "").toLowerCase().includes(needle))
+          )
+          && (
+            !itemNeedle
+            || [
+              candidate.detail,
+              candidate.command,
+              ...(candidate.choices || []).flatMap((choice) => [choice.label, choice.detail]),
+            ].filter(Boolean).join(" ").toLowerCase().includes(itemNeedle)
           )
         ));
         if (!action) {
@@ -12422,7 +12431,7 @@ async function main() {
             action.command,
           ].filter(Boolean).join(" "),
         };
-      }, name);
+      }, { residentName: name, itemName: expectedItemName });
       if (result.ok) break;
       if (stopWhen && await stopWhen()) return null;
       if (draw + 1 < deckSize) {
@@ -12467,6 +12476,10 @@ async function main() {
     assert(
       transferReceipt,
       `${name} transfer should return an exact authoritative ${expectedReceiptType} receipt: ${JSON.stringify(result.body?.events || [])}`,
+    );
+    assert(
+      !expectedItemName || transferReceipt.item_name === expectedItemName,
+      `${name} transfer should settle ${expectedItemName}, not ${transferReceipt.item_name || "an unnamed item"}`,
     );
     recordLivingItemEvidence({
       type: expectedReceiptType,
@@ -12598,7 +12611,7 @@ async function main() {
             ))
         ),
         { residentName: name, heldItemName: itemName },
-      ));
+      ), itemName);
       if (!lastPrimary) continue;
       steps.push({ label: `focus ${name} gift`, attempt, primary: lastPrimary });
       if (!/^(give|swap|trade)\b/i.test(lastPrimary)) continue;
@@ -16643,7 +16656,7 @@ async function main() {
       )) || finalState.residentItemState.some((moment) => (
         moment.item === "Watch Bell" && moment.resident === "Skull"
       )),
-      `the Watch Bell should reach Skull, perform its authored use, or complete an evolution: ${JSON.stringify({ itemStoryMoments: finalState.itemStoryMoments, residentItemState: finalState.residentItemState })}`,
+      `the Watch Bell should reach Skull, perform its authored use, or complete an evolution: ${JSON.stringify({ itemStoryMoments: finalState.itemStoryMoments, residentItemState: finalState.residentItemState, livingItemEvidence: finalState.livingItemEvidence })}`,
     );
     assert(finalState.trailExitEvents.includes("Rain-Soft Garden"), "leaving Moonlit Trail should record a trail exit event");
   }

--- a/v2/scripts/smoke-core-ruby-composition.mjs
+++ b/v2/scripts/smoke-core-ruby-composition.mjs
@@ -523,9 +523,26 @@ async function discoverExit(baseUrl, actorId, actorSession, destinationLocationI
       && exit.locked === false)) {
       return state;
     }
-    await commandExactOffer(baseUrl, actorId, actorSession, "search");
+    const scout = await drawExactOffer(
+      baseUrl,
+      actorId,
+      actorSession,
+      (offer) => offer.kind === "explore_path"
+        && Number(offer.target?.id) === Number(destinationLocationId),
+      `Scout route to ${destinationLocationId}`,
+    );
+    const result = await postJson(`${baseUrl}/commands`, {
+      actor_id: actorId,
+      actor_session: actorSession,
+      command: scout.command,
+      offer_id: scout.offer_id,
+    });
+    assert(
+      result.ok === true,
+      `Scout route to ${destinationLocationId} failed: ${JSON.stringify(result)}`,
+    );
   }
-  throw new Error(`exit ${destinationLocationId} was not discovered after 32 searches`);
+  throw new Error(`exit ${destinationLocationId} was not discovered after 32 Scout actions`);
 }
 
 async function assertContext(baseUrl, actorId, actorSession, state, {


### PR DESCRIPTION
Follow-up to #925.

Summary:
- make the core-ruby composition smoke test play the exact Scout offer for the destination
- keep item and location Inspect offers separate from route discovery
- bump version to 1.0.142

Checks:
- full npm run check pre-push suite
- core-ruby composition smoke journey